### PR TITLE
Plans (Storage): Always reflect selected storage option in the plan price

### DIFF
--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -106,11 +106,8 @@ const usePricingMetaForGridPlans = ( {
 							return addOn?.featureSlugs?.includes( selectedStorageOption );
 					  } )
 					: null;
-				const storageAddOnPrices = selectedStorageAddOn?.exceedsSiteStorageLimits
-					? null
-					: selectedStorageAddOn?.prices;
-				const storageAddOnPriceMonthly = storageAddOnPrices?.monthlyPrice || 0;
-				const storageAddOnPriceYearly = storageAddOnPrices?.yearlyPrice || 0;
+				const storageAddOnPriceMonthly = selectedStorageAddOn?.prices?.monthlyPrice || 0;
+				const storageAddOnPriceYearly = selectedStorageAddOn?.prices?.yearlyPrice || 0;
 
 				/**
 				 * 0. No plan or sitePlan (when selected site exists): planSlug is for a priceless plan.

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -98,20 +98,19 @@ const usePricingMetaForGridPlans = ( {
 	} else {
 		planPrices = Object.fromEntries(
 			planSlugs.map( ( planSlug ) => {
-				const availableForPurchase = planAvailabilityForPurchase[ planSlug ];
-				const selectedStorageOption = selectedStorageOptions?.[ planSlug ];
-				const selectedStorageAddOn = storageAddOns?.find( ( addOn ) => {
-					return selectedStorageOption && addOn?.featureSlugs?.includes( selectedStorageOption );
-				} );
-				const storageAddOnPrices =
-					selectedStorageAddOn?.purchased || selectedStorageAddOn?.exceedsSiteStorageLimits
-						? null
-						: selectedStorageAddOn?.prices;
-				const storageAddOnPriceMonthly = storageAddOnPrices?.monthlyPrice || 0;
-				const storageAddOnPriceYearly = storageAddOnPrices?.yearlyPrice || 0;
-
 				const plan = plans.data?.[ planSlug ];
 				const sitePlan = sitePlans.data?.[ planSlug ];
+				const selectedStorageOption = selectedStorageOptions?.[ planSlug ];
+				const selectedStorageAddOn = selectedStorageOption
+					? storageAddOns?.find( ( addOn ) => {
+							return addOn?.featureSlugs?.includes( selectedStorageOption );
+					  } )
+					: null;
+				const storageAddOnPrices = selectedStorageAddOn?.exceedsSiteStorageLimits
+					? null
+					: selectedStorageAddOn?.prices;
+				const storageAddOnPriceMonthly = storageAddOnPrices?.monthlyPrice || 0;
+				const storageAddOnPriceYearly = storageAddOnPrices?.yearlyPrice || 0;
 
 				/**
 				 * 0. No plan or sitePlan (when selected site exists): planSlug is for a priceless plan.
@@ -176,7 +175,7 @@ const usePricingMetaForGridPlans = ( {
 				/**
 				 * 2. Original and Discounted prices for plan available for purchase.
 				 */
-				if ( availableForPurchase ) {
+				if ( planAvailabilityForPurchase[ planSlug ] ) {
 					const originalPrice = {
 						monthly: getTotalPrice( plan.pricing.originalPrice.monthly, storageAddOnPriceMonthly ),
 						full: getTotalPrice( plan.pricing.originalPrice.full, storageAddOnPriceYearly ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/90905
Presumably fixes https://github.com/Automattic/wp-calypso/issues/90947 (although cannot stand on its own 🤷 )


## Proposed Changes

This PR makes the pricing on plans always reflect the selected storage option, irrespective of conditions that may allow a certain storage add-on to be purchasable. These are different concerns i.e. if something would "exceed storage limits" or is not "repurchasable", then these are things to be reflected in the UI that allows selections of that option.

In effect, the changes here make the pricing hook cleaner, more deterministic -> "if a storage add-on has been selected, then reflect its price in the plan price". It shouldn't be bothered with more context.

### Media 

Before/After...

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Storage options/dropdowns coupled with site context are a pretty broken mess right now. There is really no way to enable storage selection in the plans-grid without introducing ambiguity / stemming from existing storage purchased, site storage limits, and weak UI (we'll get to that later).

This PR is part of (hopefully) a series of PRs to make storage selection in the plans-grid cleaner and less ambiguous when in admin (or in a "site" context) - and to eventually enable selection over the current/spotlight plan (per https://github.com/Automattic/wp-calypso/issues/90905). We will likely not be shipping anything individually. If the whole in the end doesn't make sense, then we won't ship anything.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/add-ons` with a site on the Creator plan
* Purchase 50GB storage add-on
* In `/plans/[site]`:
    * Confirm the spotlight/current plan price reflects the additional cost of 50GB when "yearly" term selected
    * Go to `Entrepreneur` plan column and select the 100GB add-on upgrade. It should force the price of the plan to be updated.

See https://github.com/Automattic/wp-calypso/pull/91050 for testing instead as it brings more of the puzzle together

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
