### PR TITLE
Entrepreneur Signup: Use stepper's getLoginUrl(). Fix broken signup_flow_name when creating account.

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -95,11 +95,16 @@ class PasswordlessSignupForm extends Component {
 
 		const { oauth2_client_id, oauth2_redirect, ref } = queryArgs;
 
+		// I'm not sure why passwordless signup form stopped respecting flowName from variationName param,
+		// see https://github.com/Automattic/wp-calypso/pull/67225 for more details.
+		// I'm going to add a temporary hack for entrepreneur flow.
+		const signup_flow_name = queryArgs.variationName === 'entrepreneur' ? 'entrepreneur' : flowName;
+
 		try {
 			const response = await wpcom.req.post( '/users/new', {
 				email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
 				is_passwordless: true,
-				signup_flow_name: flowName,
+				signup_flow_name: signup_flow_name,
 				validate: false,
 				locale: getLocaleSlug(),
 				client_id: config( 'wpcom_signup_id' ),

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -4,11 +4,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useState } from 'react';
 import { anonIdCache } from 'calypso/data/segmentaton-survey';
-import { login } from 'calypso/lib/paths';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useFlowLocale } from '../hooks/use-flow-locale';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
@@ -59,10 +59,10 @@ const entrepreneurFlow: Flow = {
 				}
 			);
 
-			const loginUrl = login( {
-				locale,
+			const loginUrl = getLoginUrl( {
+				variationName: flowName,
 				redirectTo,
-				oauth2ClientId: queryParams.get( 'client_id' ) || undefined,
+				locale,
 			} );
 
 			return loginUrl;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Use stepper's `getLoginUrl()`. In the previous PR https://github.com/Automattic/wp-calypso/pull/90984, I switched over to the generic `loginUrl()`. IMO, we should be using stepper's `getLoginUrl()` for consistency with other signup flows, and it has specific props such as `variantName`.

* This `variantName` is supposed to be used as `signup_flow_name` when creating an account (as explained in this PR https://github.com/Automattic/wp-calypso/pull/67225). However, when the passwordless signup flow was introduced, the `variantName` was no longer respected.

* As I do not want to impact other flows, I am going to add a temporary condition that determines if we're on entrepreneur signup, we will set the `signup_flow_name` manually when calling the user creation API.

* The `signup_flow_name` value is used to determine where to redirect user to when activating the user, as it has been a prior practice from before. This will be addressed in a separate WPCOM patch.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* User creation and activation flow on Entrepreneur flow is not redirecting to the correct page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open up incognito window.
* Open up the network panel.
* Go to `/setup/entrepreneur`.
* Register for a new user while creating the signup flow.
* Look for the API endpoint related to `/user/new`.
* Check for the `signup_flow_name` value.
* You may combine testing this with D149708-code for the email verification part.

<img width="1259" alt="2024-05-23_18-05-40" src="https://github.com/Automattic/wp-calypso/assets/1287077/9d635cc7-0d04-45b6-aeea-ebb9750c6559">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?