### PR TITLE
Site Management Panel: Add the guide tour to the primary button

### DIFF
--- a/client/a8c-for-agencies/components/guided-tour-step/index.tsx
+++ b/client/a8c-for-agencies/components/guided-tour-step/index.tsx
@@ -19,8 +19,8 @@ type Props = {
 	context?: HTMLElement | null;
 	className?: string;
 	hideSteps?: boolean;
-	title?: JSX.Element;
-	description?: JSX.Element;
+	title?: JSX.Element | string;
+	description?: JSX.Element | string;
 };
 
 /**

--- a/client/a8c-for-agencies/components/guided-tour/index.tsx
+++ b/client/a8c-for-agencies/components/guided-tour/index.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useContext } from 'react';
 import { GuidedTourContext } from 'calypso/a8c-for-agencies/data/guided-tours/guided-tour-context';
-import { TourId } from 'calypso/a8c-for-agencies/data/guided-tours/use-guided-tours';
 
-const GuidedTour = ( { defaultTourId }: { defaultTourId: TourId } ) => {
+const GuidedTour = ( { defaultTourId }: { defaultTourId: string } ) => {
 	const { currentTourId, currentStep, startTour } = useContext( GuidedTourContext );
 
 	useEffect( () => {

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -83,6 +83,7 @@ export default function ItemPreviewPane( {
 			<ItemPreviewPaneHeader
 				closeItemPreviewPane={ closeItemPreviewPane }
 				itemData={ itemData }
+				isPreviewLoaded={ !! selectedFeature.preview }
 				extraProps={ itemPreviewPaneHeaderExtraProps }
 			/>
 			<div ref={ setNavRef }>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -16,12 +16,14 @@ const ICON_SIZE_REGULAR = 24;
 interface Props {
 	closeItemPreviewPane?: () => void;
 	itemData: ItemData;
+	isPreviewLoaded: boolean;
 	className?: string;
 	extraProps?: ItemPreviewPaneHeaderExtraProps;
 }
 
 export default function ItemPreviewPaneHeader( {
 	itemData,
+	isPreviewLoaded,
 	closeItemPreviewPane,
 	className,
 	extraProps,
@@ -72,24 +74,26 @@ export default function ItemPreviewPaneHeader( {
 							</Button>
 						</div>
 					</div>
-					<div className="item-preview__header-actions">
-						{ extraProps?.headerButtons ? (
-							<extraProps.headerButtons
-								focusRef={ focusRef }
-								itemData={ itemData }
-								closeSitePreviewPane={ closeItemPreviewPane || ( () => {} ) }
-							/>
-						) : (
-							<Button
-								onClick={ closeItemPreviewPane }
-								className="item-preview__close-preview"
-								aria-label={ translate( 'Close Preview' ) }
-								ref={ focusRef }
-							>
-								<Gridicon icon="cross" size={ ICON_SIZE_REGULAR } />
-							</Button>
-						) }
-					</div>
+					{ isPreviewLoaded && (
+						<div className="item-preview__header-actions">
+							{ extraProps?.headerButtons ? (
+								<extraProps.headerButtons
+									focusRef={ focusRef }
+									itemData={ itemData }
+									closeSitePreviewPane={ closeItemPreviewPane || ( () => {} ) }
+								/>
+							) : (
+								<Button
+									onClick={ closeItemPreviewPane }
+									className="item-preview__close-preview"
+									aria-label={ translate( 'Close Preview' ) }
+									ref={ focusRef }
+								>
+									<Gridicon icon="cross" size={ ICON_SIZE_REGULAR } />
+								</Button>
+							) }
+						</div>
+					) }
 				</div>
 			</div>
 		</div>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { TourId } from 'calypso/a8c-for-agencies/data/guided-tours/use-guided-tours';
 
 export interface FeaturePreviewInterface {
 	id: string;
@@ -36,7 +35,7 @@ export interface PreviewPaneProps {
 	className?: string;
 	isSmallScreen?: boolean;
 	hasError?: boolean;
-	addTourDetails?: { id: string; tourId: TourId };
+	addTourDetails?: { id: string; tourId: string };
 	itemPreviewPaneHeaderExtraProps?: ItemPreviewPaneHeaderExtraProps;
 }
 

--- a/client/a8c-for-agencies/components/layout/index.tsx
+++ b/client/a8c-for-agencies/components/layout/index.tsx
@@ -22,7 +22,7 @@ type Props = {
 	compact?: boolean;
 };
 
-export default function Layout( {
+export function MainLayout( {
 	children,
 	className,
 	title,
@@ -38,6 +38,24 @@ export default function Layout( {
 		? 'a4a-layout-with-columns__container'
 		: 'a4a-layout__container';
 
+	return (
+		<Main
+			className={ classNames( 'a4a-layout', className, {
+				'is-with-border': withBorder,
+				'is-compact': compact,
+			} ) }
+			fullWidthLayout={ wide }
+			wideLayout={ ! wide } // When we set to full width, we want to set this to false.
+		>
+			<DocumentHead title={ title } />
+			{ sidebarNavigation }
+
+			<div className={ layoutContainerClassname }>{ children }</div>
+		</Main>
+	);
+}
+
+export default function Layout( props: Props ) {
 	const guidedTours = useGuidedTours();
 
 	return (
@@ -46,19 +64,7 @@ export default function Layout( {
 			preferenceNames={ A4A_ONBOARDING_TOURS_PREFERENCE_NAME }
 			eventNames={ A4A_ONBOARDING_TOURS_EVENT_NAMES }
 		>
-			<Main
-				className={ classNames( 'a4a-layout', className, {
-					'is-with-border': withBorder,
-					'is-compact': compact,
-				} ) }
-				fullWidthLayout={ wide }
-				wideLayout={ ! wide } // When we set to full width, we want to set this to false.
-			>
-				<DocumentHead title={ title } />
-				{ sidebarNavigation }
-
-				<div className={ layoutContainerClassname }>{ children }</div>
-			</Main>
+			<MainLayout { ...props } />
 		</GuidedTourContextProvider>
 	);
 }

--- a/client/a8c-for-agencies/components/layout/index.tsx
+++ b/client/a8c-for-agencies/components/layout/index.tsx
@@ -1,6 +1,11 @@
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 import { GuidedTourContextProvider } from 'calypso/a8c-for-agencies/data/guided-tours/guided-tour-context';
+import useGuidedTours from 'calypso/a8c-for-agencies/data/guided-tours/use-guided-tours';
+import {
+	A4A_ONBOARDING_TOURS_PREFERENCE_NAME,
+	A4A_ONBOARDING_TOURS_EVENT_NAMES,
+} from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import LayoutColumn from './column';
@@ -33,8 +38,14 @@ export default function Layout( {
 		? 'a4a-layout-with-columns__container'
 		: 'a4a-layout__container';
 
+	const guidedTours = useGuidedTours();
+
 	return (
-		<GuidedTourContextProvider>
+		<GuidedTourContextProvider
+			guidedTours={ guidedTours }
+			preferenceNames={ A4A_ONBOARDING_TOURS_PREFERENCE_NAME }
+			eventNames={ A4A_ONBOARDING_TOURS_EVENT_NAMES }
+		>
 			<Main
 				className={ classNames( 'a4a-layout', className, {
 					'is-with-border': withBorder,

--- a/client/a8c-for-agencies/components/layout/index.tsx
+++ b/client/a8c-for-agencies/components/layout/index.tsx
@@ -22,7 +22,7 @@ type Props = {
 	compact?: boolean;
 };
 
-export function MainLayout( {
+function MainLayout( {
 	children,
 	className,
 	title,
@@ -55,8 +55,15 @@ export function MainLayout( {
 	);
 }
 
-export default function Layout( props: Props ) {
+export default function Layout( {
+	disableGuidedTour = false,
+	...props
+}: Props & { disableGuidedTour?: boolean } ) {
 	const guidedTours = useGuidedTours();
+
+	if ( disableGuidedTour ) {
+		return <MainLayout { ...props } />;
+	}
 
 	return (
 		<GuidedTourContextProvider

--- a/client/a8c-for-agencies/components/layout/index.tsx
+++ b/client/a8c-for-agencies/components/layout/index.tsx
@@ -55,15 +55,8 @@ function MainLayout( {
 	);
 }
 
-export default function Layout( {
-	disableGuidedTour = false,
-	...props
-}: Props & { disableGuidedTour?: boolean } ) {
+function MainLayoutWithGuidedTour( { ...props }: Props ) {
 	const guidedTours = useGuidedTours();
-
-	if ( disableGuidedTour ) {
-		return <MainLayout { ...props } />;
-	}
 
 	return (
 		<GuidedTourContextProvider
@@ -74,4 +67,15 @@ export default function Layout( {
 			<MainLayout { ...props } />
 		</GuidedTourContextProvider>
 	);
+}
+
+export default function Layout( {
+	disableGuidedTour = false,
+	...props
+}: Props & { disableGuidedTour?: boolean } ) {
+	if ( disableGuidedTour ) {
+		return <MainLayout { ...props } />;
+	}
+
+	return <MainLayoutWithGuidedTour { ...props } />;
 }

--- a/client/a8c-for-agencies/data/guided-tours/guided-tour-context.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/guided-tour-context.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, createContext, useCallback, useMemo, useState } from 'react';
 
-type TourStep = {
+export type TourStep = {
 	id: string;
 	popoverPosition: string;
 	title: string;

--- a/client/a8c-for-agencies/data/guided-tours/guided-tour-context.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/guided-tour-context.tsx
@@ -1,5 +1,4 @@
 import { ReactNode, createContext, useCallback, useMemo, useState } from 'react';
-import useGuidedTour, { type TourId } from './use-guided-tours';
 
 type TourStep = {
 	id: string;
@@ -8,15 +7,27 @@ type TourStep = {
 	description: JSX.Element | string;
 	nextStepOnTargetClick?: boolean;
 	forceShowSkipButton?: boolean;
+	classNames?: {
+		nextStepButton?: string;
+	};
 };
 
 type GuidedTourContextType = {
-	currentTourId: TourId | null;
-	startTour: ( id: TourId ) => void;
+	currentTourId: string | null;
+	startTour: ( id: string ) => void;
 	currentStep: TourStep | null;
 	currentStepCount: number;
 	stepsCount: number;
 	nextStep: () => void;
+	preferenceNames: Record< string, string >;
+	eventNames: Record< string, string >;
+};
+
+type GuidedTourContextProviderProps = {
+	children: ReactNode;
+	guidedTours: Record< string, TourStep[] >;
+	preferenceNames: Record< string, string >;
+	eventNames: Record< string, string >;
 };
 
 const defaultGuidedTourContextValue = {
@@ -26,6 +37,9 @@ const defaultGuidedTourContextValue = {
 	currentStepCount: 0,
 	stepsCount: 0,
 	nextStep: () => {},
+	guidedTours: {},
+	preferenceNames: {},
+	eventNames: {},
 };
 
 export const GuidedTourContext = createContext< GuidedTourContextType >(
@@ -36,11 +50,15 @@ export const GuidedTourContext = createContext< GuidedTourContextType >(
  * Guided Tour Context Provider
  * Provides access to interact with the contextually relevant guided tour.
  */
