### PR TITLE
Fix Help Center site picker - include domain only sites and throw when ZD widget is unavailable

### DIFF
--- a/packages/help-center/src/data/use-support-availability.ts
+++ b/packages/help-center/src/data/use-support-availability.ts
@@ -3,6 +3,9 @@ import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { OtherSupportAvailability, ChatAvailability, EmailSupportStatus } from '../types';
 
+// Bump me to invalidate the cache.
+const VERSION = 1;
+
 type ResponseType< T extends 'CHAT' | 'OTHER' | 'EMAIL' > = T extends 'CHAT'
 	? ChatAvailability
 	: T extends 'EMAIL'
@@ -19,7 +22,7 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' | 
 	enabled = true
 ) {
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >( {
-		queryKey: [ 'support-availability', supportType ],
+		queryKey: [ 'support-availability', supportType, VERSION ],
 		queryFn: async () =>
 			canAccessWpcomApis()
 				? await wpcomRequest( {

--- a/packages/help-center/src/data/use-user-sites.ts
+++ b/packages/help-center/src/data/use-user-sites.ts
@@ -2,13 +2,16 @@ import { useQuery } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { SiteDetails } from '@automattic/data-stores';
 
+// Bump this version to invalidate the cache.
+const VERSION = 2;
+
 export function useUserSites( userId: number | string, enabled = true ) {
 	return useQuery( {
-		queryKey: [ 'user-sites', userId ],
+		queryKey: [ 'user-sites', userId, VERSION ],
 		queryFn: () =>
 			wpcomRequest< { sites: SiteDetails[] } >( {
-				path: '/me/sites/',
-				apiVersion: '1.1',
+				path: '/me/sites/?include_domain_only=true',
+				apiVersion: '1.2',
 			} ),
 		refetchOnWindowFocus: false,
 		staleTime: 5 * 60 * 1000,

--- a/packages/help-center/src/hooks/use-chat-widget.ts
+++ b/packages/help-center/src/hooks/use-chat-widget.ts
@@ -57,6 +57,8 @@ export default function useChatWidget(
 					window.zE( 'messenger:set', 'conversationFields', [
 						{ id: ZENDESK_SOURCE_URL_TICKET_FIELD_ID, value: window.location.href },
 					] );
+				} else {
+					throw new Error( 'Zendesk chat widget not loaded' );
 				}
 			} )
 			.catch( () => {


### PR DESCRIPTION
The Help Center queries /sites to get the user's sites and select a site automatically for the support session, when the user has none, we ask them to enter a site. 

The query on trunk didn't include domain only sites, which made us ask the user and cause confusion. 

This also throws an error when we try to open the chat widgets and the JS needed is not available. This would make debugging this much easier. 

