### PR TITLE
Reader: Fix outdated icon for manage subscriptions

### DIFF
--- a/client/reader/components/icons/manage-subscriptions-icon.jsx
+++ b/client/reader/components/icons/manage-subscriptions-icon.jsx
@@ -1,15 +1,28 @@
 export default function ReaderManageSubscriptionsIcon() {
 	return (
 		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			viewBox="0 0 24 24"
-			className="gridicon gridicons-customize sidebar__menu-icon sidebar_svg-manage-subscriptions"
-			height="20"
+			className="sidebar__menu-icon sidebar_svg-subscriptions"
 			width="20"
+			height="20"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
 		>
-			<g>
-				<path d="M2 6c0-1.505.78-3.08 2-4 0 .845.69 2 2 2a3 3 0 013 3c0 .386-.079.752-.212 1.091a74.515 74.515 0 012.191 1.808l-2.08 2.08a75.852 75.852 0 01-1.808-2.191A2.977 2.977 0 016 10c-2.21 0-4-1.79-4-4zm12.152 6.848l1.341-1.341A4.446 4.446 0 0017.5 12 4.5 4.5 0 0022 7.5c0-.725-.188-1.401-.493-2.007L18 9l-2-2 3.507-3.507A4.446 4.446 0 0017.5 3 4.5 4.5 0 0013 7.5c0 .725.188 1.401.493 2.007L3 20l2 2 6.848-6.848a68.562 68.562 0 005.977 5.449l1.425 1.149 1.5-1.5-1.149-1.425a68.562 68.562 0 00-5.449-5.977z" />
-			</g>
+			<path
+				fill-rule="evenodd"
+				clip-rule="evenodd"
+				d="M15.5 11a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm0-1.5a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+				fill="#1E1E1E"
+			/>
+			<path
+				d="M13.25 17v-2a2.75 2.75 0 0 0-2.75-2.75h-4A2.75 2.75 0 0 0 3.75 15v2h1.5v-2c0-.69.56-1.25 1.25-1.25h4c.69 0 1.25.56 1.25 1.25v2h1.5ZM20.25 15v2h-1.5v-2c0-.69-.56-1.25-1.25-1.25H15v-1.5h2.5A2.75 2.75 0 0 1 20.25 15Z"
+				fill="#1E1E1E"
+			/>
+			<path
+				fill-rule="evenodd"
+				clip-rule="evenodd"
+				d="M11 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm-1.5 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+				fill="#1E1E1E"
+			/>
 		</svg>
 	);
 }

