### PR TITLE
Site Profiler: Add Performance Metrics hook

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -99,6 +99,17 @@ export interface UrlBasicMetricsQueryResponse {
 	token: string;
 }
 
+export interface UrlPerformanceMetricsQueryResponse {
+	webtestpage_org: {
+		report: {
+			audits: {
+				health: object;
+				performance: object;
+			};
+		};
+	};
+}
+
 export interface BasicMetricsResult extends Omit< UrlBasicMetricsQueryResponse, 'basic' > {
 	basic: BasicMetricsScored;
 }

--- a/client/data/site-profiler/use-url-performance-metrics-query.ts
+++ b/client/data/site-profiler/use-url-performance-metrics-query.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { UrlPerformanceMetricsQueryResponse } from './types';
+
+function mapResult( response: UrlPerformanceMetricsQueryResponse ) {
+	return response.webtestpage_org.report.audits;
+}
+
+export const useUrlPerformanceMetricsQuery = ( url?: string, hash?: string ) => {
+	return useQuery( {
+		queryKey: [ 'url-', url, hash ],
+		queryFn: () =>
+			wp.req.get(
+				{
+					path: '/site-profiler/metrics/advanced/performance',
+					apiNamespace: 'wpcom/v2',
+				},
+				{ url, hash }
+			),
+		meta: {
+			persist: false,
+		},
+		select: mapResult,
+		enabled: !! url,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};


### PR DESCRIPTION
## Proposed Changes

Add the Performance Metrics hook.

## Why are these changes being made?

To be used by the Performance Sections on the Site Profiler v2

## Testing Instructions

All tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?