### PR TITLE
Nav redesign: rename /dev-tools-promo => /dev-tools

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -246,7 +246,7 @@ export function redirectIfP2( context, next ) {
 }
 
 /**
- * Middleware to redirect a user to /dev-tools-promo if the site is not Atomic.
+ * Middleware to redirect a user to /dev-tools if the site is not Atomic.
  * @param   {Object}   context Context object
  * @param   {Function} next    Calls next middleware
  * @returns {void}
@@ -257,7 +257,7 @@ export function redirectToDevToolsPromoIfNotAtomic( context, next ) {
 	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 
 	if ( config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && ! isAtomicSite ) {
-		return page.redirect( `/dev-tools-promo/${ site?.slug }` );
+		return page.redirect( `/dev-tools/${ site?.slug }` );
 	}
 
 	next();

--- a/client/dev-tools-promo/controller.tsx
+++ b/client/dev-tools-promo/controller.tsx
@@ -1,7 +1,0 @@
-import { Context as PageJSContext } from '@automattic/calypso-router';
-import DevToolsPromo from 'calypso/dev-tools-promo/components/dev-tools-promo';
-
-export function devToolsPromo( context: PageJSContext, next: () => void ) {
-	context.primary = <DevToolsPromo />;
-	next();
-}

--- a/client/dev-tools/components/dev-tools-icon.jsx
+++ b/client/dev-tools/components/dev-tools-icon.jsx
@@ -1,6 +1,6 @@
 export default function DevToolsIcon() {
 	return (
-		<span className="dev-tools-promo__icon" key="blogging-prompt__dev-tools-icon">
+		<span className="dev-tools__icon" key="blogging-prompt__dev-tools-icon">
 			<svg
 				fill="none"
 				height="20"

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -15,7 +15,7 @@ type PromoCardProps = {
 };
 
 const PromoCard = ( { title, text, supportContext }: PromoCardProps ) => (
-	<Card className="dev-tools-promo__card">
+	<Card className="dev-tools__card">
 		<CardHeading>{ title }</CardHeading>
 		<p>{ text }</p>
 		{ translate( '{{supportLink}}Learn more{{/supportLink}}', {
@@ -26,7 +26,7 @@ const PromoCard = ( { title, text, supportContext }: PromoCardProps ) => (
 	</Card>
 );
 
-const DevToolsPromo = () => {
+const DevTools = () => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) || '';
 
@@ -68,22 +68,22 @@ const DevToolsPromo = () => {
 		},
 	];
 	return (
-		<div className="dev-tools-promo">
-			<div className="dev-tools-promo__hero">
+		<div className="dev-tools">
+			<div className="dev-tools__hero">
 				<h1> { translate( 'Unlock all developer tools' ) }</h1>
 				<p>
 					{ translate(
 						'Upgrade to the Creator plan or higher to get access to all developer tools'
 					) }
 				</p>
-				<Button variant="secondary" className="dev-tools-promo__button" href={ pluginsLink }>
+				<Button variant="secondary" className="dev-tools__button" href={ pluginsLink }>
 					{ translate( 'Browse plugins' ) }
 				</Button>
-				<Button variant="primary" className="dev-tools-promo__button" href={ upgradeLink }>
+				<Button variant="primary" className="dev-tools__button" href={ upgradeLink }>
 					{ translate( 'Upgrade now' ) }
 				</Button>
 			</div>
-			<div className="dev-tools-promo__cards">
+			<div className="dev-tools__cards">
 				{ promoCards.map( ( card ) => (
 					<PromoCard
 						title={ card.title }
@@ -96,4 +96,4 @@ const DevToolsPromo = () => {
 	);
 };
 
-export default DevToolsPromo;
+export default DevTools;

--- a/client/dev-tools/components/style.scss
+++ b/client/dev-tools/components/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.dev-tools-promo__hero {
+.dev-tools__hero {
 	grid-column: 1 / -1;
 	text-align: center;
 	margin-bottom: 70px;
@@ -19,7 +19,7 @@
 		font-weight: 400;
 		font-size: rem(18px);
 	}
-	.dev-tools-promo__button {
+	.dev-tools__button {
 		margin: 0 5px;
 		padding: 10px 14px;
 		font-size: rem(14px);
@@ -27,7 +27,7 @@
 	}
 }
 
-.dev-tools-promo__cards {
+.dev-tools__cards {
 	display: grid;
 	grid-template-columns: 1fr;
 	grid-column-gap: 16px;
@@ -39,7 +39,7 @@
 	}
 }
 
-.dev-tools-promo__card {
+.dev-tools__card {
 	border-radius: 4px;
 	border: 1px solid var(--studio-gray-5);
 	box-shadow: none;

--- a/client/dev-tools/controller.tsx
+++ b/client/dev-tools/controller.tsx
@@ -1,0 +1,7 @@
+import { Context as PageJSContext } from '@automattic/calypso-router';
+import DevTools from 'calypso/dev-tools/components/dev-tools';
+
+export function devTools( context: PageJSContext, next: () => void ) {
+	context.primary = <DevTools />;
+	next();
+}

--- a/client/dev-tools/index.tsx
+++ b/client/dev-tools/index.tsx
@@ -2,9 +2,9 @@ import page, { Context as PageJSContext } from '@automattic/calypso-router';
 import { makeLayout, render as clientRender, redirectIfP2 } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { siteDashboard } from 'calypso/sites-dashboard-v2/controller';
-import { DOTCOM_DEVELOPER_TOOLS_PROMO } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
+import { DOTCOM_DEVELOPER_TOOLS } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { devToolsPromo } from './controller';
+import { devTools } from './controller';
 
 const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) => {
 	const state = context.store.getState();
@@ -16,15 +16,15 @@ const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) =>
 };
 
 export default function () {
-	page( '/dev-tools-promo', siteSelection, sites, makeLayout, clientRender );
+	page( '/dev-tools', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/dev-tools-promo/:site',
+		'/dev-tools/:site',
 		siteSelection,
 		navigation,
 		redirectForNonSimpleSite,
 		redirectIfP2,
-		devToolsPromo,
-		siteDashboard( DOTCOM_DEVELOPER_TOOLS_PROMO ),
+		devTools,
+		siteDashboard( DOTCOM_DEVELOPER_TOOLS ),
 		makeLayout,
 		clientRender
 	);

--- a/client/sections.js
+++ b/client/sections.js
@@ -222,9 +222,9 @@ const sections = [
 		group: 'sites',
 	},
 	{
-		name: 'dev-tools-promo',
-		paths: [ '/dev-tools-promo' ],
-		module: 'calypso/dev-tools-promo',
+		name: 'dev-tools',
+		paths: [ '/dev-tools' ],
+		module: 'calypso/dev-tools',
 		group: 'sites',
 	},
 	{

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -411,7 +411,7 @@
 
 // Styles for site preview pane.
 .wpcom-site .a4a-layout.sites-dashboard .site-preview-pane {
-	.dev-tools-promo__icon {
+	.dev-tools__icon {
 		display: inline-block;
 		height: 18px;
 		vertical-align: top;

--- a/client/sites-dashboard-v2/site-preview-pane/constants.ts
+++ b/client/sites-dashboard-v2/site-preview-pane/constants.ts
@@ -4,7 +4,7 @@ export const DOTCOM_PHP_LOGS = 'dotcom-site-monitoring-php';
 export const DOTCOM_SERVER_LOGS = 'dotcom-site-monitoring-web';
 export const DOTCOM_GITHUB_DEPLOYMENTS = 'dotcom-github-deployments';
 export const DOTCOM_HOSTING_CONFIG = 'dotcom-hosting-config';
-export const DOTCOM_DEVELOPER_TOOLS_PROMO = 'dotcom-developer-tools-promo';
+export const DOTCOM_DEVELOPER_TOOLS = 'dotcom-developer-tools';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_OVERVIEW ]: 'overview/:site',
@@ -13,5 +13,5 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_SERVER_LOGS ]: 'site-monitoring/:site/web',
 	[ DOTCOM_GITHUB_DEPLOYMENTS ]: 'github-deployments/:site',
 	[ DOTCOM_HOSTING_CONFIG ]: 'hosting-config/:site',
-	[ DOTCOM_DEVELOPER_TOOLS_PROMO ]: 'dev-tools-promo/:site',
+	[ DOTCOM_DEVELOPER_TOOLS ]: 'dev-tools/:site',
 };

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -5,7 +5,7 @@ import ItemPreviewPane, {
 	createFeaturePreview,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
-import DevToolsIcon from 'calypso/dev-tools-promo/components/dev-tools-icon';
+import DevToolsIcon from 'calypso/dev-tools/components/dev-tools-icon';
 import {
 	DOTCOM_HOSTING_CONFIG,
 	DOTCOM_OVERVIEW,
@@ -13,7 +13,7 @@ import {
 	DOTCOM_PHP_LOGS,
 	DOTCOM_SERVER_LOGS,
 	DOTCOM_GITHUB_DEPLOYMENTS,
-	DOTCOM_DEVELOPER_TOOLS_PROMO,
+	DOTCOM_DEVELOPER_TOOLS,
 } from './constants';
 import PreviewPaneHeaderButtons from './preview-pane-header-buttons';
 
@@ -55,7 +55,7 @@ const DotcomPreviewPane = ( {
 				selectedSiteFeaturePreview
 			),
 			createFeaturePreview(
-				DOTCOM_DEVELOPER_TOOLS_PROMO,
+				DOTCOM_DEVELOPER_TOOLS,
 				<span>
 					{ __( 'Dev Tools' ) } <DevToolsIcon />
 				</span>,

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -368,7 +368,7 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 						  )
 						: undefined
 				}
-				href={ shouldLinkToDevTools ? `/dev-tools-promo/${ site.slug }` : undefined }
+				href={ shouldLinkToDevTools ? `/dev-tools/${ site.slug }` : undefined }
 				onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_site_hosting_click' ) }
 			>
 				{ shouldLinkToDevTools ? (

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -12,7 +12,7 @@ const GLOBAL_SITE_DASHBOARD_ROUTES = {
 	hosting: '/hosting-config/',
 	'github-deployments': '/github-deployments/',
 	'site-monitoring': '/site-monitoring/',
-	'dev-tools-promo': '/dev-tools-promo/',
+	'dev-tools': '/dev-tools/',
 };
 
 function isInSection( sectionName: string, sectionNames: string[] ) {


### PR DESCRIPTION
## Proposed Changes

This PR proposes to rename the existing `/dev-tools-promo/:site` route to `/dev-tools/:site`. Two reasons:

## Why are these changes being made?

- The content of this page is now not just about "promo" anymore; see https://github.com/Automattic/wp-calypso/pull/91031 where we want to support an activate button to transfer the site to Atomic.
- This route is actually is not live in production; we need to post a system request. Before this is set in stone forever, let's make this route name future-proof.

## Testing Instructions

1. Go to /sites.
2. Open a Simple site; verify that the Dev Tools tab still works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
