### PR TITLE
Make users from Hosting LP devs by default with SSO 

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -158,11 +158,12 @@ class SocialSignupForm extends Component {
 export default connect(
 	( state ) => {
 		const query = getCurrentQueryArguments( state );
+		const isDevAccount = query?.ref === 'hosting-lp' || query?.ref === 'developer-lp';
 
 		return {
 			currentRoute: getCurrentRoute( state ),
 			oauth2Client: getCurrentOAuth2Client( state ),
-			isDevAccount: query?.ref === 'developer-lp',
+			isDevAccount: isDevAccount,
 			isWoo:
 				isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
 				isWooCommerceCoreProfilerFlow( state ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7413

## Proposed Changes
This is a follow up for https://github.com/Automattic/wp-calypso/pull/91126, in which we made users who entered the signup flow from the Hosting LP devs by default when using `Continue with email` option.

This PR makes it also work with Google and Apple accounts.
Users that login with Github are always considered devs by default, regardless which page started their sing up.

## Testing Instructions

At the moment we are not aware of any method to test SSO on localhost or sandbox.
This is a very simple change. A code review should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
