### PR TITLE
Site Profiler: Implement copy strategy for Header and Basic metrics

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -113,3 +113,9 @@ export interface UrlPerformanceMetricsQueryResponse {
 export interface BasicMetricsResult extends Omit< UrlBasicMetricsQueryResponse, 'basic' > {
 	basic: BasicMetricsScored;
 }
+
+export type PerformanceCategories =
+	| 'wpcom-low-performer'
+	| 'wpcom-high-performer'
+	| 'non-wpcom-low-performer'
+	| 'non-wpcom-high-performer';

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -93,11 +93,11 @@ export function getCopies(
 
 	// TODO: Add the rest of the metrics
 	return {
-		cls,
-		lcp: cls,
-		fcp: cls,
-		fid: cls,
-		inp: cls,
 		ttfb: cls,
+		fcp: cls,
+		lcp: cls,
+		inp: cls,
+		cls,
+		fid: cls,
 	};
 }

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -1,0 +1,103 @@
+import { ReactNode } from 'react';
+import type { BasicMetricsScored, Metrics, Scores } from 'calypso/data/site-profiler/types';
+import type { I18N } from 'i18n-calypso';
+
+type SubsetScores = Exclude< Scores, 'needs-improvement' >;
+
+export type MetricsCopies = {
+	[ score in SubsetScores ]: {
+		diagnostic: string | ReactNode;
+		solution: string | ReactNode;
+		cta: string | ReactNode;
+		url: string;
+	};
+};
+
+type WpComNonWpCom = 'wpcom' | 'nonWpcom';
+
+type CopiesProps = {
+	title: string;
+} & {
+	[ key in WpComNonWpCom ]: MetricsCopies;
+};
+
+type CopiesReturnValue = {
+	[ k in Metrics ]: CopiesProps;
+};
+
+export type CopiesReturnValueList = [ Metrics, CopiesProps ][];
+
+export function getCopies(
+	basicMetrics: BasicMetricsScored,
+	translate: I18N[ 'translate' ],
+	domain: string
+): CopiesReturnValue {
+	const migrateUrl = `/setup/hosted-site-migration?ref=site-profiler&from=${ domain }`;
+	const supportUrl = '/support';
+
+	const cls: CopiesProps = {
+		title: translate( 'Cumulative Layout Shift (CLS)' ),
+		nonWpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+				),
+				cta: translate( 'Migrate for stability' ),
+				url: migrateUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					{
+						args: {
+							value: basicMetrics?.cls?.value,
+						},
+					}
+				),
+				solution: translate(
+					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+				),
+				cta: translate( 'Enhance stability' ),
+				url: migrateUrl,
+			},
+		},
+		wpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+				),
+				cta: translate( 'Explore Advanced Tips' ),
+				url: supportUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Connect with a Happiness Engineer to reduce CLS and ensure a more stable layout for your users.'
+				),
+				cta: translate( 'Improve layout stability' ),
+				url: supportUrl,
+			},
+		},
+	};
+
+	// TODO: Add the rest of the metrics
+	return {
+		cls,
+		lcp: cls,
+		fcp: cls,
+		fid: cls,
+		inp: cls,
+		ttfb: cls,
+	};
+}

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -152,52 +152,52 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s FCP is %(value)fs, providing a fast initial load. Great job on maintaining quick content display!',
+					{ args: { value: basicMetrics?.fcp?.value } }
 				),
 				solution: translate(
-					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+					'Migrate to WordPress.com to sustain this speed and further enhance your initial content load times.'
 				),
-				cta: translate( 'Migrate for stability' ),
+				cta: translate( 'Improve FCP speed' ),
 				url: migrateUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					'Your site’s FCP is %(value)fs, slower than average. Aim for under 2s to improve user experience.',
 					{
 						args: {
-							value: basicMetrics?.cls?.value,
+							value: basicMetrics?.fcp?.value,
 						},
 					}
 				),
 				solution: translate(
-					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+					'Migrate to WordPress.com for tools to reduce FCP and speed up content load.'
 				),
-				cta: translate( 'Enhance stability' ),
+				cta: translate( 'Boost Content Load' ),
 				url: migrateUrl,
 			},
 		},
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s FCP is %(value)fs, providing a fast initial load. Excellent job maintaining quick content delivery!',
+					{ args: { value: basicMetrics?.fcp?.value } }
 				),
 				solution: translate(
-					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+					'Continue optimizing your content delivery to consistently maintain this fast load time and performance.'
 				),
-				cta: translate( 'Explore Advanced Tips' ),
+				cta: translate( 'Maintain fast responses' ),
 				url: supportUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s FCP is %(value)fs, slower than average. Aim for under 2s to improve user experience.',
+					{ args: { value: basicMetrics?.fcp?.value } }
 				),
 				solution: translate(
-					'Connect with a Happiness Engineer to reduce CLS and ensure a more stable layout for your users.'
+					'Connect with a Happiness Engineer to reduce FCP and speed up initial content load.'
 				),
-				cta: translate( 'Improve layout stability' ),
+				cta: translate( 'Speed up content load' ),
 				url: supportUrl,
 			},
 		},

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -40,18 +40,18 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
 					{ args: { value: basicMetrics?.cls?.value } }
 				),
 				solution: translate(
-					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
 				),
