### PR TITLE
Support: Fix chat eligibility check

### DIFF
--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -15,7 +15,12 @@ export default function useChatStatus(
 	checkAgentAvailability = true
 ) {
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
-	const isEligibleForChat = Boolean( chatStatus?.is_user_eligible );
+
+	// All users with a support level other than 'free' are eligible for chat.
+	// See: pdDR7T-1vN-p2
+	const isEligibleForChat = Boolean(
+		chatStatus?.supportLevel && chatStatus.supportLevel !== 'free'
+	);
 
 	const { data: supportActivity, isInitialLoading: isLoadingSupportActivity } =
 		useSupportActivity( isEligibleForChat );

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -86,6 +86,11 @@ interface Availability {
 
 export interface ChatAvailability {
 	locale: string;
+	/**
+	 * @deprecated
+	 *
+	 * DO NOT USE THIS VALUE. We no longer use eligibility checks for chat. All paid users are eligible for chat.
+	 */
 	is_user_eligible: boolean;
 	supportLevel:
 		| 'free'


### PR DESCRIPTION
All paid users have access to chat now. See: pdDR7T-1vN-p2

This fixes the eligibility check to include all paid users.