### PR TITLE
Restricting fetchModuleList calls to Atomic sites only

### DIFF
--- a/client/components/data/query-jetpack-modules/index.jsx
+++ b/client/components/data/query-jetpack-modules/index.jsx
@@ -3,9 +3,12 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
 const request = ( siteId ) => ( dispatch, getState ) => {
-	if ( siteId && ! isFetchingJetpackModules( getState(), siteId ) ) {
+	const isAtomic = isSiteWpcomAtomic( getState(), siteId );
+
+	if ( siteId && ! isFetchingJetpackModules( getState(), siteId ) && isAtomic ) {
 		dispatch( fetchModuleList( siteId ) );
 	}
 };

--- a/client/components/data/query-jetpack-modules/index.jsx
+++ b/client/components/data/query-jetpack-modules/index.jsx
@@ -4,11 +4,13 @@ import { useDispatch } from 'react-redux';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 
 const request = ( siteId ) => ( dispatch, getState ) => {
+	const isJetpack = isJetpackSite( getState(), siteId );
 	const isAtomic = isSiteWpcomAtomic( getState(), siteId );
 
-	if ( siteId && ! isFetchingJetpackModules( getState(), siteId ) && isAtomic ) {
+	if ( siteId && ! isFetchingJetpackModules( getState(), siteId ) && ( isAtomic || isJetpack ) ) {
 		dispatch( fetchModuleList( siteId ) );
 	}
 };

--- a/client/components/data/query-jetpack-modules/test/query-jetpack-modules.jsx
+++ b/client/components/data/query-jetpack-modules/test/query-jetpack-modules.jsx
@@ -21,6 +21,7 @@ jest.mock( 'calypso/state/jetpack/modules/actions', () => ( {
 } ) );
 
 let isWpcomAtomic = false;
+let isJetpack = false;
 const siteId = 1;
 const mockStore = configureStore( middlewares );
 
@@ -36,6 +37,7 @@ function getStore() {
 					options: {
 						is_wpcom_atomic: isWpcomAtomic,
 					},
+					jetpack: isJetpack,
 				},
 			},
 		},
