### PR TITLE
Site Migration: Add support to reverted sites

### DIFF
--- a/client/landing/stepper/hooks/use-site-transfer/test/index.tsx
+++ b/client/landing/stepper/hooks/use-site-transfer/test/index.tsx
@@ -34,6 +34,11 @@ const TRANSFER_NOT_INITIATED = () => ( {
 	},
 } );
 
+const REVERTED_TRANSFER = () => ( {
+	atomic_transfer_id: '1254451',
+	status: 'reverted',
+} );
+
 const TRANSFER_PROVISIONED = ( siteId: number ) => ( {
 	atomic_transfer_id: '1254451',
 	blog_id: siteId,
@@ -89,6 +94,36 @@ describe( 'useSiteTransfer', () => {
 			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
 			.once()
 			.reply( 404, TRANSFER_NOT_INITIATED() )
+			.post( `/wpcom/v2/sites/${ siteId }/atomic/transfers`, {
+				context: 'unknown',
+				transfer_intent: 'migrate',
+			} )
+			.reply( 200, TRANSFER_ACTIVE( siteId ) )
+			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
+			.once()
+			.reply( 200, TRANSFER_COMPLETED( siteId ) );
+
+		const { result } = render( { siteId } );
+
+		await waitFor(
+			() => {
+				expect( result.current ).toEqual( {
+					completed: true,
+					status: 'success',
+					error: null,
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'completes the migration with success when the site was reverted', async () => {
+		const siteId = 4444;
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
+			.once()
+			.reply( 200, REVERTED_TRANSFER() )
 			.post( `/wpcom/v2/sites/${ siteId }/atomic/transfers`, {
 				context: 'unknown',
 				transfer_intent: 'migrate',

--- a/client/landing/stepper/hooks/use-site-transfer/test/index.tsx
+++ b/client/landing/stepper/hooks/use-site-transfer/test/index.tsx
@@ -117,7 +117,7 @@ describe( 'useSiteTransfer', () => {
 		);
 	} );
 
-	it( 'completes the migration with success when the site was reverted', async () => {
+	it( 'completes the site preparation when the site transfer status is "reverted"', async () => {
 		const siteId = 4444;
 
 		nock( 'https://public-api.wordpress.com:443' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
