### PR TITLE
Add configuration for plans-first signup flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -197,6 +197,17 @@ export function generateFlows( {
 			onEnterFlow: onEnterOnboarding,
 		},
 		{
+			name: 'plans-first',
+			steps: [ 'plans', 'domains', userSocialStep ],
+			destination: getSignupDestination,
+			description: 'Plans first signup flow',
+			lastModified: '2024-05-24',
+			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'coupon' ],
+			optionalDependenciesInQuery: [ 'coupon' ],
+			hideProgressIndicator: true,
+		},
+		{
 			name: 'site-migration',
 			steps: [ 'domains' ],
 			destination: getSignupDestination,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -251,7 +251,8 @@
 		"domain-transfer",
 		"site-selected",
 		"guided",
-		"domain-for-gravatar"
+		"domain-for-gravatar",
+		"plans-first"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This adds a new plans-first signup flow:
* order of steps is: plans -> domains -> registration
* accepts a coupon code using `?coupon=COUPON_CODE`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This will be used in marketing emails for future WordCamp events.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans-first/plans?coupon={COUPON_CODE}`
* You should see the Plans grid as the first step, then domains, and then register/login (if logged out)
<img width="340" alt="Screenshot 2024-05-24 at 12 36 17" src="https://github.com/Automattic/wp-calypso/assets/2749938/2f9916fb-0388-49aa-8fdf-2ca03134c629">

* You should be able to finish the signup flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
