### PR TITLE
Stats: Fix for full-width buttons in purchase flows

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -272,7 +272,7 @@ const PersonalPurchase = ( {
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
 					<ButtonComponent
-						className="is-full-width"
+						className="stats-purchase-page__full-width-button"
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						onClick={ handleCheckoutRedirect }
@@ -282,7 +282,7 @@ const PersonalPurchase = ( {
 
 					{ isNewPurchaseFlowEnabled && (
 						<ButtonComponent
-							className="is-full-width"
+							className="stats-purchase-page__full-width-button"
 							variant="secondary"
 							isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
 							busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -256,19 +256,21 @@ const PersonalPurchase = ( {
 			) }
 
 			{ subscriptionValue === 0 ? (
-				<ButtonComponent
-					className="stats-purchase-page__full-width"
-					variant="primary"
-					primary={ isWPCOMSite ? true : undefined }
-					disabled={
-						! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
-					}
-					onClick={ () =>
-						gotoCheckoutPage( { from, type: 'free', siteSlug, adminUrl, redirectUri } )
-					}
-				>
-					{ translate( 'Continue with Jetpack Stats for free' ) }
-				</ButtonComponent>
+				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
+					<ButtonComponent
+						className="stats-purchase-page__full-width-button"
+						variant="primary"
+						primary={ isWPCOMSite ? true : undefined }
+						disabled={
+							! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
+						}
+						onClick={ () =>
+							gotoCheckoutPage( { from, type: 'free', siteSlug, adminUrl, redirectUri } )
+						}
+					>
+						{ translate( 'Continue with Jetpack Stats for free' ) }
+					</ButtonComponent>
+				</div>
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
 					<ButtonComponent

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -272,7 +272,7 @@ const PersonalPurchase = ( {
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
 					<ButtonComponent
-						className="stats-purchase-page__full-width"
+						className="is-full-width"
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						onClick={ handleCheckoutRedirect }
@@ -282,7 +282,7 @@ const PersonalPurchase = ( {
 
 					{ isNewPurchaseFlowEnabled && (
 						<ButtonComponent
-							className="stats-purchase-page__full-width"
+							className="is-full-width"
 							variant="secondary"
 							isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
 							busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -258,7 +258,6 @@ const PersonalPurchase = ( {
 			{ subscriptionValue === 0 ? (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
 					<ButtonComponent
-						className="stats-purchase-page__full-width-button"
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						disabled={
@@ -274,7 +273,6 @@ const PersonalPurchase = ( {
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
 					<ButtonComponent
-						className="stats-purchase-page__full-width-button"
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						onClick={ handleCheckoutRedirect }
@@ -284,7 +282,6 @@ const PersonalPurchase = ( {
 
 					{ isNewPurchaseFlowEnabled && (
 						<ButtonComponent
-							className="stats-purchase-page__full-width-button"
 							variant="secondary"
 							isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
 							busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -203,7 +203,6 @@ const StatsCommercialPurchase = ( {
 					/>
 					<div className="stats-purchase-wizard__actions">
 						<ButtonComponent
-							className="stats-purchase-page__full-width-button"
 							variant="primary"
 							primary={ isWPCOMSite ? true : undefined }
 							onClick={ () =>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -203,7 +203,7 @@ const StatsCommercialPurchase = ( {
 					/>
 					<div className="stats-purchase-wizard__actions">
 						<ButtonComponent
-							className="is-full-width"
+							className="stats-purchase-page__full-width-button"
 							variant="primary"
 							primary={ isWPCOMSite ? true : undefined }
 							onClick={ () =>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -201,24 +201,26 @@ const StatsCommercialPurchase = ( {
 						}_stats_purchase_commercial_slider_clicked` }
 						onSliderChange={ handleSliderChanged }
 					/>
-					<ButtonComponent
-						className="stats-purchase-page__full-width"
-						variant="primary"
-						primary={ isWPCOMSite ? true : undefined }
-						onClick={ () =>
-							gotoCheckoutPage( {
-								from,
-								type: 'commercial',
-								siteSlug,
-								adminUrl,
-								redirectUri,
-								price: undefined,
-								quantity: purchaseTierQuantity,
-							} )
-						}
-					>
-						{ continueButtonText }
-					</ButtonComponent>
+					<div className="stats-purchase-wizard__actions">
+						<ButtonComponent
+							className="is-full-width"
+							variant="primary"
+							primary={ isWPCOMSite ? true : undefined }
+							onClick={ () =>
+								gotoCheckoutPage( {
+									from,
+									type: 'commercial',
+									siteSlug,
+									adminUrl,
+									redirectUri,
+									price: undefined,
+									quantity: purchaseTierQuantity,
+								} )
+							}
+						>
+							{ continueButtonText }
+						</ButtonComponent>
+					</div>
 					<div className="stats-purchase-page__footnotes">
 						<p>{ translate( '(*) 14-day money-back guarantee' ) }</p>
 					</div>

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -550,7 +550,7 @@ $button-padding: 8px 32px;
 .stats-purchase-wizard__actions {
 
 	.components-button {
-		&.is-full-width {
+		&.stats-purchase-page__full-width-button {
 			display: block;
 			width: 100%;
 			margin-bottom: 12px;

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -545,27 +545,15 @@ $button-padding: 8px 32px;
 		line-height: 40px;
 		margin-bottom: 24px;
 	}
-
-	.components-button + button.components-button {
-		margin-left: 12px;
-	}
 }
 
 .stats-purchase-wizard__actions {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 12px;
 
-	margin: 12px 0;
-
-	.components-button + button.components-button {
-		margin: 0;
-	}
-
-	button {
-		@media (max-width: $break-small) {
+	.components-button {
+		&.is-full-width {
+			display: block;
 			width: 100%;
-			justify-content: center;
+			margin-bottom: 12px;
 		}
 	}
 }

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -549,13 +549,10 @@ $button-padding: 8px 32px;
 }
 
 .stats-purchase-wizard__actions {
-
 	.components-button {
-		&.stats-purchase-page__full-width-button {
-			display: block;
-			width: 100%;
-			margin-bottom: 12px;
-		}
+		display: block;
+		width: 100%;
+		margin-bottom: 12px;
 	}
 }
 

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -578,11 +578,6 @@ $button-padding: 8px 32px;
 	margin-top: 24px;
 }
 
-.stats-purchase-page__full-width {
-	display: block;
-	width: 100%;
-}
-
 .stats-purchase-page__footnotes {
 	margin-top: 24px;
 	color: var(--gray-gray-50);

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -513,6 +513,7 @@ $button-padding: 8px 32px;
 	}
 
 	.stats-purchase-wizard__notice {
+		margin: 12px 0;
 		padding: 12px 16px;
 		background: var(--studio-yellow-5);
 		border-radius: 4px;


### PR DESCRIPTION
Also updates buttons on both flows (commercial & pwyw) to use the same CSS for full-width buttons.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/44

## Proposed Changes

Fixes the full-width buttons to work correctly in Odyssey Stats. Was previously working in Calypso but not correctly aligning the text in Odyssey. Should look like this now:

#### PWYW flow

<img width="372" alt="SCR-20240528-rkwh" src="https://github.com/Automattic/wp-calypso/assets/40267301/1d315db3-b8d6-4b80-9417-f0a57e6a7aed">

#### Commercial flow

<img width="393" alt="SCR-20240528-rkyw" src="https://github.com/Automattic/wp-calypso/assets/40267301/36482f28-52af-4596-aba6-29dd90ae89b0">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Buttons were not drawn correctly in Odyssey Stats.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow steps listed [here](PCYsg-Pp7-p2) to test these changes in Odyssey Stats.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?