### PR TITLE
Site Profiler: Change header background and title based on Score

### DIFF
--- a/client/data/site-profiler/metrics-dictionaries.ts
+++ b/client/data/site-profiler/metrics-dictionaries.ts
@@ -1,4 +1,4 @@
-import { Metrics, Scores } from './types';
+import { BasicMetricsScored, Metrics, Scores } from './types';
 
 export const SCORES: Record< string, Scores > = {
 	good: 'good',
@@ -40,4 +40,31 @@ export function getScore( metric: Metrics, value: number ): Scores {
 		return SCORES.poor;
 	}
 	return SCORES.needsImprovement;
+}
+
+/**
+ * Get the overall score of the site based on the scores of the basic metrics.
+ * It will return poor if more then 2 metrics are poor, good otherwise.
+ * Defaults to good if no metrics are provided.
+ * @param metrics A record of metrics with their scores
+ * @returns The overall score of the site
+ */
+export function getOveralScore( metrics?: BasicMetricsScored ): Scores {
+	if ( ! metrics ) {
+		return SCORES.good;
+	}
+
+	const poorMetrics = Object.values( metrics ).filter(
+		( metric ) => metric?.score === SCORES.poor
+	);
+	return poorMetrics.length > 2 ? SCORES.poor : SCORES.good;
+}
+
+/**
+ * Helper method that returns if the Score is good or false otherwise
+ * @param score The score to check
+ * @returns True if the score is good, false otherwise
+ */
+export function isScoreGood( score: Scores ): boolean {
+	return score === SCORES.good;
 }

--- a/client/site-profiler/components/results-header/index.tsx
+++ b/client/site-profiler/components/results-header/index.tsx
@@ -1,11 +1,12 @@
 import { Button, Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import './styles.scss';
-import { BasicMetricsResult } from 'calypso/data/site-profiler/types';
+import { isScoreGood } from 'calypso/data/site-profiler/metrics-dictionaries';
+import { Scores } from 'calypso/data/site-profiler/types';
 
 type Props = {
 	domain: string;
-	basicMetrics: BasicMetricsResult;
+	overallScore: Scores;
 	onGetReport: () => void;
 };
 
@@ -16,19 +17,19 @@ function getIcon() {
 }
 
 function getDomainMessage() {
-	// TODO: Implement the functionality to get the correct Icon
+	// TODO: Implement the functionality to get the correct Domain message
 	// https://github.com/Automattic/dotcom-forge/issues/7281
 	return translate( 'This site is not hosted on WordPress.com' );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getTitleMessage( basicMetrics: BasicMetricsResult ) {
-	// TODO: Implement the functionality to get the correct title
-	// https://github.com/Automattic/dotcom-forge/issues/7298
-	return translate( 'Your site needs a boost. Let’s improve it.' );
+function getTitleMessage( overallScore: Scores ) {
+	if ( ! isScoreGood( overallScore ) ) {
+		return translate( 'Your site needs a boost. Let’s improve it.' );
+	}
+	return translate( 'Your site is a top performer! Keep it up.' );
 }
 
-export const ResultsHeader = ( { domain, basicMetrics, onGetReport }: Props ) => {
+export const ResultsHeader = ( { domain, overallScore, onGetReport }: Props ) => {
 	return (
 		<div className="results-header--container">
 			<div className="results-header--domain-container">
@@ -36,7 +37,7 @@ export const ResultsHeader = ( { domain, basicMetrics, onGetReport }: Props ) =>
 				{ getIcon() }
 				<span className="domain-message">{ getDomainMessage() }</span>
 			</div>
-			<h1>{ getTitleMessage( basicMetrics ) }</h1>
+			<h1>{ getTitleMessage( overallScore ) }</h1>
 			<div className="results-header--button-container">
 				<Button onClick={ onGetReport }>
 					{ translate( 'Access full site report - It’s free' ) }

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -4,6 +4,7 @@ import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { getOveralScore, isScoreGood } from 'calypso/data/site-profiler/metrics-dictionaries';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
@@ -95,9 +96,7 @@ export default function SiteProfilerV2( props: Props ) {
 
 	const showGetReportForm = !! showBasicMetrics && !! url && isGetReportFormOpen;
 
-	// TODO: Get overall score from the API
-	// https://github.com/Automattic/dotcom-forge/issues/7298
-	const overallScore = false;
+	const overallScore = getOveralScore( basicMetrics?.basic );
 
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;
@@ -125,15 +124,15 @@ export default function SiteProfilerV2( props: Props ) {
 					<LayoutBlock
 						className={ classnames(
 							'results-header-block',
-							{ poor: ! overallScore },
-							{ good: overallScore }
+							{ poor: ! isScoreGood( overallScore ) },
+							{ good: isScoreGood( overallScore ) }
 						) }
 						width="medium"
 					>
 						{ showBasicMetrics && (
 							<ResultsHeader
 								domain={ domain }
-								basicMetrics={ basicMetrics }
+								overallScore={ overallScore }
 								onGetReport={ () => setIsGetReportFormOpen( true ) }
 							/>
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/7298

## Proposed Changes

* Add a scoring functionality that returns an overall score for the analyzed site
* Uses that functionality to display the title and background in the results header

|Poor | Good |
|-------|------|
| ![CleanShot 2024-05-24 at 13 46 01@2x](https://github.com/Automattic/wp-calypso/assets/3519124/7e908730-a1a9-426a-aa0b-aa52e47316d9) |  ![CleanShot 2024-05-24 at 13 46 11@2x](https://github.com/Automattic/wp-calypso/assets/3519124/1ebf225a-0157-4eac-9ffb-8439ba500ebc)   |



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To display the correct background and title in the results header section depending on the score

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch and in your local environment
* Navigate to a site that performs poorly, e.g. `/site-profiler/www.atliq.com`
* Check the background is red and the title reads as per the Poor screenshot above
* Navigate to a site that performs good, e.g. `/site-profiler/example.com`
* Check the background is green, and the title reads as per the Good screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
~~- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
~~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~