### PR TITLE
Plan name change to Personal/Premium/Business/Commerce

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -40,7 +40,7 @@ import { hydrate, render } from './web-util.js';
 export { setLocaleMiddleware, setSectionMiddleware } from './shared.js';
 export { hydrate, render } from './web-util.js';
 
-const PLAN_NAME_EXPERIMENT = 'wpcom_plan_name_change_starter_to_beginner_v5';
+const PLAN_NAME_EXPERIMENT = 'wpcom_plan_name_change_personal_premium_v1';
 export const ProviderWrappedLayout = ( {
 	store,
 	queryClient,

--- a/packages/calypso-products/src/plans.tsx
+++ b/packages/calypso-products/src/plans.tsx
@@ -7,7 +7,7 @@ import { getPlansListExperiment } from './experiments';
  */
 
 export const getPlanPersonalTitle = () =>
-	getPlansListExperiment( 'wpcom_plan_name_change_starter_to_beginner_v5' ) === 'treatment'
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
 		? // translators: Beginner is a plan name
 		  i18n.translate( 'Beginner' )
 		: // translators: Starter is a plan name

--- a/packages/calypso-products/src/plans.tsx
+++ b/packages/calypso-products/src/plans.tsx
@@ -8,19 +8,28 @@ import { getPlansListExperiment } from './experiments';
 
 export const getPlanPersonalTitle = () =>
 	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
-		? // translators: Beginner is a plan name
-		  i18n.translate( 'Beginner' )
+		? // translators: Personal is a plan name
+		  i18n.translate( 'Personal' )
 		: // translators: Starter is a plan name
 		  i18n.translate( 'Starter' );
 
 export const getPlanPremiumTitle = () =>
-	// translators: Explorer is a plan name
-	i18n.translate( 'Explorer' );
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
+		? // translators: Premium is a plan name
+		  i18n.translate( 'Premium' )
+		: // translators: Explorer is a plan name
+		  i18n.translate( 'Explorer' );
 
 export const getPlanBusinessTitle = () =>
-	// translators: Creator is a plan name
-	i18n.translate( 'Creator' );
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
+		? // translators: Business is a plan name
+		  i18n.translate( 'Business' )
+		: // translators: Creator is a plan name
+		  i18n.translate( 'Creator' );
 
 export const getPlanEcommerceTitle = () =>
-	// translators: Entrepreneur is a plan name
-	i18n.translate( 'Entrepreneur' );
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
+		? // translators: Commerce is a plan name
+		  i18n.translate( 'Commerce' )
+		: // translators: Entrepreneur is a plan name
+		  i18n.translate( 'Entrepreneur' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 3031-gh-martech and D150022-code.

## Proposed Changes

* Updates the experiment name for the new plan name change experiment.
* We previously ran an experiment to change "Starter" to "Beginner". The conclusion from that experiment has been to run a new experiment to revert to the old plan names - Personal / Premium / Business / Commerce. Check pbxNRc-3E6-p2.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the new plan name has been updated in all contexts. 