### PR TITLE
Site Profiler: add "get free migration" form

### DIFF
--- a/client/site-profiler/components/get-migration-form/index.tsx
+++ b/client/site-profiler/components/get-migration-form/index.tsx
@@ -1,0 +1,262 @@
+import { FormLabel, FormInputValidation, Gridicon, Button } from '@automattic/components';
+import { CheckboxControl } from '@wordpress/components';
+import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { FormEvent, useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import wp from 'calypso/lib/wp';
+import * as validators from './validators';
+import './styles.scss';
+
+type Errors = {
+	name?: string;
+	email?: string;
+	siteUrl?: string;
+	termsAccepted?: string;
+};
+
+type GetMigrationFormProps = {
+	domain?: string;
+	isOpen: boolean;
+	onClose: () => void;
+};
+
+export function GetMigrationForm( { domain, isOpen, onClose }: GetMigrationFormProps ) {
+	const [ name, setName ] = useState( '' );
+	const [ email, setEmail ] = useState( '' );
+	const [ company, setCompany ] = useState( '' );
+	const [ siteUrl, setSiteUrl ] = useState( domain );
+	const [ notes, setNotes ] = useState( '' );
+	const [ isTermsChecked, setIsTermsChecked ] = useState( false );
+	const [ errors, setErrors ] = useState< Errors | null >( null );
+	const [ responseError, setResponseError ] = useState< string | null >( null );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ responseSuccess, setResponseSuccess ] = useState( false );
+
+	const handleSubmit = async ( e: FormEvent< HTMLFormElement > ) => {
+		e.preventDefault();
+
+		const formData = new FormData( e.currentTarget );
+
+		const errors = validators.validateForm( formData );
+		if ( errors ) {
+			setErrors( errors );
+			return;
+		}
+		setErrors( null );
+		setIsSubmitting( true );
+
+		let response = null;
+		try {
+			response = await wp.req.post(
+				{
+					path: '/site-profiler/lead',
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					name: formData.get( 'name' ),
+					email: formData.get( 'email' ),
+					url,
+					hash: token,
+				}
+			);
+		} catch ( error ) {
+			setResponseError( error instanceof Error ? error.message : String( error ) );
+			return;
+		} finally {
+			setIsSubmitting( false );
+		}
+		if ( response.success ) {
+			setResponseSuccess( true );
+		}
+
+		setResponseSuccess( true );
+	};
+
+	const handleNameChange = ( e: FormEvent< HTMLInputElement > ) => {
+		const error = validators.validateName( e.currentTarget.value );
+		if ( error ) {
+			setErrors( { ...errors, name: error } );
+		} else {
+			setErrors( { ...errors, name: undefined } );
+		}
+		setName( e.currentTarget.value );
+	};
+
+	const handleEmailChange = ( e: FormEvent< HTMLInputElement > ) => {
+		const error = validators.validateEmail( e.currentTarget.value );
+		if ( error ) {
+			setErrors( { ...errors, email: error } );
+		} else {
+			setErrors( { ...errors, email: undefined } );
+		}
+		setEmail( e.currentTarget.value );
+	};
+
+	const handleTermsChange = ( e: boolean ) => {
+		const error = validators.validateTerms( e );
+		if ( error ) {
+			setErrors( { ...errors, termsAccepted: error } );
+		} else {
+			setErrors( { ...errors, termsAccepted: undefined } );
+		}
+		setIsTermsChecked( e );
+	};
+
+	const handleSiteUrlChange = ( e: FormEvent< HTMLInputElement > ) => {
+		const error = validators.validateSiteUrl( e.currentTarget.value );
+		if ( error ) {
+			setErrors( { ...errors, siteUrl: error } );
+		} else {
+			setErrors( { ...errors, siteUrl: undefined } );
+		}
+		setSiteUrl( e.currentTarget.value );
+	};
+
+	return (
+		<div
+			className={ classnames( 'get-migration-form__wrapper', {
+				'get-migration-form__wrapper--hidden': ! isOpen,
+			} ) }
+		>
+			{ responseSuccess ? (
+				<div className="get-migration-form__container">
+					<div className="get-migration-form__body">
+						<div className="get-migration-form__header">
+							<span className="description">
+								{ translate(
+									"Thank you for your request! We'll contact you soon to start your site's migration to WordPress.com."
+								) }
+							</span>
+							<span>
+								<Gridicon icon="chevron-down" onClick={ onClose } />
+							</span>
+						</div>
+					</div>
+				</div>
+			) : (
+				<div className="get-migration-form__container">
+					<div className="get-migration-form__title">
+						<span className="title">{ translate( 'Site migration' ) }</span>
+					</div>
+					<div className="get-migration-form__body">
+						<div className="get-migration-form__header">
+							<span className="description">
+								{ translate(
+									"Migrate your site to WordPress.com for a test run without affecting your live site. Experience improved speed and reliability firsthand. We'll handle everything and guide you through connecting your domain. Ready to see the difference?"
+								) }
+							</span>
+							<span>
+								<Gridicon icon="chevron-down" onClick={ onClose } />
+							</span>
+						</div>
+						<form className="get-migration-form__form" onSubmit={ handleSubmit }>
+							<div className="get-migration-form__form-body">
+								<FormFieldset>
+									<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+									<FormTextInput
+										name="name"
+										className="get-migration-form__form-name"
+										label={ translate( 'Name' ) }
+										value={ name }
+										isError={ !! errors?.name }
+										onChange={ handleNameChange }
+									/>
+
+									{ errors?.name && <FormInputValidation isError text={ errors.name } /> }
+								</FormFieldset>
+								<FormFieldset>
+									<FormLabel htmlFor="email">{ translate( 'Email address' ) }</FormLabel>
+									<FormTextInput
+										name="email"
+										className="get-migration-form__form-email"
+										label={ translate( 'Email address' ) }
+										value={ email }
+										isError={ !! errors?.email }
+										onChange={ handleEmailChange }
+									/>
+									{ errors?.email && <FormInputValidation isError text={ errors.email } /> }
+								</FormFieldset>
+								<FormFieldset>
+									<FormLabel htmlFor="company">{ translate( 'Company' ) }</FormLabel>
+									<FormTextInput
+										name="company"
+										className="get-migration-form__form-company"
+										label={ translate( 'Company' ) }
+										value={ company }
+										onChange={ ( e: FormEvent< HTMLInputElement > ) =>
+											setCompany( e.currentTarget.value )
+										}
+									/>
+								</FormFieldset>
+								<FormFieldset>
+									<FormLabel htmlFor="siteUrl">
+										{ translate( 'URL of the website you would like to transfer' ) }
+									</FormLabel>
+									<FormTextInput
+										name="siteUrl"
+										className="get-migration-form__form-siteurl"
+										label={ translate( 'URL of the website you would like to transfer' ) }
+										value={ siteUrl }
+										isError={ !! errors?.siteUrl }
+										onChange={ handleSiteUrlChange }
+									/>
+									{ errors?.siteUrl && <FormInputValidation isError text={ errors.siteUrl } /> }
+								</FormFieldset>
+								<FormFieldset>
+									<FormLabel htmlFor="notes">
+										{ translate( 'Share more with us about the site you’d like to transfer!' ) }
+									</FormLabel>
+									<FormTextarea
+										name="notes"
+										className="get-migration-form__form-notes"
+										label={ translate(
+											'Share more with us about the site you’d like to transfer!'
+										) }
+										value={ notes }
+										onChange={ ( e: FormEvent< HTMLInputElement > ) =>
+											setNotes( e.currentTarget.value )
+										}
+									/>
+								</FormFieldset>
+							</div>
+							<div className="get-migration-form__form-footer">
+								<FormFieldset>
+									<CheckboxControl
+										name="termsAccepted"
+										className="terms-checkbox"
+										checked={ isTermsChecked }
+										onChange={ handleTermsChange }
+										label={ translate(
+											`By submitting your details, you agree to WordPress.com‘s Privacy Policy and Terms of Service. You also consent to receiving occasional updates and offers. You can unsubscribe from these communications at any time through the instructions.`
+										) }
+									/>
+									{ errors?.termsAccepted && (
+										<FormInputValidation isError text={ errors.termsAccepted } />
+									) }
+								</FormFieldset>
+								<Button
+									type="submit"
+									className="submit-button"
+									busy={ isSubmitting }
+									disabled={ responseSuccess }
+								>
+									{ translate( 'Request my free migration' ) }
+								</Button>
+							</div>
+							{ responseError && <FormInputValidation isError text={ responseError } /> }
+							{ responseSuccess && (
+								<FormInputValidation
+									isError={ false }
+									text="Thank you for your request! We'll contact you soon to start your site's migration to WordPress.com."
+								/>
+							) }
+						</form>
+					</div>
+				</div>
+			) }
+		</div>
+	);
+}

