### PR TITLE
A4A > Referrals: Implement purchases view in referral details

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -29,6 +29,8 @@ export default function ItemPreviewPaneHeader( {
 	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
 	const size = isLargerThan960px ? 64 : 50;
 
+	const isSiteData = itemData?.isSiteData ?? true;
+
 	const focusRef = useRef< HTMLButtonElement >( null );
 
 	// Use useEffect to set the focus when the component mounts

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -29,8 +29,6 @@ export default function ItemPreviewPaneHeader( {
 	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
 	const size = isLargerThan960px ? 64 : 50;
 
-	const isSiteData = itemData?.isSiteData ?? true;
-
 	const focusRef = useRef< HTMLButtonElement >( null );
 
 	// Use useEffect to set the focus when the component mounts

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -111,7 +111,7 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 				paginationInfo={ data.pagination }
 				fields={ data.fields }
 				view={ data.dataViewsState }
-				search
+				search={ data?.search ?? true }
 				searchLabel={ data.searchLabel ?? translate( 'Search' ) }
 				getItemId={
 					data.getItemId ??

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -111,7 +111,7 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 				paginationInfo={ data.pagination }
 				fields={ data.fields }
 				view={ data.dataViewsState }
-				search
+				search={ data?.enableSearch ?? true }
 				searchLabel={ data.searchLabel ?? translate( 'Search' ) }
 				getItemId={
 					data.getItemId ??

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -111,7 +111,7 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 				paginationInfo={ data.pagination }
 				fields={ data.fields }
 				view={ data.dataViewsState }
-				search={ data?.search ?? true }
+				search
 				searchLabel={ data.searchLabel ?? translate( 'Search' ) }
 				getItemId={
 					data.getItemId ??

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 export interface ItemsDataViewsType< T > {
 	items: T[] | undefined;
 	pagination: DataViewsPaginationInfo;
+	search?: boolean;
 	searchLabel?: string;
 	fields: DataViewsColumn[];
 	actions?: DataViewsAction[];

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 export interface ItemsDataViewsType< T > {
 	items: T[] | undefined;
 	pagination: DataViewsPaginationInfo;
+	enableSearch?: boolean;
 	searchLabel?: string;
 	fields: DataViewsColumn[];
 	actions?: DataViewsAction[];

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces.ts
@@ -3,7 +3,6 @@ import { ReactNode } from 'react';
 export interface ItemsDataViewsType< T > {
 	items: T[] | undefined;
 	pagination: DataViewsPaginationInfo;
-	search?: boolean;
 	searchLabel?: string;
 	fields: DataViewsColumn[];
 	actions?: DataViewsAction[];

--- a/client/a8c-for-agencies/sections/referrals/common/referral-details-table/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/referral-details-table/index.tsx
@@ -1,5 +1,6 @@
-import { DATAVIEWS_TABLE } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
-import { DataViews } from 'calypso/components/dataviews';
+import { useState } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import type { ReferralPurchase } from '../../types';
 import type { DataViewsColumn } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 
@@ -12,28 +13,24 @@ interface Props {
 }
 
 export default function ReferralDetailsTable( { heading, items, fields }: Props ) {
+	const [ dataViewsState, setDataViewsState ] = useState( initialDataViewsState );
+
 	return (
 		<div className="referrals-details-table__container redesigned-a8c-table">
 			<div className="referrals-details-table__heading">{ heading }</div>
-			<DataViews
-				data={ items }
-				paginationInfo={ { totalItems: 1, totalPages: 1 } }
-				fields={ fields }
-				view={ {
-					filters: [],
-					sort: {
-						field: '',
-						direction: 'asc',
+			<ItemsDataViews
+				data={ {
+					items,
+					fields,
+					pagination: {
+						totalItems: 1,
+						totalPages: 1,
 					},
-					type: DATAVIEWS_TABLE,
-					perPage: 1,
-					page: 1,
-					hiddenFields: [],
-					layout: {},
+					enableSearch: false,
+					actions: [],
+					dataViewsState: dataViewsState,
+					setDataViewsState: setDataViewsState,
 				} }
-				search={ false }
-				supportedLayouts={ [ 'table' ] }
-				actions={ [] }
 			/>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/referrals/common/referral-details-table/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/referral-details-table/index.tsx
@@ -1,0 +1,40 @@
+import { DATAVIEWS_TABLE } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import { DataViews } from 'calypso/components/dataviews';
+import type { ReferralPurchase } from '../../types';
+import type { DataViewsColumn } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+
+import './style.scss';
+
+interface Props {
+	heading: string;
+	items: ReferralPurchase[]; // Update this when we have more types
+	fields: DataViewsColumn[];
+}
+
+export default function ReferralDetailsTable( { heading, items, fields }: Props ) {
+	return (
+		<div className="referrals-details-table__container redesigned-a8c-table">
+			<div className="referrals-details-table__heading">{ heading }</div>
+			<DataViews
+				data={ items }
+				paginationInfo={ { totalItems: 1, totalPages: 1 } }
+				fields={ fields }
+				view={ {
+					filters: [],
+					sort: {
+						field: '',
+						direction: 'asc',
+					},
+					type: DATAVIEWS_TABLE,
+					perPage: 1,
+					page: 1,
+					hiddenFields: [],
+					layout: {},
+				} }
+				search={ false }
+				supportedLayouts={ [ 'table' ] }
+				actions={ [] }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/common/referral-details-table/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/referral-details-table/style.scss
@@ -1,0 +1,22 @@
+
+.referrals-details-table__container {
+
+	.referrals-details-table__heading {
+		padding-block-end: 16px;
+		font-size: rem(20px);
+		font-weight: 500;
+	}
+
+	.dataviews-filters__view-actions {
+		display: none;
+	}
+
+	.dataviews-view-table {
+		border: 1px solid var(--color-neutral-5);
+		border-radius: 2px;
+	}
+
+	.dataviews-wrapper tr.dataviews-view-table__row:last-child td {
+		border-bottom: none;
+	}
+}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -5,6 +5,7 @@ import ItemPreviewPane, {
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import SubscriptionStatus from '../referrals-list/subscription-status';
 import ReferralCommissions from './commissions';
+import ReferralPurchases from './purchases';
 import type { Referral } from '../types';
 import type { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
 
@@ -50,7 +51,7 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				true,
 				selectedReferralTab,
 				setSelectedReferralTab,
-				'Purchases tab content'
+				<ReferralPurchases purchases={ referral.purchases } />
 			),
 			createFeaturePreview(
 				REFERRAL_COMMISSIONS_ID,

--- a/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
@@ -1,0 +1,87 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, ReactNode } from 'react';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import ReferralDetailsTable from '../common/referral-details-table';
+import StatusBadge from '../common/step-section-item/status-badge';
+import type { ReferralPurchase } from '../types';
+
+import './style.scss';
+
+export default function ReferralPurchases( { purchases }: { purchases: ReferralPurchase[] } ) {
+	const translate = useTranslate();
+
+	const { data, isFetching } = useProductsQuery();
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'product-details',
+				header: translate( 'Product Details' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
+					const product = data?.find( ( product ) => product.product_id === item.product_id );
+					return isFetching ? <TextPlaceholder /> : product?.name;
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'date',
+				header: translate( 'Date' ).toUpperCase(),
+				getValue: () => '-',
+				render: (): ReactNode => {
+					return ''; // FIXME: Add date when the data is available
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'assigned-to',
+				header: translate( 'Assigned to' ).toUpperCase(),
+				getValue: () => '-',
+				render: (): ReactNode => {
+					const isAssigned = false; // FIXME: Show the assigned site when the data is available
+					return isAssigned ? (
+						'Site Name'
+					) : (
+						<>
+							<StatusBadge
+								statusProps={ { children: translate( 'Unassigned' ), type: 'warning' } }
+							/>
+							{
+								// TODO: Implement assign to site functionality
+								<Button className="referrals-purchases__assign-button" borderless>
+									{ translate( 'Assign to site' ) }
+								</Button>
+							}
+						</>
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'total',
+				header: translate( 'Total' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
+					const product = data?.find( ( product ) => product.product_id === item.product_id );
+					return isFetching ? <TextPlaceholder /> : `$${ product?.amount }`;
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[ translate, isFetching, data ]
+	);
+
+	return (
+		<ReferralDetailsTable
+			heading={ translate( 'Purchases' ) }
+			items={ purchases }
+			fields={ fields }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
@@ -1,3 +1,11 @@
 .referral-details__subtitle {
 	margin-block-start: 16px;
 }
+
+.referrals-purchases__assign-button {
+	padding: 0;
+	position: relative;
+	top: -1px;
+	left: 8px;
+	text-decoration: underline;
+}

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -117,19 +117,21 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 	);
 
 	return (
-		<ItemsDataViews
-			data={ {
-				items: referrals,
-				pagination: {
-					totalItems: 1,
-					totalPages: 1,
-				},
-				searchLabel: translate( 'Search referrals' ),
-				fields: fields,
-				actions: [],
-				setDataViewsState: setDataViewsState,
-				dataViewsState: dataViewsState,
-			} }
-		/>
+		<div className="redesigned-a8c-table">
+			<ItemsDataViews
+				data={ {
+					items: referrals,
+					pagination: {
+						totalItems: 1,
+						totalPages: 1,
+					},
+					searchLabel: translate( 'Search referrals' ),
+					fields: fields,
+					actions: [],
+					setDataViewsState: setDataViewsState,
+					dataViewsState: dataViewsState,
+				} }
+			/>
+		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -1,12 +1,13 @@
+export interface ReferralPurchase {
+	license_id: number;
+	quantity: number;
+	product_id: number;
+}
 export interface Referral {
 	id: number;
 	client_id: number;
 	client_email: string;
-	purchases: {
-		license_id: number;
-		quantity: number;
-		product_id: number;
-	}[];
+	purchases: ReferralPurchase[];
 	commissions: number;
 	statuses: string[];
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -435,3 +435,17 @@ html {
 		border: none;
 	}
 }
+
+.redesigned-a8c-table {
+	thead .dataviews-view-table__row th {
+		font-size: 0.75rem;
+		font-weight: 500;
+		line-height: 20px;
+		color: var(--color-accent-80);
+	}
+
+	.dataviews-view-table tr td:first-child,
+	.dataviews-view-table tr th:first-child {
+		padding-inline-start: 16px;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/349

## Proposed Changes

This PR implements purchases view in referral details

NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)
- There are some UI enhancement & mobile fixes that will be done in another PR, so please ignore those for now.
- The `Date` & Assigned To` will be implemented in another PR once we have the data available. 


## Testing Instructions

1. Open the A4A live link.
2. Go to  Referrals > Dashboard.
3. Use the below API endpoint manually to create a referral if you don't have some. Create a couple of them

POST https://public-api.wordpress.com/wpcom/v2/agency/230591090/referrals?client_email={client_email}&client_message={your_message}&product_ids={product_id,products_2}

4. Patch D149816
5. Now visit the  Referrals - Dashboard & refresh the page > Once you see the list of referrals, click the `>` icon & verify the page looks like below. Verify the purchases are shown too. Please note the Commission & Activity will be empty for now.

<img width="1201" alt="Screenshot 2024-05-28 at 11 04 06 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2c8c57e6-bcd7-4806-9e67-85b17c43d4a9">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