-				cta: translate( 'Migrate for stability' ),
+				cta: translate( 'Enhance stability' ),
 				url: migrateUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
 					{
 						args: {
 							value: basicMetrics?.cls?.value,
@@ -59,9 +59,9 @@ export function getCopies(
 					}
 				),
 				solution: translate(
-					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.'
 				),
-				cta: translate( 'Enhance stability' ),
+				cta: translate( 'Migrate for stability' ),
 				url: migrateUrl,
 			},
 		},

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -208,52 +208,52 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s LCP is %(value)fs, loading main content quickly. Well done on maintaining fast load times!',
+					{ args: { value: basicMetrics?.lcp?.value } }
 				),
 				solution: translate(
-					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+					'Migrate to WordPress.com to achieve even faster LCP and enhance your site’s overall performance.'
 				),
-				cta: translate( 'Migrate for stability' ),
+				cta: translate( 'Optimize main load' ),
 				url: migrateUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					'Your site’s LCP is %(value)fs, slower than typical sites. Aim for under 2.5s for better performance.',
 					{
 						args: {
-							value: basicMetrics?.cls?.value,
+							value: basicMetrics?.lcp?.value,
 						},
 					}
 				),
 				solution: translate(
-					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+					'Migrate to WordPress.com for optimized LCP and faster main content load.'
 				),
-				cta: translate( 'Enhance stability' ),
+				cta: translate( 'Improve Main Load' ),
 				url: migrateUrl,
 			},
 		},
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s LCP is %(value)fs, loading main content quickly. Excellent job maintaining fast content display!',
+					{ args: { value: basicMetrics?.lcp?.value } }
 				),
 				solution: translate(
-					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+					'Keep optimizing images and elements to consistently maintain swift load times and performance.'
 				),
-				cta: translate( 'Explore Advanced Tips' ),
+				cta: translate( 'Optimize further' ),
 				url: supportUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s LCP is %(value)fs, slower than typical sites. Aim for under 2.5s for better performance.',
+					{ args: { value: basicMetrics?.lcp?.value } }
 				),
 				solution: translate(
-					'Connect with a Happiness Engineer to reduce CLS and ensure a more stable layout for your users.'
+					'Connect with a Happiness Engineer to optimize LCP and enhance main content load speed.'
 				),
-				cta: translate( 'Improve layout stability' ),
+				cta: translate( 'Boost main content load' ),
 				url: supportUrl,
 			},
 		},

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { ReactNode } from 'react';
 import type { BasicMetricsScored, Metrics, Scores } from 'calypso/data/site-profiler/types';
 import type { I18N } from 'i18n-calypso';
@@ -33,7 +34,7 @@ export function getCopies(
 	domain: string
 ): CopiesReturnValue {
 	const migrateUrl = `/setup/hosted-site-migration?ref=site-profiler&from=${ domain }`;
-	const supportUrl = '/support';
+	const supportUrl = localizeUrl( 'https://wordpress.com/support' );
 
 	const cls: CopiesProps = {
 		title: translate( 'Cumulative Layout Shift (CLS)' ),

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -264,52 +264,52 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s TTFB is %(value)fms, offering fast server response. Excellent job on maintaining quick response!',
+					{ args: { value: basicMetrics?.ttfb?.value } }
 				),
 				solution: translate(
-					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+					'Migrate to WordPress.com to sustain this speed and further enhance your server response times.'
 				),
-				cta: translate( 'Migrate for stability' ),
+				cta: translate( 'Enhance server speed' ),
 				url: migrateUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					'Your site’s TTFB is %(value)fms, longer than most sites. Aim for less than 600ms for better performance.',
 					{
 						args: {
-							value: basicMetrics?.cls?.value,
+							value: basicMetrics?.ttfb?.value,
 						},
 					}
 				),
 				solution: translate(
-					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+					'Migrate to WordPress.com for faster TTFB and improved server response.'
 				),
-				cta: translate( 'Enhance stability' ),
+				cta: translate( 'Enhance server speed' ),
 				url: migrateUrl,
 			},
 		},
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s TTFB is %(value)fms, offering fast server response. Excellent job on maintaining quick server performance!',
+					{ args: { value: basicMetrics?.ttfb?.value } }
 				),
 				solution: translate(
-					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+					'Continue monitoring server performance to consistently maintain these quick response times and efficiency.'
 				),
-				cta: translate( 'Explore Advanced Tips' ),
+				cta: translate( 'Monitor performance' ),
 				url: supportUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s TTFB is %(value)fms, longer than most sites. Aim for less than 600ms for better performance.',
+					{ args: { value: basicMetrics?.ttf?.value } }
 				),
 				solution: translate(
-					'Connect with a Happiness Engineer to reduce CLS and ensure a more stable layout for your users.'
+					'Connect with a Happiness Engineer to reduce TTFB and improve server response time'
 				),
