### PR TITLE
WordAds: Include Inline Ads Setting

### DIFF
--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -21,7 +21,11 @@ import { useDispatch, useSelector } from 'calypso/state';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 import { getWordadsSettings } from 'calypso/state/selectors/get-wordads-settings';
 import isSavingWordadsSettings from 'calypso/state/selectors/is-saving-wordads-settings';
-import { isJetpackSite, getCustomizerUrl } from 'calypso/state/sites/selectors';
+import {
+	isJetpackSite,
+	isJetpackMinimumVersion,
+	getCustomizerUrl,
+} from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { saveWordadsSettings } from 'calypso/state/wordads/settings/actions';
 
@@ -65,6 +69,9 @@ const AdsFormSettings = () => {
 	);
 	const wordadsSettings = useSelector( ( state ) => getWordadsSettings( state, siteId ) );
 	const widgetsUrl = useSelector( ( state ) => getCustomizerUrl( state, siteId, 'widgets' ) );
+	const supportsInlineAds = useSelector( ( state ) =>
+		isJetpackMinimumVersion( state, siteId, '13.5-a.1' )
+	);
 
 	const isLoading = ! wordadsSettings || isSavingSettings;
 	const isWordAds = site?.options?.wordads;
@@ -254,12 +261,14 @@ const AdsFormSettings = () => {
 						onChange={ () => handleDisplayToggle( 'second_belowpost' ) }
 						label={ translate( 'Second ad below post' ) }
 					/>
-					<ToggleControl
-						checked={ !! settings.display_options?.inline_enabled }
-						disabled={ isDisabled }
-						onChange={ () => handleDisplayToggle( 'inline_enabled' ) }
-						label={ translate( 'Inline within post content' ) }
-					/>
+					{ supportsInlineAds && (
+						<ToggleControl
+							checked={ !! settings.display_options?.inline_enabled }
+							disabled={ isDisabled }
+							onChange={ () => handleDisplayToggle( 'inline_enabled' ) }
+							label={ translate( 'Inline within post content' ) }
+						/>
+					) }
 					{ ! siteIsJetpack && (
 						<ToggleControl
 							checked={ !! settings.display_options?.sidebar }

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -32,6 +32,7 @@ type DisplayOptions = {
 	display_archive?: boolean;
 	enable_header_ad?: boolean;
 	second_belowpost?: boolean;
+	inline_enabled?: boolean;
 	sidebar?: boolean;
 };
 
@@ -252,6 +253,12 @@ const AdsFormSettings = () => {
 						disabled={ isDisabled }
 						onChange={ () => handleDisplayToggle( 'second_belowpost' ) }
 						label={ translate( 'Second ad below post' ) }
+					/>
+					<ToggleControl
+						checked={ !! settings.display_options?.inline_enabled }
+						disabled={ isDisabled }
+						onChange={ () => handleDisplayToggle( 'inline_enabled' ) }
+						label={ translate( 'Inline within post content' ) }
 					/>
 					{ ! siteIsJetpack && (
 						<ToggleControl

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -69,9 +69,10 @@ const AdsFormSettings = () => {
 	);
 	const wordadsSettings = useSelector( ( state ) => getWordadsSettings( state, siteId ) );
 	const widgetsUrl = useSelector( ( state ) => getCustomizerUrl( state, siteId, 'widgets' ) );
-	const supportsInlineAds = useSelector( ( state ) =>
+	const isMinVersionForInlineAds = useSelector( ( state ) =>
 		isJetpackMinimumVersion( state, siteId, '13.5-a.1' )
 	);
+	const supportsInlineAds = ! siteIsJetpack || isMinVersionForInlineAds;
 
 	const isLoading = ! wordadsSettings || isSavingSettings;
 	const isWordAds = site?.options?.wordads;

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -69,8 +69,8 @@ const AdsFormSettings = () => {
 	);
 	const wordadsSettings = useSelector( ( state ) => getWordadsSettings( state, siteId ) );
 	const widgetsUrl = useSelector( ( state ) => getCustomizerUrl( state, siteId, 'widgets' ) );
-	const isMinVersionForInlineAds = useSelector( ( state ) =>
-		isJetpackMinimumVersion( state, siteId, '13.5-a.1' )
+	const isMinVersionForInlineAds = useSelector(
+		( state ) => siteId && isJetpackMinimumVersion( state, siteId, '13.5-a.1' )
 	);
 	const supportsInlineAds = ! siteIsJetpack || isMinVersionForInlineAds;
 

--- a/client/my-sites/earn/ads/payments.tsx
+++ b/client/my-sites/earn/ads/payments.tsx
@@ -33,6 +33,7 @@ type WordAdSettings = {
 		display_page: boolean;
 		enable_header_ad: boolean;
 		second_belowpost: boolean;
+		inline_enabled: boolean;
 		sidebar: boolean;
 		display_archive: boolean;
 	};

--- a/client/state/data-layer/wpcom/wordads/settings/index.js
+++ b/client/state/data-layer/wpcom/wordads/settings/index.js
@@ -70,6 +70,7 @@ export const saveWordadsSettings = ( action ) => ( dispatch, getState ) => {
 				wordads_display_archive: settings.display_options.display_archive,
 				enable_header_ad: settings.display_options.enable_header_ad,
 				wordads_second_belowpost: settings.display_options.second_belowpost,
+				wordads_inline_enabled: settings.display_options.inline_enabled,
 				wordads_ccpa_enabled: settings.ccpa_enabled,
 				wordads_ccpa_privacy_policy_url: settings.ccpa_privacy_policy_url,
 				wordads_custom_adstxt_enabled: settings.custom_adstxt_enabled,

--- a/client/state/selectors/get-wordads-settings.js
+++ b/client/state/selectors/get-wordads-settings.js
@@ -37,6 +37,7 @@ export const getWordadsSettings = createSelector(
 					display_archive: siteSettings.wordads_display_archive,
 					enable_header_ad: siteSettings.enable_header_ad,
 					second_belowpost: siteSettings.wordads_second_belowpost,
+					inline_enabled: siteSettings.wordads_inline_enabled,
 				},
 				ccpa_enabled: siteSettings.wordads_ccpa_enabled,
 				ccpa_privacy_policy_url: siteSettings.wordads_ccpa_privacy_policy_url,

--- a/client/state/selectors/test/get-wordads-settings.js
+++ b/client/state/selectors/test/get-wordads-settings.js
@@ -90,6 +90,7 @@ describe( 'getWordadsSettings()', () => {
 						wordads_display_archive: 'wordads_display_archive-test',
 						enable_header_ad: 'enable_header_ad-test',
 						wordads_second_belowpost: 'wordads_second_belowpost-test',
+						wordads_inline_enabled: 'wordads_inline_enabled-test',
 						wordads_ccpa_enabled: 'wordads_ccpa_enabled-test',
 						wordads_ccpa_privacy_policy_url: 'wordads_ccpa_privacy_policy_url-test',
 						wordads_custom_adstxt_enabled: 'wordads_custom_adstxt_enabled-test',
@@ -116,6 +117,10 @@ describe( 'getWordadsSettings()', () => {
 		expect( output ).toHaveProperty(
 			'display_options.second_belowpost',
 			'wordads_second_belowpost-test'
+		);
+		expect( output ).toHaveProperty(
+			'display_options.inline_enabled',
+			'wordads_inline_enabled-test'
 		);
 		expect( output ).toHaveProperty( 'ccpa_enabled', 'wordads_ccpa_enabled-test' );
 		expect( output ).toHaveProperty(


### PR DESCRIPTION
Fixes #90997

## Proposed Changes

Adds the "Inline within post content" settings to the WordAds dashboard on Calypso. 

## Why are these changes being made?

These changes were already recently added to Jetpack in WP-Admin: Automattic/jetpack#37170. This PR brings parity with Calypso. 

## Testing Instructions

1. Visit `/earn/ads-settings/` and confirm that the setting is listed there
2. Toggle the setting
3. Visit `/wp-admin/admin.php?page=jetpack#/earn`, and confirm that the toggle updates to match Calypso. 
4. You can also toggle the setting in WP-Admin and ensure that it is reflected upon refreshing Calypso. 