### PR TITLE
Adding translation for Blaze Credit UX

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -132,7 +132,8 @@ const BlazePressStrings = () => {
 	translate( 'Search for locations' );
 	translate( 'You won’t be charged until the ad is approved and starts running.' );
 	translate( 'You can pause spending at any time.' );
-	translate( 'If you have Blaze credits in your account, the credits will be used first before charging your card. If the Blaze Credit balance does not cover the entire order, any outstanding balance will be taken from your provided card.' );
+	translate( 'If you have Blaze Credit in your account, the credits will be used first before charging your card.' );
+	translate( 'If the Blaze Credit balance does not cover the entire order, any outstanding balance will be taken from your provided card.' );
 	translate( 'Could not retrieve countries. Please try again later.' );
 	translate( 'Error submitting payment. Please check payment information.' );
 	translate(
@@ -177,7 +178,7 @@ const BlazePressStrings = () => {
 	translate( 'Summary' );
 	translate( 'Preview' );
 	translate( 'Depending on the platform, the ad may look different from the preview.' );
-	translate( 'Credits will be automatically applied to your order when available. Any outstanding balance will be charged to your provided card.' );
+	translate( 'Any outstanding balance will be charged to your provided card.' );
 	translate( 'Estimated Impressions' );
 	translate( 'Max Budget' );
 	translate( 'Languages' );

--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -132,6 +132,7 @@ const BlazePressStrings = () => {
 	translate( 'Search for locations' );
 	translate( 'You won’t be charged until the ad is approved and starts running.' );
 	translate( 'You can pause spending at any time.' );
+	translate( 'If you have Blaze credits in your account, the credits will be used first before charging your card. If the Blaze Credit balance does not cover the entire order, any outstanding balance will be taken from your provided card.' );
 	translate( 'Could not retrieve countries. Please try again later.' );
 	translate( 'Error submitting payment. Please check payment information.' );
 	translate(
@@ -176,6 +177,7 @@ const BlazePressStrings = () => {
 	translate( 'Summary' );
 	translate( 'Preview' );
 	translate( 'Depending on the platform, the ad may look different from the preview.' );
+	translate( 'Credits will be automatically applied to your order when available. Any outstanding balance will be charged to your provided card.' );
 	translate( 'Estimated Impressions' );
 	translate( 'Max Budget' );
 	translate( 'Languages' );

--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -132,8 +132,12 @@ const BlazePressStrings = () => {
 	translate( 'Search for locations' );
 	translate( 'You won’t be charged until the ad is approved and starts running.' );
 	translate( 'You can pause spending at any time.' );
-	translate( 'If you have Blaze Credit in your account, the credits will be used first before charging your card.' );
-	translate( 'If the Blaze Credit balance does not cover the entire order, any outstanding balance will be taken from your provided card.' );
+	translate(
+		'If you have Blaze Credit in your account, the credits will be used first before charging your card.'
+	);
+	translate(
+		'If the Blaze Credit balance does not cover the entire order, any outstanding balance will be taken from your provided card.'
+	);
 	translate( 'Could not retrieve countries. Please try again later.' );
 	translate( 'Error submitting payment. Please check payment information.' );
 	translate(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/4564116/19f9720e-830b-4074-a0dd-af9fe1e0a4a4)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
