### PR TITLE
A4A: Settings page - Allow more tabs and load the tab content + tab validation

### DIFF
--- a/client/a8c-for-agencies/components/layout/nav.tsx
+++ b/client/a8c-for-agencies/components/layout/nav.tsx
@@ -12,7 +12,8 @@ type LayoutNavigationProps = {
 	selectedCount?: number;
 };
 
-type LayoutNavigationItemProps = {
+export type LayoutNavigationItemProps = {
+	key?: string;
 	label: string;
 	compactCount?: boolean;
 	onClick?: () => void;
@@ -26,6 +27,24 @@ type LayoutNavigationTabsProps = {
 	selectedCount?: number;
 	items: LayoutNavigationItemProps[];
 };
+
+export const buildNavItems = ( {
+	items,
+	selectedKey,
+	onItemClick,
+	basePath,
+}: {
+	items: LayoutNavigationItemProps[];
+	selectedKey: string;
+	onItemClick?: () => void;
+	basePath?: string;
+} ): LayoutNavigationItemProps[] =>
+	items.map( ( navItem ) => ( {
+		...navItem,
+		selected: selectedKey === navItem.key,
+		path: `${ basePath }/${ navItem.key }`,
+		onClick: onItemClick,
+	} ) );
 
 export function LayoutNavigationTabs( {
 	selectedText,

--- a/client/a8c-for-agencies/sections/settings/constants.ts
+++ b/client/a8c-for-agencies/sections/settings/constants.ts
@@ -1,0 +1,1 @@
+export const SETTINGS_AGENCY_PROFILE_TAB = 'agency-profile';

--- a/client/a8c-for-agencies/sections/settings/controller.tsx
+++ b/client/a8c-for-agencies/sections/settings/controller.tsx
@@ -17,7 +17,7 @@ export const settingsContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Settings" path={ context.path } />
-			<Settings tab={ context.params.tab } />
+			<Settings selectedTab={ context.params.tab } />
 		</>
 	);
 

--- a/client/a8c-for-agencies/sections/settings/controller.tsx
+++ b/client/a8c-for-agencies/sections/settings/controller.tsx
@@ -1,9 +1,18 @@
 import { type Callback } from '@automattic/calypso-router';
+import page from '@automattic/calypso-router';
+import { A4A_SETTINGS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MainSidebar from '../../components/sidebar-menu/main';
+import { SETTINGS_AGENCY_PROFILE_TAB } from './constants';
 import Settings from './settings';
 
 export const settingsContext: Callback = ( context, next ) => {
+	const validTabs = [ SETTINGS_AGENCY_PROFILE_TAB ];
+	if ( ! validTabs.includes( context.params.tab ) ) {
+		page.redirect( A4A_SETTINGS_LINK );
+		return;
+	}
+
 	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = (
 		<>

--- a/client/a8c-for-agencies/sections/settings/controller.tsx
+++ b/client/a8c-for-agencies/sections/settings/controller.tsx
@@ -8,7 +8,7 @@ export const settingsContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Settings" path={ context.path } />
-			<Settings />
+			<Settings tab={ context.params.tab } />
 		</>
 	);
 

--- a/client/a8c-for-agencies/sections/settings/index.tsx
+++ b/client/a8c-for-agencies/sections/settings/index.tsx
@@ -2,16 +2,17 @@ import page from '@automattic/calypso-router';
 import { A4A_SETTINGS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { SETTINGS_AGENCY_PROFILE_TAB } from './constants';
 import { settingsContext } from './controller';
 
 export default function () {
 	// todo: we have only one tab, this redirect /settings to /settings/agency-profile
 	page( A4A_SETTINGS_LINK, () => {
-		page.redirect( `${ A4A_SETTINGS_LINK }/agency-profile` );
+		page.redirect( `${ A4A_SETTINGS_LINK }/${ SETTINGS_AGENCY_PROFILE_TAB }` );
 	} );
 
 	page(
-		`${ A4A_SETTINGS_LINK }/agency-profile`,
+		`${ A4A_SETTINGS_LINK }/:tab`,
 		requireAccessContext,
 		settingsContext,
 		makeLayout,

--- a/client/a8c-for-agencies/sections/settings/settings.tsx
+++ b/client/a8c-for-agencies/sections/settings/settings.tsx
@@ -14,7 +14,11 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AgencyProfile from './agency-profile';
 
-export default function Settings() {
+type Props = {
+	tab: string;
+};
+
+export default function Settings( { tab }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const title = translate( 'Settings' );

--- a/client/a8c-for-agencies/sections/settings/settings.tsx
+++ b/client/a8c-for-agencies/sections/settings/settings.tsx
@@ -5,6 +5,8 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutNavigation, {
+	buildNavItems,
+	LayoutNavigationItemProps,
 	LayoutNavigationTabs,
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
@@ -13,6 +15,7 @@ import { A4A_SETTINGS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-m
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AgencyProfile from './agency-profile';
+import { SETTINGS_AGENCY_PROFILE_TAB } from './constants';
 
 type Props = {
 	tab: string;
@@ -23,24 +26,39 @@ export default function Settings( { tab }: Props ) {
 	const dispatch = useDispatch();
 	const title = translate( 'Settings' );
 
-	const navItems = [
-		{
-			key: 'agency_profile',
+	// Define here all the Settings tabs
+	const settingsTabs: { [ key: string ]: LayoutNavigationItemProps } = {
+		[ SETTINGS_AGENCY_PROFILE_TAB ]: {
+			key: SETTINGS_AGENCY_PROFILE_TAB,
 			label: translate( 'Agency Profile' ),
 		},
-	].map( ( navItem ) => ( {
-		...navItem,
-		selected: true,
-		path: `${ A4A_SETTINGS_LINK }/agency-profile`,
-		onClick: () => {
-			dispatch( recordTracksEvent( 'calypso_a4a_settings_agency_profile_click' ) );
-		},
-	} ) );
-
-	const selectedItem = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
-	const selectedItemProps = {
-		selectedText: selectedItem.label,
 	};
+
+	// Build all the navigation items
+	const navItems = buildNavItems( {
+		items: Object.values( settingsTabs ),
+		selectedKey: tab,
+		basePath: A4A_SETTINGS_LINK,
+		onItemClick: () => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_settings_click', {
+					status: tab,
+				} )
+			);
+		},
+	} );
+
+	const selectedItemProps = {
+		selectedText: settingsTabs[ tab ].label,
+	};
+
+	// Content tab switch
+	let tabContent = null;
+	switch ( tab ) {
+		case SETTINGS_AGENCY_PROFILE_TAB:
+			tabContent = <AgencyProfile />;
+			break;
+	}
 
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -52,10 +70,7 @@ export default function Settings( { tab }: Props ) {
 					<LayoutNavigationTabs { ...selectedItemProps } items={ navItems } />
 				</LayoutNavigation>
 			</LayoutTop>
-			<LayoutBody>
-				<h1>This is the Settings section with tabs (WIP)</h1>
-				<AgencyProfile />
-			</LayoutBody>
+			<LayoutBody>{ tabContent }</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/settings/settings.tsx
+++ b/client/a8c-for-agencies/sections/settings/settings.tsx
@@ -18,10 +18,10 @@ import AgencyProfile from './agency-profile';
 import { SETTINGS_AGENCY_PROFILE_TAB } from './constants';
 
 type Props = {
-	tab: string;
+	selectedTab: string;
 };
 
-export default function Settings( { tab }: Props ) {
+export default function Settings( { selectedTab }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const title = translate( 'Settings' );
@@ -37,24 +37,24 @@ export default function Settings( { tab }: Props ) {
 	// Build all the navigation items
 	const navItems = buildNavItems( {
 		items: Object.values( settingsTabs ),
-		selectedKey: tab,
+		selectedKey: selectedTab,
 		basePath: A4A_SETTINGS_LINK,
 		onItemClick: () => {
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_settings_click', {
-					status: tab,
+					status: selectedTab,
 				} )
 			);
 		},
 	} );
 
 	const selectedItemProps = {
-		selectedText: settingsTabs[ tab ].label,
+		selectedText: settingsTabs[ selectedTab ].label,
 	};
 
 	// Content tab switch
 	let tabContent = null;
-	switch ( tab ) {
+	switch ( selectedTab ) {
 		case SETTINGS_AGENCY_PROFILE_TAB:
 			tabContent = <AgencyProfile />;
 			break;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/539

## Proposed Changes

This PR improves the current Settings page navigation bar, allowing to add tabs easily. Also, it add a tab validation, so if you introduce a wrong tab slug in the URL it will redirect you to the /settings root.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Go to the Settings page menu, click, and it will open the Settings page with the Agency Profile tab selected
- It will redirect you to the URL: `/settings/agency-profile`
- If you change the URL for an invalid tab, it will redirect you to the `/settings` which is redirected to `/settings/agency-profile` because we have only one tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
