### PR TITLE
Entrepreneur Flow: Add new `entrepreneur` signup flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -52,6 +52,7 @@ export function generateFlows( {
 	getDIFMSignupDestination = noop,
 	getDIFMSiteContentCollectionDestination = noop,
 	getHostingFlowDestination = noop,
+	getEntrepreneurFlowDestination = noop,
 } = {} ) {
 	const userSocialStep = getUserSocialStepOrFallback();
 	const p2Flows = getP2Flows();
@@ -701,6 +702,17 @@ export function generateFlows( {
 			description: 'Choose what brings them to WordPress.com',
 			lastModified: '2024-05-15',
 			showRecaptcha: true,
+			hideProgressIndicator: true,
+		},
+		{
+			name: 'entrepreneur',
+			steps: [ userSocialStep ],
+			destination: getEntrepreneurFlowDestination,
+			description: 'Entrepreneur Trial signup flow that goes through the trialAcknowledge step',
+			lastModified: '2024-05-29',
+			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'toStepper' ],
+			optionalDependenciesInQuery: [ 'toStepper' ],
 			hideProgressIndicator: true,
 		},
 	];

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -245,7 +245,7 @@ function getHostingFlowDestination( { stepperHostingFlow } ) {
 }
 
 function getEntrepreneurFlowDestination() {
-	return `/setup/entrepreneur/trialAcknowledge`;
+	return '/setup/entrepreneur/trialAcknowledge';
 }
 
 const flows = generateFlows( {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -244,6 +244,10 @@ function getHostingFlowDestination( { stepperHostingFlow } ) {
 	return `/setup/${ stepperHostingFlow }`;
 }
 
+function getEntrepreneurFlowDestination() {
+	return `/setup/entrepreneur/trialAcknowledge`;
+}
+
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
@@ -259,6 +263,7 @@ const flows = generateFlows( {
 	getDIFMSignupDestination,
 	getDIFMSiteContentCollectionDestination,
 	getHostingFlowDestination,
+	getEntrepreneurFlowDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -245,6 +245,7 @@
 		"ecommerce-monthly",
 		"ecommerce-2y",
 		"ecommerce-3y",
+		"entrepreneur",
 		"pro",
 		"starter",
 		"domain",


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7443

## Proposed Changes

* add new `entrepreneur` signup flow that will be used for the Entrepreneur / eCommerce signup process
  * with the destination of `/setup/entrepreneur/trialAcknowledge` (page we will end up after signing in)
  * and in the reskinned design

![Markup on 2024-05-30 at 12:01:59](https://github.com/Automattic/wp-calypso/assets/25105483/3b62ff4f-51b3-49ec-92ce-b1ed7185cffa)

Related discussion: p1716997343523629/1716809850.368589-slack-C02TCEHP3HA

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* this PR is one of the steps in resolving https://github.com/Automattic/dotcom-forge/issues/7443

## Testing Instructions

1. Check out the PR and build the app.
2. Navigate to http://calypso.localhost:3000/start/entrepreneur/user-social?variationName=entrepreneur&redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fsetup%2Fentrepreneur%2FtrialAcknowledge&toStepper=true.
3. The Signup page should load with the `/start/entrepreneur/` in the URL without any issues.
4. The destination of `/setup/entrepreneur/trialAcknowledge` post-signup will be tested with upcoming PRs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?