### PR TITLE
A4A: Implement new product filtering logic and render the new component on the product marketplace page.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/constants.ts
@@ -1,10 +1,13 @@
-export const PRODUCT_FILTER_ALL = '';
-export const PRODUCT_FILTER_PLANS = 'plans';
-export const PRODUCT_FILTER_PRODUCTS = 'products';
-export const PRODUCT_FILTER_PRESSABLE_PLANS = 'pressable-plans';
-export const PRODUCT_FILTER_WPCOM_PLANS = 'wpcom-plans';
-export const PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS = 'woocommerce-extensions';
-export const PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS = 'vaultpress-backup-addons';
+export const PRODUCT_TYPE_PLAN = 'plan';
+export const PRODUCT_TYPE_JETPACK_PLAN = 'jetpack-plan';
+export const PRODUCT_TYPE_PRODUCT = 'product';
+export const PRODUCT_TYPE_JETPACK_PRODUCT = 'jetpack-product';
+export const PRODUCT_TYPE_PRESSABLE_PLAN = 'pressable-plan';
+export const PRODUCT_TYPE_WPCOM_PLAN = 'wpcom-plan';
+export const PRODUCT_TYPE_EXTENSION = 'extension';
+export const PRODUCT_TYPE_WOO_EXTENSION = 'woocommerce-extension';
+export const PRODUCT_TYPE_ADDON = 'addon';
+export const PRODUCT_TYPE_JETPACK_BACKUP_ADDON = 'addon';
 
 export const PRODUCT_BRAND_FILTER_ALL = 'all';
 export const PRODUCT_BRAND_FILTER_WOOCOMMERCE = 'woocommerce';
@@ -25,11 +28,6 @@ export const PRODUCT_CATEGORY_CUSTOMER_SERVICE = 'customer-service';
 export const PRODUCT_CATEGORY_MERCHANDISING = 'merchandising';
 export const PRODUCT_CATEGORY_STORE_CONTENT = 'store-content-and-customization';
 export const PRODUCT_CATEGORY_STORE_MANAGEMENT = 'store-management';
-
-export const PRODUCT_TYPE_EXTENSION = 'extension';
-export const PRODUCT_TYPE_PLAN = 'plan';
-export const PRODUCT_TYPE_PRODUCT = 'product';
-export const PRODUCT_TYPE_ADDON = 'addon';
 
 export const PRODUCT_PRICE_FREE = 'free';
 export const PRODUCT_PRICE_PAID = 'paid';

--- a/client/a8c-for-agencies/sections/marketplace/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/constants.ts
@@ -13,6 +13,7 @@ export const PRODUCT_BRAND_FILTER_ALL = 'all';
 export const PRODUCT_BRAND_FILTER_WOOCOMMERCE = 'woocommerce';
 export const PRODUCT_BRAND_FILTER_JETPACK = 'jetpack';
 
+export const PRODUCT_FILTER_KEY_BRAND = 'brand';
 export const PRODUCT_FILTER_KEY_CATEGORIES = 'categories';
 export const PRODUCT_FILTER_KEY_TYPES = 'types';
 export const PRODUCT_FILTER_KEY_PRICES = 'prices';

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -6,8 +6,6 @@ import { useSelector } from 'calypso/state';
 import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-portal/licenses/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
-	PRODUCT_BRAND_FILTER_ALL,
-	PRODUCT_FILTER_KEY_BRAND,
 	PRODUCT_TYPE_JETPACK_BACKUP_ADDON,
 	PRODUCT_TYPE_JETPACK_PLAN,
 	PRODUCT_TYPE_JETPACK_PRODUCT,
@@ -79,6 +77,17 @@ const getDisplayableJetpackProducts = ( filteredProductsAndBundles: APIProductFa
 	} ) as APIProductFamilyProduct[];
 };
 
