### PR TITLE
Simple Classic: Dev tools - Add cards for upsell pages

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -357,6 +357,22 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/hosting-configuration/',
 		post_id: 160841,
 	},
+	'theme-file-editor': {
+		link: 'https://wordpress.com/support/themes/#theme-file-editor-advanced',
+		post_id: 2278,
+	},
+	'use-the-plugin-file-editor-advanced': {
+		link: 'https://wordpress.com/support/plugins/use-your-plugins/#use-the-plugin-file-editor-advanced',
+		post_id: 206930,
+	},
+	'change-the-permalink-structure': {
+		link: 'https://wordpress.com/support/change-the-permalink-structure/',
+		post_id: 366520,
+	},
+	'privacy-settings-tool': {
+		link: 'https://wordpress.com/support/how-to-create-legal-pages/#privacy-settings-tool',
+		post_id: 173927,
+	},
 };
 
 export default contextLinks;

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_SFTP } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card, Dialog } from '@automattic/components';
@@ -43,7 +44,7 @@ const DevTools = () => {
 
 	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
 	const pluginsLink = `https://wordpress.com/plugins/${ encodeURIComponent( siteSlug ) }`;
-	const promoCards = [
+	let promoCards = [
 		{
 			title: translate( 'Hosting Configuration' ),
 			text: translate(
@@ -77,35 +78,41 @@ const DevTools = () => {
 			),
 			supportContext: 'github-deployments',
 		},
-		{
-			title: translate( 'Theme File Editor' ),
-			text: translate(
-				'Unlock access to the theme file editor, a powerful way to edit the individual CSS and PHP files of your theme.'
-			),
-			supportContext: 'theme-file-editor',
-		},
-		{
-			title: translate( 'Plugin File Editor' ),
-			text: translate(
-				'Unlock the plugin file editor and make changes to any of your plugins’ individual PHP files.'
-			),
-			supportContext: 'use-the-plugin-file-editor-advanced',
-		},
-		{
-			title: translate( 'Unlock Permalinks' ),
-			text: translate(
-				'Upgrade your plan to create a custom URL structure for your permalinks and archives. Clear, informative URLs improve the aesthetics, usability, and forward-compatibility of your links.'
-			),
-			supportContext: 'change-the-permalink-structure',
-		},
-		{
-			title: translate( 'Set a Privacy Policy page' ),
-			text: translate(
-				'Create a Privacy Policy page for your site—keeping it compliant with regional requirements and making your visitors and customers aware of the details.'
-			),
-			supportContext: 'privacy-settings-tool',
-		},
 	];
+
+	const isSimpleClassic = isEnabled( 'layout/wpcom-admin-interface' );
+	if ( isSimpleClassic ) {
+		promoCards = [
+			{
+				title: translate( 'Theme File Editor' ),
+				text: translate(
+					'Unlock access to the theme file editor, a powerful way to edit the individual CSS and PHP files of your theme.'
+				),
+				supportContext: 'theme-file-editor',
+			},
+			{
+				title: translate( 'Plugin File Editor' ),
+				text: translate(
+					'Unlock the plugin file editor and make changes to any of your plugins’ individual PHP files.'
+				),
+				supportContext: 'use-the-plugin-file-editor-advanced',
+			},
+			{
+				title: translate( 'Unlock Permalinks' ),
+				text: translate(
+					'Upgrade your plan to create a custom URL structure for your permalinks and archives. Clear, informative URLs improve the aesthetics, usability, and forward-compatibility of your links.'
+				),
+				supportContext: 'change-the-permalink-structure',
+			},
+			{
+				title: translate( 'Set a Privacy Policy page' ),
+				text: translate(
+					'Create a Privacy Policy page for your site—keeping it compliant with regional requirements and making your visitors and customers aware of the details.'
+				),
+				supportContext: 'privacy-settings-tool',
+			},
+		];
+	}
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showActivationButton = canSiteGoAtomic;
@@ -120,6 +127,16 @@ const DevTools = () => {
 		} );
 		page( `/setup/transferring-hosted-site?${ params }` );
 	};
+	const heading = isSimpleClassic
+		? translate( 'Activate all developer tools and settings' )
+		: translate( 'Activate all developer tools' );
+	const description = isSimpleClassic
+		? translate(
+				'Your plan includes the developer tools and settings listed below and much more. Click "Activate Now" to begin.'
+		  )
+		: translate(
+				'Your plan includes all the developer tools listed below. Click "Activate Now" to begin.'
+		  );
 
 	if ( isSiteAtomic && hasSftpFeature ) {
 		page.replace( redirectUrl );
@@ -129,16 +146,10 @@ const DevTools = () => {
 	return (
 		<div className="dev-tools">
 			<div className="dev-tools__hero">
-				<h1>
-					{ showActivationButton
-						? translate( 'Activate all developer tools' )
-						: translate( 'Unlock all developer tools' ) }
-				</h1>
+				<h1>{ showActivationButton ? heading : translate( 'Unlock all developer tools' ) }</h1>
 				<p>
 					{ showActivationButton
-						? translate(
-								'Your plan includes all the developer tools listed below. Click "Activate Now" to begin.'
-						  )
+						? description
 						: translate(
 								'Upgrade to the Creator plan or higher to get access to all developer tools'
 						  ) }

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -89,7 +89,7 @@ const DevTools = () => {
 			text: translate(
 				'Unlock the plugin file editor and make changes to any of your plugins’ individual PHP files.'
 			),
-			supportContext: 'use-your-pluginsuse-the-plugin-file-editor-advanced',
+			supportContext: 'use-the-plugin-file-editor-advanced',
 		},
 		{
 			title: translate( 'Unlock Permalinks' ),

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -77,6 +77,34 @@ const DevTools = () => {
 			),
 			supportContext: 'github-deployments',
 		},
+		{
+			title: translate( 'Theme File Editor' ),
+			text: translate(
+				'Unlock access to the theme file editor, a powerful way to edit the individual CSS and PHP files of your theme.'
+			),
+			supportContext: 'theme-file-editor',
+		},
+		{
+			title: translate( 'Plugin File Editor' ),
+			text: translate(
+				'Unlock the plugin file editor and make changes to any of your plugins’ individual PHP files.'
+			),
+			supportContext: 'use-your-pluginsuse-the-plugin-file-editor-advanced',
+		},
+		{
+			title: translate( 'Unlock Permalinks' ),
+			text: translate(
+				'Upgrade your plan to create a custom URL structure for your permalinks and archives. Clear, informative URLs improve the aesthetics, usability, and forward-compatibility of your links.'
+			),
+			supportContext: 'change-the-permalink-structure',
+		},
+		{
+			title: translate( 'Set a Privacy Policy page' ),
+			text: translate(
+				'Create a Privacy Policy page for your site—keeping it compliant with regional requirements and making your visitors and customers aware of the details.'
+			),
+			supportContext: 'privacy-settings-tool',
+		},
 	];
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes to https://github.com/Automattic/dotcom-forge/issues/7493

## Proposed Changes

* Add cards in Dev tools for:

  - Theme File Editor
  - Plugin File Editor
  - Permalink Settings
  - Privacy Settings 

|BEFORE|AFTER|
|-|-|
|<img width="1728" alt="Screenshot 2567-05-29 at 14 16 25" src="https://github.com/Automattic/wp-calypso/assets/1881481/fc8b75ca-6c1d-4a93-87bf-18f295a93acb">|<img width="1728" alt="Screenshot 2567-05-29 at 14 19 52" src="https://github.com/Automattic/wp-calypso/assets/1881481/8620bec3-07cd-4061-a80f-b7ad785a30de"><img width="1728" alt="Screenshot 2567-05-29 at 14 15 45" src="https://github.com/Automattic/wp-calypso/assets/1881481/0faa9616-f283-42ad-b3dc-bd27e862503e">|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To inform users about these four upsell features that are activated altogether by transferring simple sites to atomic

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `wordpress.com/dev-tools/{ SITE }`
* Verify the new cards, click the "Learn more" links

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
