### PR TITLE
Redirect to Dev Tools page if site is not Atomic

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -83,6 +83,7 @@ export const redirectLoggedOutToSignup = () => {};
 export const redirectWithoutLocaleParamIfLoggedIn = () => {};
 export const redirectIfCurrentUserCannot = () => {};
 export const redirectIfP2 = () => {};
+export const redirectToDevToolsPromoIfNotAtomic = () => {};
 // eslint-disable-next-line no-unused-vars
 export const render = ( context ) => {};
 export const ProviderWrappedLayout = () => null;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -246,6 +246,24 @@ export function redirectIfP2( context, next ) {
 }
 
 /**
+ * Middleware to redirect a user to /dev-tools-promo if the site is not Atomic.
+ * @param   {Object}   context Context object
+ * @param   {Function} next    Calls next middleware
+ * @returns {void}
+ */
+export function redirectToDevToolsPromoIfNotAtomic( context, next ) {
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
+	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
+
+	if ( config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && ! isAtomicSite ) {
+		return page.redirect( `/dev-tools-promo/${ site?.slug }` );
+	}
+
+	next();
+}
+
+/**
  * Removes the locale parameter from the path, and redirects logged-in users to it.
  * @param   {Object}   context Context object
  * @param   {Function} next    Calls next middleware

--- a/client/github-deployments/index.tsx
+++ b/client/github-deployments/index.tsx
@@ -1,5 +1,9 @@
 import page from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectToDevToolsPromoIfNotAtomic,
+} from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	redirectHomeIfIneligible,
@@ -17,6 +21,7 @@ export default function () {
 	page(
 		'/github-deployments/:site',
 		siteSelection,
+		redirectToDevToolsPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		deploymentsList,
@@ -28,6 +33,7 @@ export default function () {
 	page(
 		'/github-deployments/:site/create',
 		siteSelection,
+		redirectToDevToolsPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		deploymentCreation,
@@ -39,6 +45,7 @@ export default function () {
 	page(
 		'/github-deployments/:site/manage/:deploymentId',
 		siteSelection,
+		redirectToDevToolsPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		deploymentManagement,
@@ -50,6 +57,7 @@ export default function () {
 	page(
 		'/github-deployments/:site/logs/:deploymentId',
 		siteSelection,
+		redirectToDevToolsPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		deploymentRunLogs,

--- a/client/hosting-overview/index.tsx
+++ b/client/hosting-overview/index.tsx
@@ -3,6 +3,7 @@ import {
 	makeLayout,
 	render as clientRender,
 	redirectIfCurrentUserCannot,
+	redirectToDevToolsPromoIfNotAtomic,
 	redirectIfP2,
 } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -39,6 +40,7 @@ export default function () {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
+		redirectToDevToolsPromoIfNotAtomic,
 		handleHostingPanelRedirect,
 		hostingConfiguration,
 		siteDashboard( DOTCOM_HOSTING_CONFIG ),
@@ -53,6 +55,7 @@ export default function () {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
+		redirectToDevToolsPromoIfNotAtomic,
 		handleHostingPanelRedirect,
 		hostingActivate,
 		siteDashboard( DOTCOM_HOSTING_CONFIG ),

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -2,13 +2,13 @@ import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import { canCurrentUser } from '../../state/selectors/can-current-user';
 import { GitHubDeploymentCreation } from './deployment-creation';
 import { GitHubDeploymentManagement } from './deployment-management';
 import { DeploymentRunsLogs } from './deployment-run-logs';

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,16 +1,14 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { FEATURE_SFTP } from '@automattic/calypso-products';
 import { __ } from '@wordpress/i18n';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import { canCurrentUser } from '../../state/selectors/can-current-user';
 import { GitHubDeploymentCreation } from './deployment-creation';
 import { GitHubDeploymentManagement } from './deployment-management';
 import { DeploymentRunsLogs } from './deployment-run-logs';
@@ -91,22 +89,14 @@ export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
 	const site = getSelectedSite( state );
-	const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 	const isJetpackNonAtomic = ! isAtomicSite && !! site?.jetpack;
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-		// Go to the Dev Tools screen for Simple sites transferable to Atomic.
-		if ( ! isAtomicSite && hasSftpFeature ) {
-			context.page.replace( `/dev-tools-promo/${ site?.slug }` );
-			return;
-		}
-
 		if ( isJetpackNonAtomic ) {
 			context.page.replace( `/overview/${ site?.slug }` );
 			return;
 		}
-
 		next();
 		return;
 	}

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,14 +1,16 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { FEATURE_SFTP } from '@automattic/calypso-products';
 import { __ } from '@wordpress/i18n';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import { canCurrentUser } from '../../state/selectors/can-current-user';
 import { GitHubDeploymentCreation } from './deployment-creation';
 import { GitHubDeploymentManagement } from './deployment-management';
 import { DeploymentRunsLogs } from './deployment-run-logs';
@@ -89,14 +91,22 @@ export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
 	const site = getSelectedSite( state );
+	const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 	const isJetpackNonAtomic = ! isAtomicSite && !! site?.jetpack;
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		// Go to the Dev Tools screen for Simple sites transferable to Atomic.
+		if ( ! isAtomicSite && hasSftpFeature ) {
+			context.page.replace( `/dev-tools-promo/${ site?.slug }` );
+			return;
+		}
+
 		if ( isJetpackNonAtomic ) {
 			context.page.replace( `/overview/${ site?.slug }` );
 			return;
 		}
+
 		next();
 		return;
 	}

--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -1,9 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { FEATURE_SFTP } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { createElement } from 'react';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -39,22 +37,14 @@ export async function handleHostingPanelRedirect( context, next ) {
 	const state = store.getState();
 	const siteId = getSelectedSiteId( state );
 	const site = getSelectedSite( state );
-	const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 	const isJetpackNonAtomic = ! isAtomicSite && !! site?.jetpack;
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-		// Go to the Dev Tools screen for Simple sites transferable to Atomic.
-		if ( ! isAtomicSite && hasSftpFeature ) {
-			context.page.replace( `/dev-tools-promo/${ site?.slug }` );
-			return;
-		}
-
 		if ( isJetpackNonAtomic ) {
 			context.page.replace( `/overview/${ site?.slug }` );
 			return;
 		}
-
 		next();
 		return;
 	}

--- a/client/my-sites/hosting/controller.js
+++ b/client/my-sites/hosting/controller.js
@@ -1,7 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { FEATURE_SFTP } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { createElement } from 'react';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -37,14 +39,22 @@ export async function handleHostingPanelRedirect( context, next ) {
 	const state = store.getState();
 	const siteId = getSelectedSiteId( state );
 	const site = getSelectedSite( state );
+	const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 	const isJetpackNonAtomic = ! isAtomicSite && !! site?.jetpack;
 
 	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+		// Go to the Dev Tools screen for Simple sites transferable to Atomic.
+		if ( ! isAtomicSite && hasSftpFeature ) {
+			context.page.replace( `/dev-tools-promo/${ site?.slug }` );
+			return;
+		}
+
 		if ( isJetpackNonAtomic ) {
 			context.page.replace( `/overview/${ site?.slug }` );
 			return;
 		}
+
 		next();
 		return;
 	}

--- a/client/site-monitoring/index.tsx
+++ b/client/site-monitoring/index.tsx
@@ -1,6 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectToDevToolsPromoIfNotAtomic,
+} from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { redirectHomeIfIneligible, siteMetrics } from 'calypso/my-sites/site-monitoring/controller';
 import { siteDashboard } from 'calypso/sites-dashboard-v2/controller';
@@ -22,6 +26,7 @@ export default function () {
 		page(
 			'/site-monitoring/:site',
 			siteSelection,
+			redirectToDevToolsPromoIfNotAtomic,
 			redirectHomeIfIneligible,
 			navigation,
 			siteMonitoringOverview,
@@ -32,6 +37,7 @@ export default function () {
 		page(
 			'/site-monitoring/:site/php',
 			siteSelection,
+			redirectToDevToolsPromoIfNotAtomic,
 			redirectHomeIfIneligible,
 			navigation,
 			siteMonitoringPhpLogs,
@@ -42,6 +48,7 @@ export default function () {
 		page(
 			'/site-monitoring/:site/web',
 			siteSelection,
+			redirectToDevToolsPromoIfNotAtomic,
 			redirectHomeIfIneligible,
 			navigation,
 			siteMonitoringServerLogs,
@@ -53,6 +60,7 @@ export default function () {
 		page(
 			'/site-monitoring/:siteId/:tab(php|web)?',
 			siteSelection,
+			redirectToDevToolsPromoIfNotAtomic,
 			redirectHomeIfIneligible,
 			navigation,
 			siteMetrics,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7407

## Proposed Changes

This PR implements redirection from `/hosting-config`, `/github-deployments`, and `/site-monitoring` to `/dev-tools-promo` for non-Atomic sites.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Click the ellipsis menu on a non-Atomic site row, and select any item under Hosting.
![Screenshot 2024-05-24 at 3 45 21 PM](https://github.com/Automattic/wp-calypso/assets/797888/34f97a92-c780-460d-9e20-5721f90dbdfe)

* Ensure that the Dev Tools tab is selected in the site's Site Management Panel.
![Screenshot 2024-05-24 at 3 46 12 PM](https://github.com/Automattic/wp-calypso/assets/797888/5e2328f1-a3cd-4d54-8b2a-ef0592138175)

* Also test going from one of these tabs: Hosting Config, Monitoring, PHP Logs, Server Logs, or GHD in an Atomic site, then in the collapsed Sites list switch to a Simple site. The Simple site's Site management panel should have the Dev Tools tab selected.  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
