### PR TITLE
Entrepreneur plan: Translate `Create your store` string (post-checkout thank-you page)

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -104,7 +104,7 @@ const PlanOnlyThankYou = ( {
 			subtitle = translate( "With the plan sorted, it's time to start setting up your store." );
 			headerButtons = typeof siteAdminUrl === 'string' && (
 				<Button href={ siteAdminUrl } primary>
-					Create your store
+					{ translate( 'Create your store' ) }
 				</Button>
 			);
 		} else {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7403.

## Proposed Changes

* add missing translation call to the `Create your store` string

| Before | After |
|--------|--------|
| ![Markup on 2024-05-23 at 16:46:51](https://github.com/Automattic/wp-calypso/assets/25105483/ccbfd9d6-12de-4810-8561-1b8da85cc7d3) | ![Markup on 2024-05-23 at 16:47:24](https://github.com/Automattic/wp-calypso/assets/25105483/8f8f9a93-c6f0-465c-97c4-7f74e7b60327) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* due to a bug: the button label is not displaying translated

## Testing Instructions

1. Set your WordPress.com account to a non-English locale.
2. Create a Simple site and upgrade it to the Entrepreneur plan.
3. When finishing the checkout, pause at the thank-you page.
4. The `Create your store` button label should be loaded in the WordPress.com account's locale.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?