### PR TITLE
Revert "Check the plan on launch site to show domain message or not"

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -1029,7 +1029,3 @@ export const getDIFMTieredPurchaseDetails = (
 
 	return { extraPageCount, numberOfIncludedPages, formattedCostOfExtraPages, formattedOneTimeFee };
 };
-
-export function isA4APurchase( purchase?: Purchase ) {
-	return 'a4a_agency' === purchase?.partnerType;
-}

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -3,15 +3,11 @@ import { Button, Modal } from '@wordpress/components';
 import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
-import { isA4APurchase } from 'calypso/lib/purchases';
 import { omitUrlParams } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { fetchSitePurchases } from 'calypso/state/purchases/actions';
-import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
-import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 
 import './celebrate-launch-modal.scss';
 
@@ -20,24 +16,17 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 	const translate = useTranslate();
 	const isPaidPlan = ! site?.plan?.is_free;
 	const isBilledMonthly = site?.plan?.product_slug?.includes( 'monthly' );
+
 	const transformedDomains = allDomains.map( createSiteDomainObject );
-	const [ isInitiallyLoaded, setIsInitiallyLoaded ] = useState( false );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardButtonEl = useRef( null );
 	const hasCustomDomain = Boolean(
 		transformedDomains.find( ( domain ) => ! domain.isWPCOMDomain )
 	);
-	const sitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, site?.ID ) );
-	const purchases = useSelector( ( state ) => getSitePurchases( state, site?.ID ) );
-	const actualPlanPurchase = purchases.filter(
-		( purchase ) => purchase.productSlug === sitePlanSlug
-	);
-	const isA4ASite = isA4APurchase( actualPlanPurchase[ 0 ] );
-	const isLoading = useSelector( isFetchingSitePurchases );
 
 	useEffect( () => {
-		// Remove the celebrateLaunch URL param without reloading the page as soon as the modal loads
-		// Make sure the modal is shown only once
+		// remove the celebrateLaunch URL param without reloading the page as soon as the modal loads
+		// make sure the modal is shown only once
 		window.history.replaceState(
 			null,
 			'',
@@ -45,28 +34,18 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 		);
 
 		dispatch(
-			recordTracksEvent( 'calypso_launchpad_celebration_modal_view', {
+			recordTracksEvent( `calypso_launchpad_celebration_modal_view`, {
 				product_slug: site?.plan?.product_slug,
 			} )
 		);
 	}, [] );
-
-	useEffect( () => {
-		dispatch( fetchSitePurchases( site?.ID ) );
-	}, [ dispatch, site?.ID ] );
-
-	useEffect( () => {
-		if ( ! isLoading && ( ! isPaidPlan || purchases.length > 0 ) && ! isInitiallyLoaded ) {
-			setIsInitiallyLoaded( true );
-		}
-	}, [ isLoading, purchases, isPaidPlan ] );
 
 	function renderUpsellContent() {
 		let contentElement;
 		let buttonText;
 		let buttonHref;
 
-		if ( ( ! isPaidPlan && ! hasCustomDomain ) || isA4ASite ) {
+		if ( ! isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
 				<p>
 					{ translate(
@@ -87,7 +66,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 			);
 			buttonText = translate( 'Claim your domain' );
 			buttonHref = `/domains/add/${ site.slug }`;
-		} else if ( isPaidPlan && ! hasCustomDomain && ! isA4ASite ) {
+		} else if ( isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
 				<p>
 					{ translate(
@@ -111,7 +90,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 					href={ buttonHref }
 					onClick={ () =>
 						dispatch(
-							recordTracksEvent( 'calypso_launchpad_celebration_modal_upsell_clicked', {
+							recordTracksEvent( `calypso_launchpad_celebration_modal_upsell_clicked`, {
 								product_slug: site?.plan?.product_slug,
 							} )
 						)
@@ -121,10 +100,6 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 				</Button>
 			</div>
 		);
-	}
-
-	if ( ! isInitiallyLoaded ) {
-		return null;
 	}
 
 	return (


### PR DESCRIPTION
Reverts Automattic/wp-calypso#90866

More context on why these changes were reverted: https://github.com/Automattic/dotcom-forge/issues/7164#issuecomment-2127688907

**Testing for regressions**
**Instructions to test not A4A sites**
- Go to `http://calypso.localhost:3000/sites` and create a site normally. It would be awesome to test different plans, including Free.
- In My Home, click on "Launch your site" (note: there are different launchpads, so the link to launch your site could be in a different order):
<img width="690" alt="Screenshot 2024-05-18 at 13 47 39" src="https://github.com/Automattic/wp-calypso/assets/3832570/f67e4130-bdd8-4d48-901a-901ded04074e">

You should see different popups depending on the circumstances of the blog:
- a free blog (no domain included):
<img width="1650" alt="Screenshot 2024-05-17 at 19 57 17" src="https://github.com/Automattic/wp-calypso/assets/3832570/596d29b0-47b8-4629-82e8-69684c59d5c7">

- a paid plan, including a domain:
<img width="1654" alt="Screenshot 2024-05-17 at 20 14 45" src="https://github.com/Automattic/wp-calypso/assets/3832570/10bba4ab-8c45-47c3-965f-6c1f59283238">

**Instructions to test A4A sites**
- Log into our A4A testing account (details here: pfunGA-1mD-p2).
- Create a new site (or use one of the existing sites that hasn't launched yet).
- Create a new admin user on that site. You will require the credentials of such user in your local calypso. Accept the invitation in the new admin user email.
- Login to the site using your local Calypso instance and this newly created account.
- In My Home, click on "Launch your site". In the launch popup, you should see the "your plan includes a domain" message.