--- a/client/reader/components/icons/manage-subscriptions-icon.jsx
+++ b/client/reader/components/icons/manage-subscriptions-icon.jsx
@@ -1,28 +1,25 @@
 export default function ReaderManageSubscriptionsIcon() {
 	return (
 		<svg
-			className="sidebar__menu-icon sidebar_svg-subscriptions"
+			className="sidebar__menu-icon sidebar_svg-manage-subscriptions"
 			width="20"
 			height="20"
+			viewBox="0 0 20 20"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
 		>
+			<circle cx="6.25" cy="7.375" r="2" stroke="#A2AAB2" strokeWidth="1.5" />
 			<path
-				fill-rule="evenodd"
-				clip-rule="evenodd"
-				d="M15.5 11a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm0-1.5a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
-				fill="#1E1E1E"
+				d="M1.875 16.125V13.9375C1.875 12.7294 2.85438 11.75 4.0625 11.75H8.4375C9.64562 11.75 10.625 12.7294 10.625 13.9375V16.125"
+				stroke="#A2AAB2"
+				strokeWidth="1.5"
 			/>
 			<path
-				d="M13.25 17v-2a2.75 2.75 0 0 0-2.75-2.75h-4A2.75 2.75 0 0 0 3.75 15v2h1.5v-2c0-.69.56-1.25 1.25-1.25h4c.69 0 1.25.56 1.25 1.25v2h1.5ZM20.25 15v2h-1.5v-2c0-.69-.56-1.25-1.25-1.25H15v-1.5h2.5A2.75 2.75 0 0 1 20.25 15Z"
-				fill="#1E1E1E"
+				d="M13.75 11.75H15.9375C17.1456 11.75 18.125 12.7294 18.125 13.9375V16.125"
+				stroke="#A2AAB2"
+				strokeWidth="1.5"
 			/>
-			<path
-				fill-rule="evenodd"
-				clip-rule="evenodd"
-				d="M11 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm-1.5 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
-				fill="#1E1E1E"
-			/>
+			<circle cx="14.375" cy="7.375" r="2" stroke="#A2AAB2" strokeWidth="1.5" />
 		</svg>
 	);
 }

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -20,34 +20,34 @@
 		box-shadow: none;
 
 		.form-text-input {
-			color: var(--color-sidebar-submenu-text);
-			box-shadow: 0 0 1px var(--color-sidebar-submenu-text);
+			color: var( --color-sidebar-submenu-text );
+			box-shadow: 0 0 1px var( --color-sidebar-submenu-text );
 			background-color: transparent;
 			padding: 0 8px;
 			margin: 4px 4px 4px 0;
 			font-size: $font-body-small;
 
 			&:focus {
-				box-shadow: 0 0 0 1px var(--color-sidebar-submenu-hover-text);
+				box-shadow: 0 0 0 1px var( --color-sidebar-submenu-hover-text );
 			}
 
 			&::placeholder {
-				color: var(--color-sidebar-submenu-text);
+				color: var( --color-sidebar-submenu-text );
 				opacity: 0.3; // Same as disabled button's opacity.
 			}
 		}
 
 		.form-text-input-with-action__button {
-			color: var(--color-sidebar-submenu-text);
+			color: var( --color-sidebar-submenu-text );
 
 			&:disabled {
-				color: var(--color-sidebar-submenu-text);
+				color: var( --color-sidebar-submenu-text );
 			}
 		}
 	}
 
 	.reader-sidebar-tags__all-tags-link {
-		color: var(--color-link);
+		color: var( --color-link );
 		margin-bottom: 2px;
 	}
 }
@@ -59,22 +59,22 @@ body.is-reader-page,
 .is-reader-page .layout,
 .layout.is-section-reader,
 .layout.is-section-reader .layout__content,
