### PR TITLE
Segmentation Survey: Clear answers after the Trial Acknowledge step and minor fixes

### DIFF
--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -95,9 +95,11 @@ const SegmentationSurvey = ( {
 
 	const onSkip = useCallback(
 		async ( currentQuestion: Question ) => {
+			// Clear the answer for the current question and save the skip answer.
+			onChangeAnswer( currentQuestion.key, [] );
 			await handleSave( currentQuestion, [ SKIP_ANSWER_KEY ] );
 		},
-		[ handleSave ]
+		[ handleSave, onChangeAnswer ]
 	);
 
 	const { currentPage, currentQuestion, backToPreviousPage, continueToNextPage, skipToNextPage } =

--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -21,6 +21,7 @@ type SegmentationSurveyProps = {
 	headerAlign?: string;
 	questionConfiguration?: QuestionConfiguration;
 	questionComponentMap?: QuestionComponentMap;
+	clearAnswersOnLastQuestion?: boolean;
 };
 
 /**
@@ -29,6 +30,10 @@ type SegmentationSurveyProps = {
  * @param {string} props.surveyKey - The key of the survey to render.
  * @param {() => void} [props.onBack] - A function that navigates to the previous step.
  * @param {(questionKey: string, answerKeys: string[], isLastQuestion?: boolean) => void} [props.onNext] - A function that navigates to the next question/step.
+ * @param {string} [props.headerAlign] - The alignment of the header text.
+ * @param {QuestionConfiguration} [props.questionConfiguration] - The configuration for the questions.
+ * @param {QuestionComponentMap} [props.questionComponentMap] - A map of question types to components.
+ * @param {boolean} [props.clearAnswersOnLastQuestion] - Whether to clear the answers after the last question.
  * @returns {React.ReactComponentElement}
  */
 const SegmentationSurvey = ( {
@@ -39,6 +44,7 @@ const SegmentationSurvey = ( {
 	headerAlign,
 	questionConfiguration,
 	questionComponentMap,
+	clearAnswersOnLastQuestion = true,
 }: SegmentationSurveyProps ) => {
 	const { data: questions } = useSurveyStructureQuery( { surveyKey } );
 	const { mutateAsync, isPending } = useSaveAnswersMutation( { surveyKey } );
@@ -62,7 +68,7 @@ const SegmentationSurvey = ( {
 
 				const isLastQuestion = questions?.[ questions.length - 1 ].key === currentQuestion.key;
 
-				if ( questions?.[ questions.length - 1 ].key === currentQuestion.key ) {
+				if ( clearAnswersOnLastQuestion && isLastQuestion ) {
 					clearAnswers();
 				}
 
@@ -78,7 +84,7 @@ const SegmentationSurvey = ( {
 				} );
 			}
 		},
-		[ clearAnswers, mutateAsync, onNext, questions, surveyKey ]
+		[ clearAnswers, clearAnswersOnLastQuestion, mutateAsync, onNext, questions, surveyKey ]
 	);
 
 	const onContinue = useCallback(

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -48,6 +48,7 @@ const entrepreneurFlow: Flow = {
 
 		const locale = useFlowLocale();
 		const [ isMigrationFlow, setIsMigrationFlow ] = useState( false );
+		const { clearAnswers } = useCachedAnswers( ENTREPRENEUR_TRIAL_SURVEY_KEY );
 
 		const getEntrepreneurLoginUrl = () => {
 			const redirectTo = `${ window.location.protocol }//${ window.location.host }/setup/entrepreneur/trialAcknowledge${ window.location.search }`;
@@ -84,6 +85,9 @@ const entrepreneurFlow: Flow = {
 				}
 
 				case STEPS.TRIAL_ACKNOWLEDGE.slug: {
+					// After the trial acknowledge step, the answers from the segmentation survey are cleared.
+					clearAnswers();
+
 					return navigate( STEPS.SITE_CREATION_STEP.slug );
 				}
 

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -2,7 +2,7 @@ import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import { ENTREPRENEUR_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState } from 'react';
-import { anonIdCache } from 'calypso/data/segmentaton-survey';
+import { anonIdCache, useCachedAnswers } from 'calypso/data/segmentaton-survey';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useFlowLocale } from '../hooks/use-flow-locale';
@@ -11,6 +11,7 @@ import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
+import { ENTREPRENEUR_TRIAL_SURVEY_KEY } from './internals/steps-repository/segmentation-survey';
 import type { Flow, ProvidedDependencies } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
 
@@ -48,6 +49,7 @@ const entrepreneurFlow: Flow = {
 
 		const locale = useFlowLocale();
 		const [ isMigrationFlow, setIsMigrationFlow ] = useState( false );
+		const [ lastQuestionPath, setlastQuestionPath ] = useState( '#2' );
 		const { clearAnswers } = useCachedAnswers( ENTREPRENEUR_TRIAL_SURVEY_KEY );
 
 		const getEntrepreneurLoginUrl = () => {
@@ -74,6 +76,10 @@ const entrepreneurFlow: Flow = {
 			switch ( currentStep ) {
 				case SEGMENTATION_SURVEY_SLUG: {
 					setIsMigrationFlow( !! providedDependencies.isMigrationFlow );
+
+					if ( providedDependencies.lastQuestionPath ) {
+						setlastQuestionPath( providedDependencies.lastQuestionPath as string );
+					}
 
 					if ( userIsLoggedIn ) {
 						return navigate( STEPS.TRIAL_ACKNOWLEDGE.slug );

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -49,7 +49,7 @@ const entrepreneurFlow: Flow = {
 
 		const locale = useFlowLocale();
 		const [ isMigrationFlow, setIsMigrationFlow ] = useState( false );
-		const [ lastQuestionPath, setlastQuestionPath ] = useState( '#2' );
+		const [ lastQuestionPath, setlastQuestionPath ] = useState( '#1' );
 		const { clearAnswers } = useCachedAnswers( ENTREPRENEUR_TRIAL_SURVEY_KEY );
 
 		const getEntrepreneurLoginUrl = () => {
@@ -66,7 +66,7 @@ const entrepreneurFlow: Flow = {
 
 		const goBack = () => {
 			if ( currentStep === STEPS.TRIAL_ACKNOWLEDGE.slug ) {
-				navigate( SEGMENTATION_SURVEY_SLUG + ( isMigrationFlow ? '#1' : lastQuestionPath ) );
+				navigate( SEGMENTATION_SURVEY_SLUG + lastQuestionPath );
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -66,7 +66,7 @@ const entrepreneurFlow: Flow = {
 
 		const goBack = () => {
 			if ( currentStep === STEPS.TRIAL_ACKNOWLEDGE.slug ) {
-				navigate( SEGMENTATION_SURVEY_SLUG + '#2' );
+				navigate( SEGMENTATION_SURVEY_SLUG + ( isMigrationFlow ? '#1' : lastQuestionPath ) );
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -65,6 +65,7 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 				onBack={ navigation.goBack }
 				onNext={ handleNext }
 				headerAlign="left"
+				clearAnswersOnLastQuestion={ false }
 			/>
 		</Main>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -15,14 +15,16 @@ type NavigationDecision = {
 	providedDependencies: ProvidedDependencies;
 };
 
+const checkMigrationAnswer = ( questionKey: string, answerKeys: string[] ): boolean =>
+	questionKey === WHAT_WOULD_YOU_LIKE_TO_DO_QUESTION_KEY &&
+	answerKeys.includes( MIGRATE_MY_STORE_ANSWER_KEY );
+
 const useShouldNavigate = () => {
 	const hash = useHash();
 
 	const shouldNavigate = useCallback(
 		( questionKey: string, answerKeys: string[], isLastQuestion?: boolean ): NavigationDecision => {
-			const isMigrationFlow =
-				questionKey === WHAT_WOULD_YOU_LIKE_TO_DO_QUESTION_KEY &&
-				answerKeys.includes( MIGRATE_MY_STORE_ANSWER_KEY );
+			const isMigrationFlow = checkMigrationAnswer( questionKey, answerKeys );
 
 			const proceedWithNavigation = isLastQuestion || isMigrationFlow;
 			const providedDependencies: ProvidedDependencies = { isMigrationFlow };
@@ -79,6 +81,7 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 				onNext={ handleNext }
 				headerAlign="left"
 				clearAnswersOnLastQuestion={ false }
+				skipNextNavigation={ checkMigrationAnswer }
 			/>
 		</Main>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -48,11 +48,6 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 		);
 
 		if ( proceedWithNavigation ) {
-			// For custom navigation, we need to clear the answers before the last question
-			if ( ! isLastQuestion ) {
-				clearAnswers();
-			}
-
 			recordCompleteEvent();
 			navigation.submit?.( providedDependencies );
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/segmentation-survey/index.tsx
@@ -1,12 +1,12 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import Main from 'calypso/components/main';
 import SegmentationSurvey from 'calypso/components/segmentation-survey';
 import useSegmentationSurveyTracksEvents from 'calypso/components/segmentation-survey/hooks/use-segmentation-survey-tracks-events';
-import { useCachedAnswers } from 'calypso/data/segmentaton-survey';
+import { useHash } from 'calypso/landing/stepper/hooks/use-hash';
 import type { ProvidedDependencies, Step } from '../../types';
 import './style.scss';
 
-const SURVEY_KEY = 'entrepreneur-trial';
+export const ENTREPRENEUR_TRIAL_SURVEY_KEY = 'entrepreneur-trial';
 const WHAT_WOULD_YOU_LIKE_TO_DO_QUESTION_KEY = 'what-would-you-like-to-do';
 const MIGRATE_MY_STORE_ANSWER_KEY = 'migrate-my-store';
 
@@ -15,24 +15,42 @@ type NavigationDecision = {
 	providedDependencies: ProvidedDependencies;
 };
 
-const shouldNavigate = (
-	questionKey: string,
-	answerKeys: string[],
-	isLastQuestion?: boolean
-): NavigationDecision => {
-	const isMigrationFlow =
-		questionKey === WHAT_WOULD_YOU_LIKE_TO_DO_QUESTION_KEY &&
-		answerKeys.includes( MIGRATE_MY_STORE_ANSWER_KEY );
+const useShouldNavigate = () => {
+	const hash = useHash();
 
-	return {
-		proceedWithNavigation: isLastQuestion || isMigrationFlow,
-		providedDependencies: { isMigrationFlow },
-	};
+	const shouldNavigate = useCallback(
+		( questionKey: string, answerKeys: string[], isLastQuestion?: boolean ): NavigationDecision => {
+			const isMigrationFlow =
+				questionKey === WHAT_WOULD_YOU_LIKE_TO_DO_QUESTION_KEY &&
+				answerKeys.includes( MIGRATE_MY_STORE_ANSWER_KEY );
+
+			const proceedWithNavigation = isLastQuestion || isMigrationFlow;
+			const providedDependencies: ProvidedDependencies = { isMigrationFlow };
+
+			if ( proceedWithNavigation ) {
+				const lastQuestionPath = hash;
+
+				if ( lastQuestionPath ) {
+					providedDependencies.lastQuestionPath = lastQuestionPath;
+				}
+			}
+
+			return {
+				proceedWithNavigation,
+				providedDependencies,
+			};
+		},
+		[ hash ]
+	);
+
+	return { shouldNavigate };
 };
 
 const SegmentationSurveyStep: Step = ( { navigation } ) => {
-	const { recordStartEvent, recordCompleteEvent } = useSegmentationSurveyTracksEvents( SURVEY_KEY );
-	const { clearAnswers } = useCachedAnswers( SURVEY_KEY );
+	const { recordStartEvent, recordCompleteEvent } = useSegmentationSurveyTracksEvents(
+		ENTREPRENEUR_TRIAL_SURVEY_KEY
+	);
+	const { shouldNavigate } = useShouldNavigate();
 
 	// Record Tracks start event on component mount
 	useEffect( () => {
@@ -56,7 +74,7 @@ const SegmentationSurveyStep: Step = ( { navigation } ) => {
 	return (
 		<Main className="segmentation-survey-step">
 			<SegmentationSurvey
-				surveyKey={ SURVEY_KEY }
+				surveyKey={ ENTREPRENEUR_TRIAL_SURVEY_KEY }
 				onBack={ navigation.goBack }
 				onNext={ handleNext }
 				headerAlign="left"

--- a/client/my-sites/plans/trials/trial-acknowledge/entrepreneur-acknowledge.tsx
+++ b/client/my-sites/plans/trials/trial-acknowledge/entrepreneur-acknowledge.tsx
@@ -46,6 +46,7 @@ const CallToAction = ( { onStartTrialClick, CTAButtonState }: TrialAcknowledgePr
 				<EmailVerification isSending={ isSending } email={ email } resendEmail={ resendEmail } />
 			) }
 			<NextButton
+				className="entrepreneur-trial-acknowledge__cta"
 				isBusy={ CTAButtonState?.isBusy ?? false }
 				onClick={ startTrial }
 				disabled={ ( ! isVerified || CTAButtonState?.disabled ) ?? false }

--- a/client/my-sites/plans/trials/trial-acknowledge/style.scss
+++ b/client/my-sites/plans/trials/trial-acknowledge/style.scss
@@ -1,3 +1,4 @@
+@import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/onboarding/styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
@@ -139,4 +140,26 @@
 
 .popover.info-popover__tooltip--trial-plan .popover__inner {
 	max-width: 280px;
+}
+
+$blueberry-color: #3858e9;
+$dark-blueberry-color: #2145e6;
+$blueberry-focus-color: #abc0f5;
+
+.entrepreneur button.entrepreneur-trial-acknowledge__cta {
+	background-color: $blueberry-color;
+	border-color: $blueberry-color;
+
+	&:not(:disabled) {
+		&:hover,
+		&:focus,
+		&:active {
+			background-color: $dark-blueberry-color;
+			border-color: $dark-blueberry-color;
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 1px $studio-white, 0 0 0 0.5px $blueberry-color;
+		}
+	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/91117

## Proposed Changes

* Clear answers after the Trial Acknowledge step
  * Add clearAnswersOnLastQuestion prop to the SegmentationSurvey component
* Return to the correct question when clicking Back at the Trial Acknowledge step
  * Pass the lastQuestionPath to the flow navigation

Additionally, two minor fixes were implemented:
* Clear previously selected answers from a question when skipping it
* Change CTA color on Trial Acknowledge step to match previous button colors

## Why are these changes being made?

* While adding the Trial Acknowledge step, an issue was noticed when returning to the previous step. The answers were cleaned, but it would be expected for the user to see them.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local
* Go to http://calypso.localhost:3000/setup/entrepreneur

**Testing answers persistency, back navigation, and CTA color**
* Answer the two questions from the survey (do not select "Migrate my store" on the first question)
* After submitting the second question, you should see the Trial Acknowledge step
* Check if the CTA button color matches the Continue button from the Survey step
* Click on the Back button
* You should go back to the second question, and the previously selected answers should be selected

**Testing "Migrate my store" scenario**
* Restart the test, now selecting the "Migrate my store" on the first question
* You should be redirected to the Trial Acknowledge step
* Click on the Back button
* You should go back to the first question, and the previously selected answer should be selected

**Testing Skip scenario**
* Restart the test, select an answer on the first question
* Click Continue
* Go back to the first question
* Click Skip
* Then again, go back to the first question
* No previously select answer should be selected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
