### PR TITLE
A4A > Referrals: Implement consolidated Commissions view for client

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
@@ -2,7 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .consolidated-view {
-	padding-block: 16px 48px;
 	display: flex;
 	gap: 24px;
 	flex-direction: column;

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -97,6 +97,9 @@ $data-view-border-color: #f1f1f1;
 		}
 	}
 
+	.consolidated-view {
+		padding-block: 16px 48px;
+	}
 
 	.referrals-overview__section-heading {
 		margin-block-start: 32px;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/commissions.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/commissions.tsx
@@ -1,0 +1,6 @@
+import ConsolidatedViews from '../consolidated-view';
+import type { Referral } from '../types';
+
+export default function ReferralCommissions( { referral }: { referral: Referral } ) {
+	return <ConsolidatedViews referrals={ [ referral ] } />;
+}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -4,6 +4,7 @@ import ItemPreviewPane, {
 	createFeaturePreview,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import SubscriptionStatus from '../referrals-list/subscription-status';
+import ReferralCommissions from './commissions';
 import type { Referral } from '../types';
 import type { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
 
@@ -57,7 +58,7 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				true,
 				selectedReferralTab,
 				setSelectedReferralTab,
-				'Commissions tab content'
+				<ReferralCommissions referral={ referral } />
 			),
 			createFeaturePreview(
 				REFERRAL_ACITIVTY_ID,
@@ -68,7 +69,7 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				'Activity tab content'
 			),
 		],
-		[ selectedReferralTab, setSelectedReferralTab, translate ]
+		[ referral, selectedReferralTab, translate ]
 	);
 
 	return (


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/352

## Proposed Changes

This PR implements a consolidated Commissions view for a client

NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)
- There are some UI enhancement & mobile fixes that will be done in another PR, so please ignore those for now.

## Testing Instructions

1. Open the A4A live link.
2. Go to  Referrals > Dashboard.
3. Use the below API endpoint manually to create a referral if you don't have some. Create a couple of them

POST https://public-api.wordpress.com/wpcom/v2/agency/230591090/referrals?client_email={client_email}&client_message={your_message}&product_ids={product_id,products_2}

4. Patch D149816
5. Now visit the  Referrals - Dashboard & refresh the page > Once you see the list of referrals, click the `>` icon > Click the Commission tab and verify the page looks as below, and that it is calculated correctly. 


<img width="1201" alt="Screenshot 2024-05-28 at 4 48 47 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b32863d4-5eda-4387-88ca-ae8e16ccd40f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
