### PR TITLE
Site Migration Increase retry attempts interval

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -9,6 +9,7 @@ import { usePrepareSiteForMigration } from 'calypso/landing/stepper/hooks/use-pr
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { MaybeLink } from '../site-migration-instructions/maybe-link';
 import { ShowHideInput } from '../site-migration-instructions/show-hide-input';
 import { PendingActions } from './pending-actions';
@@ -85,7 +86,24 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 
 	useEffect( () => {
 		if ( setupError ) {
+			const logError = setupError as unknown as { path: string; message: string };
+
+			logToLogstash( {
+				feature: 'calypso_client',
+				message: setupError?.message,
+				blog_id: siteId,
+				properties: {
+					env: process.env.NODE_ENV,
+					type: 'calypso_failed_to_prepare_site_for_migration',
+					site: siteId,
+					path: logError?.path,
+				},
+			} );
+
 			captureException( setupError, {
+				extra: {
+					message: logError?.message,
+				},
 				tags: {
 					blog_id: siteId,
 					calypso_section: 'setup',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -9,7 +9,6 @@ import { usePrepareSiteForMigration } from 'calypso/landing/stepper/hooks/use-pr
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { logToLogstash } from 'calypso/lib/logstash';
 import { MaybeLink } from '../site-migration-instructions/maybe-link';
 import { ShowHideInput } from '../site-migration-instructions/show-hide-input';
 import { PendingActions } from './pending-actions';
@@ -88,21 +87,10 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 		if ( setupError ) {
 			const logError = setupError as unknown as { path: string; message: string };
 
-			logToLogstash( {
-				feature: 'calypso_client',
-				message: setupError?.message,
-				blog_id: siteId,
-				properties: {
-					env: process.env.NODE_ENV,
-					type: 'calypso_failed_to_prepare_site_for_migration',
-					site: siteId,
-					path: logError?.path,
-				},
-			} );
-
 			captureException( setupError, {
 				extra: {
 					message: logError?.message,
+					path: logError?.path,
 				},
 				tags: {
 					blog_id: siteId,

--- a/client/landing/stepper/hooks/use-plugin-auto-installation.ts
+++ b/client/landing/stepper/hooks/use-plugin-auto-installation.ts
@@ -20,8 +20,8 @@ interface SiteMigrationStatus {
 }
 
 type Options = Pick< UseQueryOptions, 'enabled' | 'retry' >;
-const DEFAULT_RETRY = process.env.NODE_ENV !== 'production' ? 1 : 10;
-const DEFAULT_RETRY_DELAY = process.env.NODE_ENV !== 'production' ? 300 : 2000;
+const DEFAULT_RETRY = process.env.NODE_ENV !== 'production' ? 1 : 15;
+const DEFAULT_RETRY_DELAY = process.env.NODE_ENV !== 'production' ? 300 : 3000;
 
 const fetchPluginsForSite = async ( siteId: number ): Promise< Response > =>
 	wpcom.req.get( `/sites/${ siteId }/plugins?http_envelope=1`, {


### PR DESCRIPTION
Related to #91191

## Proposed Changes

* Increase retry attempts by 50% (10 to 15)
* Increase the interval between attempts (2000 to 3000)
* Improve the error logging
* ~Send error messages to logstash~


## Testing Instructions
* Set a wrong plugin name on [this line ](https://github.com/Automattic/wp-calypso/blob/38f4e6399f041290a5cc437c3d93c4c300fa15f8/client/landing/stepper/hooks/use-prepare-site-for-migration.ts#L6)
* Go to the instructions page and check the retry process happening.

NOTE: Retry and Retry interval are react-query features, so visual inspection is acceptable. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
