### PR TITLE
A4A > Referrals: Redesign the Payment Settings & FAQ page

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section/style.scss
@@ -33,6 +33,9 @@
 	}
 }
 
-.referrals-layout--automated .step-section .step-section__header .step-section__step-heading {
-	font-size: rem(16px);
+.referrals-layout--automated,
+.commission-overview__layout-automated {
+	.step-section .step-section__header .step-section__step-heading {
+		font-size: rem(16px);
+	}
 }

--- a/client/a8c-for-agencies/sections/referrals/controller.tsx
+++ b/client/a8c-for-agencies/sections/referrals/controller.tsx
@@ -54,7 +54,7 @@ export const referralsPaymentSettingsContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Referrals > Payment Settings" path={ context.path } />
-			<div>Payment Settings</div>
+			<ReferralsBankDetails isAutomatedReferral />
 		</>
 	);
 	context.secondary = <ReferralsSidebar path={ context.path } />;
@@ -65,7 +65,7 @@ export const referralsFAQContext: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker title="Referrals > FAQ" path={ context.path } />
-			<div>FAQ</div>
+			<CommissionOverview isAutomatedReferral />
 		</>
 	);
 	context.secondary = <ReferralsSidebar path={ context.path } />;

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -1,3 +1,5 @@
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useLayoutEffect, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -13,12 +15,23 @@ import useGetTipaltiIFrameURL from '../../hooks/use-get-tipalti-iframe-url';
 
 import './style.scss';
 
