### PR TITLE
Nav redesign: don't collapse global sidebar when navigating to My Home

### DIFF
--- a/client/layout/global-sidebar/menu-items/menu-item.tsx
+++ b/client/layout/global-sidebar/menu-items/menu-item.tsx
@@ -49,8 +49,7 @@ const SidebarMenuItem = forwardRef< HTMLButtonElement | HTMLAnchorElement, Props
 			return getShouldShowGlobalSiteSidebar(
 				state,
 				selectedSiteId,
-				currentSection !== false ? currentSection?.group ?? '' : '',
-				currentSection !== false ? currentSection?.name ?? '' : ''
+				currentSection !== false ? currentSection?.group ?? '' : ''
 			);
 		} );
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -490,23 +490,16 @@ export default withCurrentRoute(
 		const isWooCoreProfilerFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
 			isWooCommerceCoreProfilerFlow( state );
-		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-			state,
-			siteId,
-			sectionGroup,
-			sectionName
-		);
+		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 		const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 			state,
 			siteId,
-			sectionGroup,
-			sectionName
+			sectionGroup
 		);
 		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 			state,
 			siteId,
-			sectionGroup,
-			sectionName
+			sectionGroup
 		);
 		const noMasterbarForRoute =
 			isJetpackLogin ||

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -779,7 +779,6 @@ class MasterbarLoggedIn extends Component {
 export default connect(
 	( state ) => {
 		const sectionGroup = getSectionGroup( state );
-		const sectionName = getSectionName( state );
 
 		// Falls back to using the user's primary site if no site has been selected
 		// by the user yet
@@ -794,20 +793,17 @@ export default connect(
 		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
 			state,
 			currentSelectedSiteId,
-			sectionGroup,
-			sectionName
+			sectionGroup
 		);
 		const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
 			state,
 			currentSelectedSiteId,
-			sectionGroup,
-			sectionName
+			sectionGroup
 		);
 		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 			state,
 			currentSelectedSiteId,
-			sectionGroup,
-			sectionName
+			sectionGroup
 		);
 		const isDesktop = isWithinBreakpoint( '>782px' );
 		return {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -230,14 +230,8 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
-			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 			return {
 				currentUser: getCurrentUser( state ),
 				shouldShowGlobalSidebar,

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -109,26 +109,18 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
-			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
 			const siteDomain = getSiteDomain( state, siteId );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 				state,
 				siteId,
-				sectionGroup,
-				sectionName
+				sectionGroup
 			);
 			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 				state,
 				siteId,
-				sectionGroup,
-				sectionName
+				sectionGroup
 			);
 			return {
 				siteDomain,

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -234,8 +234,7 @@ export function scheduledUpdatesMultisite( context, next ) {
 	const isSidebarCollapsed = getShouldShowCollapsedGlobalSidebar(
 		state,
 		undefined,
-		context.section.group,
-		context.section.name
+		context.section.group
 	);
 
 	context.secondary = <PluginsSidebar path={ context.path } isCollapsed={ isSidebarCollapsed } />;

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -37,12 +37,7 @@ const useSiteMenuItems = () => {
 	const isAllDomainsView = '/domains/manage' === currentRoute;
 	const { currentSection } = useCurrentRoute();
 	const shouldShowGlobalSidebar = useSelector( ( state ) => {
-		return getShouldShowGlobalSidebar(
-			state,
-			selectedSiteId,
-			currentSection?.group,
-			currentSection?.name
-		);
+		return getShouldShowGlobalSidebar( state, selectedSiteId, currentSection?.group );
 	} );
 	useEffect( () => {
 		if ( selectedSiteId && siteDomain ) {

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -11,12 +11,7 @@ export function notifications( context, next ) {
 	const basePath = sectionify( context.path );
 	const mcKey = 'notifications';
 	const state = context.store.getState();
-	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-		state,
-		null,
-		'reader',
-		'notifications'
-	);
+	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, null, 'reader' );
 
 	trackPageLoad( basePath, 'Reader > Notifications', mcKey );
 	recordTrack(

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -334,14 +334,8 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
-			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
 			return {
 				isListsOpen: isListsOpen( state ),
 				isTagsOpen: isTagsOpen( state ),


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/dotcom-forge/issues/7311

## Proposed Changes

### Problem

Previously, clicking a site row from the sites dashboard table will always trigger the animation. However, there is a case where we don't want the animation to happen at all, which is when we click on My Home URL.

### Background

When we click on a site from the sites dashboard table, we update the current route ONLY AFTER the sidebar finishes the collapsing animation:

https://github.com/Automattic/wp-calypso/blob/77d5df2e1eddcebeb9e0f8cb55cb5008b3c68750/client/sites-dashboard-v2/hooks/use-sync-selected-site-feature.ts#L57-L58

This is done so that the route update does not disrupt the animation, because a route update somehow will remount some components which makes the sidebar / preview pane animation broken.

Therefore, we need to start the animation as soon as site is clicked. So, the current logic in the codebase is that, when we click on a site, the `getShouldShowCollapsedGlobalSidebar()` selector will always return true, which breaks the above My Home case.

This PR amends the logic to include the above My Home case.

### Implementation Note

Because of the above animation logic trickiness, we cannot rely on `sectionName` in the selector. We can only rely on the current URL as source of truth. Somehow, the current routing logic does not update `sectionName` as soon as the path changes, so the animation will break if we still rely on `sectionName`.

This PR also refactors the selector so that it's easier to follow. I'm specifically asking for @Addison-Stavlo's review on this since she has been working on untangling the logic of this selector 😄 

---


## Why are these changes being made?

We don't want the global sidebar to be in collapsing animation in certain conditions.

## Testing Instructions

1. Open `/sites`.
2. Search for a Simple site, and click on My Home link on the site row.
3. Verify that the global sidebar is not collapsing when the page is transitioning to My Home.
4. Test also the scenario in https://github.com/Automattic/wp-calypso/pull/90886.

### Regression tests

1. Open `/sites`.
2. Click on a site; verify that the global sidebar collapses.
3. Close the preview panel; verify that the global sidebar expands.
4. Visit Domains, Plugins, Reader; verify that the global sidebar is not collapsed.
5. Visit Plugins -> + Add New Schedule; verify that the sidebar collapses.
6. Visit nav-unified page (e.g. `/home/:site` of an Atomic Early Classic site), verify that the sidebar is correct (narrow nav-unified).
7. Visit non-nav-redesigned page (e.g. `/posts/:site` of a Simple site), verify that the sidebar is correct (wide nav-unified).
8. Basically try to break this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
