### PR TITLE
Cache Odie storage ID for a very short time

### DIFF
--- a/packages/odie-client/src/data/index.ts
+++ b/packages/odie-client/src/data/index.ts
@@ -28,6 +28,8 @@ export const useGetOdieStorage = ( key: OdieStorageKey ) => {
 				path: `/help-center/odie/history/last-chat-id`,
 			} as APIFetchOptions ).then( ( res ) => res[ storageKey ] );
 		},
+		// Give this further thought.
+		staleTime: 500, // 0.5 minute,
 	} );
 	return data;
 };

--- a/packages/odie-client/src/data/index.ts
+++ b/packages/odie-client/src/data/index.ts
@@ -29,7 +29,7 @@ export const useGetOdieStorage = ( key: OdieStorageKey ) => {
 			} as APIFetchOptions ).then( ( res ) => res[ storageKey ] );
 		},
 		// Give this further thought.
-		staleTime: 500, // 0.5 minute,
+		staleTime: 30 * 1000, // 30 seconds.
 	} );
 	return data;
 };


### PR DESCRIPTION
To avoid persisting incorrect chat IDs as the user navigates in and out of wp-admin.