### PR TITLE
Nav Redesign: Add "Activate" ability to dev tools promo

### DIFF
--- a/client/dev-tools-promo/components/dev-tools-promo.tsx
+++ b/client/dev-tools-promo/components/dev-tools-promo.tsx
@@ -1,9 +1,13 @@
+import { FEATURE_SFTP } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import CardHeading from 'calypso/components/card-heading';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector } from 'calypso/state';
+import isAutomatedTransferActive from 'calypso/state/automated-transfer/selectors/is-automated-transfer-active';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
@@ -67,21 +71,46 @@ const DevToolsPromo = () => {
 			supportContext: 'github-deployments',
 		},
 	];
+
+	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
+	const hasSftpFeature = useSelector( ( state ) => siteHasFeature( state, siteId, FEATURE_SFTP ) );
+	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
+	const hasTransfer = useSelector( ( state ) =>
+		isAutomatedTransferActive( state, siteId as number )
+	);
+	const showHostingActivationButton = canSiteGoAtomic && ! hasTransfer;
+
 	return (
 		<div className="dev-tools-promo">
 			<div className="dev-tools-promo__hero">
-				<h1> { translate( 'Unlock all developer tools' ) }</h1>
+				<h1>
+					{ showHostingActivationButton
+						? translate( 'Activate hosting configuration' )
+						: translate( 'Unlock all developer tools' ) }
+				</h1>
 				<p>
-					{ translate(
-						'Upgrade to the Creator plan or higher to get access to all developer tools'
-					) }
+					{ showHostingActivationButton
+						? translate(
+								'Your plan includes all the developer tools listed below. Click "Activate Now" to begin.'
+						  )
+						: translate(
+								'Upgrade to the Creator plan or higher to get access to all developer tools'
+						  ) }
 				</p>
-				<Button variant="secondary" className="dev-tools-promo__button" href={ pluginsLink }>
-					{ translate( 'Browse plugins' ) }
-				</Button>
-				<Button variant="primary" className="dev-tools-promo__button" href={ upgradeLink }>
-					{ translate( 'Upgrade now' ) }
-				</Button>
+				{ showHostingActivationButton ? (
+					<Button variant="primary" className="dev-tools-promo__button" href={ upgradeLink }>
+						{ translate( 'Activate now' ) }
+					</Button>
+				) : (
+					<>
+						<Button variant="secondary" className="dev-tools-promo__button" href={ pluginsLink }>
+							{ translate( 'Browse plugins' ) }
+						</Button>
+						<Button variant="primary" className="dev-tools-promo__button" href={ upgradeLink }>
+							{ translate( 'Upgrade now' ) }
+						</Button>
+					</>
+				) }
 			</div>
 			<div className="dev-tools-promo__cards">
 				{ promoCards.map( ( card ) => (

--- a/client/dev-tools-promo/components/dev-tools-promo.tsx
+++ b/client/dev-tools-promo/components/dev-tools-promo.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import CardHeading from 'calypso/components/card-heading';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import isAutomatedTransferActive from 'calypso/state/automated-transfer/selectors/is-automated-transfer-active';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -15,6 +15,7 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
+import { initiateAtomicTransfer } from 'calypso/state/atomic/transfers/actions';
 
 type PromoCardProps = {
 	title: string;
@@ -88,9 +89,9 @@ const DevToolsPromo = () => {
 	const showHostingActivationButton = canSiteGoAtomic;
 
 	const backUrl = `/hosting-config/${ siteSlug }`;
-
+	const dispatch = useDispatch();
 	const transferInitiate = ( { geo_affinity = '' } ) => {
-		initiateThemeTransfer( siteId as number, null, '', geo_affinity, 'hosting' );
+		dispatch( initiateThemeTransfer( siteId as number, null, '', geo_affinity, 'hosting' ) );
 		// page( `/setup/transferring-hosted-site/processing?siteId=${ siteId }` );
 	};
 
@@ -137,6 +138,7 @@ const DevToolsPromo = () => {
 								onProceed={ transferInitiate }
 								backUrl={ backUrl }
 								showDataCenterPicker
+								standaloneProceed
 							/>
 						</Dialog>
 					</>

--- a/client/dev-tools-promo/components/dev-tools-promo.tsx
+++ b/client/dev-tools-promo/components/dev-tools-promo.tsx
@@ -75,10 +75,10 @@ const DevToolsPromo = () => {
 	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
 	const hasSftpFeature = useSelector( ( state ) => siteHasFeature( state, siteId, FEATURE_SFTP ) );
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
-	const hasTransfer = useSelector( ( state ) =>
-		isAutomatedTransferActive( state, siteId as number )
+	const hasTransfer = useSelector(
+		( state ) => isAutomatedTransferActive( state, siteId as number ) ?? false
 	);
-	const showHostingActivationButton = canSiteGoAtomic && ! hasTransfer;
+	const showHostingActivationButton = canSiteGoAtomic;
 
 	return (
 		<div className="dev-tools-promo">
@@ -98,7 +98,12 @@ const DevToolsPromo = () => {
 						  ) }
 				</p>
 				{ showHostingActivationButton ? (
-					<Button variant="primary" className="dev-tools-promo__button" href={ upgradeLink }>
+					<Button
+						variant="primary"
+						className="dev-tools-promo__button"
+						href={ upgradeLink }
+						disabled={ hasTransfer }
+					>
 						{ translate( 'Activate now' ) }
 					</Button>
 				) : (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7348

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
