### PR TITLE
Centralise logic for calypso_customer_home_card_impression avoid null cards

### DIFF
--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -1,28 +1,33 @@
 import classnames from 'classnames';
 import { createElement, useEffect, useRef } from 'react';
-import { connect } from 'react-redux';
 import DotPager from 'calypso/components/dot-pager';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import {
 	PRIMARY_CARD_COMPONENTS,
 	isUrgentCard,
 } from 'calypso/my-sites/customer-home/locations/card-components';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import trackMyHomeCardImpression, {
+	CardLocation,
+} from 'calypso/my-sites/customer-home/track-my-home-card-impression';
 
-const Primary = ( { cards, trackCard } ) => {
+const Primary = ( { cards } ) => {
 	const viewedCards = useRef( new Set() );
 
 	const handlePageSelected = ( index ) => {
+		if ( ! cards || ! cards.length || ! cards[ index ] ) {
+			return;
+		}
+
 		const selectedCard = cards && cards[ index ];
 		if ( viewedCards.current.has( selectedCard ) ) {
 			return;
 		}
 
 		viewedCards.current.add( selectedCard );
-		trackCard( selectedCard );
+		trackMyHomeCardImpression( { card: selectedCard, location: CardLocation.PRIMARY } );
 	};
 
-	useEffect( () => handlePageSelected( 0 ) );
+	useEffect( () => handlePageSelected( 0 ), [ cards ] );
 
 	if ( ! cards || ! cards.length ) {
 		return null;
@@ -56,13 +61,4 @@ const Primary = ( { cards, trackCard } ) => {
 	);
 };
 
-const trackCardImpression = ( card ) => {
-	return composeAnalytics(
-		recordTracksEvent( 'calypso_customer_home_card_impression', { card } ),
-		bumpStat( 'calypso_customer_home_card_impression', card )
-	);
-};
-
-export default withPerformanceTrackerStop(
-	connect( null, { trackCard: trackCardImpression } )( Primary )
-);
+export default withPerformanceTrackerStop( Primary );

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -9,6 +9,9 @@ import {
 	CARD_COMPONENTS,
 	PRIMARY_CARD_COMPONENTS,
 } from 'calypso/my-sites/customer-home/locations/card-components';
+import trackMyHomeCardImpression, {
+	CardLocation,
+} from 'calypso/my-sites/customer-home/track-my-home-card-impression';
 
 const getAdditionalPropsForCard = ( { card, siteId } ) => {
 	if ( card === SECTION_BLOGGING_PROMPT || card === SECTION_BLOGANUARY_BLOGGING_PROMPT ) {
@@ -41,21 +44,34 @@ const SecondaryCard = ( { card, siteId } ) => {
 	return null;
 };
 
-const Secondary = ( { cards, siteId } ) => {
+const Secondary = ( { cards, siteId, trackFirstCardAsPrimary = false } ) => {
 	if ( ! cards || ! cards.length ) {
 		return null;
 	}
+
+	let shouldTrackCardAsPrimary = trackFirstCardAsPrimary;
+
+	const trackMyHomeCardImpressionWithFlexibleLocation = ( card ) => {
+		const location = shouldTrackCardAsPrimary ? CardLocation.PRIMARY : CardLocation.SECONDARY;
+		shouldTrackCardAsPrimary = false;
+
+		trackMyHomeCardImpression( { card, location } );
+	};
 
 	return (
 		<>
 			{ cards.map( ( card, index ) => {
 				if ( Array.isArray( card ) && card.length > 0 ) {
+					const trackInnerCardImpression = ( innerCardIndex ) =>
+						trackMyHomeCardImpressionWithFlexibleLocation( card[ innerCardIndex ] );
+
 					return (
 						<DotPager
 							key={ 'my_home_secondary_pager_' + index }
 							className="secondary__customer-home-location-content"
 							showControlLabels="true"
 							hasDynamicHeight
+							onPageSelected={ trackInnerCardImpression }
 						>
 							{ card.map( ( innerCard, innerIndex ) => {
 								return (
@@ -69,6 +85,8 @@ const Secondary = ( { cards, siteId } ) => {
 						</DotPager>
 					);
 				}
+
+				trackMyHomeCardImpressionWithFlexibleLocation( card );
 
 				return (
 					<SecondaryCard

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -1,4 +1,4 @@
-import { createElement } from 'react';
+import { createElement, useEffect } from 'react';
 import DotPager from 'calypso/components/dot-pager';
 import {
 	SECTION_BLOGGING_PROMPT,
@@ -45,10 +45,6 @@ const SecondaryCard = ( { card, siteId } ) => {
 };
 
 const Secondary = ( { cards, siteId, trackFirstCardAsPrimary = false } ) => {
-	if ( ! cards || ! cards.length ) {
-		return null;
-	}
-
 	let shouldTrackCardAsPrimary = trackFirstCardAsPrimary;
 
 	const trackMyHomeCardImpressionWithFlexibleLocation = ( card ) => {
@@ -57,6 +53,24 @@ const Secondary = ( { cards, siteId, trackFirstCardAsPrimary = false } ) => {
 
 		trackMyHomeCardImpression( { card, location } );
 	};
+
+	useEffect( () => {
+		if ( ! cards || ! cards.length ) {
+			return;
+		}
+
+		cards.forEach( ( card ) => {
+			if ( Array.isArray( card ) && card.length > 0 ) {
+				return;
+			}
+
+			trackMyHomeCardImpressionWithFlexibleLocation( card );
+		} );
+	}, [ cards ] );
+
+	if ( ! cards || ! cards.length ) {
+		return null;
+	}
 
 	return (
 		<>
@@ -85,8 +99,6 @@ const Secondary = ( { cards, siteId, trackFirstCardAsPrimary = false } ) => {
 						</DotPager>
 					);
 				}
-
-				trackMyHomeCardImpressionWithFlexibleLocation( card );
 
 				return (
 					<SecondaryCard

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { createElement, useRef, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import DotPager from 'calypso/components/dot-pager';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import {
@@ -25,7 +25,9 @@ import RespondToCustomerFeedback from 'calypso/my-sites/customer-home/cards/educ
 import SiteEditorQuickStart from 'calypso/my-sites/customer-home/cards/education/site-editor-quick-start';
 import EducationStore from 'calypso/my-sites/customer-home/cards/education/store';
 import WpCourses from 'calypso/my-sites/customer-home/cards/education/wpcourses';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import trackMyHomeCardImpression, {
+	CardLocation,
+} from 'calypso/my-sites/customer-home/track-my-home-card-impression';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const cardComponents = {
@@ -42,7 +44,6 @@ const cardComponents = {
 
 const LearnGrow = () => {
 	const cards = useLearnGrowCards();
-	const dispatch = useDispatch();
 	const viewedCards = useRef( new Set() );
 
 	const handlePageSelected = ( index ) => {
@@ -52,7 +53,7 @@ const LearnGrow = () => {
 		}
 
 		viewedCards.current.add( selectedCard );
-		dispatch( trackCardImpression( selectedCard ) );
+		trackMyHomeCardImpression( { card: selectedCard, location: CardLocation.SECONDARY } );
 	};
 
 	useEffect( () => handlePageSelected( 0 ) );
@@ -95,13 +96,6 @@ function useLearnGrowCards() {
 
 	// Remove cards we don't know how to deal with on the client-side
 	return allCards.filter( ( card ) => !! cardComponents[ card ] );
-}
-
-function trackCardImpression( card ) {
-	return composeAnalytics(
-		recordTracksEvent( 'calypso_customer_home_card_impression', { card } ),
-		bumpStat( 'calypso_customer_home_card_impression', card )
-	);
 }
 
 export default LearnGrow;

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -1,5 +1,5 @@
 import { createElement, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import QuickLinks from 'calypso/my-sites/customer-home/cards/actions/quick-links';
 import QuickLinksForEcommerceSites from 'calypso/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites';
@@ -23,7 +23,9 @@ import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-searc
 import QuickStart from 'calypso/my-sites/customer-home/cards/features/quick-start';
 import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import trackMyHomeCardImpression, {
+	CardLocation,
+} from 'calypso/my-sites/customer-home/track-my-home-card-impression';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const cardComponents = {
@@ -41,13 +43,12 @@ const cardComponents = {
 
 const ManageSite = () => {
 	const cards = useManageSiteCards();
-	const dispatch = useDispatch();
 
 	useEffect( () => {
 		if ( cards && cards.length ) {
-			dispatch( trackCardImpressions( cards ) );
+			trackCardImpressions( cards );
 		}
-	}, [ cards, dispatch ] );
+	}, [ cards ] );
 
 	if ( ! cards || ! cards.length ) {
 		return null;
@@ -74,14 +75,12 @@ function useManageSiteCards() {
 }
 
 function trackCardImpressions( cards ) {
-	const analyticsEvents = cards.reduce( ( events, card ) => {
-		return [
-			...events,
-			recordTracksEvent( 'calypso_customer_home_card_impression', { card } ),
-			bumpStat( 'calypso_customer_home_card_impression', card ),
-		];
-	}, [] );
-	return composeAnalytics( ...analyticsEvents );
+	if ( ! cards || ! cards.length ) {
+		return;
+	}
+	cards.forEach( ( card ) => {
+		trackMyHomeCardImpression( { card, location: CardLocation.TERTIARY } );
+	} );
 }
 
 export default ManageSite;

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -130,6 +130,12 @@ const Home = ( {
 		}
 	}, [ emailDnsDiagnostics ] );
 
+	const isFirstSecondaryCardInPrimaryLocation =
+		Array.isArray( layout?.primary ) &&
+		layout.primary.length === 0 &&
+		Array.isArray( layout?.secondary ) &&
+		layout.secondary.length > 0;
+
 	if ( ! canUserUseCustomerHome ) {
 		const title = translate( 'This page is not available on this site.' );
 		return (
@@ -280,7 +286,11 @@ const Home = ( {
 					<Primary cards={ layout?.primary } />
 					<div className="customer-home__layout">
 						<div className="customer-home__layout-col customer-home__layout-col-left">
-							<Secondary cards={ layout?.secondary } siteId={ siteId } />
+							<Secondary
+								cards={ layout?.secondary }
+								siteId={ siteId }
+								trackFirstCardAsPrimary={ isFirstSecondaryCardInPrimaryLocation }
+							/>
 						</div>
 						<div className="customer-home__layout-col customer-home__layout-col-right">
 							<Tertiary cards={ layout?.tertiary } />

--- a/client/my-sites/customer-home/track-my-home-card-impression.ts
+++ b/client/my-sites/customer-home/track-my-home-card-impression.ts
@@ -1,0 +1,25 @@
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+export enum CardLocation {
+	PRIMARY = 'primary',
+	SECONDARY = 'secondary',
+	TERTIARY = 'tertiary',
+}
+
+type MyHomeCardImpressionProps = {
+	card: string;
+	location: CardLocation;
+};
+
+export default function trackMyHomeCardImpression( {
+	card,
+	location,
+}: MyHomeCardImpressionProps ): void {
+	if ( ! card ) {
+		return;
+	}
+
+	recordTracksEvent( 'calypso_customer_home_card_impression', { card, location } );
+	bumpStat( 'customer_home_card_impression', card );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* While looking at Tracks events being triggered from My Home, I realised that we are logging `null` for the `card` event prop in cases where we're using the two-column layout we added for the Launchpad in My Home.
* This PR centralises the logging code into a new `trackMyHomeCardImpression()` helper function that supports a `location` value, and refactors the existing code that tracked these impressions to call the new function

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I noticed that we're logging thousands of non-events, so we ought to stop doing that.
* It also looked like our tracking for secondary cards was inconsistent, so I wanted to make sure we have visibility into which cards are being rendered
* I also realised that it would be valuable to know where a card was rendered, not only that it was rendered somewhere in My Home.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Ensure you can view Tracks events in your browser
* Navigate to My Home for sites in different states, especially sites with different intents or that are showing the launchpad in My Home for other reasons
* Verify that you see a number of `calypso_customer_home_card_impression` Tracks events, where every event includes both a `card` and a `location` property.
* Also verify that we're not triggering multiple events for any card and location pairs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
