### PR TITLE
Wrap the headerText in Stepper in a translate call

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/user/index.tsx
@@ -1,4 +1,5 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
 import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social-first';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -14,6 +15,7 @@ const StepContent: Step = ( { flow, stepName, navigation } ) => {
 	const { submit } = navigation;
 	const socialService = getSocialServiceFromClientId( '' );
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const translate = useTranslate();
 
 	if ( isLoggedIn ) {
 		submit?.();
@@ -21,7 +23,7 @@ const StepContent: Step = ( { flow, stepName, navigation } ) => {
 
 	return (
 		<>
-			<FormattedHeader align="center" headerText="Create your account" brandFont />
+			<FormattedHeader align="center" headerText={ translate( 'Create your account' ) } brandFont />
 			<SignupFormSocialFirst
 				step={ {} }
 				stepName={ stepName }


### PR DESCRIPTION
## Proposed Changes

* Wrap the "Create your account" text in FormattedHeader component in Stepper in translate call to display the translations

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* International users expect to see the UI in their language

Before:
<img width="399" alt="Screenshot 2024-05-23 at 23 25 30" src="https://github.com/Automattic/wp-calypso/assets/7847633/52e3cf35-6306-4c69-a007-2b818210a13f">
After:
<img width="399" alt="Screenshot 2024-05-23 at 23 25 12" src="https://github.com/Automattic/wp-calypso/assets/7847633/119bce27-311d-40e2-b6db-07ac4c2b7f30">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using local Calypso or calypso.live go to /setup/new-hosted-site-user-included/user/ja?flags=onboarding/user-on-stepper-hosting and confirm that "Create your account" header is localized.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
