### PR TITLE
Dashboard v2 - Sync dataViewsState to calypso selected site state

### DIFF
--- a/client/sites-dashboard-v2/hooks/use-sync-selected-site.ts
+++ b/client/sites-dashboard-v2/hooks/use-sync-selected-site.ts
@@ -1,13 +1,23 @@
+import { SiteDetails } from '@automattic/data-stores';
 import { useEffect } from 'react';
 import { useDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import type { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 
-export function useSyncSelectedSite( dataViewsState: DataViewsState ) {
+export function useSyncSelectedSite(
+	dataViewsState: DataViewsState,
+	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void,
+	selectedSite: SiteDetails | null | undefined
+) {
 	const dispatch = useDispatch();
 
 	// Update selected site globally as soon as it is clicked from the table.
 	useEffect( () => {
 		dispatch( setSelectedSiteId( dataViewsState.selectedItem?.ID ) );
 	}, [ dispatch, dataViewsState.selectedItem ] );
+
+	// If calypso state changes the selected site, ensure the dataViewsState is updated as well.
+	useEffect( () => {
+		setDataViewsState( ( prevState ) => ( { ...prevState, selectedItem: selectedSite } ) );
+	}, [ selectedSite, setDataViewsState ] );
 }

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -123,7 +123,7 @@ const SitesDashboardV2 = ( {
 	} as DataViewsState;
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( defaultDataViewsState );
 
-	useSyncSelectedSite( dataViewsState );
+	useSyncSelectedSite( dataViewsState, setDataViewsState, selectedSite );
 
 	const { selectedSiteFeature, setSelectedSiteFeature } = useSyncSelectedSiteFeature( {
 		selectedSite,
@@ -132,11 +132,6 @@ const SitesDashboardV2 = ( {
 		featureToRouteMap: FEATURE_TO_ROUTE_MAP,
 		queryParamKeys: [ 'page', 'per-page', 'status', 'search' ],
 	} );
-
-	// If calypso state changes the selected site, ensure the dataViewsState is updated as well.
-	useEffect( () => {
-		setDataViewsState( ( prevState ) => ( { ...prevState, selectedItem: selectedSite } ) );
-	}, [ selectedSite, setDataViewsState ] );
 
 	// Ensure site sort preference is applied when it loads in. This isn't always available on
 	// initial mount.

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -133,6 +133,11 @@ const SitesDashboardV2 = ( {
 		queryParamKeys: [ 'page', 'per-page', 'status', 'search' ],
 	} );
 
+	// If calypso state changes the selected site, ensure the dataViewsState is updated as well.
+	useEffect( () => {
+		setDataViewsState( ( prevState ) => ( { ...prevState, selectedItem: selectedSite } ) );
+	}, [ selectedSite, setDataViewsState ] );
+
 	// Ensure site sort preference is applied when it loads in. This isn't always available on
 	// initial mount.
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7374

## Proposed Changes

* Adds a useEffect to update the dataViewsState's selected item when the calypso state for the selected site updates. This should ensure dataViewsState is in sync with calypso.

BEFORE
![sync-state-before](https://github.com/Automattic/wp-calypso/assets/28742426/13e7387c-fcde-4a8c-93ee-0dd6c3e77ce7)

AFTER
![sync-state-after](https://github.com/Automattic/wp-calypso/assets/28742426/d7dcb374-63a6-44ea-92c4-772dac57b1c5)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When viewing the sites overview page for a selected site, and taking any link to an overview page for another site, the dataViewsState would not change its selected item and continue to display data for the previously selected site.
* This could cause issues with selecting a menu item from the ellipsis in the collapsed site list, command palette, etc.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Visit /sites dashboard.
* Select a site to open the overview.
* In the collapsed site list on the left select an option in the ellipsis menu for another site that corresponds to an overview page (like devTools, hosting overview, etc.).
* Verify we navigate to view the overview page for the site we used the ellipsis menu for. previously this would continue to be the previously selected site.
* Now switch sites using the command palette. When selecting a site here the preview pane should update to the newly selected site.

Note, you may notice that selecting a site via the command palette does not change the indicated selected site in the sidebar even though the overview pane updates. Similarly, you may notice that if you click the ellipsis menu for another site in the sidebar but close it without any action, the sidebar for some reason indicates this as the selected site. This is a pre-existing issue and tracked in Automattic/dotcom-forge#7382 . This PR will make the dataViewsState in sync with claypso, but something beyond this is out of sync with that site sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