-				cta: translate( 'Improve layout stability' ),
+				cta: translate( 'Enhance Server Response' ),
 				url: supportUrl,
 			},
 		},

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -148,7 +148,7 @@ export function getCopies(
 	};
 
 	const fcp: CopiesProps = {
-		title: translate( 'Cumulative Layout Shift (CLS)' ),
+		title: translate( 'First Contentful Paint (FCP)' ),
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
@@ -204,7 +204,7 @@ export function getCopies(
 	};
 
 	const lcp: CopiesProps = {
-		title: translate( 'Cumulative Layout Shift (CLS)' ),
+		title: translate( 'Largest Contentful Paint (LCP)' ),
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
@@ -260,7 +260,7 @@ export function getCopies(
 	};
 
 	const ttfb: CopiesProps = {
-		title: translate( 'Cumulative Layout Shift (CLS)' ),
+		title: translate( 'Time to First Byte (TTFB)' ),
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
@@ -316,7 +316,7 @@ export function getCopies(
 	};
 
 	const inp: CopiesProps = {
-		title: translate( 'Cumulative Layout Shift (CLS)' ),
+		title: translate( 'Interaction to Next Paint (INP)' ),
 		nonWpcom: {
 			good: {
 				diagnostic: translate(

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -152,7 +152,7 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s FCP is %(value)fs, providing a fast initial load. Great job on maintaining quick content display!',
+					'Your site’s FCP is %(value)fms, providing a fast initial load. Great job on maintaining quick content display!',
 					{ args: { value: basicMetrics?.fcp?.value } }
 				),
 				solution: translate(
@@ -163,7 +163,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s FCP is %(value)fs, slower than average. Aim for under 2s to improve user experience.',
+					'Your site’s FCP is %(value)fms, slower than average. Aim for under 2s to improve user experience.',
 					{
 						args: {
 							value: basicMetrics?.fcp?.value,
@@ -180,7 +180,7 @@ export function getCopies(
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s FCP is %(value)fs, providing a fast initial load. Excellent job maintaining quick content delivery!',
+					'Your site’s FCP is %(value)fms, providing a fast initial load. Excellent job maintaining quick content delivery!',
 					{ args: { value: basicMetrics?.fcp?.value } }
 				),
 				solution: translate(
@@ -191,7 +191,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s FCP is %(value)fs, slower than average. Aim for under 2s to improve user experience.',
+					'Your site’s FCP is %(value)fms, slower than average. Aim for under 2s to improve user experience.',
 					{ args: { value: basicMetrics?.fcp?.value } }
 				),
 				solution: translate(
@@ -208,7 +208,7 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s LCP is %(value)fs, loading main content quickly. Well done on maintaining fast load times!',
+					'Your site’s LCP is %(value)fms, loading main content quickly. Well done on maintaining fast load times!',
 					{ args: { value: basicMetrics?.lcp?.value } }
 				),
 				solution: translate(
@@ -219,7 +219,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s LCP is %(value)fs, slower than typical sites. Aim for under 2.5s for better performance.',
+					'Your site’s LCP is %(value)fms, slower than typical sites. Aim for under 2.5s for better performance.',
 					{
 						args: {
 							value: basicMetrics?.lcp?.value,
@@ -236,7 +236,7 @@ export function getCopies(
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s LCP is %(value)fs, loading main content quickly. Excellent job maintaining fast content display!',
+					'Your site’s LCP is %(value)fms, loading main content quickly. Excellent job maintaining fast content display!',
 					{ args: { value: basicMetrics?.lcp?.value } }
 				),
 				solution: translate(
@@ -247,7 +247,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s LCP is %(value)fs, slower than typical sites. Aim for under 2.5s for better performance.',
+					'Your site’s LCP is %(value)fms, slower than typical sites. Aim for under 2.5s for better performance.',
 					{ args: { value: basicMetrics?.lcp?.value } }
 				),
 				solution: translate(

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -91,13 +91,293 @@ export function getCopies(
 		},
 	};
 
+	const fid: CopiesProps = {
+		title: translate( 'First Input Delay (FID)' ),
+		nonWpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s FID is %(value)fms, offering quick response times. Excellent job maintaining fast interactions!',
+					{ args: { value: basicMetrics?.fid?.value } }
+				),
+				solution: translate(
+					'Migrate to WordPress.com to sustain this performance and further improve response times.'
+				),
+				cta: translate( 'Boost FID performance' ),
+				url: migrateUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s FID is %(value)fms, slower than most. Aim for less than 100ms for better responsiveness.',
+					{
+						args: {
+							value: basicMetrics?.fid?.value,
+						},
+					}
+				),
+				solution: translate(
+					'Migrate to WordPress.com for improved FID and faster user interactions.'
+				),
+				cta: translate( 'Experience Better FID' ),
+				url: migrateUrl,
+			},
+		},
+		wpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s FID is %(value)fms, offering quick response times. Excellent job on maintaining swift interactions!',
+					{ args: { value: basicMetrics?.fid?.value } }
+				),
+				solution: translate(
+					'Maintain this top-notch responsiveness by regularly optimizing your site for consistent performance.'
+				),
+				cta: translate( 'Keep layout stable' ),
+				url: supportUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s FID is %(value)fms, slower than most. Aim for less than 100ms for better responsiveness.',
+					{ args: { value: basicMetrics?.fid?.value } }
+				),
+				solution: translate(
+					'Connect with a Happiness Engineer to optimize FID and improve your site’s responsiveness'
+				),
+				cta: translate( 'Enhance responsiveness' ),
+				url: supportUrl,
+			},
+		},
+	};
+
+	const fcp: CopiesProps = {
+		title: translate( 'Cumulative Layout Shift (CLS)' ),
+		nonWpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+				),
+				cta: translate( 'Migrate for stability' ),
+				url: migrateUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					{
+						args: {
+							value: basicMetrics?.cls?.value,
+						},
+					}
+				),
+				solution: translate(
+					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+				),
+				cta: translate( 'Enhance stability' ),
+				url: migrateUrl,
+			},
+		},
+		wpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+				),
+				cta: translate( 'Explore Advanced Tips' ),
+				url: supportUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Connect with a Happiness Engineer to reduce CLS and ensure a more stable layout for your users.'
+				),
+				cta: translate( 'Improve layout stability' ),
+				url: supportUrl,
+			},
+		},
+	};
+
+	const lcp: CopiesProps = {
+		title: translate( 'Cumulative Layout Shift (CLS)' ),
+		nonWpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+				),
+				cta: translate( 'Migrate for stability' ),
+				url: migrateUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					{
+						args: {
+							value: basicMetrics?.cls?.value,
+						},
+					}
+				),
+				solution: translate(
+					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+				),
+				cta: translate( 'Enhance stability' ),
+				url: migrateUrl,
+			},
+		},
+		wpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+				),
+				cta: translate( 'Explore Advanced Tips' ),
+				url: supportUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Connect with a Happiness Engineer to reduce CLS and ensure a more stable layout for your users.'
+				),
+				cta: translate( 'Improve layout stability' ),
+				url: supportUrl,
+			},
+		},
+	};
+
+	const ttfb: CopiesProps = {
+		title: translate( 'Cumulative Layout Shift (CLS)' ),
+		nonWpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+				),
+				cta: translate( 'Migrate for stability' ),
+				url: migrateUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					{
+						args: {
+							value: basicMetrics?.cls?.value,
+						},
+					}
+				),
+				solution: translate(
+					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+				),
+				cta: translate( 'Enhance stability' ),
+				url: migrateUrl,
+			},
+		},
+		wpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+				),
+				cta: translate( 'Explore Advanced Tips' ),
+				url: supportUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Connect with a Happiness Engineer to reduce CLS and ensure a more stable layout for your users.'
+				),
+				cta: translate( 'Improve layout stability' ),
+				url: supportUrl,
+			},
+		},
+	};
+
+	const inp: CopiesProps = {
+		title: translate( 'Cumulative Layout Shift (CLS)' ),
+		nonWpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+				),
+				cta: translate( 'Migrate for stability' ),
+				url: migrateUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					{
+						args: {
+							value: basicMetrics?.cls?.value,
+						},
+					}
+				),
+				solution: translate(
+					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+				),
+				cta: translate( 'Enhance stability' ),
+				url: migrateUrl,
+			},
+		},
+		wpcom: {
+			good: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+				),
+				cta: translate( 'Explore Advanced Tips' ),
+				url: supportUrl,
+			},
+			poor: {
+				diagnostic: translate(
+					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					{ args: { value: basicMetrics?.cls?.value } }
+				),
+				solution: translate(
+					'Connect with a Happiness Engineer to reduce CLS and ensure a more stable layout for your users.'
+				),
+				cta: translate( 'Improve layout stability' ),
+				url: supportUrl,
+			},
+		},
+	};
+
 	// TODO: Add the rest of the metrics
 	return {
-		ttfb: cls,
-		fcp: cls,
-		lcp: cls,
-		inp: cls,
+		ttfb,
+		fcp,
+		lcp,
+		inp,
 		cls,
-		fid: cls,
+		fid,
 	};
 }

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -320,52 +320,52 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s INP is %(value)fms, providing smooth interactions. Great job on maintaining quick responses!',
+					{ args: { value: basicMetrics?.inp?.value } }
 				),
 				solution: translate(
-					'Migrate to WordPress.com for tools to reduce CLS and stabilize your layout.”'
+					'Migrate to WordPress.com to sustain and further enhance your site’s interaction speed.'
 				),