-export const GuidedTourContextProvider = ( { children }: { children?: ReactNode } ) => {
-	const [ currentTourId, setCurrentTourId ] = useState< TourId | null >( null );
+export const GuidedTourContextProvider = ( {
+	children,
+	guidedTours,
+	preferenceNames,
+	eventNames,
+}: GuidedTourContextProviderProps ) => {
+	const [ currentTourId, setCurrentTourId ] = useState< string >( '' );
 	const [ completedSteps, setCompletedSteps ] = useState< string[] >( [] );
-
-	const currentTour: TourStep[] = useGuidedTour( currentTourId );
+	const currentTour: TourStep[] = guidedTours[ currentTourId ] ?? [];
 
 	/**
 	 * Derive current tour state from the available vs completed steps.
@@ -71,7 +89,7 @@ export const GuidedTourContextProvider = ( { children }: { children?: ReactNode 
 	/**
 	 * Set the active guided tour.
 	 */
-	const startTour = useCallback( ( id: TourId ) => {
+	const startTour = useCallback( ( id: string ) => {
 		setCurrentTourId( id );
 	}, [] );
 
@@ -92,8 +110,19 @@ export const GuidedTourContextProvider = ( { children }: { children?: ReactNode 
 			stepsCount,
 			currentStep,
 			currentStepCount,
+			preferenceNames,
+			eventNames,
 		} ),
-		[ startTour, nextStep, currentTourId, stepsCount, currentStep, currentStepCount ]
+		[
+			startTour,
+			nextStep,
+			currentTourId,
+			stepsCount,
+			currentStep,
+			currentStepCount,
+			preferenceNames,
+			eventNames,
+		]
 	);
 
 	return (

--- a/client/a8c-for-agencies/data/guided-tours/guided-tour-context.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/guided-tour-context.tsx
@@ -18,7 +18,7 @@ type GuidedTourContextType = {
 	currentStep: TourStep | null;
 	currentStepCount: number;
 	stepsCount: number;
-	nextStep: () => void;
+	nextStep: ( completedStep: TourStep | null ) => void;
 	preferenceNames: Record< string, string >;
 	eventNames: Record< string, string >;
 };
@@ -96,11 +96,11 @@ export const GuidedTourContextProvider = ( {
 	/**
 	 * Proceed to the next available step in the active tour.
 	 */
-	const nextStep = useCallback( () => {
-		if ( currentStep ) {
-			setCompletedSteps( ( currentSteps ) => [ ...currentSteps, currentStep.id ] );
+	const nextStep = useCallback( ( completedStep: TourStep | null ) => {
+		if ( completedStep ) {
+			setCompletedSteps( ( currentSteps ) => [ ...currentSteps, completedStep.id ] );
 		}
-	}, [ currentStep ] );
+	}, [] );
 
 	const contextValue = useMemo(
 		() => ( {

--- a/client/a8c-for-agencies/data/guided-tours/use-guided-tours.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/use-guided-tours.tsx
@@ -2,8 +2,6 @@ import { useMemo } from 'react';
 import useAddNewSiteTour from './tours/use-add-new-site-tour';
 import useSitesWalkthroughTour from './tours/use-sites-walkthrough-tour';
 
-export type TourId = 'sitesWalkthrough' | 'addSiteStep1';
-
 export default function useGuidedTours() {
 	const sitesWalkthrough = useSitesWalkthroughTour();
 	const addNewSite = useAddNewSiteTour();

--- a/client/a8c-for-agencies/data/guided-tours/use-guided-tours.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/use-guided-tours.tsx
@@ -1,16 +1,19 @@
+import { useMemo } from 'react';
 import useAddNewSiteTour from './tours/use-add-new-site-tour';
 import useSitesWalkthroughTour from './tours/use-sites-walkthrough-tour';
 
 export type TourId = 'sitesWalkthrough' | 'addSiteStep1';
 
-export default function useGuidedTour( id: TourId | null ) {
+export default function useGuidedTours() {
 	const sitesWalkthrough = useSitesWalkthroughTour();
 	const addNewSite = useAddNewSiteTour();
+	const tours = useMemo(
+		() => ( {
+			sitesWalkthrough: sitesWalkthrough,
+			addSiteStep1: addNewSite,
+		} ),
+		[]
+	);
 
-	const tours = {
-		sitesWalkthrough: sitesWalkthrough,
-		addSiteStep1: addNewSite,
-	};
-
-	return id ? tours[ id ] : [];
+	return tours;
 }

--- a/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
+++ b/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
@@ -7,3 +7,8 @@ export const A4A_ONBOARDING_TOURS_PREFERENCE_NAME: Record< string, string > = {
 	sitesWalkthrough: 'a4a-sites-tour',
 	exploreMarketplace: 'a4a-marketplace-tour',
 };
+
+export const A4A_ONBOARDING_TOURS_EVENT_NAMES: Record< string, string > = {
+	startTour: 'calypso_a4a_start_tour',
+	endTour: 'calypso_a4a_end_tour',
+};

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -21,7 +21,6 @@ import LayoutNavigation, {
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { type TourId } from 'calypso/a8c-for-agencies/data/guided-tours/use-guided-tours';
 import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
 import JetpackSitesDataViews from 'calypso/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
@@ -242,7 +241,7 @@ export default function SitesDashboard() {
 					</LayoutTop>
 
 					<SiteNotifications />
-					{ tourId && <GuidedTour defaultTourId={ tourId as TourId } /> }
+					{ tourId && <GuidedTour defaultTourId={ tourId } /> }
 
 					<DashboardDataContext.Provider
 						value={ {

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,7 +1,7 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import { MainLayout } from 'calypso/a8c-for-agencies/components/layout';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import { useLoadScheduleFromId } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-load-schedule-from-id';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -47,7 +47,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 
 	return (
 		<MultisitePluginUpdateManagerContextProvider>
-			<MainLayout title={ title } wide>
+			<Layout title={ title } wide disableGuidedTour>
 				{ context === 'create' || context === 'edit' ? (
 					<LayoutColumn className="scheduled-updates-list-compact">
 						<ScheduleList
@@ -81,7 +81,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 						}
 					} )() }
 				</LayoutColumn>
-			</MainLayout>
+			</Layout>
 		</MultisitePluginUpdateManagerContextProvider>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,7 +1,7 @@
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import Layout from 'calypso/a8c-for-agencies/components/layout';
+import { MainLayout } from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import { useLoadScheduleFromId } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-load-schedule-from-id';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -47,7 +47,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 
 	return (
 		<MultisitePluginUpdateManagerContextProvider>
-			<Layout title={ title } wide>
+			<MainLayout title={ title } wide>
 				{ context === 'create' || context === 'edit' ? (
 					<LayoutColumn className="scheduled-updates-list-compact">
 						<ScheduleList
@@ -81,7 +81,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 						}
 					} )() }
 				</LayoutColumn>
-			</Layout>
+			</MainLayout>
 		</MultisitePluginUpdateManagerContextProvider>
 	);
 };

--- a/client/sites-dashboard-v2/guided-tours.scss
+++ b/client/sites-dashboard-v2/guided-tours.scss
@@ -1,4 +1,6 @@
 body:has(.wpcom-site .main.a4a-layout.sites-dashboard) .guided-tour__popover {
+	z-index: z-index("root", ".layout__secondary") - 1;
+
 	.popover__arrow::before {
 		--color-border-inverted: var(--color-neutral-100);
 	}

--- a/client/sites-dashboard-v2/guided-tours.scss
+++ b/client/sites-dashboard-v2/guided-tours.scss
@@ -1,0 +1,29 @@
+body:has(.wpcom-site .main.a4a-layout.sites-dashboard) .guided-tour__popover {
+	.popover__arrow::before {
+		--color-border-inverted: var(--color-neutral-100);
+	}
+
+	.popover__inner {
+		border-radius: 4px;
+		background-color: var(--color-neutral-100);
+	}
+
+	.guided-tour__popover-heading {
+		font-size: rem(16px);
+		color: var(--color-text-inverted);
+	}
+
+	.guided-tour__popover-description {
+		max-width: 325px;
+		margin-top: -8px;
+		font-size: rem(13px);
+		color: var(--color-neutral-0);
+	}
+
+	.guided-tour__popover-footer-right-content {
+		button {
+			padding: 8px 12px;
+			font-size: rem(13px);
+		}
+	}
+}

--- a/client/sites-dashboard-v2/onboarding-tours/constants.ts
+++ b/client/sites-dashboard-v2/onboarding-tours/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Constant holding all preference names for our onboarding tours.
+ */
+export const CALYPSO_ONBOARDING_TOURS_PREFERENCE_NAME: Record< string, string > = {
+	siteManagementPanel: 'site-management-panel',
+};
+
+export const CALYPSO_ONBOARDING_TOURS_EVENT_NAMES: Record< string, string > = {
+	startTour: 'calypso_site_dashboard_start_tour',
+	endTour: 'calypso_site_dashboard_end_tour',
+};

--- a/client/sites-dashboard-v2/onboarding-tours/index.ts
+++ b/client/sites-dashboard-v2/onboarding-tours/index.ts
@@ -1,0 +1,2 @@
+export * from './constants';
+export { default as useOnboardingTours } from './use-onboarding-tours';

--- a/client/sites-dashboard-v2/onboarding-tours/use-onboarding-tours.tsx
+++ b/client/sites-dashboard-v2/onboarding-tours/use-onboarding-tours.tsx
@@ -1,9 +1,12 @@
 import { useMemo } from 'react';
+import type { TourStep } from 'calypso/a8c-for-agencies/data/guided-tours/guided-tour-context';
 
-const useSiteManagementPanelTour = () => {
+const useSiteManagementPanelTour = (): TourStep[] => {
 	return [
 		{
 			id: 'site-management-panel-admin-button',
+			title: '',
+			description: '',
 			popoverPosition: 'bottom',
 			classNames: {
 				nextStepButton: 'is-primary',

--- a/client/sites-dashboard-v2/onboarding-tours/use-onboarding-tours.tsx
+++ b/client/sites-dashboard-v2/onboarding-tours/use-onboarding-tours.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+
+const useSiteManagementPanelTour = () => {
+	return [
+		{
+			id: 'site-management-panel-admin-button',
+			popoverPosition: 'bottom',
+			classNames: {
+				nextStepButton: 'is-primary',
+			},
+		},
+	];
+};
+
+const useOnboardingTours = () => {
+	const siteManagementTour = useSiteManagementPanelTour();
+	const tours = useMemo(
+		() => ( {
+			siteManagementTour: siteManagementTour,
+		} ),
+		[]
+	);
+
+	return tours;
+};
+
+export default useOnboardingTours;

--- a/client/sites-dashboard-v2/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/preview-pane-header-buttons.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane, itemData }: Props ) => {
-	const adminButtonRef = useRef();
+	const adminButtonRef = useRef< HTMLButtonElement | null >( null );
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
 	const { __ } = useI18n();
 

--- a/client/sites-dashboard-v2/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/preview-pane-header-buttons.tsx
@@ -1,7 +1,11 @@
 import { Button } from '@automattic/components';
+import { useMergeRefs } from '@wordpress/compose';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
+import { useRef } from 'react';
+import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
+import type { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
 
 type Props = {
 	focusRef: React.RefObject< HTMLButtonElement >;
@@ -10,8 +14,10 @@ type Props = {
 };
 
 const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane, itemData }: Props ) => {
+	const adminButtonRef = useRef();
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
 	const { __ } = useI18n();
+
 	return (
 		<>
 			<Button onClick={ closeSitePreviewPane } className="item-preview__close-preview-button">
@@ -21,10 +27,25 @@ const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane, itemData }:
 				primary
 				className="item-preview__admin-button"
 				href={ `${ adminUrl }` }
-				ref={ focusRef }
+				ref={ useMergeRefs( [ adminButtonRef, focusRef ] ) }
 			>
 				{ adminLabel }
 			</Button>
+			<GuidedTourStep
+				id="site-management-panel-admin-button"
+				tourId="siteManagementPanel"
+				context={ adminButtonRef.current }
+				title={ sprintf(
+					// translators: %s is the label of the admin
+					__( 'Link to %s' ),
+					adminLabel
+				) }
+				description={ sprintf(
+					// translators: %s is the label of the admin
+					__( 'Navigate seamlessly between your site management panel and %s with just one click' ),
+					adminLabel
+				) }
+			/>
 		</>
 	);
 };

--- a/client/sites-dashboard-v2/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/preview-pane-header-buttons.tsx
@@ -42,7 +42,9 @@ const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane, itemData }:
 				) }
 				description={ sprintf(
 					// translators: %s is the label of the admin
-					__( 'Navigate seamlessly between your site management panel and %s with just one click' ),
+					__(
+						'Navigate seamlessly between your site management panel and %s with just one click.'
+					),
 					adminLabel
 				) }
 			/>

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -16,7 +16,7 @@ import {
 	initialDataViewsState,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
-import { MainLayout } from 'calypso/a8c-for-agencies/components/layout';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
@@ -238,7 +238,7 @@ const SitesDashboardV2 = ( {
 	const isNarrowView = false;
 
 	return (
-		<MainLayout
+		<Layout
 			className={ classNames(
 				'sites-dashboard',
 				'sites-dashboard__layout',
@@ -246,6 +246,7 @@ const SitesDashboardV2 = ( {
 			) }
 			wide
 			title={ dataViewsState.selectedItem ? null : translate( 'Sites' ) }
+			disableGuidedTour
 		>
 			<DocumentHead title={ __( 'Sites' ) } />
 
@@ -289,7 +290,7 @@ const SitesDashboardV2 = ( {
 					<GuidedTour defaultTourId="siteManagementTour" />
 				</GuidedTourContextProvider>
 			) }
-		</MainLayout>
+		</Layout>
 	);
 };
 

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -9,6 +9,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
 import {
 	DATAVIEWS_LIST,
 	DATAVIEWS_TABLE,
@@ -22,6 +23,7 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import { GuidedTourContextProvider } from 'calypso/a8c-for-agencies/data/guided-tours/guided-tour-context';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import {
@@ -37,6 +39,11 @@ import { useInitializeDataViewsPage } from './hooks/use-initialize-dataviews-pag
 import { useInitializeDataViewsSelectedItem } from './hooks/use-initialize-dataviews-selected-item';
 import { useSyncSelectedSite } from './hooks/use-sync-selected-site';
 import { useSyncSelectedSiteFeature } from './hooks/use-sync-selected-site-feature';
+import {
+	CALYPSO_ONBOARDING_TOURS_PREFERENCE_NAME,
+	CALYPSO_ONBOARDING_TOURS_EVENT_NAMES,
+	useOnboardingTours,
+} from './onboarding-tours';
 import { DOTCOM_OVERVIEW, FEATURE_TO_ROUTE_MAP } from './site-preview-pane/constants';
 import DotcomPreviewPane from './site-preview-pane/dotcom-preview-pane';
 import SitesDashboardHeader from './sites-dashboard-header';
@@ -49,6 +56,8 @@ import './style.scss';
 
 // Add Dotcom specific styles
 import './dotcom-style.scss';
+
+import './guided-tours.scss';
 
 interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
@@ -188,6 +197,8 @@ const SitesDashboardV2 = ( {
 		dataViewsState.page * dataViewsState.perPage
 	);
 
+	const onboardingTours = useOnboardingTours();
+
 	useInitializeDataViewsPage( dataViewsState, setDataViewsState );
 	useInitializeDataViewsSelectedItem( { selectedSite, paginatedSites } );
 
@@ -261,15 +272,22 @@ const SitesDashboardV2 = ( {
 			) }
 
 			{ dataViewsState.selectedItem && (
-				<LayoutColumn className="site-preview-pane" wide>
-					<DotcomPreviewPane
-						site={ dataViewsState.selectedItem }
-						selectedSiteFeature={ selectedSiteFeature }
-						selectedSiteFeaturePreview={ selectedSiteFeaturePreview }
-						setSelectedSiteFeature={ setSelectedSiteFeature }
-						closeSitePreviewPane={ closeSitePreviewPane }
-					/>
-				</LayoutColumn>
+				<GuidedTourContextProvider
+					guidedTours={ onboardingTours }
+					preferenceNames={ CALYPSO_ONBOARDING_TOURS_PREFERENCE_NAME }
+					eventNames={ CALYPSO_ONBOARDING_TOURS_EVENT_NAMES }
+				>
+					<LayoutColumn className="site-preview-pane" wide>
+						<DotcomPreviewPane
+							site={ dataViewsState.selectedItem }
+							selectedSiteFeature={ selectedSiteFeature }
+							selectedSiteFeaturePreview={ selectedSiteFeaturePreview }
+							setSelectedSiteFeature={ setSelectedSiteFeature }
+							closeSitePreviewPane={ closeSitePreviewPane }
+						/>
+					</LayoutColumn>
+					<GuidedTour defaultTourId="siteManagementTour" />
+				</GuidedTourContextProvider>
 			) }
 		</Layout>
 	);

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -16,7 +16,7 @@ import {
 	initialDataViewsState,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
-import Layout from 'calypso/a8c-for-agencies/components/layout';
+import { MainLayout } from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
@@ -238,7 +238,7 @@ const SitesDashboardV2 = ( {
 	const isNarrowView = false;
 
 	return (
-		<Layout
+		<MainLayout
 			className={ classNames(
 				'sites-dashboard',
 				'sites-dashboard__layout',
@@ -289,7 +289,7 @@ const SitesDashboardV2 = ( {
 					<GuidedTour defaultTourId="siteManagementTour" />
 				</GuidedTourContextProvider>
 			) }
-		</Layout>
+		</MainLayout>
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7405

## Proposed Changes

* Refactor the GuidedTour components to make it reusable
* Add the GuidedTourStep component to the primary button (WP Admin or My Home) on the site management panel

| WP Admin | My Home |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/87d47de2-52da-4522-ae27-0c8b4d977b6c) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/51a0af92-c811-4017-bd7b-2e330e069981) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any site
* Make sure you can see the guide tour on the primary button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
