### PR TITLE
Logged out plugins page - remove sidebar

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -391,6 +391,11 @@ export function maybeRedirectLoggedOut( context, next ) {
 export function renderPluginsSidebar( context, next ) {
 	const state = context.store.getState();
 	const siteUrl = getSiteFragment( context.path );
+
+	if ( ! isUserLoggedIn( state ) ) {
+		next();
+	}
+
 	if ( ! siteUrl ) {
 		context.secondary = (
 			<PluginsSidebar


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/91221 and p1717001054299629-slack-C9EJ7KSGH 

## Proposed Changes

* Adds a logged in check to the newly introduced `renderPluginsSidebar` middleware.
* The middleware created a regression on the logged out plugins page as we dont want to render the sidebar there.


BEFORE
<img width="1479" alt="Screenshot 2024-05-29 at 1 23 54 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/24aa5f32-6853-4800-8ea9-ce4c4d002ad7">



AFTER
<img width="1508" alt="Screenshot 2024-05-29 at 1 23 33 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/e485154a-d1a1-4a9d-9fc0-db3a21133a97">




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* fix a recent regression in logged out plugins page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Visit the `/plugins` page logged out.
* Verify there is no longer an unexpected sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?