@@ -49,6 +51,9 @@ function getStore() {
 
 describe( 'fetchModuleList', () => {
 	test( "Ensure we're NOT calling fetchModuleList for simple sites", async () => {
+		isWpcomAtomic = false;
+		isJetpack = false;
+
 		render(
 			<Provider store={ getStore() }>
 				<QueryJetpackModules siteId={ siteId } />
@@ -58,8 +63,9 @@ describe( 'fetchModuleList', () => {
 		expect( mockFetchModuleList ).not.toHaveBeenCalled();
 	} );
 
-	test( "Ensure we're calling fetchModuleList only for atomic sites", async () => {
+	test( "Ensure we're calling fetchModuleList for Atomic sites", async () => {
 		isWpcomAtomic = true;
+		isJetpack = false;
 
 		render(
 			<Provider store={ getStore() }>
@@ -68,5 +74,18 @@ describe( 'fetchModuleList', () => {
 		);
 
 		expect( mockFetchModuleList ).toHaveBeenCalled();
+	} );
+
+	test( "Ensure we're calling fetchModuleList for Jetpack Non Atomic sites", async () => {
+		isWpcomAtomic = false;
+		isJetpack = true;
+
+		render(
+			<Provider store={ getStore() }>
+				<QueryJetpackModules siteId={ siteId } />
+			</Provider>
+		);
+
+		expect( mockFetchModuleList ).toHaveBeenCalledTimes( 2 );
 	} );
 } );

--- a/client/components/data/query-jetpack-modules/test/query-jetpack-modules.jsx
+++ b/client/components/data/query-jetpack-modules/test/query-jetpack-modules.jsx
@@ -65,7 +65,7 @@ describe( 'fetchModuleList', () => {
 
 	test( "Ensure we're calling fetchModuleList for Atomic sites", async () => {
 		isWpcomAtomic = true;
-		isJetpack = false;
+		isJetpack = true;
 
 		render(
 			<Provider store={ getStore() }>

--- a/client/components/data/query-jetpack-modules/test/query-jetpack-modules.jsx
+++ b/client/components/data/query-jetpack-modules/test/query-jetpack-modules.jsx
@@ -20,36 +20,37 @@ jest.mock( 'calypso/state/jetpack/modules/actions', () => ( {
 	fetchModuleList: () => mockFetchModuleList(),
 } ) );
 
-describe( 'fetchModuleList', () => {
-	test( "Ensure we're NOT calling fetchModuleList for simple sites", async () => {
-		const mockStore = configureStore( middlewares );
-		const siteId = 1;
-		const store = mockStore( {
-			currentUser: {
-				id: 1,
-				user: {
-					had_hosting_trial: false,
-				},
-			},
-			sites: {
-				items: {
-					[ siteId ]: {
-						ID: siteId,
-						options: {
-							is_wpcom_atomic: false,
-						},
+let isWpcomAtomic = false;
+const siteId = 1;
+const mockStore = configureStore( middlewares );
+
+function getStore() {
+	return mockStore( {
+		currentUser: {
+			id: 1,
+		},
+		sites: {
+			items: {
+				[ siteId ]: {
+					ID: siteId,
+					options: {
+						is_wpcom_atomic: isWpcomAtomic,
 					},
 				},
 			},
-			jetpack: {
-				modules: {
-					fetching: false,
-				},
+		},
+		jetpack: {
+			modules: {
+				fetching: false,
 			},
-		} );
+		},
+	} );
+}
 
+describe( 'fetchModuleList', () => {
+	test( "Ensure we're NOT calling fetchModuleList for simple sites", async () => {
 		render(
-			<Provider store={ store }>
+			<Provider store={ getStore() }>
 				<QueryJetpackModules siteId={ siteId } />
 			</Provider>
 		);
@@ -58,34 +59,10 @@ describe( 'fetchModuleList', () => {
 	} );
 
 	test( "Ensure we're calling fetchModuleList only for atomic sites", async () => {
-		const mockStore = configureStore( middlewares );
-		const siteId = 1;
-		const store = mockStore( {
-			currentUser: {
-				id: 1,
-				user: {
-					had_hosting_trial: false,
-				},
-			},
-			sites: {
-				items: {
-					[ siteId ]: {
-						ID: siteId,
-						options: {
-							is_wpcom_atomic: true,
-						},
-					},
-				},
-			},
-			jetpack: {
-				modules: {
-					fetching: false,
-				},
-			},
-		} );
+		isWpcomAtomic = true;
 
 		render(
-			<Provider store={ store }>
+			<Provider store={ getStore() }>
 				<QueryJetpackModules siteId={ siteId } />
 			</Provider>
 		);

--- a/client/components/data/query-jetpack-modules/test/query-jetpack-modules.jsx
+++ b/client/components/data/query-jetpack-modules/test/query-jetpack-modules.jsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+const middlewares = [ thunk ];
+
+const mockFetchModuleList = jest.fn( () => {
+	return {
+		type: 'JETPACK_MODULES_REQUEST',
+		siteId: 1,
+	};
+} );
+
+jest.mock( 'calypso/state/jetpack/modules/actions', () => ( {
+	fetchModuleList: () => mockFetchModuleList(),
+} ) );
+
+describe( 'fetchModuleList', () => {
+	test( "Ensure we're NOT calling fetchModuleList for simple sites", async () => {
+		const mockStore = configureStore( middlewares );
+		const siteId = 1;
+		const store = mockStore( {
+			currentUser: {
+				id: 1,
+				user: {
+					had_hosting_trial: false,
+				},
+			},
+			sites: {
+				items: {
+					[ siteId ]: {
+						ID: siteId,
+						options: {
+							is_wpcom_atomic: false,
+						},
+					},
+				},
+			},
+			jetpack: {
+				modules: {
+					fetching: false,
+				},
+			},
+		} );
+
+		render(
+			<Provider store={ store }>
+				<QueryJetpackModules siteId={ siteId } />
+			</Provider>
+		);
+
+		expect( mockFetchModuleList ).not.toHaveBeenCalled();
+	} );
+
+	test( "Ensure we're calling fetchModuleList only for atomic sites", async () => {
+		const mockStore = configureStore( middlewares );
+		const siteId = 1;
+		const store = mockStore( {
+			currentUser: {
+				id: 1,
+				user: {
+					had_hosting_trial: false,
+				},
+			},
+			sites: {
+				items: {
+					[ siteId ]: {
+						ID: siteId,
+						options: {
+							is_wpcom_atomic: true,
+						},
+					},
+				},
+			},
+			jetpack: {
+				modules: {
+					fetching: false,
+				},
+			},
+		} );
+
+		render(
+			<Provider store={ store }>
+				<QueryJetpackModules siteId={ siteId } />
+			</Provider>
+		);
+
+		expect( mockFetchModuleList ).toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/90758

## Proposed Changes

* We're restricting whether to make the `fetchmoduleList` call for Atomic sites only

[Here's more context to it](https://github.com/Automattic/wp-calypso/issues/90758#issuecomment-2131364772).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This isn't a fix for the issue, but instead, a performance improvement since we're avoiding a couple of unnecessary calls with it (fetchModuleList + JetpackHealthCheck). 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Be on this branch and select a simple site
* Go to `Home` on that simple site and clear your Network requests
* Go to `Pages -> All pages`
* Ensure you won't see a `/rest/v1.1/jetpack-blogs` API call

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
