### PR TITLE
Plans: Remove `@automattic/onboarding` dependency from `plans-grid-next`

### DIFF
--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -40,7 +40,6 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
-		"@automattic/onboarding": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
 		"@automattic/viewport": "workspace:^",
 		"@emotion/react": "11.11.1",

--- a/packages/plans-grid-next/src/components/plan-button/style.scss
+++ b/packages/plans-grid-next/src/components/plan-button/style.scss
@@ -1,5 +1,3 @@
-@import "@automattic/onboarding/styles/mixins";
-
 .plan-features-2023-grid__actions-button {
 	font-weight: 500;
 	line-height: 20px;

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -1,4 +1,3 @@
-@import "@automattic/onboarding/styles/mixins";
 @import "./mixins";
 @import "./media-queries";
 
@@ -230,7 +229,7 @@ $mobile-card-max-width: 440px;
 	line-height: 0.7;
 	color: var(--studio-gray-100);
 	font-weight: 400;
-	@include onboarding-font-recoleta;
+	font-family: $brand-serif;
 	letter-spacing: 0;
 }
 

--- a/packages/plans-grid-next/tsconfig.json
+++ b/packages/plans-grid-next/tsconfig.json
@@ -9,9 +9,5 @@
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],
-	"references": [
-		{ "path": "../data-stores" },
-		{ "path": "../onboarding" },
-		{ "path": "../viewport" }
-	]
+	"references": [ { "path": "../data-stores" }, { "path": "../viewport" } ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,7 +1563,6 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/format-currency": "workspace:^"
-    "@automattic/onboarding": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/viewport": "workspace:^"
     "@emotion/react": "npm:11.11.1"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Removes the `@automattic/onboarding` package from plans-grid. This probably just lingered after the refactors/cleanup. It is only used for a minor header style.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Clean up unused code and reduce dependency/context bloat from the package.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Load Storybook `yarn workspace @automattic/plans-grid-next storybook`, or go to `/start/plans`
- Confirm plan headers (titles) render with same font and letter-spacing as previously

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
