### PR TITLE
Simple Classic: Upsell pages - Handle redirection after activation

### DIFF
--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { Card, Dialog } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import CardHeading from 'calypso/components/card-heading';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -37,7 +37,7 @@ const DevTools = () => {
 	const showActivationModal = searchParams.get( 'activate' ) !== null;
 	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
 	const siteId = useSelector( getSelectedSiteId );
-	const redirectUrl = searchParams.get( 'redirect_to' ) ?? `/hosting-config/${ siteId }`;
+	const redirectUrl = useRef( searchParams.get( 'redirect_to' ) ?? `/hosting-config/${ siteId }` );
 	const { siteSlug, isSiteAtomic, hasSftpFeature } = useSelector( ( state ) => ( {
 		siteSlug: getSiteSlug( state, siteId ) || '',
 		isSiteAtomic: isSiteWpcomAtomic( state, siteId as number ),
@@ -87,7 +87,7 @@ const DevTools = () => {
 	const handleTransfer = ( options: { geo_affinity?: string } ) => {
 		const params = new URLSearchParams( {
 			siteId: String( siteId ),
-			redirect_to: redirectUrl,
+			redirect_to: redirectUrl.current,
 			feature: FEATURE_SFTP,
 			initiate_transfer_context: 'hosting',
 			initiate_transfer_geo_affinity: options.geo_affinity || '',
@@ -96,7 +96,7 @@ const DevTools = () => {
 	};
 
 	if ( isSiteAtomic && hasSftpFeature ) {
-		page.replace( redirectUrl );
+		page.replace( redirectUrl.current );
 		return;
 	}
 
@@ -141,7 +141,7 @@ const DevTools = () => {
 							<EligibilityWarnings
 								className="hosting__activating-warnings"
 								onProceed={ handleTransfer }
-								backUrl={ redirectUrl }
+								backUrl={ redirectUrl.current }
 								showDataCenterPicker
 								standaloneProceed
 								currentContext="dev-tools"

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -37,6 +37,7 @@ const DevTools = () => {
 	const showActivationModal = searchParams.get( 'activate' ) !== null;
 	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
 	const siteId = useSelector( getSelectedSiteId );
+	const redirectUrl = searchParams.get( 'redirect_to' ) ?? `/hosting-config/${ siteId }`;
 	const { siteSlug, isSiteAtomic, hasSftpFeature } = useSelector( ( state ) => ( {
 		siteSlug: getSiteSlug( state, siteId ) || '',
 		isSiteAtomic: isSiteWpcomAtomic( state, siteId as number ),
@@ -83,7 +84,6 @@ const DevTools = () => {
 
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showActivationButton = canSiteGoAtomic;
-	const redirectUrl = `/hosting-config/${ siteId }`;
 	const handleTransfer = ( options: { geo_affinity?: string } ) => {
 		const params = new URLSearchParams( {
 			siteId: String( siteId ),

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -37,6 +37,7 @@ const DevTools = () => {
 	const showActivationModal = searchParams.get( 'activate' ) !== null;
 	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
 	const siteId = useSelector( getSelectedSiteId );
+	// The ref is required to persist the value of redirect_to after renders
 	const redirectUrl = useRef( searchParams.get( 'redirect_to' ) ?? `/hosting-config/${ siteId }` );
 	const { siteSlug, isSiteAtomic, hasSftpFeature } = useSelector( ( state ) => ( {
 		siteSlug: getSiteSlug( state, siteId ) || '',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7492 D150471-code

## Proposed Changes
* Use the URL param `redirect_to` to handle redirection after the activation
* Default to `/hosting-config/{ SITE ID }`

>[!Note]
> I'll follow up with the ⚙️ diff to pass the redirection URL from the upsell pages

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To redirect users to the feature after the activation via the upsell pages 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Prepare a simple site with the Creator plan
* Go to `wordpress.com/dev-tools/{ SITE ID }/?redirect_to={ ANY URL }`
* Click on "Activate now"
* Verify you are redirected to that URL after the activation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?