### PR TITLE
Dashboard v2 - Bypass overview pane for P2 sites.

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -82,6 +82,7 @@ export const redirectLoggedOut = () => {};
 export const redirectLoggedOutToSignup = () => {};
 export const redirectWithoutLocaleParamIfLoggedIn = () => {};
 export const redirectIfCurrentUserCannot = () => {};
+export const redirectIfP2 = () => {};
 // eslint-disable-next-line no-unused-vars
 export const render = ( context ) => {};
 export const ProviderWrappedLayout = () => null;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -23,7 +23,6 @@ import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl, login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
-import { isP2Site } from 'calypso/sites-dashboard/utils.js';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getImmediateLoginEmail,
@@ -235,7 +234,7 @@ export function redirectIfCurrentUserCannot( capability ) {
 export function redirectIfP2( context, next ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
-	const isP2 = isP2Site( site );
+	const isP2 = site?.options?.is_wpforteams_site;
 	const adminInterface = getSiteOption( state, site?.ID, 'wpcom_admin_interface' );
 	const siteAdminUrl = getSiteAdminUrl( state, site?.ID );
 

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -23,6 +23,7 @@ import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl, login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
+import { isP2Site } from 'calypso/sites-dashboard/utils.js';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getImmediateLoginEmail,
@@ -223,6 +224,26 @@ export function redirectIfCurrentUserCannot( capability ) {
 
 		next();
 	};
+}
+
+/**
+ * Middleware to redirect a user if the site is a P2.
+ * @param   {Object}   context Context object
+ * @param   {Function} next    Calls next middleware
+ * @returns {void}
+ */
+export function redirectIfP2( context, next ) {
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
+	const isP2 = isP2Site( site );
+	const adminInterface = getSiteOption( state, site?.ID, 'wpcom_admin_interface' );
+	const siteAdminUrl = getSiteAdminUrl( state, site?.ID );
+
+	if ( isP2 ) {
+		return navigate( adminInterface === 'wp-admin' ? siteAdminUrl : `/home/${ site.slug }` );
+	}
+
+	next();
 }
 
 /**

--- a/client/dev-tools-promo/index.tsx
+++ b/client/dev-tools-promo/index.tsx
@@ -1,5 +1,5 @@
 import page, { Context as PageJSContext } from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender, redirectIfP2 } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { siteDashboard } from 'calypso/sites-dashboard-v2/controller';
 import { DOTCOM_DEVELOPER_TOOLS_PROMO } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
@@ -22,6 +22,7 @@ export default function () {
 		siteSelection,
 		navigation,
 		redirectForNonSimpleSite,
+		redirectIfP2,
 		devToolsPromo,
 		siteDashboard( DOTCOM_DEVELOPER_TOOLS_PROMO ),
 		makeLayout,

--- a/client/hosting-overview/index.tsx
+++ b/client/hosting-overview/index.tsx
@@ -3,6 +3,7 @@ import {
 	makeLayout,
 	render as clientRender,
 	redirectIfCurrentUserCannot,
+	redirectIfP2,
 } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { handleHostingPanelRedirect } from 'calypso/my-sites/hosting/controller';
@@ -21,6 +22,7 @@ export default function () {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
+		redirectIfP2,
 		navigation,
 		hostingOverview,
 		siteDashboard( DOTCOM_OVERVIEW ),

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -80,7 +80,7 @@ const Home = ( {
 	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
 		getIsGlobalSiteViewEnabled( state, siteId )
 	);
-	const isP2 = site.options?.is_wpforteams_site;
+	const isP2 = site?.options?.is_wpforteams_site;
 
 	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -29,7 +29,6 @@ import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
 import WooCommerceHomePlaceholder from 'calypso/my-sites/customer-home/wc-home-placeholder';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
-import { isP2Site } from 'calypso/sites-dashboard/utils';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { verifyIcannEmail } from 'calypso/state/domains/management/actions';
 import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem';
@@ -81,7 +80,7 @@ const Home = ( {
 	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
 		getIsGlobalSiteViewEnabled( state, siteId )
 	);
-	const isP2 = isP2Site( site );
+	const isP2 = site.options?.is_wpforteams_site;
 
 	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -29,6 +29,7 @@ import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
 import WooCommerceHomePlaceholder from 'calypso/my-sites/customer-home/wc-home-placeholder';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
+import { isP2Site } from 'calypso/sites-dashboard/utils';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { verifyIcannEmail } from 'calypso/state/domains/management/actions';
 import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem';
@@ -80,6 +81,7 @@ const Home = ( {
 	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
 		getIsGlobalSiteViewEnabled( state, siteId )
 	);
+	const isP2 = isP2Site( site );
 
 	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
 
@@ -154,7 +156,7 @@ const Home = ( {
 			<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
 				{ isGlobalSiteViewEnabled ? translate( 'View site' ) : translate( 'Visit site' ) }
 			</Button>
-			{ config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && isAdmin && (
+			{ config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && isAdmin && ! isP2 && (
 				<Button primary href={ `/overview/${ site.slug }` }>
 					{ translate( 'Hosting Overview' ) }
 				</Button>

--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -75,7 +75,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const isAdmin = useSelector( ( state ) => canCurrentUser( state, site.ID, 'manage_options' ) );
 
 	const onSiteClick = ( event: React.MouseEvent ) => {
-		if ( isAdmin ) {
+		if ( isAdmin && ! isP2Site ) {
 			openSitePreviewPane && openSitePreviewPane( site );
 		} else {
 			navigate( adminUrl );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7278 and https://github.com/Automattic/wp-calypso/pull/90959#issuecomment-2124336949 

## Proposed Changes

Bypasses the dashboard Overview and DevTools-promo section for P2 sites.
*  Updates the onClick behavior of p2 sites in the global sites list to redirect to their admin page (my home) instead of opening the overview pane.
* Adds redirects to the overview and devTools URLs to redirect to the sites admin page as well. 
* Hides the Overview button in My Home for P2 sites.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There are a handful of issues with the global management panes for P2s. The DevTools promo tab doesn't make sense for them, and a handful of items on the Overview pane don't make sense or are irrelevant. For now we will bypass P2s in the overview pane.
* Linked issue and PR above for more context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso.
* Go to the /sites page
* Click on a p2. Verify it redirects to myHome instead of opening the pane. 
     * Note - you may notice the sidebar animation collapsing, this is being handled in a separately PR https://github.com/Automattic/dotcom-forge#7311
* Try to visit *`/overview/$siteurl` and `*/dev-tools-promo/$siteUrl` for a P2, verify they redirect to my home.
* On My home, verify the "Hosting Overview" button is not present for P2s.
<img width="1113" alt="Screenshot 2024-05-22 at 9 59 52 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/0f1a80d8-fd96-4f20-845d-713135d14e0d">
<img width="1107" alt="Screenshot 2024-05-22 at 9 59 59 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/eb6514e3-cbef-4012-a9ea-2fd0d4bc22bb">

* Test non p2 simple and atomic, verify things continue to work as they did before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
