### PR TITLE
Nav Redesign - update notification icon in masterbar

### DIFF
--- a/client/layout/global-sidebar/menu-items/notifications/icon.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/icon.jsx
@@ -17,7 +17,12 @@ export const BellIcon = ( { newItems } ) => {
 					fill="#fff"
 					fillRule="evenodd"
 				></path>
-				<circle cx="19.2759" cy="8.56887" fill="#e26f56" r="2.97415"></circle>
+				<circle
+					cx="19.2759"
+					cy="8.56887"
+					fill="var( --color-masterbar-unread-dot-background )"
+					r="2.97415"
+				></circle>
 			</svg>
 		);
 	}

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import TranslatableString from 'calypso/components/translatable/proptype';
+import { BellIcon } from 'calypso/layout/global-sidebar/menu-items/notifications/icon';
 import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import MasterbarItem from '../item';
-import { BellIcon } from './notifications-bell-icon';
 
 import './notifications-style.scss';
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -159,6 +159,7 @@ body.is-mobile-app-view {
 	.masterbar__item-notifications {
 		svg.sidebar_svg-notifications {
 			margin: 0;
+			fill: none;
 		}
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -156,6 +156,11 @@ body.is-mobile-app-view {
 			}
 		}
 	}
+	.masterbar__item-notifications {
+		svg.sidebar_svg-notifications {
+			margin: 0;
+		}
+	}
 }
 
 .masterbar__new-menu-popover {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/7185

## Proposed Changes

* Updates notification icon in masterbar to use the same icon as in global sidebar

## Before
<img width="268" alt="Screenshot 2024-05-27 at 13 06 51" src="https://github.com/Automattic/wp-calypso/assets/5560595/27d3934e-c03b-4a16-b819-bbc26aaf9cec">

## After

<img width="275" alt="Screenshot 2024-05-27 at 13 18 14" src="https://github.com/Automattic/wp-calypso/assets/5560595/008e3a45-46aa-4735-9e92-aff2b09af292">
<img width="289" alt="Screenshot 2024-05-27 at 13 17 12" src="https://github.com/Automattic/wp-calypso/assets/5560595/8b706d22-76c1-4dc3-a02f-22f140bcad31">
<img width="262" alt="Screenshot 2024-05-27 at 13 17 04" src="https://github.com/Automattic/wp-calypso/assets/5560595/0892b42f-c3e1-418f-bf8d-f66474af7a74">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Trying to build a consistent UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the a test site's in calypso home - `http://calypso.localhost:3000/home/[testsite].wordpress.com`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
