### PR TITLE
A4A > Referrals: Implement refer products functionality in checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -1,8 +1,9 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useContext } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -17,18 +18,24 @@ import {
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSites from 'calypso/state/selectors/get-sites';
+import { MarketplaceTypeContext } from '../context';
+import withMarketplaceType, { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
 import useProductsBySlug from '../hooks/use-products-by-slug';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import useSubmitForm from '../products-overview/product-listing/hooks/use-submit-form';
 import PricingSummary from './pricing-summary';
 import ProductInfo from './product-info';
+import RequestClientPayment from './request-client-payment';
 import type { ShoppingCartItem } from '../types';
 
 import './style.scss';
 
-export default function Checkout() {
+function Checkout() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const isAutomatedReferrals = marketplaceType === MARKETPLACE_TYPE_REFERRAL;
 
 	const { selectedCartItems, onRemoveCartItem, onClearCart } = useShoppingCart();
 	const sites = useSelector( getSites );
@@ -96,10 +103,12 @@ export default function Checkout() {
 		page( A4A_SITES_LINK );
 	}, [ dispatch ] );
 
+	const title = isAutomatedReferrals ? translate( 'Referral checkout' ) : translate( 'Checkout' );
+
 	return (
 		<Layout
 			className="checkout"
-			title={ translate( 'Checkout' ) }
+			title={ title }
 			wide
 			withBorder
 			compact
@@ -114,7 +123,7 @@ export default function Checkout() {
 								href: A4A_MARKETPLACE_LINK,
 							},
 							{
-								label: translate( 'Checkout' ),
+								label: title,
 							},
 						] }
 					/>
@@ -124,7 +133,7 @@ export default function Checkout() {
 			<LayoutBody>
 				<div className="checkout__container">
 					<div className="checkout__main">
-						<h1 className="checkout__main-title">{ translate( 'Checkout' ) }</h1>
+						<h1 className="checkout__main-title">{ title }</h1>
 
 						<div className="checkout__main-list">
 							{ checkoutItems.map( ( items ) => (
@@ -135,39 +144,50 @@ export default function Checkout() {
 							) ) }
 						</div>
 					</div>
-					<div className="checkout__aside">
+					<div
+						className={ classNames( 'checkout__aside', {
+							'checkout__aside--referral': isAutomatedReferrals,
+						} ) }
+					>
 						<PricingSummary
 							items={ checkoutItems }
 							onRemoveItem={ siteId ? undefined : onRemoveItem }
+							isAutomatedReferrals={ isAutomatedReferrals }
 						/>
 
-						<div className="checkout__aside-actions">
-							<Button
-								primary
-								onClick={ onCheckout }
-								disabled={ ! checkoutItems.length || ! isReady }
-								busy={ ! isReady }
-							>
-								{ translate( 'Purchase' ) }
-							</Button>
+						{ isAutomatedReferrals ? (
+							<RequestClientPayment />
+						) : (
+							<div className="checkout__aside-actions">
+								<Button
+									primary
+									onClick={ onCheckout }
+									disabled={ ! checkoutItems.length || ! isReady }
+									busy={ ! isReady }
+								>
+									{ translate( 'Purchase' ) }
+								</Button>
 
-							{ siteId ? (
-								<Button onClick={ cancelPurchase }>{ translate( 'Cancel' ) }</Button>
-							) : (
-								<>
-									<Button onClick={ onContinueShopping }>
-										{ translate( 'Continue shopping' ) }
-									</Button>
+								{ siteId ? (
+									<Button onClick={ cancelPurchase }>{ translate( 'Cancel' ) }</Button>
+								) : (
+									<>
+										<Button onClick={ onContinueShopping }>
+											{ translate( 'Continue shopping' ) }
+										</Button>
 
-									<Button borderless onClick={ onEmptyCart }>
-										{ translate( 'Empty cart' ) }
-									</Button>
-								</>
-							) }
-						</div>
+										<Button borderless onClick={ onEmptyCart }>
+											{ translate( 'Empty cart' ) }
+										</Button>
+									</>
+								) }
+							</div>
+						) }
 					</div>
 				</div>
 			</LayoutBody>
 		</Layout>
 	);
 }
+
+export default withMarketplaceType( Checkout );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -1,0 +1,98 @@
+import { Button, FormLabel } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent, useCallback, useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+function RequestClientPayment() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ email, setEmail ] = useState( '' );
+	const [ message, setMessage ] = useState( '' );
+
+	const onEmailChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
+		setEmail( event.currentTarget.value );
+	}, [] );
+
+	const onMessageChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
+		setMessage( event.currentTarget.value );
+	}, [] );
+
+	const hasCompletedForm = !! email && !! message;
+
+	const learnMoreLink = ''; //FIXME: Add link for A4A;
+
+	const handleRequestPayment = useCallback( () => {
+		if ( ! hasCompletedForm ) {
+			return;
+		}
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_request_payment_click' )
+		);
+	}, [ dispatch, hasCompletedForm ] );
+
+	const onClickLearnMore = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_learn_more_click' ) );
+	}, [ dispatch ] );
+
+	return (
+		<>
+			<div className="checkout__client-referral-form">
+				<FormFieldset>
+					<FormLabel htmlFor="email">{ translate( 'Client’s email address' ) }</FormLabel>
+					<FormTextInput
+						name="email"
+						id="email"
+						value={ email }
+						onChange={ onEmailChange }
+						onClick={ () =>
+							dispatch( recordTracksEvent( 'calypso_a4a_client_referral_form_email_click' ) )
+						}
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="message">{ translate( 'Custom message' ) }</FormLabel>
+					<FormTextarea
+						name="message"
+						id="message"
+						placeholder="Send a message to your client about this request for payment."
+						value={ message }
+						onChange={ onMessageChange }
+						onClick={ () =>
+							dispatch( recordTracksEvent( 'calypso_a4a_client_referral_form_message_click' ) )
+						}
+					/>
+				</FormFieldset>
+			</div>
+			<div className="checkout__aside-actions">
+				<Button primary onClick={ handleRequestPayment } disabled={ ! hasCompletedForm }>
+					{ translate( 'Request payment from client' ) }
+				</Button>
+			</div>
+
+			<div className="checkout__summary-notice margin-top">
+				{ translate(
+					'The client will be billed at the end of every month. The first month may be less than the above amount. {{a}}Learn more{{/a}}',
+					{
+						components: {
+							a: (
+								<a
+									href={ learnMoreLink }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ onClickLearnMore }
+								/>
+							),
+						},
+					}
+				) }
+			</div>
+		</>
+	);
+}
+
+export default RequestClientPayment;

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -22,12 +22,10 @@
 	flex-direction: column;
 	align-items: stretch;
 
