### PR TITLE
Revert "Users created using A4A flow are marked as developers now"

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -134,7 +134,6 @@ export class UserStep extends Component {
 		subHeaderText: PropTypes.string,
 		isSocialSignupEnabled: PropTypes.bool,
 		initialContext: PropTypes.object,
-		isA4ASignup: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -368,17 +367,12 @@ export class UserStep extends Component {
 		} else if ( data.queryArgs.redirect_to ) {
 			dependencies.redirect = data.queryArgs.redirect_to;
 		}
-		const userData = {
-			...data.userData,
-			...( this.props.isA4ASignup && { is_dev_account: true } ),
-		};
 		this.props.submitSignupStep(
 			{
 				flowName,
 				stepName,
 				oauth2Signup,
 				...data,
-				userData,
 			},
 			dependencies
 		);
@@ -755,7 +749,6 @@ const ConnectedUser = connect(
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),
 			isWooPasswordless: getIsWooPasswordless( state ),
-			isA4ASignup: isA4AOAuth2Client( getCurrentOAuth2Client( state ) ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 		};


### PR DESCRIPTION
Reverts Automattic/wp-calypso#91165

After a requirement change, there is a cleaner way to mark both existing users and new users as developers from the backend.

**Testing steps**
- Apply these changes locally.
- In a terminal window, run `yarn start-a8c-for-agencies`.
- Go to `http://agencies.localhost:3000/signup` in incognito. This will show the "Signup agency flow". You don't need to fill out the form. Click the continue button at the bottom of the form.
- You will see the A4A login screen. Click on the "Create account" link.
- You will see the A4A account creation flow.
- Fill the form with an email you can access and submit it.
- Confirm your email address.
- Go to `https://wordpress.com` and log in using that account.
- Go to your profile and developer settings. You should see yourself not marked as a "developer".