### PR TITLE
Fix domain only users support access

### DIFF
--- a/packages/help-center/src/data/use-support-availability.ts
+++ b/packages/help-center/src/data/use-support-availability.ts
@@ -28,6 +28,6 @@ export function useSupportAvailability( enabled = true ) {
 		enabled,
 		refetchOnWindowFocus: false,
 		placeholderData: keepPreviousData,
-		staleTime: 6 * 60 * 60 * 1000, // 6 hours
+		staleTime: 120 * 1000, // 2 mins. It has to be short, because the user can change the plan to access support.
 	} );
 }

--- a/packages/help-center/src/data/use-support-availability.ts
+++ b/packages/help-center/src/data/use-support-availability.ts
@@ -1,41 +1,28 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
-import { OtherSupportAvailability, ChatAvailability, EmailSupportStatus } from '../types';
+import { ChatAvailability } from '../types';
 
 // Bump me to invalidate the cache.
-const VERSION = 1;
-
-type ResponseType< T extends 'CHAT' | 'OTHER' | 'EMAIL' > = T extends 'CHAT'
-	? ChatAvailability
-	: T extends 'EMAIL'
-	? EmailSupportStatus
-	: OtherSupportAvailability;
+const VERSION = 2;
 
 interface APIFetchOptions {
 	global: boolean;
 	path: string;
 }
 
-export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' | 'EMAIL' >(
-	supportType: SUPPORT_TYPE,
-	enabled = true
-) {
-	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >( {
-		queryKey: [ 'support-availability', supportType, VERSION ],
+export function useSupportAvailability( enabled = true ) {
+	return useQuery< ChatAvailability, Error >( {
+		queryKey: [ 'support-availability', VERSION ],
 		queryFn: async () =>
 			canAccessWpcomApis()
 				? await wpcomRequest( {
-						path: `help/eligibility/${
-							supportType === 'OTHER' ? 'all' : supportType.toLocaleLowerCase()
-						}/mine`,
+						path: `help/eligibility/chat/mine`,
 						apiNamespace: 'wpcom/v2/',
 						apiVersion: '2',
 				  } )
 				: await apiFetch( {
-						path: `help-center/support-availability/${
-							supportType === 'OTHER' ? 'all' : supportType.toLocaleLowerCase()
-						}`,
+						path: `help-center/support-availability/chat`,
 						global: true,
 				  } as APIFetchOptions ),
 		enabled,

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -14,13 +14,11 @@ export default function useChatStatus(
 	group: MessagingGroup = 'wpcom_messaging',
 	checkAgentAvailability = true
 ) {
-	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
+	const { data: chatStatus } = useSupportAvailability();
 
-	// All users with a support level other than 'free' are eligible for chat.
+	// All paying customers are eligible for chat.
 	// See: pdDR7T-1vN-p2
-	const isEligibleForChat = Boolean(
-		chatStatus?.supportLevel && chatStatus.supportLevel !== 'free'
-	);
+	const isEligibleForChat = Boolean( chatStatus?.is_paying_customer );
 
 	const { data: supportActivity, isInitialLoading: isLoadingSupportActivity } =
 		useSupportActivity( isEligibleForChat );

--- a/packages/help-center/src/hooks/use-should-render-email-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-email-option.tsx
@@ -1,7 +1,7 @@
 import { useSupportAvailability } from '../data/use-support-availability';
 
 export function useShouldRenderEmailOption() {
-	const { data: supportAvailability, isFetching } = useSupportAvailability( 'EMAIL' );
+	const { data: supportAvailability, isFetching } = useSupportAvailability();
 
 	return {
 		isLoading: isFetching,

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -15,9 +15,9 @@ export function isWapuuFlagSetInURL(): boolean {
 }
 
 export function useStillNeedHelpURL() {
-	const { data: supportAvailability, isLoading } = useSupportAvailability( 'OTHER' );
+	const { data: supportAvailability, isLoading } = useSupportAvailability();
 	const isWapuuEnabled = useIsWapuuEnabled() || isWapuuFlagSetInURL();
-	const isFreeUser = ! supportAvailability?.is_user_eligible_for_tickets;
+	const isFreeUser = ! supportAvailability?.is_paying_customer;
 
 	if ( ! isFreeUser ) {
 		const url = isWapuuEnabled ? '/odie' : '/contact-options';

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -92,6 +92,7 @@ export interface ChatAvailability {
 	 * DO NOT USE THIS VALUE. We no longer use eligibility checks for chat. All paid users are eligible for chat.
 	 */
 	is_user_eligible: boolean;
+	is_paying_customer: boolean;
 	supportLevel:
 		| 'free'
 		| 'personal'
@@ -108,12 +109,7 @@ export interface ChatAvailability {
 	is_presales_chat_open: boolean;
 	is_precancellation_chat_open: boolean;
 	wapuu_assistant_enabled: boolean;
-}
-
-export interface OtherSupportAvailability {
-	is_user_eligible_for_upwork: boolean;
-	is_user_eligible_for_tickets: boolean;
-	is_user_eligible_for_chat: boolean;
+	force_email_contact_form: boolean;
 }
 
 export interface EmailSupportStatus {

--- a/packages/odie-client/src/data/index.ts
+++ b/packages/odie-client/src/data/index.ts
@@ -43,7 +43,8 @@ export const useSetOdieStorage = ( key: OdieStorageKey ) => {
 					apiVersion: 'v2',
 					apiNamespace: 'wpcom/v2',
 					method: 'PUT',
-					body: { calypso_preferences: { [ storageKey ]: value } },
+					// Empty string is a way to delete the value.
+					body: { calypso_preferences: { [ storageKey ]: value ?? '' } },
 				} );
 			}
 			return apiFetch< { calypso_preferences: Record< string, string > } >( {
@@ -55,7 +56,7 @@ export const useSetOdieStorage = ( key: OdieStorageKey ) => {
 		},
 		onSuccess: ( response ) => {
 			client.setQueryData( [ storageKey ], () => {
-				return response.calypso_preferences[ storageKey ];
+				return response.calypso_preferences[ storageKey ] ?? '';
 			} );
 		},
 	} );


### PR DESCRIPTION
## Proposed Changes

This updates the support eligibility checks to allow all paid users to access support and gets rid of the distinction between chat and email support.



## Testing Instructions

1. Sadly, you'll have to checkout this branch and not use he live link, 
2. Change this [line](https://github.com/Automattic/wp-calypso/blob/fix/domain-only-users-checks/packages/help-center/src/components/help-center-contact-page.tsx#L220) to render chat option.
3. Login using a domain only user.
4. Try to access support in the Help Center.
5. You should be able to.
