### PR TITLE
Site Profiler: Add a link to domain transfer for non WP.com sites

### DIFF
--- a/client/site-profiler/components/domain-section/index.tsx
+++ b/client/site-profiler/components/domain-section/index.tsx
@@ -1,0 +1,42 @@
+import { useTranslate } from 'i18n-calypso';
+import { UrlData } from 'calypso/blocks/import/types';
+import DomainInformation from 'calypso/site-profiler/components/domain-information';
+import { MetricsSection } from 'calypso/site-profiler/components/metrics-section';
+import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
+
+interface DomainSectionProps {
+	domain: string;
+	whois: WhoIs;
+	hostingProvider?: HostingProvider;
+	urlData?: UrlData;
+	domainRef: React.RefObject< HTMLObjectElement >;
+}
+
+export const DomainSection: React.FC< DomainSectionProps > = ( props ) => {
+	const translate = useTranslate();
+	const { domain, whois, hostingProvider, urlData, domainRef } = props;
+
+	return (
+		<MetricsSection
+			name={ translate( 'Domain' ) }
+			title={ translate(
+				'Your domain {{success}}set up is good{{/success}}, but you could boost your site’s visibility and growth.',
+				{
+					components: {
+						success: <span className="success" />,
+					},
+				}
+			) }
+			subtitle={ translate( 'Optimize your domain' ) }
+			ref={ domainRef }
+		>
+			<DomainInformation
+				domain={ domain }
+				whois={ whois }
+				hostingProvider={ hostingProvider }
+				urlData={ urlData }
+				hideTitle
+			/>
+		</MetricsSection>
+	);
+};

--- a/client/site-profiler/components/domain-section/index.tsx
+++ b/client/site-profiler/components/domain-section/index.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { UrlData } from 'calypso/blocks/import/types';
 import DomainInformation from 'calypso/site-profiler/components/domain-information';
@@ -15,6 +16,12 @@ interface DomainSectionProps {
 export const DomainSection: React.FC< DomainSectionProps > = ( props ) => {
 	const translate = useTranslate();
 	const { domain, whois, hostingProvider, urlData, domainRef } = props;
+	const showSubtitle = ! urlData?.platform_data?.is_wpcom;
+	const goToDomainsPage = () => {
+		if ( showSubtitle ) {
+			page( '/setup/domain-transfer' );
+		}
+	};
 
 	return (
 		<MetricsSection
@@ -27,7 +34,8 @@ export const DomainSection: React.FC< DomainSectionProps > = ( props ) => {
 					},
 				}
 			) }
-			subtitle={ translate( 'Optimize your domain' ) }
+			subtitle={ showSubtitle ? translate( 'Optimize your domain' ) : undefined }
+			subtitleOnClick={ goToDomainsPage }
 			ref={ domainRef }
 		>
 			<DomainInformation

--- a/client/site-profiler/components/metrics-section/index.tsx
+++ b/client/site-profiler/components/metrics-section/index.tsx
@@ -7,6 +7,7 @@ interface MetricsSectionProps {
 	name: string;
 	title: string | React.ReactNode;
 	subtitle?: string | React.ReactNode;
+	subtitleOnClick?: () => void;
 	children?: React.ReactNode;
 }
 
@@ -80,17 +81,17 @@ const Content = styled.div`
 
 export const MetricsSection = forwardRef< HTMLObjectElement, MetricsSectionProps >(
 	( props, ref: ForwardedRef< HTMLObjectElement > ) => {
-		const { name, title, subtitle, children } = props;
+		const { name, title, subtitle, children, subtitleOnClick } = props;
 
 		return (
 			<Container ref={ ref }>
 				<NameSpan>{ name }</NameSpan>
 				<Title>{ title }</Title>
 				{ subtitle && (
-					<>
-						<Subtitle>{ subtitle }</Subtitle>
+					<Subtitle onClick={ subtitleOnClick }>
+						{ subtitle }
 						<SubtitleIcon icon="chevron-right" size={ 18 } />
-					</>
+					</Subtitle>
 				) }
 
 				{ children && <Content>{ children }</Content> }

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -16,7 +16,7 @@ import useScrollToTop from '../hooks/use-scroll-to-top';
 import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-analytics';
 import { getValidUrl } from '../utils/get-valid-url';
 import { normalizeWhoisField } from '../utils/normalize-whois-entry';
-import DomainInformation from './domain-information';
+import { DomainSection } from './domain-section';
 import { GetReportForm } from './get-report-form';
 import HostingInformation from './hosting-information';
 import { LandingPageHeader } from './landing-page-header';
@@ -147,27 +147,14 @@ export default function SiteProfilerV2( props: Props ) {
 									hideTitle
 								/>
 							</MetricsSection>
-							<MetricsSection
-								name={ translate( 'Domain' ) }
-								title={ translate(
-									'Your domain {{success}}set up is good{{/success}}, but you could boost your site’s visibility and growth.',
-									{
-										components: {
-											success: <span className="success" />,
-										},
-									}
-								) }
-								subtitle={ translate( 'Optimize your domain' ) }
-								ref={ domainRef }
-							>
-								<DomainInformation
-									domain={ domain }
-									whois={ siteProfilerData.whois }
-									hostingProvider={ hostingProviderData?.hosting_provider }
-									urlData={ urlData }
-									hideTitle
-								/>
-							</MetricsSection>
+
+							<DomainSection
+								domain={ domain }
+								whois={ siteProfilerData.whois }
+								hostingProvider={ hostingProviderData?.hosting_provider }
+								urlData={ urlData }
+								domainRef={ domainRef }
+							/>
 						</>
 					) }
 				</LayoutBlock>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7353

## Proposed Changes

* Isolate the DomainSection in a new component
* Add a link to `/setup/domain-transfer` on the DomainSection when the domain is not on WP.com yet.

## Why are these changes being made?

To allow users with domains not on WP.com to make the transfer.

## Testing Instructions

* Go to `/site-profiler/:url` with a non-WP.com site. Ex: `/site-profiler/example.com`
* Check if there is link to `/setup/domain-transfer` on the Domain section
* Go to `/site-profiler/:url` with a WP.com site. Ex: `/site-profiler/wordpress.com`
* Check if there is no link shown below the title.


| WP.com  | non-WP.com |
| ------------- | ------------- |
|![CleanShot 2024-05-22 at 11 42 08@2x](https://github.com/Automattic/wp-calypso/assets/5039531/0022b722-df46-48ba-ad92-4efeb38d97d9)|![CleanShot 2024-05-22 at 11 30 31](https://github.com/Automattic/wp-calypso/assets/5039531/7e835b91-03de-4c81-9ea7-2e269cedb832)|




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?