### PR TITLE
Checkout: redirect Jetpack siteless checkout to regular checkout if user is logged-in 

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -88,6 +88,7 @@ function sitelessCheckout( context, next, extraProps ) {
 	const isLoggedOut = ! isUserLoggedIn( state );
 	const { productSlug: product, purchaseId } = context.params;
 	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';
+	const { fromSiteSlug, sitelessCheckoutType } = extraProps;
 
 	setSectionMiddleware( { name: 'checkout' } )( context );
 
@@ -98,6 +99,12 @@ function sitelessCheckout( context, next, extraProps ) {
 		const translate = useTranslate();
 		return <DocumentHead title={ translate( 'Checkout' ) } />;
 	};
+
+	if ( sitelessCheckoutType === 'jetpack' && ! isLoggedOut && fromSiteSlug ) {
+		// If the user is logged in and checkout has a site, redirect to the regular checkout page
+		page( context.path.replace( '/checkout/jetpack', `/checkout/${ extraProps.fromSiteSlug }` ) );
+		return;
+	}
 
 	context.primary = (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See related task

## Proposed Changes

* This PR updates the checkout flow to redirect the user to a logged-in checkout in case they are going through a siteless checkout while logged-in and with the site information

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are adding this change so users coming from Jetpack will be redirected to the regular checkout in case they are logged into WPCOM.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Using a test site, make sure you are site-connected (not user-connected)
* On My Jetpack, click on any of the buttons that lead to an interstitial, then click to purchase a plan (VaultPress Backup, for example)
* After being redirected to the checkout, copy the path after `wordpress.com` in the URL that starts with `https://wordpress.com/checkout/jetpack/jetpack_backup_t1_yearly...`
* Logged into WPCOM, go back to the Calypso live site, and paste what you've just copied after the Calypso live domain
* Confirm that you are redirected to the checkout with the context of your site (you'll see a "Site: example.com" in the checkout)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
