### PR TITLE
Domains: Remove WPCOM upsells in Gravatar flow checkout thank-you page

### DIFF
--- a/client/components/thank-you-v2/index.tsx
+++ b/client/components/thank-you-v2/index.tsx
@@ -13,10 +13,12 @@ interface ThankYouV2Props {
 	products?: React.ReactElement | React.ReactElement[];
 	footerDetails?: ThankYouFooterDetailProps[];
 	upsellProps?: ThankYouUpsellProps;
+	isGravatarDomain?: boolean;
 }
 
 export default function ThankYouV2( props: ThankYouV2Props ) {
-	const { title, subtitle, headerButtons, products, footerDetails, upsellProps } = props;
+	const { title, subtitle, headerButtons, products, footerDetails, upsellProps, isGravatarDomain } =
+		props;
 
 	return (
 		<div className="thank-you">
@@ -26,9 +28,9 @@ export default function ThankYouV2( props: ThankYouV2Props ) {
 
 			{ products && <div className="thank-you__products">{ products }</div> }
 
-			{ footerDetails && <ThankYouFooter details={ footerDetails } /> }
+			{ footerDetails && ! isGravatarDomain && <ThankYouFooter details={ footerDetails } /> }
 
-			{ upsellProps && <ThankYouUpsell { ...upsellProps } /> }
+			{ upsellProps && ! isGravatarDomain && <ThankYouUpsell { ...upsellProps } /> }
 		</div>
 	);
 }

--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -35,6 +35,7 @@ const allowedKeys = [
 	'use_fallback_for_incomplete_languages',
 	'is_google_domain_owner',
 	'had_hosting_trial',
+	'gravatar_domain',
 ];
 const requiredKeys = [ 'ID' ];
 const decodedKeys = [ 'display_name', 'description', 'user_URL' ];

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -46,4 +46,5 @@ export type OptionalUserData = {
 	atomic_visible_site_count?: number;
 	is_google_domain_owner: boolean;
 	had_hosting_trial: boolean;
+	gravatar_domain: string;
 };

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -549,7 +549,13 @@ export class CheckoutThankYou extends Component<
 					/>
 				);
 			} else if ( isOnlyDomainPurchases( purchases ) ) {
-				pageContent = <DomainOnlyThankYou purchases={ purchases } receiptId={ receiptId } />;
+				pageContent = (
+					<DomainOnlyThankYou
+						purchases={ purchases }
+						receiptId={ receiptId }
+						gravatarDomain={ this.props.user?.gravatar_domain }
+					/>
+				);
 			} else if ( purchases.length === 1 && isPlan( purchases[ 0 ] ) ) {
 				pageContent = (
 					<PlanOnlyThankYou

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
@@ -62,14 +62,20 @@ function UpsellActions( {
 interface DomainOnlyThankYouProps {
 	purchases: ReceiptPurchase[];
 	receiptId: number;
+	gravatarDomain: string | undefined;
 }
 
-export default function DomainOnlyThankYou( { purchases, receiptId }: DomainOnlyThankYouProps ) {
+export default function DomainOnlyThankYou( {
+	purchases,
+	receiptId,
+	gravatarDomain,
+}: DomainOnlyThankYouProps ) {
 	const translate = useTranslate();
 	const [ , predicate ] = getDomainPurchaseTypeAndPredicate( purchases );
 	const domainPurchases = purchases.filter( predicate );
 	const domainNames = domainPurchases.map( ( purchase ) => purchase?.meta );
 	const domainOnlySite = useSelector( ( state ) => getSite( state, domainPurchases[ 0 ]?.blogId ) );
+	const isGravatarDomain = domainNames.length === 1 && gravatarDomain === domainNames[ 0 ];
 
 	const upsellProps: ThankYouUpsellProps = {
 		title: translate( 'Professional email' ),
@@ -101,6 +107,7 @@ export default function DomainOnlyThankYou( { purchases, receiptId }: DomainOnly
 				key={ `domain-${ purchase.meta }` }
 				siteSlug={ domainOnlySite?.slug }
 				isDomainOnly
+				isGravatarDomain={ isGravatarDomain }
 			/>
 		);
 	} );
@@ -121,6 +128,7 @@ export default function DomainOnlyThankYou( { purchases, receiptId }: DomainOnly
 				products={ products }
 				footerDetails={ getDomainFooterDetails( 'domain-only' ) }
 				upsellProps={ upsellProps }
+				isGravatarDomain={ isGravatarDomain }
 			/>
 		</>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -64,6 +64,12 @@ export default function ThankYouDomainProduct( {
 
 	if ( purchase && isDomainTransfer( purchase ) ) {
 		actions = <DomainTransferSection purchase={ purchase } currency={ currency ?? 'USD' } />;
+	} else if ( isGravatarDomain ) {
+		actions = (
+			<Button variant="primary" href="https://gravatar.com/profile">
+				{ translate( 'Manage domain at Gravatar' ) }
+			</Button>
+		);
 	} else if ( purchase?.blogId && siteSlug ) {
 		const createSiteHref = siteSlug && createSiteFromDomainOnly( siteSlug, purchase.blogId );
 		const createSiteProps = createSiteHref ? { href: createSiteHref } : { disabled: true };
@@ -84,15 +90,6 @@ export default function ThankYouDomainProduct( {
 				</Button>
 			</>
 		);
-
-		if ( isGravatarDomain ) {
-			manageDomainProps.href = 'https://gravatar.com/profile';
-			actions = (
-				<Button variant="primary" { ...manageDomainProps }>
-					{ translate( 'Manage domain at Gravatar' ) }
-				</Button>
-			);
-		}
 	} else {
 		actions = (
 			<Button variant={ isDomainOnly ? 'secondary' : 'primary' } href={ domainManagementRoot() }>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -40,6 +40,7 @@ type ThankYouDomainProductProps = {
 	isDomainOnly?: boolean;
 	siteSlug?: string | null;
 	currency?: string;
+	isGravatarDomain?: boolean;
 };
 
 export default function ThankYouDomainProduct( {
@@ -48,6 +49,7 @@ export default function ThankYouDomainProduct( {
 	isDomainOnly,
 	siteSlug,
 	currency,
+	isGravatarDomain,
 }: ThankYouDomainProductProps ) {
 	const translate = useTranslate();
 
@@ -82,6 +84,15 @@ export default function ThankYouDomainProduct( {
 				</Button>
 			</>
 		);
+
+		if ( isGravatarDomain ) {
+			manageDomainProps.href = 'https://gravatar.com/profile';
+			actions = (
+				<Button variant="primary" { ...manageDomainProps }>
+					{ translate( 'Manage domain at Gravatar' ) }
+				</Button>
+			);
+		}
 	} else {
 		actions = (
 			<Button variant={ isDomainOnly ? 'secondary' : 'primary' } href={ domainManagementRoot() }>


### PR DESCRIPTION
Related to #90414

## Proposed Changes

Depends on D149674-code.

This PR removes the WPCOM specific upsells from the checkout thank-you page when a domain for Gravatar is bought. It also replaces the CTA buttons to only one that reads "Manage domain at Gravatar", which takes the user to `https://gravatar.com/profile`.

### Screenshots

| Before | After |
| --- | --- |
| <img width="755" alt="Screenshot 2024-05-22 at 20 31 38" src="https://github.com/Automattic/wp-calypso/assets/5324818/cb08dfc5-57e3-4cdc-b228-7f44cba7aa70"> | <img width="738" alt="Screenshot 2024-05-22 at 20 31 20" src="https://github.com/Automattic/wp-calypso/assets/5324818/2b962fbc-653c-40ff-831d-8d665547f305"> |

## Why are these changes being made?

This is part of the Custom Domains on Gravatar project (pcYYhz-24z-p2).

## Testing Instructions

- Apply D149674-code to your sandbox and follow the test instructions there
- Open the live Calypso link or build this branch locally
- Navigate to the thank you page for the receipt of a Gravatar domain purchase (e.g. `/checkout/thank-you/no-site/93520523`)
- Ensure there are no WPCOM specific upsells or actions (create a site, support links, email)
- Ensure that the thank you page for other receipts look correct with the usual WPCOM specific upsells

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?