### PR TITLE
Command palette: switch site fallback

### DIFF
--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -125,9 +125,11 @@ export function useCommands() {
 					let path;
 					if ( params.currentRoute.startsWith( '/wp-admin' ) ) {
 						path = `/switch-site?route=${ encodeURIComponent( params.currentRoute ) }`;
-					} else {
+					} else if ( params.currentRoute.includes( ':site' ) ) {
 						// On a global page, navigate to the dashboard, otherwise keep current route.
-						path = params.currentRoute.includes( ':site' ) ? params.currentRoute : '/home/:site';
+						path = params.currentRoute;
+					} else {
+						path = siteUsesWpAdminInterface( params.site ) ? '/wp-admin' : '/home/:site';
 					}
 					return commandNavigation( path )( params );
 				},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Make the 'Switch site' command use the correct UI when switching sites on global pages (e.g. /sites or the reader). It'll now use either wp-admin or calypso as appropriate rather than assuming Calypso.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To respect the users preferences and to be in greater alignment with the "Open site dashboard" command.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a site that prefers wp-admin and a site that prefers calypso
2. Use the calypso live link to go to /sites and open the command palette
3. Switch to the calypso-preferring site using the Switch site command and notice you end up on /home/:site
4. Switch to /sites
5. Switch to the wp-admin preferring site using the Switch site command and notice you end up in :site/wp-admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
