### PR TITLE
refactor: create TS version of convertToCamelCase

### DIFF
--- a/client/my-sites/site-settings/publishing-tools/hooks/use-get-post-by-voice.tsx
+++ b/client/my-sites/site-settings/publishing-tools/hooks/use-get-post-by-voice.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import { convertSnakeCaseToCamelCase } from 'calypso/state/data-layer/convert-snake-case-to-camel-case';
 import type {
 	PostByVoice,
 	PostByVoiceResponse,
@@ -13,11 +14,6 @@ export const getCachePostByVoiceKey = ( siteId: number | null ) => [
 	'post-by-voice',
 ];
 
-export const parsePostByVoiceResponse = ( data: PostByVoiceResponse ): PostByVoice => ( {
-	isEnabled: data.is_enabled,
-	code: data.code,
-} );
-
 export const useGetPostByVoice = ( siteId: number | null ) => {
 	return useQuery< PostByVoice >( {
 		queryKey: getCachePostByVoiceKey( siteId ),
@@ -27,7 +23,7 @@ export const useGetPostByVoice = ( siteId: number | null ) => {
 				apiNamespace: 'wpcom/v2',
 			} );
 
-			return parsePostByVoiceResponse( response );
+			return convertSnakeCaseToCamelCase( response );
 		},
 		enabled: !! siteId,
 	} );

--- a/client/my-sites/site-settings/publishing-tools/hooks/use-toggle-post-by-voice-mutation.tsx
+++ b/client/my-sites/site-settings/publishing-tools/hooks/use-toggle-post-by-voice-mutation.tsx
@@ -3,8 +3,8 @@ import wpcom from 'calypso/lib/wp';
 import {
 	getCachePostByVoiceKey,
 	getPostByVoicePath,
-	parsePostByVoiceResponse,
 } from 'calypso/my-sites/site-settings/publishing-tools/hooks/use-get-post-by-voice';
+import { convertSnakeCaseToCamelCase } from 'calypso/state/data-layer/convert-snake-case-to-camel-case';
 import type {
 	PostByVoice,
 	PostByVoiceResponse,
@@ -22,7 +22,7 @@ export const useTogglePostByVoiceMutation = ( siteId: number | null ) => {
 				apiNamespace: 'wpcom/v2',
 			} );
 
