### PR TITLE
Site Profiler Performance: Show the list of issues from a site

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -103,11 +103,27 @@ export interface UrlPerformanceMetricsQueryResponse {
 	webtestpage_org: {
 		report: {
 			audits: {
-				health: object;
-				performance: object;
+				health: PerformanceMetricsDataQueryResponse;
+				performance: PerformanceMetricsDataQueryResponse;
 			};
 		};
 	};
+}
+
+export interface PerformanceMetricsDataQueryResponse {
+	diagnostic: Record< string, PerformanceMetricsItemQueryResponse >;
+	pass: Record< string, PerformanceMetricsItemQueryResponse >;
+}
+
+export interface PerformanceMetricsItemQueryResponse {
+	id: string;
+	description?: string;
+	displayValue?: string;
+	details?: PerformanceMetricsDetailsQueryResponse;
+}
+
+export interface PerformanceMetricsDetailsQueryResponse {
+	type: 'table' | 'oppurtunity' | 'list';
 }
 
 export interface BasicMetricsResult extends Omit< UrlBasicMetricsQueryResponse, 'basic' > {

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -117,6 +117,7 @@ export interface PerformanceMetricsDataQueryResponse {
 
 export interface PerformanceMetricsItemQueryResponse {
 	id: string;
+	title?: string;
 	description?: string;
 	displayValue?: string;
 	details?: PerformanceMetricsDetailsQueryResponse;

--- a/client/site-profiler/components/metrics-insight/index.tsx
+++ b/client/site-profiler/components/metrics-insight/index.tsx
@@ -1,7 +1,7 @@
 import { FoldableCard } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 interface MetricsInsightProps {
 	insight?: Insight;
@@ -10,8 +10,8 @@ interface MetricsInsightProps {
 }
 
 type Insight = {
-	header?: string;
-	description?: string;
+	header?: ReactNode;
+	description?: ReactNode;
 };
 
 const Card = styled( FoldableCard )`
@@ -36,7 +36,7 @@ const InsightHeader = styled.div`
 `;
 
 const InsightContent = styled.div`
-	padding: 24px;
+	padding: 24px 0;
 `;
 
 export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {

--- a/client/site-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-header.tsx
@@ -12,10 +12,18 @@ export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 
 	return (
 		<>
-			<Markdown>{ title }</Markdown>
+			<Markdown
+				components={ {
+					code( props ) {
+						return <span className="value">{ props.children }</span>;
+					},
+				} }
+			>
+				{ title }
+			</Markdown>
 			{ value && (
 				<span>
-					- <span className="value"> { value }</span>
+					&nbsp;&minus;&nbsp;<span className="value"> { value }</span>
 				</span>
 			) }
 		</>

--- a/client/site-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-header.tsx
@@ -1,0 +1,23 @@
+import Markdown from 'react-markdown';
+import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
+
+interface InsightHeaderProps {
+	data: PerformanceMetricsItemQueryResponse;
+}
+
+export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
+	const { data } = props;
+	const title = data.description ?? '';
+	const value = data.displayValue ?? '';
+
+	return (
+		<>
+			<Markdown>{ title }</Markdown>
+			{ value && (
+				<span>
+					- <span className="value"> { value }</span>
+				</span>
+			) }
+		</>
+	);
+};

--- a/client/site-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-header.tsx
@@ -7,7 +7,7 @@ interface InsightHeaderProps {
 
 export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 	const { data } = props;
-	const title = data.description ?? '';
+	const title = data.title ?? '';
 	const value = data.displayValue ?? '';
 
 	return (

--- a/client/site-profiler/components/performance-section/index.tsx
+++ b/client/site-profiler/components/performance-section/index.tsx
@@ -1,16 +1,22 @@
 import { useTranslate } from 'i18n-calypso';
+import Markdown from 'react-markdown';
+import { useUrlPerformanceMetricsQuery } from 'calypso/data/site-profiler/use-url-performance-metrics-query';
 import { MetricsInsight } from 'calypso/site-profiler/components/metrics-insight';
 import { MetricsSection } from 'calypso/site-profiler/components/metrics-section';
 import { getTitleTranslateOptions } from 'calypso/site-profiler/utils/get-title-translate-options';
 
 interface PerformanceSectionProps {
+	url?: string;
+	hash?: string;
 	performanceMetricsRef: React.RefObject< HTMLObjectElement >;
 	setIsGetReportFormOpen?: ( isOpen: boolean ) => void;
 }
 
 export const PerformanceSection: React.FC< PerformanceSectionProps > = ( props ) => {
 	const translate = useTranslate();
-	const { performanceMetricsRef, setIsGetReportFormOpen } = props;
+	const { url, hash, performanceMetricsRef, setIsGetReportFormOpen } = props;
+	const { data } = useUrlPerformanceMetricsQuery( url, hash );
+	const performanceData = data?.performance?.diagnostic ?? {};
 
 	return (
 		<MetricsSection
@@ -22,15 +28,29 @@ export const PerformanceSection: React.FC< PerformanceSectionProps > = ( props )
 			subtitle={ translate( "Boost your site's performance" ) }
 			ref={ performanceMetricsRef }
 		>
-			{ Array( 2 )
-				.fill( {
-					header:
-						'Your site reveals first content slower than 76% of peers, affecting first impressions.',
-					description: 'This is how you can improve it',
-				} )
-				.map( ( insight, index ) => (
-					<MetricsInsight key={ `insight-${ index }` } insight={ insight } />
-				) ) }
+			{ Object.keys( performanceData ).map( ( metricKey ) => {
+				const title = performanceData[ metricKey ].description ?? '';
+				const value = performanceData[ metricKey ].displayValue ?? '';
+
+				return (
+					<MetricsInsight
+						key={ `insight-${ metricKey }` }
+						insight={ {
+							header: (
+								<>
+									<Markdown>{ title }</Markdown>
+									{ value && (
+										<span>
+											- <span className="value"> { value }</span>
+										</span>
+									) }
+								</>
+							),
+							description: 'This is how you can improve it',
+						} }
+					/>
+				);
+			} ) }
 
 			{ Array( 5 )
 				.fill( {} )

--- a/client/site-profiler/components/performance-section/index.tsx
+++ b/client/site-profiler/components/performance-section/index.tsx
@@ -1,9 +1,9 @@
 import { useTranslate } from 'i18n-calypso';
-import Markdown from 'react-markdown';
 import { useUrlPerformanceMetricsQuery } from 'calypso/data/site-profiler/use-url-performance-metrics-query';
 import { MetricsInsight } from 'calypso/site-profiler/components/metrics-insight';
 import { MetricsSection } from 'calypso/site-profiler/components/metrics-section';
 import { getTitleTranslateOptions } from 'calypso/site-profiler/utils/get-title-translate-options';
+import { InsightHeader } from '../metrics-insight/insight-header';
 
 interface PerformanceSectionProps {
 	url?: string;
@@ -28,29 +28,15 @@ export const PerformanceSection: React.FC< PerformanceSectionProps > = ( props )
 			subtitle={ translate( "Boost your site's performance" ) }
 			ref={ performanceMetricsRef }
 		>
-			{ Object.keys( performanceData ).map( ( metricKey ) => {
-				const title = performanceData[ metricKey ].description ?? '';
-				const value = performanceData[ metricKey ].displayValue ?? '';
-
-				return (
-					<MetricsInsight
-						key={ `insight-${ metricKey }` }
-						insight={ {
-							header: (
-								<>
-									<Markdown>{ title }</Markdown>
-									{ value && (
-										<span>
-											- <span className="value"> { value }</span>
-										</span>
-									) }
-								</>
-							),
-							description: 'This is how you can improve it',
-						} }
-					/>
-				);
-			} ) }
+			{ Object.values( performanceData ).map( ( metric ) => (
+				<MetricsInsight
+					key={ `insight-${ metric.id }` }
+					insight={ {
+						header: <InsightHeader data={ metric } />,
+						description: 'This is how you can improve it',
+					} }
+				/>
+			) ) }
 
 			{ Array( 5 )
 				.fill( {} )

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -34,7 +34,7 @@ interface Props {
 }
 
 export default function SiteProfilerV2( props: Props ) {
-	const { routerDomain } = props;
+	const { routerDomain, hash } = props;
 	const hostingRef = useRef( null );
 	const domainRef = useRef( null );
 	const perfomanceMetricsRef = useRef( null );
@@ -160,6 +160,8 @@ export default function SiteProfilerV2( props: Props ) {
 								/>
 
 								<PerformanceSection
+									url={ url }
+									hash={ hash ?? basicMetrics?.token }
 									performanceMetricsRef={ perfomanceMetricsRef }
 									setIsGetReportFormOpen={ setIsGetReportFormOpen }
 								/>

--- a/client/site-profiler/components/styles-v2.scss
+++ b/client/site-profiler/components/styles-v2.scss
@@ -279,13 +279,49 @@
 		border-top: 1px solid var(--studio-gray-100);
 		color: var(--studio-gray-20);
 
+		.foldable-card__secondary {
+			display: none;
+		}
+
+		.foldable-card__main {
+			padding-right: 50px;
+
+			a {
+				color: var(--studio-gray-40);
+
+				&:hover {
+					color: #fff;
+				}
+			}
+
+			.value {
+				color: var(--studio-red-30);
+			}
+		}
+
+		&.is-expanded .foldable-card__main {
+			color: #fff;
+
+			a {
+				color: #fff;
+
+				&:hover {
+					color: var(--studio-gray-40);
+				}
+			}
+
+			.value {
+				color: var(--studio-red-50);
+			}
+		}
+
 		&:last-child {
 			border-bottom: 1px solid var(--studio-gray-100);
 		}
 
 		&.is-expanded {
 			.foldable-card__content {
-				border-top: 1px solid var(--studio-gray-100);
+				border-top: none;
 			}
 		}
 
@@ -297,6 +333,13 @@
 
 		.foldable-card__header {
 			padding: 16px 0;
+		}
+
+		p {
+			display: inline;
+			font-size: inherit;
+			color: inherit;
+			margin-bottom: inherit;
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7466

## Proposed Changes

* Update the titles to match better with the server response
* Get real performance insights from the Performance Section using the `useUrlPerformanceMetricsQuery`
* Create the InsightHeader component to isolate the logic for this part
  * Display Markdown data on the title
* Update styles to match the layout 


## Why are these changes being made?

To match the proposed layout at https://www.figma.com/design/P7Jjk4nbUTahUk8aHkG6NQ/Performance-Tool?m=dev&node-id=1124-2591

## Testing Instructions
* Go to `/site-profiler/:url`. Ex: `/site-profiler/wordpress.com`
* Go to the Performance section and check if real data is being shown on the list and the style matches the [proposed layout](https://www.figma.com/design/P7Jjk4nbUTahUk8aHkG6NQ/Performance-Tool?m=dev&node-id=1124-2591)


![CleanShot 2024-05-28 at 17 44 20@2x](https://github.com/Automattic/wp-calypso/assets/5039531/ef5342c5-970c-4680-8cce-655d6b0bd0fa)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
