### PR TITLE
Domains: Remove CTAs from Gravatar flow

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1757,6 +1757,7 @@ class RegisterDomainStep extends Component {
 		} = domainAvailability;
 
 		const { isSignupStep, includeOwnedDomainInSuggestions } = this.props;
+		const isGravatarFlow = this.props.flowName === 'domain-for-gravatar';
 
 		if (
 			( TRANSFERRABLE === error && this.state.lastDomainIsTransferrable ) ||
@@ -1770,7 +1771,7 @@ class RegisterDomainStep extends Component {
 		this.setState( {
 			showAvailabilityNotice: true,
 			availabilityError: error,
-			availabilityErrorData: errorData,
+			availabilityErrorData: isGravatarFlow ? { ...errorData, site: null } : errorData,
 			availabilityErrorDomain: domain,
 		} );
 	}

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -58,25 +58,27 @@ function getAvailabilityNotice(
 			);
 			break;
 		case domainAvailability.REGISTERED_SAME_SITE:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already registered on this site. {{a}}Are you trying to make this the primary address for your site?{{/a}}',
-				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						a: (
-							<SetAsPrimaryLink
-								domainName={ domain }
-								siteIdOrSlug={ site }
-								additionalProperties={ {
-									clickOrigin: 'use-a-domain-i-own',
-								} }
-								onSuccess={ () => page( domainManagementList( domain ) ) }
-							/>
-						),
-					},
-				}
-			);
+			if ( site ) {
+				message = translate(
+					'{{strong}}%(domain)s{{/strong}} is already registered on this site. {{a}}Are you trying to make this the primary address for your site?{{/a}}',
+					{
+						args: { domain },
+						components: {
+							strong: <strong />,
+							a: (
+								<SetAsPrimaryLink
+									domainName={ domain }
+									siteIdOrSlug={ site }
+									additionalProperties={ {
+										clickOrigin: 'use-a-domain-i-own',
+									} }
+									onSuccess={ () => page( domainManagementList( domain ) ) }
+								/>
+							),
+						},
+					}
+				);
+			}
 			break;
 		case domainAvailability.REGISTERED_OTHER_SITE_SAME_USER:
 			if ( site ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Prevents WordPress.com CTAs (set domain as primary, move domain to other site, map a domain, etc.) from being displayed in the Gravatar onboarding flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of the Custom Domains on Gravatar project (pcYYhz-24z-p2).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso live page or build this branch locally;
- Go to `/start/domain-for-gravatar/domain-only?search=yes&new=your-test-domain.com`;
- Search for a WordPress.com domain that is registered in another site;
- Try testing for both:
  - Search for a WordPress.com domain registration in a site you own;
  - Search for a standalone mapping in a WordPress.com site you own;
- Ensure you get error messages without any CTA (same as in the "Preview" section).

## Preview

### WordPress.com domain registered in another site
![image](https://github.com/Automattic/wp-calypso/assets/18705930/1e727b16-d969-49bc-94c8-9b3f119a7325)

### Standalone mapping in another site
![image](https://github.com/Automattic/wp-calypso/assets/18705930/2dd1919a-d8f6-456e-8986-e1237d5f623e)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?