### PR TITLE
Hosting: Remove the external icon from the Overview item on Calypso

### DIFF
--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -96,10 +96,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 		if ( ! isUnifiedSiteSidebarVisible ) {
 			return false;
 		}
-		return (
-			( item?.parent === 'jetpack' && item?.url?.startsWith( 'https://jetpack.com' ) ) ||
-			( item?.parent === 'wpcom-hosting-menu' && item?.url?.startsWith( '/overview/' ) )
-		);
+		return item?.parent === 'jetpack' && item?.url?.startsWith( 'https://jetpack.com' );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7486

## Proposed Changes

* Remove the external link icon from the Overview submenu item on Calypso

| Before | After |
| - | - |
| <img width="161" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/637acb9b-f809-434b-813b-d1190a5eac1a"> | <img width="162" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/7f51244c-fe32-4340-89ef-c379ab0b7208"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /home/<your_site>
* Make sure the external icon of the Overview item is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
