### PR TITLE
Entrepreneur Signup: Fix unable to continue to site creation step in Entrepreneur Flow after login.

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -1,13 +1,14 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import { ENTREPRENEUR_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useState } from 'react';
 import { anonIdCache } from 'calypso/data/segmentaton-survey';
+import { login } from 'calypso/lib/paths';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useFlowLocale } from '../hooks/use-flow-locale';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
-import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
@@ -49,25 +50,22 @@ const entrepreneurFlow: Flow = {
 		const [ isMigrationFlow, setIsMigrationFlow ] = useState( false );
 
 		const getEntrepreneurLoginUrl = () => {
-			let hasFlowParams = false;
-			const flowParams = new URLSearchParams();
+			const queryParams = new URLSearchParams();
 
-			if ( locale && locale !== 'en' ) {
-				flowParams.set( 'locale', locale );
-				hasFlowParams = true;
-			}
+			const redirectTo = addQueryArgs(
+				`${ window.location.protocol }//${ window.location.host }/setup/entrepreneur/create-site`,
+				{
+					...Object.fromEntries( queryParams ),
+				}
+			);
 
-			const redirectTarget =
-				`/setup/entrepreneur/create-site` + ( hasFlowParams ? '?' + flowParams.toString() : '' );
-
-			const loginUrl = getLoginUrl( {
-				variationName: flowName,
-				redirectTo: redirectTarget,
+			const loginUrl = login( {
 				locale,
+				redirectTo,
+				oauth2ClientId: queryParams.get( 'client_id' ) || undefined,
 			} );
 
-			const flags = new URLSearchParams( window.location.search ).get( 'flags' );
-			return loginUrl + ( flags ? `&flags=${ flags }` : '' );
+			return loginUrl;
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -58,8 +58,7 @@ const entrepreneurFlow: Flow = {
 			}
 
 			const redirectTarget =
-				`/setup/entrepreneur/create-site` +
-				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
+				`/setup/entrepreneur/create-site` + ( hasFlowParams ? '?' + flowParams.toString() : '' );
 
 			const loginUrl = getLoginUrl( {
 				variationName: flowName,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7357

⚠️ Note: This PR does not fix user **ending up in plans page** after **creating** an account. We'll address that separately.

## Proposed Changes

* Fix user ended up back at Segmentation Survey after logging in, when they should proceed with the site creation step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because the flow is broken.

## Testing Instructions

**Test login with password**
* Open up an incognito window.
* Go to `/setup/entrepreneur?ref=entrepreneur-signup`.
* After segmentation survey, login to an existing account with password.
* You should land at site creation step.

**Test login with email**
* Open up an incognito window.
* Go to `/setup/entrepreneur?ref=entrepreneur-signup`.
* After segmentation survey, login to an existing account using email.
* Go to your inbox, open the "Log in now" button.
* You should land at site creation step.

**Test login with social login (don't test now, can only test after merge)**
* Open up an incognito window.
* Go to `/setup/entrepreneur?ref=entrepreneur-signup`.
* After segmentation survey, login to an existing account using social login.
* You should land at site creation step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
