### PR TITLE
Sites list: Fix site URL text ellipsis when overflow

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -129,7 +129,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 						</>
 					) : (
 						<>
-							<div>
+							<div className="sites-dataviews__site-urls">
 								<a
 									className="sites-dataviews__site-url"
 									href={ siteUrl }

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -25,14 +25,17 @@
 	font-size: rem(14px);
 }
 
+.sites-dataviews__site-urls {
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+}
+
 .sites-dataviews__site-url,
 .sites-dataviews__site-wp-admin-url {
 	color: var(--color-neutral-70);
 	font-size: rem(14px);
 	font-weight: 400;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	white-space: nowrap;
 
 	&:focus {
 		border-radius: 2px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7415

## Proposed Changes

This PR fixes a regression issue where the site URL no longer overflows with an ellipsis.

| Before | After |
| --- | --- |
| ![Screenshot 2024-05-24 at 1 10 16 PM](https://github.com/Automattic/wp-calypso/assets/797888/26de449d-0c20-4936-b633-fe53ed60a76e) |  ![Screenshot 2024-05-24 at 1 10 03 PM](https://github.com/Automattic/wp-calypso/assets/797888/785f5147-9a4a-423f-935a-a5d22cabe177)|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fix a regression issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the site URLs overflow with an ellipsis.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
