### PR TITLE
Align atomic site to Jetpack site for stats subscribers empty state

### DIFF
--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -10,7 +10,6 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
 import { useSelector } from 'calypso/state';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite, getSiteSlug, isSimpleSite } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -60,18 +59,16 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	// TODO: Pass subscribersTotals as props to SubscribersHighlightSection to avoid duplicate queries.
 	const { data: subscribersTotals, isLoading } = useSubscribersTotalsQueries( siteId );
 	const isSimple = useSelector( isSimpleSite );
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const hasNoSubscriberOtherThanAdmin =
 		! subscribersTotals?.total ||
 		( subscribersTotals?.total === 1 && subscribersTotals?.is_owner_subscribing );
 	const showLaunchpad = ! isLoading && hasNoSubscriberOtherThanAdmin;
 
-	const emptyComponent =
-		isSimple || isAtomic ? (
-			<SubscriberLaunchpad launchpadContext="subscriber-stats" />
-		) : (
-			<EmptyListView />
-		);
+	const emptyComponent = isSimple ? (
+		<SubscriberLaunchpad launchpadContext="subscriber-stats" />
+	) : (
+		<EmptyListView />
+	);
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.

--- a/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
@@ -81,7 +81,7 @@ const EmptyListView = () => {
 				url={ localizeUrl( importSubscribersUrl ) }
 				eventName="calypso_subscribers_empty_view_import_subscribers_clicked"
 			/>
-			{ ! isWPCOMSite && (
+			{ isWPCOMSite && (
 				<EmptyListCTALink
 					icon={ trendingUp }
 					text={ translate( 'Grow your audience' ) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6356

## Proposed Changes

* When the site has no subscribers, render same empty state as Jetpack sites

Jetpack site
![jetpack](https://github.com/Automattic/wp-calypso/assets/6586048/23f950db-df8a-42df-bce3-0eb651c36840)

> [!NOTE]  
> the Jetpack site has one less item since it doesn't have the respective support doc link.

Atomic site

![atomic](https://github.com/Automattic/wp-calypso/assets/6586048/2602520b-0a33-4ce5-8b08-72999f6a672d)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Align Atomic sites with Jetpack core

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `cd apps/odyssey-stats`
* run `NODE_ENV=production yarn dev --sync`
* Sandbox `widgets.wp.com`
* Needs an atomic site with no subscribers
* Go to https://xxx.wpcomstaging.com/wp-admin/admin.php?page=stats#!/stats/subscribers/xxx.wpcomstaging.com?page=stats
* Links should go to wordpress.com support docs for atomic sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