-			return parsePostByVoiceResponse( response );
+			return convertSnakeCaseToCamelCase( response );
 		},
 		onMutate: async ( value: boolean ) => {
 			await queryClient.cancelQueries( {

--- a/client/state/data-layer/convert-snake-case-to-camel-case.ts
+++ b/client/state/data-layer/convert-snake-case-to-camel-case.ts
@@ -1,0 +1,37 @@
+type SnakeToCamel< S extends string > = S extends `${ infer T }_${ infer U }`
+	? `${ T }${ Capitalize< SnakeToCamel< U > > }`
+	: S;
+
+type ConvertToCamelCase< T > = T extends object
+	? T extends Array< infer U >
+		? Array< ConvertToCamelCase< U > >
+		: {
+				[ K in keyof T as SnakeToCamel< K & string > ]: ConvertToCamelCase< T[ K ] >;
+		  }
+	: T;
+
+export function convertSnakeCaseToCamelCase< T >( obj: T ): ConvertToCamelCase< T > {
+	if ( typeof obj !== 'object' || obj === null ) {
+		return obj as ConvertToCamelCase< T >;
+	}
+
+	if ( Array.isArray( obj ) ) {
+		return obj.map( ( item ) =>
+			convertSnakeCaseToCamelCase( item )
+		) as unknown as ConvertToCamelCase< T >;
+	}
+
+	const toCamelCase = ( str: string ) =>
+		str.replace( /_([a-z])/g, ( _, letter ) => letter.toUpperCase() );
+
+	const newObj: any = {};
+
+	for ( const key in obj ) {
+		if ( obj.hasOwnProperty( key ) ) {
+			const camelCaseKey = toCamelCase( key );
+			newObj[ camelCaseKey ] = convertSnakeCaseToCamelCase( obj[ key ] );
+		}
+	}
+
+	return newObj as ConvertToCamelCase< T >;
+}

--- a/client/state/data-layer/test/convert-snake-case-to-camel-case.ts
+++ b/client/state/data-layer/test/convert-snake-case-to-camel-case.ts
@@ -1,0 +1,64 @@
+import { convertSnakeCaseToCamelCase } from '../convert-snake-case-to-camel-case';
+
+describe( 'convertSnakeCaseToCamelCase', () => {
+	it( 'should convert snake_case to camelCase', () => {
+		const foo = convertSnakeCaseToCamelCase( {
+			is_disabled: true,
+			isEnabled: true,
+		} );
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.is_disabled ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.qqq ).toBeUndefined();
+
+		expect( foo.isDisabled ).toBe( true );
+		expect( foo.isEnabled ).toBe( true );
+	} );
+
+	it( 'should convert nested snake_case to camelCase', () => {
+		const foo = convertSnakeCaseToCamelCase( {
+			is_disabled: {
+				first_name: true,
+			},
+		} );
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.is_disabled ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.isDisabled.first_name ).toBeUndefined();
+
+		expect( foo.isDisabled ).toBeDefined();
+		expect( foo.isDisabled.firstName ).toBe( true );
+	} );
+
+	it( 'should convert array of nested snake_case to camelCase', () => {
+		const foo = convertSnakeCaseToCamelCase( {
+			is_disabled: [
+				{
+					first_name: {
+						second_name: true,
+					},
+				},
+			],
+		} );
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.is_disabled ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.isDisabled[ 0 ].first_name ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.isDisabled[ 0 ].first_name.second_name ).toBeUndefined();
+
+		expect( foo.isDisabled ).toBeDefined();
+		expect( foo.isDisabled[ 0 ].firstName ).toBeDefined();
+		expect( foo.isDisabled[ 0 ].firstName.secondName ).toBe( true );
+	} );
+} );

--- a/client/state/data-layer/test/convert-snake-case-to-camel-case.ts
+++ b/client/state/data-layer/test/convert-snake-case-to-camel-case.ts
@@ -55,7 +55,7 @@ describe( 'convertSnakeCaseToCamelCase', () => {
 		expect( foo.isDisabled[ 0 ].first_name ).toBeUndefined();
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-expect-error
-		expect( foo.isDisabled[ 0 ].first_name.second_name ).toBeUndefined();
+		expect( foo.isDisabled[ 0 ].firstName.second_name ).toBeUndefined();
 
 		expect( foo.isDisabled ).toBeDefined();
 		expect( foo.isDisabled[ 0 ].firstName ).toBeDefined();

--- a/client/state/data-layer/test/convert-snake-case-to-camel-case.ts
+++ b/client/state/data-layer/test/convert-snake-case-to-camel-case.ts
@@ -61,4 +61,77 @@ describe( 'convertSnakeCaseToCamelCase', () => {
 		expect( foo.isDisabled[ 0 ].firstName ).toBeDefined();
 		expect( foo.isDisabled[ 0 ].firstName.secondName ).toBe( true );
 	} );
+
+	it( 'should handle arrays of primitives', () => {
+		const foo = convertSnakeCaseToCamelCase( {
+			numbers_list: [ 1, 2, 3 ],
+		} );
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.numbers_list ).toBeUndefined();
+
+		expect( foo.numbersList ).toEqual( [ 1, 2, 3 ] );
+	} );
+
+	it( 'should handle deeply nested structures', () => {
+		const foo = convertSnakeCaseToCamelCase( {
+			level_one: {
+				level_two: {
+					level_three: {
+						some_value: 'test',
+					},
+				},
+			},
+		} );
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.level_one ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.levelOne.level_two ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.levelOne.levelTwo.level_three ).toBeUndefined();
+
+		expect( foo.levelOne ).toBeDefined();
+		expect( foo.levelOne.levelTwo ).toBeDefined();
+		expect( foo.levelOne.levelTwo.levelThree ).toBeDefined();
+		expect( foo.levelOne.levelTwo.levelThree.someValue ).toBe( 'test' );
+	} );
+
+	it( 'should handle objects with mixed types', () => {
+		const foo = convertSnakeCaseToCamelCase( {
+			string_value: 'hello',
+			number_value: 123,
+			boolean_value: true,
+			array_value: [ { nested_key: 'value' } ],
+			nested_object: {
+				another_key: 'another value',
+			},
+		} );
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.string_value ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.number_value ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.boolean_value ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.array_value ).toBeUndefined();
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		expect( foo.nested_object ).toBeUndefined();
+
+		expect( foo.stringValue ).toBe( 'hello' );
+		expect( foo.numberValue ).toBe( 123 );
+		expect( foo.booleanValue ).toBe( true );
+		expect( foo.arrayValue[ 0 ].nestedKey ).toBe( 'value' );
+		expect( foo.nestedObject.anotherKey ).toBe( 'another value' );
+	} );
 } );

