### PR TITLE
Checkout: Prevent wrapping checkout line item price

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -211,6 +211,7 @@ const LineItemPriceWrapper = styled.span< {
 	shouldUseCheckoutV2?: boolean;
 } >`
 	display: flex;
+	flex: 0 0 auto;
 	gap: 4px;
 
 	${ ( props ) =>


### PR DESCRIPTION
## Proposed Changes

This PR fixes the wrapping of prices in the checkout sidebar if the title of the line item is very long (eg: long domain names) to make sure the prices aren't squished by the title. By setting `flex-grow` and `flex-shrink` to 0, we keep prices on one line.

Before             |  After
:-------------------------:|:-------------------------:
<img width="307" alt="Screenshot 2024-05-22 at 5 09 00 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/3fca78e4-bd73-4e13-855e-28e80de9ef1d"> | <img width="308" alt="Screenshot 2024-05-22 at 5 09 54 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/d493c222-f808-46fb-a31b-dc3508054d4e">

## Testing Instructions

- Add a long domain name to your shopping cart and visit checkout.
- Verify that the price display in the sidebar (and in the main column, which should be unchanged) looks ok and is not wrapped over multiple lines.