### PR TITLE
A4A: Implement Upgrade flow for Pressable plans.

### DIFF
--- a/client/a8c-for-agencies/components/slider/index.tsx
+++ b/client/a8c-for-agencies/components/slider/index.tsx
@@ -1,6 +1,9 @@
 import classNames from 'classnames';
+import { useEffect, useRef } from 'react';
 
 import './style.scss';
+
+const THUMB_SIZE = 14;
 
 export type Option = {
 	label: string;
@@ -15,13 +18,40 @@ type Props = {
 	value: number;
 	label?: string;
 	sub?: string;
+	minimum?: number;
 };
 
-export default function A4ASlider( { className, options, onChange, value, label, sub }: Props ) {
+export default function A4ASlider( {
+	className,
+	options,
+	onChange,
+	value,
+	label,
+	sub,
+	minimum = 0,
+}: Props ) {
+	const rangeRef = useRef< HTMLInputElement >( null );
+
+	// Safeguard incase we have minimum value that is out of bounds
+	const normalizeMinimum = Math.min( minimum, options.length - 1 );
+
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const onSliderChange = ( event: any ) => {
-		onChange?.( options[ event.target.value ] );
+		const next = event.target.value;
+		onChange?.( options[ Math.max( next, normalizeMinimum ) ] );
 	};
+
+	const sliderWidth = rangeRef.current?.offsetWidth ?? 1;
+	const sliderSectionWidth = sliderWidth / ( options.length - 1 );
+
+	// It is important we have offset otherwise we will encounter some overlapping issues with the thumb and disabled area.
+	// Offset is calculated based on the Thumb size and position of the minimum value.
+	const offset = Math.round( ( THUMB_SIZE * normalizeMinimum ) / ( options.length - 1 ) );
+	const disabledAreaWidth = `${ sliderSectionWidth * normalizeMinimum - offset + 1 }px`;
+
+	useEffect( () => {
+		onChange?.( options[ Math.max( value, normalizeMinimum ) ] );
+	}, [ normalizeMinimum, onChange, options, value ] );
 
 	return (
 		<div className={ classNames( 'a4a-slider', className ) }>
@@ -33,7 +63,15 @@ export default function A4ASlider( { className, options, onChange, value, label,
 			) }
 
 			<div className="a4a-slider__input">
+				<div
+					className="a4a-slider__input-disabled-area"
+					style={ {
+						width: disabledAreaWidth,
+					} }
+				></div>
+
 				<input
+					ref={ rangeRef }
 					type="range"
 					min="0"
 					max={ options.length - 1 }
@@ -49,10 +87,10 @@ export default function A4ASlider( { className, options, onChange, value, label,
 								key={ `slider-option-${ option.value }` }
 								role="button"
 								tabIndex={ -1 }
-								onClick={ () => onChange?.( options[ index ] ) }
+								onClick={ () => onChange?.( options[ Math.max( index, normalizeMinimum ) ] ) }
 								onKeyDown={ ( event ) => {
 									if ( event.key === 'Enter' ) {
-										onChange?.( options[ index ] );
+										onChange?.( options[ Math.max( index, normalizeMinimum ) ] );
 									}
 								} }
 							>

--- a/client/a8c-for-agencies/components/slider/style.scss
+++ b/client/a8c-for-agencies/components/slider/style.scss
@@ -108,3 +108,13 @@
 .a4a-slider__marker-sub {
 	color: var(--color-success);
 }
+
+.a4a-slider__input-disabled-area {
+	min-height: 6px;
+	width: 0;
+	background-color: var(--color-primary-0);
+	position: absolute;
+	top: 22px;
+	left: -1px;
+	border-radius: 4px 0 0 4px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -31,7 +31,7 @@ import './style.scss';
 
 type Props = {
 	plan: APIProductFamilyProduct;
-	pressableOwnership?: boolean;
+	pressableOwnership?: 'regular' | 'agency' | 'none';
 	highestDiscountPercentage?: number;
 	className?: string;
 	/** The minimum height for the pricing section. */
@@ -42,7 +42,7 @@ type Props = {
 
 export default function HostingCard( {
 	plan,
-	pressableOwnership,
+	pressableOwnership = 'none',
 	highestDiscountPercentage,
 	className,
 	minPriceHeight,
@@ -136,7 +136,7 @@ export default function HostingCard( {
 	}, [ setPriceHeight ] );
 
 	const exploreButton = useMemo( () => {
-		if ( pressableOwnership ) {
+		if ( pressableOwnership === 'regular' ) {
 			return (
 				<Button
 					className="hosting-card__pressable-dashboard-button"
@@ -144,7 +144,7 @@ export default function HostingCard( {
 					rel="norefferer nooppener"
 					href={ pressableUrl }
 				>
-					{ translate( 'Go to Pressable Dashboard' ) }
+					{ translate( 'Manage in your Pressable account' ) }
 					<Icon icon={ external } size={ 18 } />
 				</Button>
 			);
@@ -190,7 +190,7 @@ export default function HostingCard( {
 			<div className="hosting-card__section">
 				<div className="hosting-card__heading">{ heading }</div>
 
-				{ pressableOwnership && (
+				{ pressableOwnership !== 'none' && (
 					<>
 						{
 							// Show the check icon and tooltip only on desktop

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -35,11 +35,19 @@ export default function HostingList( { selectedSite }: Props ) {
 
 	const wpcomOptions = wpcomBulkOptions( wpcomProducts?.discounts?.tiers );
 
-	const hasPressablePlan = useMemo( () => {
+	const pressableOwnership = useMemo( () => {
 		// Agencies can have pressable through A4A Licenses or via Pressable itself
-		return (
-			!! activeAgency?.third_party?.pressable && activeAgency?.third_party?.pressable?.pressable_id
-		);
+		const hasPressablePlan = !! activeAgency?.third_party?.pressable?.pressable_id;
+
+		if ( ! hasPressablePlan ) {
+			return 'none';
+		}
+
+		// If the agency has a regular Pressable plan (not brought through A4A marketplace), A4A id is null.
+		const hasRegularPressablePlan =
+			hasPressablePlan && activeAgency?.third_party?.pressable?.a4a_id === null;
+
+		return hasRegularPressablePlan ? 'regular' : 'agency';
 	}, [ activeAgency ] );
 
 	const { isLoadingProducts, pressablePlans, wpcomPlans } = useProductAndPlans( {
@@ -126,7 +134,7 @@ export default function HostingList( { selectedSite }: Props ) {
 				{ cheapestPressablePlan && (
 					<HostingCard
 						plan={ cheapestPressablePlan }
-						pressableOwnership={ !! hasPressablePlan }
+						pressableOwnership={ pressableOwnership }
 						highestDiscountPercentage={ highestDiscountPressable }
 						{ ...hostingCardPriceHeightProps }
 					/>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-existing-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-existing-pressable-plan.ts
@@ -7,7 +7,7 @@ type Props = {
 };
 
 export default function useExistingPressablePlan( { plans }: Props ) {
-	const { data, isSuccess: isReady, isFetching } = useFetchLicenseCounts();
+	const { data, isSuccess: isReady } = useFetchLicenseCounts();
 
 	return useMemo( () => {
 		const pressablePlans = Object.keys( data?.products ?? {} ).filter( ( slug ) =>
@@ -21,7 +21,6 @@ export default function useExistingPressablePlan( { plans }: Props ) {
 		return {
 			existingPlan: plans.find( ( plan ) => plan.slug === existingPlan ) ?? null,
 			isReady,
-			isFetching,
 		};
-	}, [ data?.products, isReady, isFetching, plans ] );
+	}, [ data?.products, isReady, plans ] );
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-existing-pressable-plan.ts
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/hooks/use-existing-pressable-plan.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+type Props = {
+	plans: APIProductFamilyProduct[];
+};
+
+export default function useExistingPressablePlan( { plans }: Props ) {
+	const { data, isSuccess: isReady, isFetching } = useFetchLicenseCounts();
+
+	return useMemo( () => {
+		const pressablePlans = Object.keys( data?.products ?? {} ).filter( ( slug ) =>
+			slug.startsWith( 'pressable-wp' )
+		);
+
+		const existingPlan = pressablePlans.find( ( slug ) => {
+			return data?.products?.[ slug ]?.not_revoked > 0;
+		} );
+
+		return {
+			existingPlan: plans.find( ( plan ) => plan.slug === existingPlan ) ?? null,
+			isReady,
+			isFetching,
+		};
+	}, [ data?.products, isReady, isFetching, plans ] );
+}

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -16,9 +16,10 @@ import getPressableShortName from '../lib/get-pressable-short-name';
 type Props = {
 	selectedPlan: APIProductFamilyProduct | null;
 	onSelectPlan: () => void;
+	isLoading?: boolean;
 };
 
-export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Props ) {
+export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLoading }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -38,6 +39,15 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan }: Pr
 	}, [ dispatch ] );
 
 	const PRESSABLE_CONTACT_LINK = 'https://pressable.com/request-demo';
+
+	if ( isLoading ) {
+		return (
+			<section className="pressable-overview-plan-selection__details is-loader">
+				<div className="pressable-overview-plan-selection__details-card"></div>
+				<div className="pressable-overview-plan-selection__details-card is-aside"></div>
+			</section>
+		);
+	}
 
 	return (
 		<section className="pressable-overview-plan-selection__details">

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -7,6 +7,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { FILTER_TYPE_INSTALL, FILTER_TYPE_VISITS } from '../constants';
+import useExistingPressablePlan from '../hooks/use-existing-pressable-plan';
 import getPressablePlan from '../lib/get-pressable-plan';
 import getSliderOptions from '../lib/get-slider-options';
 import { FilterType } from '../types';
@@ -22,6 +23,10 @@ export default function PlanSelectionFilter( { selectedPlan, plans, onSelectPlan
 	const dispatch = useDispatch();
 
 	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
+
+	const { existingPlan, isFetching: isFetchingExistingPlan } = useExistingPressablePlan( {
+		plans,
+	} );
 
 	const options = useMemo(
 		() => [
@@ -77,6 +82,10 @@ export default function PlanSelectionFilter( { selectedPlan, plans, onSelectPlan
 		'pressable-overview-plan-selection__filter'
 	);
 
+	const minimum = existingPlan
+		? options.findIndex( ( { value } ) => value === existingPlan.slug ) + 1
+		: 0;
+
 	return (
 		<section className={ wrapperClass }>
 			<div className="pressable-overview-plan-selection__filter-type">
@@ -104,7 +113,12 @@ export default function PlanSelectionFilter( { selectedPlan, plans, onSelectPlan
 				</div>
 			</div>
 
-			<A4ASlider value={ selectedOption } onChange={ onSelectOption } options={ options } />
+			<A4ASlider
+				value={ selectedOption }
+				onChange={ onSelectOption }
+				options={ options }
+				minimum={ minimum }
+			/>
 		</section>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -7,7 +7,6 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { FILTER_TYPE_INSTALL, FILTER_TYPE_VISITS } from '../constants';
-import useExistingPressablePlan from '../hooks/use-existing-pressable-plan';
 import getPressablePlan from '../lib/get-pressable-plan';
 import getSliderOptions from '../lib/get-slider-options';
 import { FilterType } from '../types';
@@ -15,18 +14,22 @@ import { FilterType } from '../types';
 type Props = {
 	selectedPlan: APIProductFamilyProduct | null;
 	plans: APIProductFamilyProduct[];
+	existingPlan?: APIProductFamilyProduct | null;
 	onSelectPlan: ( plan: APIProductFamilyProduct | null ) => void;
+	isLoading?: boolean;
 };
 
-export default function PlanSelectionFilter( { selectedPlan, plans, onSelectPlan }: Props ) {
+export default function PlanSelectionFilter( {
+	selectedPlan,
+	plans,
+	onSelectPlan,
+	existingPlan,
+	isLoading,
+}: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
-
-	const { existingPlan } = useExistingPressablePlan( {
-		plans,
-	} );
 
 	const options = useMemo(
 		() => [
@@ -85,6 +88,15 @@ export default function PlanSelectionFilter( { selectedPlan, plans, onSelectPlan
 	const minimum = existingPlan
 		? options.findIndex( ( { value } ) => value === existingPlan.slug ) + 1
 		: 0;
+
+	if ( isLoading ) {
+		return (
+			<div className="pressable-overview-plan-selection__filter is-placeholder">
+				<div className="pressable-overview-plan-selection__filter-type"></div>
+				<div className="pressable-overview-plan-selection__filter-slider"></div>
+			</div>
+		);
+	}
 
 	return (
 		<section className={ wrapperClass }>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -24,7 +24,7 @@ export default function PlanSelectionFilter( { selectedPlan, plans, onSelectPlan
 
 	const [ filterType, setFilterType ] = useState< FilterType >( FILTER_TYPE_INSTALL );
 
-	const { existingPlan, isFetching: isFetchingExistingPlan } = useExistingPressablePlan( {
+	const { existingPlan } = useExistingPressablePlan( {
 		plans,
 	} );
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -100,6 +101,26 @@ export default function PlanSelectionFilter( {
 
 	return (
 		<section className={ wrapperClass }>
+			{ !! existingPlan && (
+				<div className="pressable-overview-plan-selection__filter-owned-plan">
+					<div className="badge">
+						<Icon icon={ info } size={ 24 } />
+
+						<span>
+							{ translate( 'You own {{b}}%(planName)s plan{{/b}}', {
+								args: {
+									planName: existingPlan.name,
+								},
+								components: {
+									b: <strong />,
+								},
+								comment: '%(planName)s is the name of the Pressable plan the user owns.',
+							} ) }
+						</span>
+					</div>
+				</div>
+			) }
+
 			<div className="pressable-overview-plan-selection__filter-type">
 				<p className="pressable-overview-plan-selection__filter-label">
 					{ translate( 'Filter by:' ) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
+import useExistingPressablePlan from '../hooks/use-existing-pressable-plan';
 import PlanSelectionDetails from './details';
 import PlanSelectionFilter from './filter';
 
@@ -29,6 +30,10 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 		productSearchQuery: '',
 	} );
 
+	const { existingPlan, isReady: isExistingPlanFetched } = useExistingPressablePlan( {
+		plans: pressablePlans,
+	} );
+
 	useEffect( () => {
 		if ( pressablePlans?.length ) {
 			setSelectedPlan( pressablePlans[ 0 ] );
@@ -52,9 +57,15 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 				selectedPlan={ selectedPlan }
 				plans={ pressablePlans }
 				onSelectPlan={ onSelectPlan }
+				existingPlan={ existingPlan }
+				isLoading={ ! isExistingPlanFetched }
 			/>
 
-			<PlanSelectionDetails selectedPlan={ selectedPlan } onSelectPlan={ onPlanAddToCart } />
+			<PlanSelectionDetails
+				selectedPlan={ selectedPlan }
+				onSelectPlan={ onPlanAddToCart }
+				isLoading={ ! isExistingPlanFetched }
+			/>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -83,6 +83,24 @@
 	min-height: 40px;
 }
 
+.pressable-overview-plan-selection__filter-owned-plan {
+	text-align: center;
+
+	.badge {
+		display: inline-flex;
+		flex-direction: row;
+		gap: 16px;
+
+		background-color: var(--color-neutral-0);
+		padding: 8px 16px;
+		margin: 0 auto 32px;
+		border-radius: 4px;
+
+		align-items: center;
+		justify-content: center;
+	}
+}
+
 .pressable-overview-plan-selection__filter-type {
 	display: flex;
 	flex-direction: row;

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -164,3 +164,41 @@
 		}
 	}
 }
+
+.pressable-overview-plan-selection__filter.is-placeholder {
+	.pressable-overview-plan-selection__filter-type,
+	.pressable-overview-plan-selection__filter-slider {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		background: var(--color-neutral-10);
+		border-radius: 4px;
+	}
+
+	.pressable-overview-plan-selection__filter-type {
+		max-width: 350px;
+		width: 100%;
+		height: 36px;
+		margin: 0 auto 8px;
+	}
+
+	.pressable-overview-plan-selection__filter-slider {
+		max-width: 800px;
+		width: 100%;
+		height: 53.2px;
+		margin: 0 auto;
+	}
+}
+
+
+.pressable-overview-plan-selection__details.is-loader {
+	display: flex;
+	justify-content: space-between;
+	max-width: 800px;
+
+	.pressable-overview-plan-selection__details-card {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		background: var(--color-neutral-10);
+		border-radius: 4px;
+		max-width: 350px;
+		height: 256px;
+	}
+}


### PR DESCRIPTION
Currently, users are unable to upgrade existing Pressable plans. This PR introduces the upgrade flow for existing Pressable plans in A4A. Please note that the new upgrade flow is not accessible for agencies with a Regular Pressable plan (purchased outside A4A) as this should be handled in Pressable.


**Hosting plan will now show the Explore button but retain the checkmark (tooltip) indication that you owned existing plan.**
<img width="509" alt="Screenshot 2024-05-28 at 9 01 01 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/dcf93241-c660-4eee-b40a-d788187c830b">

**The Pressable overview page will now show which plan you currently own and will disable lower tiers**
<img width="954" alt="Screenshot 2024-05-28 at 9 01 15 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0308de97-15cb-4d24-8b08-d9090cecd961">


**In case your account is tied to an existing Pressable account, You won't be able to access the upgrade flow.**
<img width="505" alt="Screenshot 2024-05-28 at 9 07 29 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8b980589-44d2-4daf-b731-529bad3595d1">


Related to https://github.com/Automattic/jetpack-roadmap/issues/1560

## Proposed Changes

* To force an upgrade path for users with the existing Pressable plan, the A4A slider has been updated to support the **minimum** prop, similar to how we did on the WPCOM overview page. The Pressable overview page should recognize the existing Pressable plan and disable lower-tier plans using the new **minimum** prop. A badge specifying which plan the user owns will now be displayed on top of the Plan selector.
* While fetching existing Pressable plan information will take time, the Pressable overview page will show a placeholder to prevent some UI glitches during fetch.
* We identify the existing Pressable plan using the 'jetpack-licensing/licenses/counts' endpoint for querying. We chose this endpoint over the Jetpack licensing API to avoid dealing with pagination, which would likely require multiple requests, which is not ideal for us.
* Additionally, we have updated the Pressable hosting card to ensure we render the 'Explore' button for agencies with existing Pressable plans brought from A4A.


## Testing Instructions

* Use the A4A live link below and go to the `/marketplace/hosting` page.
* If you have an existing Pressable plan, confirm that you see the 'Explore' button.
* Click the Explore button to go to the Pressable Overview page.
* In the Pressable overview page, confirm that you can only select plans with a higher tier than your current Pressable plan. If you have no existing Pressable plan, you should be able to select all options. Please make sure you test both scenarios.
   <img width="583" alt="Screenshot 2024-05-28 at 9 33 55 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/55095d46-fcc8-4b43-acdb-2f3553a79b46">
* Confirm that you will be able to purchase and upgrade Pressable plans.

**Testing Regular Pressable plan**
* To do this, create a Pressable account and purchase a plan directly from Pressable.com.
* After creating the account, you will need to register a new agency using the same email you used to register the Pressable account.
* Once you sign up for the Agency account, it should be tied to your existing Pressable plan.
* Go to the `/marketplace/hosting` page.
* Confirm that instead of the 'Explore' button, you will see a link redirecting you to Pressable so you can manage it from there.
   <img width="513" alt="Screenshot 2024-05-28 at 9 33 06 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0d73f746-0b50-4602-9f99-2853cff439ca">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
