### PR TITLE
Guided Onboarding: Make questions skippable

### DIFF
--- a/client/components/segmentation-survey/hooks/use-segmentation-survey-navigation.ts
+++ b/client/components/segmentation-survey/hooks/use-segmentation-survey-navigation.ts
@@ -65,6 +65,10 @@ const useSegmentationSurveyNavigation = ( {
 		recordSkipEvent( currentQuestion );
 
 		await onSkip?.( currentQuestion );
+		if ( skipNextNavigation?.( currentQuestion.key, answers?.[ currentQuestion.key ] ) ) {
+			return;
+		}
+
 		nextPage();
 	}, [ currentQuestion, nextPage, onSkip, recordSkipEvent ] );
 

--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -101,8 +101,7 @@ const SegmentationSurvey = ( {
 
 	const onSkip = useCallback(
 		async ( currentQuestion: Question ) => {
-			// Clear the answer for the current question and save the skip answer.
-			onChangeAnswer( currentQuestion.key, [] );
+			onChangeAnswer( currentQuestion.key, [ SKIP_ANSWER_KEY ] );
 			await handleSave( currentQuestion, [ SKIP_ANSWER_KEY ] );
 		},
 		[ handleSave, onChangeAnswer ]

--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -11,7 +11,7 @@ import {
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useSegmentationSurveyNavigation from './hooks/use-segmentation-survey-navigation';
 
-const SKIP_ANSWER_KEY = 'skip';
+export const SKIP_ANSWER_KEY = 'skip';
 
 type SegmentationSurveyProps = {
 	surveyKey: string;

--- a/client/components/survey-container/types.ts
+++ b/client/components/survey-container/types.ts
@@ -29,5 +29,6 @@ export type QuestionConfiguration = Record<
 	{
 		hideContinue?: boolean;
 		hideSkip?: boolean;
+		exitOnSkip?: boolean;
 	}
 >;

--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -1,7 +1,7 @@
 import { IMPORT_HOSTED_SITE_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import SegmentationSurvey from 'calypso/components/segmentation-survey';
+import SegmentationSurvey, { SKIP_ANSWER_KEY } from 'calypso/components/segmentation-survey';
 import useSegmentationSurveyTracksEvents from 'calypso/components/segmentation-survey/hooks/use-segmentation-survey-tracks-events';
 import { flowQuestionComponentMap } from 'calypso/components/survey-container/components/question-step-mapping';
 import { QuestionConfiguration } from 'calypso/components/survey-container/types';
@@ -64,7 +64,7 @@ export default function InitialIntentStep( props: Props ) {
 
 	const shouldExitOnSkip = ( _questionKey: string, _answerKeys: string[] ) => {
 		return Boolean(
-			QUESTION_CONFIGURATION[ _questionKey ].exitOnSkip && _answerKeys.includes( 'skip' )
+			QUESTION_CONFIGURATION[ _questionKey ].exitOnSkip && _answerKeys.includes( SKIP_ANSWER_KEY )
 		);
 	};
 

--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -18,7 +18,8 @@ const SURVEY_KEY = 'guided-onboarding-flow';
 const QUESTION_CONFIGURATION: QuestionConfiguration = {
 	'what-brings-you-to-wordpress': {
 		hideContinue: true,
-		hideSkip: true,
+		hideSkip: false,
+		exitOnSkip: true,
 	},
 	'what-are-your-goals': {
 		hideContinue: false,
@@ -61,8 +62,17 @@ export default function InitialIntentStep( props: Props ) {
 		return '';
 	};
 
+	const shouldExitOnSkip = ( _questionKey: string, _answerKeys: string[] ) => {
+		return Boolean(
+			QUESTION_CONFIGURATION[ _questionKey ].exitOnSkip && _answerKeys.includes( 'skip' )
+		);
+	};
+
 	const skipNextNavigation = ( _questionKey: string, _answerKeys: string[] ) => {
-		return Boolean( getRedirectForAnswers( _answerKeys ) );
+		return (
+			Boolean( getRedirectForAnswers( _answerKeys ) ) ||
+			shouldExitOnSkip( _questionKey, _answerKeys )
+		);
 	};
 
 	const handleNext = ( _questionKey: string, _answerKeys: string[], isLastQuestion?: boolean ) => {
@@ -73,7 +83,7 @@ export default function InitialIntentStep( props: Props ) {
 			return window.location.assign( redirect );
 		}
 
-		if ( isLastQuestion ) {
+		if ( isLastQuestion || shouldExitOnSkip( _questionKey, _answerKeys ) ) {
 			recordCompleteEvent();
 			props.goToNextStep();
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7433

## Proposed Changes

This PR adds the `exitOnSkip` on the step configuration, that makes the user exit from the survey if a question is skipped.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Both questions in the survey have to be skippable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout or live link
- Go through `/start/guided`
- Check that questions are skippable, and if the q1 is skipped than it exits the survey

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
