### PR TITLE
Add typekit to CSP policy. #88482

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -502,10 +502,18 @@ function setUpCSP( req, res, next ) {
 			'https://appleid.cdn-apple.com',
 			`'nonce-${ req.context.inlineScriptNonce }'`,
 			'www.google-analytics.com',
+			'use.typekit.net',
 			...inlineScripts.map( ( hash ) => `'${ hash }'` ),
 		],
 		'base-uri': [ "'none'" ],
-		'style-src': [ "'self'", '*.wp.com', 'https://fonts.googleapis.com' ],
+		'style-src': [
+			"'self'",
+			'*.wp.com',
+			'https://fonts.googleapis.com',
+			'use.typekit.net',
+			// per https://helpx.adobe.com/ca/fonts/using/content-security-policy.html
+			"'unsafe-inline'",
+		],
 		'form-action': [ "'self'" ],
 		'object-src': [ "'none'" ],
 		'img-src': [
@@ -518,6 +526,7 @@ function setUpCSP( req, res, next ) {
 			'https://amplifypixel.outbrain.com',
 			'https://img.youtube.com',
 			'localhost:8888',
+			'p.typekit.net',
 		],
 		'frame-src': [
 			"'self'",
@@ -529,6 +538,7 @@ function setUpCSP( req, res, next ) {
 			"'self'",
 			'*.wp.com',
 			'https://fonts.gstatic.com',
+			'use.typekit.net',
 			'data:', // should remove 'data:' ASAP
 		],
 		'media-src': [ "'self'" ],


### PR DESCRIPTION
Related to #88482

## Proposed Changes

*

## Why are these changes being made?
This one was pretty annoying - it spammed up the dev console, and did 50+ http requests every time you looked at the login page.  This just implements the typekit CSP policy [requirements](https://helpx.adobe.com/ca/fonts/using/content-security-policy.html) per Adobe.  unsafe-inline is obviously not the best option, however given the report-only policy was added about 6 years ago and hasn't changed since I don't think it's a big deal.

## Testing Instructions

* Load the login page, verify that you aren't getting a bunch of CSP reports

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [n/a] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [n/a] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [n/a] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
