### PR TITLE
A4A > Referrals: Implement Request Client Payment API

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -156,7 +156,7 @@ function Checkout() {
 						/>
 
 						{ isAutomatedReferrals ? (
-							<RequestClientPayment />
+							<RequestClientPayment checkoutItems={ checkoutItems } />
 						) : (
 							<div className="checkout__aside-actions">
 								<Button

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
@@ -1,0 +1,59 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { ReferralAPIResponse } from '../../referrals/types';
+
+export interface MutationRequestClientPaymentVariables {
+	client_email: string;
+	client_message: string;
+	product_ids: string;
+}
+
+interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+}
+
+function mutationRequestClientPayment( {
+	client_email,
+	client_message,
+	product_ids,
+	agencyId,
+}: MutationRequestClientPaymentVariables & { agencyId?: number } ): Promise< ReferralAPIResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required request a client payment' );
+	}
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/referrals`,
+		body: { client_email, client_message, product_ids },
+	} );
+}
+
+export default function useRequestClientPaymentMutation< TContext = unknown >(
+	options?: UseMutationOptions<
+		ReferralAPIResponse,
+		APIError,
+		MutationRequestClientPaymentVariables,
+		TContext
+	>
+): UseMutationResult<
+	ReferralAPIResponse,
+	APIError,
+	MutationRequestClientPaymentVariables,
+	TContext
+> {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation<
+		ReferralAPIResponse,
+		APIError,
+		MutationRequestClientPaymentVariables,
+		TContext
+	>( {
+		...options,
+		mutationFn: ( args ) => mutationRequestClientPayment( { ...args, agencyId } ),
+	} );
+}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -243,6 +243,13 @@
 	@media only screen and ( min-width: 782px ) {
 		--masterbar-height: 46px;
 	}
+
+	.button[disabled],
+	.button:disabled,
+	.button.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
 }
 
 // New navigation will not include a masterbar


### PR DESCRIPTION

Closes https://github.com/Automattic/jetpack-genesis/issues/361

## Proposed Changes

This PR implements the request Client Payment API

NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)
- There are some UI enhancement & mobile fixes that will be done in another PR, so please ignore those for now.
- The `Learn more` link on the Checkout page does nothing as of now and will be implemented in another PR.

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals - Dashboard > Click the `New Referral` or `Make a referral`  button  > Verify that the `Refer products` toggle is on > Add some products > Go to Checkout > Verify that the pages look like below > Verify that you can add email and message. Click the `Request payment from client` button > Wait for the API to succeed & verify you are redirected to the referrals dashboard.

<img width="1633" alt="Screenshot 2024-05-29 at 4 03 14 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/296ba288-23f1-4488-b1e9-ae6949ec399d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
