### PR TITLE
Reduced Jetpack connection short check from 2 minutes to 15 seconds

### DIFF
--- a/client/state/jetpack-connection-health/selectors/should-request-jetpack-connection-health-status.js
+++ b/client/state/jetpack-connection-health/selectors/should-request-jetpack-connection-health-status.js
@@ -4,7 +4,7 @@ import getJetpackConnectionHealth from './get-jetpack-connection-health';
 import isJetpackConnectionProblem from './is-jetpack-connection-problem';
 
 export const STALE_CONNECTION_HEALTH_THRESHOLD = 1000 * 60 * 5; // 5 minutes
-export const STALE_CONNECTION_HEALTH_THRESHOLD_SHORT = 1000 * 60 * 2; // 2 minutes
+export const STALE_CONNECTION_HEALTH_THRESHOLD_SHORT = 1000 * 15; // 15 seconds
 
 /**
  * Returns true if the current site Jetpack site connection health status should be requested


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/90758#issuecomment-2125404916

Diff related: D149747-code

## Proposed Changes

* We're reducing the time check for broken Jetpack connections

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users are reaching HE with a broken Jetpack warning, although it's already fixed by Jetpack itself.


## How to test?

- Apply this diff and follow its test steps: D149747-code


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?