### PR TITLE
Site Migrations: Add Tracks events to site migration instructions links

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -97,9 +97,9 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 		}
 	}, [ flow, setupError, siteId ] );
 
-	const recordInstructionsLinkClick = ( event, linkName: string ) => {
+	const recordInstructionsLinkClick = ( event, linkname: string ) => {
 		recordTracksEvent( 'calypso_site_migration_instructions_link_click', {
-			linkName,
+			linkname,
 		} );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -97,6 +97,13 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 		}
 	}, [ flow, setupError, siteId ] );
 
+	const recordLinkClick = ( event, linkName: string ) => {
+		recordTracksEvent( 'calypso_site_migration_instructions_link_click', {
+			link: event.target?.href,
+			linkName,
+		} );
+	};
+
 	const stepContent = (
 		<div className="site-migration-instructions__content">
 			<ol className="site-migration-instructions__list">
@@ -110,6 +117,7 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 										href={ getPluginInstallationPage( fromUrl ) }
 										target="_blank"
 										rel="noreferrer"
+										onClick={ ( event ) => recordLinkClick( event, 'install_migrate_guru_plugin' ) }
 									/>
 								),
 							},
@@ -127,6 +135,7 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 										target="_blank"
 										rel="noreferrer"
 										fallback={ <strong /> }
+										onClick={ ( event ) => recordLinkClick( event, 'go_to_migrate_guru_page' ) }
 									/>
 								),
 								migrateButton: <DoNotTranslateIt value="Migrate" />,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -97,7 +97,7 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 		}
 	}, [ flow, setupError, siteId ] );
 
-	const recordInstructionsLinkClick = ( event, linkname: string ) => {
+	const recordInstructionsLinkClick = ( linkname: string ) => {
 		recordTracksEvent( 'calypso_site_migration_instructions_link_click', {
 			linkname,
 		} );
@@ -116,7 +116,7 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 										href={ getPluginInstallationPage( fromUrl ) }
 										target="_blank"
 										rel="noreferrer"
-										onClick={ ( event ) => recordInstructionsLinkClick( event, 'install-plugin' ) }
+										onClick={ () => recordInstructionsLinkClick( 'install-plugin' ) }
 									/>
 								),
 							},
@@ -134,9 +134,7 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 										target="_blank"
 										rel="noreferrer"
 										fallback={ <strong /> }
-										onClick={ ( event ) =>
-											recordInstructionsLinkClick( event, 'go-to-plugin-page' )
-										}
+										onClick={ () => recordInstructionsLinkClick( 'go-to-plugin-page' ) }
 									/>
 								),
 								migrateButton: <DoNotTranslateIt value="Migrate" />,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -97,9 +97,8 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 		}
 	}, [ flow, setupError, siteId ] );
 
-	const recordLinkClick = ( event, linkName: string ) => {
+	const recordInstructionsLinkClick = ( event, linkName: string ) => {
 		recordTracksEvent( 'calypso_site_migration_instructions_link_click', {
-			link: event.target?.href,
 			linkName,
 		} );
 	};
@@ -117,7 +116,7 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 										href={ getPluginInstallationPage( fromUrl ) }
 										target="_blank"
 										rel="noreferrer"
-										onClick={ ( event ) => recordLinkClick( event, 'install_migrate_guru_plugin' ) }
+										onClick={ ( event ) => recordInstructionsLinkClick( event, 'install-plugin' ) }
 									/>
 								),
 							},
@@ -135,7 +134,9 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 										target="_blank"
 										rel="noreferrer"
 										fallback={ <strong /> }
-										onClick={ ( event ) => recordLinkClick( event, 'go_to_migrate_guru_page' ) }
+										onClick={ ( event ) =>
+											recordInstructionsLinkClick( event, 'go-to-plugin-page' )
+										}
 									/>
 								),
 								migrateButton: <DoNotTranslateIt value="Migrate" />,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90743

## Proposed Changes

* Add a new Tracks event, `calypso_site_migration_instructions_link_click`, to track clicks on the links on the site migration instructions page.
* Add a `linkname` property to differentiate the two links.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We can use these to measure the performance of these links https://github.com/Automattic/wp-calypso/issues/90743

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR or use calypso.live
* Create a new migrated site by going through the `/start` flow
* Choose Import at the goal selection step
* Put in the URL to another WP-based site (Jurassic Ninja is fine)
* Choose Everything
* Either select the trial or upgrade your plan
* At the instructions screen, click on the two links to install the plugin on your source site and go to the plugin page
* You should see Tracks events like the following fire in Tracks Vigilante or the console:

<img width="1180" alt="Screenshot 2024-05-22 at 11 56 30 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/633c4ba9-3395-46de-9014-04aba01dbbbb">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- N/A Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
