### PR TITLE
Nav redesign - Use native instead of legacy in settings text

### DIFF
--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -141,7 +141,7 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 					<FormSettingExplanation>
 						{ hasEnTranslation( 'Use WordPress.com’s native dashboard to manage your site.' )
 							? translate( 'Use WordPress.com’s native dashboard to manage your site.' )
-							: translate( 'The WordPress.com redesign for a better experience.' ) }
+							: translate( 'Use WordPress.com’s legacy dashboard to manage your site.' ) }
 					</FormSettingExplanation>
 				</FormFieldset>
 			</>

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -139,8 +139,8 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 						/>
 					</FormLabel>
 					<FormSettingExplanation>
-						{ hasEnTranslation( 'Use WordPress.com’s legacy dashboard to manage your site.' )
-							? translate( 'Use WordPress.com’s legacy dashboard to manage your site.' )
+						{ hasEnTranslation( 'Use WordPress.com’s native dashboard to manage your site.' )
+							? translate( 'Use WordPress.com’s native dashboard to manage your site.' )
 							: translate( 'The WordPress.com redesign for a better experience.' ) }
 					</FormSettingExplanation>
 				</FormFieldset>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7282

## Proposed Changes

* Updates the line from `Use WordPress.com’s legacy dashboard to manage your site` to `Use WordPress.com’s native dashboard to manage your site`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Confusion over the word `legacy` as the true legacy dashboard is wp-admin

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
