### PR TITLE
Command Palette: Fix wp-admin and Calypso have different footer focus styles

### DIFF
--- a/packages/command-palette/src/style.scss
+++ b/packages/command-palette/src/style.scss
@@ -12,4 +12,5 @@ div.commands-command-menu {
 	outline: thin dotted;
 	color: var(--studio-gray-50);
 	text-decoration: none;
+	box-shadow: inherit;
 }

--- a/packages/command-palette/src/style.scss
+++ b/packages/command-palette/src/style.scss
@@ -6,3 +6,10 @@ div.commands-command-menu {
 	width: min(100% - 32px, 640px);
 	max-width: 640px;
 }
+
+.command-palette__footer-all-sites:focus,
+.command-palette__footer-current-site:focus {
+	outline: thin dotted;
+	color: var(--studio-gray-50);
+	text-decoration: none;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to
- https://github.com/Automattic/wp-calypso/issues/91105

## Proposed Changes

* Added an explicit style so that we don't use the admin's default.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* During testing we found that when we load the command palette on wp-admin and calypso the footer focus selector uses different styles.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link
* Open the command palette in a site context
* Press tab until you focus on the footer's site.
* Apply this code to your sandbox and repeat. (make sure you've sandboxed widgets.wp.com)
* The focus style should be the same in both cases.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
