### PR TITLE
Site Dashboard: Make the WordPress.com logo clickable

### DIFF
--- a/client/layout/global-sidebar/header.tsx
+++ b/client/layout/global-sidebar/header.tsx
@@ -1,7 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
-import { getSectionName } from 'calypso/state/ui/selectors';
 import SkipNavigation from '../sidebar/skip-navigation';
 import { GLOBAL_SIDEBAR_EVENTS } from './events';
 import SidebarMenuItem from './menu-items/menu-item';
@@ -9,26 +7,20 @@ import SidebarMenuItem from './menu-items/menu-item';
 export const GlobalSidebarHeader = () => {
 	const translate = useTranslate();
 
-	const sectionName = useSelector( getSectionName );
-
 	return (
 		<div className="sidebar__header">
 			<SkipNavigation
 				skipToElementId="primary"
 				displayText={ translate( 'Skip to main content' ) }
 			/>
-			{ sectionName === 'sites-dashboard' ? (
-				<span className="dotcom"></span>
-			) : (
-				<SidebarMenuItem
-					url="/sites"
-					className="link-logo"
-					tooltip={ translate( 'View all sites' ) }
-					tooltipPlacement="bottom"
-					onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.ALLSITES_CLICK ) }
-					icon={ <span className="dotcom"></span> }
-				/>
-			) }
+			<SidebarMenuItem
+				url="/sites"
+				className="link-logo"
+				tooltip={ translate( 'View all sites' ) }
+				tooltipPlacement="bottom"
+				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.ALLSITES_CLICK ) }
+				icon={ <span className="dotcom"></span> }
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7487

## Proposed Changes

* Make the WordPress.com logo look clickable on the Site Dashboard screen. However, it does nothing as the user is on the same page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Make sure the WordPress.com logo clickable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
