### PR TITLE
Stats: Update copy on commercial purchase page

### DIFF
--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -8,3 +8,6 @@ export const SUBSCRIBERS_SUPPORT_URL = 'https://wordpress.com/support/subscriber
 export const INSIGHTS_SUPPORT_URL =
 	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 	'https://wordpress.com/support/stats/learn-insights-about-your-website/';
+export const JETPACK_BLOG_ABOUT_COMMERCIAL_STATS_URL =
+	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+	'https://jetpack.com/blog/updates-to-jetpack-stats-for-commercial-sites/';

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -21,10 +21,10 @@ function useTranslatedStrings() {
 	const limits = translate( 'Monthly views limit', {
 		comment: 'Heading for Stats Upgrade slider. The monthly views limit.',
 	} ) as string;
-	const price = translate( 'You pay', {
+	const price = translate( "You'll pay", {
 		comment: 'Heading for Stats Upgrade slider. The monthly price.',
 	} ) as string;
-	const strategy = translate( 'Price per month, billed yearly', {
+	const strategy = translate( 'Price per month, billed yearly*', {
 		comment: 'Stats Upgrade slider message. The billing strategy.',
 	} ) as string;
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -103,7 +103,7 @@ const PersonalPurchase = ( {
 		: translate( 'Get Jetpack Stats' );
 
 	if ( isNewPurchaseFlowEnabled ) {
-		continueButtonText = translate( 'Contribute and continue' );
+		continueButtonText = translate( 'Contribute now and continue' );
 	}
 	const { refetch: refetchNotices } = useNoticeVisibilityQuery( siteId, 'focus_jetpack_purchase' );
 	const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
@@ -257,6 +257,7 @@ const PersonalPurchase = ( {
 
 			{ subscriptionValue === 0 ? (
 				<ButtonComponent
+					className="stats-purchase-flow__full-width-button"
 					variant="primary"
 					primary={ isWPCOMSite ? true : undefined }
 					disabled={
@@ -271,6 +272,7 @@ const PersonalPurchase = ( {
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
 					<ButtonComponent
+						className="stats-purchase-flow__full-width-button"
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						onClick={ handleCheckoutRedirect }
@@ -280,6 +282,7 @@ const PersonalPurchase = ( {
 
 					{ isNewPurchaseFlowEnabled && (
 						<ButtonComponent
+							className="stats-purchase-flow__full-width-button"
 							variant="secondary"
 							isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
 							busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />
@@ -329,7 +332,7 @@ function StatsBenefitsListing( {
 					</li>
 				) }
 				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
-					{ translate( 'No UTM tracking' ) }
+					{ translate( 'No UTM tracking for your marketing campaigns' ) }
 				</li>
 				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
 					{ translate( 'No access to upcoming advanced features' ) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -257,7 +257,7 @@ const PersonalPurchase = ( {
 
 			{ subscriptionValue === 0 ? (
 				<ButtonComponent
-					className="stats-purchase-flow__full-width-button"
+					className="stats-purchase-page__full-width"
 					variant="primary"
 					primary={ isWPCOMSite ? true : undefined }
 					disabled={
@@ -272,7 +272,7 @@ const PersonalPurchase = ( {
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
 					<ButtonComponent
-						className="stats-purchase-flow__full-width-button"
+						className="stats-purchase-page__full-width"
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						onClick={ handleCheckoutRedirect }
@@ -282,7 +282,7 @@ const PersonalPurchase = ( {
 
 					{ isNewPurchaseFlowEnabled && (
 						<ButtonComponent
-							className="stats-purchase-flow__full-width-button"
+							className="stats-purchase-page__full-width"
 							variant="secondary"
 							isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
 							busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -79,7 +79,11 @@ const StatsBenefitsCommercial = () => {
 				<li>{ translate( 'GDPR compliance' ) }</li>
 				<li>{ translate( 'Access to upcoming advanced features' ) }</li>
 				<li>{ translate( 'Priority support' ) }</li>
-				<li>{ translate( 'Commercial use' ) }</li>
+				<li>
+					{ translate( '{{strong}}Commercial use{{/strong}}', {
+						components: { strong: <strong /> },
+					} ) }
+				</li>
 				<li>
 					{ translate( 'UTM tracking' ) }
 					<Icon

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -202,7 +202,7 @@ const StatsCommercialPurchase = ( {
 						onSliderChange={ handleSliderChanged }
 					/>
 					<ButtonComponent
-						className="stats-purchase-flow__full-width-button"
+						className="stats-purchase-page__full-width"
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						onClick={ () =>
@@ -219,7 +219,7 @@ const StatsCommercialPurchase = ( {
 					>
 						{ continueButtonText }
 					</ButtonComponent>
-					<div className="stats-purchase-flow__footnotes">
+					<div className="stats-purchase-page__footnotes">
 						<p>{ translate( '(*) 14-day money-back guarantee' ) }</p>
 					</div>
 				</>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -201,6 +201,7 @@ const StatsCommercialPurchase = ( {
 						onSliderChange={ handleSliderChanged }
 					/>
 					<ButtonComponent
+						className="stats-purchase-flow__full-width-button"
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						onClick={ () =>
@@ -217,6 +218,9 @@ const StatsCommercialPurchase = ( {
 					>
 						{ continueButtonText }
 					</ButtonComponent>
+					<div className="stats-purchase-flow__footnotes">
+						<p>(*) 14-day money-back guarantee</p>
+					</div>
 				</>
 			) }
 		</>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -130,13 +130,33 @@ const StatsCommercialPurchase = ( {
 		setPurchaseTierQuantity( value );
 	}, [] );
 
-	const pageTitle = config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 )
-		? translate( 'Welcome to Jetpack Stats' )
-		: translate( 'Jetpack Stats' );
+	// Page title, info text, and button text depend on isCommercial status.
+	const isCommercial = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'is_commercial' )
+	) as boolean;
 
-	const continueButtonText = config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 )
-		? translate( 'Upgrade and continue' )
-		: translate( 'Purchase' );
+	let pageTitle = '';
+	let infoText = '';
+	let continueButtonText = '';
+	if ( ! config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 ) ) {
+		pageTitle = translate( 'Jetpack Stats' );
+		infoText = translate( 'The most advanced stats Jetpack has to offer.' );
+		continueButtonText = translate( 'Purchase' );
+	} else {
+		pageTitle = isCommercial
+			? translate( 'Upgrade and continue using Jetpack Stats' )
+			: translate( 'Simple yet powerful stats to grow your site' );
+		infoText = isCommercial
+			? translate(
+					'To continue using Stats and access its newest premium features you need to get a commercial license.'
+			  )
+			: translate(
+					"With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get premium access to:"
+			  );
+		continueButtonText = isCommercial
+			? translate( 'Upgrade and continue' )
+			: translate( 'Get started now' );
+	}
 
 	// TODO: Remove isTierUpgradeSliderEnabled code paths.
 
@@ -145,7 +165,7 @@ const StatsCommercialPurchase = ( {
 			<h1>{ pageTitle }</h1>
 			{ ! isCommercialOwned && (
 				<>
-					<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
+					<p>{ infoText }</p>
 					<StatsBenefitsCommercial />
 				</>
 			) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -9,6 +9,7 @@ import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { isJetpackSite, getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
+import { JETPACK_BLOG_ABOUT_COMMERCIAL_STATS_URL } from '../const';
 import useAvailableUpgradeTiers from '../hooks/use-available-upgrade-tiers';
 import useOnDemandCommercialClassificationMutation from '../hooks/use-on-demand-site-identification-mutation';
 import useSiteCompulsoryPlanSelectionQualifiedCheck from '../hooks/use-site-compulsory-plan-selection-qualified-check';
@@ -115,9 +116,7 @@ function useLocalizedStrings( isCommercial: boolean ) {
 				{
 					comment: '{{link}} links to explainer post on Jetpack blog.',
 					components: {
-						link: (
-							<a href="https://jetpack.com/blog/updates-to-jetpack-stats-for-commercial-sites/" />
-						),
+						link: <a href={ JETPACK_BLOG_ABOUT_COMMERCIAL_STATS_URL } />,
 					},
 					context: 'Stats: Descriptive text in the commercial purchase flow',
 				}

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -104,6 +104,36 @@ const StatsUpgradeInstructions = () => {
 	);
 };
 
+function useLocalizedStrings( isCommercial: boolean ) {
+	const translate = useTranslate();
+
+	let pageTitle = '';
+	let infoText = '';
+	let continueButtonText = '';
+
+	// Page title, info text, and button text depend on isCommercial status.
+	if ( ! config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 ) ) {
+		pageTitle = translate( 'Jetpack Stats' );
+		infoText = translate( 'The most advanced stats Jetpack has to offer.' );
+		continueButtonText = translate( 'Purchase' );
+	} else {
+		pageTitle = isCommercial
+			? translate( 'Upgrade and continue using Jetpack Stats' )
+			: translate( 'Simple yet powerful stats to grow your site' );
+		infoText = isCommercial
+			? translate(
+					'To continue using Stats and access its newest premium features you need to get a commercial license.'
+			  )
+			: translate(
+					"With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get premium access to:"
+			  );
+		continueButtonText = isCommercial
+			? translate( 'Upgrade and continue' )
+			: translate( 'Get started now' );
+	}
+	return { pageTitle, infoText, continueButtonText };
+}
+
 const StatsCommercialPurchase = ( {
 	siteId,
 	siteSlug,
@@ -134,29 +164,7 @@ const StatsCommercialPurchase = ( {
 	const isCommercial = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'is_commercial' )
 	) as boolean;
-
-	let pageTitle = '';
-	let infoText = '';
-	let continueButtonText = '';
-	if ( ! config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 ) ) {
-		pageTitle = translate( 'Jetpack Stats' );
-		infoText = translate( 'The most advanced stats Jetpack has to offer.' );
-		continueButtonText = translate( 'Purchase' );
-	} else {
-		pageTitle = isCommercial
-			? translate( 'Upgrade and continue using Jetpack Stats' )
-			: translate( 'Simple yet powerful stats to grow your site' );
-		infoText = isCommercial
-			? translate(
-					'To continue using Stats and access its newest premium features you need to get a commercial license.'
-			  )
-			: translate(
-					"With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get premium access to:"
-			  );
-		continueButtonText = isCommercial
-			? translate( 'Upgrade and continue' )
-			: translate( 'Get started now' );
-	}
+	const { pageTitle, infoText, continueButtonText } = useLocalizedStrings( isCommercial );
 
 	// TODO: Remove isTierUpgradeSliderEnabled code paths.
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -106,12 +106,11 @@ const StatsUpgradeInstructions = () => {
 function useLocalizedStrings( isCommercial: boolean ) {
 	const translate = useTranslate();
 
-	// Page title, info text, and button text depend on isCommercial status.
-	const pageTitle = isCommercial
-		? translate( 'Upgrade and continue using Jetpack Stats' )
-		: translate( 'Simple yet powerful stats to grow your site' );
-	const infoText = isCommercial
-		? ( translate(
+	// Page title, info text, and button text depend on isCommercial status of site.
+	if ( isCommercial ) {
+		return {
+			pageTitle: translate( 'Upgrade and continue using Jetpack Stats' ),
+			infoText: translate(
 				'To continue using Stats and access its newest premium features you need to get a commercial license. {{link}}Learn more about this update{{/link}}.',
 				{
 					comment: '{{link}} links to explainer post on Jetpack blog.',
@@ -122,15 +121,18 @@ function useLocalizedStrings( isCommercial: boolean ) {
 					},
 					context: 'Stats: Descriptive text in the commercial purchase flow',
 				}
-		  ) as string )
-		: translate(
-				"With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get premium access to:"
-		  );
-	const continueButtonText = isCommercial
-		? translate( 'Upgrade and continue' )
-		: translate( 'Get started now' );
+			),
+			continueButtonText: translate( 'Upgrade and continue' ),
+		};
+	}
 
-	return { pageTitle, infoText, continueButtonText };
+	return {
+		pageTitle: translate( 'Simple yet powerful stats to grow your site' ),
+		infoText: translate(
+			"With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get premium access to:"
+		),
+		continueButtonText: translate( 'Get started now' ),
+	};
 }
 
 const StatsCommercialPurchase = ( {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -121,16 +121,16 @@ function useLocalizedStrings( isCommercial: boolean ) {
 					context: 'Stats: Descriptive text in the commercial purchase flow',
 				}
 			),
-			continueButtonText: translate( 'Upgrade and continue' ),
+			continueButtonText: translate( 'Upgrade now and continue' ),
 		};
 	}
 
 	return {
 		pageTitle: translate( 'Simple yet powerful stats to grow your site' ),
 		infoText: translate(
-			"With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get premium access to:"
+			'Jetpack Stats makes it easy to see how your site is doing. No data science skills needed. Start with a commercial license and get premium access to:'
 		),
-		continueButtonText: translate( 'Get started now' ),
+		continueButtonText: translate( 'Get Stats to grow my site' ),
 	};
 }
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -193,7 +193,7 @@ const StatsCommercialPurchase = ( {
 			) }
 			{ isTierUpgradeSliderEnabled && (
 				<>
-					<p>Pick your Stats tier below:</p>
+					<p>{ translate( 'Pick your Stats tier below:' ) }</p>
 					<StatsCommercialUpgradeSlider
 						currencyCode={ currencyCode }
 						analyticsEventName={ `${
@@ -220,7 +220,7 @@ const StatsCommercialPurchase = ( {
 						{ continueButtonText }
 					</ButtonComponent>
 					<div className="stats-purchase-flow__footnotes">
-						<p>(*) 14-day money-back guarantee</p>
+						<p>{ translate( '(*) 14-day money-back guarantee' ) }</p>
 					</div>
 				</>
 			) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -112,6 +112,7 @@ function useLocalizedStrings( isCommercial: boolean ) {
 	let continueButtonText = '';
 
 	// Page title, info text, and button text depend on isCommercial status.
+	// We maintain the old behaviour for pre-FLAGS_CHECKOUT_FLOWS_V2 cases.
 	if ( ! config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 ) ) {
 		pageTitle = translate( 'Jetpack Stats' );
 		infoText = translate( 'The most advanced stats Jetpack has to offer.' );
@@ -160,7 +161,6 @@ const StatsCommercialPurchase = ( {
 		setPurchaseTierQuantity( value );
 	}, [] );
 
-	// Page title, info text, and button text depend on isCommercial status.
 	const isCommercial = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'is_commercial' )
 	) as boolean;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -193,6 +193,7 @@ const StatsCommercialPurchase = ( {
 			) }
 			{ isTierUpgradeSliderEnabled && (
 				<>
+					<p>Pick your Stats tier below:</p>
 					<StatsCommercialUpgradeSlider
 						currencyCode={ currencyCode }
 						analyticsEventName={ `${

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -122,9 +122,18 @@ function useLocalizedStrings( isCommercial: boolean ) {
 			? translate( 'Upgrade and continue using Jetpack Stats' )
 			: translate( 'Simple yet powerful stats to grow your site' );
 		infoText = isCommercial
-			? translate(
-					'To continue using Stats and access its newest premium features you need to get a commercial license.'
-			  )
+			? ( translate(
+					'To continue using Stats and access its newest premium features you need to get a commercial license. {{link}}Learn more about this update{{/link}}.',
+					{
+						comment: '{{link}} links to explainer post on Jetpack blog.',
+						components: {
+							link: (
+								<a href="https://jetpack.com/blog/updates-to-jetpack-stats-for-commercial-sites/" />
+							),
+						},
+						context: 'Stats: Descriptive text in the commercial purchase flow',
+					}
+			  ) as string )
 			: translate(
 					"With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get premium access to:"
 			  );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -260,8 +260,10 @@ const StatsPersonalPurchase = ( {
 
 	return (
 		<>
-			<h1>{ translate( 'Name your price for Jetpack Stats' ) }</h1>
-			<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
+			<h1>{ translate( 'Support Jetpack Stats and set your price' ) }</h1>
+			<p>
+				{ translate( 'Help Jetpack Stats with a non-commercial license and get these perks:' ) }
+			</p>
 			<PersonalPurchase
 				subscriptionValue={ subscriptionValue }
 				setSubscriptionValue={ setSubscriptionValue }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -107,40 +107,30 @@ const StatsUpgradeInstructions = () => {
 function useLocalizedStrings( isCommercial: boolean ) {
 	const translate = useTranslate();
 
-	let pageTitle = '';
-	let infoText = '';
-	let continueButtonText = '';
-
 	// Page title, info text, and button text depend on isCommercial status.
-	// We maintain the old behaviour for pre-FLAGS_CHECKOUT_FLOWS_V2 cases.
-	if ( ! config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 ) ) {
-		pageTitle = translate( 'Jetpack Stats' );
-		infoText = translate( 'The most advanced stats Jetpack has to offer.' );
-		continueButtonText = translate( 'Purchase' );
-	} else {
-		pageTitle = isCommercial
-			? translate( 'Upgrade and continue using Jetpack Stats' )
-			: translate( 'Simple yet powerful stats to grow your site' );
-		infoText = isCommercial
-			? ( translate(
-					'To continue using Stats and access its newest premium features you need to get a commercial license. {{link}}Learn more about this update{{/link}}.',
-					{
-						comment: '{{link}} links to explainer post on Jetpack blog.',
-						components: {
-							link: (
-								<a href="https://jetpack.com/blog/updates-to-jetpack-stats-for-commercial-sites/" />
-							),
-						},
-						context: 'Stats: Descriptive text in the commercial purchase flow',
-					}
-			  ) as string )
-			: translate(
-					"With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get premium access to:"
-			  );
-		continueButtonText = isCommercial
-			? translate( 'Upgrade and continue' )
-			: translate( 'Get started now' );
-	}
+	const pageTitle = isCommercial
+		? translate( 'Upgrade and continue using Jetpack Stats' )
+		: translate( 'Simple yet powerful stats to grow your site' );
+	const infoText = isCommercial
+		? ( translate(
+				'To continue using Stats and access its newest premium features you need to get a commercial license. {{link}}Learn more about this update{{/link}}.',
+				{
+					comment: '{{link}} links to explainer post on Jetpack blog.',
+					components: {
+						link: (
+							<a href="https://jetpack.com/blog/updates-to-jetpack-stats-for-commercial-sites/" />
+						),
+					},
+					context: 'Stats: Descriptive text in the commercial purchase flow',
+				}
+		  ) as string )
+		: translate(
+				"With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get premium access to:"
+		  );
+	const continueButtonText = isCommercial
+		? translate( 'Upgrade and continue' )
+		: translate( 'Get started now' );
+
 	return { pageTitle, infoText, continueButtonText };
 }
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -104,7 +104,7 @@ const StatsUpgradeInstructions = () => {
 	);
 };
 
-function useLocalizedStrings( isCommercial: boolean ) {
+const useLocalizedStrings = ( isCommercial: boolean ) => {
 	const translate = useTranslate();
 
 	// Page title, info text, and button text depend on isCommercial status of site.
@@ -132,7 +132,7 @@ function useLocalizedStrings( isCommercial: boolean ) {
 		),
 		continueButtonText: translate( 'Get Stats to grow my site' ),
 	};
-}
+};
 
 const StatsCommercialPurchase = ( {
 	siteId,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -84,7 +84,6 @@ interface StatsCommercialFlowOptOutFormProps {
 }
 
 const COMPONENT_CLASS_NAME = 'stats-purchase-single';
-const FLAGS_CHECKOUT_FLOWS_V2 = 'stats/checkout-flows-v2';
 
 const StatsUpgradeInstructions = () => {
 	const translate = useTranslate();
@@ -254,13 +253,9 @@ const StatsPersonalPurchase = ( {
 		page( `/stats/purchase/${ siteSlug }?productType=commercial&flags=stats/type-detection` );
 	};
 
-	const pageTitle = config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 )
-		? translate( 'Name your price for Jetpack Stats' )
-		: translate( 'Jetpack Stats' );
-
 	return (
 		<>
-			<h1>{ pageTitle }</h1>
+			<h1>{ translate( 'Name your price for Jetpack Stats' ) }</h1>
 			<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
 			<PersonalPurchase
 				subscriptionValue={ subscriptionValue }

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -589,3 +589,15 @@ $button-padding: 8px 32px;
 	font-size: $font-body-small;
 	margin-top: 24px;
 }
+
+.stats-purchase-flow__full-width-button {
+	display: block;
+	width: 100%;
+}
+
+.stats-purchase-flow__footnotes {
+	margin-top: 24px;
+	color: var(--gray-gray-50);
+	font-size: $font-body-small;
+	text-align: center;
+}

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -590,12 +590,12 @@ $button-padding: 8px 32px;
 	margin-top: 24px;
 }
 
-.stats-purchase-flow__full-width-button {
+.stats-purchase-page__full-width {
 	display: block;
 	width: 100%;
 }
 
-.stats-purchase-flow__footnotes {
+.stats-purchase-page__footnotes {
 	margin-top: 24px;
 	color: var(--gray-gray-50);
 	font-size: $font-body-small;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1HpG7-snd-p2.

## Proposed Changes

Updates the copy in the purchase flows depending on the site classification.

### Commercial sites see this

<img width="457" alt="SCR-20240523-qibx" src="https://github.com/Automattic/wp-calypso/assets/40267301/5ec22889-b9d9-42af-8843-f814f0bde4f1">

1. Updated header & description text
2. Updated styling for "commercial use" feature
3. New "Pick your tier" header
4. Updated copy in tier slider
5. Footnote indicator
6. Full-width buttons
7. Footnote text

### Non-commercial sites see this

<img width="456" alt="SCR-20240523-qjuq" src="https://github.com/Automattic/wp-calypso/assets/40267301/0f17480c-60aa-4bd9-994d-ac7aaa873619">

Same as above with different header, info, and button text.

### PWYW flow

<img width="438" alt="SCR-20240523-qgrm" src="https://github.com/Automattic/wp-calypso/assets/40267301/04a993cc-80d8-47c9-baf6-9598c8c98968">

1. Updated header & description text
2. Updated copy for UTM feature
8. Full-width buttons

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of the project to improve the paywall experience.

p1HpG7-shw-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Stats page on a new site and confirm the copy matches the second screenshot. New sites that aren't yet classified should see that.
* Visit the Stats page on a new site that has been classified as commercial (you can force this via the Blog RC tool) and confirm the copy matches the first screenshot.
* Confirm "Learn more" link is present and working when site is classified as commercial. Not pictured in screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?