### PR TITLE
Help Center: copy change

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -34,7 +34,7 @@ const SupportModeTitle = () => {
 			return (
 				<>
 					<Icon icon={ commentContent } />
-					{ __( 'Connect to our Happiness Engineers', __i18n_text_domain__ ) }
+					{ __( 'Contact WordPress.com Support', __i18n_text_domain__ ) }
 				</>
 			);
 		case 'EMAIL': {

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -34,7 +34,7 @@ const SupportModeTitle = () => {
 			return (
 				<>
 					<Icon icon={ commentContent } />
-					{ __( 'Start live chat', __i18n_text_domain__ ) }
+					{ __( 'Connect to our Happiness Engineers', __i18n_text_domain__ ) }
 				</>
 			);
 		case 'EMAIL': {

--- a/packages/help-center/src/hooks/use-contact-form-title.tsx
+++ b/packages/help-center/src/hooks/use-contact-form-title.tsx
@@ -13,7 +13,7 @@ export const useContactFormTitle = (
 } => {
 	return {
 		CHAT: {
-			formTitle: __( 'Start live chat', __i18n_text_domain__ ),
+			formTitle: __( 'Connect to our Happiness Engineers', __i18n_text_domain__ ),
 			trayText: __( 'Our WordPress experts will be with you right away', __i18n_text_domain__ ),
 			buttonLabel: __( 'Chat with us', __i18n_text_domain__ ),
 			buttonSubmittingLabel: __( 'Connecting to chat', __i18n_text_domain__ ),

--- a/packages/help-center/src/hooks/use-contact-form-title.tsx
+++ b/packages/help-center/src/hooks/use-contact-form-title.tsx
@@ -13,7 +13,7 @@ export const useContactFormTitle = (
 } => {
 	return {
 		CHAT: {
-			formTitle: __( 'Connect to our Happiness Engineers', __i18n_text_domain__ ),
+			formTitle: __( 'Contact WordPress.com Support', __i18n_text_domain__ ),
 			trayText: __( 'Our WordPress experts will be with you right away', __i18n_text_domain__ ),
 			buttonLabel: __( 'Chat with us', __i18n_text_domain__ ),
 			buttonSubmittingLabel: __( 'Connecting to chat', __i18n_text_domain__ ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Adjusting heading for the contact form in chat. More context can be found here: pdDR7T-1vN-p2#comment-2011

<img width="1054" alt="Markup 2024-05-24 at 14 33 55" src="https://github.com/Automattic/wp-calypso/assets/33258733/3a3a60e7-9b94-4f1c-8fad-930684873836">

<img width="928" alt="Markup 2024-05-24 at 14 33 44" src="https://github.com/Automattic/wp-calypso/assets/33258733/f6a423d8-71d8-466b-a09e-2d71feeecd3c">


## Testing Instructions

1. Checkout branch and launch calypso local.
2. Edit `packages/help-center/src/hooks/use-should-render-email-option.tsx` and set the `render` option on line 8 to be false: `render: false,`
3. Open help center and tell Wapuu `I want to talk to a human`
4. Click the support button
5. Verify the heading is changed.
