### PR TITLE
Enable Post by Voice feature flag

### DIFF
--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -53,12 +53,7 @@ class PublishingTools extends Component {
 		const { translate, siteIsJetpack, isAtomic } = this.props;
 
 		const renderPressThis = config.isEnabled( 'press-this' ) && ! this.isMobile();
-		const renderPostByVoice =
-			config.isEnabled( 'settings/post-by-voice' ) && ! siteIsJetpack && ! isAtomic;
-
-		if ( ! renderPressThis && ! renderPostByVoice ) {
-			return;
-		}
+		const renderPostByVoice = ! siteIsJetpack && ! isAtomic;
 
 		return (
 			<div>

--- a/config/development.json
+++ b/config/development.json
@@ -193,7 +193,6 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
-		"settings/post-by-voice": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -119,7 +119,6 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
-		"settings/post-by-voice": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
 		"signup/design-picker-preview-colors": true,

--- a/config/production.json
+++ b/config/production.json
@@ -161,7 +161,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
-		"settings/post-by-voice": false,
+		"settings/post-by-voice": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,

--- a/config/production.json
+++ b/config/production.json
@@ -161,7 +161,6 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
-		"settings/post-by-voice": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -156,7 +156,6 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
-		"settings/post-by-voice": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -156,7 +156,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
-		"settings/post-by-voice": false,
+		"settings/post-by-voice": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,

--- a/config/test.json
+++ b/config/test.json
@@ -109,7 +109,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/post-by-voice": true,
 		"settings/security/monitor": true,
 		"signup/social": true,
 		"signup/social-first": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -156,7 +156,6 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
-		"settings/post-by-voice": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7460

## Proposed Changes

Once https://github.com/Automattic/wp-calypso/pull/90819 has landed, we should enable the `settings/post-by-voice` feature flag so that the Post by Voice Calypso setting from https://github.com/Automattic/wp-calypso/pull/90489 is displayed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See pcYYuD-1Fp-p2 for background.

## Testing Instructions

Code review should suffice