### PR TITLE
E2E: Reduce VideoPress upload timeout

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/videopress-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/videopress-block.ts
@@ -34,7 +34,9 @@ export class VideoPressBlock {
 
 		await block.locator( 'input' ).setInputFiles( path );
 
-		await block.getByText( 'Upload Complete!' ).waitFor( { timeout: 50 * 1000 } );
+		// We reduced it to 10 seconds because it is taking too long when it fails and is causing
+		// some execution timeout tests. (p1716579913775549/1716577210.067319-slack-CBTN58FTJ)
+		await block.getByText( 'Upload Complete!' ).waitFor( { timeout: 10 * 1000 } );
 		await block.getByRole( 'button', { name: 'Done' } ).click();
 
 		await block.getByText( 'We are converting this video for optimal playback' ).waitFor( {


### PR DESCRIPTION
Slack discussion p1716579913775549/1716577210.067319-slack-CBTN58FTJ

## Proposed Changes

We reduced the VideoPress upload timeout on the e2e test since it's taking too much time and it's making some of tests fails caused by `Execution timeout`

