### PR TITLE
Guided Onboarding: Add hook to retrieve segment

### DIFF
--- a/client/signup/hooks/use-get-segment.tsx
+++ b/client/signup/hooks/use-get-segment.tsx
@@ -1,0 +1,39 @@
+const useGetSegment = ( intent: string, goals: string[] ): string => {
+	// Handle the case when no goals are provided (n/a)
+	if ( intent === 'migrate-or-import-site' && goals.length === 0 ) {
+		return 'Migration';
+	}
+
+	if ( intent === 'client' && goals.length === 0 ) {
+		return 'Developer / Agency';
+	}
+
+	// Handle different cases when intent is 'Create for self'
+	if ( intent === 'myself-business-or-friend' ) {
+		if ( goals.length === 0 ) {
+			return 'Unknown';
+		}
+		if ( goals.includes( 'difm' ) ) {
+			return 'DIFM'; // Do it for me
+		}
+		if ( goals.includes( 'sell' ) && ! goals.includes( 'difm' ) ) {
+			return 'Merchant';
+		}
+		if ( goals.includes( 'blog' ) ) {
+			return 'Blogger';
+		}
+		if ( goals.includes( 'educational-or-nonprofit' ) ) {
+			return 'Nonprofit';
+		}
+		if ( goals.includes( 'newsletter' ) ) {
+			return 'Newsletter';
+		}
+		// Catch-all case for when none of the specific goals are met
+		return 'Consumer / Business';
+	}
+
+	// Default return if no conditions are met
+	return 'Unrecognized';
+};
+
+export default useGetSegment;

--- a/client/signup/hooks/use-guided-flow-get-segment.tsx
+++ b/client/signup/hooks/use-guided-flow-get-segment.tsx
@@ -1,4 +1,4 @@
-const useGetSegment = ( intent: string, goals: string[] ): string => {
+const useGuidedFlowGetSegment = ( intent: string, goals: string[] ): string => {
 	// Handle the case when no goals are provided (n/a)
 	if ( intent === 'migrate-or-import-site' && goals.length === 0 ) {
 		return 'Migration';
@@ -29,6 +29,7 @@ const useGetSegment = ( intent: string, goals: string[] ): string => {
 			return 'Newsletter';
 		}
 		// Catch-all case for when none of the specific goals are met
+		// This will also account for "( ! DIFM && ! Sell ) = Consumer / Business" condition
 		return 'Consumer / Business';
 	}
 
@@ -36,4 +37,4 @@ const useGetSegment = ( intent: string, goals: string[] ): string => {
 	return 'Unrecognized';
 };
 
-export default useGetSegment;
+export default useGuidedFlowGetSegment;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7018

## Proposed Changes

* Adds the logic to determine the user's segment based on their intent and/or goals.
* These changes will help us analyze the user's choices and redirect them to the correct flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Test hook with different intent and goals values locally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
