### PR TITLE
Global Sidebar: Update back icon

### DIFF
--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -1,7 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Spinner, Gridicon } from '@automattic/components';
+import { Spinner } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { useTranslate } from 'i18n-calypso';
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import { useRtl, useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { GlobalSidebarHeader } from 'calypso/layout/global-sidebar/header';
@@ -29,6 +30,7 @@ const GlobalSidebar = ( {
 	const translate = useTranslate();
 	const currentUser = useSelector( getCurrentUser );
 	const isDesktop = useBreakpoint( '>=782px' );
+	const isRtl = useRtl();
 	const previousRoute = useSelector( getPreviousRoute );
 	const section = useSelector( getSection );
 	const [ previousLink, setPreviousLink ] = useState( '' );
@@ -79,7 +81,7 @@ const GlobalSidebar = ( {
 					{ requireBackLink && (
 						<div className="sidebar__back-link">
 							<a href={ sidebarBackLinkHref } onClick={ handleBackLinkClick }>
-								<Gridicon icon="chevron-left" size={ 24 } />
+								<Icon icon={ isRtl ? chevronRight : chevronLeft } size={ 24 } />
 							</a>
 							<span className="sidebar__site-title">{ siteTitle || translate( 'Back' ) }</span>
 						</div>

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -344,8 +344,10 @@ $brand-text: "SF Pro Text", $sans;
 			color: var(--nav-link);
 			text-decoration: none;
 			align-items: center;
+			display: inline-flex;
 			padding: 9px;
 			border-radius: 4px;
+
 			&:hover {
 				background-color: var(--color-sidebar-menu-hover-background);
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7449

## Proposed Changes

This PR updates the back button icon of the global sidebar.

| Before | After |
| --- | --- |
| ![Screenshot 2024-05-28 at 2 34 39 PM](https://github.com/Automattic/wp-calypso/assets/797888/cd20cee0-ff1b-42d0-a8fc-ff4d2e744a48) | ![Screenshot 2024-05-28 at 2 34 20 PM](https://github.com/Automattic/wp-calypso/assets/797888/bfb7603c-3660-4189-8a3f-b3679e77bb8b) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Consistency with A4A.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the back button icon is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
