### PR TITLE
A4A > Referrals: Implement Referrals list view for automated referrals.

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -73,23 +73,23 @@
 		margin-left: auto;
 	}
 
-	.badge {
+	&.badge {
 		white-space: nowrap;
 		position: relative;
 		top: -1px;
 	}
 
-	.badge--success {
+	&.badge--success {
 		background-color: var(--color-success-5);
 		color: var(--color-success-80);
 	}
 
-	.badge--warning {
+	&.badge--warning {
 		background-color: var(--color-warning-5);
 		color: var(--color-warning-80);
 	}
 
-	.badge--error {
+	&.badge--error {
 		background-color: var(--color-error-5);
 		color: var(--color-error-80);
 	}

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { Referral, ReferralAPIResponse } from '../types';
+
+export const getReferralsQueryKey = ( agencyId?: number ) => {
+	return [ 'a4a-referrals', agencyId ];
+};
+
+const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
+	const clients: Referral[] = [];
+	referrals.forEach( ( referral ) => {
+		const clientIndex = clients.findIndex( ( client ) => client.client_id === referral.client_id );
+		if ( clientIndex === -1 ) {
+			clients.push( {
+				id: referral.id,
+				client_id: referral.client_id,
+				client_email: referral.client_email,
+				purchases: referral.products,
+				commissions: referral.commission,
+				statuses: [ referral.status ],
+			} );
+		} else {
+			clients[ clientIndex ].purchases.push( ...referral.products );
+			clients[ clientIndex ].commissions += referral.commission;
+			clients[ clientIndex ].statuses.push( referral.status );
+		}
+	} );
+	return clients;
+};
+
+export default function useFetchReferrals( isEnabled: boolean ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const data = useQuery( {
+		queryKey: getReferralsQueryKey( agencyId ),
+		queryFn: () =>
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/referrals`,
+			} ),
+		enabled: isEnabled && !! agencyId,
+		refetchOnWindowFocus: false,
+		select: getClientReferrals,
+	} );
+
+	return data;
+}

--- a/client/a8c-for-agencies/sections/referrals/lib/constants.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/constants.ts
@@ -1,0 +1,3 @@
+import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+
+export const REFER_PRODUCTS_LINK = `${ A4A_MARKETPLACE_PRODUCTS_LINK }?purchase-type=referral`;

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -2,7 +2,9 @@ import { Button } from '@automattic/components';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -28,6 +30,8 @@ export default function ReferralsOverview( {
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( initialDataViewsState );
 
 	const isDesktop = useDesktopBreakpoint();
 
@@ -79,6 +83,8 @@ export default function ReferralsOverview( {
 					tipaltiData={ tipaltiData }
 					referrals={ referrals }
 					isLoading={ isLoading }
+					dataViewsState={ dataViewsState }
+					setDataViewsState={ setDataViewsState }
 				/>
 				{ ! isFetching && ! isAutomatedReferral && <ReferralsFooter /> }
 			</LayoutBody>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,11 +1,8 @@
-import { Button, WooLogo } from '@automattic/components';
-import NoticeBanner from '@automattic/components/src/notice-banner';
+import { Button } from '@automattic/components';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
-import { plugins, reusableBlock } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
+import { useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -14,29 +11,13 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import {
-	A4A_REFERRALS_BANK_DETAILS_LINK,
-	A4A_REFERRALS_COMMISSIONS_LINK,
-	A4A_MARKETPLACE_PRODUCTS_LINK,
-	A4A_REFERRALS_PAYMENT_SETTINGS,
-	A4A_REFERRALS_FAQ,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
-import { A4A_DOWNLOAD_LINK_ON_GITHUB } from 'calypso/a8c-for-agencies/constants';
-import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
-import JetpackLogo from 'calypso/components/jetpack-logo';
-import WooCommerceLogo from 'calypso/components/woocommerce-logo';
-import WordPressLogo from 'calypso/components/wordpress-logo';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { savePreference } from 'calypso/state/preferences/actions';
-import { getPreference } from 'calypso/state/preferences/selectors';
-import StepSection from '../../common/step-section';
-import StepSectionItem from '../../common/step-section-item';
+import useFetchReferrals from '../../hooks/use-fetch-referrals';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
-import { getAccountStatus } from '../../lib/get-account-status';
-import tipaltiLogo from '../../lib/tipalti-logo';
+import { REFER_PRODUCTS_LINK } from '../../lib/constants';
 import ReferralsFooter from '../footer';
+import LayoutBodyContent from './layout-body-content';
 
 import './style.scss';
 
@@ -55,77 +36,23 @@ export default function ReferralsOverview( {
 			? translate( 'Your referrals and commissions' )
 			: translate( 'Referrals' );
 
-	const onAddBankDetailsClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_referrals_add_bank_details_button_click' ) );
-	}, [ dispatch ] );
+	const { data: tipaltiData, isFetching } = useGetTipaltiPayee();
+	const { data: referrals, isFetching: isFetchingReferrals } =
+		useFetchReferrals( isAutomatedReferral );
 
-	const onDownloadA4APluginClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_referrals_download_a4a_plugin_button_click' ) );
-	}, [ dispatch ] );
-
-	const onGetStartedClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_referrals_get_started_button_click' ) );
-	}, [ dispatch ] );
-
-	const { data, isFetching } = useGetTipaltiPayee();
-
-	const accountStatus = getAccountStatus( data, translate );
-
-	const hasPayeeAccount = !! accountStatus?.status;
-
-	// Whether the user has seen the success notice in a previous session.
-	const successNoticeSeen = useSelector( ( state ) =>
-		getPreference( state, 'a4a-referrals-bank-details-success-notice-seen' )
-	);
-
-	// Track whether the preference has just been saved to avoid hiding the notice on the first render.
-	const [ successNoticePreferenceSaved, setSuccessNoticePreferenceSaved ] = useState( false );
-
-	// Whether the user has manually dismissed the success notice.
-	const [ successNoticeDismissed, setSuccessNoticeDismissed ] = useState( successNoticeSeen );
-
-	// Show the banking details success notice if the user has submitted their banking details and the notice has not been dismissed.
-	const showBankingDetailsSuccessNotice = useMemo(
-		() =>
-			accountStatus?.statusType === 'success' &&
-			! successNoticeDismissed &&
-			( ! successNoticeSeen || successNoticePreferenceSaved ),
-		[
-			accountStatus?.statusType,
-			successNoticeDismissed,
-			successNoticePreferenceSaved,
-			successNoticeSeen,
-		]
-	);
-
-	// Only display the success notice for submitted banking details once.
-	useEffect( () => {
-		if ( accountStatus?.statusType === 'success' && ! successNoticeSeen ) {
-			dispatch( savePreference( 'a4a-referrals-bank-details-success-notice-seen', true ) );
-			setSuccessNoticePreferenceSaved( true );
-		}
-	}, [ dispatch, successNoticeSeen, accountStatus ] );
+	const hasReferrals = !! referrals?.length;
 
 	const makeAReferral = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_make_a_referral_button_click' ) );
 	}, [ dispatch ] );
 
-	let bankAccountCTAText = hasPayeeAccount
-		? translate( 'Edit my bank details' )
-		: translate( 'Enter bank details' );
-
-	if ( isAutomatedReferral ) {
-		bankAccountCTAText = hasPayeeAccount
-			? translate( 'Edit my details' )
-			: translate( 'Add my details' );
-	}
-
-	const referProductsLink = `${ A4A_MARKETPLACE_PRODUCTS_LINK }?purchase-type=refer-products`;
+	const isLoading = isFetching || isFetchingReferrals;
 
 	return (
 		<Layout
 			className={ classNames( 'referrals-layout', {
 				'referrals-layout--automated': isAutomatedReferral,
+				'referrals-layout--full-width': isAutomatedReferral && ( isLoading || hasReferrals ),
 			} ) }
 			title={ title }
 			wide
@@ -138,8 +65,8 @@ export default function ReferralsOverview( {
 					{ isAutomatedReferral && (
 						<Actions>
 							<MobileSidebarNavigation />
-							<Button primary href={ referProductsLink } onClick={ makeAReferral }>
-								{ translate( 'Make a referral' ) }
+							<Button primary href={ REFER_PRODUCTS_LINK } onClick={ makeAReferral }>
+								{ hasReferrals ? translate( 'New referral' ) : translate( 'Make a referral' ) }
 							</Button>
 						</Actions>
 					) }
@@ -147,207 +74,12 @@ export default function ReferralsOverview( {
 			</LayoutTop>
 
 			<LayoutBody>
-				{ showBankingDetailsSuccessNotice && (
-					<div className="referrals-overview__section-notice">
-						<NoticeBanner level="success" onClose={ () => setSuccessNoticeDismissed( true ) }>
-							{ translate(
-								'Thanks for entering your bank and tax information. Our team will confirm and review your submission.'
-							) }
-						</NoticeBanner>
-					</div>
-				) }
-				{ isAutomatedReferral && (
-					<div className="referrals-overview__section-icons">
-						<JetpackLogo className="jetpack-logo" size={ 24 } />
-						<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
-						<img src={ pressableIcon } alt="Pressable" />
-						<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
-					</div>
-				) }
-				<div className="referrals-overview__section-heading">
-					{ isAutomatedReferral ? (
-						<>
-							{ translate( 'Recommend our products.' ) } <br />
-							{ translate( 'Earn up to a 50% commission.' ) }
-						</>
-					) : (
-						<>
-							{ translate( 'Recommend our products. Earn up to a 50% commission.' ) } <br />
-							{ translate( ' No promo codes required.' ) }
-						</>
-					) }
-				</div>
-
-				<div className="referrals-overview__section-subtitle">
-					{ isAutomatedReferral ? (
-						translate(
-							'Make money when your clients buy Automattic products, hosting, or use WooPayments. No promo codes needed.'
-						)
-					) : (
-						<>
-							<div>
-								{ translate(
-									'Make money on each product your clients buy from Automattic. They can buy WooCommerce extensions, tools from Jetpack, and hosting services from Pressable or WordPress.com'
-								) }
-							</div>
-							<div>
-								{ translate(
-									'You can also make money when people buy things on your clients’ websites using WooPayments. {{a}}How much can I earn?{{/a}}',
-									{
-										components: {
-											a: <a href={ A4A_REFERRALS_COMMISSIONS_LINK } />,
-										},
-									}
-								) }
-							</div>
-						</>
-					) }
-				</div>
-
-				<div className="referrals-overview__section-container">
-					{ isFetching ? (
-						<>
-							<TextPlaceholder />
-							<TextPlaceholder />
-							<TextPlaceholder />
-							<TextPlaceholder />
-						</>
-					) : (
-						<>
-							{ ! isAutomatedReferral && <MigrationOffer /> }
-							<StepSection
-								heading={
-									isAutomatedReferral
-										? translate( 'How do I start?' )
-										: translate( 'How do I get started?' )
-								}
-							>
-								<StepSectionItem
-									isAutomatedReferral={ isAutomatedReferral }
-									icon={ tipaltiLogo }
-									heading={
-										isAutomatedReferral
-											? translate( 'Prepare to get paid' )
-											: translate( 'Enter your bank details so we can pay you commissions' )
-									}
-									description={
-										isAutomatedReferral
-											? translate( 'With {{a}}Tipalti ↗{{/a}}, our secure platform.', {
-													components: {
-														a: (
-															<a
-																className="referrals-overview__link"
-																href="https://tipalti.com/"
-																target="_blank"
-																rel="noopener noreferrer"
-															/>
-														),
-													},
-											  } )
-											: translate(
-													'Get paid seamlessly by adding your bank details and tax forms to Tipalti, our trusted and secure platform for commission payments.'
-											  )
-									}
-									buttonProps={ {
-										children: bankAccountCTAText,
-										href: isAutomatedReferral
-											? A4A_REFERRALS_PAYMENT_SETTINGS
-											: A4A_REFERRALS_BANK_DETAILS_LINK,
-										onClick: onAddBankDetailsClick,
-										primary: ! hasPayeeAccount,
-										compact: true,
-									} }
-									statusProps={
-										accountStatus
-											? {
-													children: accountStatus?.status,
-													type: accountStatus?.statusType,
-													tooltip: accountStatus?.statusReason,
-											  }
-											: undefined
-									}
-								/>
-								{ isAutomatedReferral ? (
-									<StepSectionItem
-										iconClassName="referrals-overview__opacity-70-percent"
-										isAutomatedReferral
-										icon={ reusableBlock }
-										heading={ translate( 'Refer products and hosting' ) }
-										description={ translate( 'Receive up to a 50% commission.' ) }
-										buttonProps={ {
-											children: translate( 'Get started' ),
-											compact: true,
-											primary: hasPayeeAccount,
-											href: referProductsLink,
-											onClick: onGetStartedClick,
-										} }
-									/>
-								) : (
-									<StepSectionItem
-										iconClassName="referrals-overview__opacity-70-percent"
-										icon={ plugins }
-										heading={ translate( 'Verify your relationship with your clients' ) }
-										description={ translate(
-											'Install the A4A plugin on your clients’ sites. This shows you have a direct relationship with the client.'
-										) }
-										buttonProps={ {
-											children: translate( 'Download the plugin now' ),
-											compact: true,
-											href: A4A_DOWNLOAD_LINK_ON_GITHUB,
-											onClick: onDownloadA4APluginClick,
-										} }
-									/>
-								) }
-								<StepSectionItem
-									isAutomatedReferral={ isAutomatedReferral }
-									className="referrals-overview__step-section-woo-payments"
-									icon={ <WooLogo /> }
-									heading={
-										isAutomatedReferral
-											? translate( 'Install WooPayments' )
-											: translate( 'Install WooPayments on your clients’ online stores' )
-									}
-									description={
-										isAutomatedReferral
-											? translate( 'Receive a rev share of 0.05% per sale.' )
-											: translate(
-													'Receive a revenue share of 5 basis points (0.05%) on new WooPayments total payments volume (TPV) on clients’ sites.'
-											  )
-									}
-									buttonProps={ {
-										children: isAutomatedReferral
-											? translate( 'Learn how' )
-											: translate( 'Learn about WooPayments' ),
-										compact: isAutomatedReferral,
-										primary: isAutomatedReferral && hasPayeeAccount,
-										borderless: ! isAutomatedReferral,
-										href: 'https://woocommerce.com/payments/',
-										rel: 'noreferrer',
-										target: '_blank',
-									} }
-								/>
-							</StepSection>
-							{ isAutomatedReferral && (
-								<StepSection
-									className="referrals-overview__step-section-learn-more"
-									heading={ translate( 'Find out more about the program' ) }
-								>
-									<Button className="a8c-blue-link" borderless href={ A4A_REFERRALS_FAQ }>
-										{ translate( 'How much money will I make?' ) }
-									</Button>
-									<br />
-									{
-										// FIXME: Add link
-										<Button className="a8c-blue-link" borderless href="#">
-											{ translate( 'How does it work?' ) }
-										</Button>
-									}
-								</StepSection>
-							) }
-						</>
-					) }
-				</div>
-
+				<LayoutBodyContent
+					isAutomatedReferral={ isAutomatedReferral }
+					tipaltiData={ tipaltiData }
+					referrals={ referrals }
+					isLoading={ isLoading }
+				/>
 				{ ! isFetching && ! isAutomatedReferral && <ReferralsFooter /> }
 			</LayoutBody>
 		</Layout>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -4,6 +4,7 @@ import { plugins, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import {
 	A4A_REFERRALS_BANK_DETAILS_LINK,
 	A4A_REFERRALS_COMMISSIONS_LINK,
@@ -33,6 +34,8 @@ interface Props {
 	tipaltiData?: any;
 	referrals?: Referral[];
 	isLoading: boolean;
+	dataViewsState: DataViewsState;
+	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
 }
 
 export default function LayoutBodyContent( {
@@ -40,6 +43,8 @@ export default function LayoutBodyContent( {
 	tipaltiData,
 	referrals,
 	isLoading,
+	dataViewsState,
+	setDataViewsState,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -103,7 +108,13 @@ export default function LayoutBodyContent( {
 	);
 
 	if ( isAutomatedReferral && referrals?.length ) {
-		return <ReferralList referrals={ referrals } />;
+		return (
+			<ReferralList
+				referrals={ referrals }
+				dataViewsState={ dataViewsState }
+				setDataViewsState={ setDataViewsState }
+			/>
+		);
 	}
 
 	return (

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -1,0 +1,312 @@
+import { Button, WooLogo } from '@automattic/components';
+import NoticeBanner from '@automattic/components/src/notice-banner';
+import { plugins, reusableBlock } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo, useState, useEffect } from 'react';
+import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
+import {
+	A4A_REFERRALS_BANK_DETAILS_LINK,
+	A4A_REFERRALS_COMMISSIONS_LINK,
+	A4A_REFERRALS_PAYMENT_SETTINGS,
+	A4A_REFERRALS_FAQ,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import { A4A_DOWNLOAD_LINK_ON_GITHUB } from 'calypso/a8c-for-agencies/constants';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import WooCommerceLogo from 'calypso/components/woocommerce-logo';
+import WordPressLogo from 'calypso/components/wordpress-logo';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import StepSection from '../../common/step-section';
+import StepSectionItem from '../../common/step-section-item';
+import { REFER_PRODUCTS_LINK } from '../../lib/constants';
+import { getAccountStatus } from '../../lib/get-account-status';
+import tipaltiLogo from '../../lib/tipalti-logo';
+import ReferralList from '../../referrals-list';
+import type { Referral } from '../../types';
+
+interface Props {
+	isAutomatedReferral?: boolean;
+	tipaltiData?: any;
+	referrals?: Referral[];
+	isLoading: boolean;
+}
+
+export default function LayoutBodyContent( {
+	isAutomatedReferral,
+	tipaltiData,
+	referrals,
+	isLoading,
+}: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onAddBankDetailsClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_referrals_add_bank_details_button_click' ) );
+	}, [ dispatch ] );
+
+	const onDownloadA4APluginClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_referrals_download_a4a_plugin_button_click' ) );
+	}, [ dispatch ] );
+
+	const onGetStartedClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_referrals_get_started_button_click' ) );
+	}, [ dispatch ] );
+
+	const accountStatus = getAccountStatus( tipaltiData, translate );
+
+	const hasPayeeAccount = !! accountStatus?.status;
+	let bankAccountCTAText = hasPayeeAccount
+		? translate( 'Edit my bank details' )
+		: translate( 'Enter bank details' );
+
+	if ( isAutomatedReferral ) {
+		bankAccountCTAText = hasPayeeAccount
+			? translate( 'Edit my details' )
+			: translate( 'Add my details' );
+	}
+
+	// Track whether the preference has just been saved to avoid hiding the notice on the first render.
+	const [ successNoticePreferenceSaved, setSuccessNoticePreferenceSaved ] = useState( false );
+
+	// Whether the user has seen the success notice in a previous session.
+	const successNoticeSeen = useSelector( ( state ) =>
+		getPreference( state, 'a4a-referrals-bank-details-success-notice-seen' )
+	);
+
+	// Only display the success notice for submitted banking details once.
+	useEffect( () => {
+		if ( accountStatus?.statusType === 'success' && ! successNoticeSeen ) {
+			dispatch( savePreference( 'a4a-referrals-bank-details-success-notice-seen', true ) );
+			setSuccessNoticePreferenceSaved( true );
+		}
+	}, [ dispatch, successNoticeSeen, accountStatus ] );
+
+	// Whether the user has manually dismissed the success notice.
+	const [ successNoticeDismissed, setSuccessNoticeDismissed ] = useState( successNoticeSeen );
+
+	// Show the banking details success notice if the user has submitted their banking details and the notice has not been dismissed.
+	const showBankingDetailsSuccessNotice = useMemo(
+		() =>
+			accountStatus?.statusType === 'success' &&
+			! successNoticeDismissed &&
+			( ! successNoticeSeen || successNoticePreferenceSaved ),
+		[
+			accountStatus?.statusType,
+			successNoticeDismissed,
+			successNoticePreferenceSaved,
+			successNoticeSeen,
+		]
+	);
+
+	if ( isAutomatedReferral && referrals?.length ) {
+		return <ReferralList referrals={ referrals } />;
+	}
+
+	return (
+		<>
+			{ showBankingDetailsSuccessNotice && (
+				<div className="referrals-overview__section-notice">
+					<NoticeBanner level="success" onClose={ () => setSuccessNoticeDismissed( true ) }>
+						{ translate(
+							'Thanks for entering your bank and tax information. Our team will confirm and review your submission.'
+						) }
+					</NoticeBanner>
+				</div>
+			) }
+			{ isAutomatedReferral && (
+				<div className="referrals-overview__section-icons">
+					<JetpackLogo className="jetpack-logo" size={ 24 } />
+					<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
+					<img src={ pressableIcon } alt="Pressable" />
+					<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
+				</div>
+			) }
+			<div className="referrals-overview__section-heading">
+				{ isAutomatedReferral ? (
+					<>
+						{ translate( 'Recommend our products.' ) } <br />
+						{ translate( 'Earn up to a 50% commission.' ) }
+					</>
+				) : (
+					<>
+						{ translate( 'Recommend our products. Earn up to a 50% commission.' ) } <br />
+						{ translate( ' No promo codes required.' ) }
+					</>
+				) }
+			</div>
+
+			<div className="referrals-overview__section-subtitle">
+				{ isAutomatedReferral ? (
+					translate(
+						'Make money when your clients buy Automattic products, hosting, or use WooPayments. No promo codes needed.'
+					)
+				) : (
+					<>
+						<div>
+							{ translate(
+								'Make money on each product your clients buy from Automattic. They can buy WooCommerce extensions, tools from Jetpack, and hosting services from Pressable or WordPress.com'
+							) }
+						</div>
+						<div>
+							{ translate(
+								'You can also make money when people buy things on your clients’ websites using WooPayments. {{a}}How much can I earn?{{/a}}',
+								{
+									components: {
+										a: <a href={ A4A_REFERRALS_COMMISSIONS_LINK } />,
+									},
+								}
+							) }
+						</div>
+					</>
+				) }
+			</div>
+			<div className="referrals-overview__section-container">
+				{ isLoading ? (
+					<>
+						<TextPlaceholder />
+						<TextPlaceholder />
+						<TextPlaceholder />
+						<TextPlaceholder />
+					</>
+				) : (
+					<>
+						{ ! isAutomatedReferral && <MigrationOffer /> }
+						<StepSection
+							heading={
+								isAutomatedReferral
+									? translate( 'How do I start?' )
+									: translate( 'How do I get started?' )
+							}
+						>
+							<StepSectionItem
+								isAutomatedReferral={ isAutomatedReferral }
+								icon={ tipaltiLogo }
+								heading={
+									isAutomatedReferral
+										? translate( 'Prepare to get paid' )
+										: translate( 'Enter your bank details so we can pay you commissions' )
+								}
+								description={
+									isAutomatedReferral
+										? translate( 'With {{a}}Tipalti ↗{{/a}}, our secure platform.', {
+												components: {
+													a: (
+														<a
+															className="referrals-overview__link"
+															href="https://tipalti.com/"
+															target="_blank"
+															rel="noopener noreferrer"
+														/>
+													),
+												},
+										  } )
+										: translate(
+												'Get paid seamlessly by adding your bank details and tax forms to Tipalti, our trusted and secure platform for commission payments.'
+										  )
+								}
+								buttonProps={ {
+									children: bankAccountCTAText,
+									href: isAutomatedReferral
+										? A4A_REFERRALS_PAYMENT_SETTINGS
+										: A4A_REFERRALS_BANK_DETAILS_LINK,
+									onClick: onAddBankDetailsClick,
+									primary: ! hasPayeeAccount,
+									compact: true,
+								} }
+								statusProps={
+									accountStatus
+										? {
+												children: accountStatus?.status,
+												type: accountStatus?.statusType,
+												tooltip: accountStatus?.statusReason,
+										  }
+										: undefined
+								}
+							/>
+							{ isAutomatedReferral ? (
+								<StepSectionItem
+									iconClassName="referrals-overview__opacity-70-percent"
+									isAutomatedReferral
+									icon={ reusableBlock }
+									heading={ translate( 'Refer products and hosting' ) }
+									description={ translate( 'Receive up to a 50% commission.' ) }
+									buttonProps={ {
+										children: translate( 'Get started' ),
+										compact: true,
+										primary: hasPayeeAccount,
+										href: REFER_PRODUCTS_LINK,
+										onClick: onGetStartedClick,
+									} }
+								/>
+							) : (
+								<StepSectionItem
+									iconClassName="referrals-overview__opacity-70-percent"
+									icon={ plugins }
+									heading={ translate( 'Verify your relationship with your clients' ) }
+									description={ translate(
+										'Install the A4A plugin on your clients’ sites. This shows you have a direct relationship with the client.'
+									) }
+									buttonProps={ {
+										children: translate( 'Download the plugin now' ),
+										compact: true,
+										href: A4A_DOWNLOAD_LINK_ON_GITHUB,
+										onClick: onDownloadA4APluginClick,
+									} }
+								/>
+							) }
+							<StepSectionItem
+								isAutomatedReferral={ isAutomatedReferral }
+								className="referrals-overview__step-section-woo-payments"
+								icon={ <WooLogo /> }
+								heading={
+									isAutomatedReferral
+										? translate( 'Install WooPayments' )
+										: translate( 'Install WooPayments on your clients’ online stores' )
+								}
+								description={
+									isAutomatedReferral
+										? translate( 'Receive a rev share of 0.05% per sale.' )
+										: translate(
+												'Receive a revenue share of 5 basis points (0.05%) on new WooPayments total payments volume (TPV) on clients’ sites.'
+										  )
+								}
+								buttonProps={ {
+									children: isAutomatedReferral
+										? translate( 'Learn how' )
+										: translate( 'Learn about WooPayments' ),
+									compact: isAutomatedReferral,
+									primary: isAutomatedReferral && hasPayeeAccount,
+									borderless: ! isAutomatedReferral,
+									href: 'https://woocommerce.com/payments/',
+									rel: 'noreferrer',
+									target: '_blank',
+								} }
+							/>
+						</StepSection>
+						{ isAutomatedReferral && (
+							<StepSection
+								className="referrals-overview__step-section-learn-more"
+								heading={ translate( 'Find out more about the program' ) }
+							>
+								<Button className="a8c-blue-link" borderless href={ A4A_REFERRALS_FAQ }>
+									{ translate( 'How much money will I make?' ) }
+								</Button>
+								<br />
+								{
+									// FIXME: Add link
+									<Button className="a8c-blue-link" borderless href="#">
+										{ translate( 'How does it work?' ) }
+									</Button>
+								}
+							</StepSection>
+						) }
+					</>
+				) }
+			</div>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -71,6 +71,12 @@
 		max-width: 550px;
 	}
 
+	&.referrals-layout--full-width {
+		.a4a-layout__body-wrapper {
+			max-width: 100%;
+		}
+	}
+
 	.referrals-overview__step-section-woo-payments {
 		margin-block-end: 0;
 

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -1,0 +1,107 @@
+import { Button, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, ReactNode } from 'react';
+import { DATAVIEWS_TABLE } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import { DataViews } from 'calypso/components/dataviews';
+import SubscriptionStatus from './subscription-status';
+import type { Referral } from '../types';
+
+interface Props {
+	referrals: Referral[];
+}
+
+export default function ReferralList( { referrals }: Props ) {
+	const translate = useTranslate();
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'client',
+				header: translate( 'Client' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: Referral } ): ReactNode => {
+					return item.client_email;
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'purchases',
+				header: translate( 'Purchases' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: Referral } ): ReactNode => {
+					return item.purchases.length;
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'pending-orders',
+				header: translate( 'Pending Orders' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: Referral } ): ReactNode => {
+					return item.statuses.filter( ( status ) => status === 'pending' ).length;
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'commissions',
+				header: translate( 'Commissions' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: Referral } ): ReactNode => {
+					return `$${ item.commissions }`;
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'subscription-status',
+				header: translate( 'Subscription Status' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: Referral } ): ReactNode => <SubscriptionStatus item={ item } />,
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'actions',
+				header: translate( 'Actions' ).toUpperCase(),
+				render: () => {
+					return (
+						// TODO: Show details preview panel
+						<div>
+							<Button borderless>
+								<Gridicon icon="chevron-right" />
+							</Button>
+						</div>
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[ translate ]
+	);
+	return (
+		<DataViews
+			data={ referrals }
+			paginationInfo={ { totalItems: 1, totalPages: 1 } }
+			fields={ fields }
+			view={ {
+				filters: [],
+				sort: {
+					field: '',
+					direction: 'asc',
+				},
+				type: DATAVIEWS_TABLE,
+				perPage: 1,
+				page: 1,
+				hiddenFields: [],
+				layout: {},
+			} }
+			search={ false } // TODO: Implement search
+			supportedLayouts={ [ 'table' ] }
+			actions={ [] }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -1,16 +1,18 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, ReactNode } from 'react';
-import { DATAVIEWS_TABLE } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
-import { DataViews } from 'calypso/components/dataviews';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import SubscriptionStatus from './subscription-status';
 import type { Referral } from '../types';
 
 interface Props {
 	referrals: Referral[];
+	dataViewsState: DataViewsState;
+	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
 }
 
-export default function ReferralList( { referrals }: Props ) {
+export default function ReferralList( { referrals, dataViewsState, setDataViewsState }: Props ) {
 	const translate = useTranslate();
 
 	const fields = useMemo(
@@ -83,25 +85,20 @@ export default function ReferralList( { referrals }: Props ) {
 		[ translate ]
 	);
 	return (
-		<DataViews
-			data={ referrals }
-			paginationInfo={ { totalItems: 1, totalPages: 1 } }
-			fields={ fields }
-			view={ {
-				filters: [],
-				sort: {
-					field: '',
-					direction: 'asc',
+		<ItemsDataViews
+			data={ {
+				items: referrals,
+				pagination: {
+					totalItems: 1,
+					totalPages: 1,
 				},
-				type: DATAVIEWS_TABLE,
-				perPage: 1,
-				page: 1,
-				hiddenFields: [],
-				layout: {},
+				itemFieldId: 'ref',
+				searchLabel: translate( 'Search referrals' ),
+				fields: fields,
+				actions: [],
+				setDataViewsState: setDataViewsState,
+				dataViewsState: dataViewsState,
 			} }
-			search={ false } // TODO: Implement search
-			supportedLayouts={ [ 'table' ] }
-			actions={ [] }
 		/>
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
@@ -31,7 +31,7 @@ export default function SubscriptionStatus( { item }: { item: Referral } ): Reac
 		if ( pendingStatuses.length === item.statuses.length ) {
 			return {
 				status: translate( 'Pending' ),
-				type: 'success',
+				type: 'warning',
 			};
 		}
 		return {

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
@@ -1,0 +1,46 @@
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode } from 'react';
+import StatusBadge from '../common/step-section-item/status-badge';
+import type { Referral } from '../types';
+
+export default function SubscriptionStatus( { item }: { item: Referral } ): ReactNode {
+	const translate = useTranslate();
+
+	const getStatus = (
+		item: Referral
+	): {
+		status: string | null;
+		type: 'warning' | 'success' | null;
+	} => {
+		const activeStatuses = item.statuses.filter( ( status ) => status === 'active' );
+		const pendingStatuses = item.statuses.filter( ( status ) => status === 'pending' );
+
+		if ( ! item.statuses.length ) {
+			return {
+				status: null,
+				type: null,
+			};
+		}
+
+		if ( activeStatuses.length === item.statuses.length ) {
+			return {
+				status: translate( 'Active' ),
+				type: 'success',
+			};
+		}
+		if ( pendingStatuses.length === item.statuses.length ) {
+			return {
+				status: translate( 'Pending' ),
+				type: 'success',
+			};
+		}
+		return {
+			status: translate( 'Mixed' ),
+			type: 'warning',
+		};
+	};
+
+	const { status, type } = getStatus( item );
+
+	return status && type ? <StatusBadge statusProps={ { children: status, type } } /> : null;
+}

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -1,0 +1,25 @@
+export interface Referral {
+	id: number;
+	client_id: number;
+	client_email: string;
+	purchases: {
+		license_id: number;
+		quantity: number;
+		product_id: number;
+	}[];
+	commissions: number;
+	statuses: string[];
+}
+
+export interface ReferralAPIResponse {
+	id: number;
+	client_id: number;
+	client_email: string;
+	products: {
+		license_id: number;
+		quantity: number;
+		product_id: number;
+	}[];
+	commission: number;
+	status: string;
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/344
Closes https://github.com/Automattic/jetpack-genesis/issues/345
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/514

## Proposed Changes

This PR:

- Implements UI for the referrals list view for automated referrals.
- Implements API endpoint hook to create referrals.
- Refactors the `referrals-overview` to keep the code clean

NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)
- I have different commits for the above changes to make it easier for the PR review.
- We have reused the existing component since we will get rid of the old UI very soon.

## Testing Instructions

1. Open the A4A live link.
2. Append the /referrals URL as /referrals?flags=-a4a-automated-referrals, and verify that the above changes are not reflected and that the Referrals page matches the production.
3. Remove the feature flag > Go to  Referrals - Dashboard & Verify the UI looks like below when there are no referrals.

<img width="1285" alt="Screenshot 2024-05-22 at 3 31 46 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6aaf9738-06e5-4fc6-ac02-a36b4ba60ff7">

4. Use the below API endpoint manually to create a referral. Create a couple of them

POST https://public-api.wordpress.com/wpcom/v2/agency/230591090/referrals?agency_id={your_agency_id}&client_email={client_email}&client_message={your_message}&product_ids={product_id,products_2}

5. Patch D149816
6. Now visit the  Referrals - Dashboard & refresh the page and verify that the page looks like below. Please note the search along with UI fixes & actions will be implemented later in a different PR.

<img width="1432" alt="Screenshot 2024-05-24 at 6 38 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/906bfb15-f08e-4ac0-99b2-f444d5d99d08">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
