### PR TITLE
A4A: Replace Marketpalce 'Add to cart' to 'Add to referral' button when in referral mode.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { Icon, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
 import {
@@ -21,6 +21,7 @@ import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import '../product-card/style.scss';
 
 interface Props {
+	asReferral?: boolean;
 	products: APIProductFamilyProduct[];
 	isSelected: boolean;
 	isDisabled?: boolean;
@@ -37,6 +38,7 @@ interface Props {
 
 export default function MultiProductCard( props: Props ) {
 	const {
+		asReferral,
 		products,
 		isSelected,
 		isDisabled,
@@ -147,6 +149,13 @@ export default function MultiProductCard( props: Props ) {
 		}
 	}, [ selectedOption ] );
 
+	const ctaLabel = useMemo( () => {
+		if ( asReferral ) {
+			return isSelected ? translate( 'Added to referral' ) : translate( 'Add to referral' );
+		}
+		return isSelected ? translate( 'Added to cart' ) : translate( 'Add to cart' );
+	}, [ asReferral, isSelected, translate ] );
+
 	return (
 		<>
 			<div
@@ -195,7 +204,7 @@ export default function MultiProductCard( props: Props ) {
 							tabIndex={ -1 }
 						>
 							{ isSelected && <Icon icon={ check } /> }
-							{ isSelected ? translate( 'Added to cart' ) : translate( 'Add to cart' ) }
+							{ ctaLabel }
 						</Button>
 						{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
 							<LicenseLightboxLink

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { Icon, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import {
 	useProductDescription,
@@ -19,6 +19,7 @@ import { APIProductFamilyProduct } from '../../../../../state/partner-portal/typ
 import './style.scss';
 
 interface Props {
+	asReferral?: boolean;
 	product: APIProductFamilyProduct;
 	isSelected: boolean;
 	isDisabled?: boolean;
@@ -30,6 +31,7 @@ interface Props {
 
 export default function ProductCard( props: Props ) {
 	const {
+		asReferral,
 		product,
 		isSelected,
 		isDisabled,
@@ -114,6 +116,13 @@ export default function ProductCard( props: Props ) {
 		setShowLightbox( false );
 	}, [ resetParams ] );
 
+	const ctaLabel = useMemo( () => {
+		if ( asReferral ) {
+			return isSelected ? translate( 'Added to referral' ) : translate( 'Add to referral' );
+		}
+		return isSelected ? translate( 'Added to cart' ) : translate( 'Add to cart' );
+	}, [ asReferral, isSelected, translate ] );
+
 	return (
 		<>
 			<div
@@ -156,7 +165,7 @@ export default function ProductCard( props: Props ) {
 							tabIndex={ -1 }
 						>
 							{ isSelected && <Icon icon={ check } /> }
-							{ isSelected ? translate( 'Added to cart' ) : translate( 'Add to cart' ) }
+							{ ctaLabel }
 						</Button>
 						{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
 							<LicenseLightboxLink

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -243,6 +243,7 @@ export default function ProductListing( {
 		return products.map( ( productOption ) =>
 			Array.isArray( productOption ) ? (
 				<MultiProductCard
+					asReferral={ isReferingProducts }
 					key={ productOption.map( ( { slug } ) => slug ).join( ',' ) }
 					products={ productOption }
 					onSelectProduct={ onSelectOrReplaceProduct }
@@ -264,6 +265,7 @@ export default function ProductListing( {
 				/>
 			) : (
 				<ProductCard
+					asReferral={ isReferingProducts }
 					key={ productOption.slug }
 					product={ productOption }
 					onSelectProduct={ onSelectProduct }


### PR DESCRIPTION
During referral mode, the CTA button on the product card should display 'Add to referral' instead of 'Add to cart'. This PR fixes this.

| Regular | Referral mode |
|--------|--------|
| <img width="1544" alt="Screenshot 2024-05-24 at 6 30 06 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e398c214-da85-4ed8-ac48-7cb2ae96ef51"> | <img width="1573" alt="Screenshot 2024-05-24 at 6 29 55 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8e369330-68f3-4b9e-b5cc-94287bbdeeab"> | 


Depends on https://github.com/Automattic/wp-calypso/pull/91090
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/527


## Proposed Changes

* Add new 'asReferral' property to both the Multi-product and product card, and use the property to determine the CTA label the card will render.


## Testing Instructions

* Use the A4A live link below and go to `/marketplace/products`
* Toggle 'Referral mode' at the top right corner.
* Confirm that the product cards display the 'Add to referral' text on the CTA button.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
