### PR TITLE
Sidebar notices: Improve layout on mobile viewports

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -560,12 +560,6 @@ $font-size: rem(14px);
 
 	/* stylelint-disable-next-line no-duplicate-selectors */
 	.is-unified-site-sidebar-visible {
-		.current-site__notices {
-			max-width: 220px;
-			margin-left: auto;
-			margin-right: auto;
-		}
-
 		.upsell-nudge.banner.card.is-compact {
 			margin-top: 0;
 			padding: 8px;
@@ -1113,6 +1107,16 @@ $font-size: rem(14px);
 		.is-unified-site-sidebar-visible {
 			.upsell-nudge.banner.card.is-compact {
 				margin-top: 8px;
+
+				.banner__content {
+					flex-direction: row;
+					flex-wrap: nowrap;
+				}
+
+				.banner__info,
+				.banner__action {
+					width: auto;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7318

## Proposed Changes

Adjusts the layout of the sidebar notices on classic sites for mobile viewports.

Before | After
--- | ---
<img width="504" alt="Screenshot 2024-05-23 at 16 24 48" src="https://github.com/Automattic/wp-calypso/assets/1233880/97bff313-c122-4299-86dd-7f2145914747"> | <img width="547" alt="Screenshot 2024-05-23 at 16 24 34" src="https://github.com/Automattic/wp-calypso/assets/1233880/e28e0d86-8771-4743-88e1-ddc80a1c174a">


## Why are these changes being made?

To improve the overall look & feel.

## Testing Instructions

- Use the Calypso live link below
- Switch to a classic site
- Resize your browser to use a mobile viewport
- Open the sidebar
- Make sure the sidebar notices are full width now with the CTA placed on the right.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
