### PR TITLE
Users created using A4A flow are marked as developers now

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -29,11 +29,7 @@ import {
 	canDoMagicLogin,
 	getLoginLinkPageUrl,
 } from 'calypso/lib/login';
-import {
-	isCrowdsignalOAuth2Client,
-	isWooOAuth2Client,
-	isA4AOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -651,15 +647,10 @@ export class LoginForm extends Component {
 
 	getSignupUrl() {
 		const { oauth2Client, currentQuery, currentRoute, pathname, locale } = this.props;
-		const signupUrl = this.props.signupUrl
+
+		return this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
 			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
-
-		const delimiter = signupUrl.includes( '?' ) ? '&' : '?';
-
-		return isA4AOAuth2Client( this.props.oauth2Client )
-			? signupUrl + delimiter + 'ref=a4a_signup'
-			: signupUrl;
 	}
 
 	handleMagicLoginClick = ( origin ) => {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -29,7 +29,11 @@ import {
 	canDoMagicLogin,
 	getLoginLinkPageUrl,
 } from 'calypso/lib/login';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isCrowdsignalOAuth2Client,
+	isWooOAuth2Client,
+	isA4AOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -647,10 +651,15 @@ export class LoginForm extends Component {
 
 	getSignupUrl() {
 		const { oauth2Client, currentQuery, currentRoute, pathname, locale } = this.props;
-
-		return this.props.signupUrl
+		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
 			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
+
+		const delimiter = signupUrl.includes( '?' ) ? '&' : '?';
+
+		return isA4AOAuth2Client( this.props.oauth2Client )
+			? signupUrl + delimiter + 'ref=a4a_signup'
+			: signupUrl;
 	}
 
 	handleMagicLoginClick = ( origin ) => {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -134,6 +134,7 @@ export class UserStep extends Component {
 		subHeaderText: PropTypes.string,
 		isSocialSignupEnabled: PropTypes.bool,
 		initialContext: PropTypes.object,
+		isA4ASignup: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -367,12 +368,17 @@ export class UserStep extends Component {
 		} else if ( data.queryArgs.redirect_to ) {
 			dependencies.redirect = data.queryArgs.redirect_to;
 		}
+		const userData = {
+			...data.userData,
+			...( this.props.isA4ASignup && { is_dev_account: true } ),
+		};
 		this.props.submitSignupStep(
 			{
 				flowName,
 				stepName,
 				oauth2Signup,
 				...data,
+				userData,
 			},
 			dependencies
 		);
@@ -749,6 +755,7 @@ const ConnectedUser = connect(
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),
 			isWooPasswordless: getIsWooPasswordless( state ),
+			isA4ASignup: isA4AOAuth2Client( getCurrentOAuth2Client( state ) ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 		};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7414

## Proposed Changes

This PR marks as developer accounts the users created following the A4A flow.

## Why are these changes being made?
More context here: https://github.com/Automattic/dotcom-forge/issues/7414

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply these changes locally.
- In a terminal window, run `yarn start-a8c-for-agencies`.
- Go to `http://agencies.localhost:3000/signup` in incognito. This will show the "Signup agency flow". You don't need to fill out the form. Click the continue button at the bottom of the form.
- You will see the A4A login screen. Click on the "Create account" link.
- You will see the A4A account creation flow.
- Fill the form with an email you can access and submit it.
- Confirm your email address.
- Go to `https://wordpress.com` and log in using that account.
- Go to your profile and developer settings. You should see yourself marked as a "developer".
- As regression tests, you can go to `http://calypso.localhost:3000/log-in` and click `create account`. Create an account normally. Your newly created account shouldn't be marked as "developer" on the normal flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
