### PR TITLE
Update/improve Authorize ToS coming from My Jetpack.

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1208,10 +1208,14 @@ export class JetpackAuthorize extends Component {
 			);
 		}
 
-		const { blogname } = this.props.authQuery;
+		const { blogname, from } = this.props.authQuery;
 		return (
 			<LoggedOutFormFooter className="jetpack-connect__action-disclaimer">
-				<Disclaimer siteName={ decodeEntities( blogname ) } companyName={ this.getCompanyName() } />
+				<Disclaimer
+					siteName={ decodeEntities( blogname ) }
+					companyName={ this.getCompanyName() }
+					from={ from }
+				/>
 				<Button
 					primary
 					disabled={ this.isAuthorizing() || this.props.hasXmlrpcError }

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1056,6 +1056,7 @@ export class JetpackAuthorize extends Component {
 							<Disclaimer
 								siteName={ decodeEntities( authQuery.blogname ) }
 								companyName={ this.getCompanyName() }
+								from={ authQuery.from }
 							/>
 							<div className="jetpack-connect__jetpack-logo-wrapper">
 								<JetpackLogo monochrome size={ 18 } />{ ' ' }

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -50,6 +50,8 @@ class JetpackConnectDisclaimer extends PureComponent {
 								companyName,
 								siteName,
 							},
+							comment:
+								'`companyName` is the site domain receiving the data (typically WordPress.com), and `siteName` is the site domain sharing the data.',
 						}
 				  );
 

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -17,7 +17,7 @@ class JetpackConnectDisclaimer extends PureComponent {
 	};
 
 	render() {
-		const { companyName = 'WordPress.com', siteName, translate } = this.props;
+		const { companyName = 'WordPress.com', siteName, from, translate } = this.props;
 
 		const detailsLink = (
 			<a
@@ -30,12 +30,13 @@ class JetpackConnectDisclaimer extends PureComponent {
 		);
 
 		const text =
-			this.props.from === 'my-jetpack'
+			from === 'my-jetpack'
 				? translate(
 						'By clicking {{strong}}Approve{{/strong}}, you agree to {{detailsLink}}sync your site‘s data{{/detailsLink}} with us.',
 						{
 							components: {
 								strong: <strong />,
+								detailsLink,
 							},
 						}
 				  )

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -9,10 +9,11 @@ class JetpackConnectDisclaimer extends PureComponent {
 	static propTypes = {
 		companyName: PropTypes.string,
 		siteName: PropTypes.string.isRequired,
+		from: PropTypes.string,
 	};
 
 	handleClickDisclaimer = () => {
-		this.props.recordTracksEvent( 'calypso_jpc_disclaimer_link_click' );
+		this.props.recordTracksEvent( 'calypso_jpc_disclaimer_link_click', { ...this.props } );
 	};
 
 	render() {
@@ -28,18 +29,28 @@ class JetpackConnectDisclaimer extends PureComponent {
 			/>
 		);
 
-		const text = translate(
-			'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between %(companyName)s and %(siteName)s.',
-			{
-				components: {
-					detailsLink,
-				},
-				args: {
-					companyName,
-					siteName,
-				},
-			}
-		);
+		const text =
+			this.props.from === 'my-jetpack'
+				? translate(
+						'By clicking {{strong}}Approve{{/strong}}, you agree to {{detailsLink}}sync your site‘s data{{/detailsLink}} with us.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+				  )
+				: translate(
+						'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between %(companyName)s and %(siteName)s.',
+						{
+							components: {
+								detailsLink,
+							},
+							args: {
+								companyName,
+								siteName,
+							},
+						}
+				  );
 
 		return <p className="jetpack-connect__tos-link">{ text }</p>;
 	}


### PR DESCRIPTION
As part of the Improve ToS Messaging project ( pbNhbs-aAg-p2 ), this PR updates the Terms of Service messaging on the Jetpack Connect authorize form coming from My Jetpack in the plugin.

It changes the ToS message 

From: "_By connecting your site, you agree to [share details] between WordPress.com and [site name]._"

To: "_By clicking Approve, you agree to [sync your site‘s data] with us._"

Screenshot:

![Screen Shot 2024-05-29 at 16 01 04](https://github.com/Automattic/wp-calypso/assets/11078128/db63f72c-c090-4304-a93a-096559152868)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/jetpack-roadmap/issues/1554#issuecomment-2130211533

## Proposed Changes

* Update ToS message in authorize form when coming from My Jetpack in the plugin.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See P2 post: ToS placements to be updated - pbNhbs-aBE-p2

## Testing Instructions

- Check out this PR and fire up Calypso blue (`yarn start`)
- Start from an unconnected Jetpack site.
- Go to My Jetpack, scroll to the bottom of the page and click Connect.
- When you see the Authorize form, in the url replace `wordpress.com` with `calypso.localhost:3000`
- Verify the ToS message has been updated to: "_By clicking Approve, you agree to [sync your site‘s data] with us._"

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?