### PR TITLE
Hosting Config: Fix anchor scrolling in site management panel

### DIFF
--- a/client/components/scroll-to-anchor-on-mount/index.tsx
+++ b/client/components/scroll-to-anchor-on-mount/index.tsx
@@ -1,11 +1,19 @@
 import { useEffect } from 'react';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 
-export function ScrollToAnchorOnMount( { offset = 0, timeout = 100 } ) {
+export function ScrollToAnchorOnMount( {
+	offset = 0,
+	timeout = 100,
+	container,
+}: {
+	offset?: number;
+	timeout?: number;
+	container?: HTMLElement;
+} ) {
 	useEffect( () => {
 		setTimeout( () => {
-			scrollToAnchor( { offset } );
+			scrollToAnchor( { offset, container } );
 		}, timeout );
-	}, [ offset, timeout ] );
+	}, [ offset, timeout, container ] );
 	return null;
 }

--- a/client/lib/navigate/index.ts
+++ b/client/lib/navigate/index.ts
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { logmeinUrl } from 'calypso/lib/logmein';
+import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 
 // Using page() for cross origin navigations would throw a `History.pushState` exception
 // about creating state object with a cross-origin URL.
@@ -21,6 +22,24 @@ function shouldNavigateWithinSamePage( path: string ): boolean {
 	return currentPath === targetUrl.pathname && !! targetUrl.hash;
 }
 
+function getScrollableContainer( node: HTMLElement ): HTMLElement | undefined {
+	if ( node === document.body ) {
+		return undefined;
+	}
+
+	const overflowY = window.getComputedStyle( node ).overflowY;
+	const isScrollable = overflowY !== 'visible' && overflowY !== 'hidden';
+	if ( isScrollable && node.scrollHeight >= node.clientHeight ) {
+		return node;
+	}
+
+	if ( node.parentNode ) {
+		return getScrollableContainer( node.parentNode as HTMLElement );
+	}
+
+	return undefined;
+}
+
 export function navigate( path: string, openInNewTab = false, forceReload = false ): void {
 	if ( isSameOrigin( path ) ) {
 		if ( openInNewTab ) {
@@ -35,14 +54,10 @@ export function navigate( path: string, openInNewTab = false, forceReload = fals
 			const targetUrl = new URL( path, window.location.origin );
 			const element = document.querySelector( targetUrl.hash );
 			if ( element ) {
-				// Offset by the height of the navigation header from the top of the page.
-				const fixedHeaderHeight = 72;
-				const elementPosition = element.getBoundingClientRect().top + window.scrollY;
-				const offsetPosition = elementPosition - fixedHeaderHeight;
 				window.location.hash = targetUrl.hash;
-				window.scrollTo( {
-					top: offsetPosition,
-					behavior: 'smooth',
+				scrollToAnchor( {
+					offset: 72,
+					container: getScrollableContainer( element as HTMLElement ),
 				} );
 			}
 		} else {

--- a/client/lib/scroll-to-anchor/index.ts
+++ b/client/lib/scroll-to-anchor/index.ts
@@ -6,7 +6,11 @@ function getOffsetTop( element: HTMLElement, container?: HTMLElement ): number {
 	const offset = element.offsetTop;
 
 	if ( container ) {
-		return element.getBoundingClientRect().top - container.getBoundingClientRect().top;
+		return (
+			container.scrollTop +
+			element.getBoundingClientRect().top -
+			container.getBoundingClientRect().top
+		);
 	}
 
 	if ( element.offsetParent ) {

--- a/client/lib/scroll-to-anchor/index.ts
+++ b/client/lib/scroll-to-anchor/index.ts
@@ -2,12 +2,18 @@ import scrollTo from 'calypso/lib/scroll-to';
 
 // Danger! Recursive
 // (relatively safe since the DOM tree is only so deep)
-function getOffsetTop( element: HTMLElement ): number {
+function getOffsetTop( element: HTMLElement, container?: HTMLElement ): number {
 	const offset = element.offsetTop;
 
-	return element.offsetParent
-		? offset + getOffsetTop( element.offsetParent as HTMLElement )
-		: offset;
+	if ( container ) {
+		return element.getBoundingClientRect().top - container.getBoundingClientRect().top;
+	}
+
+	if ( element.offsetParent ) {
+		return offset + getOffsetTop( element.offsetParent as HTMLElement );
+	}
+
+	return offset;
 }
 
 /**
@@ -16,7 +22,7 @@ function getOffsetTop( element: HTMLElement ): number {
  * Wait for page.js to update the URL, then see if we are linking
  * directly to a section of this page.
  */
-export default function scrollToAnchor( options: { offset: number } ) {
+export default function scrollToAnchor( options: { offset: number; container?: HTMLElement } ) {
 	const offset = options.offset;
 
 	if ( ! window || ! window.location ) {
@@ -30,7 +36,7 @@ export default function scrollToAnchor( options: { offset: number } ) {
 
 	if ( hash && el ) {
 		const offsetHeight = document.getElementById( 'header' )?.offsetHeight || 0;
-		const y = getOffsetTop( el ) - offsetHeight - offset;
-		scrollTo( { y } );
+		const y = getOffsetTop( el, options.container ) - offsetHeight - offset;
+		scrollTo( { y, container: options.container } );
 	}
 }

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -410,7 +410,17 @@ const Hosting = ( props ) => {
 				'hosting--is-two-columns': isEnabled( 'layout/dotcom-nav-redesign-v2' ),
 			} ) }
 		>
-			{ ! isLoadingSftpData && <ScrollToAnchorOnMount offset={ HEADING_OFFSET } /> }
+			{ ! isLoadingSftpData && (
+				<ScrollToAnchorOnMount
+					offset={ HEADING_OFFSET }
+					timeout={ 250 }
+					container={
+						isEnabled( 'layout/dotcom-nav-redesign-v2' )
+							? document.querySelector( '.item-preview__content' )
+							: undefined
+					}
+				/>
+			) }
 			<PageViewTracker path="/hosting-config/:site" title="Hosting" />
 			<DocumentHead title={ translate( 'Hosting' ) } />
 			<NavigationHeader

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -110,7 +110,7 @@ export function handleQueryParamChange( queryParams: SitesDashboardQueryParams )
 	} );
 
 	// Use relative URL to avoid full page refresh.
-	page.replace( url.pathname + url.search );
+	page.replace( url.pathname + url.search + url.hash );
 }
 
 export const SitesContentControls = ( {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7504

## Proposed Changes

Ensures that hosting commands that links to specific sections of the `/hosting-config/:page` navigate to the expected anchors.

This wasn't working in the new site management panel because the window is no longer scrollable in favor of the new frame that lives in `.item-preview__content`.

**Before**


https://github.com/Automattic/wp-calypso/assets/1233880/99854b83-d977-49e7-be40-71cf33fcbd9f

**After**

https://github.com/Automattic/wp-calypso/assets/1233880/6c227d29-6a1a-4d0f-abf8-ec477bec2c1a



## Why are these changes being made?

Because the hosting commands were not navigating to the expected sections.

## Testing Instructions

- Use the Calypso live link below
- Go to `/sites`
- Open the command palette
- Select the "Manage cache settings" command and select a site
- Make sure the "Cache" section of the Hosting Config page is visible
- While on the Hosting Config page, open the palette and select the "Change PHP version" command
- Make sure the "Web server settings" section is visible
- Add the `?flags=-layout/dotcom-nav-redesign-v2` param URL to disable the nav redesign.
- Repeat the above test and make sure there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
