### PR TITLE
Add: Add sender from name newsletter setting

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/SenderNameSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SenderNameSetting.tsx
@@ -1,5 +1,6 @@
 import { FormLabel, FormInputValidation } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent } from 'react';
 import { useSelector } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -43,7 +44,7 @@ export const SenderNameSetting = ( {
 				name="jetpack_subscriptions_from_name"
 				id="jetpack_subscriptions_from_name"
 				value={ value }
-				onChange={ ( event ) => {
+				onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
 					return updateFields( { jetpack_subscriptions_from_name: event.target.value } );
 				} }
 				disabled={ disabled }

--- a/client/my-sites/site-settings/settings-newsletter/SenderNameSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SenderNameSetting.tsx
@@ -1,0 +1,71 @@
+import { FormLabel, FormInputValidation } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+
+type SenderNameSettingProps = {
+	value?: string;
+	disabled?: boolean;
+	replyToValue?: string;
+	updateFields: ( fields: { [ key: string ]: unknown } ) => void;
+};
+
+function replyToExampleEmail( replyToEmail?: string ) {
+	if ( replyToEmail === 'author' ) {
+		return 'author-name@example.com';
+	}
+	if ( replyToEmail === 'comment' ) {
+		return `comment-reply@wordpress.com'`;
+	}
+
+	return 'donotreply@wordpress.com';
+}
+
+export const SenderNameSetting = ( {
+	value = '',
+	disabled,
+	replyToValue,
+	updateFields,
+}: SenderNameSettingProps ) => {
+	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const placeholder = selectedSite?.name || translate( 'Sender name' );
+	const reply_to_email = replyToExampleEmail( replyToValue );
+
+	return (
+		<FormFieldset>
+			<FormLabel>{ translate( 'Sender name' ) }</FormLabel>
+
+			<FormTextInput
+				name="jetpack_subscriptions_from_name"
+				id="jetpack_subscriptions_from_name"
+				value={ value }
+				onChange={ ( event ) => {
+					return updateFields( { jetpack_subscriptions_from_name: event.target.value } );
+				} }
+				disabled={ disabled }
+				placeholder={ placeholder }
+			/>
+			<FormInputValidation
+				hasIcon={ false }
+				text={ translate( 'Example: %(value)s <%(email)s>', {
+					args: {
+						value: value || placeholder,
+						email: reply_to_email,
+					},
+				} ) }
+				isMuted
+				isError={ false }
+			/>
+
+			<FormSettingExplanation>
+				{ translate(
+					"This is the name that appears in subscribers' inboxes. It's usually the name of your newsletter or the author."
+				) }
+			</FormSettingExplanation>
+		</FormFieldset>
+	);
+};

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -17,6 +17,7 @@ import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
 import { ReplyToSetting } from './ReplyToSetting';
+import { SenderNameSetting } from './SenderNameSetting';
 import { SubscribeModalOnCommentSetting } from './SubscribeModalOnCommentSetting';
 import { SubscribeModalSetting } from './SubscribeModalSetting';
 import { SubscribePostEndSetting } from './SubscribePostEndSetting';
@@ -38,6 +39,7 @@ type Fields = {
 	wpcom_newsletter_categories_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	jetpack_subscriptions_reply_to?: string;
+	jetpack_subscriptions_from_name?: string;
 	sm_enabled?: boolean;
 	jetpack_subscriptions_subscribe_post_end_enabled?: boolean;
 	jetpack_subscriptions_login_navigation_enabled?: boolean;
@@ -56,6 +58,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt,
 		jetpack_subscriptions_reply_to,
+		jetpack_subscriptions_from_name,
 		sm_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled,
 		jetpack_subscriptions_login_navigation_enabled,
@@ -69,6 +72,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_newsletter_categories_enabled: !! wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
 		jetpack_subscriptions_reply_to: jetpack_subscriptions_reply_to || '',
+		jetpack_subscriptions_from_name: jetpack_subscriptions_from_name || '',
 		sm_enabled: !! sm_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled:
 			!! jetpack_subscriptions_subscribe_post_end_enabled,
@@ -104,6 +108,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		wpcom_featured_image_in_email,
 		wpcom_subscription_emails_use_excerpt,
 		jetpack_subscriptions_reply_to,
+		jetpack_subscriptions_from_name,
 		subscription_options,
 		sm_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled,
@@ -202,6 +207,14 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					disabled={ disabled }
 					updateFields={ updateFields }
 					value={ wpcom_subscription_emails_use_excerpt }
+				/>
+			</Card>
+			<Card className="site-settings__card">
+				<SenderNameSetting
+					disabled={ disabled }
+					updateFields={ updateFields }
+					value={ jetpack_subscriptions_from_name }
+					replyToValue={ jetpack_subscriptions_reply_to }
 				/>
 			</Card>
 			<Card className="site-settings__card">

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -204,6 +204,12 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 							path,
 						} );
 						break;
+					case 'jetpack_subscriptions_from_name':
+						trackTracksEvent( 'calypso_setting_jetpack_subscriptions_from_name_updated', {
+							value: fields.jetpack_subscriptions_from_name,
+							path,
+						} );
+						break;
 					case 'jetpack_subscriptions_login_navigation_enabled':
 						trackTracksEvent( 'calypso_settings_subscriber_login_navigation_updated', {
 							value: fields.jetpack_subscriptions_login_navigation_enabled,

--- a/packages/components/src/forms/form-input-validation/index.tsx
+++ b/packages/components/src/forms/form-input-validation/index.tsx
@@ -12,6 +12,7 @@ interface Props {
 	isValid?: boolean;
 	isMuted?: boolean;
 	text: ReactNode;
+	hasIcon?: boolean;
 	ariaLabel?: string;
 	icon?: string;
 	id?: string;
@@ -27,6 +28,7 @@ const FormInputValidation: React.FC< Props > = ( {
 	className,
 	ariaLabel = '',
 	text,
+	hasIcon = true,
 	icon,
 	id,
 	children,
@@ -37,6 +39,7 @@ const FormInputValidation: React.FC< Props > = ( {
 		'is-error': isError,
 		'is-hidden': isHidden,
 		'is-muted': isMuted,
+		'has-icon': hasIcon,
 	} );
 
 	const defaultIcon = isError || isWarning ? info : check;
@@ -45,11 +48,12 @@ const FormInputValidation: React.FC< Props > = ( {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		<div aria-label={ ariaLabel } className={ classes } role="alert">
 			<span id={ id }>
-				{ icon ? (
-					<Gridicon size={ 20 } icon={ icon } />
-				) : (
-					<Icon size={ 20 } icon={ defaultIcon } />
-				) }
+				{ hasIcon &&
+					( icon ? (
+						<Gridicon size={ 20 } icon={ icon } />
+					) : (
+						<Icon size={ 20 } icon={ defaultIcon } />
+					) ) }
 				{ text }
 				{ children }
 			</span>

--- a/packages/components/src/forms/form-input-validation/style.scss
+++ b/packages/components/src/forms/form-input-validation/style.scss
@@ -3,7 +3,7 @@
 .form-input-validation {
 	color: var(--color-success);
 	position: relative;
-	padding: 6px 24px 11px 34px;
+	padding: 6px 24px 11px 0;
 	border-radius: 2px;
 	box-sizing: border-box;
 	font-size: $font-body-small;
@@ -16,6 +16,10 @@
 
 	&.is-warning {
 		color: var(--color-warning);
+	}
+
+	&.has-icon {
+		padding-left: 34px;
 	}
 
 	&.is-hidden {


### PR DESCRIPTION

Related to https://github.com/Automattic/jetpack/pull/37362 
## Proposed Changes

* This Pr ads from name to the calypso newsletter setting. 


<img width="786" alt="Screenshot 2024-05-28 at 2 36 43 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/240f7f93-7241-42b0-85e1-8937809216c1">

## Why are these changes being made?

* Adds the new setting. 
* Adds the track event for that setting. 
* Adds form-input-validation hasIcon={ false } property which make is so that you can have form input validation also without an icon. 

## Testing Instructions

* Visit Settings/Newsletter and notice the new setting. 
* Change it make sure that the example preview updates as expected. 
* Save the value. 
* Make sure that the subscription email goes out with the new from name.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
