### PR TITLE
Remove English locale check

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/hooks/use-get-upgrade-plan-site-metrics.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/hooks/use-get-upgrade-plan-site-metrics.tsx
@@ -1,4 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { getQueryArg } from '@wordpress/url';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
 import {
@@ -16,24 +15,21 @@ const calcPercentageDifferenceFromThreshold = ( value: number, threshold: number
 };
 
 export const useGetUpgradePlanSiteMetrics = () => {
-	const isEnglishLocale = useIsEnglishLocale();
 	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
 	const { data: siteMetricData, isFetching } = useUrlBasicMetricsQuery( importSiteQueryParam );
 
 	let lcpPercentageDifference = 0;
 	let fidPercentageDifference = 0;
 
-	if ( isEnglishLocale ) {
-		lcpPercentageDifference = calcPercentageDifferenceFromThreshold(
-			siteMetricData?.basic?.lcp?.value ?? 0,
-			upgradePlanSiteMetricsLcpThreshold
-		);
+	lcpPercentageDifference = calcPercentageDifferenceFromThreshold(
+		siteMetricData?.basic?.lcp?.value ?? 0,
+		upgradePlanSiteMetricsLcpThreshold
+	);
 
-		fidPercentageDifference = calcPercentageDifferenceFromThreshold(
-			siteMetricData?.basic?.fid?.value ?? 0,
-			upgradePlanSiteMetricsFidThreshold
-		);
-	}
+	fidPercentageDifference = calcPercentageDifferenceFromThreshold(
+		siteMetricData?.basic?.fid?.value ?? 0,
+		upgradePlanSiteMetricsFidThreshold
+	);
 
 	return {
 		isFetching,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90962

## Proposed Changes

* Since the [translations for the dynamic metrics](https://translate.wordpress.com/localci/status/automattic/wp-calypso/add/migration-flow-faster-response-data) of the migration flow are complete, we are removing the english locale check to display it in any language.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The translations are complete.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use the live link.
* Go to your Wordpress.com user settings and change your user language to another one.
* Manually update the line `siteMetricData?.basic?.fid?.value` to `150` (a not good FID).
* Navigate to: `/setup/site-migration/site-migration-upgrade-plan?from=https://www.mazdausa.com&siteSlug={FREE_SITE_SLUG}`
* Check that you see the following texts in your selected language:
  * `'%(wordpressLcpPercentage)s of sites on WordPress.com are at least %(sitePercentageDifference)s faster than yours.'`
  * `'%(wordpressFidPercentage)s of sites on WordPress.com respond at least %(sitePercentageDifference)s faster than yours on the first interaction.'`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
