### PR TITLE
Fix button alignment issues

### DIFF
--- a/packages/tour-kit/src/variants/wpcom/styles.scss
+++ b/packages/tour-kit/src/variants/wpcom/styles.scss
@@ -60,7 +60,7 @@ $wpcom-tour-kit-step-card-overlay-controls-button-bg-color: #32373c; // former $
 }
 
 .wpcom-tour-kit-step-card {
-	width: 400px;
+	width: 412px;
 	max-width: 92vw;
 
 	&.wpcom-tour-kit-step-card.is-elevated {

--- a/packages/tour-kit/src/variants/wpcom/styles.scss
+++ b/packages/tour-kit/src/variants/wpcom/styles.scss
@@ -60,7 +60,7 @@ $wpcom-tour-kit-step-card-overlay-controls-button-bg-color: #32373c; // former $
 }
 
 .wpcom-tour-kit-step-card {
-	width: 412px;
+	width: 416px;
 	max-width: 92vw;
 
 	&.wpcom-tour-kit-step-card.is-elevated {


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#792

## Proposed Changes

Increase the width of the parent container of the Welcome Guide from 400px to 416px to prevent button wrapping issues.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
The Welcome Guide/Tour, initiated from the Site Editor (Appearances --> Editor), has 10 steps. When initiated from other places, like when creating new Pages, it has only 9 steps. The extra step causes the Dutch translation of 'Take the tour' to wrap, resulting in poor presentation. This fix widens the parent container to prevent wrapping.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set your user Interface Language to Dutch
2. Initiate the Welcome Guide/Tour from the Site Editor (Appearances --> Editor) 
3. Verify that the 'Take the tour' button in Dutch does not wrap and is presented correctly.
4. Initiate the Welcome Guide/Tour from other places, like creating a new Post/Pages.
5. Confirm that the button presentation remains consistent.

#### Before:
<img src="https://github.com/Automattic/wp-calypso/assets/31164683/20fb8588-37a7-4429-b606-636f51655a09" width="50%">

#### After:
<img src="https://github.com/Automattic/wp-calypso/assets/31164683/6a12980a-a19a-4be3-8ed4-e85d66c8dcb9" width="50%">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
