### PR TITLE
Allow simple sites to use Jetpack social in Jetpack Cloud

### DIFF
--- a/client/jetpack-cloud/sections/jetpack-social/connections.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/connections.jsx
@@ -1,7 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
+import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
@@ -10,12 +9,17 @@ import QueryPublicizeConnections from 'calypso/components/data/query-publicize-c
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import SharingServicesGroup from 'calypso/my-sites/marketing/connections/services-group';
+import { useSelector } from 'calypso/state';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import 'calypso/my-sites/marketing/style.scss';
 import './style.scss';
 
-export const Connections = ( { siteId, translate } ) => {
+export const Connections = () => {
+	const siteId = useSelector( getSelectedSiteId );
+	const isSimple = useSelector( ( state ) => isSimpleSite( state, siteId ) );
+
 	const titleHeader = translate( 'Social Connections', {
 		context: 'Title of the Jetpack Social connections page',
 	} );
@@ -37,7 +41,7 @@ export const Connections = ( { siteId, translate } ) => {
 			<DocumentHead title={ titleHeader } />
 			<QueryKeyringConnections />
 			<QueryKeyringServices />
-			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
+			{ ! isSimple && siteId && <QueryJetpackModules siteId={ siteId } /> }
 			{ siteId && <QueryPublicizeConnections siteId={ siteId } /> }
 			<FormattedHeader
 				className="connections__page-heading"
@@ -57,8 +61,4 @@ export const Connections = ( { siteId, translate } ) => {
 	);
 };
 
-export default connect( ( state ) => {
-	return {
-		siteId: getSelectedSiteId( state ),
-	};
-} )( localize( Connections ) );
+export default Connections;

--- a/client/jetpack-cloud/sections/jetpack-social/controller.tsx
+++ b/client/jetpack-cloud/sections/jetpack-social/controller.tsx
@@ -7,6 +7,7 @@ import {
 	isJetpackSite,
 	isJetpackModuleActive,
 	isJetpackConnectionPluginActive,
+	isSimpleSite,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectionsPage from './connections';
@@ -17,6 +18,7 @@ export const connections: Callback = ( context, next ) => {
 	const { dispatch } = store;
 	const state = store.getState();
 	const site = getSelectedSite( state );
+	const isSimple = isSimpleSite( state, site?.ID );
 	const isJetpack = site?.ID && isJetpackSite( state, site.ID );
 	const isPublicizeActive = site?.ID && isJetpackModuleActive( state, site.ID, 'publicize' );
 
@@ -28,7 +30,7 @@ export const connections: Callback = ( context, next ) => {
 		);
 	}
 
-	if ( isJetpack || isPublicizeActive ) {
+	if ( isJetpack || isPublicizeActive || isSimple ) {
 		context.primary = <ConnectionsPage />;
 	} else {
 		context.primary = (

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import Notice from 'calypso/components/notice';
 import SocialLogo from 'calypso/components/social-logo';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice, warningNotice } from 'calypso/state/notices/actions';
@@ -604,7 +605,7 @@ export class SharingService extends Component {
 											icon
 											iconSize={ 14 }
 											href={ localizeUrl(
-												this.props.isJetpack
+												this.props.isJetpack || isJetpackCloud()
 													? 'https://jetpack.com/2023/04/29/the-end-of-twitter-auto-sharing/'
 													: 'https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/'
 											) }

--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -7,6 +7,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import { Notice } from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains.ts';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
@@ -228,14 +229,23 @@ export const WpcomFediverseSettingsSection = ( { siteId, needsBorders = true } )
 				/>
 				{ isPrivate && (
 					<Notice status="is-warning" translate={ translate } isCompact>
-						{ translate(
-							'You cannot enter the fediverse until your site is publicly launched. {{link}}Review Privacy settings{{/link}}.',
-							{
-								components: {
-									link: <a href={ `/settings/general/${ domain }` } />,
-								},
-							}
-						) }
+						{ isJetpackCloud()
+							? translate(
+									'You cannot enter the fediverse until your site is publicly launched. {{link}}Review Privacy settings on WordPress.com{{/link}}.',
+									{
+										components: {
+											link: <a href={ `https://wordpress.com/settings/general/${ domain }` } />,
+										},
+									}
+							  )
+							: translate(
+									'You cannot enter the fediverse until your site is publicly launched. {{link}}Review Privacy settings{{/link}}.',
+									{
+										components: {
+											link: <a href={ `/settings/general/${ domain }` } />,
+										},
+									}
+							  ) }
 					</Notice>
 				) }
 			</Wrapper>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7343

## Proposed Changes


| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/e0eb3b3a-81aa-43d6-a106-f49a7782d72b">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/fb3f64ef-5af8-4cfe-b090-1ac8ba45f250">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The same set of features is available in `/marketing/connections/:site` for free sites, so we shouldn't show the upsell here for Jetpack Social

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
> [!NOTE]  
> Since we only allow Simple sites to show locally, to test the changes please start the local environment by running `yarn start-jetpack-cloud`
The live link is used to test for regressions, make sure we don't break anything that's already in production

* Go to a `/jetpack-social/:simpleSite`
* No upsell banner is shown
* Try to connect to the services

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