-
 	@include break-large {
 		flex-direction: row;
 		height: 100%;
 	}
-
 }
 
 .checkout__main {
@@ -58,6 +56,10 @@
 		max-width: 443px;
 		padding: 128px 48px;
 		background: var(--color-neutral-0);
+	}
+
+	&.checkout__aside--referral {
+		padding-block-start: 64px;
 	}
 }
 
@@ -139,6 +141,10 @@
 		text-decoration: underline;
 		color: var(--color-black);
 	}
+
+	&.margin-top {
+		margin-block-start: 16px;
+	}
 }
 
 .checkout__aside-actions {
@@ -219,4 +225,8 @@
 		font-weight: 400;
 		margin-block: 4px 0;
 	}
+}
+
+.checkout__client-referral-form {
+	padding-block-start: 48px;
 }

--- a/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
@@ -7,7 +7,9 @@ type ContextProps = {
 	defaultMarketplaceType?: MarketplaceType;
 };
 
-const MARKETPLACE_TYPE_SESSION_STORAGE_KEY = 'marketplace-type';
+export const MARKETPLACE_TYPE_SESSION_STORAGE_KEY = 'marketplace-type';
+export const MARKETPLACE_TYPE_REFERRAL = 'referral';
+export const MARKETPLACE_TYPE_REGULAR = 'regular';
 
 function withMarketplaceType< T >(
 	WrappedComponent: ComponentType< T & ContextProps >
@@ -17,9 +19,9 @@ function withMarketplaceType< T >(
 		const usedMarketplaceType =
 			props.defaultMarketplaceType ??
 			( sessionStorage.getItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY ) as MarketplaceType ) ??
-			'regular';
+			MARKETPLACE_TYPE_REGULAR;
 
-		const defaultType = isAutomatedReferrals ? usedMarketplaceType : 'regular';
+		const defaultType = isAutomatedReferrals ? usedMarketplaceType : MARKETPLACE_TYPE_REGULAR;
 		const [ marketplaceType, setMarketplaceType ] = useState( defaultType );
 
 		const updateMarketplaceType = ( type: MarketplaceType ) => {
@@ -31,7 +33,10 @@ function withMarketplaceType< T >(
 			if ( ! isAutomatedReferrals ) {
 				return;
 			}
-			const nextType = marketplaceType === 'regular' ? 'referral' : 'regular';
+			const nextType =
+				marketplaceType === MARKETPLACE_TYPE_REGULAR
+					? MARKETPLACE_TYPE_REFERRAL
+					: MARKETPLACE_TYPE_REGULAR;
 			updateMarketplaceType( nextType );
 		};
 

--- a/client/a8c-for-agencies/sections/referrals/lib/constants.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/constants.ts
@@ -1,3 +1,0 @@
-import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-
-export const REFER_PRODUCTS_LINK = `${ A4A_MARKETPLACE_PRODUCTS_LINK }?purchase-type=referral`;

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -17,11 +17,15 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
+	MARKETPLACE_TYPE_REFERRAL,
+} from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useFetchReferrals from '../../hooks/use-fetch-referrals';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
-import { REFER_PRODUCTS_LINK } from '../../lib/constants';
 import ReferralDetails from '../../referral-details';
 import ReferralsFooter from '../footer';
 import LayoutBodyContent from './layout-body-content';
@@ -52,6 +56,7 @@ export default function ReferralsOverview( {
 	const hasReferrals = !! referrals?.length;
 
 	const makeAReferral = useCallback( () => {
+		sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, MARKETPLACE_TYPE_REFERRAL );
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_make_a_referral_button_click' ) );
 	}, [ dispatch ] );
 
@@ -78,7 +83,7 @@ export default function ReferralsOverview( {
 						{ isAutomatedReferral && (
 							<Actions>
 								<MobileSidebarNavigation />
-								<Button primary href={ REFER_PRODUCTS_LINK } onClick={ makeAReferral }>
+								<Button primary href={ A4A_MARKETPLACE_PRODUCTS_LINK } onClick={ makeAReferral }>
 									{ hasReferrals ? translate( 'New referral' ) : translate( 'Make a referral' ) }
 								</Button>
 							</Actions>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -10,9 +10,14 @@ import {
 	A4A_REFERRALS_COMMISSIONS_LINK,
 	A4A_REFERRALS_PAYMENT_SETTINGS,
 	A4A_REFERRALS_FAQ,
+	A4A_MARKETPLACE_PRODUCTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { A4A_DOWNLOAD_LINK_ON_GITHUB } from 'calypso/a8c-for-agencies/constants';
+import {
+	MARKETPLACE_TYPE_REFERRAL,
+	MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
+} from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WooCommerceLogo from 'calypso/components/woocommerce-logo';
@@ -24,7 +29,6 @@ import { getPreference } from 'calypso/state/preferences/selectors';
 import StepSection from '../../common/step-section';
 import StepSectionItem from '../../common/step-section-item';
 import ConsolidatedViews from '../../consolidated-view';
-import { REFER_PRODUCTS_LINK } from '../../lib/constants';
 import { getAccountStatus } from '../../lib/get-account-status';
 import tipaltiLogo from '../../lib/tipalti-logo';
 import ReferralList from '../../referrals-list';
@@ -59,6 +63,7 @@ export default function LayoutBodyContent( {
 	}, [ dispatch ] );
 
 	const onGetStartedClick = useCallback( () => {
+		sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, MARKETPLACE_TYPE_REFERRAL );
 		dispatch( recordTracksEvent( 'calypso_a4a_referrals_get_started_button_click' ) );
 	}, [ dispatch ] );
 
@@ -253,7 +258,7 @@ export default function LayoutBodyContent( {
 										children: translate( 'Get started' ),
 										compact: true,
 										primary: hasPayeeAccount,
-										href: REFER_PRODUCTS_LINK,
+										href: A4A_MARKETPLACE_PRODUCTS_LINK,
 										onClick: onGetStartedClick,
 									} }
 								/>


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/359
Closes https://github.com/Automattic/jetpack-genesis/issues/360

## Proposed Changes

This PR implements refer products functionality in checkout.

NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)
- There are some UI enhancement & mobile fixes that will be done in another PR, so please ignore those for now.
- The `Request payment from client` button &  the  `Learn more` link on the Checkout page does nothing as of now and will be implemented in another PR.

## Testing Instructions

1. Open the A4A live link.
2. Go to Marketplace > Add a product > Go to Checkout > Verify it works well by comparing it with the production version.
3. Go to Referrals - Dashboard > Click the `New Referral` or `Make a referral`  button  > Verify that the `Refer products` toggle is on > Add some products > Go to Checkout > Verify that the pages look like below > Verify that you can add email and message. The `Request payment from client` button does nothing as of now and will be implemented in another PR.

<img width="1633" alt="Screenshot 2024-05-29 at 1 01 59 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/1962911e-f353-4e3e-9bd6-74eb72a80044">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