-				cta: translate( 'Migrate for stability' ),
+				cta: translate( 'Improve INP speed' ),
 				url: migrateUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					'Your site’s INP is %(value)fms, higher than average. Aim for less than 100ms for smoother interactions.',
 					{
 						args: {
-							value: basicMetrics?.cls?.value,
+							value: basicMetrics?.inp?.value,
 						},
 					}
 				),
 				solution: translate(
-					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+					'Migrate to WordPress.com for tools to optimize INP and interaction speed.'
 				),
-				cta: translate( 'Enhance stability' ),
+				cta: translate( 'Improve INP speed' ),
 				url: migrateUrl,
 			},
 		},
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s INP is %(value)fms, providing smooth interactions. Excellent performance, keep it up!',
+					{ args: { value: basicMetrics?.inp?.value } }
 				),
 				solution: translate(
-					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+					'Keep refining interactive elements to sustain this high level of performance and user satisfaction.'
 				),
-				cta: translate( 'Explore Advanced Tips' ),
+				cta: translate( 'Refine interactions' ),
 				url: supportUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
-					{ args: { value: basicMetrics?.cls?.value } }
+					'Your site’s INP is %(value)fms, higher than average. Aim for less than 100ms for smoother interactions.',
+					{ args: { value: basicMetrics?.inp?.value } }
 				),
 				solution: translate(
-					'Connect with a Happiness Engineer to reduce CLS and ensure a more stable layout for your users.'
+					'Connect with a Happiness Engineer to optimize INP and improve interaction speed.'
 				),
