### PR TITLE
[Woo Blaze] Display jetpack connect error notice

### DIFF
--- a/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/components/disconnected-site.jsx
@@ -1,15 +1,28 @@
 import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import privateSiteGraphic from 'calypso/assets/images/blaze/site-private-graphic@3x.png';
+import Notice from 'calypso/components/notice';
 
 export default function DisconnectedSite() {
 	const translate = useTranslate();
+	const [ jetpackErrorMessage ] = useState( window.configData.jetpack_error_message );
 	const connectUrl = config( 'connect_url' );
 
 	return (
 		<>
 			<div className="promote-post-i2__inner-container">
+				{ jetpackErrorMessage && (
+					<Notice
+						className="promote-post-notice promote-post-i2__aux-wrapper setup-pages__notice"
+						status="is-error"
+						icon="mention"
+						showDismiss={ false }
+					>
+						{ jetpackErrorMessage }
+					</Notice>
+				) }
 				<div className="promote-post-i2__setup-icon">
 					<img src={ privateSiteGraphic } alt="" />
 				</div>

--- a/apps/blaze-dashboard/src/pages/setup/style.scss
+++ b/apps/blaze-dashboard/src/pages/setup/style.scss
@@ -12,6 +12,11 @@
 		flex-direction: column;
 		padding-bottom: 95px;
 
+		div.notice.promote-post-notice.setup-pages__notice {
+			margin-top: 10px;
+			text-align: left;
+		}
+
 		.setup-pages__title {
 			font-weight: 400;
 			font-size: 2.75rem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR displays any error message during Jetpack connection attemp

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Sometimes when there is an issue with connection, clicking the connect button just reloads the page and nothing happens and the user cannot determine why.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Active Jetpack connect IDC Simulator
* Try to click "Connect now"
* The page should reload and the corresponding error be displayed
<img width="1726" alt="error display" src="https://github.com/Automattic/wp-calypso/assets/9039613/fcf98c87-7009-41ae-bf6a-190a1eac95a3">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
