### PR TITLE
All Domains: Implement empty state

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -17,6 +17,7 @@ import {
 	fetchSite,
 	fetchSiteDomains,
 } from '../domains-table-fetch-functions';
+import EmptyState from './empty-state';
 import GoogleDomainOwnerBanner from './google-domain-owner-banner';
 import OptionsDomainButton from './options-domain-button';
 import { usePurchaseActions } from './use-purchase-actions';
@@ -29,7 +30,7 @@ interface BulkAllDomainsProps {
 }
 
 export default function BulkAllDomains( props: BulkAllDomainsProps ) {
-	const { domains, isLoading } = useDomainsTable( fetchAllDomains );
+	const { domains = [], isFetched, isLoading } = useDomainsTable( fetchAllDomains );
 	const translate = useTranslate();
 	const isInSupportSession = Boolean( useSelector( isSupportSession ) );
 	const sitesDashboardGlobalStyles = css`
@@ -299,8 +300,10 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 		),
 	};
 
-	const buttons = [ <OptionsDomainButton key="breadcrumb_button_1" allDomainsList /> ];
-
+	const isDomainsEmpty = isFetched && domains.length === 0;
+	const buttons = ! isDomainsEmpty
+		? [ <OptionsDomainButton key="breadcrumb_button_1" allDomainsList /> ]
+		: [];
 	const purchaseActions = usePurchaseActions();
 
 	return (
@@ -310,23 +313,32 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 			<Main>
 				<DocumentHead title={ translate( 'Domains' ) } />
 				<BodySectionCssClass
-					bodyClass={ [ 'edit__body-white', 'is-bulk-domains-page', 'is-bulk-all-domains-page' ] }
+					bodyClass={ [
+						'edit__body-white',
+						'is-bulk-domains-page',
+						'is-bulk-all-domains-page',
+						...( isDomainsEmpty ? [ 'is-bulk-all-domains-page--is-empty' ] : [] ),
+					] }
 				/>
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
-				{ ! isLoading && <GoogleDomainOwnerBanner /> }
-				<DomainsTable
-					isLoadingDomains={ isLoading }
-					domains={ domains }
-					isAllSitesView
-					domainStatusPurchaseActions={ purchaseActions }
-					currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
-					fetchAllDomains={ fetchAllDomains }
-					fetchSite={ fetchSite }
-					fetchSiteDomains={ fetchSiteDomains }
-					createBulkAction={ createBulkAction }
-					fetchBulkActionStatus={ fetchBulkActionStatus }
-					deleteBulkActionStatus={ deleteBulkActionStatus }
-				/>
+				{ ! isLoading && ! isDomainsEmpty && <GoogleDomainOwnerBanner /> }
+				{ ! isDomainsEmpty ? (
+					<DomainsTable
+						isLoadingDomains={ isLoading }
+						domains={ domains }
+						isAllSitesView
+						domainStatusPurchaseActions={ purchaseActions }
+						currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
+						fetchAllDomains={ fetchAllDomains }
+						fetchSite={ fetchSite }
+						fetchSiteDomains={ fetchSiteDomains }
+						createBulkAction={ createBulkAction }
+						fetchBulkActionStatus={ fetchBulkActionStatus }
+						deleteBulkActionStatus={ deleteBulkActionStatus }
+					/>
+				) : (
+					<EmptyState />
+				) }
 			</Main>
 		</>
 	);

--- a/client/my-sites/domains/domain-management/list/empty-state/index.tsx
+++ b/client/my-sites/domains/domain-management/list/empty-state/index.tsx
@@ -1,0 +1,37 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import page from '@automattic/calypso-router';
+import { __experimentalText as Text, Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+
+export default function EmptyState() {
+	const translate = useTranslate();
+
+	const handleClickUseMyDomain = () => {
+		recordTracksEvent( 'calypso_domain_management_list_empty_state_use_my_domain_click' );
+		page( '/setup/domain-transfer' );
+	};
+
+	const handleClickAddNewDomain = () => {
+		recordTracksEvent( 'calypso_domain_management_list_empty_state_add_new_domain_click' );
+		page( '/start/domain' );
+	};
+
+	return (
+		<div className="domains-empty-state">
+			<Text as="p">
+				{ translate(
+					"Enhance your brand credibility with a custom domain, free for the first year on WordPress.com annual plans. Seamlessly manage your site and domain, or transfer your existing domain effortlessly. Let's get started."
+				) }
+			</Text>
+			<div className="domains-empty-state-actions">
+				<Button __next40pxDefaultSize variant="secondary" onClick={ handleClickUseMyDomain }>
+					{ translate( 'Transfer domain' ) }
+				</Button>
+				<Button __next40pxDefaultSize variant="primary" onClick={ handleClickAddNewDomain }>
+					{ translate( 'Find a domain' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/domains/domain-management/list/empty-state/index.tsx
+++ b/client/my-sites/domains/domain-management/list/empty-state/index.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import page from '@automattic/calypso-router';
 import { __experimentalText as Text, Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
@@ -9,12 +8,10 @@ export default function EmptyState() {
 
 	const handleClickUseMyDomain = () => {
 		recordTracksEvent( 'calypso_domain_management_list_empty_state_use_my_domain_click' );
-		page( '/setup/domain-transfer' );
 	};
 
 	const handleClickAddNewDomain = () => {
 		recordTracksEvent( 'calypso_domain_management_list_empty_state_add_new_domain_click' );
-		page( '/start/domain' );
 	};
 
 	return (
@@ -25,10 +22,20 @@ export default function EmptyState() {
 				) }
 			</Text>
 			<div className="domains-empty-state-actions">
-				<Button __next40pxDefaultSize variant="secondary" onClick={ handleClickUseMyDomain }>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					href="/setup/domain-transfer"
+					onClick={ handleClickUseMyDomain }
+				>
 					{ translate( 'Transfer domain' ) }
 				</Button>
-				<Button __next40pxDefaultSize variant="primary" onClick={ handleClickAddNewDomain }>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					href="/start/domain"
+					onClick={ handleClickAddNewDomain }
+				>
 					{ translate( 'Find a domain' ) }
 				</Button>
 			</div>

--- a/client/my-sites/domains/domain-management/list/empty-state/style.scss
+++ b/client/my-sites/domains/domain-management/list/empty-state/style.scss
@@ -1,0 +1,41 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.is-bulk-all-domains-page.is-bulk-all-domains-page--is-empty .layout__content .main .navigation-header {
+	border-block-end: 1px solid var(--studio-gray-0);
+	padding-bottom: 1rem;
+	padding-inline: 1rem;
+	padding-top: 1rem;
+
+	@include break-large {
+		margin: 0;
+		padding-bottom: 1.5rem;
+		padding-inline: 4rem;
+		padding-top: 1.5rem;
+	}
+}
+
+.domains-empty-state {
+	padding-inline: 1rem;
+	text-align: left;
+
+	@include break-large {
+		padding-inline: 4rem;
+	}
+
+	@include break-wide {
+		max-width: 50%;
+	}
+
+	p {
+		color: var(--studio-gray-100);
+		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
+		line-height: 1.625;
+		margin: 1.5rem auto;
+	}
+}
+
+.domains-empty-state-actions {
+	display: flex;
+	gap: 8px;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6868

## Proposed Changes

This PR implements an empty state to the All Domains page.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/797888/815ffae8-7a18-4dee-93c1-8a5309bfe841)| ![image](https://github.com/Automattic/wp-calypso/assets/797888/566c8f4d-3417-40e2-b18b-a9abd8e7d830)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improve the empty state.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/domains/manage`.
* Ensure that the empty state is updated as shown above.

To test the empty state, you can clear the Redux store and block the network request as seen in the screenshot below:
![Screenshot 2024-05-24 at 12 05 54 PM](https://github.com/Automattic/wp-calypso/assets/797888/0ab14dd1-cdfd-4fca-82c2-708c67a1cb5e)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
