### PR TITLE
Remove profile picture link from Woo login switch user flow

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -85,11 +85,7 @@ function ContinueAsUser( {
 		  } );
 
 	const gravatarLink = (
-		<a
-			style={ { pointerEvents: isLoading ? 'none' : 'auto' } }
-			href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
-			className="continue-as-user__gravatar-link"
-		>
+		<div className="continue-as-user__gravatar-content">
 			<Gravatar
 				user={ currentUser }
 				className="continue-as-user__gravatar"
@@ -98,7 +94,7 @@ function ContinueAsUser( {
 			/>
 			<div className="continue-as-user__username">{ userName }</div>
 			<div className="continue-as-user__email">{ currentUser.email }</div>
-		</a>
+		</div>
 	);
 
 	if ( isWooOAuth2Client ) {

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -30,24 +30,6 @@
 		}
 	}
 
-	.continue-as-user__gravatar-link {
-		color: var(--color-text);
-		margin: 0 auto;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 150%;
-
-		.continue-as-user__username {
-			margin-top: 12px;
-			font-size: $font-title-small;
-			font-weight: 600;
-		}
-		.continue-as-user__email {
-			margin-top: 4px;
-			font-size: $font-body;
-			margin-bottom: 48px;
-		}
-	}
-
 	.continue-as-user__gravatar {
 		display: inline;
 		border: 1px solid #a7aaad;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -505,7 +505,7 @@ $breakpoint-mobile: 660px;
 			max-width: 472px;
 		}
 
-		.continue-as-user__gravatar-link {
+		.continue-as-user__gravatar-content {
 			pointer-events: auto;
 			display: grid;
 			grid-template-columns: 56px 1fr;
@@ -532,13 +532,9 @@ $breakpoint-mobile: 660px;
 				font-size: 1rem;
 				font-weight: 600;
 				line-height: 24px;
-				color: var(--color-gray-100);
+				color: var(--color-text);
 				grid-area: username;
 				margin-top: 0;
-
-				&:hover {
-					color: var(--color-gray-100);
-				}
 			}
 
 			.continue-as-user__email {
@@ -1495,7 +1491,7 @@ $breakpoint-mobile: 660px;
 			}
 
 
-			.continue-as-user__gravatar-link {
+			.continue-as-user__gravatar-content {
 				display: flex;
 				flex-direction: column;
 				margin: 0 0 8px;


### PR DESCRIPTION
Related to 20613-gh-Automattic/woocommerce.com

## Proposed Changes

Makes the profile picture not clickable in the Woo switch user flow as that was a source for user confusion.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See linked issue above for more context. 
* You can also see the original issue report here: p6JqRr-cuu-p2

## Testing Instructions

1. Make sure you have a [working Calypso installation](https://github.com/automattic/wp-calypso/?tab=readme-ov-file#getting-started).
2. Switch to this branch.
3. Make sure Calypso is started `yarn start`.
4. Create a test WooCommerce installation ([JN can help](https://jurassic.ninja/))
5. Make sure you are logged in to woocommerce.com and wordpress.com.
6. Connect the site to woocommerce.com by visiting /wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions and clicking Connect account.
7. Now you should ideally see this connect screen:

![CleanShot 2024-05-27 at 10 52 34](https://github.com/Automattic/wp-calypso/assets/533/8d60942e-2d99-4db5-837d-3c9116810914)

8. Click `Use a different WooCommerce.com account`. You may also see the next screen directly if you are not logged in to woocommerce.com:

![CleanShot 2024-05-27 at 10 53 35](https://github.com/Automattic/wp-calypso/assets/533/07ed24ee-f472-4a23-a6cf-6fdc4c6aa522)

9. In a new tab, copy the URL, but replace `https://wordpress.com/log-in?` with `http://calypso.localhost:3000/log-in?`
10. Make sure that in the Calypso page, the profile picture is not clickable.
11. Make sure there are no style differences between the pages.
12. Please test around this issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?