### PR TITLE
GSV: Fix Colour Scheme Not Reverting to User's Choice

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -278,15 +278,13 @@ class Layout extends Component {
 
 		if ( typeof document !== 'undefined' ) {
 			const classList = document.querySelector( 'body' ).classList;
-
-			// We only want to apply the `modern` color scheme when the global sidebar is visible
 			const globalColorScheme = 'modern';
 
 			if ( this.props.isGlobalSidebarVisible ) {
-				// Remove the color scheme in case it was set before
+				// Force the global color scheme when the global sidebar is visible.
 				nextColorScheme = globalColorScheme;
 			} else {
-				// Revert to user's color scheme when the global sidebar is gone
+				// Revert back to user's color scheme when the global sidebar is gone.
 				prevColorScheme = globalColorScheme;
 			}
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -280,10 +280,14 @@ class Layout extends Component {
 			const classList = document.querySelector( 'body' ).classList;
 
 			// We only want to apply the `modern` color scheme when the global sidebar is visible
-			if ( this.props.isGlobalSidebarVisible && nextColorScheme !== 'modern' ) {
+			const globalColorScheme = 'modern';
+
+			if ( this.props.isGlobalSidebarVisible ) {
 				// Remove the color scheme in case it was set before
-				classList.remove( `is-${ nextColorScheme }` );
-				nextColorScheme = 'modern';
+				nextColorScheme = globalColorScheme;
+			} else {
+				// Revert to user's color scheme when the global sidebar is gone
+				prevColorScheme = globalColorScheme;
 			}
 
 			classList.remove( `is-${ prevColorScheme }` );


### PR DESCRIPTION
## Proposed Changes

This fixes the Global Site View from not reverting to the user's selected colour scheme choice after they've switched back to an individual site view. 

## Why are these changes being made?

Bug fix - it was intended for the Modern scheme to only be forced in GSV. See #90158. 

## Testing Instructions

1. Set your colour scheme under Me > Account Settings to any scheme other than Modern
2. Go to an individual site
3. Switch sites to enter GSV 
4. Confirm that it switches to Modern
5. Switch back to an individual site view (eg. clicking "My Home" after selecting a site) 

Currently, after step five, the colour scheme remains Modern. This PR should switch it back to whatever scheme you were previously using. If that was already Modern, then it should stay the same. 

cc @eoigal, @davemart-in, @Addison-Stavlo 