--- a/client/state/data-layer/test/convert-snake-case-to-camel-case.ts
+++ b/client/state/data-layer/test/convert-snake-case-to-camel-case.ts
@@ -7,11 +7,9 @@ describe( 'convertSnakeCaseToCamelCase', () => {
 			isEnabled: true,
 		} );
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'is_disabled' does not exist on type '{ isDisabled: boolean; isEnabled: boolean; }'.
 		expect( foo.is_disabled ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'qqq' does not exist on type '{ isDisabled: boolean; isEnabled: boolean; }'.
 		expect( foo.qqq ).toBeUndefined();
 
 		expect( foo.isDisabled ).toBe( true );
@@ -25,11 +23,9 @@ describe( 'convertSnakeCaseToCamelCase', () => {
 			},
 		} );
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'is_disabled' does not exist on type '{ isDisabled: { firstName: boolean; }; }'.
 		expect( foo.is_disabled ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'isDisabled.first_name' does not exist on type '{ isDisabled: { firstName: boolean; }; }'.
 		expect( foo.isDisabled.first_name ).toBeUndefined();
 
 		expect( foo.isDisabled ).toBeDefined();
@@ -47,14 +43,11 @@ describe( 'convertSnakeCaseToCamelCase', () => {
 			],
 		} );
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'is_disabled' does not exist on type '{ isDisabled: { firstName: { secondName: boolean; }; }[]; }'.
 		expect( foo.is_disabled ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'isDisabled[0].first_name' does not exist on type '{ isDisabled: { firstName: { secondName: boolean; }; }[]; }'.
 		expect( foo.isDisabled[ 0 ].first_name ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'isDisabled[0].firstName.second_name' does not exist on type '{ isDisabled: { firstName: { secondName: boolean; }; }[]; }'.
 		expect( foo.isDisabled[ 0 ].firstName.second_name ).toBeUndefined();
 
 		expect( foo.isDisabled ).toBeDefined();
@@ -67,8 +60,7 @@ describe( 'convertSnakeCaseToCamelCase', () => {
 			numbers_list: [ 1, 2, 3 ],
 		} );
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'numbers_list' does not exist on type '{ numbersList: number[]; }'.
 		expect( foo.numbers_list ).toBeUndefined();
 
 		expect( foo.numbersList ).toEqual( [ 1, 2, 3 ] );
@@ -85,14 +77,11 @@ describe( 'convertSnakeCaseToCamelCase', () => {
 			},
 		} );
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'level_one' does not exist on type '{ levelOne: { levelTwo: { levelThree: { someValue: string; }; }; }'.
 		expect( foo.level_one ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'levelOne.level_two' does not exist on type '{ levelOne: { levelTwo: { levelThree: { someValue: string; }; }; }'.
 		expect( foo.levelOne.level_two ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'levelOne.levelTwo.level_three' does not exist on type '{ levelOne: { levelTwo: { levelThree: { someValue: string; }; }; }'.
 		expect( foo.levelOne.levelTwo.level_three ).toBeUndefined();
 
 		expect( foo.levelOne ).toBeDefined();
@@ -112,20 +101,15 @@ describe( 'convertSnakeCaseToCamelCase', () => {
 			},
 		} );
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'string_value' does not exist on type '{ stringValue: string; numberValue: number; booleanValue: boolean; arrayValue: { nestedKey: string; }[]; nestedObject: { anotherKey: string; }; }'.
 		expect( foo.string_value ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'number_value' does not exist on type '{ stringValue: string; numberValue: number; booleanValue: boolean; arrayValue: { nestedKey: string; }[]; nestedObject: { anotherKey: string; }; }'.
 		expect( foo.number_value ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'boolean_value' does not exist on type '{ stringValue: string; numberValue: number; booleanValue: boolean; arrayValue: { nestedKey: string; }[]; nestedObject: { anotherKey: string; }; }'.
 		expect( foo.boolean_value ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'array_value' does not exist on type '{ stringValue: string; numberValue: number; booleanValue: boolean; arrayValue: { nestedKey: string; }[]; nestedObject: { anotherKey: string; }; }'.
 		expect( foo.array_value ).toBeUndefined();
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
+		// @ts-expect-error Property 'nested_object' does not exist on type '{ stringValue: string; numberValue: number; booleanValue: boolean; arrayValue: { nestedKey: string; }[]; nestedObject: { anotherKey: string; }; }'.
 		expect( foo.nested_object ).toBeUndefined();
 
 		expect( foo.stringValue ).toBe( 'hello' );

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -38,7 +38,7 @@ export function convertKeysBy( obj, fn ) {
 }
 
 /**
- * !!! There is TS version of this function: `import { convertSnakeCaseToCamelCase } from 'calypso/state/data-layer/convert-snake-case-to-camel-case';`
+ * @deprecated Use TS version of this function: `import { convertSnakeCaseToCamelCase } from 'calypso/state/data-layer/convert-snake-case-to-camel-case';`
  *
  * Deeply converts keys from the specified object to camelCase notation.
  * @param {Object} obj object to convert

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -38,6 +38,8 @@ export function convertKeysBy( obj, fn ) {
 }
 
 /**
+ * !!! There is TS version of this function: `import { convertSnakeCaseToCamelCase } from 'calypso/state/data-layer/convert-snake-case-to-camel-case';`
+ *
  * Deeply converts keys from the specified object to camelCase notation.
  * @param {Object} obj object to convert
  * @returns {Object} a new object with all keys converted


### PR DESCRIPTION
## Proposed Changes
We have [convertToCamelCase](https://github.com/Automattic/wp-calypso/blob/e1f240e1fb5a4083592a787b3e6a4f4c9f553692/client/state/data-layer/utils.js#L45) function which is written with the help of `JS`. 

This PR adds TS version of this function.

## Why are these changes being made?
The main issue - we lose TS-types if we use this function inside `ts / tsx` modules.

## Testing Instructions (let's test existing case, where we integrated this function)
1) Create Simple website
2) Open settings -> Writing
3) Assert that you see "Post my Voice" and "Press this" in the "Publishign tools" section <br /><img width="741" alt="Screenshot 2024-05-15 at 12 46 53" src="https://github.com/Automattic/wp-calypso/assets/5598437/5bf3495b-96c2-4679-a240-92ac35d1c20d">

4) Turn on "Post by Voice"
5) Assert that the code is generated, success notice "Changes saved successfully!" appeared and you see the next UI <br /><img width="720" alt="Screenshot 2024-05-16 at 17 07 28" src="https://github.com/Automattic/wp-calypso/assets/5598437/843f7c6b-411c-412e-98dc-3ba314742f28">
6) Click on "Regenerate code" and assert that it's regenerrated and success notice "Code regenerated successfully!" appeared
7) Turn off "Post by voice" and assert that UI works and looks good <br /><img width="721" alt="Screenshot 2024-05-16 at 17 08 58" src="https://github.com/Automattic/wp-calypso/assets/5598437/37eac862-0b22-4723-ab7d-a76d5e6ab14d">