### PR TITLE
Subscribers Page: don't exclude the owner of the site from the list

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -39,12 +39,17 @@ const SubscriberListContainer = ( {
 		isLoading,
 		subscribers,
 		pages,
+		isOwnerSubscribed,
 	} = useSubscribersPage();
 	useRecordSearch();
 
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
+	const shouldShowLaunchpad =
+		! isLoading && ! searchTerm && ( ! grandTotal || ( grandTotal === 1 && isOwnerSubscribed ) );
+	const shouldShowSubscriberList = ! isLoading && Boolean( grandTotal ) && ! shouldShowLaunchpad;
+	const shouldShowSubscriberHeader = Boolean( grandTotal ) && ! shouldShowLaunchpad;
 
 	useEffect( () => {
 		if ( ! isLoading && subscribers.length === 0 && page > 1 ) {
@@ -54,7 +59,7 @@ const SubscriberListContainer = ( {
 
 	return (
 		<section className="subscriber-list-container">
-			{ Boolean( grandTotal ) && (
+			{ shouldShowSubscriberHeader && (
 				<>
 					<div className="subscriber-list-container__header">
 						<span className="subscriber-list-container__title">
@@ -88,7 +93,7 @@ const SubscriberListContainer = ( {
 						<div className="loading-placeholder small hidden"></div>
 					</div>
 				) ) }
-			{ ! isLoading && Boolean( grandTotal ) && (
+			{ shouldShowSubscriberList && (
 				<>
 					{ Boolean( total ) && (
 						<SubscriberList
@@ -110,7 +115,7 @@ const SubscriberListContainer = ( {
 					<GrowYourAudience />
 				</>
 			) }
-			{ ! isLoading && ! grandTotal && ! searchTerm && <EmptyComponent /> }
+			{ shouldShowLaunchpad && <EmptyComponent /> }
 		</section>
 	);
 };

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -7,16 +7,11 @@ import { useDebounce } from 'use-debounce';
 import { usePagination } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import useManySubsSite from '../../hooks/use-many-subs-site';
-import {
-	useSubscriberCountQuery,
-	useSubscriberDetailsQuery,
-	useSubscribersQuery,
-} from '../../queries';
+import { useSubscriberCountQuery, useSubscribersQuery } from '../../queries';
 import { migrateSubscribers } from './migrate-subscribers-query';
 
 type SubscribersPageProviderProps = {
@@ -124,13 +119,8 @@ export const SubscribersPageProvider = ( {
 
 	// Current user is not included in the subscribers list, so we need to remove from the total
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId );
-	const userId = useSelector( getCurrentUserId ) ?? undefined;
-	const { data: isCurrentUserSubscribed } = useSubscriberDetailsQuery( siteId, undefined, userId );
 
-	const grandTotal =
-		isCurrentUserSubscribed && subscribersTotals?.email_subscribers
-			? subscribersTotals.email_subscribers - 1
-			: subscribersTotals?.email_subscribers ?? 0;
+	const grandTotal = subscribersTotals?.email_subscribers ?? 0;
 
 	const { pageChangeCallback } = usePagination(
 		pageNumber,

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -51,6 +51,7 @@ type SubscribersPageContextProps = {
 	siteId: number | null;
 	isLoading: boolean;
 	pages?: number;
+	isOwnerSubscribed: boolean;
 };
 
 const SubscribersPageContext = createContext< SubscribersPageContextProps | undefined >(
@@ -193,10 +194,11 @@ export const SubscribersPageProvider = ( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const { total, per_page, subscribers } = subscribersQueryResult.data || {
+	const { total, per_page, subscribers, is_owner_subscribed } = subscribersQueryResult.data || {
 		total: 0,
 		per_page: DEFAULT_PER_PAGE,
 		subscribers: [],
+		is_owner_subscribed: false,
 	};
 
 	// If we receive a different perPage value from the query, update the state
@@ -230,6 +232,7 @@ export const SubscribersPageProvider = ( {
 				siteId,
 				isLoading: subscribersQueryResult.isLoading,
 				pages,
+				isOwnerSubscribed: is_owner_subscribed,
 			} }
 		>
 			{ children }

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -6,6 +6,7 @@ export type SubscriberEndpointResponse = {
 	page: number;
 	pages: number;
 	subscribers: Subscriber[];
+	is_owner_subscribed: boolean;
 };
 
 export type SubscriptionPlan = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7369

## Proposed Changes

This PR makes the site's owner count as one of the site's subscribers (if the owner is subscribed, of course). Up until this point, the owner was removed from the subscriber count.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Multiple reports of subscriber count inconsistencies made by our users made us act on this. For more context, check this: pejTkB-14x-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Setup**
- To best test this PR, test it alongside this patch: D150374-code
- Apply these changes locally and run the application.
- You will need a site with no subscribers (other than the owner of the site) and a site with more subscribers (including the owner). Ideally, instead of having one site with more subscribers, we should test with an atomic site and a simple site with more subscribers, including the owner.

**Testing steps**
Follow the same steps on each of the aforementioned sites.
- Go to `Users -> Subscribers`. You should see:
  - In the site with no subscribers, the "No subscribers yet?" launchpad is used.
  - In the sites with more subscribers, the correct number of subscribers and the owner are in the list of subscribers.
- Unsubscribe the owner of the site.
  - In the site with no subscribers, the "No subscribers yet?" launchpad is used.
  - In the sites with more subscribers, the correct number of subscribers appears (one less), and the site owner shouldn't be on the list anymore.

**Regression tests**
- As regression tests you could test the numbers and the appearance of the site owner in `Stats -> Subscribers` and the Subscriber Block properties in the editor.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?