### PR TITLE
Migration Flow: Update to call Guides endpoint on step change

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -90,6 +90,7 @@ const siteMigration: Flow = {
 
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
+		const { siteSlug, siteId } = useSiteData();
 		const variantSlug = this.variantSlug;
 		const flowPath = variantSlug ?? flowName;
 		const siteCount =
@@ -110,8 +111,8 @@ const siteMigration: Flow = {
 
 		// Call triggerGuidesForStep for the current step
 		useEffect( () => {
-			triggerGuidesForStep( flowName, currentStep );
-		}, [ flowName, currentStep ] );
+			triggerGuidesForStep( flowName, currentStep, siteSlug, siteId );
+		}, [ flowName, currentStep, siteSlug, siteId ] );
 
 		// TODO - We may need to add `...params: string[]` back once we start adding more steps.
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {


### PR DESCRIPTION
## Proposed Changes

Updated the triggerGuidesForStep function on step change in the Migration flow to include siteSlug and siteId.

## Testing Instructions

- Go to  `/setup/site-migration`
- You may be redirected to start/domains. Select "Choose domain later"
- Go through the flow to select Free plan
- When you get to "What are your goals?"
- Open the browser network log.
- Select "Import Existing Content or Website"
- When you get to `setup/site-migration` confirm that a network request is sent to `guides/trigger` endpoint. Confirm the `flow`, `step`, `siteSlug`, and `siteId` matches your workflow. 

<img width="733" alt="CleanShot 2024-05-22 at 09 53 40@2x" src="https://github.com/Automattic/wp-calypso/assets/135139690/04c88ece-7b59-4b22-b071-c900a90c1953">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
