### PR TITLE
A4A: Update the Multi-product card to follow the new design.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
@@ -185,24 +185,25 @@ export default function MultiProductCard( props: Props ) {
 								</div>
 
 								<div className="product-card__description">{ productDescription }</div>
-
-								{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
-									<LicenseLightboxLink
-										productName={ getProductShortTitle( product ) }
-										onClick={ onShowLightbox }
-									/>
-								) }
 							</div>
-
-							<Button
-								className="product-card__select-button"
-								primary={ ! isSelected }
-								tabIndex={ -1 }
-							>
-								{ isSelected && <Icon icon={ check } /> }
-								{ isSelected ? translate( 'Added' ) : translate( 'Add to cart' ) }
-							</Button>
 						</div>
+					</div>
+					<div className="product-card__buttons">
+						<Button
+							className="product-card__select-button"
+							primary={ ! isSelected }
+							tabIndex={ -1 }
+						>
+							{ isSelected && <Icon icon={ check } /> }
+							{ isSelected ? translate( 'Added to cart' ) : translate( 'Add to cart' ) }
+						</Button>
+						{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
+							<LicenseLightboxLink
+								customText={ translate( 'View details' ) }
+								productName={ getProductShortTitle( product ) }
+								onClick={ onShowLightbox }
+							/>
+						) }
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This PR fixes the Multi-product card to follow the new design.

| Before | After |
|--------|--------|
| <img width="510" alt="Screenshot 2024-05-24 at 4 37 49 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c0105be8-1db0-4761-8b1a-9133770bda5f"> | <img width="508" alt="Screenshot 2024-05-24 at 4 37 56 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/438664c4-319a-43cc-b5c4-db0125af21bc"> | 

Follow up https://github.com/Automattic/wp-calypso/pull/90969

## Proposed Changes

* Update the Multi-product card component to follow the new design.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/products`
* Look for the Jetpack Security plan.
* Confirm that it follows the new design.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
