### PR TITLE
Update triggerGuidesForStep function for Migration Flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -90,7 +90,7 @@ const siteMigration: Flow = {
 
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
-		const { siteSlug, siteId } = useSiteData();
+		const { siteId } = useSiteData();
 		const variantSlug = this.variantSlug;
 		const flowPath = variantSlug ?? flowName;
 		const siteCount =
@@ -111,8 +111,8 @@ const siteMigration: Flow = {
 
 		// Call triggerGuidesForStep for the current step
 		useEffect( () => {
-			triggerGuidesForStep( flowName, currentStep, siteSlug, siteId );
-		}, [ flowName, currentStep, siteSlug, siteId ] );
+			triggerGuidesForStep( flowName, currentStep, siteId );
+		}, [ flowName, currentStep, siteId ] );
 
 		// TODO - We may need to add `...params: string[]` back once we start adding more steps.
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {

--- a/client/lib/guides/trigger-guides-for-step.ts
+++ b/client/lib/guides/trigger-guides-for-step.ts
@@ -7,20 +7,8 @@ import wpcom from 'calypso/lib/wp';
 const previousRequests = new Set< string >();
 
 // trigger guides on step movement, we don't care about failures or response
-export function triggerGuidesForStep(
-	flowName: string,
-	stepName?: string,
-	siteSlug?: string,
-	siteId?: number
-) {
-	const key =
-		flowName +
-		':' +
-		( stepName || '' ) +
-		':' +
-		( siteSlug || 'no-site' ) +
-		':' +
-		( siteId || 'no-id' );
+export function triggerGuidesForStep( flowName: string, stepName?: string, siteId?: number ) {
+	const key = flowName + ':' + ( stepName || '' ) + ':' + ( siteId || 'no-id' );
 	if ( previousRequests.has( key ) ) {
 		return;
 	}
@@ -34,7 +22,6 @@ export function triggerGuidesForStep(
 			{
 				flow: flowName,
 				step: stepName,
-				siteSlug: siteSlug,
 				siteId: siteId,
 			}
 		)


### PR DESCRIPTION
## Proposed Changes

Updated the triggerGuidesForStep function on step change in the Migration flow to remove siteSlug.

## Testing Instructions

- Go to `/setup/site-migration`
- You may be redirected to start/domains. Select "Choose domain later"
- Go through the flow to select Free plan
- When you get to "What are your goals?"
- Open the browser network log.
- Select "Import Existing Content or Website"
- When you get to setup/site-migration confirm that a network request is sent to `guides/trigger` endpoint. Confirm the `flow`, `step`, and `siteId` matches your workflow.

<img width="632" alt="CleanShot 2024-05-23 at 09 49 35@2x" src="https://github.com/Automattic/wp-calypso/assets/135139690/626464c9-56cf-480b-8c56-21892f394e00">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
