### PR TITLE
Trail Map: launch the v3 experiment

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
+++ b/client/my-sites/plans-features-main/hooks/use-experiment-for-trail-map.ts
@@ -23,13 +23,15 @@ function useExperimentForTrailMap( { flowName, isInSignup, intent }: Params ): {
 	isTrailMapStructure: boolean;
 } {
 	const [ isLoading, assignment ] = useExperiment(
-		'calypso_signup_onboarding_plans_trail_map_feature_grid_v2',
+		'calypso_signup_onboarding_plans_trail_map_feature_grid_v3',
 		{
 			isEligible: flowName === 'onboarding' || ( ! isInSignup && intent === 'plans-default-wpcom' ),
 		}
 	);
 
-	let variant = ( assignment?.variationName ?? 'control' ) as VariantType;
+	let variant = (
+		assignment?.variationName === 'treatment' ? 'treatment_copy_and_structure' : 'control'
+	) as VariantType;
 
 	if ( config.isEnabled( 'onboarding/trail-map-feature-grid-copy' ) ) {
 		variant = 'treatment_copy';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR relaunches the trail map language offering experiment as v3, which differs to v2 as:

* There are only `control` and `treatment` variants
* All locales are included, instead of en-only

I originally attempted a full clean-up approach: https://github.com/Automattic/wp-calypso/pull/91155, but decided to go with the minimal approach here instead so it's safer and faster. What this PR does is simply converting `treatment` into `treatment_copy_and_structure`, so all the other logics won't need to be changed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

More context can be found from the latest comment in p1715686846735269-slack-C06P2UC516Y. In summary, we want to accelerate the convergence by reducing the number of variants and exposing it to the global audience, so that we can catch the timing of the next round of Trail Map experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to the Abacus profile: 21808-explat-experiment

* Assigning yourself to the control variation, the same plans grid as in production now should show in `/start/plans` and `/plans`
* Assigning yourself to the control variation, the trail map version plans grid should show in `/start/plans` and `/plans`, i.e. the `treatment_copy_and_structure` variation in v2.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
