### PR TITLE
Sidebar: Fix incorrect Scheduled Updates highlight

### DIFF
--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -39,6 +39,10 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		}
 	}
 
+	if ( pathIncludes( currentPath, 'plugins', 1 ) ) {
+		return pathIncludes( path, 'plugins', 1 ) && fragmentIsEqual( path, currentPath, 2 );
+	}
+
 	if ( pathIncludes( currentPath, 'settings', 1 ) ) {
 		// Jetpack Cloud uses a simpler /settings/:site pattern, and A4A uses /settings/:tab, for the settings page.
 		if ( isJetpackCloud() || isA8CForAgencies() ) {


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/6940

## Proposed Changes

Prevents the "Plugins > Scheduled Updates" submenu from being incorrectly highlighted when visiting the Plugins Marketplace

Before | After
--- | ---
<img width="1279" alt="Screenshot 2024-05-28 at 13 55 56" src="https://github.com/Automattic/wp-calypso/assets/1233880/5862ab17-c0c2-4c55-93e1-00ad57fcd2a5"> | <img width="1278" alt="Screenshot 2024-05-28 at 13 55 42" src="https://github.com/Automattic/wp-calypso/assets/1233880/ca51cd1e-0ca7-4dbd-ad57-dd2e17971c99">


## Why are these changes being made?
Because highlighting a submenu that is not the one for the current page is confusing

## Testing Instructions

- Use the Calypso live link below
- Go to `/plugins/:site` for an Atomic site with the default admin interface
- Make sure the "Plugins > Add New Plugin" submenu is highlighted (no other submenus should be highlighted)
- Switch to an Atomic site with the classic admin interface
- Make sure none of the submenus are highlighted (this is expected for now, it'll be addressed by https://github.com/Automattic/jetpack/pull/37521)
- Go to `/plugins/scheduled-updates/:site` for an Atomic site with the default admin interface
- Make sure the "Plugins > Scheduled Updates" submenu is highlighted (no other submenus should be highlighted)
- Switch to an Atomic site with the classic admin interface
- Make sure the "Plugins > Scheduled Updates" submenu is highlighted (no other submenus should be highlighted)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
