### PR TITLE
Help Center: reset Odie chat after contacting support

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -7,7 +7,7 @@ import config from '@automattic/calypso-config';
 import { Spinner, GMClosureNotice, FormInputValidation } from '@automattic/components';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
-import { useGetOdieStorage } from '@automattic/odie-client';
+import { useGetOdieStorage, useSetOdieStorage } from '@automattic/odie-client';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useMemo } from '@wordpress/element';
 import { hasTranslation, sprintf } from '@wordpress/i18n';
@@ -91,6 +91,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	}, [] );
 
 	const wapuuChatId = useGetOdieStorage( 'chat_id' );
+	const setWapuuChatId = useSetOdieStorage( 'chat_id' );
 
 	const { isOpeningChatWidget, openChatWidget } = useChatWidget(
 		'zendesk_support_chat_key',
@@ -180,6 +181,8 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 							message: '',
 							siteUrl: currentSite?.URL,
 							onError: () => setHasSubmittingError( true ),
+							// Reset Odie chat after passing to support
+							onSuccess: () => setWapuuChatId( null ),
 						} );
 					} }
 				>


### PR DESCRIPTION
## Proposed Changes

Reset the Odie chat ID to clear the history after the user is passed to Zendesk.

## Why are these changes being made?

Currently the Odie chat history never clears. When a user is forwarded to WordPress.com support the Odie history has a direct link button to WordPress.com support that is never removed. When the user returns to Odie they are immediately given a button to talk to WordPress.com support likely bypassing Odie.

Resetting the chat session after a successful pass to Zendesk gives the user a fresh Odie chat when they return.

## Testing Instructions

1. Pull changes and `yarn start`
2. Open Help Center and ask Odie "I want to talk to a human"
3. Click the button to contact support
4. Close Zendesk and open Help Center again and open Odie to see an empty chat.