### PR TITLE
Hide P2 sites in Jetpack Cloud

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { omit } from 'lodash';
 import wpcom from 'calypso/lib/wp';
@@ -89,7 +89,13 @@ export function requestSites() {
 				filters: siteFilter.length > 0 ? siteFilter.join( ',' ) : undefined,
 			} )
 			.then( ( response ) => {
-				dispatch( receiveSites( response.sites ) );
+				dispatch(
+					receiveSites(
+						isEnabled( 'jetpack/manage-simple-sites' )
+							? response.sites.filter( ( site ) => ! site?.options?.is_wpforteams_site )
+							: response.sites
+					)
+				);
 				dispatch( {
 					type: SITES_REQUEST_SUCCESS,
 				} );

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -1,6 +1,7 @@
 import config, { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { omit } from 'lodash';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import wpcom from 'calypso/lib/wp';
 import { purchasesRoot } from 'calypso/me/purchases/paths';
 import {
@@ -91,8 +92,9 @@ export function requestSites() {
 			.then( ( response ) => {
 				dispatch(
 					receiveSites(
-						isEnabled( 'jetpack/manage-simple-sites' )
-							? response.sites.filter( ( site ) => ! site?.options?.is_wpforteams_site )
+						isEnabled( 'jetpack/manage-simple-sites' ) && isJetpackCloud()
+							? // Filter out P2 sites for Jetpack Cloud that has the feature enabled
+							  response.sites.filter( ( site ) => ! site?.options?.is_wpforteams_site )
 							: response.sites
 					)
 				);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7346

## Proposed Changes

* Hides P2 sites in Jetpack Cloud since after Simple sites are allowed, P2 sites will also be fetched

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* P2 is now mainly for internal use and won't be using the features in Jetpack Cloud

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]  
> Since we only allow Simple sites to show locally for now, to test the changes please start the local environment by running `yarn start-jetpack-cloud`
The live link is used to test for regressions, make sure we don't break anything that's already in production

* Check in the Site selector that P2 sites are now hidden

![no p2 sites here](https://github.com/Automattic/wp-calypso/assets/6586048/7722fa1e-6ea6-4d4d-8a61-4375b0ffef37)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
