### PR TITLE
A4A: Hide Jetpack Manage header when the component is rendered in A4A

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-jetpack-manage-license.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-jetpack-manage-license.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import ProductPriceWithDiscount from '../primary/product-price-with-discount-info';
 
@@ -14,10 +15,13 @@ const LicenseLightboxJetpackManageLicense: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
+	// Once this component is ported to A4A, we can get remove this conditional
+	const isA4A = isA8CForAgencies();
+
 	return (
 		<div className="license-lightbox__jetpack-manage-license">
 			<h3 className="license-lightbox__jetpack-manage-license-title">
-				{ translate( 'Jetpack Manage license:' ) }
+				{ ! isA4A && translate( 'Jetpack Manage license:' ) }
 			</h3>
 
 			<div className="license-lightbox__pricing">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/530

## Proposed Changes

* Hide the "Jetpack Manage license:" header when the component is rendered in A4A.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because we should not mention Jetpack Manage anywhere within A4A.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start A4A locally or via Live Branch.
* Visit `/marketplace/products?show_license_modal=jetpack-ai`.
* Verify the "Jetpack Manage license:" is not present anymore.
* Start Jetpack Cloud locally or via Live Branch.
* Visit `partner-portal/issue-license?show_license_modal=jetpack-ai`.
* Verify the "Jetpack Manage license:" is still present.

<table>
<tr>
<th>A4A</th>
<th>Jetpack Manage</th>
</tr>
<tr>
<td><img width="1381" alt="Screenshot 2024-05-22 at 16 28 18" src="https://github.com/Automattic/wp-calypso/assets/3418513/6a91b4a4-2b53-4a0f-967b-6f795b876e59"></td>
<td><img width="1420" alt="Screenshot 2024-05-22 at 16 26 45" src="https://github.com/Automattic/wp-calypso/assets/3418513/525138e5-c749-4130-99b0-268b40c76b50"></td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
