### PR TITLE
JetpackCloud: fix wp-admin link for simple sites

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -13,7 +13,7 @@ import Sidebar, {
 import { useDispatch, useSelector } from 'calypso/state';
 import { loadTrackingTool, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
-import { getJetpackAdminUrl } from 'calypso/state/sites/selectors';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import UserFeedbackModalForm from '../user-feedback-modal-form';
 import SidebarHeader from './header';
@@ -60,7 +60,7 @@ const JetpackCloudSidebar = ( {
 	const isAgency = useSelector( isAgencyUser );
 	const siteId = useSelector( getSelectedSiteId );
 	const jetpackAdminUrl = useSelector( ( state ) =>
-		siteId ? getJetpackAdminUrl( state, siteId ) : null
+		siteId ? getSiteAdminUrl( state, siteId ) : null
 	);
 
 	const translate = useTranslate();


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7345

## Proposed Changes
`WP Admin` link in Jetpack Cloud (left sidebar) points to `/wp-admin/admin.php?page=my-jetpack`, but we don't have this link for Simple websites (it leads to 404 page). So we decided to point users to root `/wp-admin` (the same as we have for Atomic websites).


## Testing Instructions
1) Checkout to this branch
2) run `yarn start-jetpack-cloud`
3) Open `http://jetpack.cloud.localhost:3000`
4) Select Atomic website
5) Find `WP Admin` link in the left sidebar <br /><img width="286" alt="Screenshot 2024-05-29 at 12 24 56" src="https://github.com/Automattic/wp-calypso/assets/5598437/38b6bd51-99eb-4e6a-bb05-541160097560">
6) Assert that the link still (as previously) points to `/wp-admin/`
7) Now let's test Simple website - find any your Simple website and select it
8) Assert that the link points to `/wp-admin/` as well. (Previously the link led to broken page `/wp-admin/admin.php?page=my-jetpack`)