### PR TITLE
Checkout: Show "your subscription will last until" promo period text for renewal

### DIFF
--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -88,7 +88,8 @@ function getMessageForTermsOfServiceRecordUnknown(
 	const manageSubscriptionLink = `/purchases/subscriptions/${ siteSlug }`;
 
 	if ( doesTermsOfServiceRecordHaveDates( args ) ) {
-		const endDate = formatDate( args.subscription_end_of_promotion_date );
+		const promotionEndDate = formatDate( args.subscription_end_of_promotion_date );
+		const subscriptionEndDate = formatDate( args.subscription_expiry_date );
 		const numberOfDays = args.subscription_pre_renew_reminder_days || 7;
 		const renewalDate = formatDate( args.subscription_auto_renew_date );
 		const proratedRenewalDate = formatDate(
@@ -101,7 +102,16 @@ function getMessageForTermsOfServiceRecordUnknown(
 				args: {
 					productName,
 					startDate,
-					endDate,
+					endDate: promotionEndDate,
+				},
+			}
+		);
+		const renewalTermLengthText = translate(
+			'After you renew today, your %(productName)s subscription will last until %(endDate)s.',
+			{
+				args: {
+					productName,
+					endDate: subscriptionEndDate,
 				},
 			}
 		);
@@ -186,9 +196,12 @@ function getMessageForTermsOfServiceRecordUnknown(
 			return true;
 		} )();
 
+		const shouldShowRenewalTermText =
+			args.is_renewal && args.remaining_promotional_auto_renewals === 0;
+
 		return (
 			<>
-				{ termLengthText } { nextRenewalText }{ ' ' }
+				{ shouldShowRenewalTermText ? renewalTermLengthText : termLengthText } { nextRenewalText }{ ' ' }
 				{ shouldShowEndOfPromotionText && endOfPromotionChargeText }{ ' ' }
 				{ shouldShowRegularPriceNoticeText && regularPriceNoticeText } { taxesNotIncludedText }{ ' ' }
 				{ emailNoticesText }{ ' ' }

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -1,11 +1,12 @@
 import { formatCurrency } from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import {
 	TermsOfServiceRecord,
 	TermsOfServiceRecordArgsRenewal,
 	useShoppingCart,
 } from '@automattic/shopping-cart';
 import { EDIT_PAYMENT_DETAILS } from '@automattic/urls';
+import { hasTranslation } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
@@ -67,6 +68,7 @@ function MessageForTermsOfServiceRecordUnknown( {
 	currency: string;
 } ): ReactNode {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 	const args = termsOfServiceRecord.args;
 	if ( ! args ) {
 		return null;
@@ -111,6 +113,11 @@ function MessageForTermsOfServiceRecordUnknown( {
 				},
 			}
 		);
+		const isRenewalTermLengthTextTranslated =
+			isEnglishLocale ||
+			hasTranslation(
+				'After you renew today, your %(productName)s subscription will last until %(endDate)s.'
+			);
 		const renewalTermLengthText = translate(
 			'After you renew today, your %(productName)s subscription will last until %(endDate)s.',
 			{
@@ -202,7 +209,9 @@ function MessageForTermsOfServiceRecordUnknown( {
 		} )();
 
 		const shouldShowRenewalTermText =
-			args.is_renewal && args.remaining_promotional_auto_renewals === 0;
+			isRenewalTermLengthTextTranslated &&
+			args.is_renewal &&
+			args.remaining_promotional_auto_renewals === 0;
 
 		return (
 			<>

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -7,7 +7,8 @@ import {
 } from '@automattic/shopping-cart';
 import { EDIT_PAYMENT_DETAILS } from '@automattic/urls';
 import debugFactory from 'debug';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode } from 'react';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector } from 'calypso/state';
@@ -16,7 +17,6 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 const debug = debugFactory( 'calypso:composite-checkout:additional-terms-of-service' );
 
 export default function AdditionalTermsOfServiceInCart() {
-	const translate = useTranslate();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -28,11 +28,12 @@ export default function AdditionalTermsOfServiceInCart() {
 	return (
 		<>
 			{ responseCart.terms_of_service.map( ( termsOfServiceRecord ) => {
-				const message = getMessageForTermsOfServiceRecord(
-					termsOfServiceRecord,
-					translate,
-					siteSlug,
-					responseCart.currency
+				const message = (
+					<MessageForTermsOfServiceRecord
+						termsOfServiceRecord={ termsOfServiceRecord }
+						siteSlug={ siteSlug }
+						currency={ responseCart.currency }
+					/>
 				);
 
 				if ( ! message ) {
@@ -56,15 +57,19 @@ function formatDate( isoDate: string ): string {
 	} );
 }
 
-function getMessageForTermsOfServiceRecordUnknown(
-	termsOfServiceRecord: TermsOfServiceRecord,
-	translate: ReturnType< typeof useTranslate >,
-	siteSlug: string | null,
-	currency: string
-): TranslateResult {
+function MessageForTermsOfServiceRecordUnknown( {
+	termsOfServiceRecord,
+	siteSlug,
+	currency,
+}: {
+	termsOfServiceRecord: TermsOfServiceRecord;
+	siteSlug: string | null;
+	currency: string;
+} ): ReactNode {
+	const translate = useTranslate();
 	const args = termsOfServiceRecord.args;
 	if ( ! args ) {
-		return '';
+		return null;
 	}
 
 	const productName = args.product_name + ( args.product_meta ? ` (${ args.product_meta })` : '' );
@@ -224,26 +229,30 @@ function getMessageForTermsOfServiceRecordUnknown(
 	);
 }
 
-function getMessageForTermsOfServiceRecord(
-	termsOfServiceRecord: TermsOfServiceRecord,
-	translate: ReturnType< typeof useTranslate >,
-	siteSlug: string | null,
-	currency: string
-): TranslateResult {
+function MessageForTermsOfServiceRecord( {
+	termsOfServiceRecord,
+	siteSlug,
+	currency,
+}: {
+	termsOfServiceRecord: TermsOfServiceRecord;
+	siteSlug: string | null;
+	currency: string;
+} ) {
 	switch ( termsOfServiceRecord.code ) {
 		case 'terms_for_bundled_trial_unknown_payment_method':
-			return getMessageForTermsOfServiceRecordUnknown(
-				termsOfServiceRecord,
-				translate,
-				siteSlug,
-				currency
+			return (
+				<MessageForTermsOfServiceRecordUnknown
+					termsOfServiceRecord={ termsOfServiceRecord }
+					siteSlug={ siteSlug }
+					currency={ currency }
+				/>
 			);
 		default:
 			debug(
 				`Unknown terms of service code: ${ termsOfServiceRecord.code }`,
 				termsOfServiceRecord
 			);
-			return '';
+			return null;
 	}
 }
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -830,6 +830,20 @@ export interface TermsOfServiceRecordArgsBase {
 	 * This price is an integer in the currency's smallest unit.
 	 */
 	maybe_prorated_regular_renewal_price_integer: number;
+
+	/**
+	 * True if the product in the cart which has these terms is a manual renewal
+	 * (as opposed to a new purchase or a quantity upgrade).
+	 */
+	is_renewal: boolean;
+
+	/**
+	 * The number of auto-renewals after the current purchase completes which
+	 * will be affected by the promotional pricing. If the product is affected by
+	 * a prorated introductory offer, then the auto-renewal where the user will
+	 * be charged the prorated price is not counted by this number.
+	 */
+	remaining_promotional_auto_renewals: number;
 }
 
 export interface TermsOfServiceRecordArgsRenewal extends TermsOfServiceRecordArgsBase {


### PR DESCRIPTION
## Proposed Changes

When you renew a subscription that has an introductory offer and the price for the current checkout does not match the price for the next auto-renewal, we show "promotional period" text at the bottom of checkout. The text explains the predicted prices and dates of the upcoming auto-renewals.

However, it begins with the text "Your promotional period lasts from X to Y". For a manual renewal of a 3 month prorated introductory offer, we currently show a 3 month time window starting with the original subscription date and the former end date. This might be confusing in the case of the renewal because the renewal is going to change the "end" date, probably to today. All the other information in that text is explaining what will happen _after_ the current cart is purchased, but for a renewal, those dates represent the state before the purchase.

In this PR we replace that text with different text that reads "After you renew today, your subscription will last until X" if the current cart is a renewal and the next auto-renewal will not persist the introductory offer.

Before             |  After
:-------------------------:|:-------------------------:
<img width="571" alt="Screenshot 2024-05-23 at 4 57 53 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/3ca4c5e3-0706-4109-93c8-a5b3eccab932"> | <img width="557" alt="Screenshot 2024-05-23 at 4 58 46 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/7eaac32c-0c2f-401e-9885-980e17d2b935">

Requires D149834-code

Fixes https://github.com/Automattic/payments-shilling/issues/2791

## Testing Instructions

Apply D149834-code and sandbox the API. You'll then need to test two different scenarios; an initial purchase and a renewal. 

First, the initial purchase. 

- Add an annual Titan Mail subscription to your cart and visit checkout (you may need to also add a domain to your cart if you do not already own one).
- Scroll to the bottom of checkout and look for the promotional period text. Verify that it is unchanged by this PR (it should be the same on this branch or trunk).
- Complete the purchase so that we can test the renewal _or_ use an existing Titan Mail subscription for the next part.

Now the test of the renewal.

- Visit `/me/purchases` and select the Titan Mail subscription. Click "Renew now" to add it to your cart and visit checkout.
- Scroll to the bottom of checkout and look for the promotional period text. Verify that the first sentence reads "After you renew today..." and that the date is the correct date of when the subscription will end _after the renewal happens_. If this is the first renewal of a prorated introductory offer, it will complete the prorated period and the date shown should be the end of the year. If this is not the first renewal, then the date should be one year past the current expiry date.