### PR TITLE
Nav Redesign: Add "Activate" ability to "Dev Tools"

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -440,6 +440,10 @@ function mergeProps(
 			? WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
 			: FEATURE_INSTALL_PLUGINS;
 		ctaName = 'calypso-plugin-details-eligibility-upgrade-nudge';
+	} else if ( ownProps.currentContext === 'dev-tools' ) {
+		context = ownProps.currentContext;
+		feature = FEATURE_SFTP;
+		ctaName = 'calypso-dev-tools-eligibility-upgrade-nudge';
 	} else if ( includes( ownProps.backUrl, 'plugins' ) ) {
 		context = 'plugins-upload';
 		feature = FEATURE_UPLOAD_PLUGINS;

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -115,6 +115,16 @@ function getWarningDescription(
 				}
 			);
 
+		case 'dev-tools':
+			return translate(
+				'By activating all developer tools the following change will be made to the site:',
+				'By activating all developer tools the following changes will be made to the site:',
+				{
+					count: warningCount,
+					args: warningCount,
+				}
+			);
+
 		default:
 			return defaultCopy;
 	}

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -81,7 +81,7 @@ const DevTools = () => {
 	];
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
-	const showHostingActivationButton = canSiteGoAtomic;
+	const showActivationButton = canSiteGoAtomic;
 	const backUrl = `/hosting-config/${ siteSlug }`;
 	const dispatch = useDispatch();
 	const transferInitiate = ( siteId: number, { geo_affinity = '' } = {} ) => {
@@ -94,12 +94,12 @@ const DevTools = () => {
 		<div className="dev-tools">
 			<div className="dev-tools__hero">
 				<h1>
-					{ showHostingActivationButton
-						? translate( 'Activate hosting configuration' )
+					{ showActivationButton
+						? translate( 'Activate all developer tools' )
 						: translate( 'Unlock all developer tools' ) }
 				</h1>
 				<p>
-					{ showHostingActivationButton
+					{ showActivationButton
 						? translate(
 								'Your plan includes all the developer tools listed below. Click "Activate Now" to begin.'
 						  )
@@ -107,13 +107,13 @@ const DevTools = () => {
 								'Upgrade to the Creator plan or higher to get access to all developer tools'
 						  ) }
 				</p>
-				{ showHostingActivationButton ? (
+				{ showActivationButton ? (
 					<>
 						<Button
 							variant="primary"
 							className="dev-tools__button"
 							onClick={ () => {
-								if ( showHostingActivationButton ) {
+								if ( showActivationButton ) {
 									return setShowEligibility( true );
 								}
 							} }

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -83,7 +83,7 @@ const DevTools = () => {
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showActivationButton = canSiteGoAtomic;
-	const backUrl = `/hosting-config/${ siteId }`;
+	const redirectUrl = `/hosting-config/${ siteId }`;
 	const dispatch = useDispatch();
 	const transferInitiate = ( siteId: number, { geo_affinity = '' } = {} ) => {
 		setIsActivating( true );
@@ -91,7 +91,7 @@ const DevTools = () => {
 			.then( () => {
 				const params = new URLSearchParams( {
 					siteId: String( siteId ),
-					redirect_to: backUrl,
+					redirect_to: redirectUrl,
 					feature: FEATURE_SFTP,
 				} );
 				page( `/setup/transferring-hosted-site?${ params }` );
@@ -100,6 +100,11 @@ const DevTools = () => {
 				setIsActivating( false );
 			} );
 	};
+
+	if ( isSiteAtomic && hasSftpFeature ) {
+		page.replace( redirectUrl );
+		return;
+	}
 
 	return (
 		<div className="dev-tools">
@@ -142,7 +147,7 @@ const DevTools = () => {
 							<EligibilityWarnings
 								className="hosting__activating-warnings"
 								onProceed={ () => transferInitiate( siteId as number ) }
-								backUrl={ backUrl }
+								backUrl={ redirectUrl }
 								showDataCenterPicker
 								standaloneProceed
 								currentContext="dev-tools"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -2,9 +2,13 @@
 import config from '@automattic/calypso-config';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
+import { requestSite } from 'calypso/state/sites/actions';
+import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
@@ -34,6 +38,8 @@ export const transferStates = {
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
 const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
+	const [ searchParams ] = useSearchParams();
+	const reduxDispatch = useReduxDispatch();
 	const { submit } = navigation;
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
@@ -75,49 +81,79 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 		} );
 	};
 
+	const waitForTransfer = async () => {
+		const startTime = new Date().getTime();
+		const totalTimeout = 1000 * 300;
+		const maxFinishTime = startTime + totalTimeout;
+
+		// Poll for transfer status
+		let stopPollingTransfer = false;
+		while ( ! stopPollingTransfer ) {
+			await wait( 3000 );
+			await requestLatestAtomicTransfer( siteId );
+			const transfer = getSiteLatestAtomicTransfer( siteId );
+			const transferError = getSiteLatestAtomicTransferError( siteId );
+			const transferStatus = transfer?.status;
+			const isTransferringStatusFailed = transferError && transferError?.status >= 500;
+
+			if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
+				handleTransferFailure( {
+					type: 'transfer',
+					error: transferError?.message || '',
+					code: transferError?.code || '',
+				} );
+				throw new Error( 'transfer error' );
+			}
+
+			if ( maxFinishTime < new Date().getTime() ) {
+				handleTransferFailure( {
+					type: 'transfer_timeout',
+					error: 'transfer took too long',
+					code: 'transfer_timeout',
+				} );
+				throw new Error( 'transfer timeout' );
+			}
+
+			stopPollingTransfer = transferStatus === transferStates.COMPLETED;
+		}
+	};
+
+	// Request the site features to ensure the specific feature is active.
+	const waitForFeature = async () => {
+		const feature = searchParams.get( 'feature' );
+		if ( ! feature ) {
+			return;
+		}
+
+		let stopPollingSiteFeatures = false;
+		while ( ! stopPollingSiteFeatures ) {
+			await wait( 1000 );
+			const siteFeatures = await reduxDispatch( fetchSiteFeatures( siteId ) );
+			stopPollingSiteFeatures = siteFeatures.active.indexOf( feature ) >= 0;
+		}
+	};
+
+	// Request the latest site data to ensure the value of the `is_wpcom_atomic` is true.
+	const waitForLatestSiteData = async () => {
+		await reduxDispatch( requestSite( siteId ) );
+	};
+
 	useEffect( () => {
 		if ( ! siteId ) {
 			return;
 		}
 
 		setPendingAction( async () => {
-			const startTime = new Date().getTime();
-			const totalTimeout = 1000 * 300;
-			const maxFinishTime = startTime + totalTimeout;
+			await waitForTransfer();
+			await waitForFeature();
+			await waitForLatestSiteData();
 
-			// Poll for transfer status
-			let stopPollingTransfer = false;
-
-			while ( ! stopPollingTransfer ) {
-				await wait( 3000 );
-				await requestLatestAtomicTransfer( siteId );
-				const transfer = getSiteLatestAtomicTransfer( siteId );
-				const transferError = getSiteLatestAtomicTransferError( siteId );
-				const transferStatus = transfer?.status;
-				const isTransferringStatusFailed = transferError && transferError?.status >= 500;
-
-				if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
-					handleTransferFailure( {
-						type: 'transfer',
-						error: transferError?.message || '',
-						code: transferError?.code || '',
-					} );
-					throw new Error( 'transfer error' );
-				}
-
-				if ( maxFinishTime < new Date().getTime() ) {
-					handleTransferFailure( {
-						type: 'transfer_timeout',
-						error: 'transfer took too long',
-						code: 'transfer_timeout',
-					} );
-					throw new Error( 'transfer timeout' );
-				}
-
-				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
-			}
-
-			return { finishedWaitingForAtomic: true, siteId, siteSlug: data?.siteSlug };
+			return {
+				finishedWaitingForAtomic: true,
+				siteId,
+				siteSlug: data?.siteSlug,
+				redirectTo: searchParams.get( 'redirect_to' ),
+			};
 		} );
 
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -153,11 +153,11 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 		}
 	};
 
-	// Request the latest site data to ensure the value of the `is_wpcom_atomic` is true.
+	// Request the latest site data to ensure the value of the `is_wpcom_atomic` and `manage_options` are true.
 	const waitForLatestSiteData = async () => {
 		while ( true ) {
 			const site = await reduxDispatch( requestSite( siteId ) );
-			if ( site?.options.is_wpcom_atomic ) {
+			if ( site?.options?.is_wpcom_atomic && site?.capabilities?.manage_options ) {
 				break;
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -129,7 +129,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 		while ( ! stopPollingSiteFeatures ) {
 			await wait( 1000 );
 			const siteFeatures = await reduxDispatch( fetchSiteFeatures( siteId ) );
-			stopPollingSiteFeatures = siteFeatures.active.indexOf( feature ) >= 0;
+			stopPollingSiteFeatures = siteFeatures?.active?.indexOf( feature ) >= 0;
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -9,6 +9,7 @@ import { logToLogstash } from 'calypso/lib/logstash';
 import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { requestSite } from 'calypso/state/sites/actions';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
+import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
@@ -79,6 +80,23 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 				code: failureInfo.code,
 			},
 		} );
+	};
+
+	const waitForInitiateTransfer = async () => {
+		const initiateTransferContext = searchParams.get( 'initiate_transfer_context' );
+		if ( ! initiateTransferContext ) {
+			return;
+		}
+
+		await reduxDispatch(
+			initiateThemeTransfer(
+				siteId,
+				null,
+				'',
+				searchParams.get( 'initiate_transfer_geo_affinity' ) || '',
+				initiateTransferContext
+			)
+		);
 	};
 
 	const waitForTransfer = async () => {
@@ -153,6 +171,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 		}
 
 		setPendingAction( async () => {
+			await waitForInitiateTransfer();
 			await waitForTransfer();
 			await waitForFeature();
 			await waitForLatestSiteData();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -129,7 +129,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 		while ( ! stopPollingSiteFeatures ) {
 			await wait( 1000 );
 			const siteFeatures = await reduxDispatch( fetchSiteFeatures( siteId ) );
-			stopPollingSiteFeatures = siteFeatures?.active?.indexOf( feature ) >= 0;
+			stopPollingSiteFeatures = siteFeatures?.active?.indexOf?.( feature ) >= 0;
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -12,7 +12,7 @@ import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import type { Step } from '../../types';
-import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
+import type { OnboardSelect, SiteSelect, SiteDetails } from '@automattic/data-stores';
 
 export interface FailureInfo {
 	type: string;
@@ -144,7 +144,9 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 		}
 
 		while ( true ) {
-			const siteFeatures = await reduxDispatch( fetchSiteFeatures( siteId ) );
+			const siteFeatures = await reduxDispatch< Promise< { active: string[] } > >(
+				fetchSiteFeatures( siteId )
+			);
 			if ( siteFeatures?.active?.indexOf?.( feature ) >= 0 ) {
 				break;
 			}
@@ -156,7 +158,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 	// Request the latest site data to ensure the value of the `is_wpcom_atomic` and `manage_options` are true.
 	const waitForLatestSiteData = async () => {
 		while ( true ) {
-			const site = await reduxDispatch( requestSite( siteId ) );
+			const site = await reduxDispatch< SiteDetails >( requestSite( siteId ) );
 			if ( site?.options?.is_wpcom_atomic && site?.capabilities?.manage_options ) {
 				break;
 			}

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -1,7 +1,6 @@
 import { TRANSFERRING_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useDispatch as useReduxDispatch } from 'react-redux';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { ONBOARD_STORE } from '../stores';
@@ -30,15 +29,10 @@ const transferringHostedSite: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 		const siteId = useSiteIdParam();
-		const exitTo = useQuery().get( 'to' ) || 'home';
 		const dispatch = useReduxDispatch();
 
 		const exitFlow = ( to: string ) => {
-			const timeoutDuration = to === 'home' ? 0 : 3000;
-
-			setTimeout( () => {
-				window.location.assign( to );
-			}, timeoutDuration );
+			window.location.assign( to );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
@@ -54,7 +48,7 @@ const transferringHostedSite: Flow = {
 
 					dispatch( requestAdminMenu( siteId ) );
 
-					return exitFlow( `/${ exitTo }/${ siteId }` );
+					return exitFlow( providedDependencies?.redirectTo ?? `/home/${ siteId }` );
 				}
 
 				case 'waitForAtomic': {

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -48,7 +48,10 @@ const transferringHostedSite: Flow = {
 
 					dispatch( requestAdminMenu( siteId ) );
 
-					return exitFlow( providedDependencies?.redirectTo ?? `/home/${ siteId }` );
+					const redirectTo = providedDependencies?.redirectTo
+						? providedDependencies?.redirectTo
+						: `/home/${ siteId }`;
+					return exitFlow( redirectTo as string );
 				}
 
 				case 'waitForAtomic': {

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -1,6 +1,7 @@
 import { TRANSFERRING_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useDispatch as useReduxDispatch } from 'react-redux';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { ONBOARD_STORE } from '../stores';
@@ -29,10 +30,13 @@ const transferringHostedSite: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 		const siteId = useSiteIdParam();
+		const exitTo = useQuery().get( 'to' ) || 'home';
 		const dispatch = useReduxDispatch();
 
 		const exitFlow = ( to: string ) => {
-			window.location.assign( to );
+			setTimeout( () => {
+				window.location.assign( to );
+			}, 500 );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
@@ -48,7 +52,7 @@ const transferringHostedSite: Flow = {
 
 					dispatch( requestAdminMenu( siteId ) );
 
-					return exitFlow( '/home/' + siteId );
+					return exitFlow( `/${ exitTo }/${ siteId }` );
 				}
 
 				case 'waitForAtomic': {

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -34,9 +34,11 @@ const transferringHostedSite: Flow = {
 		const dispatch = useReduxDispatch();
 
 		const exitFlow = ( to: string ) => {
+			const timeoutDuration = to === 'home' ? 0 : 3000;
+
 			setTimeout( () => {
 				window.location.assign( to );
-			}, 500 );
+			}, timeoutDuration );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -19,9 +19,10 @@ import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import getSuperProps from 'calypso/lib/analytics/super-props';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
+import { onDisablePersistence } from 'calypso/lib/user/store';
 import { createReduxStore } from 'calypso/state';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
-import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
+import { getInitialState, getStateFromCache, persistOnChange } from 'calypso/state/initial-state';
 import { createQueryClient } from 'calypso/state/query-client';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
@@ -91,6 +92,7 @@ window.AppBoot = async () => {
 	const initialState = getInitialState( initialReducer, userId );
 	const reduxStore = createReduxStore( initialState, initialReducer );
 	setStore( reduxStore, getStateFromCache( userId ) );
+	onDisablePersistence( persistOnChange( reduxStore, userId ) );
 	setupLocale( user, reduxStore );
 
 	user && initializeCalypsoUserStore( reduxStore, user as CurrentUser );

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -107,7 +107,7 @@ export function requestSites() {
  * Returns a function which, when invoked, triggers a network request to fetch
  * a site.
  * @param {number|string} siteFragment Site ID or slug
- * @returns {Function}              Action thunk
+ * @returns {import('redux-thunk').ThunkAction} Action thunk
  */
 export function requestSite( siteFragment ) {
 	function doRequest( forceWpcom ) {

--- a/client/state/sites/features/actions.js
+++ b/client/state/sites/features/actions.js
@@ -14,11 +14,6 @@ import { createSiteFeaturesObject } from './assembler';
 
 const debug = debugFactory( 'calypso:site-features:actions' );
 
-export const requestSiteFeatures = ( siteId ) =>
-	wpcom.req
-		.get( `/sites/${ siteId }/features` )
-		.then( ( data ) => createSiteFeaturesObject( data ) );
-
 /**
  * Fetches features for the given site.
  * @param {number} siteId identifier of the site
@@ -31,7 +26,8 @@ export function fetchSiteFeatures( siteId ) {
 			siteId,
 		} );
 
-		return requestSiteFeatures( siteId )
+		return wpcom.req
+			.get( `/sites/${ siteId }/features` )
 			.then( ( features ) => {
 				dispatch( fetchSiteFeaturesCompleted( siteId, features ) );
 				return features;
@@ -103,6 +99,6 @@ export function fetchSiteFeaturesCompleted( siteId, features ) {
 	return {
 		type: SITE_FEATURES_FETCH_COMPLETED,
 		siteId,
-		features,
+		features: createSiteFeaturesObject( features ),
 	};
 }

--- a/client/state/sites/features/actions.js
+++ b/client/state/sites/features/actions.js
@@ -14,6 +14,11 @@ import { createSiteFeaturesObject } from './assembler';
 
 const debug = debugFactory( 'calypso:site-features:actions' );
 
+export const requestSiteFeatures = ( siteId ) =>
+	wpcom.req
+		.get( `/sites/${ siteId }/features` )
+		.then( ( data ) => createSiteFeaturesObject( data ) );
+
 /**
  * Fetches features for the given site.
  * @param {number} siteId identifier of the site
@@ -26,10 +31,10 @@ export function fetchSiteFeatures( siteId ) {
 			siteId,
 		} );
 
-		return wpcom.req
-			.get( `/sites/${ siteId }/features` )
-			.then( ( data ) => {
-				dispatch( fetchSiteFeaturesCompleted( siteId, data ) );
+		return requestSiteFeatures( siteId )
+			.then( ( features ) => {
+				dispatch( fetchSiteFeaturesCompleted( siteId, features ) );
+				return features;
 			} )
 			.catch( ( error ) => {
 				debug( 'Fetching site features failed: ', error );
@@ -91,13 +96,13 @@ function fetchJetpackSitesFeaturesReceive( features ) {
  * Returns an action object to be used in signalling that an object containing
  * the features for a given site have been received.
  * @param {number} siteId - identifier of the site
- * @param {Object} features - list of features received from the API
+ * @param {Object} features - the features of the site.
  * @returns {Object} the corresponding action object
  */
 export function fetchSiteFeaturesCompleted( siteId, features ) {
 	return {
 		type: SITE_FEATURES_FETCH_COMPLETED,
 		siteId,
-		features: createSiteFeaturesObject( features ),
+		features,
 	};
 }

--- a/client/state/sites/features/actions.js
+++ b/client/state/sites/features/actions.js
@@ -92,7 +92,7 @@ function fetchJetpackSitesFeaturesReceive( features ) {
  * Returns an action object to be used in signalling that an object containing
  * the features for a given site have been received.
  * @param {number} siteId - identifier of the site
- * @param {Object} features - the features of the site.
+ * @param {Object} features - list of features received from the API
  * @returns {Object} the corresponding action object
  */
 export function fetchSiteFeaturesCompleted( siteId, features ) {

--- a/client/state/sites/features/actions.js
+++ b/client/state/sites/features/actions.js
@@ -17,7 +17,7 @@ const debug = debugFactory( 'calypso:site-features:actions' );
 /**
  * Fetches features for the given site.
  * @param {number} siteId identifier of the site
- * @returns {Function} a promise that will resolve once fetching is completed
+ * @returns {import('redux-thunk').ThunkAction} Action thunk - a promise that will resolve once fetching is completed
  */
 export function fetchSiteFeatures( siteId ) {
 	return ( dispatch ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7348

## Proposed Changes

* This PR adds the ability to "Activate" aka transfer to Atomic a Simple site on a Creator or higher plan from the "Dev Tools" tab in the nav-redesign.
* It changes the copy and button in Dev Tools if it is a Simple site that can be made Atomic.
* It shows a modal popup with eligibility warnings before transfer to Atomic
* On confirmation and during the transfer a loading screen is shown
* After the transfer is complete, the user is directed to /hosting-config/ for the site.

The video below is cropped off center on purpose.


https://github.com/Automattic/wp-calypso/assets/140841/5845f67b-583e-41a8-b29a-f4826b802db8



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improved UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new Creator site but do NOT take it Atomic
* Go to the new site on /sites
* Select the "Dev tools" tab
* You should see an "Activate" button and supporting copy. (You should see the old buttons and copy on Creator and lower plan sites.)
* Click "Activate"
* You should see a modal popup asking you to confirm you want to "go Atomic"
* Confirm and you should see a waiting process screen.
* When it completes you should be directed to the now functional /hosting-config/ page.
* Test around this issue
* Ensure we only show the "Activate" button to eligible sites
* Test the that you can set your Host location in the modal popup

Regression test:
* The https://wordpress.com/setup/new-hosted-site/plans flow also uses `transferring-hosted-site-flow.ts`. Test this flow to ensure it still works.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
