### PR TITLE
A4A > Referrals: Implement UI for the referrals' 3-column consolidated view

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -1,0 +1,56 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import type { Referral } from '../types';
+
+import './style.scss';
+
+const getConsolidatedData = ( referrals: Referral[] ) => {
+	const consolidatedData = {
+		allTimeCommissions: 0,
+		pendingOrders: 0,
+		pendingCommission: 0,
+	};
+
+	referrals.forEach( ( referral ) => {
+		consolidatedData.allTimeCommissions += referral.commissions;
+		consolidatedData.pendingOrders += referral.statuses.filter(
+			( status ) => status === 'pending'
+		).length;
+		if ( referral.statuses.includes( 'pending' ) ) {
+			consolidatedData.pendingCommission += referral.commissions;
+		}
+	} );
+
+	return consolidatedData;
+};
+
+export default function ConsolidatedViews( { referrals }: { referrals: Referral[] } ) {
+	const translate = useTranslate();
+
+	const date = new Date();
+	const month = date.toLocaleString( 'default', { month: 'long' } );
+
+	const { allTimeCommissions, pendingOrders, pendingCommission } = getConsolidatedData( referrals );
+
+	return (
+		<div className="consolidated-view">
+			<Card compact>
+				<div className="consolidated-view__value">{ `$${ allTimeCommissions }` }</div>
+				<div className="consolidated-view__label">{ translate( 'All time commissions' ) }</div>
+			</Card>
+			<Card compact>
+				<div className="consolidated-view__value">{ `$${ pendingCommission }` }</div>
+				<div className="consolidated-view__label">
+					{ translate( 'Commissions expected in %(month)s', {
+						args: { month },
+						comment: 'month is the name of the current month',
+					} ) }
+				</div>
+			</Card>
+			<Card compact>
+				<div className="consolidated-view__value">{ pendingOrders }</div>
+				<div className="consolidated-view__label">{ translate( 'Pending order' ) }</div>
+			</Card>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
@@ -1,0 +1,31 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.consolidated-view {
+	padding-block: 16px 48px;
+	display: flex;
+	gap: 24px;
+	flex-direction: column;
+
+	@include break-large {
+		flex-direction: row;
+	}
+
+	.card {
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 6px;
+		width: 100%;
+		padding: 24px;
+
+		.consolidated-view__value {
+			font-size: rem(24px);
+			color: var(--color-accent-100);
+			font-weight: 700;
+			margin-block-end: 8px;
+		}
+		.consolidated-view__label {
+			color: var(--color-accent);
+			font-size: rem(12px);
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -23,6 +23,7 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import StepSection from '../../common/step-section';
 import StepSectionItem from '../../common/step-section-item';
+import ConsolidatedViews from '../../consolidated-view';
 import { REFER_PRODUCTS_LINK } from '../../lib/constants';
 import { getAccountStatus } from '../../lib/get-account-status';
 import tipaltiLogo from '../../lib/tipalti-logo';
@@ -109,11 +110,14 @@ export default function LayoutBodyContent( {
 
 	if ( isAutomatedReferral && referrals?.length ) {
 		return (
-			<ReferralList
-				referrals={ referrals }
-				dataViewsState={ dataViewsState }
-				setDataViewsState={ setDataViewsState }
-			/>
+			<>
+				<ConsolidatedViews referrals={ referrals } />
+				<ReferralList
+					referrals={ referrals }
+					dataViewsState={ dataViewsState }
+					setDataViewsState={ setDataViewsState }
+				/>
+			</>
 		);
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/346

## Proposed Changes

This PR implements UI for the referrals' 3-column consolidated view


NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)

## Testing Instructions

1. Open the A4A live link.
2. Append the /referrals URL as /referrals?flags=-a4a-automated-referrals, and verify that the above changes are not reflected and that the Referrals page matches the production.
3. Remove the feature flag > Go to  Referrals - Dashboard.
4. Use the below API endpoint manually to create a referral if you don't have some. Create a couple of them

POST https://public-api.wordpress.com/wpcom/v2/agency/230591090/referrals?agency_id={your_agency_id}&client_email={client_email}&client_message={your_message}&product_ids={product_id,products_2}

5. Patch D149816
6. Now visit the  Referrals - Dashboard & refresh the page and verify that the page looks like below & everything shown is calculated correctly. 

<img width="1432" alt="Screenshot 2024-05-24 at 2 09 24 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3aefa211-459a-495c-b92d-428a40fab191">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
