### PR TITLE
Gravatar Domains: Show the regular price formatting when the domain is not on sale

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -839,6 +839,7 @@ export function getDomainPriceRule(
 		product_slug?: string;
 		productSlug?: string;
 		cost?: string;
+		sale_cost?: number;
 		domain_name?: string;
 		is_premium?: boolean;
 	},
@@ -863,7 +864,7 @@ export function getDomainPriceRule(
 	}
 
 	if ( isDomainForGravatarFlow( flowName ) ) {
-		return 'FREE_FOR_FIRST_YEAR';
+		return suggestion.sale_cost === 0 ? 'FREE_FOR_FIRST_YEAR' : 'PRICE';
 	}
 
 	if ( domainAndPlanUpsellFlow ) {


### PR DESCRIPTION
Fixes an issue where the Gravatar flow introduced in PR https://github.com/Automattic/wp-calypso/pull/90414 was showing discounted prices even when the discount was not applied.

This needs to be tested with D149042-code

### Testing instructions:
* Go through the Domain for Gravatar flow ( details in the related diff )
* Search for a domain and observe the results
* If the discount applies to your account, it should show `free for the first year` with the price struck out.
* If the discount does not apply, the normal price for each domain should be shown.