### PR TITLE
A4A: Add the new Partner Directory section

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -1,5 +1,14 @@
 import config from '@automattic/calypso-config';
-import { category, currencyDollar, home, moveTo, reusableBlock, tag, cog } from '@wordpress/icons';
+import {
+	category,
+	currencyDollar,
+	home,
+	moveTo,
+	reusableBlock,
+	tag,
+	cog,
+	commentAuthorAvatar,
+} from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
@@ -122,7 +131,7 @@ const useMainMenuItems = ( path: string ) => {
 			...( isSectionNameEnabled( 'a8c-for-agencies-partner-directory' )
 				? [
 						{
-							icon: cog,
+							icon: commentAuthorAvatar,
 							path: '/dashboard',
 							link: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 							title: translate( 'Partner Directory' ),

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -13,6 +13,7 @@ import {
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MIGRATIONS_LINK,
 	A4A_SETTINGS_LINK,
+	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_REFERRALS_DASHBOARD,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
@@ -114,6 +115,19 @@ const useMainMenuItems = ( path: string ) => {
 							title: translate( 'Migrations' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Migrations',
+							},
+						},
+				  ]
+				: [] ),
+			...( isSectionNameEnabled( 'a8c-for-agencies-partner-directory' )
+				? [
+						{
+							icon: cog,
+							path: '/dashboard',
+							link: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
+							title: translate( 'Partner Directory' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Partner Directory',
 							},
 						},
 				  ]

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-partner-directory-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-partner-directory-menu-items.ts
@@ -5,8 +5,13 @@ import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/
 import { createItem } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/utils';
 import {
 	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
 } from 'calypso/a8c-for-agencies/sections/partner-directory/constants';
+
+const isSelected = ( path: string, links: string[] ) => {
+	return links.includes( path );
+};
 
 const usePartnerDirectoryMenuItems = ( path: string ) => {
 	const translate = useTranslate();
@@ -21,6 +26,9 @@ const usePartnerDirectoryMenuItems = ( path: string ) => {
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Partner Directory / Dashboard',
 					},
+					isSelected: isSelected( path, [
+						`${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_DASHBOARD_SLUG }`,
+					] ),
 				},
 				path
 			),
@@ -33,6 +41,10 @@ const usePartnerDirectoryMenuItems = ( path: string ) => {
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Partner Directory / Agency details',
 					},
+					isSelected: isSelected( path, [
+						`${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
+						`${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`,
+					] ),
 				},
 				path
 			),

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-partner-directory-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-partner-directory-menu-items.ts
@@ -1,0 +1,44 @@
+import { category, cog } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { createItem } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/utils';
+import {
+	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+	PARTNER_DIRECTORY_DASHBOARD_SLUG,
+} from 'calypso/a8c-for-agencies/sections/partner-directory/constants';
+
+const usePartnerDirectoryMenuItems = ( path: string ) => {
+	const translate = useTranslate();
+	const menuItems = useMemo( () => {
+		return [
+			createItem(
+				{
+					icon: category,
+					path: A4A_PARTNER_DIRECTORY_LINK,
+					link: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_DASHBOARD_SLUG }`,
+					title: translate( 'Dashboard' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Partner Directory / Dashboard',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: cog,
+					path: A4A_PARTNER_DIRECTORY_LINK,
+					link: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
+					title: translate( 'Agency details' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Partner Directory / Agency details',
+					},
+				},
+				path
+			),
+		];
+	}, [ path, translate ] );
+	return menuItems;
+};
+
+export default usePartnerDirectoryMenuItems;

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -33,3 +33,5 @@ export const A4A_SIGNUP_LINK = '/signup';
 export const A4A_SIGNUP_FINISH_LINK = '/signup/finish';
 export const A4A_MIGRATIONS_LINK = '/migrations';
 export const A4A_SETTINGS_LINK = '/settings';
+export const A4A_PARTNER_DIRECTORY_LINK = '/partner-directory';
+export const A4A_PARTNER_DIRECTORY_DASHBOARD_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/dashboard`;

--- a/client/a8c-for-agencies/components/sidebar-menu/partner-directory.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/partner-directory.tsx
@@ -1,0 +1,35 @@
+import page from '@automattic/calypso-router';
+import { chevronLeft } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import Sidebar from 'calypso/a8c-for-agencies/components/sidebar';
+import {
+	A4A_OVERVIEW_LINK,
+	A4A_PARTNER_DIRECTORY_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import usePartnerDirectoryMenuItems from './hooks/use-partner-directory-menu-items';
+
+type Props = {
+	path: string;
+};
+
+export default function ( { path }: Props ) {
+	const translate = useTranslate();
+	const menuItems = usePartnerDirectoryMenuItems( path );
+
+	return (
+		<Sidebar
+			path={ A4A_PARTNER_DIRECTORY_LINK }
+			title={ translate( 'Partner Directory' ) }
+			description={ translate( 'Boost your agency’s visibility across Automattic platforms.' ) }
+			backButtonProps={ {
+				label: translate( 'Back to overview' ),
+				icon: chevronLeft,
+				onClick: () => {
+					page( A4A_OVERVIEW_LINK );
+				},
+			} }
+			menuItems={ menuItems }
+			withUserProfileFooter
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -1,0 +1,9 @@
+const AgencyDetails = () => {
+	return (
+		<div>
+			<h2>Agency Details</h2>
+		</div>
+	);
+};
+
+export default AgencyDetails;

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -1,0 +1,9 @@
+const AgencyExpertise = () => {
+	return (
+		<div>
+			<h2>Agency Expertise</h2>
+		</div>
+	);
+};
+
+export default AgencyExpertise;

--- a/client/a8c-for-agencies/sections/partner-directory/constants.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/constants.ts
@@ -1,0 +1,3 @@
+export const PARTNER_DIRECTORY_DASHBOARD_SLUG = 'dashboard';
+export const PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG = 'agency-details';
+export const PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG = 'agency-expertise';

--- a/client/a8c-for-agencies/sections/partner-directory/controller.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/controller.tsx
@@ -4,13 +4,18 @@ import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PartnerDirectorySideBar from '../../components/sidebar-menu/partner-directory';
 import {
-	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
+	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
 } from './constants';
 import PartnerDirectory from './partner-directory';
 
 export const partnerDirectoryDashboardContext: Callback = ( context, next ) => {
-	const validSections = [ PARTNER_DIRECTORY_DASHBOARD_SLUG, PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ];
+	const validSections = [
+		PARTNER_DIRECTORY_DASHBOARD_SLUG,
+		PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+		PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
+	];
 
 	const selectedSection = context.params.section ?? PARTNER_DIRECTORY_DASHBOARD_SLUG;
 

--- a/client/a8c-for-agencies/sections/partner-directory/controller.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/controller.tsx
@@ -1,0 +1,30 @@
+import { type Callback } from '@automattic/calypso-router';
+import page from '@automattic/calypso-router';
+import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import PartnerDirectorySideBar from '../../components/sidebar-menu/partner-directory';
+import {
+	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+	PARTNER_DIRECTORY_DASHBOARD_SLUG,
+} from './constants';
+import PartnerDirectory from './partner-directory';
+
+export const partnerDirectoryDashboardContext: Callback = ( context, next ) => {
+	const validSections = [ PARTNER_DIRECTORY_DASHBOARD_SLUG, PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ];
+
+	const selectedSection = context.params.section ?? PARTNER_DIRECTORY_DASHBOARD_SLUG;
+
+	if ( ! validSections.includes( selectedSection ) ) {
+		page.redirect( A4A_PARTNER_DIRECTORY_LINK );
+		return;
+	}
+
+	context.primary = (
+		<>
+			<PageViewTracker title="Partner Directory > Dashboard" path={ context.path } />
+			<PartnerDirectory selectedSection={ selectedSection } />
+		</>
+	);
+	context.secondary = <PartnerDirectorySideBar path={ context.path } />;
+	next();
+};

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -1,0 +1,9 @@
+const PartnerDirectoryDashboard = () => {
+	return (
+		<div>
+			<h2>Partner Directory Dashboard</h2>
+		</div>
+	);
+};
+
+export default PartnerDirectoryDashboard;

--- a/client/a8c-for-agencies/sections/partner-directory/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/index.tsx
@@ -1,0 +1,21 @@
+import page from '@automattic/calypso-router';
+import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { PARTNER_DIRECTORY_DASHBOARD_SLUG } from './constants';
+import { partnerDirectoryDashboardContext } from './controller';
+
+export default function () {
+	// Redirect to the Dashboard page: /partner-directory/dashboard
+	page( A4A_PARTNER_DIRECTORY_LINK, () => {
+		page.redirect( `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_DASHBOARD_SLUG }` );
+	} );
+
+	page(
+		`${ A4A_PARTNER_DIRECTORY_LINK }/:section?`,
+		requireAccessContext,
+		partnerDirectoryDashboardContext,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -1,0 +1,78 @@
+import { useTranslate } from 'i18n-calypso';
+import React, { ReactNode } from 'react';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderBreadcrumb as Breadcrumb,
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
+import AgencyDetails from './agency-details';
+import AgencyExpertise from './agency-expertise';
+import {
+	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
+	PARTNER_DIRECTORY_DASHBOARD_SLUG,
+} from './constants';
+import Dashboard from './dashboard';
+
+type Props = {
+	selectedSection: string;
+};
+
+export default function PartnerDirectory( { selectedSection }: Props ) {
+	const translate = useTranslate();
+	const title = translate( 'Partner Directory' );
+
+	const section: { content: ReactNode | undefined; breadcrumbItems: BreadcrumbItem[] } = {
+		content: <Dashboard />,
+		breadcrumbItems: [
+			{
+				label: translate( 'Partner Directory' ),
+				href: A4A_PARTNER_DIRECTORY_LINK,
+			},
+		],
+	};
+
+	switch ( selectedSection ) {
+		case PARTNER_DIRECTORY_DASHBOARD_SLUG:
+			section.content = <Dashboard />;
+			break;
+		case PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG:
+			section.content = <AgencyDetails />;
+			section.breadcrumbItems.push( {
+				label: translate( 'Agency Details' ),
+				href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
+			} );
+			break;
+		case PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG:
+			section.content = <AgencyExpertise />;
+			section.breadcrumbItems.push( {
+				label: translate( 'Agency Details' ),
+				href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
+			} );
+			section.breadcrumbItems.push( {
+				label: translate( 'Agency Expertise' ),
+				href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`,
+			} );
+			break;
+	}
+
+	return (
+		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					{ section.breadcrumbItems.length === 1 ? (
+						<Title>{ title }</Title>
+					) : (
+						<Breadcrumb items={ section.breadcrumbItems } />
+					) }
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>{ section.content }</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import React, { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -23,43 +23,56 @@ type Props = {
 	selectedSection: string;
 };
 
+interface Section {
+	content: ReactNode;
+	breadcrumbItems: BreadcrumbItem[];
+}
+
 export default function PartnerDirectory( { selectedSection }: Props ) {
 	const translate = useTranslate();
 	const title = translate( 'Partner Directory' );
 
-	const section: { content: ReactNode | undefined; breadcrumbItems: BreadcrumbItem[] } = {
-		content: <Dashboard />,
-		breadcrumbItems: [
-			{
-				label: translate( 'Partner Directory' ),
-				href: A4A_PARTNER_DIRECTORY_LINK,
-			},
-		],
-	};
+	// Define the sub-menu sections
+	const sections: { [ slug: string ]: Section } = useMemo( () => {
+		const sections: { [ slug: string ]: Section } = {};
 
-	switch ( selectedSection ) {
-		case PARTNER_DIRECTORY_DASHBOARD_SLUG:
-			section.content = <Dashboard />;
-			break;
-		case PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG:
-			section.content = <AgencyDetails />;
-			section.breadcrumbItems.push( {
-				label: translate( 'Agency Details' ),
-				href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
-			} );
-			break;
-		case PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG:
-			section.content = <AgencyExpertise />;
-			section.breadcrumbItems.push( {
-				label: translate( 'Agency Details' ),
-				href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
-			} );
-			section.breadcrumbItems.push( {
-				label: translate( 'Agency Expertise' ),
-				href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`,
-			} );
-			break;
-	}
+		sections[ PARTNER_DIRECTORY_DASHBOARD_SLUG ] = {
+			content: <Dashboard />,
+			breadcrumbItems: [
+				{
+					label: translate( 'Partner Directory' ),
+					href: A4A_PARTNER_DIRECTORY_LINK,
+				},
+			],
+		};
+
+		sections[ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ] = {
+			content: <AgencyDetails />,
+			breadcrumbItems: [
+				...sections[ PARTNER_DIRECTORY_DASHBOARD_SLUG ].breadcrumbItems,
+				{
+					label: translate( 'Agency Details' ),
+					href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
+				},
+			],
+		};
+
+		sections[ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG ] = {
+			content: <AgencyExpertise />,
+			breadcrumbItems: [
+				...sections[ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ].breadcrumbItems,
+				{
+					label: translate( 'Agency Expertise' ),
+					href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`,
+				},
+			],
+		};
+
+		return sections;
+	}, [ translate ] );
+
+	// Set the selected section
+	const section: Section = sections[ selectedSection ];
 
 	return (
 		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>

--- a/client/sections.js
+++ b/client/sections.js
@@ -808,6 +808,12 @@ const sections = [
 		group: 'a8c-for-agencies',
 	},
 	{
+		name: 'a8c-for-agencies-partner-directory',
+		paths: [ '/partner-directory' ],
+		module: 'calypso/a8c-for-agencies/sections/partner-directory',
+		group: 'a8c-for-agencies',
+	},
+	{
 		name: 'a8c-for-agencies-signup',
 		paths: [ '/signup', '/signup/finish', '/signup/oauth/token' ],
 		module: 'calypso/a8c-for-agencies/sections/signup',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -171,6 +171,7 @@
 		"a8c-for-agencies-referrals": false,
 		"a8c-for-agencies-migrations": false,
 		"a8c-for-agencies-settings": false,
+		"a8c-for-agencies-partner-directory": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -52,6 +52,7 @@
 		"a8c-for-agencies-signup": true,
 		"a8c-for-agencies-referrals": true,
 		"a8c-for-agencies-settings": true,
+		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -45,6 +45,7 @@
 		"a8c-for-agencies-signup": true,
 		"a8c-for-agencies-referrals": true,
 		"a8c-for-agencies-settings": true,
+		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -45,6 +45,7 @@
 		"a8c-for-agencies-signup": true,
 		"a8c-for-agencies-referrals": true,
 		"a8c-for-agencies-settings": false,
+		"a8c-for-agencies-partner-directory": false,
 		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -47,6 +47,7 @@
 		"a8c-for-agencies-signup": true,
 		"a8c-for-agencies-referrals": true,
 		"a8c-for-agencies-settings": false,
+		"a8c-for-agencies-partner-directory": false,
 		"a8c-for-agencies-migrations": true
 	},
 	"site_filter": [],


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/548

## Proposed Changes

This PR adds the initial base code for the Partner Directory section with submenu sections:

- Partner Directory: `/partner-directory`
   - Dashboard: `/partner-directory/dashboard` (default for the partner-directory section)
   - Agency details: `/partner-directory/agency-details`
   - Agency expertise: `/partner-directory/agency-expertise`

## Why are these changes being made?

PT: pfunGA-oW-p2

## Testing Instructions

- Check the code
- Ensure the section is correctly behind `a8c-for-agencies-partner-directory` and only available in `development` and `horizon`. It should be available in `production` or `stage`.
- Click on the Partner Directory menu it sends you to `/partner-directory` and redirect to `/partner-directory/dashboard`
- Ensure that the selected menu has the is-selected background color on each section.
- Click on Agency details; it sends you to `/partner-directory/agency-details` and opens the page. You will see the breadcrumb: `Partner Directory > Agency Details`.
- Manually check: `/partner-directory/agency-expertise` page. You will see the breadcrumb: `Partner Directory > Agency Expertise`.
- The upper items in the breadcrumb are clickable links. Check them.
- Check that any wrong slug `partner-directory/dafasdf` will redirect to `partner-directory/dashboard`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?