### PR TITLE
Make users from Hosting LP devs by default

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -73,6 +73,7 @@ class PasswordlessSignupForm extends Component {
 			password: '',
 		};
 		const { flowName, queryArgs = {} } = this.props;
+		const isDevAccount = queryArgs.ref === 'hosting-lp' || queryArgs.ref === 'developer-lp';
 
 		// If not in a flow, submit the form as a standard signup form.
 		// Since it is a passwordless form, we don't need to submit a password.
@@ -80,7 +81,7 @@ class PasswordlessSignupForm extends Component {
 			this.props.submitForm( {
 				email: this.state.email,
 				is_passwordless: true,
-				is_dev_account: queryArgs.ref === 'developer-lp',
+				is_dev_account: isDevAccount,
 			} );
 			return;
 		}
@@ -93,7 +94,7 @@ class PasswordlessSignupForm extends Component {
 			form,
 		} );
 
-		const { oauth2_client_id, oauth2_redirect, ref } = queryArgs;
+		const { oauth2_client_id, oauth2_redirect } = queryArgs;
 
 		// I'm not sure why passwordless signup form stopped respecting flowName from variationName param,
 		// see https://github.com/Automattic/wp-calypso/pull/67225 for more details.
@@ -114,7 +115,7 @@ class PasswordlessSignupForm extends Component {
 					oauth2_redirect: oauth2_redirect && `0@${ oauth2_redirect }`,
 				} ),
 				anon_id: getTracksAnonymousUserId(),
-				is_dev_account: ref === 'developer-lp',
+				is_dev_account: isDevAccount,
 				extra: { has_segmentation_survey: queryArgs.variationName === 'entrepreneur' },
 			} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7413

## Proposed Changes

We are making users who entered the signup flow from the Hosting LP devs by default.
That means, account creation started on https://wordpress.com/hosting page should have `is_dev_account` option as **true**.

## Testing Instructions

Before starting, log out from you Wordpress account.
Using incognito window also works.

The https://wordpress.com/hosting page is not on calypso.
But its `Create a site` button links to `setup/new-hosted-site?ref=hosting-lp&section=hero`. So you can start the flow on opening:

http://calypso.localhost:3000/setup/new-hosted-site?ref=hosting-lp&section=hero

Choose `Continue with Email` and create a new account.

Even on `trunk` branch, localhost Calypso will not proceed you the the site creation. It will display the same `Create your account` page. Even though, the previews step is enough to create a new account and log you in on wordpress.com.

Open https://wordpress.com/me/developer.

The `I am a developer. Opt me into previews of new developer-focused features.` should be toggled on.
![image](https://github.com/Automattic/wp-calypso/assets/33497086/e20e8495-b12a-47c7-915a-2e8145af21e7)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
