### PR TITLE
Send domain-only users to email support

### DIFF
--- a/packages/help-center/src/hooks/use-should-render-email-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-email-option.tsx
@@ -3,8 +3,13 @@ import { useSupportAvailability } from '../data/use-support-availability';
 export function useShouldRenderEmailOption() {
 	const { data: supportAvailability, isFetching } = useSupportAvailability();
 
+	// Domain only customers should always see the email option
+	// Domain only users have this combination of support level === free, and paying customer status.
+	const isDomainOnlyUser =
+		supportAvailability?.is_paying_customer && supportAvailability?.supportLevel === 'free';
+
 	return {
 		isLoading: isFetching,
-		render: supportAvailability?.force_email_contact_form ?? false,
+		render: isDomainOnlyUser || ( supportAvailability?.force_email_contact_form ?? false ),
 	};
 }


### PR DESCRIPTION
This sends domain only support to email support instead of ZD because of this issue: pdDR7T-1vN-p2#comment-1997