### PR TITLE
A4A: Add Woo label on licenses that are for WooCommerce products.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -161,7 +161,16 @@ export default function LicensePreview( {
 				} ) }
 			>
 				<div>
-					<span className="license-preview__product">{ productTitle }</span>
+					<span className="license-preview__product">
+						{ licenseKey.startsWith( 'woocommerce-' ) && (
+							<span>
+								<Badge className="license-preview__product-woo-badge" type="info">
+									{ translate( 'Woo' ) }
+								</Badge>
+							</span>
+						) }
+						{ productTitle }
+					</span>
 				</div>
 
 				<div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -103,6 +103,12 @@
 			display: inline;
 		}
 	}
+
+	&-woo-badge {
+		background: #7f54b3;
+		color: var(--studio-white);
+		margin-right: 0.5rem;
+	}
 }
 
 .license-preview__label {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
