### PR TITLE
StepperMigration: Fixes user already logged in state complexity and other related fixes

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -40,10 +40,11 @@ function ContinueAsUser( {
 	currentUser,
 	redirectUrlFromQuery,
 	onChangeAccount,
-	redirectPath,
+	redirectPath = '',
 	isSignUpFlow,
 	isWooOAuth2Client,
 	isWooPasswordless,
+	onContinue,
 } ) {
 	const translate = useTranslate();
 	const { url: validatedRedirectUrlFromQuery, loading: validatingQueryURL } =
@@ -164,13 +165,19 @@ function ContinueAsUser( {
 		<div className="continue-as-user">
 			<div className="continue-as-user__user-info">
 				{ gravatarLink }
-				<Button
-					busy={ isLoading }
-					primary
-					href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
-				>
-					{ translate( 'Continue' ) }
-				</Button>
+				{ onContinue ? (
+					<Button busy={ isLoading } primary onClick={ onContinue }>
+						{ translate( 'Continue' ) }
+					</Button>
+				) : (
+					<Button
+						busy={ isLoading }
+						primary
+						href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
+					>
+						{ translate( 'Continue' ) }
+					</Button>
+				) }
 			</div>
 			<div className="continue-as-user__not-you">{ notYouText }</div>
 		</div>

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -40,11 +40,10 @@ function ContinueAsUser( {
 	currentUser,
 	redirectUrlFromQuery,
 	onChangeAccount,
-	redirectPath = '',
+	redirectPath,
 	isSignUpFlow,
 	isWooOAuth2Client,
 	isWooPasswordless,
-	onContinue,
 } ) {
 	const translate = useTranslate();
 	const { url: validatedRedirectUrlFromQuery, loading: validatingQueryURL } =
@@ -165,19 +164,13 @@ function ContinueAsUser( {
 		<div className="continue-as-user">
 			<div className="continue-as-user__user-info">
 				{ gravatarLink }
-				{ onContinue ? (
-					<Button busy={ isLoading } primary onClick={ onContinue }>
-						{ translate( 'Continue' ) }
-					</Button>
-				) : (
-					<Button
-						busy={ isLoading }
-						primary
-						href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
-					>
-						{ translate( 'Continue' ) }
-					</Button>
-				) }
+				<Button
+					busy={ isLoading }
+					primary
+					href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
+				>
+					{ translate( 'Continue' ) }
+				</Button>
 			</div>
 			<div className="continue-as-user__not-you">{ notYouText }</div>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/user/index.tsx
@@ -1,4 +1,5 @@
 import { StepContainer } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
@@ -63,6 +64,8 @@ const StepContent: Step = ( { flow, stepName, navigation } ) => {
 };
 
 const UserStep: Step = function UserStep( props ) {
+	const translate = useTranslate();
+
 	return (
 		<StepContainer
 			stepName="user"
@@ -72,11 +75,21 @@ const UserStep: Step = function UserStep( props ) {
 			isHorizontalLayout={ false }
 			isWideLayout={ false }
 			isFullLayout
-			hideFormattedHeader
 			isLargeSkipLayout={ false }
-			hideBack={ false }
+			hideBack
 			stepContent={ <StepContent { ...props } /> }
 			recordTracksEvent={ recordTracksEvent }
+			customizedActionButtons={
+				<Button
+					className="step-wrapper__navigation-link forward"
+					href={ login( {
+						signupUrl: window.location.pathname + window.location.search,
+					} ) }
+					variant="link"
+				>
+					<span>{ translate( 'Log in' ) }</span>
+				</Button>
+			}
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/user/index.tsx
@@ -1,11 +1,16 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { AnyAction } from 'redux';
+import ContinueAsUser from 'calypso/blocks/login/continue-as-user';
 import SignupFormSocialFirst from 'calypso/blocks/signup-form/signup-form-social-first';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import { login } from 'calypso/lib/paths';
 import { useSelector } from 'calypso/state';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { Step } from '../../types';
 
@@ -15,10 +20,27 @@ const StepContent: Step = ( { flow, stepName, navigation } ) => {
 	const { submit } = navigation;
 	const socialService = getSocialServiceFromClientId( '' );
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isStepSubmittedOnce = useRef( false );
 
 	if ( isLoggedIn ) {
+		if ( isStepSubmittedOnce.current ) {
+			return (
+				<ContinueAsUser
+					onContinue={ () => submit?.() }
+					onChangeAccount={ () => {
+						dispatch( redirectToLogout( window.location.href ) as unknown as AnyAction );
+					} }
+					isSignUpFlow
+					isWooOAuth2Client={ false }
+				/>
+			);
+		}
+		isStepSubmittedOnce.current = true;
 		submit?.();
+	} else {
+		isStepSubmittedOnce.current = false;
 	}
 
 	return (
@@ -32,7 +54,10 @@ const StepContent: Step = ( { flow, stepName, navigation } ) => {
 				logInUrl={ login( {
 					signupUrl: window.location.pathname + window.location.search,
 				} ) }
-				handleSocialResponse={ () => submit?.() }
+				handleSocialResponse={ () => {
+					isStepSubmittedOnce.current = true;
+					submit?.();
+				} }
 				socialService={ socialService ?? '' }
 				socialServiceResponse={ {} }
 				isReskinned

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/user/style.scss
@@ -1,5 +1,8 @@
 @import "calypso/signup/style.scss";
-
+body.is-section-stepper .step-route {
+	--color-accent: #117ac9;
+	--color-accent-60: #0e64a5;
+}
 
 .step-container.user {
 	display: flex;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/user/style.scss
@@ -4,13 +4,33 @@ body.is-section-stepper .step-route {
 	--color-accent-60: #0e64a5;
 }
 
-.step-container.user {
+
+.step-route.user {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
 	min-height: calc(100vh - 96px);
 	margin: 48px 0 0;
+
+	a.step-wrapper__navigation-link {
+		color: #1d2327;
+		font-family: "SF Pro Text", sans-serif;
+		font-size: 0.875rem;
+		font-style: normal;
+		font-weight: 500;
+		line-height: 20px;
+		text-underline-offset: 5px;
+		margin-left: auto;
+	}
+
+	.signup-header .wordpress-logo {
+		position: absolute;
+		inset-inline-start: 20px;
+		inset-block-start: 20px;
+		fill: var(--color-text);
+		transform-origin: 0 0;
+	}
 	.formatted-header__title {
 		line-height: 3.25;
 		font-size: 2rem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

- Resolve the logged in user once logged in or on load so that the step submits if the user step is not required
- Fixes colour issues
- Adds login navigation button

<img width="500" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/4b80c5fe-74c9-4d3a-8040-b4e907dcae8c">



## Why are these changes being made?
* Bug raised by @niranjan-uma-shankar 
> 5. The header on the email step is missing the [logo and log-in link](https://href.li/?![mUeqhe.png](https://github.com/Automattic/wp-calypso/assets/3422709/41c3e8d5-4769-4818-947f-8abbaa62ccda)). The color scheme of the create account button seems different from the one in other Stepper flows.
> 7. I tried creating an account with Google sign-in and after registration, was taken to the plans step. At this point, when I went to wordpress.com, there was no account created – I was redirected to the LOHP when I was expecting to be taken to the logged-in Calypso page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/new-site-hosting-user-included`
* Above screenshot should be visible (WP Logo and login link on the header)
* On clicking the email login the button should be blue

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?