### PR TITLE
Scheduled Updates: Fix sidebar menu glitch

### DIFF
--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -1,6 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { isWithinBreakpoint } from '@automattic/viewport';
-import isScheduledUpdatesMultisiteRoute from 'calypso/state/selectors/is-scheduled-updates-multisite-route';
+import isScheduledUpdatesMultisiteRoute, {
+	isScheduledUpdatesMultisiteCreateRoute,
+	isScheduledUpdatesMultisiteEditRoute,
+} from 'calypso/state/selectors/is-scheduled-updates-multisite-route';
 import { isGlobalSiteViewEnabled } from '../sites/selectors';
 import type { AppState } from 'calypso/types';
 
@@ -91,8 +94,8 @@ export const getShouldShowCollapsedGlobalSidebar = (
 		] );
 
 	const isPluginsScheduledUpdatesEditMode =
-		! siteId &&
-		isInRoute( state, [ '/plugins/scheduled-updates/edit', '/plugins/scheduled-updates/create' ] );
+		isScheduledUpdatesMultisiteCreateRoute( state ) ||
+		isScheduledUpdatesMultisiteEditRoute( state );
 
 	const isBulkDomainsDashboard = isInRoute( state, [ '/domains/manage' ] );
 	const isSmallScreenDashboard =
@@ -113,8 +116,12 @@ export const getShouldShowUnifiedSiteSidebar = (
 	sectionName: string
 ) => {
 	return (
-		isGlobalSiteViewEnabled( state, siteId ) &&
-		sectionGroup === 'sites' &&
-		! shouldShowGlobalSiteDashboard( state, siteId, sectionName )
+		( isGlobalSiteViewEnabled( state, siteId ) &&
+			sectionGroup === 'sites' &&
+			sectionName !== 'plugins' &&
+			! shouldShowGlobalSiteDashboard( state, siteId, sectionName ) ) ||
+		( isGlobalSiteViewEnabled( state, siteId ) &&
+			sectionName === 'plugins' &&
+			! isScheduledUpdatesMultisiteRoute( state ) )
 	);
 };

--- a/client/state/selectors/is-scheduled-updates-multisite-route.js
+++ b/client/state/selectors/is-scheduled-updates-multisite-route.js
@@ -1,5 +1,41 @@
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
+export function isScheduledUpdatesMultisiteBaseRoute( state ) {
+	const route = getCurrentRoute( state );
+
+	if ( ! route ) {
+		return false;
+	}
+
+	const RGX = /^\/plugins\/scheduled-updates\/?$/;
+
+	return RGX.test( route );
+}
+
+export function isScheduledUpdatesMultisiteCreateRoute( state ) {
+	const route = getCurrentRoute( state );
+
+	if ( ! route ) {
+		return false;
+	}
+
+	const RGX = /^\/plugins\/scheduled-updates\/create\/?$/;
+
+	return RGX.test( route );
+}
+
+export function isScheduledUpdatesMultisiteEditRoute( state ) {
+	const route = getCurrentRoute( state );
+
+	if ( ! route ) {
+		return false;
+	}
+
+	const RGX = /^\/plugins\/scheduled-updates\/edit\/[a-f0-9]+-(daily|weekly)-\d+-\d{2}:\d{2}\/?$/;
+
+	return RGX.test( route );
+}
+
 /**
  * Returns true if the current route is a scheduled updates multisite route.
  * @param {Object} state Global state tree
@@ -12,10 +48,9 @@ export default function isScheduledUpdatesMultisiteRoute( state ) {
 		return false;
 	}
 
-	const rgxMsBase = /^\/plugins\/scheduled-updates\/?$/;
-	const rgxMsCreate = /^\/plugins\/scheduled-updates\/create\/?$/;
-	const rgxMsEdit =
-		/^\/plugins\/scheduled-updates\/edit\/[a-f0-9]+-(daily|weekly)-\d+-\d{2}:\d{2}\/?$/;
-
-	return rgxMsBase.test( route ) || rgxMsCreate.test( route ) || rgxMsEdit.test( route );
+	return (
+		isScheduledUpdatesMultisiteBaseRoute( state ) ||
+		isScheduledUpdatesMultisiteCreateRoute( state ) ||
+		isScheduledUpdatesMultisiteEditRoute( state )
+	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/91179

## Proposed Changes

* Fixes sidebar menu glitch

## Testing Instructions

* Go to `/sites`
* Select any atomic site
* Then, click on the "Plugins" item
* Check if the sidebar has the proper width

| Before | After |
|--------|--------|
| <img width="333" alt="Screenshot 2024-05-28 at 10 22 08" src="https://github.com/Automattic/wp-calypso/assets/1241413/74b65c44-9c67-421a-9c1f-b8396660b4f4"> | <img width="473" alt="Screenshot 2024-05-28 at 10 22 22" src="https://github.com/Automattic/wp-calypso/assets/1241413/3ddf1ea7-b0a7-482e-83f1-223afe99e287"> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
