### PR TITLE
Site Migration: Add a migration card on the domains step

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -101,6 +101,12 @@ class ReskinSideExplainer extends Component {
 				ctaText = translate( 'Use a domain I own' );
 				break;
 
+			case 'site-migration':
+				title = translate( 'Migrating an existing site?' );
+				subtitle = translate( 'We will get your site working on our infrastructure in no time!' );
+				ctaText = translate( 'Migrate my site' );
+				break;
+
 			case 'free-domain-only-explainer':
 				title = translate(
 					'Get a {{b}}free{{/b}} one-year domain registration with any paid annual plan.',

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -35,6 +35,7 @@ export const SIGNUP_DOMAIN_ORIGIN = {
 	FREE: 'free',
 	CUSTOM: 'custom',
 	NOT_SET: 'not-set',
+	SITE_MIGRATION: 'site-migration',
 };
 
 export function recordSignupComplete(

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -197,6 +197,16 @@ export function generateFlows( {
 			onEnterFlow: onEnterOnboarding,
 		},
 		{
+			name: 'site-migration',
+			steps: [ 'domains' ],
+			destination: getSignupDestination,
+			description: 'Take users to the site migration flow from the domains step.',
+			lastModified: '2024-05-09',
+			showRecaptcha: true,
+			hideProgressIndicator: true,
+			onEnterFlow: onEnterOnboarding,
+		},
+		{
 			name: 'onboarding-2023-pricing-grid',
 			steps: isEnabled( 'signup/professional-email-step' )
 				? [ userSocialStep, 'domains', 'emails', 'plans' ]

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -689,6 +689,9 @@ class Signup extends Component {
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToStep = ( stepName, stepSectionName, flowName = this.props.flowName ) => {
+		if ( flowName === 'site-migration' && ! stepName ) {
+			page( '/setup/migration-signup' );
+		}
 		// The `stepName` might be undefined after the user finish the last step but the value of
 		// `isEveryStepSubmitted` is still false. Thus, check the `stepName` here to avoid going
 		// to invalid step.

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -342,6 +342,10 @@ body.is-section-signup.is-white-signup {
 			@include break-medium {
 				width: 290px;
 				margin: 0 20px;
+
+				&.domains__domain-site-migration {
+					margin-right: 0;
+				}
 			}
 
 			@include break-large {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #87390

**NOTE: This was first reviewed and approved in #90517 but I ran into test failures (which seemed unrelated to the change). Attempting again here.**

## Proposed Changes

This adds a new card to the Domains step giving users the option to migrate. Clicking "Migrate my site" takes the user to the `/setup/migration-signup` flow.

The new card is being set up as an ExPlat experiment which hasn't been published yet.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you _are not_ sandboxed!
* Use either the calypso.live url or check out the branch and run it locally.
* Go to `/start`.
* Verify that you _don't_ see the new migration card on the Domains step.

Now manually assign your user to the "Treatment" group of the experiment. Full instructions are in PCYsg-SwK-p2 but the basic process is:

1. Create a bookmarklet named `treatment - calypso_signup_domains_show_migrate_cta_2024` with the code from 3485d-pb
2. Visit the experiment page 21794-explat-experiment.
3. Click on the bookmarklet you created and enter your wpcom username.

* Now revisit `/start`.
* You should see a new "Migrating an existing site?" card on the domains step..
<img width="341" alt="CleanShot 2024-05-09 at 11 51 18@2x" src="https://github.com/Automattic/wp-calypso/assets/917632/8bbb5d87-8aec-4aec-afa1-9c84011ef0d4">

* Click "Migrate my site".
* You should be taken into the `/setup/migration-signup` flow which eventually end on the Migration Instructions step.
* Now go back to `/start`.
* Verify that you can search for and select a domain.
* Verify that the "Use my own" domain button still takes you to the correct step.
* Verify that "Check paid plans" works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?