### PR TITLE
Site actions: Replace "Hosting" with "Dev Tools" if a plan upgrade is required

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -26,6 +26,7 @@ import { useSiteCopy } from 'calypso/landing/stepper/hooks/use-site-copy';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
@@ -342,6 +343,9 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 		offset: -8,
 	} );
 	const upsellPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
+	const currentRoute = useSelector( getCurrentRoute );
+	const hostingConfigUrl = getHostingConfigUrl( site.slug );
+	const shouldShowHostingConfigLink = currentRoute !== hostingConfigUrl;
 
 	if ( submenuItems.length === 0 ) {
 		return null;
@@ -389,18 +393,20 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 							),
 							upsellPlanName
 						) }
-						<Button
-							compact
-							primary
-							href={ getHostingConfigUrl( site.slug ) }
-							onClick={ () =>
-								recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_upsell_click', {
-									product_slug: site.plan?.product_slug,
-								} )
-							}
-						>
-							{ __( 'See full feature list' ) }
-						</Button>
+						{ shouldShowHostingConfigLink && (
+							<Button
+								compact
+								primary
+								href={ getHostingConfigUrl( site.slug ) }
+								onClick={ () =>
+									recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_upsell_click', {
+										product_slug: site.plan?.product_slug,
+									} )
+								}
+							>
+								{ __( 'See full feature list' ) }
+							</Button>
+						) }
 					</UpsellMenuGroup>
 				) : (
 					submenuItems.map( ( item ) => (

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -397,7 +397,7 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 							<Button
 								compact
 								primary
-								href={ getHostingConfigUrl( site.slug ) }
+								href={ hostingConfigUrl }
 								onClick={ () =>
 									recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_upsell_click', {
 										product_slug: site.plan?.product_slug,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7313

## Proposed Changes

Change the site actions (i.e. ellipsis menu) to replace the "Hosting" action with a "Dev Tools" action is the site does not have access to hosting features.

Scenario | Before | After
--- | --- | ---
Simple site | <img width="1277" alt="Screenshot 2024-05-22 at 14 39 33" src="https://github.com/Automattic/wp-calypso/assets/1233880/5af770bb-9d1e-44c1-a75c-7efb80d86e3c"> | <img width="1276" alt="Screenshot 2024-05-22 at 14 39 43" src="https://github.com/Automattic/wp-calypso/assets/1233880/5553db7f-a498-47a1-9442-d82957519517">
Atomic site with an expired plan | <img width="1270" alt="Screenshot 2024-05-22 at 14 41 50" src="https://github.com/Automattic/wp-calypso/assets/1233880/655fb63c-b5da-48b3-a403-1a625adc73af"> | <img width="1280" alt="Screenshot 2024-05-22 at 14 42 08" src="https://github.com/Automattic/wp-calypso/assets/1233880/6271bcb7-b84d-4986-97f0-8b476cb82602">






## Why are these changes being made?

Because it opens the `/hosting-config/:site` screen and it looks broken when you're on that page.

## Testing Instructions

- Use the Calypso live link below
- Go to `/sites`
- Click on the site actions (i.e. ellipsis menu) of a Simple site with a Free plan
- Make sure there isn't a "Hosting" action
- Make sure there is a "Dev Tools" action instead
- Make sure it redirects to the Dev Tools tab
- Repeat with an Atomic site with an expired plan
- Test now with a site with access to hosting features
- Make sure the "Hosting" action is there now with all the expected submenus
- Disable the Nav Redesign feature flag by adding the `flags=-layout/dotcom-nav-redesign-v2` to the URL.
- Make sure the current "Hosting" action with the current upsell is visible on Free sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
