### PR TITLE
Domains: Prepare `DomainOnlyThankYou` component to the Gravatar domain flow

### DIFF
--- a/client/components/thank-you-v2/index.tsx
+++ b/client/components/thank-you-v2/index.tsx
@@ -13,10 +13,12 @@ interface ThankYouV2Props {
 	products?: React.ReactElement | React.ReactElement[];
 	footerDetails?: ThankYouFooterDetailProps[];
 	upsellProps?: ThankYouUpsellProps;
+	isGravatarDomain?: boolean;
 }
 
 export default function ThankYouV2( props: ThankYouV2Props ) {
-	const { title, subtitle, headerButtons, products, footerDetails, upsellProps } = props;
+	const { title, subtitle, headerButtons, products, footerDetails, upsellProps, isGravatarDomain } =
+		props;
 
 	return (
 		<div className="thank-you">
@@ -26,9 +28,9 @@ export default function ThankYouV2( props: ThankYouV2Props ) {
 
 			{ products && <div className="thank-you__products">{ products }</div> }
 
-			{ footerDetails && <ThankYouFooter details={ footerDetails } /> }
+			{ footerDetails && ! isGravatarDomain && <ThankYouFooter details={ footerDetails } /> }
 
-			{ upsellProps && <ThankYouUpsell { ...upsellProps } /> }
+			{ upsellProps && ! isGravatarDomain && <ThankYouUpsell { ...upsellProps } /> }
 		</div>
 	);
 }

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -549,7 +549,13 @@ export class CheckoutThankYou extends Component<
 					/>
 				);
 			} else if ( isOnlyDomainPurchases( purchases ) ) {
-				pageContent = <DomainOnlyThankYou purchases={ purchases } receiptId={ receiptId } />;
+				pageContent = (
+					<DomainOnlyThankYou
+						purchases={ purchases }
+						receiptId={ receiptId }
+						isGravatarDomain={ false }
+					/>
+				);
 			} else if ( purchases.length === 1 && isPlan( purchases[ 0 ] ) ) {
 				pageContent = (
 					<PlanOnlyThankYou

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
@@ -62,9 +62,14 @@ function UpsellActions( {
 interface DomainOnlyThankYouProps {
 	purchases: ReceiptPurchase[];
 	receiptId: number;
+	isGravatarDomain: boolean;
 }
 
-export default function DomainOnlyThankYou( { purchases, receiptId }: DomainOnlyThankYouProps ) {
+export default function DomainOnlyThankYou( {
+	purchases,
+	receiptId,
+	isGravatarDomain,
+}: DomainOnlyThankYouProps ) {
 	const translate = useTranslate();
 	const [ , predicate ] = getDomainPurchaseTypeAndPredicate( purchases );
 	const domainPurchases = purchases.filter( predicate );
@@ -101,6 +106,7 @@ export default function DomainOnlyThankYou( { purchases, receiptId }: DomainOnly
 				key={ `domain-${ purchase.meta }` }
 				siteSlug={ domainOnlySite?.slug }
 				isDomainOnly
+				isGravatarDomain={ isGravatarDomain }
 			/>
 		);
 	} );
@@ -121,6 +127,7 @@ export default function DomainOnlyThankYou( { purchases, receiptId }: DomainOnly
 				products={ products }
 				footerDetails={ getDomainFooterDetails( 'domain-only' ) }
 				upsellProps={ upsellProps }
+				isGravatarDomain={ isGravatarDomain }
 			/>
 		</>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -40,6 +40,7 @@ type ThankYouDomainProductProps = {
 	isDomainOnly?: boolean;
 	siteSlug?: string | null;
 	currency?: string;
+	isGravatarDomain?: boolean;
 };
 
 export default function ThankYouDomainProduct( {
@@ -48,6 +49,7 @@ export default function ThankYouDomainProduct( {
 	isDomainOnly,
 	siteSlug,
 	currency,
+	isGravatarDomain,
 }: ThankYouDomainProductProps ) {
 	const translate = useTranslate();
 
@@ -62,6 +64,12 @@ export default function ThankYouDomainProduct( {
 
 	if ( purchase && isDomainTransfer( purchase ) ) {
 		actions = <DomainTransferSection purchase={ purchase } currency={ currency ?? 'USD' } />;
+	} else if ( isGravatarDomain ) {
+		actions = (
+			<Button variant="primary" href="https://gravatar.com/profile">
+				{ translate( 'Manage domain at Gravatar' ) }
+			</Button>
+		);
 	} else if ( purchase?.blogId && siteSlug ) {
 		const createSiteHref = siteSlug && createSiteFromDomainOnly( siteSlug, purchase.blogId );
 		const createSiteProps = createSiteHref ? { href: createSiteHref } : { disabled: true };


### PR DESCRIPTION
Related to #90414

## Proposed Changes

This PR prepares the `DomainOnlyThankYou` component for Gravatar domain purchases by removing the WPCOM specific upsells. It also replaces the CTA buttons to only one that reads "Manage domain at Gravatar", which takes the user to `https://gravatar.com/profile`.
### Screenshots

| Before | After |
| --- | --- |
| <img width="755" alt="Screenshot 2024-05-22 at 20 31 38" src="https://github.com/Automattic/wp-calypso/assets/5324818/cb08dfc5-57e3-4cdc-b228-7f44cba7aa70"> | <img width="738" alt="Screenshot 2024-05-22 at 20 31 20" src="https://github.com/Automattic/wp-calypso/assets/5324818/2b962fbc-653c-40ff-831d-8d665547f305"> |

## Why are these changes being made?

This is part of the Custom Domains on Gravatar project (pcYYhz-24z-p2).

## Testing Instructions

- Build this branch locally
- Navigate to the thank you page for the receipt of a Gravatar domain purchase (e.g. `/checkout/thank-you/no-site/93520523`)
- Ensure the usual WPCOM CTAs are shown
- In he `CheckoutThankYou` component, change the `isGravatarDomain` property from `false` to `true` here:

```
<DomainOnlyThankYou
  purchases={ purchases }
  receiptId={ receiptId }
  isGravatarDomain={ false }
/>
```

- Open the thank-you page again and ensure no WPCOM CTAs are shown, like in the screenshot above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?