### PR TITLE
Domains: Remove WPCOM upsells in Gravatar flow checkout thank-you page (alternative)

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -553,7 +553,7 @@ export class CheckoutThankYou extends Component<
 					<DomainOnlyThankYou
 						purchases={ purchases }
 						receiptId={ receiptId }
-						isGravatarDomain={ false }
+						isGravatarDomain={ false } // TODO: Replace by the correct value
 					/>
 				);
 			} else if ( purchases.length === 1 && isPlan( purchases[ 0 ] ) ) {

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -553,7 +553,7 @@ export class CheckoutThankYou extends Component<
 					<DomainOnlyThankYou
 						purchases={ purchases }
 						receiptId={ receiptId }
-						isGravatarDomain={ false } // TODO: Replace by the correct value
+						isGravatarDomain={ !! this.props.receipt.data?.isGravatarDomain }
 					/>
 				);
 			} else if ( purchases.length === 1 && isPlan( purchases[ 0 ] ) ) {

--- a/client/my-sites/checkout/src/lib/normalize-transaction-response.ts
+++ b/client/my-sites/checkout/src/lib/normalize-transaction-response.ts
@@ -14,6 +14,7 @@ const emptyResponse: WPCOMTransactionEndpointResponseFailed = {
 	price_integer: 0,
 	price_float: 0,
 	currency: 'USD',
+	is_gravatar_domain: false,
 };
 
 export default function normalizeTransactionResponse(

--- a/client/state/receipts/assembler.ts
+++ b/client/state/receipts/assembler.ts
@@ -40,6 +40,7 @@ export function createReceiptObject(
 		currency: data.currency,
 		priceInteger: data.price_integer,
 		priceFloat: data.price_float,
+		isGravatarDomain: Boolean( data.is_gravatar_domain ),
 		purchases: purchases.map( ( purchase ) => {
 			return {
 				delayedProvisioning: Boolean( purchase.delayed_provisioning ),

--- a/client/state/receipts/test/assembler.ts
+++ b/client/state/receipts/test/assembler.ts
@@ -10,6 +10,7 @@ const rawReceiptEndpointReceipt: RawReceiptData = {
 	price_float: 100,
 	price_integer: 10000,
 	currency: 'USD',
+	is_gravatar_domain: false,
 	purchases: [
 		{
 			user_email: '',
@@ -72,6 +73,7 @@ const standardAssembledReceipt: ReceiptData = {
 	failedPurchases: [],
 	priceFloat: 100,
 	priceInteger: 10000,
+	isGravatarDomain: false,
 	purchases: [
 		{
 			delayedProvisioning: false,

--- a/client/state/receipts/types.ts
+++ b/client/state/receipts/types.ts
@@ -36,6 +36,7 @@ export interface RawReceiptData {
 	price_integer: number;
 	currency: string;
 	purchases: Purchase[] | undefined | false;
+	is_gravatar_domain: boolean;
 }
 
 export interface ReceiptData {
@@ -46,6 +47,7 @@ export interface ReceiptData {
 	priceInteger: number;
 	purchases: ReceiptPurchase[];
 	failedPurchases: FailedReceiptPurchase[];
+	isGravatarDomain: boolean;
 }
 
 export interface ReceiptState {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -16,6 +16,7 @@ export type WPCOMTransactionEndpointResponseSuccess = {
 	price_integer: number;
 	price_float: number;
 	currency: string;
+	is_gravatar_domain: boolean;
 };
 
 export type WPCOMTransactionEndpointResponseFailed = {
@@ -31,6 +32,7 @@ export type WPCOMTransactionEndpointResponseFailed = {
 	price_integer: number;
 	price_float: number;
 	currency: string;
+	is_gravatar_domain: boolean;
 };
 
 export type WPCOMTransactionEndpointResponseRedirect = {


### PR DESCRIPTION
Related to #90414

## Proposed Changes

Depends on D149807-code.

This PR removes the WPCOM specific upsells from the checkout thank-you page when a domain for Gravatar is bought. It also replaces the CTA buttons to only one that reads "Manage domain at Gravatar", which takes the user to `https://gravatar.com/profile`.

### Screenshots

| Before | After |
| --- | --- |
| <img width="755" alt="Screenshot 2024-05-22 at 20 31 38" src="https://github.com/Automattic/wp-calypso/assets/5324818/cb08dfc5-57e3-4cdc-b228-7f44cba7aa70"> | <img width="738" alt="Screenshot 2024-05-22 at 20 31 20" src="https://github.com/Automattic/wp-calypso/assets/5324818/2b962fbc-653c-40ff-831d-8d665547f305"> |

## Why are these changes being made?

This is part of the Custom Domains on Gravatar project (pcYYhz-24z-p2).

## Testing Instructions

- Apply D149807-code to your sandbox
- Open the live Calypso link or build this branch locally
- Navigate to the thank you page for the receipt of a Gravatar domain purchase (e.g. `/checkout/thank-you/no-site/93520523`)
- Ensure no WPCOM CTAs are shown
- Open the thank-you page for any other domain-only purchase receipt and ensure the usual WPCOM CTAs are shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?