### PR TITLE
Site Profiler: Update text class names

### DIFF
--- a/client/site-profiler/components/domain-section/index.tsx
+++ b/client/site-profiler/components/domain-section/index.tsx
@@ -30,11 +30,11 @@ export const DomainSection: React.FC< DomainSectionProps > = ( props ) => {
 			title={
 				isWPcom
 					? translate(
-							"Your domain {{success}}set up is excelent{{/success}}, contributing positively to your site's visibility and growth.",
+							"Your domain {{good}}set up is excelent{{/good}}, contributing positively to your site's visibility and growth.",
 							getTitleTranslateOptions()
 					  )
 					: translate(
-							"Your domain {{success}}set up is good{{/success}}, but you could boost your site's visibility and growth.",
+							"Your domain {{good}}set up is good{{/good}}, but you could boost your site's visibility and growth.",
 							getTitleTranslateOptions()
 					  )
 			}

--- a/client/site-profiler/components/hosting-section/index.tsx
+++ b/client/site-profiler/components/hosting-section/index.tsx
@@ -23,11 +23,11 @@ export const HostingSection: React.FC< HostingSectionProps > = ( props ) => {
 			title={
 				isWPcom
 					? translate(
-							'Your hosting {{success}}speed and uptime{{/success}} is excellent, providing a reliable and enjoyable user experience.',
+							'Your hosting {{good}}speed and uptime{{/good}} is excellent, providing a reliable and enjoyable user experience.',
 							getTitleTranslateOptions()
 					  )
 					: translate(
-							'Struggles with hosting {{alert}}speed and uptime{{/alert}} deter visitors. A switch to WordPress.com could transform the user experience.',
+							'Struggles with hosting {{poor}}speed and uptime{{/poor}} deter visitors. A switch to WordPress.com could transform the user experience.',
 							getTitleTranslateOptions()
 					  )
 			}

--- a/client/site-profiler/components/metrics-section/index.tsx
+++ b/client/site-profiler/components/metrics-section/index.tsx
@@ -40,14 +40,14 @@ const Title = styled.div`
 		line-height: 100%;
 		letter-spacing: -1.5px;
 
-		&.success {
+		&.good {
 			background: linear-gradient( 270deg, #349f4b 49.73%, #3858e9 100% );
 			background-clip: text;
 			-webkit-background-clip: text;
 			-webkit-text-fill-color: transparent;
 		}
 
-		&.alert {
+		&.poor {
 			background: linear-gradient( 270deg, #d63638 10.23%, #5200ff 100% );
 			background-clip: text;
 			-webkit-background-clip: text;

--- a/client/site-profiler/utils/get-title-translate-options.tsx
+++ b/client/site-profiler/utils/get-title-translate-options.tsx
@@ -3,8 +3,8 @@ import { TranslateOptions } from 'i18n-calypso';
 export const getTitleTranslateOptions = (): TranslateOptions => {
 	return {
 		components: {
-			success: <span className="success" />,
-			alert: <span className="alert" />,
+			good: <span className="good" />,
+			poor: <span className="poor" />,
 		},
 	};
 };


### PR DESCRIPTION
## Proposed Changes

Update the class names from `success` and `alert` to `good` and `poor`.

## Why are these changes being made?

To match with the `Score` type already in use.

## Testing Instructions

No differences on the text or highlighted parts should be seen from production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?