### PR TITLE
add check for self hosted jetpackfor redirect url

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -23,6 +23,7 @@ import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl, login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
+import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils.js';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getImmediateLoginEmail,
@@ -216,9 +217,13 @@ export function redirectIfCurrentUserCannot( capability ) {
 		const currentUserCan = canCurrentUser( state, site?.ID, capability );
 		const adminInterface = getSiteOption( state, site?.ID, 'wpcom_admin_interface' );
 		const siteAdminUrl = getSiteAdminUrl( state, site?.ID );
+		const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
+
+		const redirectUrl =
+			adminInterface === 'wp-admin' || isJetpackNotAtomic ? siteAdminUrl : `/home/${ site.slug }`;
 
 		if ( site && ! currentUserCan ) {
-			return navigate( adminInterface === 'wp-admin' ? siteAdminUrl : `/home/${ site.slug }` );
+			return navigate( redirectUrl );
 		}
 
 		next();

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -23,7 +23,6 @@ import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl, login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
-import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils.js';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getImmediateLoginEmail,
@@ -217,7 +216,7 @@ export function redirectIfCurrentUserCannot( capability ) {
 		const currentUserCan = canCurrentUser( state, site?.ID, capability );
 		const adminInterface = getSiteOption( state, site?.ID, 'wpcom_admin_interface' );
 		const siteAdminUrl = getSiteAdminUrl( state, site?.ID );
-		const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
+		const isJetpackNotAtomic = site?.jetpack && ! site?.is_wpcom_atomic;
 
 		const redirectUrl =
 			adminInterface === 'wp-admin' || isJetpackNotAtomic ? siteAdminUrl : `/home/${ site.slug }`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/90886 

## Proposed Changes

* Adds a check for self hosted jetpack sites to the redirectIfCurrentUserCannot middleware. Allowing them to go to wp-admin without requiring the wpcom based site option.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The PR referenced above updated the redirect to go to wp-admin when the site is under that interface setting. Generally we count self hosted jetpack sites as having that setting, but they do not have the site option. Therefore we check if the site is self hosted jetpack to determine if it should go to wp-admin or my home.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select a self hosted site you are not an admin of (like an editor)
* Verify this redirects to wp-admin instead of my home.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
