### PR TITLE
Jetpack Backup: Add Tracks events for when a backup is in progress and when it completes.

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-in-progress.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-in-progress.tsx
@@ -9,7 +9,8 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import { backupMainPath } from 'calypso/my-sites/backup/paths';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import useGetDisplayDate from '../use-get-display-date';
 import BackupTips from './backup-tips';
@@ -28,9 +29,11 @@ const BackupInProgress: React.FC< Props > = ( { percent, inProgressDate, lastBac
 		? getDisplayDate( lastBackupDate, false )
 		: undefined;
 
+	const dispatch = useDispatch();
 	useEffect( () => {
 		recordLogRocketEvent( 'calypso_jetpack_backup_in_progress' );
-	}, [] );
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_in_progress' ) );
+	}, [ dispatch ] );
 
 	return (
 		<>

--- a/client/components/jetpack/daily-backup-status/status-card/backup-just-completed.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-just-completed.tsx
@@ -8,7 +8,8 @@ import { preventWidows } from 'calypso/lib/formatting';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import { backupMainPath } from 'calypso/my-sites/backup/paths';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import useGetDisplayDate from '../use-get-display-date';
 import BackupTips from './backup-tips';
@@ -25,9 +26,11 @@ const BackupJustCompleted: React.FC< Props > = ( { justCompletedBackupDate, last
 	const justCompletedDisplayDate = getDisplayDate( justCompletedBackupDate, false );
 	const lastBackupDisplayDate = getDisplayDate( lastBackupDate, false );
 
+	const dispatch = useDispatch();
 	useEffect( () => {
 		recordLogRocketEvent( 'calypso_jetpack_backup_just_completed' );
-	}, [] );
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_just_completed' ) );
+	}, [ dispatch ] );
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/489

## Proposed Changes
* Add `calypso_jetpack_backup_in_progress` Tracks event when a backup is in progress
* Add `calypso_jetpack_backup_just_completed`Tracks event when a backup completes successfully

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
These specific Tracks events will help us validate the feature usage of the on-demand feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch
* Open the Network tab in your developer tools
* Navigate to Jetpack Cloud > Backup
* Click on `Back up now`
* Once the backup starts, you should see a request to `t.gif` with the `calypso_jetpack_backup_in_progress` event.
* Once the backup completes, you should see a request to `t.gif` with the `calypso_jetpack_backup_just_completed` event.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
