### PR TITLE
Command palette: Make wider

### DIFF
--- a/packages/command-palette/src/style.scss
+++ b/packages/command-palette/src/style.scss
@@ -1,3 +1,8 @@
 .commands-command-menu__overlay {
 	z-index: z-index("root", ".commands-commands-menu__overlay");
 }
+
+div.commands-command-menu {
+	width: min(100% - 32px, 640px);
+	max-width: 640px;
+}


### PR DESCRIPTION
Making the command palette wider than it is taller feels more natural for this kind of tool.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90931

## Proposed Changes

Make the command palette wider - up to 640px depending upon the screen width.. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Having it wider than it is taller feels more natural.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Calypso
1. Use calypso live link
2. Go to calypso page and invoke the command palette with ⌘k
3. Look at the command palette using a variety of screen widths

### wp-admin 
5. Use the automatically generated command below on your sandbox
6. Sandbox widgets.wp.com
7. Go to yoursite .wordpress.com/wp-admin and repeat as before

Edit: Weirdly the wp-admin install-plugin command hasn't been generated, it should be `install-plugin.sh command-palette-wp-admin update/command-palette-width`

Before | After
-------|------
<img width="1459" alt="Screenshot 2024-05-22 at 15 08 46" src="https://github.com/Automattic/wp-calypso/assets/93301/4b30606d-7ce7-4a5f-9958-4feb1dbfe099"> | <img width="1459" alt="Screenshot 2024-05-22 at 15 09 07" src="https://github.com/Automattic/wp-calypso/assets/93301/4fad0e1e-a35d-4a5f-b339-62679d1f68fc">



https://github.com/Automattic/wp-calypso/assets/93301/e08c1307-7d20-4883-92c6-ab304b4a23ef




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
