### PR TITLE
E2E tests: Reintroduce eCommerce plan exception in Jetpack tests

### DIFF
--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -70,15 +70,28 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// eCommerce plan sites attempt to load Calypso, but with
+			// third-party cookies disabled the fallback route to WP-Admin
+			// kicks in after some time.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
+			await testAccount.authenticate( page );
+		}
 	} );
 
 	it( 'Navigate to Full Site Editor', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page );
 
-		// Explicitly doing sidebar navigation to ensure Calypso navigation is intact.
-		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.navigate( 'Appearance', 'Editor' );
+		// eCommerce plan loads WP-Admin for home dashboard,
+		// so instead navigate straight to the FSE page.
+		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
+		} else {
+			// Explicitly doing sidebar navigation to ensure Calypso navigation is intact.
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Appearance', 'Editor' );
+		}
 	} );
 
 	it( 'Editor endpoint loads', async function () {

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
@@ -36,7 +36,16 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC !== true )(
 
 		beforeAll( async function () {
 			page = await browser.newPage();
-			await testAccount.authenticate( page );
+
+			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+				// eCommerce plan sites attempt to load Calypso, but with
+				// third-party cookies disabled the fallback route to WP-Admin
+				// kicks in after some time.
+				await testAccount.authenticate( page, { url: /wp-admin/ } );
+			} else {
+				await testAccount.authenticate( page );
+			}
+
 			jetpackDashboardPage = new JetpackDashboardPage( page );
 		} );
 

--- a/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
+++ b/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
@@ -37,7 +37,14 @@ skipDescribeIf( ! envVariables.TEST_ON_ATOMIC )(
 
 			testAccount = new TestAccount( accountName );
 
-			await testAccount.authenticate( page );
+			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+				// Switching to or logging into eCommerce plan sites inevitably
+				// loads WP-Admin instead of Calypso, but the rediret occurs
+				// only after Calypso attempts to load.
+				await testAccount.authenticate( page, { url: /wp-admin/ } );
+			} else {
+				await testAccount.authenticate( page );
+			}
 		} );
 
 		it( 'Navigate to Settings > Hosting Configuration', async function () {

--- a/test/e2e/specs/media/media__edit.ts
+++ b/test/e2e/specs/media/media__edit.ts
@@ -39,7 +39,14 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// Switching to or logging into eCommerce plan sites inevitably
+			// loads WP-Admin instead of Calypso, but the rediret occurs
+			// only after Calypso attempts to load.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
+			await testAccount.authenticate( page );
+		}
 
 		mediaPage = new MediaPage( page );
 	} );

--- a/test/e2e/specs/media/media__upload.ts
+++ b/test/e2e/specs/media/media__upload.ts
@@ -48,14 +48,27 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// Switching to or logging into eCommerce plan sites inevitably
+			// loads WP-Admin instead of Calypso, but the rediret occurs
+			// only after Calypso attempts to load.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
+			await testAccount.authenticate( page );
+		}
 
 		mediaPage = new MediaPage( page );
 	} );
 
 	it( 'Navigate to Media', async function () {
-		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.navigate( 'Media' );
+		// eCommerce plan loads WP-Admin for home dashboard,
+		// so instead navigate straight to the Media page.
+		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+			await mediaPage.visit( testAccount.credentials.testSites?.primary.url as string );
+		} else {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Media' );
+		}
 	} );
 
 	it( 'Upload image and confirm addition to gallery', async function () {

--- a/test/e2e/specs/media/settings__media.ts
+++ b/test/e2e/specs/media/settings__media.ts
@@ -37,7 +37,14 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () 
 
 		testAccount = new TestAccount( accountName );
 
-		await testAccount.authenticate( page );
+		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// Switching to or logging into eCommerce plan sites inevitably
+			// loads WP-Admin instead of Calypso, but the rediret occurs
+			// only after Calypso attempts to load.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
+			await testAccount.authenticate( page );
+		}
 	} );
 
 	if ( envVariables.JETPACK_TARGET === 'remote-site' ) {
@@ -75,8 +82,14 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () 
 		let wpAdminMediaSettingsPage: WpAdminMediaSettingsPage;
 
 		it( 'Navigate to Settings > Media', async function () {
-			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Settings', 'Media' );
+			// eCommerce plan loads WP-Admin for home dashboard,
+			// so instead navigate straight to the Media page.
+			if ( testAccount.accountName === 'jetpackAtomicEcommPlanUser' ) {
+				await page.goto( `${ testAccount.getSiteURL() }wp-admin/options-media.php` );
+			} else {
+				const sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Settings', 'Media' );
+			}
 			wpAdminMediaSettingsPage = new WpAdminMediaSettingsPage( page );
 		} );
 

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -107,7 +107,14 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 		let feedbackInboxPage: FeedbackInboxPage;
 
 		beforeAll( async function () {
-			await testAccount.authenticate( page );
+			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+				// eCommerce plan sites attempt to load Calypso, but with
+				// third-party cookies disabled the fallback route to WP-Admin
+				// kicks in after some time.
+				await testAccount.authenticate( page, { url: /wp-admin/ } );
+			} else {
+				await testAccount.authenticate( page );
+			}
 		} );
 
 		it( 'Navigate to the Jetpack Forms Inbox', async function () {

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -35,7 +35,14 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		if ( testAccount.accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// eCommerce plan sites attempt to load Calypso, but with
+			// third-party cookies disabled the fallback route to WP-Admin
+			// kicks in after some time.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
+			await testAccount.authenticate( page );
+		}
 	} );
 
 	it( 'Navigate to Stats', async function () {


### PR DESCRIPTION
## Proposed Changes

After we started to direct Entrepreneur users to Calypso My Home, by removing the feature flag on [90408](https://github.com/Automattic/wp-calypso/pull/90408), a few E2E tests broke because it expected to land on `wp-admin`.

@tbradsha fixed those on [90709](https://github.com/Automattic/wp-calypso/pull/90709) and [90753](https://github.com/Automattic/wp-calypso/pull/90753). But reverting to the `wp-admin` landing page on [90951](https://github.com/Automattic/wp-calypso/pull/90951), made the same tests fail again.

For that reason we are reintroducing the eCommerce plan exception in Jetpack tests.
## Testing Instructions

- Checkout to this branch.
- Run, one by one, the following tests on your terminal:
```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/fse/fse__temp-smoke-test.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/media/media__edit.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/media/media__upload.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/media/settings__media.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/published-content/forms__submissions.ts
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=ecomm-plan TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test --debug -- test/e2e/specs/stats/stats.ts
```

Note: I had a few timeout issues running this.
I was able to get consistent results increasing the timeout tolerance on [calypso-e2e/src/lib/test-account.ts](https://github.com/Automattic/wp-calypso/blob/91d44367a39b79eff3966ac3dfa4c72452651722/packages/calypso-e2e/src/lib/test-account.ts#L55)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
