### PR TITLE
E2E test fix Jetpack forms AI + like comments

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -40,15 +40,15 @@ export class FormAiFlow implements BlockFlow {
 		let aiInputParentLocator: Locator;
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 			// On mobile, it's attached to the editor block toolbar, which is apart from the block DOM.
-			aiInputParentLocator = await context.editorPage.getEditorCanvas();
+			aiInputParentLocator = await context.editorPage.getEditorParent();
 		} else {
 			// On desktop, it's within the block DOM node.
 			aiInputParentLocator = context.addedBlockLocator;
 		}
 
-		const aiInputReadyLocator = aiInputParentLocator.getByRole( 'textbox', {
-			name: 'Ask Jetpack AI to create your form',
-		} );
+		const aiInputReadyLocator = aiInputParentLocator.getByPlaceholder(
+			'Ask Jetpack AI to create your form'
+		);
 		const aiInputBusyLocator = aiInputParentLocator.getByRole( 'textbox', {
 			name: 'Creating your form. Please wait a few moments.',
 			disabled: true,

--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -87,6 +87,9 @@ export class CommentsComponent {
 		}
 
 		await this.page.getByText( comment ).scrollIntoViewIfNeeded();
+		// The first click opens a window to auto-log-in, the second click likes the comment.
+		await likeButton.waitFor();
+		await likeButton.click();
 		await likeButton.waitFor();
 		await likeButton.click();
 		await likedStatus.waitFor();

--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -87,12 +87,14 @@ export class CommentsComponent {
 		}
 
 		await this.page.getByText( comment ).scrollIntoViewIfNeeded();
-		// The first click opens a window to auto-log-in, the second click likes the comment.
 		await likeButton.waitFor();
 		await likeButton.click();
-		await this.page.waitForTimeout( 5 * 1000 );
-		await likeButton.waitFor();
-		await likeButton.click();
+		// On Atomic, we add a second click since the first one opens a window to log-in the user.
+		if ( envVariables.TEST_ON_ATOMIC ) {
+			await this.page.waitForTimeout( 5 * 1000 );
+			await likeButton.waitFor();
+			await likeButton.click();
+		}
 		await likedStatus.waitFor();
 	}
 

--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -90,6 +90,7 @@ export class CommentsComponent {
 		// The first click opens a window to auto-log-in, the second click likes the comment.
 		await likeButton.waitFor();
 		await likeButton.click();
+		await this.page.waitForTimeout( 5 * 1000 );
 		await likeButton.waitFor();
 		await likeButton.click();
 		await likedStatus.waitFor();


### PR DESCRIPTION
## Proposed Changes

Checking E2E test for Gutenberg 18.4.0 release, we found two failing tests:
- `specs/published-content/likes__comment.ts` fails liking a comment
I found the like button opens a window on first click to validate the user. I added a second click to like the comment.
- `specs/blocks/blocks__jetpack-forms.ts` fails on AI form input for mobile

#### TO DO
- ~~Fix `specs/blocks/blocks__media.ts` > `Blocks: Media (Upload) › Populate post with media blocks › VideoPress block: upload video file`~~ < Flaky

## Testing Instructions

* Run `TEST_ON_ATOMIC=true GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test -- specs/published-content/likes__comment.ts`
* Run `TEST_ON_ATOMIC=true GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test -- specs/blocks/blocks__jetpack-forms.ts`
