### PR TITLE
Stats: Fix for full-width buttons in paywall flows

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -272,6 +272,7 @@ const PersonalPurchase = ( {
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
 					<ButtonComponent
+						className="is-full-width"
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						onClick={ handleCheckoutRedirect }
@@ -281,6 +282,7 @@ const PersonalPurchase = ( {
 
 					{ isNewPurchaseFlowEnabled && (
 						<ButtonComponent
+							className="is-full-width"
 							variant="secondary"
 							isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
 							busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -271,25 +271,29 @@ const PersonalPurchase = ( {
 				</ButtonComponent>
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
-					<ButtonComponent
-						className="stats-purchase-page__full-width"
-						variant="primary"
-						primary={ isWPCOMSite ? true : undefined }
-						onClick={ handleCheckoutRedirect }
-					>
-						{ continueButtonText }
-					</ButtonComponent>
-
-					{ isNewPurchaseFlowEnabled && (
+					<div className="stats-purchase-page__full-width-block">
 						<ButtonComponent
 							className="stats-purchase-page__full-width"
-							variant="secondary"
-							isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
-							busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />
-							onClick={ handleCheckoutPostponed }
+							variant="primary"
+							primary={ isWPCOMSite ? true : undefined }
+							onClick={ handleCheckoutRedirect }
 						>
-							{ translate( 'I will do it later' ) }
+							{ continueButtonText }
 						</ButtonComponent>
+					</div>
+
+					{ isNewPurchaseFlowEnabled && (
+						<div className="stats-purchase-page__full-width-block">
+							<ButtonComponent
+								className="stats-purchase-page__full-width"
+								variant="secondary"
+								isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
+								busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />
+								onClick={ handleCheckoutPostponed }
+							>
+								{ translate( 'I will do it later' ) }
+							</ButtonComponent>
+						</div>
 					) }
 				</div>
 			) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -271,29 +271,23 @@ const PersonalPurchase = ( {
 				</ButtonComponent>
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
-					<div className="stats-purchase-page__full-width-block">
-						<ButtonComponent
-							className="stats-purchase-page__full-width"
-							variant="primary"
-							primary={ isWPCOMSite ? true : undefined }
-							onClick={ handleCheckoutRedirect }
-						>
-							{ continueButtonText }
-						</ButtonComponent>
-					</div>
+					<ButtonComponent
+						variant="primary"
+						primary={ isWPCOMSite ? true : undefined }
+						onClick={ handleCheckoutRedirect }
+					>
+						{ continueButtonText }
+					</ButtonComponent>
 
 					{ isNewPurchaseFlowEnabled && (
-						<div className="stats-purchase-page__full-width-block">
-							<ButtonComponent
-								className="stats-purchase-page__full-width"
-								variant="secondary"
-								isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
-								busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />
-								onClick={ handleCheckoutPostponed }
-							>
-								{ translate( 'I will do it later' ) }
-							</ButtonComponent>
-						</div>
+						<ButtonComponent
+							variant="secondary"
+							isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
+							busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />
+							onClick={ handleCheckoutPostponed }
+						>
+							{ translate( 'I will do it later' ) }
+						</ButtonComponent>
 					) }
 				</div>
 			) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -104,13 +104,16 @@ const StatsUpgradeInstructions = () => {
 	);
 };
 
+// TODO: Fix for full-width buttons.
+// See continueButtonText below.
+
 const useLocalizedStrings = ( isCommercial: boolean ) => {
 	const translate = useTranslate();
 
 	// Page title, info text, and button text depend on isCommercial status of site.
 	if ( isCommercial ) {
 		return {
-			pageTitle: translate( 'Upgrade and continue using Jetpack Stats' ),
+			pageTitle: translate( 'Upgrade and continue using Jetpack Stats ABC' ),
 			infoText: translate(
 				'To continue using Stats and access its newest premium features you need to get a commercial license. {{link}}Learn more about this update{{/link}}.',
 				{

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -204,24 +204,25 @@ const StatsCommercialPurchase = ( {
 						}_stats_purchase_commercial_slider_clicked` }
 						onSliderChange={ handleSliderChanged }
 					/>
-					<ButtonComponent
-						className="stats-purchase-page__full-width"
-						variant="primary"
-						primary={ isWPCOMSite ? true : undefined }
-						onClick={ () =>
-							gotoCheckoutPage( {
-								from,
-								type: 'commercial',
-								siteSlug,
-								adminUrl,
-								redirectUri,
-								price: undefined,
-								quantity: purchaseTierQuantity,
-							} )
-						}
-					>
-						{ continueButtonText }
-					</ButtonComponent>
+					<div className="stats-purchase-page__full-width-block">
+						<ButtonComponent
+							variant="primary"
+							primary={ isWPCOMSite ? true : undefined }
+							onClick={ () =>
+								gotoCheckoutPage( {
+									from,
+									type: 'commercial',
+									siteSlug,
+									adminUrl,
+									redirectUri,
+									price: undefined,
+									quantity: purchaseTierQuantity,
+								} )
+							}
+						>
+							{ continueButtonText }
+						</ButtonComponent>
+					</div>
 					<div className="stats-purchase-page__footnotes">
 						<p>{ translate( '(*) 14-day money-back guarantee' ) }</p>
 					</div>

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -590,7 +590,7 @@ $button-padding: 8px 32px;
 	margin-top: 24px;
 }
 
-.stats-purchase-page__full-width {
+.stats-purchase-page__full-width-block {
 	.components-button {
 		display: block;
 		width: 100%;

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -555,9 +555,11 @@ $button-padding: 8px 32px;
 	display: block;
 	margin: 12px 0;
 
-	.components-button + button.components-button {
-		width: 100%;
-		margin-bottom: 12px;
+	.components-button {
+		&.is-full-width {
+			margin: 12px 0;
+			width: 100%;
+		}
 	}
 }
 

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -547,7 +547,10 @@ $button-padding: 8px 32px;
 	}
 
 	.components-button + button.components-button {
-		margin-left: 12px;
+		// margin-left: 12px;
+		margin: 12px 0;
+		width: 100%;
+		display: block;
 	}
 }
 

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -591,8 +591,10 @@ $button-padding: 8px 32px;
 }
 
 .stats-purchase-page__full-width {
-	display: block;
-	width: 100%;
+	.components-button {
+		display: block;
+		width: 100%;
+	}
 }
 
 .stats-purchase-page__footnotes {

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -556,11 +556,12 @@ $button-padding: 8px 32px;
 
 .stats-purchase-wizard__actions {
 	display: block;
-	margin: 12px 0;
+	// margin: 12px 0;
 
 	.components-button {
 		&.is-full-width {
-			margin: 12px 0;
+			// margin: 12px 0;
+			display: block;
 			width: 100%;
 		}
 	}

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -552,21 +552,12 @@ $button-padding: 8px 32px;
 }
 
 .stats-purchase-wizard__actions {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 12px;
-
+	display: block;
 	margin: 12px 0;
 
 	.components-button + button.components-button {
-		margin: 0;
-	}
-
-	button {
-		@media (max-width: $break-small) {
-			width: 100%;
-			justify-content: center;
-		}
+		width: 100%;
+		margin-bottom: 12px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
