### PR TITLE
Segmentation Survey: Make segmentation survey locale aware.

### DIFF
--- a/client/data/segmentaton-survey/queries/use-survey-structure-query.ts
+++ b/client/data/segmentaton-survey/queries/use-survey-structure-query.ts
@@ -39,7 +39,7 @@ const mapSurveyStructureResponse = ( response: SurveyStructureResponse ): Questi
 const useSurveyStructureQuery = ( { surveyKey }: SurveyStructureQueryArgs ) => {
 	// This follows exact logic as addLocaleQueryParam() middleware
 	// which will add _locale to the query param and we want to cache
-	// our surveys with by the same locale value.
+	// our surveys with the same locale value.
 	const locale = i18n.getLocaleVariant() || i18n.getLocaleSlug();
 	const queryKey = [ 'survey-structure', surveyKey, ...( locale ? [ locale ] : [] ) ];
 

--- a/client/data/segmentaton-survey/queries/use-survey-structure-query.ts
+++ b/client/data/segmentaton-survey/queries/use-survey-structure-query.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import i18n from 'i18n-calypso';
 import { Question, QuestionType } from 'calypso/components/survey-container/types';
 import wpcom from 'calypso/lib/wp';
 
@@ -36,8 +37,14 @@ const mapSurveyStructureResponse = ( response: SurveyStructureResponse ): Questi
 	} );
 
 const useSurveyStructureQuery = ( { surveyKey }: SurveyStructureQueryArgs ) => {
+	// This follows exact logic as addLocaleQueryParam() middleware
+	// which will add _locale to the query param and we want to cache
+	// our surveys with by the same locale value.
+	const locale = i18n.getLocaleVariant() || i18n.getLocaleSlug();
+	const queryKey = [ 'survey-structure', surveyKey, ...( locale ? [ locale ] : [] ) ];
+
 	return useQuery( {
-		queryKey: [ 'survey-structure', surveyKey ],
+		queryKey,
 		queryFn: () => {
 			return wpcom.req.get( {
 				path: `/segmentation-survey/${ surveyKey }`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Make segmentation survey locale aware, so it pulls the right language out of local storage.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Segmentation survey is not locale aware.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Setup**
* Sandbox public-api.wordpress.com.
* Ensure your sandbox is the latest from trunk (as this patch is now merged D149479-code)
* Run `wpsh`.
* Run `wp_cache_flush_group('segmentation_survey');`

**Testing**
* Open up an incognito window.
* Go to `calypso.localhost:3000/setup/entrepreneur`, you should see English.
* Go to `calypso.localhost:3000/setup/entrepreneur/nl`, you should see Dutch.
* Go to `calypso.localhost:3000/setup/entrepreneur/fr`, you should see French.
* Go to `calypso.localhost:3000/setup/entrepreneur/de`, you should see German.

**Note:**
 - It is OK if you see a flash of English before the language changes to Dutch/French/German.
 - It is OK if you refresh the page, and suddenly it goes back to English, that is by design. That's because the locale is no longer in the URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?