### PR TITLE
Plugins: Add the Plugins as the default under the Plugins page

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -123,7 +123,14 @@ export const ScheduleList = ( props: Props ) => {
 	return (
 		<div className="plugins-update-manager plugins-update-manager-multisite">
 			<div className="plugins-update-manager-multisite__header">
-				<h1>{ translate( 'Scheduled Updates' ) }</h1>
+				<div className="plugins-update-manager-multisite__header-main">
+					<h1>{ translate( 'Scheduled Updates' ) }</h1>
+					<p>
+						{ translate(
+							'Streamline your workflow with scheduled updates, timed to suit your needs.'
+						) }
+					</p>
+				</div>
 				{ showNewScheduleBtn && ! isScheduleEmpty && (
 					<Button
 						__next40pxDefaultSize={ ! compact }

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -192,8 +192,6 @@ export function scheduledUpdates( context, next ) {
 }
 
 export function scheduledUpdatesMultisite( context, next ) {
-	const state = context.store.getState();
-
 	const goToScheduledUpdatesList = () => page.show( `/plugins/scheduled-updates/` );
 	const goToScheduleEdit = ( id ) => page.show( `/plugins/scheduled-updates/edit/${ id }` );
 	const goToScheduleLogs = ( id, siteSlug ) =>
@@ -230,15 +228,6 @@ export function scheduledUpdatesMultisite( context, next ) {
 			} );
 			break;
 	}
-
-	const isSidebarCollapsed = getShouldShowCollapsedGlobalSidebar(
-		state,
-		undefined,
-		context.section.group,
-		context.section.name
-	);
-
-	context.secondary = <PluginsSidebar path={ context.path } isCollapsed={ isSidebarCollapsed } />;
 
 	next();
 }
@@ -396,5 +385,25 @@ export function maybeRedirectLoggedOut( context, next ) {
 	if ( siteFragment ) {
 		return redirectLoggedOut( context, next );
 	}
+	next();
+}
+
+export function renderPluginsSidebar( context, next ) {
+	const state = context.store.getState();
+	const siteUrl = getSiteFragment( context.path );
+	if ( ! siteUrl ) {
+		context.secondary = (
+			<PluginsSidebar
+				path={ context.path }
+				isCollapsed={ getShouldShowCollapsedGlobalSidebar(
+					state,
+					undefined,
+					context.section.group,
+					context.section.name
+				) }
+			/>
+		);
+	}
+
 	next();
 }

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -25,6 +25,7 @@ import {
 	navigationIfLoggedIn,
 	maybeRedirectLoggedOut,
 	redirectStagingSites,
+	renderPluginsSidebar,
 } from './controller';
 import { plans, upload } from './controller-logged-in';
 
@@ -62,6 +63,7 @@ export default function ( router ) {
 		siteSelection,
 		navigationIfLoggedIn,
 		redirectTrialSites,
+		renderPluginsSidebar,
 		browsePlugins,
 		makeLayout,
 		clientRender
@@ -96,6 +98,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigationIfLoggedIn,
+		renderPluginsSidebar,
 		browsePlugins,
 		makeLayout,
 		clientRender
@@ -124,6 +127,7 @@ export default function ( router ) {
 		siteSelection,
 		navigation,
 		redirectTrialSites,
+		renderPluginsSidebar,
 		plugins,
 		makeLayout,
 		clientRender
@@ -138,6 +142,7 @@ export default function ( router ) {
 		navigation,
 		redirectTrialSites,
 		jetpackCanUpdate,
+		renderPluginsSidebar,
 		plugins,
 		makeLayout,
 		clientRender
@@ -152,6 +157,7 @@ export default function ( router ) {
 			],
 			redirectLoggedOut,
 			navigation,
+			renderPluginsSidebar,
 			scheduledUpdatesMultisite,
 			makeLayout,
 			clientRender
@@ -184,6 +190,7 @@ export default function ( router ) {
 		siteSelection,
 		navigationIfLoggedIn,
 		redirectTrialSites,
+		renderPluginsSidebar,
 		relatedPlugins,
 		makeLayout,
 		clientRender
@@ -210,6 +217,7 @@ export default function ( router ) {
 		siteSelection,
 		navigationIfLoggedIn,
 		redirectTrialSites,
+		renderPluginsSidebar,
 		browsePluginsOrPlugin,
 		makeLayout,
 		clientRender

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list.tsx
@@ -39,7 +39,9 @@ export default function PluginAvailableOnSitesList( props: Props ) {
 			<div className="plugin-details-v2__title">{ translate( 'Available on' ) }</div>
 			<SitesList
 				{ ...props }
-				items={ sitesWithSecondarySites.map( ( site ) => site.site ) }
+				items={ sitesWithSecondarySites
+					.map( ( site ) => site.site )
+					.filter( ( site ) => site && ! site.is_deleted ) }
 				columns={ columns }
 			/>
 		</div>

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -100,7 +100,9 @@ export default function SitesWithInstalledPluginsList( {
 				{ ...rest }
 				plugin={ plugin }
 				selectedSite={ selectedSite }
-				items={ sitesWithSecondarySites.map( ( site ) => site.site ) }
+				items={ sitesWithSecondarySites
+					.map( ( site ) => site.site )
+					.filter( ( site ) => site && ! site.is_deleted ) }
 				columns={ columns }
 				renderActions={ renderActions }
 			/>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -132,6 +132,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	if ( ! isRequestingSitesData && noPermissionsError ) {
 		return <NoPermissionsError title={ __( 'Plugins' ) } />;
 	}
+
 	return (
 		<MainComponent wideLayout isLoggedOut={ ! isLoggedIn }>
 			<QueryProductsList persist />

--- a/client/my-sites/plugins/related-plugins-page/index.tsx
+++ b/client/my-sites/plugins/related-plugins-page/index.tsx
@@ -1,12 +1,18 @@
+import { useBreakpoint } from '@automattic/viewport-react';
 import { UseQueryResult } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import MainComponent from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { RelatedPlugin } from 'calypso/data/marketplace/types';
 import { useGetRelatedPlugins } from 'calypso/data/marketplace/use-get-related-plugins';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
+import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
+import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
+
 import './style.scss';
 
 export function RelatedPluginsPage( {
@@ -16,16 +22,29 @@ export function RelatedPluginsPage( {
 	pluginSlug: string;
 	siteUrl: string;
 } ) {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
+	const isWide = useBreakpoint( '>960px' );
+	const breadcrumbs = useSelector( getBreadcrumbs );
 
 	const { data: relatedPlugins = [], isLoading } = useGetRelatedPlugins(
 		pluginSlug,
 		20
 	) as UseQueryResult< RelatedPlugin[] >;
 
+	useEffect( () => {
+		dispatch(
+			appendBreadcrumb( {
+				label: translate( 'Related' ),
+				id: 'plugins-related',
+			} )
+		);
+	}, [] );
+
 	return (
 		<MainComponent wideLayout className="related-plugins-page">
+			<NavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs } />
 			<PluginsBrowserList
 				title={ translate( 'Related Plugins' ) }
 				subtitle=""

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import GlobalSidebar from 'calypso/layout/global-sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
+import { SidebarIconPlugins } from '../../sidebar/static-data/global-sidebar-menu';
 import { SidebarIconCalendar } from './icons';
 import './style.scss';
 
@@ -26,6 +27,16 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 				) }
 			</p>
 			<SidebarMenu>
+				<SidebarItem
+					className="sidebar__menu-item--plugins"
+					link="/plugins"
+					label={ translate( 'Plugins' ) }
+					tooltip={ isCollapsed && translate( 'Plugins' ) }
+					selected={
+						path.startsWith( '/plugins' ) && ! path.startsWith( '/plugins/scheduled-updates' )
+					}
+					customIcon={ <SidebarIconPlugins /> }
+				/>
 				<SidebarItem
 					className="sidebar__menu-item--plugins"
 					link="/plugins/scheduled-updates"

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -25,8 +25,8 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 				<SidebarItem
 					className="sidebar__menu-item--plugins"
 					link="/plugins"
-					label={ translate( 'Plugins' ) }
-					tooltip={ isCollapsed && translate( 'Plugins' ) }
+					label={ translate( 'Marketplace' ) }
+					tooltip={ isCollapsed && translate( 'Marketplace' ) }
 					selected={
 						path.startsWith( '/plugins' ) && ! path.startsWith( '/plugins/scheduled-updates' )
 					}

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -21,11 +21,6 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 			requireBackLink
 			backLinkHref="/sites"
 		>
-			<p className="sidebar__description">
-				{ translate(
-					'Streamline your workflow with scheduled updates, timed to suit your needs.'
-				) }
-			</p>
 			<SidebarMenu>
 				<SidebarItem
 					className="sidebar__menu-item--plugins"

--- a/client/my-sites/plugins/sidebar/style.scss
+++ b/client/my-sites/plugins/sidebar/style.scss
@@ -2,11 +2,5 @@
 	.sidebar__back-link {
 		margin-bottom: 1rem;
 	}
-
-	.sidebar__description {
-		font-size: rem(13px);
-		padding: 0 rem(12px);
-		margin-bottom: 1rem;
-	}
 }
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -70,7 +70,6 @@ body.is-section-plugins {
 	}
 
 	.is-section-plugins.is-global-sidebar-collapsed {
-		.sidebar__description,
 		.sidebar__back-link .sidebar__site-title {
 			display: none;
 		}
@@ -129,6 +128,20 @@ body.is-section-plugins {
 
 			@include breakpoint-deprecated( "<660px" ) {
 				padding: 1rem 0;
+			}
+		}
+
+		.plugins-update-manager-multisite__header {
+			display: flex;
+			justify-content: space-between;
+			align-items: flex-start;
+			flex-wrap: nowrap;
+			gap: 16px;
+
+			p {
+				margin-bottom: 0;
+				font-size: 0.875rem;
+				color: var(--color-neutral-60);
 			}
 		}
 

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -2,6 +2,23 @@ import { isEnabled } from '@automattic/calypso-config';
 import { category, Icon } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 
+export const SidebarIconPlugins = () => (
+	<svg
+		className="sidebar__menu-icon svg-plugins"
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M10.5 4L10.5 8H13.5V4H15V8H16.5C17.0523 8 17.5 8.44772 17.5 9V13L14.5 17V19C14.5 19.5523 14.0523 20 13.5 20H10.5C9.94772 20 9.5 19.5523 9.5 19V17L6.5 13V9C6.5 8.44772 6.94772 8 7.5 8H9L9 4H10.5ZM11 16.5V18.5H13V16.5L16 12.5V9.5H8V12.5L11 16.5Z"
+		/>
+	</svg>
+);
+
 /**
  * Menu items that support all sites screen.
  */
@@ -27,27 +44,12 @@ export default function globalSidebarMenu() {
 
 	isEnabled( 'layout/dotcom-nav-redesign-v2' ) &&
 		menuItems.push( {
-			icon: (
-				<svg
-					className="sidebar__menu-icon svg-plugins"
-					width="24"
-					height="24"
-					viewBox="0 0 24 24"
-					fill="none"
-					xmlns="http://www.w3.org/2000/svg"
-				>
-					<path
-						fillRule="evenodd"
-						clipRule="evenodd"
-						d="M10.5 4L10.5 8H13.5V4H15V8H16.5C17.0523 8 17.5 8.44772 17.5 9V13L14.5 17V19C14.5 19.5523 14.0523 20 13.5 20H10.5C9.94772 20 9.5 19.5523 9.5 19V17L6.5 13V9C6.5 8.44772 6.94772 8 7.5 8H9L9 4H10.5ZM11 16.5V18.5H13V16.5L16 12.5V9.5H8V12.5L11 16.5Z"
-					/>
-				</svg>
-			),
+			icon: <SidebarIconPlugins />,
 			slug: 'plugins',
 			title: translate( 'Plugins' ),
 			navigationLabel: translate( 'Plugins' ),
 			type: 'menu-item',
-			url: '/plugins/scheduled-updates',
+			url: '/plugins/',
 			forceChevronIcon: true,
 		} );
 

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -49,7 +49,7 @@ export default function globalSidebarMenu() {
 			title: translate( 'Plugins' ),
 			navigationLabel: translate( 'Plugins' ),
 			type: 'menu-item',
-			url: '/plugins/',
+			url: '/plugins',
 			forceChevronIcon: true,
 		} );
 

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -323,6 +323,7 @@
 							opacity: 0;
 							display: block !important;
 							width: 0;
+							white-space: nowrap;
 						}
 						.sidebar__menu-link {
 							width: fit-content;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7489

## Proposed Changes

* Add the Plugins item under the /plugins page. I keep the name "Plugins" to align the title on the plugins page
* Make the Plugins item as the default item under the page
* Add the Navigation Header to the Related Plugins page
* Filter out the deleted sites so the "Manage Sites" button won't lead to WSOD

| Plugins | Plugin Details | Related Plugins |
| - | - | - |
| <img width="1391" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/48bed046-c34f-4da5-8c42-d71637d3c514"> | <img width="1392" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/7d7651f8-b7e4-49da-ac34-2b2652a822c0"> | <img width="1391" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/05748642-cb3b-4783-b496-f4eabe394c4f"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /
* Select Plugins
* Make sure it opens the Plugins page as the default page, and the Plugins item is shown on the sidebar
* Go through the details of the Plugins page, and make sure everything works well
* Go to /plugins/:site
* Go through the details of the Plugins page, and make sure everything works well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
