### PR TITLE
Verbum Editor: update upload and clean script

### DIFF
--- a/packages/verbum-block-editor/package.json
+++ b/packages/verbum-block-editor/package.json
@@ -23,9 +23,9 @@
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"types": "dist/types",
 	"scripts": {
-		"clean": "",
+		"clean": "rm -rf dist",
 		"build": "NODE_ENV=production yarn dev && yarn translate",
-		"upload": "yarn build && rsync -ahz --exclude='.*' dist/ wpcom-sandbox:/home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
+		"upload": "yarn build && rsync -ahz --delete --exclude='.*' dist/ wpcom-sandbox:/home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
 		"build:app": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
 		"watch": "tsc --build ./tsconfig.json --watch",


### PR DESCRIPTION
## Proposed Changes

This edits the clean and upload script for Verbum Block Editor

## Why are these changes being made?
 
The upload process for deploying was not clearing the old stuff properly and was uploading incorrect files.

## Testing Instructions

Pull branch and run `yarn upload` from packages/verbum-block-editor`