### PR TITLE
Site Profiler: Open the migration form on the Hosting Section link

### DIFF
--- a/client/site-profiler/components/hosting-section/index.tsx
+++ b/client/site-profiler/components/hosting-section/index.tsx
@@ -10,11 +10,12 @@ interface HostingSectionProps {
 	urlData?: UrlData;
 	hostingProvider?: HostingProvider;
 	hostingRef: React.RefObject< HTMLObjectElement >;
+	openMigrationForm?: () => void;
 }
 
 export const HostingSection: React.FC< HostingSectionProps > = ( props ) => {
 	const translate = useTranslate();
-	const { dns = [], urlData, hostingProvider, hostingRef } = props;
+	const { dns = [], urlData, hostingProvider, hostingRef, openMigrationForm } = props;
 	const isWPcom = hostingProvider?.slug?.toLowerCase() === 'automattic';
 
 	return (
@@ -31,7 +32,8 @@ export const HostingSection: React.FC< HostingSectionProps > = ( props ) => {
 							getTitleTranslateOptions()
 					  )
 			}
-			subtitle={ translate( 'Upgrade your hosting with WordPress.com' ) }
+			subtitle={ ! isWPcom ? translate( 'Upgrade your hosting with WordPress.com' ) : undefined }
+			subtitleOnClick={ openMigrationForm }
 			ref={ hostingRef }
 		>
 			<HostingInformation

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -148,6 +148,7 @@ export default function SiteProfilerV2( props: Props ) {
 									urlData={ urlData }
 									hostingProvider={ hostingProviderData?.hosting_provider }
 									hostingRef={ hostingRef }
+									openMigrationForm={ () => setIsGetMigrationFormOpen( true ) }
 								/>
 
 								<DomainSection


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7354
Depends on https://github.com/Automattic/wp-calypso/pull/91125

## Proposed Changes

When the user clicks on `Upgrade your hosting with WordPress.com` on the Hosting Section, it should open the migration form.

![CleanShot 2024-05-24 at 13 00 04](https://github.com/Automattic/wp-calypso/assets/5039531/fca6612e-ac41-407c-8c29-ef86a6779972)


## Why are these changes being made?

To match the proposed design in Figma

## Testing Instructions

* Go to `/site-profiler/:url` with a non-WP.com site. Ex: `/site-profiler/example.com`
* Check the link is displayed
* Click on the link and check if the migration form is open
* Go to `/site-profiler/:url` with a WP.com site. Ex: `/site-profiler/wordpress.com`
* Check if the link is NOT shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?