### PR TITLE
A4A: Implement filtering component in the Product marketplace.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/constants.ts
@@ -9,3 +9,27 @@ export const PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS = 'vaultpress-backup-addons
 export const PRODUCT_BRAND_FILTER_ALL = 'all';
 export const PRODUCT_BRAND_FILTER_WOOCOMMERCE = 'woocommerce';
 export const PRODUCT_BRAND_FILTER_JETPACK = 'jetpack';
+
+export const PRODUCT_FILTER_KEY_CATEGORIES = 'categories';
+export const PRODUCT_FILTER_KEY_TYPES = 'types';
+export const PRODUCT_FILTER_KEY_PRICES = 'prices';
+
+export const PRODUCT_CATEGORY_SECURITY = 'security';
+export const PRODUCT_CATEGORY_PERFORMANCE = 'performance';
+export const PRODUCT_CATEGORY_SOCIAL = 'social';
+export const PRODUCT_CATEGORY_GROWTH = 'growth';
+export const PRODUCT_CATEGORY_PAYMENTS = 'payments';
+export const PRODUCT_CATEGORY_SHIPPING_DELIVERY_FULFILLMENT = 'shipping-delivery-fulfillment';
+export const PRODUCT_CATEGORY_CONVERSION = 'conversion';
+export const PRODUCT_CATEGORY_CUSTOMER_SERVICE = 'customer-service';
+export const PRODUCT_CATEGORY_MERCHANDISING = 'merchandising';
+export const PRODUCT_CATEGORY_STORE_CONTENT = 'store-content-and-customization';
+export const PRODUCT_CATEGORY_STORE_MANAGEMENT = 'store-management';
+
+export const PRODUCT_TYPE_EXTENSION = 'extension';
+export const PRODUCT_TYPE_PLAN = 'plan';
+export const PRODUCT_TYPE_PRODUCT = 'product';
+export const PRODUCT_TYPE_ADDON = 'addon';
+
+export const PRODUCT_PRICE_FREE = 'free';
+export const PRODUCT_PRICE_PAID = 'paid';

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -11,9 +11,7 @@ export type SelectedFilters = {
 };
 
 export function hasSelectedFilter( selectedFilters: SelectedFilters ) {
-	return Object.keys( selectedFilters ).some( ( key ) => {
-		return Object.values( selectedFilters[ key as keyof SelectedFilters ] ).some(
-			( selected ) => selected
-		);
+	return Object.values( selectedFilters ).some( ( filter ) => {
+		return Object.values( filter ).some( ( selected ) => selected );
 	} );
 }

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -1,0 +1,19 @@
+import {
+	PRODUCT_FILTER_KEY_CATEGORIES,
+	PRODUCT_FILTER_KEY_PRICES,
+	PRODUCT_FILTER_KEY_TYPES,
+} from '../constants';
+
+export type SelectedFilters = {
+	[ PRODUCT_FILTER_KEY_CATEGORIES ]: Record< string, boolean >;
+	[ PRODUCT_FILTER_KEY_TYPES ]: Record< string, boolean >;
+	[ PRODUCT_FILTER_KEY_PRICES ]: Record< string, boolean >;
+};
+
+export function hasSelectedFilter( selectedFilters: SelectedFilters ) {
+	return Object.keys( selectedFilters ).some( ( key ) => {
+		return Object.values( selectedFilters[ key as keyof SelectedFilters ] ).some(
+			( selected ) => selected
+		);
+	} );
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-on-screen.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-on-screen.ts
@@ -1,0 +1,19 @@
+import { RefObject, useEffect, useMemo, useState } from 'react';
+
+export default function useOnScreen( ref: RefObject< HTMLElement > ) {
+	const [ isIntersecting, setIntersecting ] = useState( false );
+
+	const observer = useMemo(
+		() => new IntersectionObserver( ( [ entry ] ) => setIntersecting( entry.isIntersecting ) ),
+		[]
+	);
+
+	useEffect( () => {
+		if ( ref && ref.current ) {
+			observer.observe( ref.current );
+		}
+		return () => observer.disconnect();
+	}, [ observer, ref ] );
+
+	return isIntersecting;
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.ts
@@ -1,0 +1,59 @@
+import { useTranslate } from 'i18n-calypso';
+import {
+	PRODUCT_CATEGORY_CONVERSION,
+	PRODUCT_CATEGORY_CUSTOMER_SERVICE,
+	PRODUCT_CATEGORY_GROWTH,
+	PRODUCT_CATEGORY_MERCHANDISING,
+	PRODUCT_CATEGORY_PAYMENTS,
+	PRODUCT_CATEGORY_PERFORMANCE,
+	PRODUCT_CATEGORY_SECURITY,
+	PRODUCT_CATEGORY_SHIPPING_DELIVERY_FULFILLMENT,
+	PRODUCT_CATEGORY_SOCIAL,
+	PRODUCT_CATEGORY_STORE_CONTENT,
+	PRODUCT_CATEGORY_STORE_MANAGEMENT,
+	PRODUCT_FILTER_KEY_CATEGORIES,
+	PRODUCT_FILTER_KEY_PRICES,
+	PRODUCT_FILTER_KEY_TYPES,
+	PRODUCT_PRICE_FREE,
+	PRODUCT_PRICE_PAID,
+	PRODUCT_TYPE_ADDON,
+	PRODUCT_TYPE_EXTENSION,
+	PRODUCT_TYPE_PLAN,
+	PRODUCT_TYPE_PRODUCT,
+} from '../../../constants';
+
+export default function useProductFilterOptions() {
+	const translate = useTranslate();
+
+	return {
+		[ PRODUCT_FILTER_KEY_CATEGORIES ]: [
+			{ key: PRODUCT_CATEGORY_SECURITY, label: translate( 'Security' ) },
+			{ key: PRODUCT_CATEGORY_PERFORMANCE, label: translate( 'Performance' ) },
+			{ key: PRODUCT_CATEGORY_SOCIAL, label: translate( 'Social' ) },
+			{ key: PRODUCT_CATEGORY_GROWTH, label: translate( 'Growth' ) },
+			{ key: PRODUCT_CATEGORY_PAYMENTS, label: translate( 'Payments' ) },
+			{
+				key: PRODUCT_CATEGORY_SHIPPING_DELIVERY_FULFILLMENT,
+				label: translate( 'Shipping, Delivery, and Fulfillment' ),
+			},
+			{ key: PRODUCT_CATEGORY_CONVERSION, label: translate( 'Conversion' ) },
+			{ key: PRODUCT_CATEGORY_CUSTOMER_SERVICE, label: translate( 'Customer Service' ) },
+			{ key: PRODUCT_CATEGORY_MERCHANDISING, label: translate( 'Merchandising' ) },
+			{
+				key: PRODUCT_CATEGORY_STORE_CONTENT,
+				label: translate( 'Store Content and Customization' ),
+			},
+			{ key: PRODUCT_CATEGORY_STORE_MANAGEMENT, label: translate( 'Store Management' ) },
+		],
+		[ PRODUCT_FILTER_KEY_TYPES ]: [
+			{ key: PRODUCT_TYPE_EXTENSION, label: translate( 'Extension' ) },
+			{ key: PRODUCT_TYPE_PLAN, label: translate( 'Plan' ) },
+			{ key: PRODUCT_TYPE_PRODUCT, label: translate( 'Product' ) },
+			{ key: PRODUCT_TYPE_ADDON, label: translate( 'Addon' ) },
+		],
+		[ PRODUCT_FILTER_KEY_PRICES ]: [
+			{ key: PRODUCT_PRICE_FREE, label: translate( 'Free' ) },
+			{ key: PRODUCT_PRICE_PAID, label: translate( 'Paid' ) },
+		],
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
@@ -2,12 +2,14 @@ import { SubmenuPopover, useSubmenuPopoverProps } from '@automattic/components';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { Icon, chevronRight, funnel, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useRef, useState } from 'react';
 import {
 	PRODUCT_FILTER_KEY_CATEGORIES,
 	PRODUCT_FILTER_KEY_PRICES,
 	PRODUCT_FILTER_KEY_TYPES,
 } from '../../constants';
 import { SelectedFilters } from '../../lib/product-filter';
+import useOnScreen from './hooks/use-on-screen';
 import useProductFilterOptions from './hooks/use-product-filter-options';
 
 import './style.scss';
@@ -57,6 +59,11 @@ type Props = {
 export default function ProductFilter( { selectedFilters, setSelectedFilters }: Props ) {
 	const translate = useTranslate();
 
+	const [ openDropdown, setOpenDropdown ] = useState< boolean >( false );
+
+	const ref = useRef< HTMLDivElement >( null );
+	const isVisible = useOnScreen( ref );
+
 	const {
 		[ PRODUCT_FILTER_KEY_CATEGORIES ]: categories,
 		[ PRODUCT_FILTER_KEY_TYPES ]: types,
@@ -73,35 +80,46 @@ export default function ProductFilter( { selectedFilters, setSelectedFilters }: 
 		} );
 	};
 
+	useEffect( () => {
+		// Dropdown doesn't play well with our layout when scrolling. We need to close it when the toggle is not visible to avoid overlapping issues.
+		if ( openDropdown && ! isVisible ) {
+			setOpenDropdown( false );
+		}
+	}, [ isVisible, openDropdown ] );
+
 	return (
-		<DropdownMenu
-			className="product-filter"
-			label={ translate( 'Filter' ) }
-			icon={ funnel }
-			variant="product-filter"
-		>
-			{ () => (
-				<MenuGroup className="product-filter__group">
-					<ProductFilterItem
-						label={ translate( 'Category' ) }
-						options={ categories }
-						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
-						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option ) }
-					/>
-					<ProductFilterItem
-						label={ translate( 'Type' ) }
-						options={ types }
-						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
-						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
-					/>
-					<ProductFilterItem
-						label={ translate( 'Price' ) }
-						options={ prices }
-						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
-						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
-					/>
-				</MenuGroup>
-			) }
-		</DropdownMenu>
+		<div ref={ ref }>
+			<DropdownMenu
+				className="product-filter"
+				label={ translate( 'Filter' ) }
+				icon={ funnel }
+				variant="product-filter"
+				open={ openDropdown }
+				onToggle={ () => setOpenDropdown( ! openDropdown ) }
+			>
+				{ () => (
+					<MenuGroup className="product-filter__group">
+						<ProductFilterItem
+							label={ translate( 'Category' ) }
+							options={ categories }
+							selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
+							onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option ) }
+						/>
+						<ProductFilterItem
+							label={ translate( 'Type' ) }
+							options={ types }
+							selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
+							onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
+						/>
+						<ProductFilterItem
+							label={ translate( 'Price' ) }
+							options={ prices }
+							selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
+							onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
+						/>
+					</MenuGroup>
+				) }
+			</DropdownMenu>
+		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
@@ -1,0 +1,107 @@
+import { SubmenuPopover, useSubmenuPopoverProps } from '@automattic/components';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { Icon, chevronRight, funnel, check } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import {
+	PRODUCT_FILTER_KEY_CATEGORIES,
+	PRODUCT_FILTER_KEY_PRICES,
+	PRODUCT_FILTER_KEY_TYPES,
+} from '../../constants';
+import { SelectedFilters } from '../../lib/product-filter';
+import useProductFilterOptions from './hooks/use-product-filter-options';
+
+import './style.scss';
+
+type ProductFilterItemProps = {
+	label: string;
+	options: { key: string; label: string }[];
+	selectedOptions: { [ key: string ]: boolean };
+	onOptionClick?: ( option: string ) => void;
+};
+
+export function ProductFilterItem( {
+	label,
+	options,
+	selectedOptions,
+	onOptionClick,
+}: ProductFilterItemProps ) {
+	const submenu = useSubmenuPopoverProps< HTMLDivElement >( {
+		flip: false,
+	} );
+
+	return (
+		<div { ...submenu.parent }>
+			<MenuItem icon={ chevronRight }>{ label }</MenuItem>
+			<SubmenuPopover { ...submenu.submenu } className="components-popover is-product-filter">
+				<MenuGroup className="product-filter__group">
+					{ options.map( ( option ) => (
+						<MenuItem key={ option.key } onClick={ () => onOptionClick?.( option.key ) }>
+							<Icon
+								icon={ check }
+								style={ { visibility: selectedOptions[ option.key ] ? 'visible' : 'hidden' } } // We need to hide the check icon but still keep the space for it
+							/>
+							{ option.label }
+						</MenuItem>
+					) ) }
+				</MenuGroup>
+			</SubmenuPopover>
+		</div>
+	);
+}
+
+type Props = {
+	selectedFilters: SelectedFilters;
+	setSelectedFilters: ( selectedFilters: SelectedFilters ) => void;
+};
+
+export default function ProductFilter( { selectedFilters, setSelectedFilters }: Props ) {
+	const translate = useTranslate();
+
+	const {
+		[ PRODUCT_FILTER_KEY_CATEGORIES ]: categories,
+		[ PRODUCT_FILTER_KEY_TYPES ]: types,
+		[ PRODUCT_FILTER_KEY_PRICES ]: prices,
+	} = useProductFilterOptions();
+
+	const updateFilter = ( type: string, filter: string ) => {
+		setSelectedFilters( {
+			...selectedFilters,
+			[ type ]: {
+				...selectedFilters[ type as keyof SelectedFilters ],
+				[ filter ]: ! selectedFilters[ type as keyof SelectedFilters ][ filter ],
+			},
+		} );
+	};
+
+	return (
+		<DropdownMenu
+			className="product-filter"
+			label={ translate( 'Filter' ) }
+			icon={ funnel }
+			variant="product-filter"
+		>
+			{ () => (
+				<MenuGroup className="product-filter__group">
+					<ProductFilterItem
+						label={ translate( 'Category' ) }
+						options={ categories }
+						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
+						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option ) }
+					/>
+					<ProductFilterItem
+						label={ translate( 'Type' ) }
+						options={ types }
+						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
+						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
+					/>
+					<ProductFilterItem
+						label={ translate( 'Price' ) }
+						options={ prices }
+						selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
+						onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
+					/>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -6,6 +6,7 @@
 .components-popover.is-product-filter {
 	border-radius: 4px;
 	border: 1px solid var(--color-neutral-5);
+	z-index: 1;
 }
 
 .product-filter__group {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -1,0 +1,32 @@
+.product-filter {
+	max-height: 33px;
+	max-width: 33px;
+}
+
+.components-popover.is-product-filter {
+	border-radius: 4px;
+	border: 1px solid var(--color-neutral-5);
+}
+
+.product-filter__group {
+	padding: 8px;
+}
+
+.product-filter__group .components-menu-item__button.components-button {
+	border-radius: 4px;
+	padding: 8px 12px;
+
+	&:focus,
+	&:focus-visible,
+	&:focus-within,
+	&:hover:not(:disabled) {
+		border: none;
+		box-shadow: none;
+		background-color: var(--color-neutral-0);
+	}
+}
+
+.product-filter__group .components-menu-item__item {
+	display: flex;
+	gap: 8px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -298,6 +298,9 @@ export default function ProductListing( {
 
 	const shouldShowResetButton = hasSelectedFilter( selectedFilters );
 
+	// FIXME: For now we hide the filtering until we complete the implementation. We will remove this flag later.
+	const hideFilter = true;
+
 	if ( isLoadingProducts ) {
 		return (
 			<div className="product-listing">
@@ -318,10 +321,12 @@ export default function ProductListing( {
 						onClick={ trackClickCallback( 'search' ) }
 					/>
 
-					<ProductFilter
-						selectedFilters={ selectedFilters }
-						setSelectedFilters={ setSelectedFilters }
-					/>
+					{ ! hideFilter && (
+						<ProductFilter
+							selectedFilters={ selectedFilters }
+							setSelectedFilters={ setSelectedFilters }
+						/>
+					) }
 
 					{ shouldShowResetButton && (
 						<Button

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -1,4 +1,4 @@
-import { JetpackLogo, WooLogo } from '@automattic/components';
+import { Button, JetpackLogo, WooLogo } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
@@ -11,11 +11,18 @@ import {
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import FilterSearch from '../../../../components/filter-search';
+import {
+	PRODUCT_FILTER_KEY_CATEGORIES,
+	PRODUCT_FILTER_KEY_PRICES,
+	PRODUCT_FILTER_KEY_TYPES,
+} from '../../constants';
 import { MarketplaceTypeContext, ShoppingCartContext } from '../../context';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
+import { SelectedFilters, hasSelectedFilter } from '../../lib/product-filter';
 import ListingSection from '../../listing-section';
 import MultiProductCard from '../multi-product-card';
 import ProductCard from '../product-card';
+import ProductFilter from '../product-filter';
 import { getSupportedBundleSizes, useProductBundleSize } from './hooks/use-product-bundle-size';
 import useSubmitForm from './hooks/use-submit-form';
 import VolumePriceSelector from './volume-price-selector';
@@ -31,6 +38,12 @@ interface ProductListingProps {
 	productBrand: string;
 }
 
+export const DEFAULT_SELECTED_FILTERS = {
+	[ PRODUCT_FILTER_KEY_CATEGORIES ]: {},
+	[ PRODUCT_FILTER_KEY_TYPES ]: {},
+	[ PRODUCT_FILTER_KEY_PRICES ]: {},
+};
+
 export default function ProductListing( {
 	selectedSite,
 	suggestedProduct,
@@ -44,6 +57,10 @@ export default function ProductListing( {
 	const isReferingProducts = marketplaceType === 'referral';
 
 	const [ productSearchQuery, setProductSearchQuery ] = useState< string >( '' );
+
+	const [ selectedFilters, setSelectedFilters ] = useState< SelectedFilters >( {
+		...DEFAULT_SELECTED_FILTERS,
+	} );
 
 	const {
 		selectedSize: selectedBundleSize,
@@ -279,6 +296,8 @@ export default function ProductListing( {
 		);
 	};
 
+	const shouldShowResetButton = hasSelectedFilter( selectedFilters );
+
 	if ( isLoadingProducts ) {
 		return (
 			<div className="product-listing">
@@ -292,11 +311,32 @@ export default function ProductListing( {
 			<QueryProductsList currency="USD" />
 
 			<div className="product-listing__actions">
-				<FilterSearch
-					label={ translate( 'Search plans, products, add-ons, and extensions' ) }
-					onSearch={ onProductSearch }
-					onClick={ trackClickCallback( 'search' ) }
-				/>
+				<div className="product-listing__actions-search-and-filter">
+					<FilterSearch
+						label={ translate( 'Search' ) }
+						onSearch={ onProductSearch }
+						onClick={ trackClickCallback( 'search' ) }
+					/>
+
+					<ProductFilter
+						selectedFilters={ selectedFilters }
+						setSelectedFilters={ setSelectedFilters }
+					/>
+
+					{ shouldShowResetButton && (
+						<Button
+							className="product-listing__reset-filter-button"
+							plain
+							onClick={ () =>
+								setSelectedFilters( {
+									...DEFAULT_SELECTED_FILTERS,
+								} )
+							}
+						>
+							{ translate( 'Reset filter' ) }
+						</Button>
+					) }
+				</div>
 
 				{ ! isReferingProducts && availableBundleSizes.length > 1 && (
 					<VolumePriceSelector

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -90,3 +90,29 @@ p.product-listing__description {
 		min-width: 430px;
 	}
 }
+
+.product-listing__actions-search-and-filter {
+	display: flex;
+	gap: 8px;
+}
+
+.product-listing__reset-filter-button {
+	white-space: nowrap;
+	max-height: 36px;
+	font-size: rem(13px);
+	cursor: pointer;
+	color: var(--color-primary-60);
+	padding: 8px 12px;
+	border-radius: 4px;
+
+	&:focus-visible {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		outline: 3px solid transparent;
+	}
+
+	&:hover {
+		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
+		color: var(--color-accent-60);
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
@@ -81,3 +81,9 @@
 .products-overview .a4a-layout__body {
 	overflow-y: scroll; // We need to show the scrollbar so we avoid UI from shifting when filtering items.
 }
+
+.products-overview {
+	.a4a-layout__top-wrapper {
+		z-index: 10;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
@@ -77,3 +77,7 @@
 
 	}
 }
+
+.products-overview .a4a-layout__body {
+	overflow-y: scroll; // We need to show the scrollbar so we avoid UI from shifting when filtering items.
+}


### PR DESCRIPTION
This PR implements the Filter selector in the Product marketplace. 

<img width="897" alt="Screenshot 2024-05-24 at 4 15 05 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a78ebc04-84d2-4797-8773-2ccc45ffc48c">

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/525

## Proposed Changes

* Implement a filter selector based on the DropdownMenu core component. The design should closely match the one used in the DataView component on the Sites page. Unfortunately, we couldn't reuse the same filtering, so we have to build it on our own.

## Testing Instructions

* You will need to test this locally and modify a temporary flag. Change the following [variable](https://github.com/Automattic/wp-calypso/pull/91082/files#diff-7b904678f91e762c73c08df920bfbff7e446449959f4a77b7d1d204a754f980dR300) to **false**.
  ```
   	const hideFilter = false;
  ```
*  Go to http://agencies.localhost:3000/marketplace/products
* Confirm that the filter button is visible and is working as expected.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
