### PR TITLE
Help Center: update initial message to Zendesk

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -4,6 +4,7 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
+import { getPlan } from '@automattic/calypso-products';
 import { Spinner, GMClosureNotice, FormInputValidation } from '@automattic/components';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
@@ -32,6 +33,7 @@ import {
 import { Mail } from '../icons';
 import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
+import type { HelpCenterSite } from '@automattic/data-stores';
 
 type ContactOption = 'chat' | 'email';
 const generateContactOnClickEvent = (
@@ -84,7 +86,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	);
 
 	const [ hasSubmittingError, setHasSubmittingError ] = useState< boolean >( false );
-
+	const sectionName = useSelector( getSectionName );
 	const currentSite = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return helpCenterSelect.getSite();
@@ -170,22 +172,34 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	};
 
 	const renderChatOption = () => {
+		const productSlug = ( currentSite as HelpCenterSite )?.plan?.product_slug;
+		const plan = getPlan( productSlug );
+		const productId = plan?.getProductId();
+
+		const handleOnClick = () => {
+			contactOptionsEventMap.chat();
+
+			recordTracksEvent( 'calypso_help_live_chat_begin', {
+				site_plan_product_id: productId,
+				is_automated_transfer: currentSite?.is_wpcom_atomic,
+				force_site_id: true,
+				location: 'help-center',
+				section: sectionName,
+			} );
+
+			openChatWidget( {
+				aiChatId: `wapuuChatId`,
+				message: `Support request started with <strong>Wapuu</strong><br>Site: ${ currentSite?.URL }<br />Wapuu Chat: <a href="https://mc.a8c.com/odie/odie-chat.php?chat_id=${ wapuuChatId }">${ wapuuChatId }</a>`,
+				siteUrl: currentSite?.URL,
+				onError: () => setHasSubmittingError( true ),
+				// Reset Odie chat after passing to support
+				onSuccess: () => setWapuuChatId( null ),
+			} );
+		};
+
 		return (
 			<div>
-				<button
-					disabled={ isOpeningChatWidget }
-					onClick={ () => {
-						contactOptionsEventMap.chat();
-						openChatWidget( {
-							aiChatId: wapuuChatId,
-							message: '',
-							siteUrl: currentSite?.URL,
-							onError: () => setHasSubmittingError( true ),
-							// Reset Odie chat after passing to support
-							onSuccess: () => setWapuuChatId( null ),
-						} );
-					} }
-				>
+				<button disabled={ isOpeningChatWidget } onClick={ handleOnClick }>
 					<div className="help-center-contact-page__box chat" role="button" tabIndex={ 0 }>
 						<div className="help-center-contact-page__box-icon">
 							<Icon icon={ comment } />

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -188,7 +188,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 			} );
 
 			openChatWidget( {
-				aiChatId: `wapuuChatId`,
+				aiChatId: wapuuChatId,
 				message: `Support request started with <strong>Wapuu</strong><br>Site: ${ currentSite?.URL }<br />Wapuu Chat: <a href="https://mc.a8c.com/odie/odie-chat.php?chat_id=${ wapuuChatId }">${ wapuuChatId }</a>`,
 				siteUrl: currentSite?.URL,
 				onError: () => setHasSubmittingError( true ),

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -202,7 +202,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 			openChatWidget( {
 				aiChatId: escapedWapuuChatId,
 				message: message,
-				siteUrl: currentSite?.URL,
+				siteUrl: escapedSiteUrl,
 				onError: () => setHasSubmittingError( true ),
 				// Reset Odie chat after passing to support
 				onSuccess: () => setWapuuChatId( null ),

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -188,7 +188,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 			} );
 
 			openChatWidget( {
-				aiChatId: wapuuChatId,
+				aiChatId: `wapuuChatId`,
 				message: `Support request started with <strong>Wapuu</strong><br>Site: ${ currentSite?.URL }<br />Wapuu Chat: <a href="https://mc.a8c.com/odie/odie-chat.php?chat_id=${ wapuuChatId }">${ wapuuChatId }</a>`,
 				siteUrl: currentSite?.URL,
 				onError: () => setHasSubmittingError( true ),

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -4,7 +4,6 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { getPlan } from '@automattic/calypso-products';
 import { Spinner, GMClosureNotice, FormInputValidation } from '@automattic/components';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
@@ -33,7 +32,6 @@ import {
 import { Mail } from '../icons';
 import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
-import type { HelpCenterSite } from '@automattic/data-stores';
 
 type ContactOption = 'chat' | 'email';
 const generateContactOnClickEvent = (
@@ -86,7 +84,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	);
 
 	const [ hasSubmittingError, setHasSubmittingError ] = useState< boolean >( false );
-	const sectionName = useSelector( getSectionName );
+
 	const currentSite = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return helpCenterSelect.getSite();
@@ -172,34 +170,22 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	};
 
 	const renderChatOption = () => {
-		const productSlug = ( currentSite as HelpCenterSite )?.plan?.product_slug;
-		const plan = getPlan( productSlug );
-		const productId = plan?.getProductId();
-
-		const handleOnClick = () => {
-			contactOptionsEventMap.chat();
-
-			recordTracksEvent( 'calypso_help_live_chat_begin', {
-				site_plan_product_id: productId,
-				is_automated_transfer: currentSite?.is_wpcom_atomic,
-				force_site_id: true,
-				location: 'help-center',
-				section: sectionName,
-			} );
-
-			openChatWidget( {
-				aiChatId: `wapuuChatId`,
-				message: `Support request started with <strong>Wapuu</strong><br>Site: ${ currentSite?.URL }<br />Wapuu Chat: <a href="https://mc.a8c.com/odie/odie-chat.php?chat_id=${ wapuuChatId }">${ wapuuChatId }</a>`,
-				siteUrl: currentSite?.URL,
-				onError: () => setHasSubmittingError( true ),
-				// Reset Odie chat after passing to support
-				onSuccess: () => setWapuuChatId( null ),
-			} );
-		};
-
 		return (
 			<div>
-				<button disabled={ isOpeningChatWidget } onClick={ handleOnClick }>
+				<button
+					disabled={ isOpeningChatWidget }
+					onClick={ () => {
+						contactOptionsEventMap.chat();
+						openChatWidget( {
+							aiChatId: wapuuChatId,
+							message: '',
+							siteUrl: currentSite?.URL,
+							onError: () => setHasSubmittingError( true ),
+							// Reset Odie chat after passing to support
+							onSuccess: () => setWapuuChatId( null ),
+						} );
+					} }
+				>
 					<div className="help-center-contact-page__box chat" role="button" tabIndex={ 0 }>
 						<div className="help-center-contact-page__box-icon">
 							<Icon icon={ comment } />

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -187,9 +187,21 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 				section: sectionName,
 			} );
 
+			let message = '';
+			const escapedWapuuChatId = encodeURIComponent( wapuuChatId || '' );
+			const escapedSiteUrl = encodeURIComponent( currentSite?.URL || '' );
+
+			if ( wapuuChatId ) {
+				message += `Support request started with <strong>Wapuu</strong><br />Wapuu Chat: <a href="https://mc.a8c.com/odie/odie-chat.php?chat_id=${ escapedWapuuChatId }">${ escapedWapuuChatId }</a><br />`;
+			}
+
+			if ( currentSite?.URL ) {
+				message += `Site: ${ escapedSiteUrl }<br />`;
+			}
+
 			openChatWidget( {
-				aiChatId: wapuuChatId,
-				message: `Support request started with <strong>Wapuu</strong><br>Site: ${ currentSite?.URL }<br />Wapuu Chat: <a href="https://mc.a8c.com/odie/odie-chat.php?chat_id=${ wapuuChatId }">${ wapuuChatId }</a>`,
+				aiChatId: escapedWapuuChatId,
+				message: message,
 				siteUrl: currentSite?.URL,
 				onError: () => setHasSubmittingError( true ),
 				// Reset Odie chat after passing to support

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -4,6 +4,7 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
+import { getPlan } from '@automattic/calypso-products';
 import { Spinner, GMClosureNotice, FormInputValidation } from '@automattic/components';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { getLanguage, useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
@@ -32,6 +33,7 @@ import {
 import { Mail } from '../icons';
 import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterActiveTicketNotice } from './help-center-notice';
+import type { HelpCenterSite } from '@automattic/data-stores';
 
 type ContactOption = 'chat' | 'email';
 const generateContactOnClickEvent = (
@@ -84,7 +86,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	);
 
 	const [ hasSubmittingError, setHasSubmittingError ] = useState< boolean >( false );
-
+	const sectionName = useSelector( getSectionName );
 	const currentSite = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return helpCenterSelect.getSite();
@@ -170,22 +172,34 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	};
 
 	const renderChatOption = () => {
+		const productSlug = ( currentSite as HelpCenterSite )?.plan?.product_slug;
+		const plan = getPlan( productSlug );
+		const productId = plan?.getProductId();
+
+		const handleOnClick = () => {
+			contactOptionsEventMap.chat();
+
+			recordTracksEvent( 'calypso_help_live_chat_begin', {
+				site_plan_product_id: productId,
+				is_automated_transfer: currentSite?.is_wpcom_atomic,
+				force_site_id: true,
+				location: 'help-center',
+				section: sectionName,
+			} );
+
+			openChatWidget( {
+				aiChatId: wapuuChatId,
+				message: `Support request started with <strong>Wapuu</strong><br>Site: ${ currentSite?.URL }<br />Wapuu Chat: <a href="https://mc.a8c.com/odie/odie-chat.php?chat_id=${ wapuuChatId }">${ wapuuChatId }</a>`,
+				siteUrl: currentSite?.URL,
+				onError: () => setHasSubmittingError( true ),
+				// Reset Odie chat after passing to support
+				onSuccess: () => setWapuuChatId( null ),
+			} );
+		};
+
 		return (
 			<div>
-				<button
-					disabled={ isOpeningChatWidget }
-					onClick={ () => {
-						contactOptionsEventMap.chat();
-						openChatWidget( {
-							aiChatId: wapuuChatId,
-							message: '',
-							siteUrl: currentSite?.URL,
-							onError: () => setHasSubmittingError( true ),
-							// Reset Odie chat after passing to support
-							onSuccess: () => setWapuuChatId( null ),
-						} );
-					} }
-				>
+				<button disabled={ isOpeningChatWidget } onClick={ handleOnClick }>
 					<div className="help-center-contact-page__box chat" role="button" tabIndex={ 0 }>
 						<div className="help-center-contact-page__box-icon">
 							<Icon icon={ comment } />


### PR DESCRIPTION
## Proposed Changes

Add Odie chat context to the initial message to Zendesk.

## Why are these changes being made?

There is no details being given to the HE's when an interaction is started. This provides the context for the issue from the chat that the user had with Odie.

## Testing Instructions

Make sure Help Center ⇢ Odie ⇢ Zendesk flow works. There is no way to test the message in Zendesk staging.