### PR TITLE
Segmentation Survey: Fix header alignment on the Entrepreneur survey

### DIFF
--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -114,6 +114,7 @@ const SegmentationSurvey = ( { surveyKey, onBack, onNext }: SegmentationSurveyPr
 				onSkip={ skipToNextPage }
 				onChange={ onChangeAnswer }
 				disabled={ isPending }
+				headerAlign="left"
 			/>
 		</>
 	);

--- a/client/components/survey-container/components/question-step.tsx
+++ b/client/components/survey-container/components/question-step.tsx
@@ -21,6 +21,7 @@ type QuestionStepType = {
 	onContinue: () => void;
 	onSkip: () => void;
 	hideBack?: boolean;
+	headerAlign?: string;
 } & QuestionSelectionComponentProps;
 
 const QuestionStep = ( {
@@ -32,6 +33,7 @@ const QuestionStep = ( {
 	onSkip,
 	disabled,
 	hideBack,
+	headerAlign = 'center',
 }: QuestionStepType ) => {
 	const translate = useTranslate();
 	const flowPath = window.location.pathname;
@@ -48,7 +50,7 @@ const QuestionStep = ( {
 			goNext={ onSkip }
 			formattedHeader={
 				<FormattedHeader
-					align="center"
+					align={ headerAlign }
 					headerText={ question.headerText }
 					subHeaderText={ question.subHeaderText }
 				/>

--- a/client/components/survey-container/index.tsx
+++ b/client/components/survey-container/index.tsx
@@ -11,6 +11,7 @@ type SurveyContainerProps = {
 	onChange: ( questionKey: string, value: string[] ) => void;
 	hideBackOnFirstPage?: boolean;
 	disabled?: boolean;
+	headerAlign?: string;
 };
 
 const SurveyContainer = ( {
@@ -23,6 +24,7 @@ const SurveyContainer = ( {
 	onChange,
 	hideBackOnFirstPage = true,
 	disabled,
+	headerAlign,
 }: SurveyContainerProps ) => {
 	const currentQuestion = questions[ currentPage - 1 ];
 	const hideBack = hideBackOnFirstPage && currentPage === 1;
@@ -41,6 +43,7 @@ const SurveyContainer = ( {
 			onSkip={ onSkip }
 			disabled={ disabled }
 			hideBack={ hideBack }
+			headerAlign={ headerAlign }
 		/>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/7390

## Proposed Changes

* Create a `headerAlign` prop on the `QuestionStep` component

**Before**
![Image](https://github.com/Automattic/dotcom-forge/assets/3113712/a77d9aeb-7164-4ab0-83a7-38b7719e4623)

**After**
<img width="830" alt="Screenshot 2024-05-22 at 18 20 16" src="https://github.com/Automattic/wp-calypso/assets/3113712/c3c66a2d-46c9-4644-8ec8-7af79449e1e5">

## Why are these changes being made?

* The `QuestionStep` component was updated with a different header alignment to match visual changes on other pages. It should become a component prop so that different alignments are covered.

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur
* You should see the header left-aligned

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
