### PR TITLE
A4A > Referrals: Implement referral details view

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -29,8 +29,6 @@ export default function ItemPreviewPaneHeader( {
 	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
 	const size = isLargerThan960px ? 64 : 50;
 
-	const isSiteData = itemData?.isSiteData ?? true;
-
 	const focusRef = useRef< HTMLButtonElement >( null );
 
 	// Use useEffect to set the focus when the component mounts
@@ -46,7 +44,7 @@ export default function ItemPreviewPaneHeader( {
 	return (
 		<div className={ classNames( 'item-preview__header', className ) }>
 			<div className="item-preview__header-content">
-				{ isSiteData && (
+				{ !! itemData?.withIcon && (
 					<SiteFavicon
 						blogId={ itemData.blogId }
 						fallback={ siteIconFallback }
@@ -59,7 +57,7 @@ export default function ItemPreviewPaneHeader( {
 					<div className="item-preview__header-title-summary">
 						<div className="item-preview__header-title">{ itemData.title }</div>
 						<div className="item-preview__header-summary">
-							{ isSiteData ? (
+							{ itemData?.url ? (
 								<Button
 									variant="link"
 									className="item-preview__header-summary-link"

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -29,6 +29,8 @@ export default function ItemPreviewPaneHeader( {
 	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
 	const size = isLargerThan960px ? 64 : 50;
 
+	const isSiteData = itemData?.isSiteData ?? true;
+
 	const focusRef = useRef< HTMLButtonElement >( null );
 
 	// Use useEffect to set the focus when the component mounts
@@ -44,32 +46,38 @@ export default function ItemPreviewPaneHeader( {
 	return (
 		<div className={ classNames( 'item-preview__header', className ) }>
 			<div className="item-preview__header-content">
-				<SiteFavicon
-					blogId={ itemData.blogId }
-					fallback={ siteIconFallback }
-					color={ itemData.color }
-					className="item-preview__header-favicon"
-					size={ size }
-				/>
+				{ isSiteData && (
+					<SiteFavicon
+						blogId={ itemData.blogId }
+						fallback={ siteIconFallback }
+						color={ itemData.color }
+						className="item-preview__header-favicon"
+						size={ size }
+					/>
+				) }
 				<div className="item-preview__header-info">
 					<div className="item-preview__header-title-summary">
 						<div className="item-preview__header-title">{ itemData.title }</div>
 						<div className="item-preview__header-summary">
-							<Button
-								variant="link"
-								className="item-preview__header-summary-link"
-								href={ itemData.url }
-								target="_blank"
-							>
-								<span>
-									{ itemData.subtitle }
-									<Icon
-										className="sidebar-v2__external-icon"
-										icon={ external }
-										size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
-									/>
-								</span>
-							</Button>
+							{ isSiteData ? (
+								<Button
+									variant="link"
+									className="item-preview__header-summary-link"
+									href={ itemData.url }
+									target="_blank"
+								>
+									<span>
+										{ itemData.subtitle }
+										<Icon
+											className="sidebar-v2__external-icon"
+											icon={ external }
+											size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
+										/>
+									</span>
+								</Button>
+							) : (
+								itemData.subtitle
+							) }
 						</div>
 					</div>
 					<div className="item-preview__header-actions">

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -19,13 +19,14 @@ export interface FeatureTabInterface {
 
 export interface ItemData {
 	title: string;
-	subtitle: string;
+	subtitle: string | React.ReactNode;
 	url?: string;
 	icon?: string;
 	color?: string;
 	blogId?: number;
 	isDotcomSite?: boolean;
 	adminUrl?: string;
+	isSiteData?: boolean;
 }
 
 export interface PreviewPaneProps {

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -26,7 +26,7 @@ export interface ItemData {
 	blogId?: number;
 	isDotcomSite?: boolean;
 	adminUrl?: string;
-	isSiteData?: boolean;
+	withIcon?: boolean;
 }
 
 export interface PreviewPaneProps {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -63,7 +63,7 @@ export default function ReferralsOverview( {
 		<Layout
 			className={ classNames( 'referrals-layout', {
 				'referrals-layout--automated': isAutomatedReferral,
-				'referrals-layout--full-width': isAutomatedReferral && ( isLoading || hasReferrals ),
+				'referrals-layout--full-width': isAutomatedReferral && hasReferrals,
 				'referrals-layout--has-selected': selectedItem,
 			} ) }
 			title={ title }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -3,10 +3,14 @@ import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
-import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import {
+	DATAVIEWS_TABLE,
+	initialDataViewsState,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 	LayoutHeaderActions as Actions,
@@ -18,6 +22,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useFetchReferrals from '../../hooks/use-fetch-referrals';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
 import { REFER_PRODUCTS_LINK } from '../../lib/constants';
+import ReferralDetails from '../../referral-details';
 import ReferralsFooter from '../footer';
 import LayoutBodyContent from './layout-body-content';
 
@@ -52,42 +57,61 @@ export default function ReferralsOverview( {
 
 	const isLoading = isFetching || isFetchingReferrals;
 
+	const selectedItem = dataViewsState.selectedItem;
+
 	return (
 		<Layout
 			className={ classNames( 'referrals-layout', {
 				'referrals-layout--automated': isAutomatedReferral,
 				'referrals-layout--full-width': isAutomatedReferral && ( isLoading || hasReferrals ),
+				'referrals-layout--has-selected': selectedItem,
 			} ) }
 			title={ title }
 			wide
 			sidebarNavigation={ ! isAutomatedReferral && <MobileSidebarNavigation /> }
 			withBorder={ isAutomatedReferral }
 		>
-			<LayoutTop>
-				<LayoutHeader>
-					<Title>{ title } </Title>
-					{ isAutomatedReferral && (
-						<Actions>
-							<MobileSidebarNavigation />
-							<Button primary href={ REFER_PRODUCTS_LINK } onClick={ makeAReferral }>
-								{ hasReferrals ? translate( 'New referral' ) : translate( 'Make a referral' ) }
-							</Button>
-						</Actions>
-					) }
-				</LayoutHeader>
-			</LayoutTop>
+			<LayoutColumn wide className="referrals-layout__column">
+				<LayoutTop>
+					<LayoutHeader>
+						<Title>{ title } </Title>
+						{ isAutomatedReferral && (
+							<Actions>
+								<MobileSidebarNavigation />
+								<Button primary href={ REFER_PRODUCTS_LINK } onClick={ makeAReferral }>
+									{ hasReferrals ? translate( 'New referral' ) : translate( 'Make a referral' ) }
+								</Button>
+							</Actions>
+						) }
+					</LayoutHeader>
+				</LayoutTop>
 
-			<LayoutBody>
-				<LayoutBodyContent
-					isAutomatedReferral={ isAutomatedReferral }
-					tipaltiData={ tipaltiData }
-					referrals={ referrals }
-					isLoading={ isLoading }
-					dataViewsState={ dataViewsState }
-					setDataViewsState={ setDataViewsState }
-				/>
-				{ ! isFetching && ! isAutomatedReferral && <ReferralsFooter /> }
-			</LayoutBody>
+				<LayoutBody>
+					<LayoutBodyContent
+						isAutomatedReferral={ isAutomatedReferral }
+						tipaltiData={ tipaltiData }
+						referrals={ referrals }
+						isLoading={ isLoading }
+						dataViewsState={ dataViewsState }
+						setDataViewsState={ setDataViewsState }
+					/>
+					{ ! isFetching && ! isAutomatedReferral && <ReferralsFooter /> }
+				</LayoutBody>
+			</LayoutColumn>
+			{ dataViewsState.selectedItem && (
+				<LayoutColumn wide>
+					<ReferralDetails
+						referral={ dataViewsState.selectedItem }
+						closeSitePreviewPane={ () =>
+							setDataViewsState( {
+								...dataViewsState,
+								type: DATAVIEWS_TABLE,
+								selectedItem: undefined,
+							} )
+						}
+					/>
+				</LayoutColumn>
+			) }
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -111,7 +111,7 @@ export default function LayoutBodyContent( {
 	if ( isAutomatedReferral && referrals?.length ) {
 		return (
 			<>
-				<ConsolidatedViews referrals={ referrals } />
+				{ ! dataViewsState.selectedItem && <ConsolidatedViews referrals={ referrals } /> }
 				<ReferralList
 					referrals={ referrals }
 					dataViewsState={ dataViewsState }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -1,6 +1,8 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+$data-view-border-color: #f1f1f1;
+
 .referrals-overview__section-notice {
 	margin-block-end: 48px;
 }
@@ -103,6 +105,58 @@
 	&.main.a4a-layout.is-with-border .a4a-layout__top-wrapper:not(.has-navigation) {
 		padding-block-start: 24px;
 		padding-block-end: 0;
+	}
+
+	&.main.a4a-layout {
+		@include break-large {
+			background: inherit;
+		}
+	}
+
+	&.referrals-layout--has-selected {
+		ul.dataviews-view-list {
+			margin: 0;
+			list-style: none;
+		}
+
+		li:not(.section-nav-tab) {
+			margin-inline: -24px;
+			padding: 16px 24px;
+			border-bottom: 1px solid $data-view-border-color;
+		}
+
+		.dataviews-view-list__item .components-flex {
+			gap: 0;
+		}
+
+		.dataviews-filters__view-actions {
+			border-bottom: 1px solid $data-view-border-color;
+			margin-inline-start: -24px;
+			padding-inline: 24px;
+			padding-block-end: 16px;
+			margin-block-end: 0;
+		}
+
+		.a4a-layout__top-wrapper > *,
+		.a4a-layout__body > * {
+			padding-inline: 24px;
+		}
+
+		.referrals-layout__column {
+			flex: unset;
+			height: 100%;
+			transition: all 0.2s;
+			width: 400px;
+			display: none;
+
+			@include break-large {
+				display: block;
+			}
+		}
+
+		.a4a-layout__header-actions a.button {
+			text-wrap: nowrap;
+		}
 	}
 }
 

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -195,3 +195,9 @@ $data-view-border-color: #f1f1f1;
 		color: var(--color-accent-100);
 	}
 }
+
+// FIXME: This is a temporary fix to make the referral layout columns the same height
+.main.a4a-layout-column.referrals-layout__column {
+	height: auto;
+	overflow-y: scroll;
+}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -21,7 +21,7 @@ const REFERRAL_ACITIVTY_ID = 'referral-activity';
 export default function ReferralDetails( { referral, closeSitePreviewPane }: Props ) {
 	const translate = useTranslate();
 
-	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( REFERRAL_PURCHASES_ID );
+	const [ selectedReferralTab, setSelectedReferralTab ] = useState( REFERRAL_PURCHASES_ID );
 
 	const itemData: ItemData = {
 		title: referral.client_email,
@@ -38,7 +38,7 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				} ) }
 			</div>
 		),
-		isSiteData: false,
+		withIcon: false,
 	};
 
 	const features = useMemo(
@@ -47,28 +47,28 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				REFERRAL_PURCHASES_ID,
 				translate( 'Purchases' ),
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedReferralTab,
+				setSelectedReferralTab,
 				'Purchases tab content'
 			),
 			createFeaturePreview(
 				REFERRAL_COMMISSIONS_ID,
 				translate( 'Commissions' ),
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedReferralTab,
+				setSelectedReferralTab,
 				'Commissions tab content'
 			),
 			createFeaturePreview(
 				REFERRAL_ACITIVTY_ID,
 				translate( 'Activity' ),
 				true,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
+				selectedReferralTab,
+				setSelectedReferralTab,
 				'Activity tab content'
 			),
 		],
-		[ selectedSiteFeature, setSelectedSiteFeature, translate ]
+		[ selectedReferralTab, setSelectedReferralTab, translate ]
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -1,0 +1,81 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, useState } from 'react';
+import ItemPreviewPane, {
+	createFeaturePreview,
+} from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
+import SubscriptionStatus from '../referrals-list/subscription-status';
+import type { Referral } from '../types';
+import type { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
+
+interface Props {
+	referral: Referral;
+	closeSitePreviewPane: () => void;
+}
+
+import './style.scss';
+
+const REFERRAL_PURCHASES_ID = 'referral-purchases';
+const REFERRAL_COMMISSIONS_ID = 'referral-commissions';
+const REFERRAL_ACITIVTY_ID = 'referral-activity';
+
+export default function ReferralDetails( { referral, closeSitePreviewPane }: Props ) {
+	const translate = useTranslate();
+
+	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( REFERRAL_PURCHASES_ID );
+
+	const itemData: ItemData = {
+		title: referral.client_email,
+		subtitle: (
+			<div className="referral-details__subtitle">
+				{ translate( 'Payment status {{badge}}%(status)s{{/badge}}', {
+					args: {
+						status: referral.statuses[ 0 ],
+					},
+					comment: '%(status) is subscription status',
+					components: {
+						badge: <SubscriptionStatus item={ referral } />,
+					},
+				} ) }
+			</div>
+		),
+		isSiteData: false,
+	};
+
+	const features = useMemo(
+		() => [
+			createFeaturePreview(
+				REFERRAL_PURCHASES_ID,
+				translate( 'Purchases' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				'Purchases tab content'
+			),
+			createFeaturePreview(
+				REFERRAL_COMMISSIONS_ID,
+				translate( 'Commissions' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				'Commissions tab content'
+			),
+			createFeaturePreview(
+				REFERRAL_ACITIVTY_ID,
+				translate( 'Activity' ),
+				true,
+				selectedSiteFeature,
+				setSelectedSiteFeature,
+				'Activity tab content'
+			),
+		],
+		[ selectedSiteFeature, setSelectedSiteFeature, translate ]
+	);
+
+	return (
+		<ItemPreviewPane
+			itemData={ itemData }
+			closeItemPreviewPane={ closeSitePreviewPane }
+			features={ features }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
@@ -1,0 +1,3 @@
+.referral-details__subtitle {
+	margin-block-start: 16px;
+}

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -124,9 +124,6 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 					totalItems: 1,
 					totalPages: 1,
 				},
-				getItemId: ( item: any ) => {
-					return item.id;
-				},
 				searchLabel: translate( 'Search referrals' ),
 				fields: fields,
 				actions: [],

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, ReactNode } from 'react';
+import { useMemo, useCallback, ReactNode } from 'react';
+import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import SubscriptionStatus from './subscription-status';
@@ -15,75 +16,106 @@ interface Props {
 export default function ReferralList( { referrals, dataViewsState, setDataViewsState }: Props ) {
 	const translate = useTranslate();
 
-	const fields = useMemo(
-		() => [
-			{
-				id: 'client',
-				header: translate( 'Client' ).toUpperCase(),
-				getValue: () => '-',
-				render: ( { item }: { item: Referral } ): ReactNode => {
-					return item.client_email;
-				},
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
-				id: 'purchases',
-				header: translate( 'Purchases' ).toUpperCase(),
-				getValue: () => '-',
-				render: ( { item }: { item: Referral } ): ReactNode => {
-					return item.purchases.length;
-				},
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
-				id: 'pending-orders',
-				header: translate( 'Pending Orders' ).toUpperCase(),
-				getValue: () => '-',
-				render: ( { item }: { item: Referral } ): ReactNode => {
-					return item.statuses.filter( ( status ) => status === 'pending' ).length;
-				},
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
-				id: 'commissions',
-				header: translate( 'Commissions' ).toUpperCase(),
-				getValue: () => '-',
-				render: ( { item }: { item: Referral } ): ReactNode => {
-					return `$${ item.commissions }`;
-				},
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
-				id: 'subscription-status',
-				header: translate( 'Subscription Status' ).toUpperCase(),
-				getValue: () => '-',
-				render: ( { item }: { item: Referral } ): ReactNode => <SubscriptionStatus item={ item } />,
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
-				id: 'actions',
-				header: translate( 'Actions' ).toUpperCase(),
-				render: () => {
-					return (
-						// TODO: Show details preview panel
-						<div>
-							<Button borderless>
-								<Gridicon icon="chevron-right" />
-							</Button>
-						</div>
-					);
-				},
-				enableHiding: false,
-				enableSorting: false,
-			},
-		],
-		[ translate ]
+	const openSitePreviewPane = useCallback(
+		( referral: Referral ) => {
+			setDataViewsState( ( prevState: DataViewsState ) => ( {
+				...prevState,
+				selectedItem: referral,
+				type: DATAVIEWS_LIST,
+			} ) );
+		},
+		[ setDataViewsState ]
 	);
+
+	const fields = useMemo(
+		() =>
+			dataViewsState.selectedItem
+				? [
+						{
+							id: 'client',
+							header: translate( 'Client' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: Referral } ): ReactNode => {
+								return (
+									<Button onClick={ () => openSitePreviewPane( item ) } borderless>
+										{ item.client_email }
+									</Button>
+								);
+							},
+							enableHiding: false,
+							enableSorting: false,
+						},
+				  ]
+				: [
+						{
+							id: 'client',
+							header: translate( 'Client' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: Referral } ): ReactNode => {
+								return item.client_email;
+							},
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'purchases',
+							header: translate( 'Purchases' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: Referral } ): ReactNode => {
+								return item.purchases.length;
+							},
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'pending-orders',
+							header: translate( 'Pending Orders' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: Referral } ): ReactNode => {
+								return item.statuses.filter( ( status ) => status === 'pending' ).length;
+							},
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'commissions',
+							header: translate( 'Commissions' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: Referral } ): ReactNode => {
+								return `$${ item.commissions }`;
+							},
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'subscription-status',
+							header: translate( 'Subscription Status' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: Referral } ): ReactNode => (
+								<SubscriptionStatus item={ item } />
+							),
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'actions',
+							header: translate( 'Actions' ).toUpperCase(),
+							render: ( { item }: { item: Referral } ) => {
+								return (
+									<div>
+										<Button onClick={ () => openSitePreviewPane( item ) } borderless>
+											<Gridicon icon="chevron-right" />
+										</Button>
+									</div>
+								);
+							},
+							enableHiding: false,
+							enableSorting: false,
+						},
+				  ],
+		[ dataViewsState.selectedItem, openSitePreviewPane, translate ]
+	);
+
 	return (
 		<ItemsDataViews
 			data={ {
@@ -92,7 +124,9 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 					totalItems: 1,
 					totalPages: 1,
 				},
-				itemFieldId: 'ref',
+				getItemId: ( item: any ) => {
+					return item.id;
+				},
 				searchLabel: translate( 'Search referrals' ),
 				fields: fields,
 				actions: [],


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/347

## Proposed Changes

This PR implements UI for the referral details view

NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)
- There are some UI enhancement & mobile fixes that will be done in another PR, so please ignore those for now.
## Testing Instructions

1. Open the A4A live link.
2. Append the /referrals URL as /referrals?flags=-a4a-automated-referrals, and verify that the above changes are not reflected and that the Referrals page matches the production.
3. Remove the feature flag > Go to  Referrals - Dashboard.
4. Use the below API endpoint manually to create a referral if you don't have some. Create a couple of them

POST https://public-api.wordpress.com/wpcom/v2/agency/230591090/referrals?client_email={client_email}&client_message={your_message}&product_ids={product_id,products_2}

5. Patch D149816
6. Now visit the  Referrals - Dashboard & refresh the page > Once you see the list of referrals, click the `>` icon & verify the page looks like below. It will be mostly empty in this PR.

<img width="1647" alt="Screenshot 2024-05-27 at 2 15 46 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8bbfc598-b31d-4f38-983a-5bbb9a236cdc">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
