### PR TITLE
`DomainsTableFilters`: Set the same active style as the one on the sites page

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -170,6 +170,12 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				transition: none;
 			}
 
+			.search-component.domains-table-filter__search.is-open.has-focus {
+				border-color: var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
+				box-shadow: 0 0 0 0.5px
+					var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
+			}
+
 			@media only screen and ( min-width: 782px ) {
 				.is-global-sidebar-visible {
 					header.navigation-header {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/91057

## Proposed Changes

* Adjust the styles of the search field on the domains page so it looks like the one on the sites page.

## Testing Instructions

* Open the live preview
* Go to `/sites` and `/domains/manage`, check that the style of the search field when it's active looks the same

|Before|After|
|---|---|
|![image](https://github.com/Automattic/wp-calypso/assets/8511199/05d5e236-e621-4e73-91e0-b16a825af3e1) ![image](https://github.com/Automattic/wp-calypso/assets/8511199/dbbb99aa-97c1-442e-88d9-13fbb3901be1)|![image](https://github.com/Automattic/wp-calypso/assets/8511199/c6715708-872c-4f24-a378-71d5ed14931c) ![image](https://github.com/Automattic/wp-calypso/assets/8511199/5eeb42ef-9c85-4053-8905-259a142119b7)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