-export default function ReferralsBankDetails() {
+export default function ReferralsBankDetails( {
+	isAutomatedReferral = false,
+}: {
+	isAutomatedReferral?: boolean;
+} ) {
 	const translate = useTranslate();
+	const isDesktop = useDesktopBreakpoint();
 
 	const [ iFrameHeight, setIFrameHeight ] = useState( '100%' );
 
-	const title = translate( 'Add bank details' );
+	const automatedReferralTitle = isDesktop
+		? translate( 'Your referrals and commissions: Set up secure payments' )
+		: translate( 'Payment Settings' );
+
+	const title = isAutomatedReferral
+		? automatedReferralTitle
+		: translate( 'Referrals: Add bank details' );
 
 	const { data, isFetching } = useGetTipaltiIFrameURL();
 
@@ -39,17 +52,29 @@ export default function ReferralsBankDetails() {
 	}, [] );
 
 	return (
-		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+		<Layout
+			className={ classNames( 'bank-details__layout', {
+				'bank-details__layout--automated': isAutomatedReferral,
+			} ) }
+			title={ title }
+			wide
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+		>
 			<LayoutTop>
 				<LayoutHeader>
 					<Breadcrumb
 						items={ [
 							{
-								label: translate( 'Referrals' ),
+								label:
+									isAutomatedReferral && isDesktop
+										? translate( 'Your referrals and commissions' )
+										: translate( 'Referrals' ),
 								href: A4A_REFERRALS_LINK,
 							},
 							{
-								label: title,
+								label: isAutomatedReferral
+									? translate( 'Set up secure payments' )
+									: translate( 'Add bank details' ),
 							},
 						] }
 					/>
@@ -57,13 +82,39 @@ export default function ReferralsBankDetails() {
 			</LayoutTop>
 
 			<LayoutBody>
-				<div className="bank-details__iframe-container">
-					{ isFetching ? (
-						<TextPlaceholder />
-					) : (
-						<iframe width="100%" height={ iFrameHeight } src={ iFrameSrc } title={ title } />
+				<>
+					{ isAutomatedReferral && (
+						<>
+							<div className="bank-details__heading">
+								{ translate( 'Connect your bank to receive payments' ) }
+							</div>
+							<div className="bank-details__subheading">
+								{ translate(
+									'Enter your bank details to start receiving payments through {{a}}Tipalti ↗{{/a}}, our secure payments platform.',
+									{
+										components: {
+											a: (
+												<a
+													className="referrals-overview__link"
+													href="https://tipalti.com/"
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									}
+								) }
+							</div>
+						</>
 					) }
-				</div>
+					<div className="bank-details__iframe-container">
+						{ isFetching ? (
+							<TextPlaceholder />
+						) : (
+							<iframe width="100%" height={ iFrameHeight } src={ iFrameSrc } title={ title } />
+						) }
+					</div>
+				</>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -1,9 +1,48 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+$iframe-background-color: #f7f7f7;
+
 .bank-details__iframe-container {
 	margin-block-start: 24px;
-	height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
+	min-height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
+	height: 100%; // Setting the height to 100% to make sure the iFrame is always visible
 
 	.a4a-text-placeholder {
 		display: block;
+		min-height: calc(100vh - 182px); // Take the full height & hide the scrollbar on the main page
 		height: 100%;
+	}
+}
+
+.bank-details__layout.main.a4a-layout {
+	height: 100%; // Setting the height to 100% to make sure the iFrame is always visible
+
+	@include breakpoint-deprecated( ">660px" ) {
+		height: calc(100vh - 32px);
+	}
+
+	.a4a-layout__body {
+		background-color: $iframe-background-color;
+	}
+}
+
+.bank-details__heading {
+	padding-block: 8px;
+	font-size: rem(24px);
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.bank-details__subheading {
+	font-size: rem(16px);
+	line-height: 1.5;
+	color: var(--color-neutral-60);
+}
+
+.bank-details__layout--automated {
+	.a4a-layout__top-wrapper {
+		padding-block-start: 24px;
+		padding-block-end: 0;
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -1,4 +1,6 @@
 import { FoldableCard } from '@automattic/components';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
@@ -17,14 +19,27 @@ import ReferralsFooter from '../footer';
 
 import './style.scss';
 
-export default function CommissionOverview() {
+export default function CommissionOverview( {
+	isAutomatedReferral,
+}: {
+	isAutomatedReferral?: boolean;
+} ) {
 	const translate = useTranslate();
+	const isDesktop = useDesktopBreakpoint();
 
-	const title = translate( 'Referrals - Commission details and terms' );
+	const automatedReferralTitle = isDesktop
+		? translate( 'Your referrals and commissions - FAQ' )
+		: translate( 'FAQ' );
+
+	const title = isAutomatedReferral
+		? automatedReferralTitle
+		: translate( 'Referrals - Commission details and terms' );
 
 	return (
 		<Layout
-			className="commission-overview"
+			className={ classNames( 'commission-overview', {
+				'commission-overview__layout-automated': isAutomatedReferral,
+			} ) }
 			title={ title }
 			wide
 			sidebarNavigation={ <MobileSidebarNavigation /> }
@@ -33,14 +48,36 @@ export default function CommissionOverview() {
 				<LayoutHeader>
 					<Breadcrumb
 						items={ [
-							{ label: translate( 'Referrals' ), href: A4A_REFERRALS_LINK },
-							{ label: translate( 'Commission details and terms' ) },
+							{
+								label:
+									isAutomatedReferral && isDesktop
+										? translate( 'Your referrals and commissions' )
+										: translate( 'Referrals' ),
+								href: A4A_REFERRALS_LINK,
+							},
+							{
+								label: isAutomatedReferral
+									? translate( 'FAQ' )
+									: translate( 'Commission details and terms' ),
+							},
 						] }
 					/>
 				</LayoutHeader>
 			</LayoutTop>
 
 			<LayoutBody>
+				{ isAutomatedReferral && (
+					<>
+						<div className="commission-overview__section-heading">
+							{ translate( 'Referrals and commissions Frequently Asked Questions (FAQ)' ) }
+						</div>
+						<div className="commission-overview__section-subtitle">
+							{ translate(
+								'A list of frequently asked questions and answers related to referrals and commissions.'
+							) }
+						</div>
+					</>
+				) }
 				<div className="commission-overview__section-container">
 					<StepSection heading={ translate( 'How much can I earn?' ) }>
 						<FoldableCard

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
@@ -54,3 +54,29 @@
 		padding: 0 24px 24px;
 	}
 }
+
+.commission-overview__layout-automated {
+	.a4a-layout__top-wrapper {
+		padding-block: 24px 0;
+	}
+
+	.commission-overview .commission-overview__section-container {
+		margin-block: 24px 0;
+	}
+}
+
+.commission-overview__section-heading {
+	font-size: rem(24px);
+	margin-block-end: 8px;
+	font-weight: 600;
+}
+.commission-overview__section-subtitle {
+	font-size: rem(14px);
+	font-weight: 400;
+	color: var(--color-neutral-50);
+}
+
+.a4a-overview-hosting__wp-logo {
+	fill: var(--color-primary-50);
+	margin: 0;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/354
Resolves https://github.com/Automattic/jetpack-genesis/issues/365

## Proposed Changes

This PR redesigns the Payment Settings & FAQ page for Automated Referrals

[Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)

NOTE: 

- We have reused the existing component since we will get rid of the old UI very soon.

## Testing Instructions

1. Open the A4A live link.
2. Append the /referrals URL as /referrals?flags=-a4a-automated-referrals, and verify that the above changes are not reflected and that the Referrals page matches the production.
3. Remove the feature flag > Go to  Referrals - Payment Settings & Verify the UI looks like below

<img width="1388" alt="Screenshot 2024-05-23 at 11 15 55 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/01ac14f1-8609-4d0a-866a-de8ad619ee8e">

<img width="424" alt="Screenshot 2024-05-23 at 11 14 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3ba4f1ea-51f2-44dc-b6c5-3232520308d9">

4.  Go to  Referrals - FAQ & Verify the UI looks like below

<img width="1388" alt="Screenshot 2024-05-23 at 11 16 05 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9c375e88-6fd3-40c5-8d1c-deeb469e1a8b">

<img width="424" alt="Screenshot 2024-05-23 at 11 14 27 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c4f6cca0-b5d1-49d6-af9a-9473e5a872f8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
