### PR TITLE
A4A > Referrals: Fix Referral iFrame scroll issue

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import { useLayoutEffect, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -15,11 +16,27 @@ import './style.scss';
 export default function ReferralsBankDetails() {
 	const translate = useTranslate();
 
+	const [ iFrameHeight, setIFrameHeight ] = useState( '100%' );
+
 	const title = translate( 'Add bank details' );
 
 	const { data, isFetching } = useGetTipaltiIFrameURL();
 
 	const iFrameSrc = data?.iframe_url || '';
+
+	const tipaltiHandler = ( event: MessageEvent ) => {
+		if ( event.data && event.data.TipaltiIframeInfo ) {
+			const height = event.data.TipaltiIframeInfo?.height || '100%';
+			setIFrameHeight( height );
+		}
+	};
+
+	useLayoutEffect( () => {
+		window.addEventListener( 'message', tipaltiHandler, false );
+		return () => {
+			window.removeEventListener( 'message', tipaltiHandler, false );
+		};
+	}, [] );
 
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
@@ -44,7 +61,7 @@ export default function ReferralsBankDetails() {
 					{ isFetching ? (
 						<TextPlaceholder />
 					) : (
-						<iframe width="100%" height="100%" src={ iFrameSrc } title={ title } />
+						<iframe width="100%" height={ iFrameHeight } src={ iFrameSrc } title={ title } />
 					) }
 				</div>
 			</LayoutBody>


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/517

## Proposed Changes

This PR fixes the scrolling issue of the iFrame on the Referrals page 


## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals > Add/Edit bank details > Append the URL with ?flags=-a4a-automated-referrals > Verify that you can scroll to the button and click the `Next` button
3. To reproduce this issue > Visit the same page on production 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
