### PR TITLE
Verbum Editor: add process define to fix broken block

### DIFF
--- a/packages/verbum-block-editor/webpack.config.js
+++ b/packages/verbum-block-editor/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require( 'path' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const webpack = require( 'webpack' );
 
 /* Arguments to this function replicate webpack's so this config can be used on the command line,
  * with individual options overridden by command line args.
@@ -37,6 +38,12 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 		externals: {
 			'@wordpress/i18n': [ 'wp', 'i18n' ],
 		},
+		plugins: [
+			...webpackConfig.plugins,
+			new webpack.DefinePlugin( {
+				'process.env.IS_GUTENBERG_PLUGIN': true,
+			} ),
+		],
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

Set `IS_GUTENBERG_PLUGIN` to true in the process.env. Some blocks are looking for this to be defined specifically the Quote block.

## Why are these changes being made?

<img width="420" alt="Markup 2024-05-28 at 14 30 57" src="https://github.com/Automattic/wp-calypso/assets/33258733/3b6ab0de-dcda-41c7-ab68-8477f0a90fc6">

When adding a quote block to the comment block editor it returns an error and the block is not added. This fixes that error.

## Testing Instructions

1. Pull changes and `yarn dev --sync` from `packages/verbum-block-editor`
2. Sandbox widgets.wp.com
3. Go to your simple test site and try to add a quote block to your comment section.
4. There should be no errors and the quote block should be working.