### PR TITLE
Site Profiler Hosting: Add a link for site migration

### DIFF
--- a/client/site-profiler/components/hosting-section/index.tsx
+++ b/client/site-profiler/components/hosting-section/index.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import HostingInformation from 'calypso/site-profiler/components/hosting-information';
 import { MetricsSection } from 'calypso/site-profiler/components/metrics-section';
@@ -7,6 +8,7 @@ import type { DNS, HostingProvider } from 'calypso/data/site-profiler/types';
 
 interface HostingSectionProps {
 	dns: DNS[];
+	domain?: string;
 	urlData?: UrlData;
 	hostingProvider?: HostingProvider;
 	hostingRef: React.RefObject< HTMLObjectElement >;
@@ -14,7 +16,7 @@ interface HostingSectionProps {
 
 export const HostingSection: React.FC< HostingSectionProps > = ( props ) => {
 	const translate = useTranslate();
-	const { dns = [], urlData, hostingProvider, hostingRef } = props;
+	const { dns = [], domain, urlData, hostingProvider, hostingRef } = props;
 	const isWPcom = hostingProvider?.slug?.toLowerCase() === 'automattic';
 
 	return (
@@ -31,7 +33,10 @@ export const HostingSection: React.FC< HostingSectionProps > = ( props ) => {
 							getTitleTranslateOptions()
 					  )
 			}
-			subtitle={ translate( 'Upgrade your hosting with WordPress.com' ) }
+			subtitle={ ! isWPcom ? translate( 'Upgrade your hosting with WordPress.com' ) : null }
+			subtitleOnClick={ () =>
+				page( `/setup/hosted-site-migration?ref=site-profiler&from=${ domain }` )
+			}
 			ref={ hostingRef }
 		>
 			<HostingInformation

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -147,6 +147,7 @@ export default function SiteProfilerV2( props: Props ) {
 							<>
 								{ showBasicMetrics && <BasicMetrics basicMetrics={ basicMetrics.basic } /> }
 								<HostingSection
+									domain={ domain }
 									dns={ siteProfilerData.dns }
 									urlData={ urlData }
 									hostingProvider={ hostingProviderData?.hosting_provider }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7354

## Proposed Changes

Add a link for site migration on the Site Profiler Hosting section when the site is not already on WP.com

## Why are these changes being made?

* Go to `/site-profiler/:url` with a non-WP.com site. Ex: `/site-profiler/example.com`
* Check the link is displayed
* Click on the link and you should be redirected to the site migration flow
* Go to `/site-profiler/:url` with a WP.com site. Ex: `/site-profiler/wordpress.com`
* Check if the link is NOT shown

| WP.com  | non-WP.com |
| ------------- | ------------- |
|![CleanShot 2024-05-29 at 11 59 39@2x](https://github.com/Automattic/wp-calypso/assets/5039531/360fa702-fdc1-4d7f-b517-31ec1c83eead)|![CleanShot 2024-05-29 at 12 00 23](https://github.com/Automattic/wp-calypso/assets/5039531/8f629ed5-0153-4c4b-ac79-1706ef996eca)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?