-				cta: translate( 'Improve layout stability' ),
+				cta: translate( 'Improve Interaction Speed' ),
 				url: supportUrl,
 			},
 		},

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -305,7 +305,7 @@ export function getCopies(
 			poor: {
 				diagnostic: translate(
 					'Your site’s TTFB is %(value)fms, longer than most sites. Aim for less than 600ms for better performance.',
-					{ args: { value: basicMetrics?.ttf?.value } }
+					{ args: { value: basicMetrics?.ttfb?.value } }
 				),
 				solution: translate(
 					'Connect with a Happiness Engineer to reduce TTFB and improve server response time'

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { ForwardedRef, forwardRef } from 'react';
-import { BASIC_METRICS_UNITS, SCORES } from 'calypso/data/site-profiler/metrics-dictionaries';
+import { BASIC_METRICS_UNITS } from 'calypso/data/site-profiler/metrics-dictionaries';
 import { calculateMetricsSectionScrollOffset } from 'calypso/site-profiler/utils/calculate-metrics-section-scroll-offset';
 import type { BasicMetricsScored, Metrics, Scores } from 'calypso/data/site-profiler/types';
 import './styles.scss';
@@ -19,9 +19,9 @@ const SubtitleIcon = styled( Gridicon )`
 
 function getIcon( score: Scores ) {
 	switch ( score ) {
-		case SCORES.good:
+		case 'good':
 			return 'checkmark';
-		case SCORES.poor:
+		case 'poor':
 			return 'info-outline';
 		default:
 			return 'info-outline';
@@ -53,7 +53,7 @@ export const BasicMetric = ( {
 }: BasicMetricProps ) => {
 	const { value, score } = basicMetrics[ metric ];
 	const showMetric = value !== undefined && value !== null;
-	const isPositiveScore = score === SCORES.good;
+	const isPositiveScore = score === 'good';
 
 	return (
 		showMetric && (

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -55,7 +55,7 @@ export const BasicMetric = ( { metric, basicMetrics, name, copies }: BasicMetric
 					</div>
 				</div>
 				<h3>{ isPositiveScore ? copies.good.diagnostic : copies.poor.diagnostic }</h3>
-				<h4>{ isPositiveScore ? copies.good.diagnostic : copies.poor.diagnostic }</h4>
+				<h4>{ isPositiveScore ? copies.good.solution : copies.poor.solution }</h4>
 				<a href={ isPositiveScore ? copies.good.url : copies.poor.url }>
 					{ isPositiveScore ? copies.good.cta : copies.poor.cta }
 					<SubtitleIcon icon="chevron-right" size={ 18 } />

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -2,9 +2,10 @@ import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ForwardedRef, forwardRef } from 'react';
+import { ForwardedRef, forwardRef, useMemo } from 'react';
 import { BASIC_METRICS_UNITS } from 'calypso/data/site-profiler/metrics-dictionaries';
 import { calculateMetricsSectionScrollOffset } from 'calypso/site-profiler/utils/calculate-metrics-section-scroll-offset';
+import { CopiesReturnValueList, MetricsCopies, getCopies } from './copies';
 import type { BasicMetricsScored, Metrics, Scores } from 'calypso/data/site-profiler/types';
 import './styles.scss';
 
@@ -32,25 +33,10 @@ type BasicMetricProps = {
 	metric: Metrics;
 	basicMetrics: BasicMetricsScored;
 	name: string;
-	positiveHeading: string;
-	negativeHeading: string;
-	positiveSubheading: string;
-	negativeSubheading: string;
-	url: string;
-	urlText: string;
+	copies: MetricsCopies;
 };
 
-export const BasicMetric = ( {
-	metric,
-	basicMetrics,
-	name,
-	positiveHeading,
-	negativeHeading,
-	positiveSubheading,
-	negativeSubheading,
-	url,
-	urlText,
-}: BasicMetricProps ) => {
+export const BasicMetric = ( { metric, basicMetrics, name, copies }: BasicMetricProps ) => {
 	const { value, score } = basicMetrics[ metric ];
 	const showMetric = value !== undefined && value !== null;
 	const isPositiveScore = score === 'good';
@@ -68,10 +54,10 @@ export const BasicMetric = ( {
 						{ BASIC_METRICS_UNITS[ metric ] }
 					</div>
 				</div>
-				<h3>{ isPositiveScore ? positiveHeading : negativeHeading }</h3>
-				<h4>{ isPositiveScore ? positiveSubheading : negativeSubheading }</h4>
-				<a href={ url }>
-					{ urlText }
+				<h3>{ isPositiveScore ? copies.good.diagnostic : copies.poor.diagnostic }</h3>
+				<h4>{ isPositiveScore ? copies.good.diagnostic : copies.poor.diagnostic }</h4>
+				<a href={ isPositiveScore ? copies.good.url : copies.poor.url }>
+					{ isPositiveScore ? copies.good.cta : copies.poor.cta }
 					<SubtitleIcon icon="chevron-right" size={ 18 } />
 				</a>
 			</div>
@@ -81,128 +67,36 @@ export const BasicMetric = ( {
 
 export const BasicMetrics = forwardRef(
 	(
-		{ basicMetrics }: { basicMetrics: BasicMetricsScored },
+		{
+			basicMetrics,
+			domain,
+			isWpCom,
+		}: { basicMetrics: BasicMetricsScored; domain: string; isWpCom: boolean },
 		ref: ForwardedRef< HTMLObjectElement >
 	) => {
 		const translate = useTranslate();
 
+		const copies = useMemo(
+			() => getCopies( basicMetrics, translate, domain ),
+			[ basicMetrics, translate, domain ]
+		);
+
 		return (
 			<Container className="basic-metrics" ref={ ref }>
 				<div className="basic-metric-details result-list">
-					<BasicMetric
-						metric="cls"
-						basicMetrics={ basicMetrics }
-						name={ translate( 'Cumulative Layout Shift' ) }
-						positiveHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						negativeHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						positiveSubheading={ translate(
-							'WordPress.com’s optimized themes can reduce layout shifts, providing a more stable and enjoyable experience.'
-						) }
-						negativeSubheading={ translate(
-							'WordPress.com’s optimized themes can reduce layout shifts, providing a more stable and enjoyable experience.'
-						) }
-						url="https://wordpress.com/start/"
-						urlText={ translate( 'Stabilize with us' ) }
-					/>
-					<BasicMetric
-						metric="fid"
-						basicMetrics={ basicMetrics }
-						name={ translate( 'First Input Delay' ) }
-						positiveHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						negativeHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						positiveSubheading={ translate(
-							'WordPress.com’s optimized themes can reduce layout shifts, providing a more stable and enjoyable experience.'
-						) }
-						negativeSubheading={ translate(
-							'WordPress.com’s optimized themes can reduce layout shifts, providing a more stable and enjoyable experience.'
-						) }
-						url="https://wordpress.com/start/"
-						urlText={ translate( 'Stabilize with us' ) }
-					/>
-					<BasicMetric
-						metric="lcp"
-						basicMetrics={ basicMetrics }
-						name={ translate( 'Largest Contentful Paint' ) }
-						positiveHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						negativeHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						positiveSubheading={ translate(
-							'WordPress.com’s efficient resource management ensures faster responses to user actions.'
-						) }
-						negativeSubheading={ translate(
-							'WordPress.com’s efficient resource management ensures faster responses to user actions.'
-						) }
-						url="https://wordpress.com/start/"
-						urlText={ translate( 'Boost interactivity' ) }
-					/>
-					<BasicMetric
-						metric="fcp"
-						basicMetrics={ basicMetrics }
-						name={ translate( 'First Contentful Paint' ) }
-						positiveHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						negativeHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						positiveSubheading={ translate(
-							'Maintain this performance by using best practices for layout stability, ensuring content remains stable as it loads.'
-						) }
-						negativeSubheading={ translate(
-							'Maintain this performance by using best practices for layout stability, ensuring content remains stable as it loads.'
-						) }
-						url="https://wordpress.com/start/"
-						urlText={ translate( 'Keep layout stable' ) }
-					/>
-					<BasicMetric
-						metric="ttfb"
-						basicMetrics={ basicMetrics }
-						name={ translate( 'Time to First Byte' ) }
-						positiveHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						negativeHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						positiveSubheading={ translate(
-							'WordPress.com’s optimized themes can reduce layout shifts, providing a more stable and enjoyable experience.'
-						) }
-						negativeSubheading={ translate(
-							'WordPress.com’s optimized themes can reduce layout shifts, providing a more stable and enjoyable experience.'
-						) }
-						url="https://wordpress.com/themes/"
-						urlText={ translate( 'Load faster with us' ) }
-					/>
-					<BasicMetric
-						metric="inp"
-						basicMetrics={ basicMetrics }
-						name={ translate( 'Interaction to Next Paint' ) }
-						positiveHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						negativeHeading={ translate(
-							'Your site experiences more layout shifts than most, frustrating users and leading to higher bounce rates.'
-						) }
-						positiveSubheading={ translate(
-							'WordPress.com’s efficient content management ensures quicker load times and better engagement.'
-						) }
-						negativeSubheading={ translate(
-							'WordPress.com’s efficient content management ensures quicker load times and better engagement.'
-						) }
-						url="https://wordpress.com/themes/"
-						urlText={ translate( 'Load faster with us' ) }
-					/>
+					{ ( Object.entries( copies ) as CopiesReturnValueList ).map(
+						( [ metricKey, metricCopies ] ) => {
+							return (
+								<BasicMetric
+									key={ metricKey }
+									metric={ metricKey }
+									basicMetrics={ basicMetrics }
+									name={ metricCopies.title }
+									copies={ isWpCom ? metricCopies.wpcom : metricCopies.nonWpcom }
+								/>
+							);
+						}
+					) }
 				</div>
 			</Container>
 		);

--- a/client/site-profiler/components/results-header/index.tsx
+++ b/client/site-profiler/components/results-header/index.tsx
@@ -9,7 +9,7 @@ import './styles.scss';
 
 type Props = {
 	domain: string;
-	overallScore: PerformanceCategories;
+	performanceCategory: PerformanceCategories;
 	urlData?: UrlData;
 	onGetReport: () => void;
 };
@@ -28,20 +28,20 @@ function getIsWpComSiteMessage( urlData?: UrlData ) {
 	return translate( 'This site is not hosted on WordPress.com' );
 }
 
-function getTitleMessage( overallScore: PerformanceCategories ) {
-	if ( overallScore === 'non-wpcom-low-performer' ) {
+function getTitleMessage( performanceCategory: PerformanceCategories ) {
+	if ( performanceCategory === 'non-wpcom-low-performer' ) {
 		return translate( 'Boost needed! Improve your site with us.' );
 	}
-	if ( overallScore === 'non-wpcom-high-performer' ) {
+	if ( performanceCategory === 'non-wpcom-high-performer' ) {
 		return translate( 'Good, but you can make it even better.' );
 	}
-	if ( overallScore === 'wpcom-high-performer' ) {
+	if ( performanceCategory === 'wpcom-high-performer' ) {
 		return translate( 'Your site is a top performer! Keep it up.' );
 	}
 	return translate( 'Room for growth! Let’s optimize your site.' );
 }
 
-export const ResultsHeader = ( { domain, overallScore, urlData, onGetReport }: Props ) => {
+export const ResultsHeader = ( { domain, performanceCategory, urlData, onGetReport }: Props ) => {
 	return (
 		<div className="results-header--container">
 			<div className="results-header--domain-container">
@@ -49,7 +49,7 @@ export const ResultsHeader = ( { domain, overallScore, urlData, onGetReport }: P
 				{ getIcon( urlData ) }
 				<span className="domain-message">{ getIsWpComSiteMessage( urlData ) }</span>
 			</div>
-			<h1>{ getTitleMessage( overallScore ) }</h1>
+			<h1>{ getTitleMessage( performanceCategory ) }</h1>
 			<div className="results-header--button-container">
 				<Button onClick={ onGetReport }>
 					{ translate( 'Access full site report - It’s free' ) }

--- a/client/site-profiler/components/results-header/index.tsx
+++ b/client/site-profiler/components/results-header/index.tsx
@@ -3,14 +3,13 @@ import { translate } from 'i18n-calypso';
 import nonWpComSiteIcon from 'calypso/assets/images/site-profiler/non-wpcom-site.svg';
 import wpComSiteIcon from 'calypso/assets/images/site-profiler/wpcom-site.svg';
 import { UrlData } from 'calypso/blocks/import/types';
-import { isScoreGood } from 'calypso/data/site-profiler/metrics-dictionaries';
-import { Scores } from 'calypso/data/site-profiler/types';
+import { PerformanceCategories } from 'calypso/data/site-profiler/types';
 
 import './styles.scss';
 
 type Props = {
 	domain: string;
-	overallScore: Scores;
+	overallScore: PerformanceCategories;
 	urlData?: UrlData;
 	onGetReport: () => void;
 };
@@ -29,11 +28,17 @@ function getIsWpComSiteMessage( urlData?: UrlData ) {
 	return translate( 'This site is not hosted on WordPress.com' );
 }
 
-function getTitleMessage( overallScore: Scores ) {
-	if ( ! isScoreGood( overallScore ) ) {
-		return translate( 'Your site needs a boost. Let’s improve it.' );
+function getTitleMessage( overallScore: PerformanceCategories ) {
+	if ( overallScore === 'non-wpcom-low-performer' ) {
+		return translate( 'Boost needed! Improve your site with us.' );
 	}
-	return translate( 'Your site is a top performer! Keep it up.' );
+	if ( overallScore === 'non-wpcom-high-performer' ) {
+		return translate( 'Good, but you can make it even better.' );
+	}
+	if ( overallScore === 'wpcom-high-performer' ) {
+		return translate( 'Your site is a top performer! Keep it up.' );
+	}
+	return translate( 'Room for growth! Let’s optimize your site.' );
 }
 
 export const ResultsHeader = ( { domain, overallScore, urlData, onGetReport }: Props ) => {

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -4,7 +4,7 @@ import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { getOveralScore, isScoreGood } from 'calypso/data/site-profiler/metrics-dictionaries';
+import { getPerformanceCategory } from 'calypso/data/site-profiler/metrics-dictionaries';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
@@ -98,7 +98,7 @@ export default function SiteProfilerV2( props: Props ) {
 
 	const showGetReportForm = !! showBasicMetrics && !! url && isGetReportFormOpen;
 
-	const overallScore = getOveralScore( basicMetrics?.basic );
+	const overallScore = getPerformanceCategory( basicMetrics?.basic, urlData );
 
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;
@@ -126,8 +126,8 @@ export default function SiteProfilerV2( props: Props ) {
 					<LayoutBlock
 						className={ classnames(
 							'results-header-block',
-							{ poor: ! isScoreGood( overallScore ) },
-							{ good: isScoreGood( overallScore ) }
+							{ poor: overallScore === 'non-wpcom-low-performer' },
+							{ good: overallScore !== 'non-wpcom-low-performer' }
 						) }
 						width="medium"
 					>

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -98,7 +98,7 @@ export default function SiteProfilerV2( props: Props ) {
 
 	const showGetReportForm = !! showBasicMetrics && !! url && isGetReportFormOpen;
 
-	const overallScore = getPerformanceCategory( basicMetrics?.basic, urlData );
+	const performanceCategory = getPerformanceCategory( basicMetrics?.basic, urlData );
 
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;
@@ -126,15 +126,15 @@ export default function SiteProfilerV2( props: Props ) {
 					<LayoutBlock
 						className={ classnames(
 							'results-header-block',
-							{ poor: overallScore === 'non-wpcom-low-performer' },
-							{ good: overallScore !== 'non-wpcom-low-performer' }
+							{ poor: performanceCategory === 'non-wpcom-low-performer' },
+							{ good: performanceCategory !== 'non-wpcom-low-performer' }
 						) }
 						width="medium"
 					>
 						{ showBasicMetrics && (
 							<ResultsHeader
 								domain={ domain }
-								overallScore={ overallScore }
+								performanceCategory={ performanceCategory }
 								urlData={ urlData }
 								onGetReport={ () => setIsGetReportFormOpen( true ) }
 							/>

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -106,6 +106,8 @@ export default function SiteProfilerV2( props: Props ) {
 		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
 	};
 
+	const isWpCom = !! urlData?.platform_data?.is_wpcom;
+
 	return (
 		<div id="site-profiler-v2">
 			{ ! showResultScreen && (
@@ -143,7 +145,13 @@ export default function SiteProfilerV2( props: Props ) {
 					<LayoutBlock width="medium">
 						{ siteProfilerData && (
 							<>
-								{ showBasicMetrics && <BasicMetrics basicMetrics={ basicMetrics.basic } /> }
+								{ showBasicMetrics && (
+									<BasicMetrics
+										basicMetrics={ basicMetrics.basic }
+										domain={ domain }
+										isWpCom={ isWpCom }
+									/>
+								) }
 								<HostingSection
 									dns={ siteProfilerData.dns }
 									urlData={ urlData }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -17,7 +17,6 @@ import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-an
 import { getValidUrl } from '../utils/get-valid-url';
 import { normalizeWhoisField } from '../utils/normalize-whois-entry';
 import { AdvancedMetrics } from './advanced-metrics';
-import { BasicMetrics } from './basic-metrics';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
 import { GetReportForm } from './get-report-form';
@@ -171,7 +170,6 @@ export default function SiteProfiler( props: Props ) {
 								healthScoresRef={ healthScoresRef }
 								onCTAClick={ () => setIsGetReportFormOpen( true ) }
 							/>
-							<BasicMetrics ref={ basicMetricsRef } basicMetrics={ basicMetrics.basic } />
 							<AdvancedMetrics
 								performanceMetricsRef={ performanceMetricsRef }
 								healthScoresRef={ healthScoresRef }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/7435
## Proposed Changes

* Create four different categories to display the results header
* Create a copies component that returns the translated copies, titles, and CTA URLs for the basic cards
* Generalizes the Basic Card component to use the list of copy-objects returned by the copies component above
* Add all the copies for the main title and basic metric cards as currently defined in the P2 p9Jlb4-bWg-p2

> [!WARNING]  
> The copies' content is still under discussion, and many of them will change. They are an initial prototype, and they have been added before review and approval to progress with the development iteratively.

> [!WARNING]  
> The metrics that are considered as `needs-improvement` by the google docs are considered to be not good in this implementation. This can change after further discussions and reviews.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To add the copies required for the Site Profiler tool

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Select four different sites with the following characteristics. I have listed some examples here 34a1c-pb/#plain
  * Performs poorly, and it is not hosted on WP.com
  * Performs well, and it is not hosted on WP.com
  * Performs well, and it is hosted on WP.com
  * Performs poorly, and it is hosted on WP.com
* For each of the sites above
* Check that the title copy and header background correspond with the expected one as described in the P2 p9Jlb4-bWg-p2
* Check that all the values in each of the Basic Metric cards are the expected ones as described in the P2 p9Jlb4-bWg-p2
* Additionally, you can manually tweak [this condition](https://github.com/Automattic/wp-calypso/blob/1c6338144db69777cb21dd42e2a74e08e8ed0947/client/site-profiler/components/basic-metrics/index.tsx#L42) to make all the results bad or all of them good for the 4 different categories, so all the texts can be checked without needing to find a site that fits into that category for that metric.


| Category | Screenshot |
|--------|--------|
| Non-WPCOM high performer | ![nwpcom-good](https://github.com/Automattic/wp-calypso/assets/11555574/3ad557ee-da48-4017-8ade-22c3aec1b05e) |
| Non-WPCOM low performer | ![nwpcom-bad](https://github.com/Automattic/wp-calypso/assets/11555574/bb580884-a65d-4b01-bb2a-2069b04d4660) |
| WPCOM high performer | ![wpcom-good](https://github.com/Automattic/wp-calypso/assets/11555574/e4478ec8-effe-4fe3-aeaf-c133fcf40997) |
| WPCOM low performer | ![wpcom-bad](https://github.com/Automattic/wp-calypso/assets/11555574/4e26ea55-217d-4d4f-a7bf-d6163f5696e0) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
~~- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
~~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~