### PR TITLE
[WIP] Try to rethink Stepper and logins

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -11,6 +11,7 @@ import React, { useEffect, useCallback, useMemo, Suspense, lazy } from 'react';
 import Modal from 'react-modal';
 import { Navigate, Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
+import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
@@ -102,6 +103,7 @@ const useStepNavigationWithLogin = (
 		return {
 			...stepNavigation,
 			submit: () => {
+				recordSubmitStep( {}, '', flow.name, currentStepRoute, flow.variantSlug );
 				return stepNavigate( nextStep );
 			},
 		};
@@ -349,7 +351,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				{ flowSteps.map( ( step ) => (
 					<Route
 						key={ step.slug }
-						path={ `/${ flow.variantSlug ?? flow.name }/${ step.slug }` }
+						path={ `/${ flowPath }/${ step.slug }` }
 						element={
 							<StepRoute
 								step={ step }
@@ -364,9 +366,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 					path="*"
 					element={
 						<Navigate
-							to={ `/${ flow.variantSlug ?? flow.name }/${ stepPaths[ 0 ] }${
-								window.location.search
-							}` }
+							to={ `/${ flowPath }/${ stepPaths[ 0 ] }${ window.location.search }` }
 							replace
 						/>
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -176,6 +176,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/trial-acknowledge' ),
 	},
 
+	USER: {
+		slug: 'user',
+		asyncComponent: () => import( './steps-repository/user' ),
+	},
+
 	VERIFY_EMAIL: {
 		slug: 'verifyEmail',
 		asyncComponent: () => import( './steps-repository/import-verify-email' ),

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -96,6 +96,7 @@ export type UseSideEffectHook< FlowSteps extends StepperStep[] > = (
 
 export type Flow = {
 	name: string;
+	usesLocalLogin?: boolean;
 	/**
 	 * If this flow extends another flow, the variant slug will be added as a class name to the root element of the flow.
 	 */

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow-user-included.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow-user-included.ts
@@ -4,6 +4,7 @@ import { NEW_HOSTED_SITE_FLOW_USER_INCLUDED } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useLayoutEffect } from 'react';
+import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
 import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/ad-track-trial-start';
 import {
 	setSignupCompleteSlug,
@@ -15,7 +16,7 @@ import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-us
 import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import { Flow, ProvidedDependencies } from './internals/types';
+import type { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import './internals/new-hosted-site-flow.scss';
@@ -25,20 +26,11 @@ const hosting: Flow = {
 	isSignupFlow: true,
 	useSteps() {
 		return [
-			{ slug: 'user', asyncComponent: () => import( './internals/steps-repository/user' ) },
-			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
-			{
-				slug: 'trialAcknowledge',
-				asyncComponent: () => import( './internals/steps-repository/trial-acknowledge' ),
-			},
-			{
-				slug: 'createSite',
-				asyncComponent: () => import( './internals/steps-repository/create-site' ),
-			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
+			STEPS.USER,
+			STEPS.PLANS,
+			STEPS.TRIAL_ACKNOWLEDGE,
+			STEPS.SITE_CREATION_STEP,
+			STEPS.PROCESSING,
 		];
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow-user-included.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow-user-included.ts
@@ -24,9 +24,10 @@ import './internals/new-hosted-site-flow.scss';
 const hosting: Flow = {
 	name: NEW_HOSTED_SITE_FLOW_USER_INCLUDED,
 	isSignupFlow: true,
+	usesLocalLogin: true,
 	useSteps() {
 		return [
-			STEPS.USER,
+			//STEPS.USER,
 			STEPS.PLANS,
 			STEPS.TRIAL_ACKNOWLEDGE,
 			STEPS.SITE_CREATION_STEP,
@@ -54,9 +55,11 @@ const hosting: Flow = {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
 
 			switch ( _currentStepSlug ) {
+				/*
 				case 'user': {
 					return navigate( 'plans' );
 				}
+				*/
 				case 'plans': {
 					const productSlug = ( providedDependencies.plan as MinimalRequestCartProduct )
 						.product_slug;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/90680

## Proposed Changes

* This PR builds on the exploration in https://github.com/Automattic/wp-calypso/pull/90680 to see if we can pull login handling into the core Stepper logic in a way that requires minimal work from someone building a flow. There are a few elements to the exploration:
  - A flow needs to set the `usesLocalLogin` flag to opt in to the new handling
  - When opted in, the flow doesn't need to specify the user step in `useSteps()`, as the framework will add the user step as the first step if the current user isn't logged in. This also means the fallback/default logic for no step (`''`) will show the user step.
    * This logic will need to be relaxed/expanded to handle flows where some steps don't require a login, but we can solve for that later.
  - If we're rendering a step other than the `user` step, but we detect that the user isn't logged in and the flow is opted in to the new behaviour, we redirect to the `user` step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This PR explores what it might look like for the Stepper to more fully abstract away some of the complications that arise from having the user/login step available to us.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Open a window where you are not logged in and navigate to `/`
* Open the developer console and enter the following in the JS console to enable the new flow: 
```
sessionStorage.setItem('flags', 'onboarding/user-on-stepper-hosting' );
```

* Navigate to `/setup/new-hosted-site-user-included`
  - Verify that you're redirected to the `user` step
* Navigate to `/setup/new-hosted-site-user-included/`
  - Verify that you're redirected to the user step
* Navigate to `/setup/new-hosted-site-user-included/plans` (or any other step)
  - Verify that you're redirected to the user step
* Log in from the user step
  - Verify that you're taken to the plans step (I haven't tested this - I wasn't sure how to trigger a login for an existing account)

We'll also want to triple-check that these changes have no impact on the standard/existing Stepper functionality. (They _shouldn't_ but we should check!)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
