### PR TITLE
explat-client: calypso-lib: Skip requests for E2E

### DIFF
--- a/client/lib/explat/internals/fetch-experiment-assignment.ts
+++ b/client/lib/explat/internals/fetch-experiment-assignment.ts
@@ -1,3 +1,4 @@
+import { isE2ETest } from 'calypso/lib/e2e';
 import wpcom from 'calypso/lib/wp';
 
 // SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check
@@ -11,6 +12,15 @@ export default function fetchExperimentAssignment( {
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > {
+	if ( isE2ETest() ) {
+		return new Promise( () => ( {
+			variations: {
+				[ experimentName ]: null,
+			},
+			ttl: 60,
+		} ) );
+	}
+
 	return wpcom.req.get(
 		{
 			path: '/experiments/0.1.0/assignments/calypso',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See pbmo2S-2yX-p2#comment-3159

## Proposed Changes

* Skip requests if in E2E env

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Should pass E2E tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?