### PR TITLE
Site Profiler: migration banners

### DIFF
--- a/client/site-profiler/components/migration-banner-big/index.tsx
+++ b/client/site-profiler/components/migration-banner-big/index.tsx
@@ -3,12 +3,12 @@ import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import WPCOMLogo from 'calypso/assets/images/a8c-for-agencies/wpcom-logo.svg';
 import siteProfilerBackground from 'calypso/assets/images/site-profiler/background-results-good.svg';
 import { LayoutBlock } from 'calypso/site-profiler/components/layout';
 
 const StyledLayoutBlock = styled( LayoutBlock )`
 	position: relative;
-	overflow: hidden;
 	z-index: 0;
 	&:before {
 		content: '';
@@ -19,9 +19,17 @@ const StyledLayoutBlock = styled( LayoutBlock )`
 		transform: scaleY( -1 );
 		z-index: -1;
 	}
+	&.migration-banner-big h1 {
+		font-size: 60px;
+	}
 `;
 
-const Heading = styled.h1`
+const StyledWPCOMLogo = styled.img`
+	margin-bottom: 30px;
+	filter: brightness( 0 ) saturate( 100% ) invert( 56% ) sepia( 96% ) saturate( 6609% )
+		hue-rotate( 225deg ) brightness( 95% ) contrast( 93% );
+`;
+const Heading = styled.h2`
 	&#migration-banner-heading {
 		font-size: 60px;
 	}
@@ -49,10 +57,9 @@ export const MigrationBannerBig = () => {
 	const translate = useTranslate();
 
 	return (
-		<StyledLayoutBlock width="medium">
-			<Heading id="migration-banner-heading">
-				{ translate( 'Boost your site performance' ) }
-			</Heading>
+		<StyledLayoutBlock className="migration-banner-big" width="medium">
+			<StyledWPCOMLogo src={ WPCOMLogo } />
+			<Heading>{ translate( 'Boost your site performance' ) }</Heading>
 			<Description>
 				{ translate(
 					"Experience top-tier speed and reliability on WordPress.com.{{br/}}It's time to give your site the platform it deserves.",

--- a/client/site-profiler/components/migration-banner-big/index.tsx
+++ b/client/site-profiler/components/migration-banner-big/index.tsx
@@ -13,36 +13,43 @@ const StyledLayoutBlock = styled( LayoutBlock )`
 	&:before {
 		content: '';
 		position: absolute;
+		right: 0;
+		bottom: 0;
 		width: 100%;
 		height: 100%;
-		background: url( ${ siteProfilerBackground } ) no-repeat right bottom;
+		background: url( ${ siteProfilerBackground } ) no-repeat right top;
 		transform: scaleY( -1 );
 		z-index: -1;
 	}
-	&.migration-banner-big h1 {
-		font-size: 60px;
+
+	&.l-block {
+		padding-bottom: 200px;
 	}
 `;
-
 const StyledWPCOMLogo = styled.img`
 	margin-bottom: 30px;
 	filter: brightness( 0 ) saturate( 100% ) invert( 56% ) sepia( 96% ) saturate( 6609% )
 		hue-rotate( 225deg ) brightness( 95% ) contrast( 93% );
 `;
-const Heading = styled.h2`
-	&#migration-banner-heading {
-		font-size: 60px;
-	}
+const Heading = styled.div`
+	font-size: 60px;
+	line-height: 50px;
+	margin-bottom: 15px;
 `;
 const Description = styled.div`
 	margin-bottom: 60px;
 	color: var( --studio-gray-20 );
 	font-size: 16px;
 `;
-
 const StyledButton = styled( Button )`
-	&.migration-banner-button {
-		padding: 10px 24px;
+	background-color: var( --color-button );
+	border: none;
+	color: #fff;
+	padding: 10px 24px;
+
+	&:hover {
+		color: #fff;
+		background-color: var( --color-button-60 );
 	}
 `;
 
