### PR TITLE
Remove contact form for chat

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -4,16 +4,19 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { Spinner, GMClosureNotice } from '@automattic/components';
+import { Spinner, GMClosureNotice, FormInputValidation } from '@automattic/components';
+import { HelpCenterSelect } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
+import { useGetOdieStorage } from '@automattic/odie-client';
+import { useSelect } from '@wordpress/data';
 import { useEffect, useMemo } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
 import { comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Link, LinkProps } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
@@ -21,19 +24,14 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 import { BackButton } from '..';
 import {
 	useChatStatus,
+	useChatWidget,
 	useShouldRenderEmailOption,
 	useStillNeedHelpURL,
 	useZendeskMessaging,
 } from '../hooks';
 import { Mail } from '../icons';
+import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
-
-const ConditionalLink: FC< { active: boolean } & LinkProps > = ( { active, ...props } ) => {
-	if ( active ) {
-		return <Link { ...props } />;
-	}
-	return <span { ...props }></span>;
-};
 
 type ContactOption = 'chat' | 'email';
 const generateContactOnClickEvent = (
@@ -82,6 +80,20 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	useZendeskMessaging(
 		'zendesk_support_chat_key',
 		isEligibleForChat || hasActiveChats,
+		isEligibleForChat || hasActiveChats
+	);
+
+	const [ hasSubmittingError, setHasSubmittingError ] = useState< boolean >( false );
+
+	const currentSite = useSelect( ( select ) => {
+		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+		return helpCenterSelect.getSite();
+	}, [] );
+
+	const wapuuChatId = useGetOdieStorage( 'chat_id' );
+
+	const { isOpeningChatWidget, openChatWidget } = useChatWidget(
+		'zendesk_support_chat_key',
 		isEligibleForChat || hasActiveChats
 	);
 
@@ -142,13 +154,6 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 		);
 	}
 
-	// Create URLSearchParams for chat
-	const chatUrlSearchParams = new URLSearchParams( {
-		mode: 'CHAT',
-		wapuuFlow: hideHeaders.toString(),
-	} );
-	const chatUrl = `/contact-form?${ chatUrlSearchParams.toString() }`;
-
 	// Create URLSearchParams for email
 	const emailUrlSearchParams = new URLSearchParams( {
 		mode: 'EMAIL',
@@ -166,7 +171,18 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	const renderChatOption = () => {
 		return (
 			<div>
-				<ConditionalLink active to={ chatUrl } onClick={ contactOptionsEventMap[ 'chat' ] }>
+				<button
+					disabled={ isOpeningChatWidget }
+					onClick={ () => {
+						contactOptionsEventMap.chat();
+						openChatWidget( {
+							aiChatId: wapuuChatId,
+							message: '',
+							siteUrl: currentSite?.URL,
+							onError: () => setHasSubmittingError( true ),
+						} );
+					} }
+				>
 					<div className="help-center-contact-page__box chat" role="button" tabIndex={ 0 }>
 						<div className="help-center-contact-page__box-icon">
 							<Icon icon={ comment } />
@@ -176,7 +192,13 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 							<p>{ __( 'Our Happiness team will get back to you soon', __i18n_text_domain__ ) }</p>
 						</div>
 					</div>
-				</ConditionalLink>
+				</button>
+				{ hasSubmittingError && (
+					<FormInputValidation
+						isError
+						text={ __( 'Something went wrong, please try again later.', __i18n_text_domain__ ) }
+					/>
+				) }
 			</div>
 		);
 	};

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -344,6 +344,7 @@
 				overflow: hidden;
 				border-radius: 2px;
 				cursor: pointer;
+				text-align: left;
 
 				.help-center-contact-page__box-icon {
 					border-radius: 2px 0 0 2px;


### PR DESCRIPTION
## Proposed Changes

This removes the contact form step for chat users.

## Why are these changes being made?
pdDR7T-1vN-p2#comment-1998

## Testing Instructions

1. Check this branch locally.
2. Change [this](https://github.com/Automattic/wp-calypso/blob/remove/contant-form-for-chat/packages/help-center/src/components/help-center-contact-page.tsx#L242) check to `false`.
3. Open the Help Center. 
4. Ask Wapuu for a human.
5. Click the support button.
6. It should open the chat widget.

**Regression testing**
1. Clear the change you made to the check mentioned above.
2. Open the Help Center.
3. Ask Wapuu for a human.
4. Click the email option.
5. You should see the contact form.