### PR TITLE
A4A > Referrals: Redesign the A4A Referrals empty page

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import React from 'react';
 import StatusBadge from './status-badge';
+import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
@@ -11,10 +12,12 @@ const ICON_SIZE = 24;
 interface StepSectionItemProps {
 	icon: JSX.Element;
 	heading: string;
-	description: string | JSX.Element;
+	description: TranslateResult;
 	buttonProps?: React.ComponentProps< typeof Button >;
 	statusProps?: React.ComponentProps< typeof Badge > & { tooltip?: string };
 	className?: string;
+	iconClassName?: string;
+	isAutomatedReferral?: boolean;
 }
 
 export default function StepSectionItem( {
@@ -24,12 +27,24 @@ export default function StepSectionItem( {
 	buttonProps,
 	statusProps,
 	className,
+	iconClassName,
+	isAutomatedReferral = false,
 }: StepSectionItemProps ) {
 	const status = <StatusBadge statusProps={ statusProps } />;
 
+	const buttonContent = buttonProps && (
+		<div className="step-section-item__button">
+			<Button { ...buttonProps } />
+		</div>
+	);
+
+	const statusContent = statusProps && (
+		<div className="step-section-item__status is-large-screen">{ status }</div>
+	);
+
 	return (
 		<div className={ classNames( 'step-section-item', className ) }>
-			<div className="step-section-item__icon">
+			<div className={ classNames( 'step-section-item__icon', iconClassName ) }>
 				<Icon
 					className="sidebar__menu-icon"
 					style={ { fill: 'currentcolor' } }
@@ -41,15 +56,13 @@ export default function StepSectionItem( {
 				{ statusProps && (
 					<div className="step-section-item__status is-small-screen">{ status }</div>
 				) }
-				<div className="step-section-item__heading">{ heading }</div>
+				<div className="step-section-item__heading">
+					{ heading } { isAutomatedReferral && statusContent }
+				</div>
 				<div className="step-section-item__description">{ description }</div>
-				{ buttonProps && (
-					<div className="step-section-item__button">
-						<Button { ...buttonProps } />
-					</div>
-				) }
+				{ ! isAutomatedReferral && buttonContent }
 			</div>
-			{ statusProps && <div className="step-section-item__status is-large-screen">{ status }</div> }
+			{ isAutomatedReferral ? buttonContent : statusContent }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -14,7 +14,6 @@
 
 	.step-section-item__icon {
 		display: none;
-		opacity: 0.7;
 
 		@include break-large {
 			display: block;
@@ -97,5 +96,26 @@
 .step-section-item__content {
 	@include break-large {
 		max-width: 70%;
+	}
+}
+
+.referrals-layout--automated .step-section-item {
+	.step-section-item__button .button {
+		min-width: 120px;
+	}
+
+	.step-section-item__button {
+		@include break-large {
+			margin-block: auto;
+		}
+	}
+
+	.step-section-item__status.is-large-screen {
+		@include break-large {
+			display: inline-flex;
+			position: relative;
+			left: 4px;
+		}
+
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -75,6 +75,8 @@
 
 	.badge {
 		white-space: nowrap;
+		position: relative;
+		top: -1px;
 	}
 
 	.badge--success {

--- a/client/a8c-for-agencies/sections/referrals/common/step-section/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 
 import './style.scss';
@@ -6,11 +7,17 @@ interface StepSectionProps {
 	heading: string;
 	stepCount?: number;
 	children: React.ReactNode;
+	className?: string;
 }
 
-export default function StepSection( { stepCount, heading, children }: StepSectionProps ) {
+export default function StepSection( {
+	stepCount,
+	heading,
+	children,
+	className,
+}: StepSectionProps ) {
 	return (
-		<div className="step-section">
+		<div className={ classNames( 'step-section', className ) }>
 			<div className="step-section__header">
 				{ !! stepCount && <div className="step-section__step-count">{ stepCount }</div> }
 				<div className="step-section__step-heading">{ heading }</div>

--- a/client/a8c-for-agencies/sections/referrals/common/step-section/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section/style.scss
@@ -32,3 +32,7 @@
 		}
 	}
 }
+
+.referrals-layout--automated .step-section .step-section__header .step-section__step-heading {
+	font-size: rem(16px);
+}

--- a/client/a8c-for-agencies/sections/referrals/controller.tsx
+++ b/client/a8c-for-agencies/sections/referrals/controller.tsx
@@ -43,7 +43,7 @@ export const referralsDashboardContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Referrals > Dashboard" path={ context.path } />
-			<div>Dashboard</div>
+			<ReferralsOverview isAutomatedReferral />
 		</>
 	);
 	context.secondary = <ReferralsSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/referrals/index.ts
+++ b/client/a8c-for-agencies/sections/referrals/index.ts
@@ -15,28 +15,6 @@ import * as controller from './controller';
 const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
 
 export default function () {
-	// Remove the following when the automated referrals feature flag is removed
-	page(
-		A4A_REFERRALS_LINK,
-		requireAccessContext,
-		controller.referralsContext,
-		makeLayout,
-		clientRender
-	);
-	page(
-		A4A_REFERRALS_BANK_DETAILS_LINK,
-		requireAccessContext,
-		controller.referralsBankDetailsContext,
-		makeLayout,
-		clientRender
-	);
-	page(
-		A4A_REFERRALS_COMMISSIONS_LINK,
-		requireAccessContext,
-		controller.referralsCommissionOverviewContext,
-		makeLayout,
-		clientRender
-	);
 	if ( isAutomatedReferralsEnabled ) {
 		page(
 			A4A_REFERRALS_DASHBOARD,
@@ -60,5 +38,28 @@ export default function () {
 			clientRender
 		);
 		page( A4A_REFERRALS_LINK, () => page.redirect( A4A_REFERRALS_DASHBOARD ) );
+	} else {
+		// Remove the following when the automated referrals feature flag is removed
+		page(
+			A4A_REFERRALS_LINK,
+			requireAccessContext,
+			controller.referralsContext,
+			makeLayout,
+			clientRender
+		);
+		page(
+			A4A_REFERRALS_BANK_DETAILS_LINK,
+			requireAccessContext,
+			controller.referralsBankDetailsContext,
+			makeLayout,
+			clientRender
+		);
+		page(
+			A4A_REFERRALS_COMMISSIONS_LINK,
+			requireAccessContext,
+			controller.referralsCommissionOverviewContext,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,6 +1,7 @@
 import { Button, WooLogo } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
-import { plugins } from '@wordpress/icons';
+import { plugins, reusableBlock } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
@@ -8,15 +9,23 @@ import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import {
 	A4A_REFERRALS_BANK_DETAILS_LINK,
 	A4A_REFERRALS_COMMISSIONS_LINK,
+	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_REFERRALS_PAYMENT_SETTINGS,
+	A4A_REFERRALS_FAQ,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { A4A_DOWNLOAD_LINK_ON_GITHUB } from 'calypso/a8c-for-agencies/constants';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import WooCommerceLogo from 'calypso/components/woocommerce-logo';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
@@ -30,11 +39,17 @@ import ReferralsFooter from '../footer';
 
 import './style.scss';
 
-export default function ReferralsOverview() {
+export default function ReferralsOverview( {
+	isAutomatedReferral = false,
+}: {
+	isAutomatedReferral?: boolean;
+} ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const title = translate( 'Referrals' );
+	const title = isAutomatedReferral
+		? translate( 'Your referrals and commissions' )
+		: translate( 'Referrals' );
 
 	const onAddBankDetailsClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_add_bank_details_button_click' ) );
@@ -42,6 +57,10 @@ export default function ReferralsOverview() {
 
 	const onDownloadA4APluginClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_download_a4a_plugin_button_click' ) );
+	}, [ dispatch ] );
+
+	const onGetStartedClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_referrals_get_started_button_click' ) );
 	}, [ dispatch ] );
 
 	const { data, isFetching } = useGetTipaltiPayee();
@@ -83,16 +102,43 @@ export default function ReferralsOverview() {
 		}
 	}, [ dispatch, successNoticeSeen, accountStatus ] );
 
+	const makeAReferral = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_referrals_make_a_referral_button_click' ) );
+	}, [ dispatch ] );
+
+	let bankAccountCTAText = hasPayeeAccount
+		? translate( 'Edit my bank details' )
+		: translate( 'Enter bank details' );
+
+	if ( isAutomatedReferral ) {
+		bankAccountCTAText = hasPayeeAccount
+			? translate( 'Edit my details' )
+			: translate( 'Add my details' );
+	}
+
+	const referProductsLink = `${ A4A_MARKETPLACE_PRODUCTS_LINK }?purchase-type=refer-products`;
+
 	return (
 		<Layout
-			className="referrals-layout"
+			className={ classNames( 'referrals-layout', {
+				'referrals-layout--automated': isAutomatedReferral,
+			} ) }
 			title={ title }
 			wide
-			sidebarNavigation={ <MobileSidebarNavigation /> }
+			sidebarNavigation={ ! isAutomatedReferral && <MobileSidebarNavigation /> }
+			withBorder={ isAutomatedReferral }
 		>
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title } </Title>
+					{ isAutomatedReferral && (
+						<Actions>
+							<MobileSidebarNavigation />
+							<Button primary href={ referProductsLink } onClick={ makeAReferral }>
+								{ translate( 'Make a referral' ) }
+							</Button>
+						</Actions>
+					) }
 				</LayoutHeader>
 			</LayoutTop>
 
@@ -106,27 +152,52 @@ export default function ReferralsOverview() {
 						</NoticeBanner>
 					</div>
 				) }
+				{ isAutomatedReferral && (
+					<div className="referrals-overview__section-icons">
+						<JetpackLogo className="jetpack-logo" size={ 24 } />
+						<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
+						<img src={ pressableIcon } alt="Pressable" />
+						<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
+					</div>
+				) }
 				<div className="referrals-overview__section-heading">
-					{ translate( 'Recommend our products. Earn up to a 50% commission.' ) } <br />
-					{ translate( ' No promo codes required.' ) }
+					{ isAutomatedReferral ? (
+						<>
+							{ translate( 'Recommend our products.' ) } <br />
+							{ translate( 'Earn up to a 50% commission.' ) }
+						</>
+					) : (
+						<>
+							{ translate( 'Recommend our products. Earn up to a 50% commission.' ) } <br />
+							{ translate( ' No promo codes required.' ) }
+						</>
+					) }
 				</div>
 
 				<div className="referrals-overview__section-subtitle">
-					<div>
-						{ translate(
-							'Make money on each product your clients buy from Automattic. They can buy WooCommerce extensions, tools from Jetpack, and hosting services from Pressable or WordPress.com'
-						) }
-					</div>
-					<div>
-						{ translate(
-							'You can also make money when people buy things on your clients’ websites using WooPayments. {{a}}How much can I earn?{{/a}}',
-							{
-								components: {
-									a: <a href={ A4A_REFERRALS_COMMISSIONS_LINK } />,
-								},
-							}
-						) }
-					</div>
+					{ isAutomatedReferral ? (
+						translate(
+							'Make money when your clients buy Automattic products, hosting, or use WooPayments. No promo codes needed.'
+						)
+					) : (
+						<>
+							<div>
+								{ translate(
+									'Make money on each product your clients buy from Automattic. They can buy WooCommerce extensions, tools from Jetpack, and hosting services from Pressable or WordPress.com'
+								) }
+							</div>
+							<div>
+								{ translate(
+									'You can also make money when people buy things on your clients’ websites using WooPayments. {{a}}How much can I earn?{{/a}}',
+									{
+										components: {
+											a: <a href={ A4A_REFERRALS_COMMISSIONS_LINK } />,
+										},
+									}
+								) }
+							</div>
+						</>
+					) }
 				</div>
 
 				<div className="referrals-overview__section-container">
@@ -139,19 +210,45 @@ export default function ReferralsOverview() {
 						</>
 					) : (
 						<>
-							<MigrationOffer />
-							<StepSection heading={ translate( 'How do I get started?' ) }>
+							{ ! isAutomatedReferral && <MigrationOffer /> }
+							<StepSection
+								heading={
+									isAutomatedReferral
+										? translate( 'How do I start?' )
+										: translate( 'How do I get started?' )
+								}
+							>
 								<StepSectionItem
+									isAutomatedReferral={ isAutomatedReferral }
 									icon={ tipaltiLogo }
-									heading={ translate( 'Enter your bank details so we can pay you commissions' ) }
-									description={ translate(
-										'Get paid seamlessly by adding your bank details and tax forms to Tipalti, our trusted and secure platform for commission payments.'
-									) }
+									heading={
+										isAutomatedReferral
+											? translate( 'Prepare to get paid' )
+											: translate( 'Enter your bank details so we can pay you commissions' )
+									}
+									description={
+										isAutomatedReferral
+											? translate( 'With {{a}}Tipalti ↗{{/a}}, our secure platform.', {
+													components: {
+														a: (
+															<a
+																className="referrals-overview__link"
+																href="https://tipalti.com/"
+																target="_blank"
+																rel="noopener noreferrer"
+															/>
+														),
+													},
+											  } )
+											: translate(
+													'Get paid seamlessly by adding your bank details and tax forms to Tipalti, our trusted and secure platform for commission payments.'
+											  )
+									}
 									buttonProps={ {
-										children: hasPayeeAccount
-											? translate( 'Edit my bank details' )
-											: translate( 'Enter bank details' ),
-										href: A4A_REFERRALS_BANK_DETAILS_LINK,
+										children: bankAccountCTAText,
+										href: isAutomatedReferral
+											? A4A_REFERRALS_PAYMENT_SETTINGS
+											: A4A_REFERRALS_BANK_DETAILS_LINK,
 										onClick: onAddBankDetailsClick,
 										primary: ! hasPayeeAccount,
 										compact: true,
@@ -166,47 +263,88 @@ export default function ReferralsOverview() {
 											: undefined
 									}
 								/>
+								{ isAutomatedReferral ? (
+									<StepSectionItem
+										iconClassName="referrals-overview__opacity-70-percent"
+										isAutomatedReferral
+										icon={ reusableBlock }
+										heading={ translate( 'Refer products and hosting' ) }
+										description={ translate( 'Receive up to a 50% commission.' ) }
+										buttonProps={ {
+											children: translate( 'Get started' ),
+											compact: true,
+											primary: hasPayeeAccount,
+											href: referProductsLink,
+											onClick: onGetStartedClick,
+										} }
+									/>
+								) : (
+									<StepSectionItem
+										iconClassName="referrals-overview__opacity-70-percent"
+										icon={ plugins }
+										heading={ translate( 'Verify your relationship with your clients' ) }
+										description={ translate(
+											'Install the A4A plugin on your clients’ sites. This shows you have a direct relationship with the client.'
+										) }
+										buttonProps={ {
+											children: translate( 'Download the plugin now' ),
+											compact: true,
+											href: A4A_DOWNLOAD_LINK_ON_GITHUB,
+											onClick: onDownloadA4APluginClick,
+										} }
+									/>
+								) }
 								<StepSectionItem
-									icon={ plugins }
-									heading={ translate( 'Verify your relationship with your clients' ) }
-									description={ translate(
-										'Install the A4A plugin on your clients’ sites. This shows you have a direct relationship with the client.'
-									) }
-									buttonProps={ {
-										children: translate( 'Download the plugin now' ),
-										compact: true,
-										href: A4A_DOWNLOAD_LINK_ON_GITHUB,
-										onClick: onDownloadA4APluginClick,
-									} }
-								/>
-								<StepSectionItem
+									isAutomatedReferral={ isAutomatedReferral }
 									className="referrals-overview__step-section-woo-payments"
 									icon={ <WooLogo /> }
-									heading={ translate( 'Install WooPayments on your clients’ online stores' ) }
-									description={
-										<>
-											{ translate(
-												'Receive a revenue share of 5 basis points (0.05%) on new WooPayments total payments volume (TPV) on clients’ sites.'
-											) }
-											<div>
-												<Button
-													borderless
-													href="https://woocommerce.com/payments/"
-													rel="noreferrer"
-													target="_blank"
-												>
-													{ translate( 'Learn about WooPayments' ) }
-												</Button>
-											</div>
-										</>
+									heading={
+										isAutomatedReferral
+											? translate( 'Install WooPayments' )
+											: translate( 'Install WooPayments on your clients’ online stores' )
 									}
+									description={
+										isAutomatedReferral
+											? translate( 'Receive a rev share of 0.05% per sale.' )
+											: translate(
+													'Receive a revenue share of 5 basis points (0.05%) on new WooPayments total payments volume (TPV) on clients’ sites.'
+											  )
+									}
+									buttonProps={ {
+										children: isAutomatedReferral
+											? translate( 'Learn how' )
+											: translate( 'Learn about WooPayments' ),
+										compact: isAutomatedReferral,
+										primary: isAutomatedReferral && hasPayeeAccount,
+										borderless: ! isAutomatedReferral,
+										href: 'https://woocommerce.com/payments/',
+										rel: 'noreferrer',
+										target: '_blank',
+									} }
 								/>
 							</StepSection>
+							{ isAutomatedReferral && (
+								<StepSection
+									className="referrals-overview__step-section-learn-more"
+									heading={ translate( 'Find out more about the program' ) }
+								>
+									<Button className="a8c-blue-link" borderless href={ A4A_REFERRALS_FAQ }>
+										{ translate( 'How much money will I make?' ) }
+									</Button>
+									<br />
+									{
+										// FIXME: Add link
+										<Button className="a8c-blue-link" borderless href="#">
+											{ translate( 'How does it work?' ) }
+										</Button>
+									}
+								</StepSection>
+							) }
 						</>
 					) }
 				</div>
 
-				{ ! isFetching && <ReferralsFooter /> }
+				{ ! isFetching && ! isAutomatedReferral && <ReferralsFooter /> }
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,5 +1,6 @@
 import { Button, WooLogo } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { plugins, reusableBlock } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -47,9 +48,12 @@ export default function ReferralsOverview( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const title = isAutomatedReferral
-		? translate( 'Your referrals and commissions' )
-		: translate( 'Referrals' );
+	const isDesktop = useDesktopBreakpoint();
+
+	const title =
+		isAutomatedReferral && isDesktop
+			? translate( 'Your referrals and commissions' )
+			: translate( 'Referrals' );
 
 	const onAddBankDetailsClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_add_bank_details_button_click' ) );

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .referrals-overview__section-notice {
 	margin-block-end: 48px;
 }
@@ -20,14 +23,14 @@
 
 
 .referrals-overview__step-section-woo-payments {
-	a,
-	a:visited {
-		color: var(--color-neutral-100);
+	a.button,
+	a.button:visited {
 		text-decoration: underline;
+		justify-content: flex-start;
 	}
 
-	.step-section-item__icon {
-		opacity: 1;
+	&.step-section-item .step-section-item__button {
+		margin-block-start: 0;
 	}
 }
 
@@ -43,4 +46,92 @@
 
 .referrals-overview__section-container .a4a-text-placeholder {
 	height: 80px;
+}
+
+.referrals-layout--automated {
+	.referrals-overview__section-container {
+		gap: 32px;
+	}
+
+	.referrals-overview__step-section-learn-more {
+		a.button {
+			padding-block: 4px;
+		}
+
+		.step-section__header {
+			margin-block-end: 0;
+		}
+	}
+
+	.referrals-overview__section-subtitle {
+		margin-block-end: 32px;
+	}
+
+	.a4a-layout__body-wrapper {
+		max-width: 550px;
+	}
+
+	.referrals-overview__step-section-woo-payments {
+		margin-block-end: 0;
+
+		a,
+		a:visited {
+			text-decoration: none;
+			justify-content: center;
+		}
+
+		&.step-section-item .step-section-item__button {
+			margin-block-start: 16px;
+
+			@include break-large {
+				margin-block: auto;
+			}
+		}
+	}
+
+
+	.referrals-overview__section-heading {
+		margin-block-start: 32px;
+	}
+
+	&.main.a4a-layout.is-with-border .a4a-layout__top-wrapper:not(.has-navigation) {
+		padding-block-start: 24px;
+		padding-block-end: 0;
+	}
+}
+
+.referrals-overview__opacity-70-percent {
+	opacity: 0.7;
+}
+
+.jetpack-logo {
+	fill: var(--color-jetpack);
+}
+
+.woocommerce-logo {
+	fill: var(--color-woocommerce);
+}
+
+.referrals-overview__section-icons {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+	margin-block-start: 56px;
+}
+
+.a4a-layout__header-actions {
+	a.button {
+		text-wrap: pretty;
+	}
+}
+
+.referrals-overview__link {
+	color: var(--color-accent-100);
+	text-decoration: underline;
+
+	&:hover,
+	&:visited,
+	&:focus {
+		color: var(--color-accent-100);
+	}
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -197,6 +197,11 @@
 	.button.is-borderless {
 		background: none;
 		color: var(--color-accent-80);
+
+		&.a8c-blue-link {
+			color: var(--color-primary-50);
+			text-decoration: underline;
+		}
 	}
 
 	.split-button .button {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/342

## Proposed Changes

This PR redesigns the empty A4A Referrals page.

[Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-122443&m=dev)

NOTE: 

- We have reused the existing component since we will get rid of the old UI very soon.
- `How does it work?` link doesn't work and will be fixed later
- The button `Add my details` will be the primary one, while the others will be secondary. Once the user fills in the data, the button becomes secondary, and the other buttons become primary.

## Testing Instructions

1. Open the A4A live link.
2. Append the /referrals URL as /referrals?flags=-a4a-automated-referrals, and verify that the above changes are not reflected and that the Referrals page matches the production.
3. Remove the feature flag > Go to  Referrals Dashboard & Verify the UI looks like below: 

<img width="1285" alt="Screenshot 2024-05-22 at 3 31 46 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6aaf9738-06e5-4fc6-ac02-a36b4ba60ff7">

<img width="373" alt="Screenshot 2024-05-22 at 5 15 49 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4a899d06-b98e-4afd-bfc4-fb3fd7ab47b4">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
