### PR TITLE
Entrepreneur Signup: Remember path to last step during trial acknowledgement.

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -1,7 +1,6 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import { ENTREPRENEUR_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useState } from 'react';
 import { anonIdCache } from 'calypso/data/segmentaton-survey';
 import { useSelector } from 'calypso/state';
@@ -51,14 +50,7 @@ const entrepreneurFlow: Flow = {
 		const [ isMigrationFlow, setIsMigrationFlow ] = useState( false );
 
 		const getEntrepreneurLoginUrl = () => {
-			const queryParams = new URLSearchParams();
-
-			const redirectTo = addQueryArgs(
-				`${ window.location.protocol }//${ window.location.host }/setup/entrepreneur/trialAcknowledge`,
-				{
-					...Object.fromEntries( queryParams ),
-				}
-			);
+			const redirectTo = `${ window.location.protocol }//${ window.location.host }/setup/entrepreneur/trialAcknowledge${ window.location.search }`;
 
 			const loginUrl = getLoginUrl( {
 				variationName: flowName,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/index.tsx
@@ -3,6 +3,7 @@ import {
 	isNewHostedSiteCreationFlow,
 	isEntrepreneurSignupFlow,
 } from '@automattic/onboarding';
+import { useSaveEntrepreneurFlowPathStep } from 'calypso/landing/stepper/hooks/use-save-entrepreneur-flow-path-step';
 import { useSaveHostingFlowPathStep } from 'calypso/landing/stepper/hooks/use-save-hosting-flow-path-step';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { EntrepreneurTrialAcknowledge } from './entrepreneur-trial-acknowledge';
@@ -14,7 +15,15 @@ import './style.scss';
 const TrialAcknowledge: Step = function TrialAcknowledge( { navigation, flow, stepName } ) {
 	const { goBack } = navigation;
 
+	// TODO: Refactor component & hook to have better support for different flows.
+	// This won't execute for Entrepreneur flow has internally it checks for specifically hosting flow.
 	useSaveHostingFlowPathStep( flow, `/setup/${ flow }/${ stepName }` );
+
+	// This will execute for Entrepreneur flow
+	useSaveEntrepreneurFlowPathStep(
+		flow,
+		`/setup/${ flow }/${ stepName }${ window.location.search }`
+	);
 
 	const getStepContent = () => {
 		if ( isEntrepreneurSignupFlow( flow ) ) {

--- a/client/landing/stepper/hooks/use-save-entrepreneur-flow-path-step.ts
+++ b/client/landing/stepper/hooks/use-save-entrepreneur-flow-path-step.ts
@@ -1,0 +1,19 @@
+import { ENTREPRENEUR_FLOW } from '@automattic/onboarding';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getCurrentUserId, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+
+export function useSaveEntrepreneurFlowPathStep( flow: string | null, currentPath: string ) {
+	const dispatch = useDispatch();
+	const userId = useSelector( getCurrentUserId );
+	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
+	const pathStep = isEmailVerified ? null : currentPath;
+
+	useEffect( () => {
+		if ( ! isEmailVerified && flow === ENTREPRENEUR_FLOW ) {
+			const prefKey = `entrepreneur-flow-path-step-${ userId }`;
+			dispatch( savePreference( prefKey, pathStep ) );
+		}
+	}, [ userId, isEmailVerified, pathStep, flow, dispatch ] );
+}

--- a/client/my-sites/plans/trials/trial-acknowledge/entrepreneur-acknowledge.tsx
+++ b/client/my-sites/plans/trials/trial-acknowledge/entrepreneur-acknowledge.tsx
@@ -83,7 +83,7 @@ export const EntrepreneurTrialAcknowledgement = ( {
 				)
 				.map( ( feature ) => feature.getTitle() as string ) }
 			subtitle={ sprintf(
-				/* translators: thhe planName could be "Pro", "Business", "Hosting" or "Entrepreneur"; the trialDuration could be 7 or 14. */
+				/* translators: the planName could be "Pro", "Business", "Hosting" or "Entrepreneur"; the trialDuration could be 7 or 14. */
 				__(
 					'Give the %(planName)s plan a try with the %(trialDuration)d-day free trial, and create your site without costs'
 				),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

⚠️ This is currently a fork of this PR. https://github.com/Automattic/wp-calypso/pull/91113

## Proposed Changes

* Store the path to come back to after email verification during trial acknowledgement step.
* The path is stored in Calypso preferences.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that users can come back to the trial acknowledgement step after clicking email verification link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open incognito window (as this is only for unverified users).
* Open network panel.
* Go to `/setup/entrepreneur?ref=entrepreneur-signup`.
* Create an account (or login into an unverified account).
* When you arrive at the Trial Acknowledge step, look for POST `preferences` API call in the network panel.
* You should see the key `entrepreneur-flow-path-step-<user_id>` being stored.
 
<img width="1305" alt="2024-05-24_21-58-02" src="https://github.com/Automattic/wp-calypso/assets/1287077/3317f760-816d-48cd-a771-934e8718c553">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