--- a/client/site-profiler/components/get-migration-form/index.tsx
+++ b/client/site-profiler/components/get-migration-form/index.tsx
@@ -6,7 +6,6 @@ import { FormEvent, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
-import wp from 'calypso/lib/wp';
 import * as validators from './validators';
 import './styles.scss';
 
@@ -31,7 +30,6 @@ export function GetMigrationForm( { domain, isOpen, onClose }: GetMigrationFormP
 	const [ notes, setNotes ] = useState( '' );
 	const [ isTermsChecked, setIsTermsChecked ] = useState( false );
 	const [ errors, setErrors ] = useState< Errors | null >( null );
-	const [ responseError, setResponseError ] = useState< string | null >( null );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const [ responseSuccess, setResponseSuccess ] = useState( false );
 
@@ -47,31 +45,6 @@ export function GetMigrationForm( { domain, isOpen, onClose }: GetMigrationFormP
 		}
 		setErrors( null );
 		setIsSubmitting( true );
-
-		let response = null;
-		try {
-			response = await wp.req.post(
-				{
-					path: '/site-profiler/lead',
-					apiNamespace: 'wpcom/v2',
-				},
-				{
-					name: formData.get( 'name' ),
-					email: formData.get( 'email' ),
-					url,
-					hash: token,
-				}
-			);
-		} catch ( error ) {
-			setResponseError( error instanceof Error ? error.message : String( error ) );
-			return;
-		} finally {
-			setIsSubmitting( false );
-		}
-		if ( response.success ) {
-			setResponseSuccess( true );
-		}
-
 		setResponseSuccess( true );
 	};
 
@@ -246,7 +219,6 @@ export function GetMigrationForm( { domain, isOpen, onClose }: GetMigrationFormP
 									{ translate( 'Request my free migration' ) }
 								</Button>
 							</div>
-							{ responseError && <FormInputValidation isError text={ responseError } /> }
 							{ responseSuccess && (
 								<FormInputValidation
 									isError={ false }

--- a/client/site-profiler/components/get-migration-form/styles.scss
+++ b/client/site-profiler/components/get-migration-form/styles.scss
@@ -1,0 +1,112 @@
+.get-migration-form__wrapper {
+	color: #000;
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	z-index: 10;
+	background-color: var(--studio-gray-0);
+	border: 1px solid #cbcbcb;
+	padding: 0 1.5rem;
+	transition: transform ease-out 500ms;
+
+	&--hidden {
+		transform: translateY(100%);
+	}
+}
+.get-migration-form__container {
+	box-sizing: border-box;
+	padding: 3rem 0;
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 20px;
+	margin: 0 auto;
+	max-width: 1224px;
+}
+.get-migration-form__title {
+	color: #000;
+	flex-basis: 170px;
+}
+
+.get-migration-form__body {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	flex-basis: 620px;
+	gap: 20px;
+	flex-grow: 1;
+}
+
+.get-migration-form__header {
+	display: flex;
+	gap: 10px;
+	justify-content: space-between;
+
+	.description {
+		color: #3c4043;
+		//stylelint-disable-next-line scales/font-weights
+		font-weight: 300;
+	}
+	.gridicon {
+		cursor: pointer;
+	}
+}
+
+.get-migration-form__form {
+	display: flex;
+	gap: 25px;
+	flex-wrap: wrap;
+}
+
+
+.get-migration-form__form-body {
+	display: flex;
+	gap: 30px;
+	flex-wrap: wrap;
+	flex-grow: 1;
+	max-width: 800px;
+
+	& fieldset {
+		flex-basis: calc(50% - 15px);
+		margin-bottom: 0;
+	}
+
+	& fieldset:last-child {
+		flex-basis: 100%;
+	}
+}
+
+
+.get-migration-form__form-footer {
+	--wp-components-color-accent: var(--color-button);
+	display: flex;
+	gap: 20px;
+	align-items: center;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	& fieldset {
+		margin-bottom: 0;
+		flex-basis: 735px;
+	}
+	.terms-checkbox {
+		color: #000;
+		font-size: 0.75rem;
+		line-height: 1.5;
+	}
+	.submit-button {
+		background-color: var(--color-button);
+		color: #fff;
+		border-radius: 4px;
+		font-weight: 500;
+		font-size: 1rem;
+		padding: 1rem;
+		line-height: 1;
+		text-decoration: none;
+		min-width: 191px;
+		border: none;
+		svg {
+			margin-left: 1rem;
+		}
+	}
+}

--- a/client/site-profiler/components/get-migration-form/validators.tsx
+++ b/client/site-profiler/components/get-migration-form/validators.tsx
@@ -1,0 +1,60 @@
+import emailValidator from 'email-validator';
+import { translate } from 'i18n-calypso';
+
+export const validateName = ( name: string ) => {
+	if ( ! name ) {
+		return translate( 'Name is required' );
+	}
+	return null;
+};
+
+export const validateEmail = ( email: string, fullValidation = false ) => {
+	if ( ! email ) {
+		return translate( 'Email is required' );
+	}
+	if ( fullValidation && ! emailValidator.validate( email ) ) {
+		return translate( 'Please enter a valid email address' );
+	}
+	return null;
+};
+
+export const validateTerms = ( terms: boolean ) => {
+	if ( ! terms ) {
+		return translate( 'Terms must be accepted' );
+	}
+	return null;
+};
+
+export const validateSiteUrl = ( url: string ) => {
+	if ( ! url ) {
+		return translate( 'URL is required' );
+	}
+	return null;
+};
+
+export function validateForm( formData: FormData ) {
+	let errors = {};
+	let hasErrors = false;
+
+	let error = validateName( formData.get( 'name' ) as string );
+	if ( error ) {
+		errors = { ...errors, name: error };
+		hasErrors = true;
+	}
+	error = validateEmail( formData.get( 'email' ) as string, true );
+	if ( error ) {
+		errors = { ...errors, email: error };
+		hasErrors = true;
+	}
+	error = validateSiteUrl( formData.get( 'siteUrl' ) as string );
+	if ( error ) {
+		errors = { ...errors, siteUrl: error };
+		hasErrors = true;
+	}
+	error = validateTerms( Boolean( formData.get( 'termsAccepted' ) ) );
+	if ( error ) {
+		errors = { ...errors, termsAccepted: error };
+		hasErrors = true;
+	}
+	return hasErrors ? errors : null;
+}

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -19,6 +19,7 @@ import { getValidUrl } from '../utils/get-valid-url';
 import { normalizeWhoisField } from '../utils/normalize-whois-entry';
 import { BasicMetrics } from './basic-metrics';
 import { DomainSection } from './domain-section';
+import { GetMigrationForm } from './get-migration-form';
 import { GetReportForm } from './get-report-form';
 import { HostingSection } from './hosting-section';
 import { LandingPageHeader } from './landing-page-header';
@@ -37,6 +38,7 @@ export default function SiteProfilerV2( props: Props ) {
 	const hostingRef = useRef( null );
 	const domainRef = useRef( null );
 	const [ isGetReportFormOpen, setIsGetReportFormOpen ] = useState( false );
+	const [ isGetMigrationFormOpen, setIsGetMigrationFormOpen ] = useState( true );
 
 	const {
 		domain,
@@ -166,6 +168,11 @@ export default function SiteProfilerV2( props: Props ) {
 				token={ basicMetrics?.token }
 				isOpen={ showGetReportForm }
 				onClose={ () => setIsGetReportFormOpen( false ) }
+			/>
+			<GetMigrationForm
+				domain={ domain }
+				isOpen={ isGetMigrationFormOpen }
+				onClose={ () => setIsGetMigrationFormOpen( false ) }
 			/>
 		</div>
 	);

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -38,7 +38,7 @@ export default function SiteProfilerV2( props: Props ) {
 	const hostingRef = useRef( null );
 	const domainRef = useRef( null );
 	const [ isGetReportFormOpen, setIsGetReportFormOpen ] = useState( false );
-	const [ isGetMigrationFormOpen, setIsGetMigrationFormOpen ] = useState( true );
+	const [ isGetMigrationFormOpen, setIsGetMigrationFormOpen ] = useState( false );
 
 	const {
 		domain,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/7309

## Proposed Changes

- create a new `get-migration-form` component by cloning the existing `get-request-form`
- add additional fields to new form
- customize the component to match figma designs
- add collapsed state to the new component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're creating a new layout for Site Profiler

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Open `client/site-profiler/components/site-profiler-v2.tsx` and set the default value of `isGetMigrationFormOpen` to `true`
* In your local environment navigate to `/site-profiler`
* Add a URL and click on `Check site`
* Check that the request migration form is shown and the styles match the Figma [Desktop](https://www.figma.com/design/P7Jjk4nbUTahUk8aHkG6NQ/Performance-Tool?node-id=433-22002&m=dev)
* Fill out the form details and check the validation (Note: the form won't be posted)

Note that in it's current state, the form data is not sent. I'm still working on replicating the submit functionality on https://wordpress.com/support/request-a-free-migration/ More context: p1716561166271279-slack-C02JPCHEKDY

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