@@ -57,7 +64,7 @@ export const MigrationBannerBig = () => {
 	const translate = useTranslate();
 
 	return (
-		<StyledLayoutBlock className="migration-banner-big" width="medium">
+		<StyledLayoutBlock width="medium">
 			<StyledWPCOMLogo src={ WPCOMLogo } />
 			<Heading>{ translate( 'Boost your site performance' ) }</Heading>
 			<Description>
@@ -70,7 +77,7 @@ export const MigrationBannerBig = () => {
 					}
 				) }
 			</Description>
-			<StyledButton className="migration-banner-button button-action" onClick={ onMigrateSite }>
+			<StyledButton onClick={ onMigrateSite }>
 				{ translate( 'Start your free migration' ) }
 			</StyledButton>
 		</StyledLayoutBlock>

--- a/client/site-profiler/components/migration-banner-big/index.tsx
+++ b/client/site-profiler/components/migration-banner-big/index.tsx
@@ -1,0 +1,71 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import page from '@automattic/calypso-router';
+import { Button } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import siteProfilerBackground from 'calypso/assets/images/site-profiler/background-results-good.svg';
+import { LayoutBlock } from 'calypso/site-profiler/components/layout';
+
+const StyledLayoutBlock = styled( LayoutBlock )`
+	position: relative;
+	overflow: hidden;
+	z-index: 0;
+	&:before {
+		content: '';
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		background: url( ${ siteProfilerBackground } ) no-repeat right bottom;
+		transform: scaleY( -1 );
+		z-index: -1;
+	}
+`;
+
+const Heading = styled.h1`
+	&#migration-banner-heading {
+		font-size: 60px;
+	}
+`;
+const Description = styled.div`
+	margin-bottom: 60px;
+	color: var( --studio-gray-20 );
+	font-size: 16px;
+`;
+
+const StyledButton = styled( Button )`
+	&.migration-banner-button {
+		padding: 10px 24px;
+	}
+`;
+
+const onMigrateSite = () => {
+	recordTracksEvent( 'calypso_site_profiler_cta', {
+		cta_name: 'migrateSiteBannerBig',
+	} );
+	page( `/setup/hosted-site-migration?ref=site-profiler` );
+};
+
+export const MigrationBannerBig = () => {
+	const translate = useTranslate();
+
+	return (
+		<StyledLayoutBlock width="medium">
+			<Heading id="migration-banner-heading">
+				{ translate( 'Boost your site performance' ) }
+			</Heading>
+			<Description>
+				{ translate(
+					"Experience top-tier speed and reliability on WordPress.com.{{br/}}It's time to give your site the platform it deserves.",
+					{
+						components: {
+							br: <br />,
+						},
+					}
+				) }
+			</Description>
+			<StyledButton className="migration-banner-button button-action" onClick={ onMigrateSite }>
+				{ translate( 'Start your free migration' ) }
+			</StyledButton>
+		</StyledLayoutBlock>
+	);
+};

