### PR TITLE
Plugins page: Align header style with domains and sites pages

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -94,6 +94,8 @@ body.command-palette-modal-open {
 		}
 	}
 
+	// The plugins site view needs the header to be full width, so the padding
+	// is added on the header and .plugins-browser__content-wrapper instead
 	.is-section-plugins & {
 		padding: 79px 0 32px calc(var(--sidebar-width-max) + 1px);
 	}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -94,6 +94,10 @@ body.command-palette-modal-open {
 		}
 	}
 
+	.is-section-plugins & {
+		padding: 79px 0 32px calc(var(--sidebar-width-max) + 1px);
+	}
+
 	// This is needed to ensure the WebPreview component
 	// displays at full height.
 	.is-section-preview & {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -160,10 +160,10 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 					search={ search }
 				/>
 			) }
-			{ selectedSite && isJetpack && isPossibleJetpackConnectionProblem && (
-				<JetpackConnectionHealthBanner siteId={ siteId } />
-			) }
 			<div className="plugins-browser__content-wrapper">
+				{ selectedSite && isJetpack && isPossibleJetpackConnectionProblem && (
+					<JetpackConnectionHealthBanner siteId={ siteId } />
+				) }
 				<SearchBoxHeader
 					searchRef={ searchRef }
 					categoriesRef={ categoriesRef }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -163,39 +163,41 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 			{ selectedSite && isJetpack && isPossibleJetpackConnectionProblem && (
 				<JetpackConnectionHealthBanner siteId={ siteId } />
 			) }
-			<SearchBoxHeader
-				searchRef={ searchRef }
-				categoriesRef={ categoriesRef }
-				stickySearchBoxRef={ searchHeaderRef }
-				isSticky={ isAboveElement }
-				searchTerm={ search }
-				isSearching={ isFetchingPluginsBySearchTerm }
-				title={
-					'en' === locale || hasTranslation( 'Flex your site’s features with plugins' )
-						? __( 'Flex your site’s features with plugins' )
-						: __( 'Plugins you need to get your projects done' )
-				}
-				subtitle={
-					! isLoggedIn &&
-					( 'en' === locale ||
-						hasTranslation(
-							'Add new functionality and integrations to your site with thousands of plugins.'
-						) ) &&
-					__( 'Add new functionality and integrations to your site with thousands of plugins.' )
-				}
-				searchTerms={ searchTerms }
-				renderTitleInH1={ ! category }
-			/>
+			<div className="plugins-browser__content-wrapper">
+				<SearchBoxHeader
+					searchRef={ searchRef }
+					categoriesRef={ categoriesRef }
+					stickySearchBoxRef={ searchHeaderRef }
+					isSticky={ isAboveElement }
+					searchTerm={ search }
+					isSearching={ isFetchingPluginsBySearchTerm }
+					title={
+						'en' === locale || hasTranslation( 'Flex your site’s features with plugins' )
+							? __( 'Flex your site’s features with plugins' )
+							: __( 'Plugins you need to get your projects done' )
+					}
+					subtitle={
+						! isLoggedIn &&
+						( 'en' === locale ||
+							hasTranslation(
+								'Add new functionality and integrations to your site with thousands of plugins.'
+							) ) &&
+						__( 'Add new functionality and integrations to your site with thousands of plugins.' )
+					}
+					searchTerms={ searchTerms }
+					renderTitleInH1={ ! category }
+				/>
 
-			<div ref={ categoriesRef }>
-				<Categories selected={ category } noSelection={ search ? true : false } />
-			</div>
-			<div className="plugins-browser__main-container">{ renderList() }</div>
-			{ ! category && ! search && (
-				<div className="plugins-browser__marketplace-footer">
-					<MarketplaceFooter />
+				<div ref={ categoriesRef }>
+					<Categories selected={ category } noSelection={ search ? true : false } />
 				</div>
-			) }
+				<div className="plugins-browser__main-container">{ renderList() }</div>
+				{ ! category && ! search && (
+					<div className="plugins-browser__marketplace-footer">
+						<MarketplaceFooter />
+					</div>
+				) }
+			</div>
 		</MainComponent>
 	);
 };

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -1,5 +1,6 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -134,7 +135,13 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	}
 
 	return (
-		<MainComponent className="plugins-browser" wideLayout isLoggedOut={ ! isLoggedIn }>
+		<MainComponent
+			className={ classNames( 'plugins-browser', {
+				'plugins-browser--site-view': !! selectedSite,
+			} ) }
+			wideLayout
+			isLoggedOut={ ! isLoggedIn }
+		>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -134,7 +134,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	}
 
 	return (
-		<MainComponent wideLayout isLoggedOut={ ! isLoggedIn }>
+		<MainComponent className="plugins-browser" wideLayout isLoggedOut={ ! isLoggedIn }>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -1,3 +1,7 @@
+.main.is-wide-layout.plugins-browser--site-view {
+	max-width: 100%;
+}
+
 .plugins-browser__billling-interval-switcher {
 	margin-right: 15px;
 }

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -171,7 +171,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 			navigationItems={ breadcrumbs }
 			compactBreadcrumb={ isMobile }
 			ref={ navigationHeaderRef }
-			title={ translate( 'Plugins' ) }
+			title={ translate( 'Plugins marketplace' ) }
 		>
 			<ManageButton
 				shouldShowManageButton={ shouldShowManageButton }

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -171,7 +171,9 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 			navigationItems={ breadcrumbs }
 			compactBreadcrumb={ isMobile }
 			ref={ navigationHeaderRef }
-			title={ translate( 'Plugins marketplace' ) }
+			title={ translate( 'Plugins {{wbr}}{{/wbr}}marketplace', {
+				components: { wbr: <wbr /> },
+			} ) }
 		>
 			<ManageButton
 				shouldShowManageButton={ shouldShowManageButton }

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -8,7 +8,6 @@ import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { useLocalizedPlugins, useServerEffect } from 'calypso/my-sites/plugins/utils';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -173,14 +172,6 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 			compactBreadcrumb={ isMobile }
 			ref={ navigationHeaderRef }
 			title={ translate( 'Plugins' ) }
-			subtitle={ translate(
-				'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-				{
-					components: {
-						learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
-					},
-				}
-			) }
 		>
 			<ManageButton
 				shouldShowManageButton={ shouldShowManageButton }

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -20,6 +20,8 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
+import './style.scss';
+
 const UploadPluginButton = ( { isMobile, siteSlug, hasUploadPlugins } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -166,6 +168,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 
 	return (
 		<NavigationHeader
+			className="plugins-navigation-header"
 			navigationItems={ breadcrumbs }
 			compactBreadcrumb={ isMobile }
 			ref={ navigationHeaderRef }

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -37,6 +37,10 @@
 	.plugins-navigation-header.navigation-header {
 		padding-inline: 0;
 
+		@media (max-width: $break-small ) {
+			padding-inline: 16px;
+		}
+
 		> div {
 			box-sizing: border-box;
 			margin: auto;

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -21,4 +21,10 @@
 			padding-inline: 64px;
 		}
 	}
+
+	.formatted-header__title {
+		font-family: "SF Pro Display", sans-serif;
+		font-size: 1.5rem;
+		line-height: 1.2;
+	}
 }

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -4,6 +4,10 @@
 .plugins-navigation-header.navigation-header {
 	padding-inline: 16px;
 
+	.navigation-header__main {
+		align-items: center;
+	}
+
 	@include break-medium {
 		border-block-end: 1px solid var(--color-border-secondary);
 	}

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -32,3 +32,27 @@
 		line-height: 1.2;
 	}
 }
