### PR TITLE
Fix Jetpack Cloud monetize upsell for simple sites

### DIFF
--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -22,6 +22,7 @@ import FormButton from 'calypso/components/forms/form-button';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { WordAdsStatus } from 'calypso/my-sites/earn/ads/types';
+import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useDispatch, useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSiteWordadsStatus from 'calypso/state/selectors/get-site-wordads-status';
@@ -210,7 +211,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	};
 
 	const renderUpsell = () => {
-		const bannerURL = `/checkout/${ siteSlug }/premium`;
+		const bannerURL = buildCheckoutURL( siteSlug as string, PLAN_PREMIUM );
 		const plan = getPlan( PLAN_PREMIUM ) as Plan;
 		const jetpackFeatures = plan?.get2023PricingGridSignupJetpackFeatures?.();
 		const jetpackFeaturesObject = getPlanFeaturesObject( jetpackFeatures );
@@ -242,7 +243,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 				list={ [
 					translate( 'Instantly enroll into the WordAds network.' ),
 					translate( 'Earn money from your content and traffic.' ),
-					...jetpackFeaturesObject.map( ( feature ) => feature.getSlug() ),
+					...jetpackFeaturesObject.map( ( feature ) => feature.getTitle() ),
 				] }
 			/>
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7334

## Proposed Changes

* Render the feature name for the slug

| Calypso  | Jetpack Cloud |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/620c4e05-5327-4b9a-9dc5-a5fd193ce071">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/51ff8ba7-a904-42a5-8366-5992861b71d3">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Upsell on Jetpack Cloud showed the slugs instead of Feature names
* The Upgrade button in Jetpack Cloud directs to a not found page
![image](https://github.com/Automattic/wp-calypso/assets/6586048/52444e31-e4f7-4268-a667-d77a6565edd5)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On a site lower than the Explorer plan:
* Jetpack: `yarn start-jetpack-cloud` Calypso: you can use the live link
* Calypso: Go to `/earn/ads-earnings/:site`
* Jetpack: Go to `/monetize/ads-earnings/:site`
* Check the copy and make sure the Upgrade button puts the Explorer plan in the checkout cart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
