### PR TITLE
A4A: referrals shopping cart update

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -142,6 +142,7 @@ export default function ProductsOverview( {
 							onCheckout={ () => {
 								page( A4A_MARKETPLACE_CHECKOUT_LINK );
 							} }
+							marketplaceType={ marketplaceType }
 						/>
 					</Actions>
 				</LayoutHeader>

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
@@ -9,7 +9,7 @@ import {
 import usePaymentMethod from '../../purchases/payment-methods/hooks/use-payment-method';
 import ShoppingCartIcon from './shopping-cart-icon';
 import ShoppingCartMenu from './shopping-cart-menu';
-import type { ShoppingCartItem } from '../types';
+import type { MarketplaceType, ShoppingCartItem } from '../types';
 
 import './style.scss';
 
@@ -20,6 +20,7 @@ type Props = {
 	showCart: boolean;
 	setShowCart: ( state: boolean ) => void;
 	toggleCart: () => void;
+	marketplaceType?: MarketplaceType;
 };
 
 export const CART_URL_HASH_FRAGMENT = '#cart';
@@ -31,6 +32,7 @@ export default function ShoppingCart( {
 	showCart,
 	setShowCart,
 	toggleCart,
+	marketplaceType = 'regular',
 }: Props ) {
 	const { paymentMethodRequired } = usePaymentMethod();
 
@@ -70,6 +72,7 @@ export default function ShoppingCart( {
 					items={ items }
 					onCheckout={ handleOnCheckout }
 					onRemoveItem={ onRemoveItem }
+					marketplaceType={ marketplaceType }
 				/>
 			) }
 		</div>

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
@@ -81,10 +81,20 @@
 .shopping-cart__menu-footer {
 	display: flex;
 	flex-direction: column;
-	gap: 24px;
+	gap: 4px;
 	border-block-start: 1px solid var(--color-neutral-10);
 	padding-block-start: 16px;
 	align-items: stretch;
+}
+
+.shopping-cart__menu-commission {
+	color: var(--color-success);
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	font-weight: 500;
+	font-size: 1rem;
+	line-height: 1.5;
 }
 
 .shopping-cart__menu-total {
@@ -104,4 +114,5 @@
 	font-size: rem(14px);
 	font-weight: 600;
 	border-radius: 4px;
+	margin-block-start: 20px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/358

## Proposed Changes

Update shopping cart while in Referral mode.
<img width="502" alt="Screenshot 2024-05-23 at 1 48 26 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/10912579-d836-4c6c-aa69-b3d4816e9b44">

Note: commission values are currently hardcoded and will be addressed in the future.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to `/marketplace/products?purchase_type=referral`.
- Add several items to cart and open it.
- Check that UI is correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