+
+.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column).plugins-browser--site-view {
+	.plugins-navigation-header.navigation-header {
+		padding-inline: 0;
+
+		> div {
+			box-sizing: border-box;
+			margin: auto;
+			max-width: 1040px;
+
+			@include break-small {
+				padding-left: 2rem;
+				padding-right: 2rem;
+			}
+
+		}
+
+		@include break-xhuge {
+			.navigation-header__main {
+				padding-inline: 0;
+			}
+		}
+	}
+}

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -1,0 +1,24 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.plugins-navigation-header {
+	padding-inline: 16px;
+
+	@include break-medium {
+		border-block-end: 1px solid var(--color-border-secondary);
+	}
+
+	@include break-huge {
+		padding-inline: 64px;
+	}
+
+	@include break-xhuge {
+		max-width: 100%;
+
+		.navigation-header__main {
+			max-width: 1400px;
+			margin: 0 auto;
+			padding-inline: 64px;
+		}
+	}
+}

--- a/client/my-sites/plugins/plugins-navigation-header/style.scss
+++ b/client/my-sites/plugins/plugins-navigation-header/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.plugins-navigation-header {
+.plugins-navigation-header.navigation-header {
 	padding-inline: 16px;
 
 	@include break-medium {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -62,16 +62,13 @@ body.is-section-plugins {
 		&:not(.plugins-browser),
 		&.plugins-browser .plugins-browser__content-wrapper {
 			@include break-small {
-				padding-left: 1rem;
-				padding-right: 1rem;
-			}
-			@include break-small {
 				padding-left: 2rem;
 				padding-right: 2rem;
 			}
 		}
 
-		.plugins-browser__content-wrapper {
+		&.plugins-browser--site-view .plugins-browser__content-wrapper {
+			box-sizing: border-box;
 			margin: auto;
 			max-width: 1040px;
 		}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -59,13 +59,15 @@ body.is-section-plugins {
 	}
 
 	.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column) {
-		@include break-small {
-			padding-left: 1rem;
-			padding-right: 1rem;
-		}
-		@include break-small {
-			padding-left: 2rem;
-			padding-right: 2rem;
+		.plugins-browser__content-wrapper {
+			@include break-small {
+				padding-left: 1rem;
+				padding-right: 1rem;
+			}
+			@include break-small {
+				padding-left: 2rem;
+				padding-right: 2rem;
+			}
 		}
 	}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -59,7 +59,8 @@ body.is-section-plugins {
 	}
 
 	.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column) {
-		.plugins-browser__content-wrapper {
+		&:not(.plugins-browser),
+		&.plugins-browser .plugins-browser__content-wrapper {
 			@include break-small {
 				padding-left: 1rem;
 				padding-right: 1rem;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -70,6 +70,11 @@ body.is-section-plugins {
 				padding-right: 2rem;
 			}
 		}
+
+		.plugins-browser__content-wrapper {
+			margin: auto;
+			max-width: 1040px;
+		}
 	}
 
 	.is-section-plugins.is-global-sidebar-collapsed {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7491

## Proposed Changes

* Adjust the styles of the header on the plugins page so it looks like the ones on domains and sites pages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Design consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Check that the header on `/plugins` has the same style as those on `/sites` and `/domains/manage`

|Before|After|
|---|---|
|![image](https://github.com/Automattic/wp-calypso/assets/8511199/322976ef-70a6-403f-b103-1164b83cbe19)|![image](https://github.com/Automattic/wp-calypso/assets/8511199/66ab9d1c-37a8-404e-987a-58da6f8eeefc)|

Check also the site view (`/plugins/{siteSlug}`) and plugin view (`/plugins/woocommerce-subscriptions`).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
