### PR TITLE
Site Migration: Redirect straight to importer after selecting Content Only

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -239,10 +239,11 @@ const siteMigration: Flow = {
 							addQueryArgs(
 								{
 									siteSlug,
-									siteId,
+									from: fromQueryParam ?? '',
+									option: 'content',
 									backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }`,
 								},
-								'/setup/site-setup/importList'
+								`/setup/site-setup/importerWordpress`
 							)
 						);
 					}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -529,6 +529,10 @@ const siteSetupFlow: Flow = {
 					return navigate( `importList?siteSlug=${ siteSlug }` );
 
 				case 'importerWordpress':
+					if ( backToFlow ) {
+						return goToFlow( backToFlow );
+					}
+
 					if ( urlQueryParams.get( 'option' ) === 'content' ) {
 						return navigate( `importList?siteSlug=${ siteSlug }` );
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

When a user gets to this screen and selects `Content only` they should be redirected to the WordPress importer. Right now they are being redirected to the importer list.
<img width="633" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/40acc8b7-d58d-4d80-b6ee-6bc0a3019b02">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I was doing some research into the site analyzer and found that this was happening. This bug is particularly annoying If the site is on WordPress, but it's not detected then the user will follow the following sequence of steps:
1. [Analyze] -> Fails to detect WP site
2. [Import List] -> The user selects WP
3. [Migrate/Content only] -> The user selects content only
4. [Import List] -> 🤦 
5. Luckily, when selecting WordPress for the second time, it will work

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or use the calypso.live link
* Go to `/setup/hosted-site-migration`
* Enter the URL of a site on WP that doesn't get picked up by the Analyzer. I've used the one on this comment: p1716566949252509/1716560916.959729-slack-C0Q664T29
* Select WordPress in the import list
* Select `Content only`
* Verify you are redirected to the correct importer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?