### PR TITLE
Admin interface: Redirect to wp-admin after selecting Classic style

### DIFF
--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -122,9 +122,7 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
 						/>
 					</FormLabel>
 					<FormSettingExplanation>
-						{ hasEnTranslation( 'Use WP-Admin to manage your site.' )
-							? translate( 'Use WP-Admin to manage your site.' )
-							: translate( 'The classic WP-Admin WordPress interface.' ) }
+						{ translate( 'Use WP-Admin to manage your site.' ) }
 					</FormSettingExplanation>
 				</FormFieldset>
 				<FormFieldset>

--- a/client/my-sites/site-settings/site-admin-interface/use-select-interface-mutation.ts
+++ b/client/my-sites/site-settings/site-admin-interface/use-select-interface-mutation.ts
@@ -1,11 +1,14 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useState } from 'react';
+import { navigate } from 'calypso/lib/navigate';
 import wp from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import { receiveSite, requestSite } from 'calypso/state/sites/actions';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 
 const SET_SITE_INTERFACE_MUTATION_KEY = 'set-site-interface-mutation-key';
 const PERSISTENT_DATA_DELAY = 1200;
@@ -38,6 +41,7 @@ export const useSiteInterfaceMutation = (
 ) => {
 	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getRawSite( state, siteId ) );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, site?.ID ) );
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 	const [ hasSuccessfullyFinished, setHasSuccessfullyFinished ] = useState( false );
 	useEffect( () => {
@@ -65,11 +69,15 @@ export const useSiteInterfaceMutation = (
 		},
 		mutationKey: queryKey,
 		onSuccess: ( ...params ) => {
-			dispatch( requestAdminMenu( siteId ) );
-			setHasSuccessfullyFinished( true );
 			const [ data ] = params;
 			if ( ! data?.interface || ! site ) {
 				throw new Error( 'Invalid response from hosting/admin-interface' );
+			}
+			if ( data.interface === 'wp-admin' && siteAdminUrl ) {
+				navigate( addQueryArgs( siteAdminUrl, { 'admin-interface-changed': true } ) );
+			} else {
+				dispatch( requestAdminMenu( siteId ) );
+				setHasSuccessfullyFinished( true );
 			}
 			const newOptions = {
 				...( site.options || {} ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7406

## Proposed Changes

Redirects to WP Admin (with `?admin-interface-changed=true` param) after switching to the classic admin interface.


https://github.com/Automattic/wp-calypso/assets/1233880/29fb4d5c-dead-4f6c-ad58-2bb6e3f52654

In a follow-up, we'll use the `?admin-interface-changed=true` param to display a success notification and/or [the wp-admin intro tour](https://github.com/Automattic/dotcom-forge/issues/7404).

## Why are these changes being made?

So we can display the wp-admin tour when a user activates the classic admin interface.

## Testing Instructions

- Use the Calypso live link below
- Switch to a site with the default admin interface
- Go to `/settings/general/:site`
- Activate the classic admin interface
- Make sure you land in WP Admin
- Go back to `/settings/general/:site`
- Activate the default admin interface
- Make sure you stay in Calypso and the success notification shows up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
