### PR TITLE
Stats: Copy & layout updates for commercial opt-out form

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -227,7 +227,7 @@ const StatsSingleItemCard = ( { children }: { children: React.ReactNode } ) => {
 		<div className={ classNames( COMPONENT_CLASS_NAME, `${ COMPONENT_CLASS_NAME }--single` ) }>
 			<Card className={ `${ COMPONENT_CLASS_NAME }__card-parent` }>
 				<div className={ `${ COMPONENT_CLASS_NAME }__card` }>
-					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--left` }>{ children }</div>
+					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--single` }>{ children }</div>
 				</div>
 			</Card>
 		</div>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -478,7 +478,9 @@ function StatsCommercialFlowOptOutForm( {
 					},
 				}
 		  )
-		: translate( 'To use a non-commercial license you must agree to the following:' );
+		: translate(
+				'For non-commercial use, get started with a non-commercial license, including an optional contribution. Please agree to the following terms:'
+		  );
 
 	return (
 		<>

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -47,6 +47,7 @@ $button-padding: 8px 32px;
 				.components-checkbox-control__label {
 					font-size: var(--font-body);
 					line-height: 24px;
+					width: auto;
 					color: var(--jp-black);
 				}
 			}

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -182,6 +182,16 @@ $button-padding: 8px 32px;
 		}
 	}
 
+	.stats-purchase-wizard__card-inner--single {
+		padding: 64px;
+		box-sizing: border-box;
+		flex: 2 2 auto;
+
+		@media (max-width: $break-medium) {
+			padding: 32px 24px;
+		}
+	}
+
 	.stats-purchase-wizard__card-inner--left {
 		padding: 64px;
 		box-sizing: border-box;

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -188,6 +188,13 @@ $button-padding: 8px 32px;
 		box-sizing: border-box;
 		flex: 2 2 auto;
 
+		p {
+			width: 36em;
+			@media (max-width: $break-medium) {
+				width: unset;
+			}
+		}
+
 		@media (max-width: $break-medium) {
 			padding: 32px 24px;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/44

## Proposed Changes

1. Makes the form header full-width if space is available
2. Updates descriptive text below the header
3. Adds a max line length to descriptive text
4. Prevents clicks in white space from toggling checkboxes

<img width="850" alt="SCR-20240529-qnmd" src="https://github.com/Automattic/wp-calypso/assets/40267301/3f0f8302-906a-4eec-a140-569ef60d284f">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of our Paywall Improvements project. — p1HpG7-shw-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow steps listed [here](https://github.com/Automattic/wp-calypso/pull/PCYsg-Pp7-p2) to test these changes in Odyssey Stats.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?