### PR TITLE
Guided Onboarding: Fix skipping the last question

### DIFF
--- a/client/components/segmentation-survey/hooks/use-segmentation-survey-navigation.ts
+++ b/client/components/segmentation-survey/hooks/use-segmentation-survey-navigation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { Answers, Question } from 'calypso/components/survey-container/types';
 import { useHash } from 'calypso/landing/stepper/hooks/use-hash';
+import { SKIP_ANSWER_KEY } from '..';
 import useSegmentationSurveyTracksEvents from './use-segmentation-survey-tracks-events';
 
 type SegmentationSurveyNavigationProps = {
@@ -65,7 +66,7 @@ const useSegmentationSurveyNavigation = ( {
 		recordSkipEvent( currentQuestion );
 
 		await onSkip?.( currentQuestion );
-		if ( skipNextNavigation?.( currentQuestion.key, answers?.[ currentQuestion.key ] ) ) {
+		if ( skipNextNavigation?.( currentQuestion.key, [ SKIP_ANSWER_KEY ] ) ) {
 			return;
 		}
 

--- a/client/components/segmentation-survey/hooks/use-segmentation-survey-navigation.ts
+++ b/client/components/segmentation-survey/hooks/use-segmentation-survey-navigation.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
+import { SKIP_ANSWER_KEY } from 'calypso/components/segmentation-survey';
 import { Answers, Question } from 'calypso/components/survey-container/types';
 import { useHash } from 'calypso/landing/stepper/hooks/use-hash';
-import { SKIP_ANSWER_KEY } from '..';
 import useSegmentationSurveyTracksEvents from './use-segmentation-survey-tracks-events';
 
 type SegmentationSurveyNavigationProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes an error happening when skipping the last question in a survey.
What would happen is that the cancellation of answers was called before the check on skipping the next navigation happened, resulting in an error thrown (still working, but you could see the error in the console)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We just need to return 'skip', so we can have the check even after deleting the answers.
Looking at the code is way easier :)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go through `/setup/guided`
- Skip the second question
- No error should be shown in the console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
