### PR TITLE
Nav Redesign: Fix Header separator is not full width when viewport width > 1920px

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -182,7 +182,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					header.navigation-header {
 						padding-top: 24px;
 						padding-inline: 16px;
-						border-block-end: 1px solid var( --studio-gray-0 );
+						border-block-end: 1px solid var( --color-border-secondary );
 					}
 					.layout__primary > main {
 						background: var( --color-surface );

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -150,8 +150,13 @@
 				padding-inline: 64px;
 			}
 			@include break-xhuge {
-				margin: 0 auto;
-				max-width: 1400px;
+				max-width: 100%;
+
+				.navigation-header__main {
+					max-width: 1400px;
+					margin: 0 auto;
+					padding-inline: 64px;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7425

## Proposed Changes

* Change the header to be full width, and the inner div to be 1400px wide with the same padding and margin as /sites.
* The bottom border of the header should now be full width at this screen size (the light gray is hard to see).

Before:
<img width="1920" alt="Screen Shot 2024-05-24 at 6 02 52 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/5cd2ed80-dfdc-48ea-8ce8-5d04f9b1b786">

After:
<img width="1920" alt="Screen Shot 2024-05-24 at 6 02 32 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/2a88aeb8-861c-44a4-8cfa-139c17fd9165">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that the bottom border of the header matches /sites (consistency).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains/manage on a screen size > 1920 and check that the bottom border on the header is full width.
* Click to Sites and back to Domains, checking that there's no difference in the header positions.
* Resize the window and check that the header is correct on smaller screen sizes.
* Resize back to > 1920 and check that the table still looks the right width (it jumped while I was testing, but I couldn't replicate it).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