--- a/client/site-profiler/components/migration-banner/index.tsx
+++ b/client/site-profiler/components/migration-banner/index.tsx
@@ -41,7 +41,7 @@ export const MigrationBanner = () => {
 
 	return (
 		<LayoutBlock width="medium">
-			<Heading>{ translate( 'Want to see how much better your site could be? ' ) }</Heading>
+			<Heading>{ translate( 'Want to see how much better your site could be?' ) }</Heading>
 			<Description>
 				{ translate( 'Migrate for free and get access to our advanced performance tools.' ) }
 				<Link onClick={ onMigrateSite }>

--- a/client/site-profiler/components/migration-banner/index.tsx
+++ b/client/site-profiler/components/migration-banner/index.tsx
@@ -1,0 +1,54 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import page from '@automattic/calypso-router';
+import { Gridicon } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { LayoutBlock } from 'calypso/site-profiler/components/layout';
+
+const Heading = styled.h3``;
+const Description = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	gap: 50px;
+	justify-content: space-between;
+	margin-bottom: 8px;
+	color: var( --studio-gray-20 );
+	font-size: 16px;
+`;
+const Link = styled.div`
+	color: var( --color-button );
+	text-decoration: none;
+	&:hover {
+		text-decoration: underline;
+		color: var( --color-button );
+		cursor: pointer;
+	}
+`;
+const LinkIcon = styled( Gridicon )`
+	transform: translate( 0, 3px );
+	margin-left: 8px;
+`;
+
+const onMigrateSite = () => {
+	recordTracksEvent( 'calypso_site_profiler_cta', {
+		cta_name: 'migrateSiteBanner',
+	} );
+	page( `/setup/hosted-site-migration?ref=site-profiler` );
+};
+
+export const MigrationBanner = () => {
+	const translate = useTranslate();
+
+	return (
+		<LayoutBlock width="medium">
+			<Heading>{ translate( 'Want to see how much better your site could be? ' ) }</Heading>
+			<Description>
+				{ translate( 'Migrate for free and get access to our advanced performance tools.' ) }
+				<Link onClick={ onMigrateSite }>
+					{ translate( 'Bring your WordPress site to WordPress.com' ) }
+					<LinkIcon icon="chevron-right" size={ 18 } />
+				</Link>
+			</Description>
+		</LayoutBlock>
+	);
+};

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -171,7 +171,7 @@ export default function SiteProfilerV2( props: Props ) {
 					<MigrationBannerBig />
 				</>
 			) }
-			<MigrationBanner />
+			{ ! showResultScreen && <MigrationBanner /> }
 			<GetReportForm
 				url={ basicMetrics?.final_url }
 				token={ basicMetrics?.token }

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -23,6 +23,7 @@ import { GetReportForm } from './get-report-form';
 import { HostingSection } from './hosting-section';
 import { LandingPageHeader } from './landing-page-header';
 import { MigrationBanner } from './migration-banner';
+import { MigrationBannerBig } from './migration-banner-big';
 import { PerformanceSection } from './performance-section';
 import { ResultsHeader } from './results-header';
 import './styles-v2.scss';
@@ -167,6 +168,7 @@ export default function SiteProfilerV2( props: Props ) {
 							</>
 						) }
 					</LayoutBlock>
+					<MigrationBannerBig />
 				</>
 			) }
 			<MigrationBanner />

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -22,6 +22,7 @@ import { DomainSection } from './domain-section';
 import { GetReportForm } from './get-report-form';
 import { HostingSection } from './hosting-section';
 import { LandingPageHeader } from './landing-page-header';
+import { MigrationBanner } from './migration-banner';
 import { PerformanceSection } from './performance-section';
 import { ResultsHeader } from './results-header';
 import './styles-v2.scss';
@@ -168,7 +169,7 @@ export default function SiteProfilerV2( props: Props ) {
 					</LayoutBlock>
 				</>
 			) }
-
+			<MigrationBanner />
 			<GetReportForm
 				url={ basicMetrics?.final_url }
 				token={ basicMetrics?.token }

--- a/client/site-profiler/components/styles-v2.scss
+++ b/client/site-profiler/components/styles-v2.scss
@@ -67,7 +67,7 @@
 		color: #fff;
 		text-decoration: underline;
 		font-size: 1rem;
-		font-size: 500;
+		font-weight: 500;
 
 		&:hover {
 			color: var(--studio-gray-40);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7295#event-12957597001 and https://github.com/Automattic/dotcom-forge/issues/7307#event-12957986724

## Proposed Changes

* Adds two migration banners in Site Profiler

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* Make sure only the small banner is displayed, link should go to the migration flow
* Test a URL, only big banner is displayed, link should go to the migration flow

|Small | Big|
|-------|------|
|![CleanShot 2024-05-29 at 15 41 05@2x](https://github.com/Automattic/wp-calypso/assets/12430020/7ddf7966-3c74-4e3b-9bba-3d4982fd4db7)|![CleanShot 2024-05-29 at 15 40 07@2x](https://github.com/Automattic/wp-calypso/assets/12430020/b8cd98c7-01f4-464f-bf0f-8bba61474d71)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
