### PR TITLE
A4A: add wpcom hosting referral logic

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -85,7 +85,7 @@ function WpcomOverview() {
 	}, [ creatorPlan, isLicenseCountsReady, licenseCounts?.products ] );
 
 	// For referral mode we only display 1 option.
-	const dispalyQuantity = referralMode ? 1 : ( selectedTier.value as number ) - ownedPlans;
+	const displayQuantity = referralMode ? 1 : ( selectedTier.value as number ) - ownedPlans;
 	const displayDiscount = referralMode ? options[ 0 ].discount : selectedTier.discount;
 
 	const onclickMoreInfo = useCallback( () => {
@@ -185,7 +185,7 @@ function WpcomOverview() {
 				{ creatorPlan && (
 					<WPCOMPlanCard
 						plan={ creatorPlan }
-						quantity={ dispalyQuantity } // We only calculate the difference between the selected tier and the owned plans
+						quantity={ displayQuantity } // We only calculate the difference between the selected tier and the owned plans
 						discount={ displayDiscount }
 						onSelect={ onAddToCart }
 						isLoading={ ! isLicenseCountsReady }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -1,5 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
 import {
 	Icon,
 	blockMeta,
@@ -11,7 +13,7 @@ import {
 	external,
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useContext, useMemo, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -31,6 +33,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingOverview from '../common/hosting-overview';
 import HostingOverviewFeatures from '../common/hosting-overview-features';
+import { MarketplaceTypeContext } from '../context';
 import withMarketplaceType from '../hoc/with-marketplace-type';
 import useProductAndPlans from '../hooks/use-product-and-plans';
 import useShoppingCart from '../hooks/use-shopping-cart';
@@ -46,6 +49,10 @@ import './style.scss';
 function WpcomOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
+	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
+	const referralMode = marketplaceType === 'referral';
 
 	const {
 		selectedCartItems,
@@ -77,6 +84,10 @@ function WpcomOverview() {
 		}
 	}, [ creatorPlan, isLicenseCountsReady, licenseCounts?.products ] );
 
+	// For referral mode we only display 1 option.
+	const dispalyQuantity = referralMode ? 1 : ( selectedTier.value as number ) - ownedPlans;
+	const displayDiscount = referralMode ? options[ 0 ].discount : selectedTier.discount;
+
 	const onclickMoreInfo = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_hosting_wpcom_view_all_features_click' )
@@ -107,7 +118,6 @@ function WpcomOverview() {
 			wide
 			withBorder
 			compact
-			sidebarNavigation={ <MobileSidebarNavigation /> }
 		>
 			<LayoutTop>
 				<LayoutHeader>
@@ -127,7 +137,19 @@ function WpcomOverview() {
 						] }
 					/>
 
-					<Actions>
+					<Actions className="a4a-marketplace__header-actions">
+						<MobileSidebarNavigation />
+						{ isAutomatedReferrals && (
+							<div className="a4a-marketplace__toggle-marketplace-type">
+								<ToggleControl
+									onChange={ toggleMarketplaceType }
+									checked={ marketplaceType === 'referral' }
+									id="a4a-marketplace__toggle-marketplace-type"
+									label={ translate( 'Refer products' ) }
+								/>
+								<Gridicon icon="info-outline" size={ 16 } />
+							</div>
+						) }
 						<ShoppingCart
 							showCart={ showCart }
 							setShowCart={ setShowCart }
@@ -151,18 +173,20 @@ function WpcomOverview() {
 					) }
 				/>
 
-				<WPCOMBulkSelector
-					selectedTier={ selectedTier }
-					onSelectTier={ onSelectTier }
-					ownedPlans={ ownedPlans }
-					isLoading={ ! isLicenseCountsReady }
-				/>
+				{ ! referralMode && (
+					<WPCOMBulkSelector
+						selectedTier={ selectedTier }
+						onSelectTier={ onSelectTier }
+						ownedPlans={ ownedPlans }
+						isLoading={ ! isLicenseCountsReady }
+					/>
+				) }
 
 				{ creatorPlan && (
 					<WPCOMPlanCard
 						plan={ creatorPlan }
-						quantity={ ( selectedTier.value as number ) - ownedPlans } // We only calculate the difference between the selected tier and the owned plans
-						discount={ selectedTier.discount }
+						quantity={ dispalyQuantity } // We only calculate the difference between the selected tier and the owned plans
+						discount={ displayDiscount }
 						onSelect={ onAddToCart }
 						isLoading={ ! isLicenseCountsReady }
 					/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-genesis/issues/363

## Proposed Changes

This logic removes Volume selector for wpcom plans and correctly presents it in shopping cart.
Note: I will address `pressable` separately after https://github.com/Automattic/wp-calypso/pull/91202 get merged.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/marketplace/hosting/wpcom`.
- Check the `referral switch` left to cart.
- Observe the behavior. 
- With some WPCOM plan already purchased, when switched to referral mode, no discount should be applied in the cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
