### PR TITLE
Scheduled Updates: Scroll to top on create/edit success

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/utils.ts
+++ b/client/blocks/plugin-scheduled-updates-common/utils.ts
@@ -1,0 +1,4 @@
+// Scroll to top of the page
+export const scrollToTop = () => {
+	window.scrollTo( 0, 0 );
+};

--- a/client/blocks/plugins-scheduled-updates/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-create.tsx
@@ -6,6 +6,7 @@ import { info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { Banner } from 'calypso/components/banner';
+import { scrollToTop } from '../plugin-scheduled-updates-common/utils';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useCreateMonitor } from './hooks/use-create-monitor';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
@@ -53,6 +54,7 @@ export const ScheduleCreate = ( props: Props ) => {
 
 		createMonitor();
 		setSyncError( '' );
+		scrollToTop();
 
 		return onNavBack && onNavBack();
 	};

--- a/client/blocks/plugins-scheduled-updates/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-edit.tsx
@@ -5,6 +5,7 @@ import { info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { scrollToTop } from '../plugin-scheduled-updates-common/utils';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
@@ -54,6 +55,7 @@ export const ScheduleEdit = ( props: Props ) => {
 		} );
 
 		setSyncError( '' );
+		scrollToTop();
 
 		return onNavBack && onNavBack();
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/91253

## Proposed Changes

* Scroll window to top on the schedule create/edit success event

## Testing Instructions

**Single site context:**
* Go to "/plugins/scheduled-updates/{ATOMIC_SITE_SLUG}"
* Click on the "New Schedule" button
* Populate the form and scroll it down
* Click on the "Create" button
* Check if it scroll to the top onSuccess event

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
