### PR TITLE
Fix Help Center for domain only sites

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -297,7 +297,8 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 			}
 		}
 
-		const productSlug = ( supportSite as HelpCenterSite )?.plan.product_slug;
+		// Domain only sites don't have plans.
+		const productSlug = ( supportSite as HelpCenterSite )?.plan?.product_slug;
 		const plan = getPlan( productSlug );
 		const productId = plan?.getProductId();
 		const productName = plan?.getTitle();


### PR DESCRIPTION
The Help Center assumes every site has a plan. But that's not true for domain-only sites. This adds a null check before accessing the plan slug to make sure a null value does not break submission.

### Testing instructions
1. Using a domain-only user, open the Help Center.
2. Open Wapuu, ask it something. 
3. Give it 👎🏼 do Wapuu's answer.
4. The contact options should show.
5. Pick email.
6. Submit a ticket.
7. It should go through.