### PR TITLE
Site Migration: Replace migrate/:siteSlug flow with the new site-migration flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -96,8 +96,12 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 	);
 
 	const urlQueryParams = useQuery();
+
 	const shouldHideBack = () => {
-		const isEntrepreneurSignup = urlQueryParams.get( 'ref' ) === 'entrepreneur-signup';
+		const isEntrepreneurSignup = [ 'entrepreneur-signup', 'wp-admin-importer' ].includes(
+			urlQueryParams.get( 'ref' ) || ''
+		);
+
 		return variantSlug === HOSTED_SITE_MIGRATION_FLOW || isEntrepreneurSignup;
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -98,7 +98,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 	const urlQueryParams = useQuery();
 
 	const shouldHideBack = () => {
-		const isEntrepreneurSignup = [ 'entrepreneur-signup', 'wp-admin-importer' ].includes(
+		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'wp-admin-importer' ].includes(
 			urlQueryParams.get( 'ref' ) || ''
 		);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -99,7 +99,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 
 	const shouldHideBackButton = () => {
 		const ref = urlQueryParams.get( 'ref' ) || '';
-		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'wp-admin-importer' ].includes( ref );
+		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'calypso-importer' ].includes( ref );
 		const shouldHideBasedOnVariant = [ HOSTED_SITE_MIGRATION_FLOW ].includes( variantSlug || '' );
 
 		return shouldHideBasedOnRef || shouldHideBasedOnVariant;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -97,12 +97,12 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 
 	const urlQueryParams = useQuery();
 
-	const shouldHideBack = () => {
-		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'wp-admin-importer' ].includes(
-			urlQueryParams.get( 'ref' ) || ''
-		);
+	const shouldHideBackButton = () => {
+		const ref = urlQueryParams.get( 'ref' ) || '';
+		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'wp-admin-importer' ].includes( ref );
+		const shouldHideBasedOnVariant = [ HOSTED_SITE_MIGRATION_FLOW ].includes( variantSlug || '' );
 
-		return variantSlug === HOSTED_SITE_MIGRATION_FLOW || isEntrepreneurSignup;
+		return shouldHideBasedOnRef || shouldHideBasedOnVariant;
 	};
 
 	return (
@@ -112,7 +112,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 				stepName="site-migration-identify"
 				flowName="site-migration"
 				className="import__onboarding-page"
-				hideBack={ shouldHideBack() }
+				hideBack={ shouldHideBackButton() }
 				hideSkip
 				hideFormattedHeader
 				goBack={ navigation.goBack }

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -80,7 +80,8 @@ function getConfig( {
 				},
 			}
 		),
-		overrideDestination: '/migrate/%SITE_SLUG%',
+		overrideDestination:
+			'/setup/site-migration?siteSlug=%SITE_SLUG%&siteId=%SITE_ID%&ref=wp-admin-importer',
 		weight: 1,
 	};
 

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -81,7 +81,7 @@ function getConfig( {
 			}
 		),
 		overrideDestination:
-			'/setup/site-migration?siteSlug=%SITE_SLUG%&siteId=%SITE_ID%&ref=wp-admin-importer',
+			'/setup/site-migration?siteSlug=%SITE_SLUG%&siteId=%SITE_ID%&ref=calypso-importer',
 		weight: 1,
 	};
 

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -93,7 +93,9 @@ class FileImporter extends PureComponent {
 			 *
 			 * This is used for the new Migration logic for the moment.
 			 */
-			cardProps.href = overrideDestination.replace( '%SITE_SLUG%', site.slug );
+			cardProps.href = overrideDestination
+				.replace( '%SITE_SLUG%', site.slug )
+				.replace( '%SITE_ID%', site.ID );
 			cardProps.onClick = this.handleClick.bind( this, false );
 		}
 

--- a/packages/calypso-e2e/src/lib/pages/site-import-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-import-page.ts
@@ -21,7 +21,7 @@ const selectors = {
  * Class representing the Site Import page.
  */
 export class SiteImportPage {
-	static services = [ 'WordPress', 'Blogger', 'Medium', 'Squarespace', 'Wix' ] as const;
+	static services = [ 'Blogger', 'Medium', 'Squarespace', 'Wix' ] as const;
 	private page: Page;
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/site-import-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-import-page.ts
@@ -21,7 +21,7 @@ const selectors = {
  * Class representing the Site Import page.
  */
 export class SiteImportPage {
-	static services = [ 'Blogger', 'Medium', 'Squarespace', 'Wix' ] as const;
+	static services = [ 'WordPress', 'Blogger', 'Medium', 'Squarespace', 'Wix' ] as const;
 	private page: Page;
 
 	/**

--- a/test/e2e/specs/tools/import__site.ts
+++ b/test/e2e/specs/tools/import__site.ts
@@ -24,6 +24,9 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 	} );
 
 	it.each( SiteImportPage.services )( 'Select service provider: %s', async function ( service ) {
+		if ( service === 'WordPress' ) {
+			return;
+		}
 		siteImportPage = new SiteImportPage( page );
 		await siteImportPage.selectService( service );
 		await siteImportPage.verifyImporter( service );

--- a/test/e2e/specs/tools/import__site.ts
+++ b/test/e2e/specs/tools/import__site.ts
@@ -29,4 +29,13 @@ describe( DataHelper.createSuiteTitle( 'Site Import' ), function () {
 		await siteImportPage.verifyImporter( service );
 		await siteImportPage.cancel();
 	} );
+
+	// Extracted from the generic "Select service provider: %s" and skipped due to a new migration flow changes.
+	// More context on Automattic/wp-calypso/pull/90994
+	it.skip( 'Select service provider: WordPress', async function () {
+		siteImportPage = new SiteImportPage( page );
+		await siteImportPage.selectService( 'WordPress' );
+		await siteImportPage.verifyImporter( 'WordPress' );
+		await siteImportPage.cancel();
+	} );
 } );


### PR DESCRIPTION



## Proposed Changes
This PR aims to explore the idea of replacing at lest temporarily the migration process started by wp-admin > Tools > Import > Wordpress task.

## Why are these changes being made?
We have as a goal to enable more users to use the new migration flow and the migrate/:siteSlug is a important entry point of users. 


## Testing Instructions
* Create a simple site
* Access the wp-admin (home/:YOUR_SITE_SLUG)
* Go to Tools > Import > WordPress
* Check if you are redirected to the `/setup/site-migration/*`
* Follow the migration steps and check if your site was migrated. 

**Starting Point**
<img width="1194" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/820fefcd-4326-4d4c-b701-e673b0d182eb">





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
