### PR TITLE
Nav redesign: don't collapse global sidebar when navigating to My Home (pt 2)

### DIFF
--- a/client/layout/global-sidebar/menu-items/menu-item.tsx
+++ b/client/layout/global-sidebar/menu-items/menu-item.tsx
@@ -49,7 +49,8 @@ const SidebarMenuItem = forwardRef< HTMLButtonElement | HTMLAnchorElement, Props
 			return getShouldShowGlobalSiteSidebar(
 				state,
 				selectedSiteId,
-				currentSection !== false ? currentSection?.group ?? '' : ''
+				currentSection !== false ? currentSection?.group ?? '' : '',
+				currentSection !== false ? currentSection?.name ?? '' : ''
 			);
 		} );
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -490,16 +490,23 @@ export default withCurrentRoute(
 		const isWooCoreProfilerFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
 			isWooCommerceCoreProfilerFlow( state );
-		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+			state,
+			siteId,
+			sectionGroup,
+			sectionName
+		);
 		const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 			state,
 			siteId,
-			sectionGroup
+			sectionGroup,
+			sectionName
 		);
 		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 			state,
 			siteId,
-			sectionGroup
+			sectionGroup,
+			sectionName
 		);
 		const noMasterbarForRoute =
 			isJetpackLogin ||

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -779,6 +779,7 @@ class MasterbarLoggedIn extends Component {
 export default connect(
 	( state ) => {
 		const sectionGroup = getSectionGroup( state );
+		const sectionName = getSectionName( state );
 
 		// Falls back to using the user's primary site if no site has been selected
 		// by the user yet
@@ -793,17 +794,20 @@ export default connect(
 		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
 			state,
 			currentSelectedSiteId,
-			sectionGroup
+			sectionGroup,
+			sectionName
 		);
 		const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
 			state,
 			currentSelectedSiteId,
-			sectionGroup
+			sectionGroup,
+			sectionName
 		);
 		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 			state,
 			currentSelectedSiteId,
-			sectionGroup
+			sectionGroup,
+			sectionName
 		);
 		const isDesktop = isWithinBreakpoint( '>782px' );
 		return {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -230,8 +230,14 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
+			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+				state,
+				siteId,
+				sectionGroup,
+				sectionName
+			);
 			return {
 				currentUser: getCurrentUser( state ),
 				shouldShowGlobalSidebar,

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -109,18 +109,26 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
+			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
 			const siteDomain = getSiteDomain( state, siteId );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+				state,
+				siteId,
+				sectionGroup,
+				sectionName
+			);
 			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
 				state,
 				siteId,
-				sectionGroup
+				sectionGroup,
+				sectionName
 			);
 			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
 				state,
 				siteId,
-				sectionGroup
+				sectionGroup,
+				sectionName
 			);
 			return {
 				siteDomain,

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -234,7 +234,8 @@ export function scheduledUpdatesMultisite( context, next ) {
 	const isSidebarCollapsed = getShouldShowCollapsedGlobalSidebar(
 		state,
 		undefined,
-		context.section.group
+		context.section.group,
+		context.section.name
 	);
 
 	context.secondary = <PluginsSidebar path={ context.path } isCollapsed={ isSidebarCollapsed } />;

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -37,7 +37,12 @@ const useSiteMenuItems = () => {
 	const isAllDomainsView = '/domains/manage' === currentRoute;
 	const { currentSection } = useCurrentRoute();
 	const shouldShowGlobalSidebar = useSelector( ( state ) => {
-		return getShouldShowGlobalSidebar( state, selectedSiteId, currentSection?.group );
+		return getShouldShowGlobalSidebar(
+			state,
+			selectedSiteId,
+			currentSection?.group,
+			currentSection?.name
+		);
 	} );
 	useEffect( () => {
 		if ( selectedSiteId && siteDomain ) {

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -11,7 +11,12 @@ export function notifications( context, next ) {
 	const basePath = sectionify( context.path );
 	const mcKey = 'notifications';
 	const state = context.store.getState();
-	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, null, 'reader' );
+	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+		state,
+		null,
+		'reader',
+		'notifications'
+	);
 
 	trackPageLoad( basePath, 'Reader > Notifications', mcKey );
 	recordTrack(

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -334,8 +334,14 @@ export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
+			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+				state,
+				siteId,
+				sectionGroup,
+				sectionName
+			);
 			return {
 				isListsOpen: isListsOpen( state ),
 				isTagsOpen: isTagsOpen( state ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/90986#pullrequestreview-2072695304

## Proposed Changes

This PR fixes a regression introduced by https://github.com/Automattic/wp-calypso/pull/90986. It turns out, `sectionName` is still required for determining the global sidebar states...

This PR reverts the removal of `sectionName`s from the logic and then amends the logic in `shouldShowGlobalSiteDashboard()` to prevent the double sidebar issue mentioned above.

## Why are these changes being made?

It fixes a regression.

## Testing Instructions

1. Retest the cases in https://github.com/Automattic/wp-calypso/pull/90986.
2. Test the case mentioned in https://github.com/Automattic/wp-calypso/pull/90986#pullrequestreview-2072695304 (clicking My Home from the site management panel), and verify that the transition to My Home is smooth without double sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
