### PR TITLE
A4A: add marketplace type switch to hosting

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/context.ts
+++ b/client/a8c-for-agencies/sections/marketplace/context.ts
@@ -16,4 +16,7 @@ export const MarketplaceTypeContext = createContext< MarketplaceTypeContextInter
 	setMarketplaceType: () => {
 		return undefined;
 	},
+	toggleMarketplaceType: () => {
+		return undefined;
+	},
 } );

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { type Callback } from '@automattic/calypso-router';
 import page from '@automattic/calypso-router';
 import { A4A_MARKETPLACE_HOSTING_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -19,12 +18,10 @@ export const marketplaceContext: Callback = () => {
 
 export const marketplaceProductsContext: Callback = ( context, next ) => {
 	const { site_id, product_slug, purchase_type } = context.query;
-	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
 	const productBrand = context.params.brand;
 
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
-	const purchaseType =
-		isAutomatedReferrals && purchase_type === 'referral' ? 'referral' : 'regular';
+	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Products" path={ context.path } />
@@ -40,33 +37,40 @@ export const marketplaceProductsContext: Callback = ( context, next ) => {
 };
 
 export const marketplaceHostingContext: Callback = ( context, next ) => {
+	const { purchase_type } = context.query;
+	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
+
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Hosting" path={ context.path } />
-			<HostingOverview />
+			<HostingOverview defaultMarketplaceType={ purchaseType } />
 		</>
 	);
 	next();
 };
 
 export const marketplacePressableContext: Callback = ( context, next ) => {
+	const { purchase_type } = context.query;
+	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Hosting > Pressable" path={ context.path } />
-			<PressableOverview />
+			<PressableOverview defaultMarketplaceType={ purchaseType } />
 		</>
 	);
 	next();
 };
 
 export const marketplaceWpcomContext: Callback = ( context, next ) => {
+	const { purchase_type } = context.query;
+	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Hosting > WordPress.com" path={ context.path } />
-			<WpcomOverview />
+			<WpcomOverview defaultMarketplaceType={ purchaseType } />
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
@@ -1,19 +1,48 @@
+import { isEnabled } from '@automattic/calypso-config';
 import React, { ComponentType, useState } from 'react';
 import { MarketplaceTypeContext } from '../context';
 import { MarketplaceType } from '../types';
 
 type ContextProps = {
-	defaultMarketplaceType: MarketplaceType;
+	defaultMarketplaceType?: MarketplaceType;
 };
+
+const MARKETPLACE_TYPE_SESSION_STORAGE_KEY = 'marketplace-type';
 
 function withMarketplaceType< T >(
 	WrappedComponent: ComponentType< T & ContextProps >
 ): ComponentType< T & ContextProps > {
 	return ( props ) => {
-		const [ marketplaceType, setMarketplaceType ] = useState( props.defaultMarketplaceType );
+		const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
+		const usedMarketplaceType =
+			props.defaultMarketplaceType ??
+			( sessionStorage.getItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY ) as MarketplaceType ) ??
+			'regular';
+
+		const defaultType = isAutomatedReferrals ? usedMarketplaceType : 'regular';
+		const [ marketplaceType, setMarketplaceType ] = useState( defaultType );
+
+		const updateMarketplaceType = ( type: MarketplaceType ) => {
+			sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, type );
+			setMarketplaceType( type );
+		};
+
+		const toggleMarketplaceType = () => {
+			if ( ! isAutomatedReferrals ) {
+				return;
+			}
+			const nextType = marketplaceType === 'regular' ? 'referral' : 'regular';
+			updateMarketplaceType( nextType );
+		};
 
 		return (
-			<MarketplaceTypeContext.Provider value={ { marketplaceType, setMarketplaceType } }>
+			<MarketplaceTypeContext.Provider
+				value={ {
+					marketplaceType,
+					setMarketplaceType: updateMarketplaceType,
+					toggleMarketplaceType,
+				} }
+			>
 				<WrappedComponent { ...props } />
 			</MarketplaceTypeContext.Provider>
 		);

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -1,6 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import { Gridicon } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -13,13 +17,17 @@ import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { MarketplaceTypeContext } from '../context';
+import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import HostingList from './hosting-list';
 
-export default function Hosting() {
+function Hosting() {
+	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
 	const translate = useTranslate();
 
+	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
 	const { selectedCartItems, onRemoveCartItem, showCart, setShowCart, toggleCart } =
 		useShoppingCart();
 
@@ -45,8 +53,19 @@ export default function Hosting() {
 						] }
 					/>
 
-					<Actions>
+					<Actions className="a4a-marketplace__header-actions">
 						<MobileSidebarNavigation />
+						{ isAutomatedReferrals && (
+							<div className="a4a-marketplace__toggle-marketplace-type">
+								<ToggleControl
+									onChange={ toggleMarketplaceType }
+									checked={ marketplaceType === 'referral' }
+									id="a4a-marketplace__toggle-marketplace-type"
+									label={ translate( 'Refer products' ) }
+								/>
+								<Gridicon icon="info-outline" size={ 16 } />
+							</div>
+						) }
 						<ShoppingCart
 							showCart={ showCart }
 							setShowCart={ setShowCart }
@@ -67,3 +86,5 @@ export default function Hosting() {
 		</Layout>
 	);
 }
+
+export default withMarketplaceType( Hosting );

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -20,6 +20,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingOverview from '../common/hosting-overview';
+import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import PressableOverviewFeatures from './footer';
@@ -27,7 +28,7 @@ import PressableOverviewPlanSelection from './plan-selection';
 
 import './style.scss';
 
-export default function PressableOverview() {
+function PressableOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -131,3 +132,5 @@ export default function PressableOverview() {
 		</Layout>
 	);
 }
+
+export default withMarketplaceType( PressableOverview );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -42,7 +42,7 @@ function ProductsOverview( { siteId, suggestedProduct, productBrand }: Props ) {
 
 	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
 	const [ selectedSite, setSelectedSite ] = useState< SiteDetails | null | undefined >( null );
-	const { marketplaceType, setMarketplaceType } = useContext( MarketplaceTypeContext );
+	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
 
 	const {
 		selectedCartItems,
@@ -54,14 +54,6 @@ function ProductsOverview( { siteId, suggestedProduct, productBrand }: Props ) {
 	} = useShoppingCart();
 
 	const { isLoading } = useProductsQuery();
-
-	const toggleMarketplaceType = () => {
-		if ( ! isAutomatedReferrals ) {
-			return;
-		}
-		const nextType = marketplaceType === 'regular' ? 'referral' : 'regular';
-		setMarketplaceType( nextType );
-	};
 
 	const sites = useSelector( getSites );
 

--- a/client/a8c-for-agencies/sections/marketplace/types.ts
+++ b/client/a8c-for-agencies/sections/marketplace/types.ts
@@ -15,6 +15,7 @@ export interface ShoppingCartContext {
 export interface MarketplaceTypeContext {
 	marketplaceType: MarketplaceType;
 	setMarketplaceType: ( value: MarketplaceType ) => void;
+	toggleMarketplaceType: () => void;
 }
 
 export interface AssignLicenseProps {

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -31,6 +31,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingOverview from '../common/hosting-overview';
 import HostingOverviewFeatures from '../common/hosting-overview-features';
+import withMarketplaceType from '../hoc/with-marketplace-type';
 import useProductAndPlans from '../hooks/use-product-and-plans';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { getWPCOMCreatorPlan } from '../lib/hosting';
@@ -42,7 +43,7 @@ import WPCOMPlanCard from './wpcom-card';
 
 import './style.scss';
 
-export default function WpcomOverview() {
+function WpcomOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -234,3 +235,5 @@ export default function WpcomOverview() {
 		</Layout>
 	);
 }
+
+export default withMarketplaceType( WpcomOverview );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-genesis/issues/362

## Proposed Changes

Similar to https://github.com/Automattic/wp-calypso/pull/91027 we are adding a toggle to refer products on hosting page. Note, I will address wpcom and pressable pages separately to avoid making this PR too big.
Some additional changes:
- Moved some logic into `with-marketplace-type` HOC to reduce duplications.
- Added `marketplaceType` to `sessionStorage` to make experience more consistent through the pages. @jeffgolenski @madebynoam let me know if it was not desired.


https://github.com/Automattic/wp-calypso/assets/60262784/5c2c9e84-e5aa-468b-ac7b-718ff2865b38


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-Navigate to /marketplace/hosting/ and check the toggle and it's behavior.
- Navigate to /marketplace/hosting?purchase_type=referral, you should be immediately in referral mode.
- Check for consistent behavior throughout.
- Check that with flag disabled flags=-a4a-automated-referrals Marketplace acts as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