-.is-section-reader:not(.is-reader-full-post) {
+.is-section-reader:not( .is-reader-full-post ) {
 	background: initial;
 }
-body.is-section-reader:not(.is-reader-full-post) {
-	background: var(--studio-gray-0);
+body.is-section-reader:not( .is-reader-full-post ) {
+	background: var( --studio-gray-0 );
 
 	&.rtl .layout__content {
-		padding: 16px calc(var(--sidebar-width-max)) 16px 16px;
+		padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
 	}
 
 	.layout__content {
 		// Add border around everything
 		overflow: hidden;
 		min-height: 100vh;
-		@media only screen and (min-width: 782px) {
-			padding: 16px 16px 16px calc(var(--sidebar-width-max)) !important;
+		@media only screen and ( min-width: 782px ) {
+			padding: 16px 16px 16px calc( var( --sidebar-width-max ) ) !important;
 		}
 		.layout_primary > div {
 			padding-bottom: 0;
@@ -89,7 +89,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 		padding-top: 16px;
 	}
 
-	@media only screen and (max-width: 600px) {
+	@media only screen and ( max-width: 600px ) {
 		.navigation-header__main {
 			justify-content: normal;
 			align-items: center;
@@ -99,23 +99,23 @@ body.is-section-reader:not(.is-reader-full-post) {
 		}
 	}
 
-	@media only screen and (max-width: 781px) {
+	@media only screen and ( max-width: 781px ) {
 		.layout__primary > div {
-			background: var(--color-surface);
+			background: var( --color-surface );
 			margin: 0;
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			height: calc(100vh - 46px);
+			height: calc( 100vh - 46px );
 		}
 	}
 
 	.is-discover-stream {
 		header.navigation-header.discover-stream-header {
 			padding: 0;
-			@media only screen and (max-width: 600px) {
+			@media only screen and ( max-width: 600px ) {
 				padding: 0 24px;
 			}
 		}
-		@media only screen and (max-width: 660px) {
+		@media only screen and ( max-width: 660px ) {
 			.discover-stream-navigation {
 				margin-left: 0;
 				margin-right: 0;
@@ -144,22 +144,22 @@ body.is-section-reader:not(.is-reader-full-post) {
 		padding: 4px 6px;
 		line-height: 1;
 		min-width: 22px;
-		background-color: var(--color-sidebar-menu-hover-background);
-		border-color: var(--color-sidebar-menu-hover-background);
-		outline-color: var(--color-sidebar-menu-hover-background);
-		color: var(--color-sidebar-text-alternative);
+		background-color: var( --color-sidebar-menu-hover-background );
+		border-color: var( --color-sidebar-menu-hover-background );
+		outline-color: var( --color-sidebar-menu-hover-background );
+		color: var( --color-sidebar-text-alternative );
 	}
 
 	.sidebar__menu-link:hover .count {
-		border-color: var(--color-sidebar-menu-hover-text);
+		border-color: var( --color-sidebar-menu-hover-text );
 		outline-color: #f00;
-		color: var(--color-sidebar-menu-hover-text);
+		color: var( --color-sidebar-menu-hover-text );
 	}
 
 	.selected .sidebar__menu-link .count {
 		background: transparent;
-		color: var(--color-sidebar-menu-selected-text);
-		border-color: var(--color-sidebar-menu-selected-text);
+		color: var( --color-sidebar-menu-selected-text );
+		border-color: var( --color-sidebar-menu-selected-text );
 	}
 
 	.sidebar__menu-item-siteicon {
@@ -172,7 +172,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 		display: block;
 		font-style: italic;
 		font-size: $font-body-extra-small;
-		color: var(--color-sidebar-text-alternative);
+		color: var( --color-sidebar-text-alternative );
 	}
 
 	.sidebar__separator {
@@ -188,7 +188,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 	}
 
 	.sidebar-streams__following-load-more {
-		color: var(--color-link);
+		color: var( --color-link );
 		cursor: pointer;
 		font-size: $font-body-extra-small;
 		text-align: center;
@@ -197,7 +197,7 @@ body.is-section-reader:not(.is-reader-full-post) {
 		width: 100%;
 
 		&:hover {
-			color: var(--color-link-dark);
+			color: var( --color-link-dark );
 		}
 	}
 
@@ -221,37 +221,38 @@ body.is-section-reader:not(.is-reader-full-post) {
 		&:focus {
 			.sidebar__menu-icon.sidebar_svg-add {
 				g {
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var( --color-sidebar-gridicon-hover-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
-				fill: var(--color-sidebar-gridicon-hover-fill);
-				g {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+				fill: var( --color-sidebar-menu-hover-background );
+				circle,
+				path {
+					stroke: var( --color-sidebar-gridicon-hover-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-conversations {
-				fill: var(--color-sidebar-menu-hover-background);
+				fill: var( --color-sidebar-menu-hover-background );
 				g {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var( --color-sidebar-gridicon-hover-fill );
 				}
 				g g {
 					stroke: unset;
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var( --color-sidebar-gridicon-hover-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-following,
 			.sidebar__menu-icon.sidebar_svg-likes,
 			.sidebar__menu-icon.sidebar_svg-notifications {
-				fill: var(--color-sidebar-menu-hover-background);
+				fill: var( --color-sidebar-menu-hover-background );
 				path {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var( --color-sidebar-gridicon-hover-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-p2 {
-				fill: var(--color-sidebar-menu-hover-background);
+				fill: var( --color-sidebar-menu-hover-background );
 				path {
-					fill: var(--color-sidebar-gridicon-hover-fill);
+					fill: var( --color-sidebar-gridicon-hover-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-a8c,
@@ -260,46 +261,47 @@ body.is-section-reader:not(.is-reader-full-post) {
 			.sidebar__menu-icon.sidebar_svg-search,
 			.sidebar__menu-icon.sidebar_svg-tag,
 			.sidebar__menu-icon.sidebar_svg-discover {
-				fill: var(--color-sidebar-menu-hover-background);
+				fill: var( --color-sidebar-menu-hover-background );
 				g {
-					stroke: var(--color-sidebar-gridicon-hover-fill);
+					stroke: var( --color-sidebar-gridicon-hover-fill );
 				}
 			}
 		}
 		/* Default styles */
 		.sidebar__menu-icon.sidebar_svg-add {
 			g {
-				fill: var(--color-sidebar-gridicon-fill);
+				fill: var( --color-sidebar-gridicon-fill );
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
-			fill: var(--color-sidebar-gridicon-fill);
-			g {
-				stroke: var(--color-sidebar-gridicon-fill);
+			fill: var( --color-sidebar-background );
+			circle,
+			path {
+				stroke: var( --color-sidebar-gridicon-fill );
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-conversations {
-			fill: var(--color-sidebar-background);
+			fill: var( --color-sidebar-background );
 			g {
-				stroke: var(--color-sidebar-gridicon-fill);
+				stroke: var( --color-sidebar-gridicon-fill );
 			}
 			g g {
 				stroke: unset;
-				fill: var(--color-sidebar-gridicon-fill);
+				fill: var( --color-sidebar-gridicon-fill );
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-following,
 		.sidebar__menu-icon.sidebar_svg-likes,
 		.sidebar__menu-icon.sidebar_svg-notifications {
-			fill: var(--color-sidebar-background);
+			fill: var( --color-sidebar-background );
 			path {
-				stroke: var(--color-sidebar-gridicon-fill);
+				stroke: var( --color-sidebar-gridicon-fill );
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-p2 {
-			fill: var(--color-sidebar-background);
+			fill: var( --color-sidebar-background );
 			path {
-				fill: var(--color-sidebar-gridicon-fill);
+				fill: var( --color-sidebar-gridicon-fill );
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-a8c,
@@ -308,9 +310,9 @@ body.is-section-reader:not(.is-reader-full-post) {
 		.sidebar__menu-icon.sidebar_svg-search,
 		.sidebar__menu-icon.sidebar_svg-tag,
 		.sidebar__menu-icon.sidebar_svg-discover {
-			fill: var(--color-sidebar-background);
+			fill: var( --color-sidebar-background );
 			g {
-				stroke: var(--color-sidebar-gridicon-fill);
+				stroke: var( --color-sidebar-gridicon-fill );
 			}
 		}
 	}
@@ -320,37 +322,38 @@ body.is-section-reader:not(.is-reader-full-post) {
 		.sidebar__menu-link {
 			.sidebar__menu-icon.sidebar_svg-add {
 				g {
-					fill: var(--color-sidebar-gridicon-selected-fill);
+					fill: var( --color-sidebar-gridicon-selected-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
-				fill: var(--color-sidebar-gridicon-selected-fill);
-				g {
-					stroke: var(--color-sidebar-gridicon-selected-fill);
+				fill: var( --color-sidebar-menu-hover-background );
+				circle,
+				path {
+					stroke: var( --color-sidebar-gridicon-selected-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-conversations {
-				fill: var(--color-sidebar-menu-hover-background);
+				fill: var( --color-sidebar-menu-hover-background );
 				g {
-					stroke: var(--color-sidebar-gridicon-selected-fill);
+					stroke: var( --color-sidebar-gridicon-selected-fill );
 				}
 				g g {
 					stroke: unset;
-					fill: var(--color-sidebar-gridicon-selected-fill);
+					fill: var( --color-sidebar-gridicon-selected-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-following,
 			.sidebar__menu-icon.sidebar_svg-likes,
 			.sidebar__menu-icon.sidebar_svg-notifications {
-				fill: var(--color-sidebar-menu-hover-background);
+				fill: var( --color-sidebar-menu-hover-background );
 				path {
-					stroke: var(--color-sidebar-gridicon-selected-fill);
+					stroke: var( --color-sidebar-gridicon-selected-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-p2 {
-				fill: var(--color-sidebar-menu-hover-background);
+				fill: var( --color-sidebar-menu-hover-background );
 				path {
-					fill: var(--color-sidebar-gridicon-selected-fill);
+					fill: var( --color-sidebar-gridicon-selected-fill );
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-a8c,
@@ -359,9 +362,9 @@ body.is-section-reader:not(.is-reader-full-post) {
 			.sidebar__menu-icon.sidebar_svg-search,
 			.sidebar__menu-icon.sidebar_svg-tag,
 			.sidebar__menu-icon.sidebar_svg-discover {
-				fill: var(--color-sidebar-menu-hover-background);
+				fill: var( --color-sidebar-menu-hover-background );
 				g {
-					stroke: var(--color-sidebar-gridicon-selected-fill);
+					stroke: var( --color-sidebar-gridicon-selected-fill );
 				}
 			}
 		}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -20,34 +20,34 @@
 		box-shadow: none;
 
 		.form-text-input {
-			color: var( --color-sidebar-submenu-text );
-			box-shadow: 0 0 1px var( --color-sidebar-submenu-text );
+			color: var(--color-sidebar-submenu-text);
+			box-shadow: 0 0 1px var(--color-sidebar-submenu-text);
 			background-color: transparent;
 			padding: 0 8px;
 			margin: 4px 4px 4px 0;
 			font-size: $font-body-small;
 
 			&:focus {
-				box-shadow: 0 0 0 1px var( --color-sidebar-submenu-hover-text );
+				box-shadow: 0 0 0 1px var(--color-sidebar-submenu-hover-text);
 			}
 
 			&::placeholder {
-				color: var( --color-sidebar-submenu-text );
+				color: var(--color-sidebar-submenu-text);
 				opacity: 0.3; // Same as disabled button's opacity.
 			}
 		}
 
 		.form-text-input-with-action__button {
-			color: var( --color-sidebar-submenu-text );
+			color: var(--color-sidebar-submenu-text);
 
 			&:disabled {
-				color: var( --color-sidebar-submenu-text );
+				color: var(--color-sidebar-submenu-text);
 			}
 		}
 	}
 
 	.reader-sidebar-tags__all-tags-link {
-		color: var( --color-link );
+		color: var(--color-link);
 		margin-bottom: 2px;
 	}
 }
@@ -59,14 +59,14 @@ body.is-reader-page,
 .is-reader-page .layout,
 .layout.is-section-reader,
 .layout.is-section-reader .layout__content,
-.is-section-reader:not( .is-reader-full-post ) {
+.is-section-reader:not(.is-reader-full-post) {
 	background: initial;
 }
-body.is-section-reader:not( .is-reader-full-post ) {
-	background: var( --studio-gray-0 );
+body.is-section-reader:not(.is-reader-full-post) {
+	background: var(--studio-gray-0);
 
 	&.rtl .layout__content {
-		padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;
+		padding: 16px calc(var(--sidebar-width-max)) 16px 16px;
 	}
 
 	.layout__content {
@@ -74,7 +74,7 @@ body.is-section-reader:not( .is-reader-full-post ) {
 		overflow: hidden;
 		min-height: 100vh;
 		@media only screen and ( min-width: 782px ) {
-			padding: 16px 16px 16px calc( var( --sidebar-width-max ) ) !important;
+			padding: 16px 16px 16px calc(var(--sidebar-width-max)) !important;
 		}
 		.layout_primary > div {
 			padding-bottom: 0;
@@ -101,10 +101,10 @@ body.is-section-reader:not( .is-reader-full-post ) {
 
 	@media only screen and ( max-width: 781px ) {
 		.layout__primary > div {
-			background: var( --color-surface );
+			background: var(--color-surface);
 			margin: 0;
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			height: calc( 100vh - 46px );
+			height: calc(100vh - 46px);
 		}
 	}
 
@@ -144,22 +144,22 @@ body.is-section-reader:not( .is-reader-full-post ) {
 		padding: 4px 6px;
 		line-height: 1;
 		min-width: 22px;
-		background-color: var( --color-sidebar-menu-hover-background );
-		border-color: var( --color-sidebar-menu-hover-background );
-		outline-color: var( --color-sidebar-menu-hover-background );
-		color: var( --color-sidebar-text-alternative );
+		background-color: var(--color-sidebar-menu-hover-background);
+		border-color: var(--color-sidebar-menu-hover-background);
+		outline-color: var(--color-sidebar-menu-hover-background);
+		color: var(--color-sidebar-text-alternative);
 	}
 
 	.sidebar__menu-link:hover .count {
-		border-color: var( --color-sidebar-menu-hover-text );
+		border-color: var(--color-sidebar-menu-hover-text);
 		outline-color: #f00;
-		color: var( --color-sidebar-menu-hover-text );
+		color: var(--color-sidebar-menu-hover-text);
 	}
 
 	.selected .sidebar__menu-link .count {
 		background: transparent;
-		color: var( --color-sidebar-menu-selected-text );
-		border-color: var( --color-sidebar-menu-selected-text );
+		color: var(--color-sidebar-menu-selected-text);
+		border-color: var(--color-sidebar-menu-selected-text);
 	}
 
 	.sidebar__menu-item-siteicon {
@@ -172,7 +172,7 @@ body.is-section-reader:not( .is-reader-full-post ) {
 		display: block;
 		font-style: italic;
 		font-size: $font-body-extra-small;
-		color: var( --color-sidebar-text-alternative );
+		color: var(--color-sidebar-text-alternative);
 	}
 
 	.sidebar__separator {
@@ -188,7 +188,7 @@ body.is-section-reader:not( .is-reader-full-post ) {
 	}
 
 	.sidebar-streams__following-load-more {
-		color: var( --color-link );
+		color: var(--color-link);
 		cursor: pointer;
 		font-size: $font-body-extra-small;
 		text-align: center;
@@ -197,7 +197,7 @@ body.is-section-reader:not( .is-reader-full-post ) {
 		width: 100%;
 
 		&:hover {
-			color: var( --color-link-dark );
+			color: var(--color-link-dark);
 		}
 	}
 
@@ -221,38 +221,38 @@ body.is-section-reader:not( .is-reader-full-post ) {
 		&:focus {
 			.sidebar__menu-icon.sidebar_svg-add {
 				g {
-					fill: var( --color-sidebar-gridicon-hover-fill );
+					fill: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				circle,
 				path {
-					stroke: var( --color-sidebar-gridicon-hover-fill );
+					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-conversations {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var( --color-sidebar-gridicon-hover-fill );
+					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 				g g {
 					stroke: unset;
-					fill: var( --color-sidebar-gridicon-hover-fill );
+					fill: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-following,
 			.sidebar__menu-icon.sidebar_svg-likes,
 			.sidebar__menu-icon.sidebar_svg-notifications {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					stroke: var( --color-sidebar-gridicon-hover-fill );
+					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-p2 {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					fill: var( --color-sidebar-gridicon-hover-fill );
+					fill: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-a8c,
@@ -261,47 +261,47 @@ body.is-section-reader:not( .is-reader-full-post ) {
 			.sidebar__menu-icon.sidebar_svg-search,
 			.sidebar__menu-icon.sidebar_svg-tag,
 			.sidebar__menu-icon.sidebar_svg-discover {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var( --color-sidebar-gridicon-hover-fill );
+					stroke: var(--color-sidebar-gridicon-hover-fill);
 				}
 			}
 		}
 		/* Default styles */
 		.sidebar__menu-icon.sidebar_svg-add {
 			g {
-				fill: var( --color-sidebar-gridicon-fill );
+				fill: var(--color-sidebar-gridicon-fill);
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
-			fill: var( --color-sidebar-background );
+			fill: var(--color-sidebar-background);
 			circle,
 			path {
-				stroke: var( --color-sidebar-gridicon-fill );
+				stroke: var(--color-sidebar-gridicon-fill);
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-conversations {
-			fill: var( --color-sidebar-background );
+			fill: var(--color-sidebar-background);
 			g {
-				stroke: var( --color-sidebar-gridicon-fill );
+				stroke: var(--color-sidebar-gridicon-fill);
 			}
 			g g {
 				stroke: unset;
-				fill: var( --color-sidebar-gridicon-fill );
+				fill: var(--color-sidebar-gridicon-fill);
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-following,
 		.sidebar__menu-icon.sidebar_svg-likes,
 		.sidebar__menu-icon.sidebar_svg-notifications {
-			fill: var( --color-sidebar-background );
+			fill: var(--color-sidebar-background);
 			path {
-				stroke: var( --color-sidebar-gridicon-fill );
+				stroke: var(--color-sidebar-gridicon-fill);
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-p2 {
-			fill: var( --color-sidebar-background );
+			fill: var(--color-sidebar-background);
 			path {
-				fill: var( --color-sidebar-gridicon-fill );
+				fill: var(--color-sidebar-gridicon-fill);
 			}
 		}
 		.sidebar__menu-icon.sidebar_svg-a8c,
@@ -310,9 +310,9 @@ body.is-section-reader:not( .is-reader-full-post ) {
 		.sidebar__menu-icon.sidebar_svg-search,
 		.sidebar__menu-icon.sidebar_svg-tag,
 		.sidebar__menu-icon.sidebar_svg-discover {
-			fill: var( --color-sidebar-background );
+			fill: var(--color-sidebar-background);
 			g {
-				stroke: var( --color-sidebar-gridicon-fill );
+				stroke: var(--color-sidebar-gridicon-fill);
 			}
 		}
 	}
@@ -322,38 +322,38 @@ body.is-section-reader:not( .is-reader-full-post ) {
 		.sidebar__menu-link {
 			.sidebar__menu-icon.sidebar_svg-add {
 				g {
-					fill: var( --color-sidebar-gridicon-selected-fill );
+					fill: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-manage-subscriptions {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				circle,
 				path {
-					stroke: var( --color-sidebar-gridicon-selected-fill );
+					stroke: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-conversations {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var( --color-sidebar-gridicon-selected-fill );
+					stroke: var(--color-sidebar-gridicon-selected-fill);
 				}
 				g g {
 					stroke: unset;
-					fill: var( --color-sidebar-gridicon-selected-fill );
+					fill: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-following,
 			.sidebar__menu-icon.sidebar_svg-likes,
 			.sidebar__menu-icon.sidebar_svg-notifications {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					stroke: var( --color-sidebar-gridicon-selected-fill );
+					stroke: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-p2 {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				path {
-					fill: var( --color-sidebar-gridicon-selected-fill );
+					fill: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 			.sidebar__menu-icon.sidebar_svg-a8c,
@@ -362,9 +362,9 @@ body.is-section-reader:not( .is-reader-full-post ) {
 			.sidebar__menu-icon.sidebar_svg-search,
 			.sidebar__menu-icon.sidebar_svg-tag,
 			.sidebar__menu-icon.sidebar_svg-discover {
-				fill: var( --color-sidebar-menu-hover-background );
+				fill: var(--color-sidebar-menu-hover-background);
 				g {
-					stroke: var( --color-sidebar-gridicon-selected-fill );
+					stroke: var(--color-sidebar-gridicon-selected-fill);
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
Update the `Manage subscription` icon to match the others and match with Jetpack Cloud > Subscribers.

Before | After
------------- | -------------
<img width="343" alt="Screenshot 2024-05-24 at 16 52 28" src="https://github.com/Automattic/wp-calypso/assets/25607244/e21f64b2-2a4e-407c-ba19-5c2e9a3d1abd"> | <img width="369" alt="Screenshot 2024-05-24 at 16 52 15" src="https://github.com/Automattic/wp-calypso/assets/25607244/6cd7cb49-9424-4c97-b724-eb618f2ca55c">

## Testing Instructions

* Switch to this branch and navigate to /read

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
