### PR TITLE
Add loading screen component

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -126,6 +126,7 @@ export interface UrlPerformanceMetricsQueryResponse {
 			performance: number;
 			overall_score: number;
 		};
+		status: string;
 	};
 }
 

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -94,7 +94,10 @@ export type BasicMetricsScoredList = [ Metrics, { value: number; score: Scores }
 
 export interface UrlBasicMetricsQueryResponse {
 	final_url: string;
-	basic: BasicMetrics;
+	basic: {
+		data: BasicMetrics;
+		success: boolean;
+	};
 	advanced: Record< string, string >;
 	token: string;
 }

--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -11,15 +11,18 @@ import { getScore } from './metrics-dictionaries';
 function mapScores( response: UrlBasicMetricsQueryResponse ) {
 	const { basic } = response;
 
-	const basicMetricsScored = ( Object.entries( basic ) as BasicMetricsList ).reduce(
-		( acc, [ key, value ] ) => {
-			acc[ key ] = { value: value, score: getScore( key as Metrics, value ) };
-			return acc;
-		},
-		{} as BasicMetricsScored
-	);
+	let basicMetricsScored;
+	if ( basic.success ) {
+		basicMetricsScored = ( Object.entries( basic.data ) as BasicMetricsList ).reduce(
+			( acc, [ key, value ] ) => {
+				acc[ key ] = { value: value, score: getScore( key as Metrics, value ) };
+				return acc;
+			},
+			{} as BasicMetricsScored
+		);
+	}
 
-	return { ...response, basic: basicMetricsScored };
+	return { ...response, success: basic.success, basic: basicMetricsScored };
 }
 
 export const useUrlBasicMetricsQuery = ( url?: string ) => {

--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -11,7 +11,7 @@ import { getScore } from './metrics-dictionaries';
 function mapScores( response: UrlBasicMetricsQueryResponse ) {
 	const { basic } = response;
 
-	let basicMetricsScored;
+	let basicMetricsScored = {} as BasicMetricsScored;
 	if ( basic.success ) {
 		basicMetricsScored = ( Object.entries( basic.data ) as BasicMetricsList ).reduce(
 			( acc, [ key, value ] ) => {

--- a/client/data/site-profiler/use-url-performance-metrics-query.ts
+++ b/client/data/site-profiler/use-url-performance-metrics-query.ts
@@ -24,5 +24,7 @@ export const useUrlPerformanceMetricsQuery = ( url?: string, hash?: string ) => 
 		enabled: !! url,
 		retry: false,
 		refetchOnWindowFocus: false,
+		refetchInterval: ( query ) =>
+			query.state.data?.webtestpage_org?.status === 'completed' ? false : 1000, // 1 second	;
 	} );
 };

--- a/client/site-profiler/components/footnote/index.tsx
+++ b/client/site-profiler/components/footnote/index.tsx
@@ -9,9 +9,11 @@ const StyledLayoutBlock = styled( LayoutBlock )`
 		display: flex;
 		gap: 90px;
 		justify-content: space-between;
+		align-items: flex-end;
 
 		@media ( max-width: 980px ) {
 			flex-direction: column;
+			align-items: flex-start;
 			gap: 30px;
 		}
 	}

--- a/client/site-profiler/components/loading-screen/index.tsx
+++ b/client/site-profiler/components/loading-screen/index.tsx
@@ -1,12 +1,11 @@
 import { ProgressBar } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
 import { LayoutBlock } from 'calypso/site-profiler/components/layout';
 import './styles.scss';
 
 const Progress = styled( ProgressBar )`
-	background-color: #349f4b;
-
 	div {
 		background: linear-gradient( 90deg, #3858e9 0%, #349f4b 100% );
 	}
@@ -15,11 +14,23 @@ const Progress = styled( ProgressBar )`
 export const LoadingScreen = () => {
 	const translate = useTranslate();
 
+	const [ progress, setProgress ] = useState( 0 );
+
+	const interval = setInterval( () => {
+		setProgress( progress + 20 );
+	}, 1000 );
+
+	useEffect( () => {
+		if ( progress >= 100 ) {
+			clearInterval( interval );
+		}
+	}, [ progress, interval ] );
+
 	return (
 		<LayoutBlock className="landing-page-header-block" width="medium">
 			<div className="landing-page-loading-screen">
 				<h2>{ translate( "Crunching your site's numbers…" ) }</h2>
-				<Progress value={ 20 } total={ 100 } />
+				<Progress value={ progress } total={ 100 } />
 			</div>
 		</LayoutBlock>
 	);

--- a/client/site-profiler/components/loading-screen/index.tsx
+++ b/client/site-profiler/components/loading-screen/index.tsx
@@ -1,0 +1,26 @@
+import { ProgressBar } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { LayoutBlock } from 'calypso/site-profiler/components/layout';
+import './styles.scss';
+
+const Progress = styled( ProgressBar )`
+	background-color: #349f4b;
+
+	div {
+		background: linear-gradient( 90deg, #3858e9 0%, #349f4b 100% );
+	}
+`;
+
+export const LoadingScreen = () => {
+	const translate = useTranslate();
+
+	return (
+		<LayoutBlock className="landing-page-header-block" width="medium">
+			<div className="landing-page-loading-screen">
+				<h2>{ translate( "Crunching your site's numbers…" ) }</h2>
+				<Progress value={ 50 } total={ 100 } />
+			</div>
+		</LayoutBlock>
+	);
+};

--- a/client/site-profiler/components/loading-screen/index.tsx
+++ b/client/site-profiler/components/loading-screen/index.tsx
@@ -23,21 +23,21 @@ export const LoadingScreen = () => {
 
 	const [ progress, setProgress ] = useState( 0 );
 
-	const interval = setInterval( () => {
-		setProgress( progress + 20 );
-	}, 1000 );
-
 	useEffect( () => {
-		if ( progress >= 100 ) {
-			clearInterval( interval );
-		}
-	}, [ progress, interval ] );
+		setTimeout( () => {
+			if ( progress >= 100 ) {
+				setProgress( 0 );
+			} else {
+				setProgress( progress + 10 );
+			}
+		}, 1000 );
+	}, [ progress ] );
 
 	return (
 		<LayoutBlock className="landing-page-header-block" width="medium">
 			<div className="landing-page-loading-screen">
-				<h2>{ progressHeadings[ Math.floor( ( progress / 100 ) * progressHeadings.length ) ] }</h2>
-				<Progress value={ progress } total={ 100 } />
+				<h2>{ progressHeadings[ Math.floor( ( progress / 101 ) * progressHeadings.length ) ] }</h2>
+				<Progress value={ progress } total={ 100 } canGoBackwards />
 			</div>
 		</LayoutBlock>
 	);

--- a/client/site-profiler/components/loading-screen/index.tsx
+++ b/client/site-profiler/components/loading-screen/index.tsx
@@ -19,7 +19,7 @@ export const LoadingScreen = () => {
 		<LayoutBlock className="landing-page-header-block" width="medium">
 			<div className="landing-page-loading-screen">
 				<h2>{ translate( "Crunching your site's numbers…" ) }</h2>
-				<Progress value={ 50 } total={ 100 } />
+				<Progress value={ 20 } total={ 100 } />
 			</div>
 		</LayoutBlock>
 	);

--- a/client/site-profiler/components/loading-screen/index.tsx
+++ b/client/site-profiler/components/loading-screen/index.tsx
@@ -14,6 +14,13 @@ const Progress = styled( ProgressBar )`
 export const LoadingScreen = () => {
 	const translate = useTranslate();
 
+	const progressHeadings = [
+		translate( "Crunching your site's numbers…" ),
+		translate( 'Analyzing speed metrics…' ),
+		translate( 'Comparing with top sites…' ),
+		translate( 'Finalizing your report…' ),
+	];
+
 	const [ progress, setProgress ] = useState( 0 );
 
 	const interval = setInterval( () => {
@@ -29,7 +36,7 @@ export const LoadingScreen = () => {
 	return (
 		<LayoutBlock className="landing-page-header-block" width="medium">
 			<div className="landing-page-loading-screen">
-				<h2>{ translate( "Crunching your site's numbers…" ) }</h2>
+				<h2>{ progressHeadings[ Math.floor( ( progress / 100 ) * progressHeadings.length ) ] }</h2>
 				<Progress value={ progress } total={ 100 } />
 			</div>
 		</LayoutBlock>

--- a/client/site-profiler/components/loading-screen/index.tsx
+++ b/client/site-profiler/components/loading-screen/index.tsx
@@ -3,11 +3,18 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { LayoutBlock } from 'calypso/site-profiler/components/layout';
-import './styles.scss';
 
 const Progress = styled( ProgressBar )`
 	div {
 		background: linear-gradient( 90deg, #3858e9 0%, #349f4b 100% );
+	}
+`;
+
+const StyledLoadingScreen = styled.div`
+	padding: 100px 40px;
+
+	h2 {
+		text-align: center;
 	}
 `;
 
@@ -28,17 +35,17 @@ export const LoadingScreen = () => {
 			if ( progress >= 100 ) {
 				setProgress( 0 );
 			} else {
-				setProgress( progress + 10 );
+				setProgress( progress + 3 );
 			}
 		}, 1000 );
 	}, [ progress ] );
 
 	return (
 		<LayoutBlock className="landing-page-header-block" width="medium">
-			<div className="landing-page-loading-screen">
+			<StyledLoadingScreen>
 				<h2>{ progressHeadings[ Math.floor( ( progress / 101 ) * progressHeadings.length ) ] }</h2>
 				<Progress value={ progress } total={ 100 } canGoBackwards />
-			</div>
+			</StyledLoadingScreen>
 		</LayoutBlock>
 	);
 };

--- a/client/site-profiler/components/loading-screen/styles.scss
+++ b/client/site-profiler/components/loading-screen/styles.scss
@@ -1,7 +1,0 @@
-.landing-page-loading-screen {
-	padding: 80px 40px;
-
-	h2 {
-		text-align: center;
-	}
-}

--- a/client/site-profiler/components/loading-screen/styles.scss
+++ b/client/site-profiler/components/loading-screen/styles.scss
@@ -1,0 +1,7 @@
+.landing-page-loading-screen {
+	padding: 80px 40px;
+
+	h2 {
+		text-align: center;
+	}
+}

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -9,6 +9,7 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
+import { useUrlPerformanceMetricsQuery } from 'calypso/data/site-profiler/use-url-performance-metrics-query';
 import { LayoutBlock } from 'calypso/site-profiler/components/layout';
 import useDefineConversionAction from 'calypso/site-profiler/hooks/use-define-conversion-action';
 import useDomainParam from 'calypso/site-profiler/hooks/use-domain-param';
@@ -24,6 +25,7 @@ import { GetReportForm } from './get-report-form';
 import { HealthSection } from './health-section';
 import { HostingSection } from './hosting-section';
 import { LandingPageHeader } from './landing-page-header';
+import { LoadingScreen } from './loading-screen';
 import { MigrationBannerBig } from './migration-banner-big';
 import { PerformanceSection } from './performance-section';
 import { ResultsHeader } from './results-header';
@@ -106,6 +108,8 @@ export default function SiteProfilerV2( props: Props ) {
 
 	const performanceCategory = getPerformanceCategory( basicMetrics?.basic, urlData );
 
+	const { data: performanceMetrics } = useUrlPerformanceMetricsQuery( url, basicMetrics?.token );
+
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;
 		// URL param is the source of truth
@@ -129,7 +133,8 @@ export default function SiteProfilerV2( props: Props ) {
 					/>
 				</LayoutBlock>
 			) }
-			{ showResultScreen && (
+			{ showResultScreen && ! performanceMetrics && <LoadingScreen /> }
+			{ showResultScreen && performanceMetrics && (
 				<>
 					<LayoutBlock
 						className={ classnames(

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -94,7 +94,8 @@ export default function SiteProfilerV2( props: Props ) {
 		isFetching: isFetchingBasicMetrics,
 	} = useUrlBasicMetricsQuery( url );
 
-	const showBasicMetrics = basicMetrics && ! isFetchingBasicMetrics && ! errorBasicMetrics;
+	const showBasicMetrics =
+		basicMetrics && basicMetrics.success && ! isFetchingBasicMetrics && ! errorBasicMetrics;
 
 	// TODO: Remove this debug statement once we have a better error handling mechanism
 	if ( errorBasicMetrics ) {
@@ -108,7 +109,10 @@ export default function SiteProfilerV2( props: Props ) {
 
 	const performanceCategory = getPerformanceCategory( basicMetrics?.basic, urlData );
 
-	const { data: performanceMetrics } = useUrlPerformanceMetricsQuery( url, basicMetrics?.token );
+	const { data: performanceMetrics } = useUrlPerformanceMetricsQuery(
+		basicMetrics?.final_url,
+		basicMetrics?.token
+	);
 
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7451

## Proposed Changes

* Add loading screen component
* Show loading screen while fetching performance metrics

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're updating the Site Profiler UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply the patch D150503-code and sandbox public-api
- Go to the `/site-profiler/:url` and enter a site URL
- Open devtools Network tab, and click the Check site button
- Check that the loading screen is shown
- Check that the `/basic` and `/advanced/performance` requests are sent out

https://github.com/Automattic/wp-calypso/assets/11555574/5cfc4e00-2fef-4f58-a55d-3391c3fb22e2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?