### PR TITLE
Jetpack Backup: Update copy site flow to use the getRestoreProgress selector as restore status source of truth

### DIFF
--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -27,7 +27,6 @@ import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
 import getBackupStagingSites from 'calypso/state/rewind/selectors/get-backup-staging-sites';
 import hasFetchedStagingSitesList from 'calypso/state/rewind/selectors/has-fetched-staging-sites-list';
 import isFetchingStagingSitesList from 'calypso/state/rewind/selectors/is-fetching-staging-sites-list';
-import getInProgressRewindStatus from 'calypso/state/selectors/get-in-progress-rewind-status';
 import getJetpackCredentials from 'calypso/state/selectors/get-jetpack-credentials';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
@@ -120,10 +119,12 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 		return '';
 	};
 
-	const inProgressRewindStatus = useSelector( ( state ) => {
-		return getInProgressRewindStatus( state, restoreSiteId, backupPeriod );
-	} );
-	const { message, percent, currentEntry, status } = useSelector( ( state ) => {
+	const {
+		message,
+		percent,
+		currentEntry,
+		status: inProgressRewindStatus,
+	} = useSelector( ( state ) => {
 		return getRestoreProgress( state, restoreSiteId ) || ( {} as RestoreProgress );
 	} );
 
@@ -451,7 +452,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 					} ) }
 				</h3>
 				<ProgressBar
-					isReady={ 'running' === status }
+					isReady={ 'running' === inProgressRewindStatus }
 					initializationMessage={ translate( 'Initializing the copy process' ) }
 					message={ message }
 					entry={ currentEntry }

--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -435,6 +435,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 
 	const renderInProgress = () => (
 		<>
+			<QueryRewindRestoreStatus siteId={ restoreSiteId } restoreId={ restoreId } />
 			<Card>
 				<div className="clone-flow__progress-header">
 					<img
@@ -578,9 +579,6 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 					<QueryRewindBackups siteId={ siteId } />
 					<QueryRewindState siteId={ siteId } />
 					<QueryBackupStagingSitesList siteId={ siteId } />
-					{ restoreId && 'running' === inProgressRewindStatus && (
-						<QueryRewindRestoreStatus siteId={ restoreSiteId } restoreId={ restoreId } />
-					) }
 					{ render() }
 				</div>
 			</Main>

--- a/client/my-sites/backup/clone-flow/test/index.jsx
+++ b/client/my-sites/backup/clone-flow/test/index.jsx
@@ -6,7 +6,7 @@ import Modal from 'react-modal';
 import useRewindableActivityLogQuery from 'calypso/data/activity-log/use-rewindable-activity-log-query';
 import documentHead from 'calypso/state/document-head/reducer';
 import preferences from 'calypso/state/preferences/reducer';
-import getInProgressRewindStatus from 'calypso/state/selectors/get-in-progress-rewind-status';
+import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import ui from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
@@ -71,8 +71,8 @@ jest.mock( 'calypso/state/rewind/selectors/get-backup-staging-sites', () =>
 jest.mock( 'calypso/state/rewind/selectors/has-fetched-staging-sites-list' );
 jest.mock( 'calypso/state/rewind/selectors/is-fetching-staging-sites-list' );
 jest.mock( 'calypso/data/activity-log/use-rewindable-activity-log-query' );
-jest.mock( 'calypso/state/selectors/get-in-progress-rewind-status' );
 jest.mock( 'calypso/state/selectors/get-rewind-state' );
+jest.mock( 'calypso/state/selectors/get-restore-progress' );
 jest.mock( 'calypso/state/selectors/get-site-gmt-offset' );
 jest.mock( 'calypso/state/selectors/get-site-timezone-value' );
 jest.mock( 'calypso/state/selectors/get-jetpack-credentials-test-status' );
@@ -182,7 +182,6 @@ function progressThroughFlow() {
 describe( 'BackupCloneFlow render', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		getInProgressRewindStatus.mockImplementation( () => undefined );
 	} );
 
 	test( 'Render RewindFlowLoading if state is not initialized', () => {
@@ -216,7 +215,7 @@ describe( 'BackupCloneFlow render', () => {
 
 	test( 'Render finished text if the clone is finished', () => {
 		getRewindState.mockImplementation( () => ( { state: 'active' } ) );
-		getInProgressRewindStatus.mockImplementation( () => 'finished' );
+		getRestoreProgress.mockImplementation( () => ( { status: 'finished' } ) );
 		render( <BackupCloneFlow /> );
 
 		progressThroughFlow();
@@ -225,7 +224,7 @@ describe( 'BackupCloneFlow render', () => {
 
 	test( 'Render error if it is in the wrong status', () => {
 		getRewindState.mockImplementation( () => ( { state: 'active' } ) );
-		getInProgressRewindStatus.mockImplementation( () => 'wrong-status' );
+		getRestoreProgress.mockImplementation( () => ( { status: 'wrong-status' } ) );
 		render( <BackupCloneFlow /> );
 
 		progressThroughFlow();


### PR DESCRIPTION
Related to p1716438389407439-slack-CS8UYNPEE

## Proposed Changes
* Use `getRestoreProgress()` from `calypso/state/selectors/get-restore-progress` as the source of truth of the restore progress.

## Why are these changes being made?

The clone flow uses two APIs to validate the restore progress:
`GET /rewind` — to determine if the restore finished (among other things)
`GET /rewind/{restoreId}/restore-status` — for the progress bar status

There are cases where `/restore-status` reports as finished, but `/rewind` does not yet due to cache issues or an error fetching the restore status. This will cause the restore progress page to stop querying the restore status and become stuck.

So the plan is to use `/restore-status and` its corresponding `getRestoreProgress()` selector to be the source of truth and prevent the progress from becoming stuck.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Unit tests

Ensure unit tests are passing:
```
yarn run test-client client/my-sites/backup/clone-flow/test/index.jsx

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        4.754 s
Ran all test suites matching /client\/my-sites\/backup\/clone-flow\/test\/index.jsx/i.
```

You might see some selectors warning that we should optimize in another iteration.

### Test copy site flow
* Spin up a Jetpack Cloud live branch
* Spin up a Jurassic Ninja site
* Pick an existing site with Jetpack VaultPress Backup plan and at least one backup
* Navigate to the Backup page in the sidebar menu
* Click on `Copy site` at the top right of the page
* Now follow the instructions depending on the type of test you want to make:

#### New staging site
* Click on `Enter credentials for a new destination site +`
* Enter your Jurassic Ninja server credentials and then click on `Confirm credentials`
* After validating credentials, click on `Continue`
* Select the backup point
* Click on `Confirm configuration`
* Ensure the copy completes successfully

#### Existing staging site
* Search for a site that has been previously configured as a staging site
* Select the backup point
* Click on `Confirm configuration`
* Ensure the copy completes successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?