+const getDisplayableWoocommerceExtensions = (
+	filteredProductsAndBundles: APIProductFamilyProduct[]
+) => {
+	const extensions = filterProductsAndPlansByType(
+		PRODUCT_TYPE_WOO_EXTENSION,
+		filteredProductsAndBundles
+	);
+
+	return extensions.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+};
+
 export default function useProductAndPlans( {
 	selectedBundleSize = 1,
 	selectedSite,
@@ -93,25 +102,7 @@ export default function useProductAndPlans( {
 	);
 
 	return useMemo( () => {
-		// List only products that matches the selected product brand filter.
-		const selectedProductBrandFilter = selectedProductFilters
-			? selectedProductFilters[ PRODUCT_FILTER_KEY_BRAND ] ?? PRODUCT_BRAND_FILTER_ALL
-			: PRODUCT_BRAND_FILTER_ALL;
-
-		let filteredProductsAndBundles =
-			selectedProductBrandFilter === PRODUCT_BRAND_FILTER_ALL
-				? data
-				: data?.filter( ( { slug } ) => slug.startsWith( selectedProductBrandFilter ) );
-
-		filteredProductsAndBundles = filteredProductsAndBundles ?? [];
-
-		// List only products that matches the selected product filters.
-		if ( selectedProductFilters && filteredProductsAndBundles ) {
-			filteredProductsAndBundles = filterProductsAndPlans(
-				selectedProductFilters,
-				filteredProductsAndBundles
-			);
-		}
+		let filteredProductsAndBundles = filterProductsAndPlans( data ?? [], selectedProductFilters );
 
 		// List only products that is compatible with current bundle size.
 		filteredProductsAndBundles =
@@ -152,10 +143,7 @@ export default function useProductAndPlans( {
 				PRODUCT_TYPE_JETPACK_BACKUP_ADDON,
 				filteredProductsAndBundles
 			),
-			wooExtensions: filterProductsAndPlansByType(
-				PRODUCT_TYPE_WOO_EXTENSION,
-				filteredProductsAndBundles
-			),
+			wooExtensions: getDisplayableWoocommerceExtensions( filteredProductsAndBundles ),
 			pressablePlans: filterProductsAndPlansByType(
 				PRODUCT_TYPE_PRESSABLE_PLAN,
 				filteredProductsAndBundles

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -7,6 +7,7 @@ import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-porta
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
 	PRODUCT_BRAND_FILTER_ALL,
+	PRODUCT_FILTER_KEY_BRAND,
 	PRODUCT_TYPE_JETPACK_BACKUP_ADDON,
 	PRODUCT_TYPE_JETPACK_PLAN,
 	PRODUCT_TYPE_JETPACK_PRODUCT,
@@ -28,7 +29,6 @@ const MERGABLE_PRODUCTS = [ 'jetpack-backup' ];
 type Props = {
 	selectedBundleSize?: number;
 	selectedSite?: SiteDetails | null;
-	selectedProductBrandFilter?: string | null;
 	productSearchQuery?: string;
 	usePublicQuery?: boolean;
 	selectedProductFilters?: SelectedFilters;
@@ -82,7 +82,6 @@ const getDisplayableJetpackProducts = ( filteredProductsAndBundles: APIProductFa
 export default function useProductAndPlans( {
 	selectedBundleSize = 1,
 	selectedSite,
-	selectedProductBrandFilter = PRODUCT_BRAND_FILTER_ALL,
 	selectedProductFilters,
 	productSearchQuery,
 	usePublicQuery = false,
@@ -95,8 +94,12 @@ export default function useProductAndPlans( {
 
 	return useMemo( () => {
 		// List only products that matches the selected product brand filter.
+		const selectedProductBrandFilter = selectedProductFilters
+			? selectedProductFilters[ PRODUCT_FILTER_KEY_BRAND ] ?? PRODUCT_BRAND_FILTER_ALL
+			: PRODUCT_BRAND_FILTER_ALL;
+
 		let filteredProductsAndBundles =
-			! selectedProductBrandFilter || selectedProductBrandFilter === PRODUCT_BRAND_FILTER_ALL
+			selectedProductBrandFilter === PRODUCT_BRAND_FILTER_ALL
 				? data
 				: data?.filter( ( { slug } ) => slug.startsWith( selectedProductBrandFilter ) );
 
@@ -164,7 +167,6 @@ export default function useProductAndPlans( {
 			suggestedProductSlugs,
 		};
 	}, [
-		selectedProductBrandFilter,
 		data,
 		selectedProductFilters,
 		selectedBundleSize,

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -1,25 +1,24 @@
 import { getQueryArg } from '@wordpress/url';
 import { useMemo } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import {
-	isWooCommerceProduct,
-	isWpcomHostingProduct,
-} from 'calypso/jetpack-cloud/sections/partner-portal/lib';
 import { isProductMatch } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/filter';
 import { useSelector } from 'calypso/state';
 import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-portal/licenses/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
 	PRODUCT_BRAND_FILTER_ALL,
-	PRODUCT_FILTER_ALL,
-	PRODUCT_FILTER_PLANS,
-	PRODUCT_FILTER_PRESSABLE_PLANS,
-	PRODUCT_FILTER_PRODUCTS,
-	PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
-	PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
-	PRODUCT_FILTER_WPCOM_PLANS,
+	PRODUCT_TYPE_JETPACK_BACKUP_ADDON,
+	PRODUCT_TYPE_JETPACK_PLAN,
+	PRODUCT_TYPE_JETPACK_PRODUCT,
+	PRODUCT_TYPE_PRESSABLE_PLAN,
+	PRODUCT_TYPE_WOO_EXTENSION,
+	PRODUCT_TYPE_WPCOM_PLAN,
 } from '../constants';
-import { isPressableHostingProduct, isWPCOMHostingProduct } from '../lib/hosting';
+import {
+	SelectedFilters,
+	filterProductsAndPlans,
+	filterProductsAndPlansByType,
+} from '../lib/product-filter';
 import type { SiteDetails } from '@automattic/data-stores';
 
 // Plans and Products that we can merged into 1 card.
@@ -29,65 +28,18 @@ const MERGABLE_PRODUCTS = [ 'jetpack-backup' ];
 type Props = {
 	selectedBundleSize?: number;
 	selectedSite?: SiteDetails | null;
-	selectedProductFilter?: string | null;
 	selectedProductBrandFilter?: string | null;
 	productSearchQuery?: string;
 	usePublicQuery?: boolean;
-};
-
-const getProductsAndPlansByFilter = (
-	filter: string | null,
-	allProductsAndPlans?: APIProductFamilyProduct[]
-) => {
-	switch ( filter ) {
-		case PRODUCT_FILTER_PRODUCTS:
-			return (
-				allProductsAndPlans?.filter(
-					( { family_slug } ) =>
-						family_slug !== 'jetpack-packs' &&
-						family_slug !== 'jetpack-backup-storage' &&
-						! isWooCommerceProduct( family_slug ) &&
-						! isWpcomHostingProduct( family_slug ) &&
-						! isPressableHostingProduct( family_slug )
-				) || []
-			);
-		case PRODUCT_FILTER_PLANS:
-			return (
-				allProductsAndPlans?.filter( ( { family_slug } ) => family_slug === 'jetpack-packs' ) || []
-			);
-
-		case PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS:
-			return (
-				allProductsAndPlans
-					?.filter( ( { family_slug } ) => family_slug === 'jetpack-backup-storage' )
-					.sort( ( a, b ) => a.product_id - b.product_id ) || []
-			);
-
-		case PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS:
-			return (
-				allProductsAndPlans?.filter( ( { family_slug } ) => isWooCommerceProduct( family_slug ) ) ||
-				[]
-			);
-		case PRODUCT_FILTER_PRESSABLE_PLANS:
-			return (
-				allProductsAndPlans?.filter( ( { family_slug } ) =>
-					isPressableHostingProduct( family_slug )
-				) || []
-			);
-		case PRODUCT_FILTER_WPCOM_PLANS:
-			return (
-				allProductsAndPlans?.filter( ( { family_slug } ) =>
-					isWPCOMHostingProduct( family_slug )
-				) || []
-			);
-	}
-
-	return allProductsAndPlans || [];
+	selectedProductFilters?: SelectedFilters;
 };
 
 // This function gets the displayable Plans based on how it should be arranged in the listing.
-const getDisplayablePlans = ( filteredProductsAndBundles: APIProductFamilyProduct[] ) => {
-	const plans = getProductsAndPlansByFilter( PRODUCT_FILTER_PLANS, filteredProductsAndBundles );
+const getDisplayableJetpackPlans = ( filteredProductsAndBundles: APIProductFamilyProduct[] ) => {
+	const plans = filterProductsAndPlansByType(
+		PRODUCT_TYPE_JETPACK_PLAN,
+		filteredProductsAndBundles
+	);
 
 	const filteredPlans = MERGABLE_PLANS.map( ( filter ) => {
 		return plans.filter( ( { slug } ) => slug.startsWith( filter ) );
@@ -103,9 +55,9 @@ const getDisplayablePlans = ( filteredProductsAndBundles: APIProductFamilyProduc
 };
 
 // This function gets the displayable Products based on how it should be arranged in the listing.
-const getDisplayableProducts = ( filteredProductsAndBundles: APIProductFamilyProduct[] ) => {
-	const products = getProductsAndPlansByFilter(
-		PRODUCT_FILTER_PRODUCTS,
+const getDisplayableJetpackProducts = ( filteredProductsAndBundles: APIProductFamilyProduct[] ) => {
+	const products = filterProductsAndPlansByType(
+		PRODUCT_TYPE_JETPACK_PRODUCT,
 		filteredProductsAndBundles
 	);
 	const filteredProducts = MERGABLE_PRODUCTS.map( ( filter ) => {
@@ -130,8 +82,8 @@ const getDisplayableProducts = ( filteredProductsAndBundles: APIProductFamilyPro
 export default function useProductAndPlans( {
 	selectedBundleSize = 1,
 	selectedSite,
-	selectedProductFilter = PRODUCT_FILTER_ALL,
 	selectedProductBrandFilter = PRODUCT_BRAND_FILTER_ALL,
+	selectedProductFilters,
 	productSearchQuery,
 	usePublicQuery = false,
 }: Props ) {
@@ -143,25 +95,29 @@ export default function useProductAndPlans( {
 
 	return useMemo( () => {
 		// List only products that matches the selected product brand filter.
-		const filteredProductBrand =
+		let filteredProductsAndBundles =
 			! selectedProductBrandFilter || selectedProductBrandFilter === PRODUCT_BRAND_FILTER_ALL
 				? data
 				: data?.filter( ( { slug } ) => slug.startsWith( selectedProductBrandFilter ) );
 
+		filteredProductsAndBundles = filteredProductsAndBundles ?? [];
+
+		// List only products that matches the selected product filters.
+		if ( selectedProductFilters && filteredProductsAndBundles ) {
+			filteredProductsAndBundles = filterProductsAndPlans(
+				selectedProductFilters,
+				filteredProductsAndBundles
+			);
+		}
+
 		// List only products that is compatible with current bundle size.
-		const supportedProducts =
+		filteredProductsAndBundles =
 			selectedBundleSize > 1
-				? filteredProductBrand?.filter(
+				? filteredProductsAndBundles?.filter(
 						( { supported_bundles } ) =>
 							supported_bundles?.some?.( ( { quantity } ) => selectedBundleSize === quantity )
 				  )
-				: filteredProductBrand;
-
-		// We pre-filter the list by current selected filter
-		let filteredProductsAndBundles = getProductsAndPlansByFilter(
-			selectedProductFilter,
-			supportedProducts
-		);
+				: filteredProductsAndBundles;
 
 		// Filter products based on the search term
 		if ( productSearchQuery ) {
@@ -187,22 +143,22 @@ export default function useProductAndPlans( {
 			isLoadingProducts,
 			data,
 			filteredProductsAndBundles,
-			plans: getDisplayablePlans( filteredProductsAndBundles ),
-			products: getDisplayableProducts( filteredProductsAndBundles ),
-			backupAddons: getProductsAndPlansByFilter(
-				PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+			jetpackPlans: getDisplayableJetpackPlans( filteredProductsAndBundles ),
+			jetpackProducts: getDisplayableJetpackProducts( filteredProductsAndBundles ),
+			jetpackBackupAddons: filterProductsAndPlansByType(
+				PRODUCT_TYPE_JETPACK_BACKUP_ADDON,
 				filteredProductsAndBundles
 			),
-			wooExtensions: getProductsAndPlansByFilter(
-				PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+			wooExtensions: filterProductsAndPlansByType(
+				PRODUCT_TYPE_WOO_EXTENSION,
 				filteredProductsAndBundles
 			),
-			pressablePlans: getProductsAndPlansByFilter(
-				PRODUCT_FILTER_PRESSABLE_PLANS,
+			pressablePlans: filterProductsAndPlansByType(
+				PRODUCT_TYPE_PRESSABLE_PLAN,
 				filteredProductsAndBundles
 			),
-			wpcomPlans: getProductsAndPlansByFilter(
-				PRODUCT_FILTER_WPCOM_PLANS,
+			wpcomPlans: filterProductsAndPlansByType(
+				PRODUCT_TYPE_WPCOM_PLAN,
 				filteredProductsAndBundles
 			),
 			suggestedProductSlugs,
@@ -210,8 +166,8 @@ export default function useProductAndPlans( {
 	}, [
 		selectedProductBrandFilter,
 		data,
+		selectedProductFilters,
 		selectedBundleSize,
-		selectedProductFilter,
 		productSearchQuery,
 		selectedSite,
 		addedPlanAndProducts,

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -1,8 +1,24 @@
 import {
+	isWooCommerceProduct,
+	isWpcomHostingProduct,
+} from 'calypso/jetpack-cloud/sections/partner-portal/lib';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import {
 	PRODUCT_FILTER_KEY_CATEGORIES,
 	PRODUCT_FILTER_KEY_PRICES,
 	PRODUCT_FILTER_KEY_TYPES,
+	PRODUCT_TYPE_ADDON,
+	PRODUCT_TYPE_EXTENSION,
+	PRODUCT_TYPE_JETPACK_BACKUP_ADDON,
+	PRODUCT_TYPE_JETPACK_PLAN,
+	PRODUCT_TYPE_JETPACK_PRODUCT,
+	PRODUCT_TYPE_PLAN,
+	PRODUCT_TYPE_PRESSABLE_PLAN,
+	PRODUCT_TYPE_PRODUCT,
+	PRODUCT_TYPE_WOO_EXTENSION,
+	PRODUCT_TYPE_WPCOM_PLAN,
 } from '../constants';
+import { isPressableHostingProduct, isWPCOMHostingProduct } from '../lib/hosting';
 
 export type SelectedFilters = {
 	[ PRODUCT_FILTER_KEY_CATEGORIES ]: Record< string, boolean >;
@@ -14,4 +30,65 @@ export function hasSelectedFilter( selectedFilters: SelectedFilters ) {
 	return Object.values( selectedFilters ).some( ( filter ) => {
 		return Object.values( filter ).some( ( selected ) => selected );
 	} );
+}
+
+export function filterProductsAndPlans(
+	selectedFilters: SelectedFilters,
+	productsAndPlans: APIProductFamilyProduct[]
+) {
+	return productsAndPlans;
+}
+
+export function filterProductsAndPlansByType(
+	filter: string | null,
+	allProductsAndPlans?: APIProductFamilyProduct[]
+) {
+	switch ( filter ) {
+		case PRODUCT_TYPE_JETPACK_PRODUCT:
+		case PRODUCT_TYPE_PRODUCT: // Right now this is the same as jetpack product but once we have more non-jetpack products we can separate them.
+			return (
+				allProductsAndPlans?.filter(
+					( { family_slug } ) =>
+						family_slug !== 'jetpack-packs' &&
+						family_slug !== 'jetpack-backup-storage' &&
+						! isWooCommerceProduct( family_slug ) &&
+						! isWpcomHostingProduct( family_slug ) &&
+						! isPressableHostingProduct( family_slug )
+				) || []
+			);
+		case PRODUCT_TYPE_JETPACK_PLAN:
+		case PRODUCT_TYPE_PLAN: // Right now this is the same as jetpack plan but once we have more non-jetpack plans we can separate them.
+			return (
+				allProductsAndPlans?.filter( ( { family_slug } ) => family_slug === 'jetpack-packs' ) || []
+			);
+
+		case PRODUCT_TYPE_JETPACK_BACKUP_ADDON:
+		case PRODUCT_TYPE_ADDON: // Right now this is the same as jetpack backup addons but once we have more non-jetpack addons we can separate them.
+			return (
+				allProductsAndPlans
+					?.filter( ( { family_slug } ) => family_slug === 'jetpack-backup-storage' )
+					.sort( ( a, b ) => a.product_id - b.product_id ) || []
+			);
+
+		case PRODUCT_TYPE_WOO_EXTENSION:
+		case PRODUCT_TYPE_EXTENSION:
+			return (
+				allProductsAndPlans?.filter( ( { family_slug } ) => isWooCommerceProduct( family_slug ) ) ||
+				[]
+			);
+		case PRODUCT_TYPE_PRESSABLE_PLAN:
+			return (
+				allProductsAndPlans?.filter( ( { family_slug } ) =>
+					isPressableHostingProduct( family_slug )
+				) || []
+			);
+		case PRODUCT_TYPE_WPCOM_PLAN:
+			return (
+				allProductsAndPlans?.filter( ( { family_slug } ) =>
+					isWPCOMHostingProduct( family_slug )
+				) || []
+			);
+	}
+
+	return allProductsAndPlans || [];
 }

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -4,10 +4,24 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
+	PRODUCT_BRAND_FILTER_ALL,
+	PRODUCT_CATEGORY_CONVERSION,
+	PRODUCT_CATEGORY_CUSTOMER_SERVICE,
+	PRODUCT_CATEGORY_GROWTH,
+	PRODUCT_CATEGORY_MERCHANDISING,
+	PRODUCT_CATEGORY_PAYMENTS,
+	PRODUCT_CATEGORY_PERFORMANCE,
+	PRODUCT_CATEGORY_SECURITY,
+	PRODUCT_CATEGORY_SHIPPING_DELIVERY_FULFILLMENT,
+	PRODUCT_CATEGORY_SOCIAL,
+	PRODUCT_CATEGORY_STORE_CONTENT,
+	PRODUCT_CATEGORY_STORE_MANAGEMENT,
 	PRODUCT_FILTER_KEY_BRAND,
 	PRODUCT_FILTER_KEY_CATEGORIES,
 	PRODUCT_FILTER_KEY_PRICES,
 	PRODUCT_FILTER_KEY_TYPES,
+	PRODUCT_PRICE_FREE,
+	PRODUCT_PRICE_PAID,
 	PRODUCT_TYPE_ADDON,
 	PRODUCT_TYPE_EXTENSION,
 	PRODUCT_TYPE_JETPACK_BACKUP_ADDON,
@@ -39,17 +53,160 @@ export function hasSelectedFilter( selectedFilters: SelectedFilters ) {
 }
 
 export function filterProductsAndPlans(
-	selectedFilters: SelectedFilters,
-	productsAndPlans: APIProductFamilyProduct[]
+	productsAndPlans: APIProductFamilyProduct[],
+	selectedFilters?: SelectedFilters
 ) {
+	if ( ! selectedFilters ) {
+		return productsAndPlans;
+	}
+
+	let filteredProductsAndBundles = [];
+
+	// List only products that matches the selected prices.
+	filteredProductsAndBundles = filterProductsAndPlansByPrices(
+		productsAndPlans,
+		getSelectedFilters( PRODUCT_FILTER_KEY_PRICES, selectedFilters )
+	);
+
+	// List only products that matches the selected product brand filter.
+	filteredProductsAndBundles = filterProductsAndPlansByBrand(
+		filteredProductsAndBundles,
+		selectedFilters[ PRODUCT_FILTER_KEY_BRAND ]
+	);
+
+	// List only products that matches the selected product types.
+	filteredProductsAndBundles = filterProductsAndPlansByTypes(
+		filteredProductsAndBundles,
+		getSelectedFilters( PRODUCT_FILTER_KEY_TYPES, selectedFilters )
+	);
+
+	// List only products that matches the selected product categories.
+	filteredProductsAndBundles = filterProductsAndPlansByCategories(
+		filteredProductsAndBundles,
+		getSelectedFilters( PRODUCT_FILTER_KEY_CATEGORIES, selectedFilters )
+	);
+
+	return filteredProductsAndBundles;
+}
+
+/*
+ * Get selected filters.
+ *
+ * @param {string} key - Selected filter key.
+ * @param {SelectedFilters} selectedFilters - Selected filters.
+ * @return {string[]} Selected filters.
+ */
+function getSelectedFilters( key: string, selectedFilters: SelectedFilters ) {
+	const record = selectedFilters[ key as keyof SelectedFilters ] as Record< string, boolean >;
+	return Object.keys( record ).filter( ( filter ) => record[ filter ] );
+}
+
+/*
+ * Filter products and plans by brand.
+ *
+ * @param {APIProductFamilyProduct[]} productsAndPlans - List of products and plans.
+ * @param {string} productBrand - Selected product brand filter.
+ * @return {APIProductFamilyProduct[]} Filtered products and plans.
+ */
+function filterProductsAndPlansByBrand(
+	productsAndPlans: APIProductFamilyProduct[],
+	productBrand?: string
+) {
+	const selectedProductBrandFilter = productBrand ?? PRODUCT_BRAND_FILTER_ALL;
+
+	return selectedProductBrandFilter === PRODUCT_BRAND_FILTER_ALL
+		? productsAndPlans
+		: productsAndPlans.filter( ( { slug } ) => slug.startsWith( selectedProductBrandFilter ) );
+}
+
+/*
+ * Filter products and plans by types.
+ *
+ * @param {APIProductFamilyProduct[]} productsAndPlans - List of products and plans.
+ * @param {string[]} types - Selected product types.
+ * @return {APIProductFamilyProduct[]} Filtered products and plans.
+ */
+function filterProductsAndPlansByTypes(
+	productsAndPlans: APIProductFamilyProduct[],
+	types: string[]
+) {
+	if ( ! types.length ) {
+		return productsAndPlans;
+	}
+
+	const filteredData: Set< APIProductFamilyProduct > = new Set();
+
+	types.forEach( ( type ) => {
+		filterProductsAndPlansByType( type, productsAndPlans ).forEach( ( item ) => {
+			filteredData.add( item );
+		} );
+	} );
+
+	return Array.from( filteredData );
+}
+
+/*
+ * Filter products and plans by prices.
+ *
+ * @param {APIProductFamilyProduct[]} productsAndPlans - List of products and plans.
+ * @param {string[]} prices - Selected product prices.
+ * @return {APIProductFamilyProduct[]} Filtered products and plans.
+ */
+function filterProductsAndPlansByPrices(
+	productsAndPlans: APIProductFamilyProduct[],
+	prices: string[]
+) {
+	if ( prices.length === 1 ) {
+		if ( prices[ 0 ] === PRODUCT_PRICE_FREE ) {
+			return productsAndPlans.filter( ( { amount } ) => Number( amount ) === 0 );
+		}
+
+		if ( prices[ 0 ] === PRODUCT_PRICE_PAID ) {
+			return productsAndPlans.filter( ( { amount } ) => Number( amount ) > 0 );
+		}
+	}
+
 	return productsAndPlans;
 }
 
+/*
+ * Filter products and plans by categories.
+ *
+ * @param {APIProductFamilyProduct[]} productsAndPlans - List of products and plans.
+ * @param {string[]} categories - Selected product categories.
+ * @return {APIProductFamilyProduct[]} Filtered products and plans.
+ */
+function filterProductsAndPlansByCategories(
+	productAndPlans: APIProductFamilyProduct[],
+	categories: string[]
+) {
+	if ( ! categories.length ) {
+		return productAndPlans;
+	}
+
+	const filteredData: Set< APIProductFamilyProduct > = new Set();
+
+	categories.forEach( ( category ) => {
+		filterProductsAndPlansByCategory( category, productAndPlans ).forEach( ( item ) => {
+			filteredData.add( item );
+		} );
+	} );
+
+	return Array.from( filteredData );
+}
+
+/*
+ * Filter products and plans by type.
+ *
+ * @param {string} filter - Selected product type filter.
+ * @param {APIProductFamilyProduct[]} allProductsAndPlans - List of products and plans.
+ * @return {APIProductFamilyProduct[]} Filtered products and plans.
+ */
 export function filterProductsAndPlansByType(
-	filter: string | null,
+	type: string | null,
 	allProductsAndPlans?: APIProductFamilyProduct[]
 ) {
-	switch ( filter ) {
+	switch ( type ) {
 		case PRODUCT_TYPE_JETPACK_PRODUCT:
 		case PRODUCT_TYPE_PRODUCT: // Right now this is the same as jetpack product but once we have more non-jetpack products we can separate them.
 			return (
@@ -97,4 +254,126 @@ export function filterProductsAndPlansByType(
 	}
 
 	return allProductsAndPlans || [];
+}
+
+/*
+ * Filter products and plans by category.
+ *
+ * @param {string} category - Selected product category filter.
+ * @param {APIProductFamilyProduct[]} allProductsAndPlans - List of products and plans.
+ * @return {APIProductFamilyProduct[]} Filtered products and plans.
+ */
+function filterProductsAndPlansByCategory(
+	category: string,
+	allProductsAndPlans: APIProductFamilyProduct[]
+) {
+	switch ( category ) {
+		case PRODUCT_CATEGORY_SECURITY:
+			return allProductsAndPlans.filter(
+				( { slug, family_slug } ) =>
+					[
+						'jetpack-backup',
+						'jetpack-scan',
+						'jetpack-anti-spam',
+						'jetpack-monitor',
+						'jetpack-backup-storage',
+					].includes( family_slug ) || slug === 'jetpack-complete'
+			);
+		case PRODUCT_CATEGORY_PERFORMANCE:
+			return allProductsAndPlans.filter(
+				( { slug, family_slug } ) =>
+					[ 'jetpack-boost', 'jetpack-search', 'jetpack-videopress' ].includes( family_slug ) ||
+					slug === 'jetpack-complete'
+			);
+		case PRODUCT_CATEGORY_SOCIAL:
+			return allProductsAndPlans.filter(
+				( { slug, family_slug } ) => family_slug === 'jetpack-social' || slug === 'jetpack-complete'
+			);
+		case PRODUCT_CATEGORY_GROWTH:
+			return allProductsAndPlans.filter(
+				( { slug, family_slug } ) =>
+					[ 'jetpack-creator', 'jetpack-ai', 'jetpack-stats' ].includes( family_slug ) ||
+					slug === 'jetpack-complete'
+			);
+		case PRODUCT_CATEGORY_PAYMENTS:
+			return allProductsAndPlans.filter(
+				( { family_slug } ) => family_slug === 'woocommerce-woopayments'
+			);
+		case PRODUCT_CATEGORY_SHIPPING_DELIVERY_FULFILLMENT:
+			return allProductsAndPlans.filter( ( { family_slug } ) =>
+				[
+					'woocommerce-advanced-notifications',
+					'woocommerce-all-products-woo-subscriptions',
+					'woocommerce-conditional-shipping-payments',
+					'woocommerce-flat-rate-box-shipping',
+					'woocommerce-per-product-shipping',
+					'woocommerce-shipping-multiple-addresses',
+					'woocommerce-table-rate-shipping',
+					'woocommerce-distance-rate-shipping',
+					'woocommerce-order-barcodes',
+					'woocommerce-shipping',
+				].includes( family_slug )
+			);
+		case PRODUCT_CATEGORY_CONVERSION:
+			return allProductsAndPlans.filter( ( { family_slug } ) =>
+				[
+					'woocommerce-back-in-stock-notifications',
+					'woocommerce-checkout-field-editor',
+					'woocommerce-product-recommendations',
+					'woocommerce-coupon-campaigns',
+					'woocommerce-points-and-rewards',
+					'woocommerce-product-add-ons',
+					'woocommerce-product-bundles',
+				].includes( family_slug )
+			);
+		case PRODUCT_CATEGORY_CUSTOMER_SERVICE:
+			return allProductsAndPlans.filter( ( { family_slug } ) =>
+				[
+					'woocommerce-automatewoo',
+					'woocommerce-automatewoo-birthdays',
+					'woocommerce-automatewoo-refer-a-friend',
+					'woocommerce-returns-warranty-requests',
+					'woocommerce-shipment-tracking',
+				].includes( family_slug )
+			);
+		case PRODUCT_CATEGORY_MERCHANDISING:
+			return allProductsAndPlans.filter( ( { family_slug } ) =>
+				[
+					'woocommerce-composite-products',
+					'woocommerce-eu-vat-number',
+					'woocommerce-gift-cards',
+					'woocommerce-gifting-wc-subscriptions',
+					'woocommerce-product-vendors',
+					'woocommerce-deposits',
+					'woocommerce-pre-orders',
+					'woocommerce-purchase-order-gateway',
+					'woocommerce-subscription-downloads',
+					'woocommerce-subscriptions',
+				].includes( family_slug )
+			);
+		case PRODUCT_CATEGORY_STORE_CONTENT:
+			return allProductsAndPlans.filter( ( { family_slug } ) =>
+				[
+					'woocommerce-accommodations-bookings',
+					'woocommerce-additional-image-variations',
+					'woocommerce-bookings',
+					'woocommerce-bookings-availability',
+					'woocommerce-box-office',
+					'woocommerce-brands',
+					'woocommerce-minmax-quantities',
+					'woocommerce-one-page-checkout',
+				].includes( family_slug )
+			);
+		case PRODUCT_CATEGORY_STORE_MANAGEMENT:
+			return allProductsAndPlans.filter( ( { family_slug } ) =>
+				[
+					'woocommerce-bulk-stock-management',
+					'woocommerce-product-csv-import-suite',
+					'woocommerce-tax',
+					'woocommerce-woopayments',
+				].includes( family_slug )
+			);
+	}
+
+	return allProductsAndPlans;
 }

--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -4,6 +4,7 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
+	PRODUCT_FILTER_KEY_BRAND,
 	PRODUCT_FILTER_KEY_CATEGORIES,
 	PRODUCT_FILTER_KEY_PRICES,
 	PRODUCT_FILTER_KEY_TYPES,
@@ -21,15 +22,20 @@ import {
 import { isPressableHostingProduct, isWPCOMHostingProduct } from '../lib/hosting';
 
 export type SelectedFilters = {
+	[ PRODUCT_FILTER_KEY_BRAND ]: string;
 	[ PRODUCT_FILTER_KEY_CATEGORIES ]: Record< string, boolean >;
 	[ PRODUCT_FILTER_KEY_TYPES ]: Record< string, boolean >;
 	[ PRODUCT_FILTER_KEY_PRICES ]: Record< string, boolean >;
 };
 
 export function hasSelectedFilter( selectedFilters: SelectedFilters ) {
-	return Object.values( selectedFilters ).some( ( filter ) => {
-		return Object.values( filter ).some( ( selected ) => selected );
-	} );
+	return Object.keys( selectedFilters )
+		.filter( ( key ) => key !== PRODUCT_FILTER_KEY_BRAND )
+		.some( ( key ) => {
+			return Object.values( selectedFilters[ key as keyof SelectedFilters ] ).some(
+				( selected ) => selected
+			);
+		} );
 }
 
 export function filterProductsAndPlans(

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
@@ -71,12 +71,16 @@ export default function ProductFilter( { selectedFilters, setSelectedFilters }: 
 	} = useProductFilterOptions();
 
 	const updateFilter = ( type: string, filter: string ) => {
+		const record = selectedFilters[ type as keyof SelectedFilters ] as Record< string, boolean >;
+
+		const newFilters = {
+			...record,
+			[ filter ]: ! record[ filter ],
+		};
+
 		setSelectedFilters( {
 			...selectedFilters,
-			[ type ]: {
-				...selectedFilters[ type as keyof SelectedFilters ],
-				[ filter ]: ! selectedFilters[ type as keyof SelectedFilters ][ filter ],
-			},
+			[ type ]: newFilters,
 		} );
 	};
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-selected-product-filters.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-selected-product-filters.tsx
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+	PRODUCT_FILTER_KEY_BRAND,
+	PRODUCT_FILTER_KEY_CATEGORIES,
+	PRODUCT_FILTER_KEY_PRICES,
+	PRODUCT_FILTER_KEY_TYPES,
+} from '../../../constants';
+import { SelectedFilters, hasSelectedFilter } from '../../../lib/product-filter';
+
+const DEFAULT_SELECTED_FILTERS = {
+	[ PRODUCT_FILTER_KEY_BRAND ]: '',
+	[ PRODUCT_FILTER_KEY_CATEGORIES ]: {},
+	[ PRODUCT_FILTER_KEY_TYPES ]: {},
+	[ PRODUCT_FILTER_KEY_PRICES ]: {},
+};
+
+type Props = {
+	productBrand: string;
+};
+
+export default function useSelectedProductFilters( { productBrand }: Props ) {
+	const [ selectedFilters, setSelectedFilters ] = useState< SelectedFilters >( {
+		...DEFAULT_SELECTED_FILTERS,
+		[ PRODUCT_FILTER_KEY_BRAND ]: productBrand,
+	} );
+
+	const resetFilters = useCallback( () => {
+		setSelectedFilters( {
+			...DEFAULT_SELECTED_FILTERS,
+			[ PRODUCT_FILTER_KEY_BRAND ]: productBrand,
+		} );
+	}, [ productBrand ] );
+
+	useEffect( () => {
+		setSelectedFilters( ( state ) => ( {
+			...state,
+			[ PRODUCT_FILTER_KEY_BRAND ]: productBrand,
+		} ) );
+	}, [ productBrand ] );
+
+	return useMemo(
+		() => ( {
+			selectedFilters,
+			setSelectedFilters,
+			resetFilters,
+			hasSelected: hasSelectedFilter( selectedFilters ),
+		} ),
+		[ resetFilters, selectedFilters ]
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -11,19 +11,14 @@ import {
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import FilterSearch from '../../../../components/filter-search';
-import {
-	PRODUCT_FILTER_KEY_CATEGORIES,
-	PRODUCT_FILTER_KEY_PRICES,
-	PRODUCT_FILTER_KEY_TYPES,
-} from '../../constants';
 import { MarketplaceTypeContext, ShoppingCartContext } from '../../context';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
-import { SelectedFilters, hasSelectedFilter } from '../../lib/product-filter';
 import ListingSection from '../../listing-section';
 import MultiProductCard from '../multi-product-card';
 import ProductCard from '../product-card';
 import ProductFilter from '../product-filter';
 import { getSupportedBundleSizes, useProductBundleSize } from './hooks/use-product-bundle-size';
+import useSelectedProductFilters from './hooks/use-selected-product-filters';
 import useSubmitForm from './hooks/use-submit-form';
 import VolumePriceSelector from './volume-price-selector';
 import type { ShoppingCartItem } from '../../types';
@@ -37,12 +32,6 @@ interface ProductListingProps {
 	suggestedProduct?: string;
 	productBrand: string;
 }
-
-export const DEFAULT_SELECTED_FILTERS = {
-	[ PRODUCT_FILTER_KEY_CATEGORIES ]: {},
-	[ PRODUCT_FILTER_KEY_TYPES ]: {},
-	[ PRODUCT_FILTER_KEY_PRICES ]: {},
-};
 
 export default function ProductListing( {
 	selectedSite,
@@ -58,15 +47,18 @@ export default function ProductListing( {
 
 	const [ productSearchQuery, setProductSearchQuery ] = useState< string >( '' );
 
-	const [ selectedFilters, setSelectedFilters ] = useState< SelectedFilters >( {
-		...DEFAULT_SELECTED_FILTERS,
-	} );
-
 	const {
 		selectedSize: selectedBundleSize,
 		availableSizes: availableBundleSizes,
 		setSelectedSize: setSelectedBundleSize,
 	} = useProductBundleSize();
+
+	const {
+		selectedFilters,
+		setSelectedFilters,
+		resetFilters,
+		hasSelected: shouldShowResetButton,
+	} = useSelectedProductFilters( { productBrand } );
 
 	const quantity = useMemo(
 		() => ( isReferingProducts ? 1 : selectedBundleSize ),
@@ -85,7 +77,6 @@ export default function ProductListing( {
 	} = useProductAndPlans( {
 		selectedSite,
 		selectedBundleSize: quantity,
-		selectedProductBrandFilter: productBrand,
 		selectedProductFilters: selectedFilters,
 		productSearchQuery,
 	} );
@@ -297,8 +288,6 @@ export default function ProductListing( {
 		);
 	};
 
-	const shouldShowResetButton = hasSelectedFilter( selectedFilters );
-
 	if ( isLoadingProducts ) {
 		return (
 			<div className="product-listing">
@@ -325,15 +314,7 @@ export default function ProductListing( {
 					/>
 
 					{ shouldShowResetButton && (
-						<Button
-							className="product-listing__reset-filter-button"
-							plain
-							onClick={ () =>
-								setSelectedFilters( {
-									...DEFAULT_SELECTED_FILTERS,
-								} )
-							}
-						>
+						<Button className="product-listing__reset-filter-button" plain onClick={ resetFilters }>
 							{ translate( 'Reset filter' ) }
 						</Button>
 					) }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -76,9 +76,9 @@ export default function ProductListing( {
 	const {
 		filteredProductsAndBundles,
 		isLoadingProducts,
-		plans,
-		backupAddons,
-		products,
+		jetpackPlans,
+		jetpackBackupAddons,
+		jetpackProducts,
 		wooExtensions,
 		data,
 		suggestedProductSlugs,
@@ -86,6 +86,7 @@ export default function ProductListing( {
 		selectedSite,
 		selectedBundleSize: quantity,
 		selectedProductBrandFilter: productBrand,
+		selectedProductFilters: selectedFilters,
 		productSearchQuery,
 	} );
 
@@ -298,9 +299,6 @@ export default function ProductListing( {
 
 	const shouldShowResetButton = hasSelectedFilter( selectedFilters );
 
-	// FIXME: For now we hide the filtering until we complete the implementation. We will remove this flag later.
-	const hideFilter = true;
-
 	if ( isLoadingProducts ) {
 		return (
 			<div className="product-listing">
@@ -321,12 +319,10 @@ export default function ProductListing( {
 						onClick={ trackClickCallback( 'search' ) }
 					/>
 
-					{ ! hideFilter && (
-						<ProductFilter
-							selectedFilters={ selectedFilters }
-							setSelectedFilters={ setSelectedFilters }
-						/>
-					) }
+					<ProductFilter
+						selectedFilters={ selectedFilters }
+						setSelectedFilters={ setSelectedFilters }
+					/>
 
 					{ shouldShowResetButton && (
 						<Button
@@ -365,7 +361,7 @@ export default function ProductListing( {
 				</ListingSection>
 			) }
 
-			{ plans.length > 0 && (
+			{ jetpackPlans.length > 0 && (
 				<ListingSection
 					id="jetpack-plans"
 					icon={ <JetpackLogo size={ 26 } /> }
@@ -374,11 +370,11 @@ export default function ProductListing( {
 						'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
 					) } // FIXME: Add proper description for A4A
 				>
-					{ getProductCards( plans ) }
+					{ getProductCards( jetpackPlans ) }
 				</ListingSection>
 			) }
 
-			{ products.length > 0 && (
+			{ jetpackProducts.length > 0 && (
 				<ListingSection
 					icon={ <JetpackLogo size={ 26 } /> }
 					title={ translate( 'Jetpack Products' ) }
@@ -386,11 +382,11 @@ export default function ProductListing( {
 						'Mix and match powerful security, performance, and growth tools for your sites.'
 					) }
 				>
-					{ getProductCards( products ) }
+					{ getProductCards( jetpackProducts ) }
 				</ListingSection>
 			) }
 
-			{ backupAddons.length > 0 && (
+			{ jetpackBackupAddons.length > 0 && (
 				<ListingSection
 					icon={ <JetpackLogo size={ 26 } /> }
 					title={ translate( 'Jetpack VaultPress Backup Add-ons' ) }
@@ -398,7 +394,7 @@ export default function ProductListing( {
 						'Add additional storage to your current VaultPress Backup plans.'
 					) }
 				>
-					{ getProductCards( backupAddons ) }
+					{ getProductCards( jetpackBackupAddons ) }
 				</ListingSection>
 			) }
 		</div>


### PR DESCRIPTION
This is a continuation of https://github.com/Automattic/wp-calypso/pull/91082, which implements the filtering logic based on the new design.


https://github.com/Automattic/wp-calypso/assets/56598660/a9d7f625-d34d-49d3-9a36-b3285e035294



Depends on https://github.com/Automattic/wp-calypso/pull/91082
Closes https://github.com/Automattic/wp-calypso/pull/91082

## Proposed Changes

* Refactor the `useProductsAndPlans` hook to simplify and declutter the Filtering logic.
* Implement the filtering logic based on the new design. Please refer to 348e1-pb for the full list of products under a category.
* Remove temporary flags hiding the ProductFilter component.

## Testing Instructions


* Use the A4A live link below and go to `/marketplace/products`
* Test the filtering to confirm that it filters products based on the selected Category, type, and price filters.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
