### PR TITLE
Revert "Domains: Remove WPCOM upsells in Gravatar flow checkout thank-you page (alternative)"

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -553,7 +553,7 @@ export class CheckoutThankYou extends Component<
 					<DomainOnlyThankYou
 						purchases={ purchases }
 						receiptId={ receiptId }
-						isGravatarDomain={ !! this.props.receipt.data?.isGravatarDomain }
+						isGravatarDomain={ false }
 					/>
 				);
 			} else if ( purchases.length === 1 && isPlan( purchases[ 0 ] ) ) {

--- a/client/my-sites/checkout/src/lib/normalize-transaction-response.ts
+++ b/client/my-sites/checkout/src/lib/normalize-transaction-response.ts
@@ -14,7 +14,6 @@ const emptyResponse: WPCOMTransactionEndpointResponseFailed = {
 	price_integer: 0,
 	price_float: 0,
 	currency: 'USD',
-	is_gravatar_domain: false,
 };
 
 export default function normalizeTransactionResponse(

--- a/client/state/receipts/assembler.ts
+++ b/client/state/receipts/assembler.ts
@@ -40,7 +40,6 @@ export function createReceiptObject(
 		currency: data.currency,
 		priceInteger: data.price_integer,
 		priceFloat: data.price_float,
-		isGravatarDomain: Boolean( data.is_gravatar_domain ),
 		purchases: purchases.map( ( purchase ) => {
 			return {
 				delayedProvisioning: Boolean( purchase.delayed_provisioning ),

--- a/client/state/receipts/test/assembler.ts
+++ b/client/state/receipts/test/assembler.ts
@@ -10,7 +10,6 @@ const rawReceiptEndpointReceipt: RawReceiptData = {
 	price_float: 100,
 	price_integer: 10000,
 	currency: 'USD',
-	is_gravatar_domain: false,
 	purchases: [
 		{
 			user_email: '',
@@ -73,7 +72,6 @@ const standardAssembledReceipt: ReceiptData = {
 	failedPurchases: [],
 	priceFloat: 100,
 	priceInteger: 10000,
-	isGravatarDomain: false,
 	purchases: [
 		{
 			delayedProvisioning: false,

--- a/client/state/receipts/types.ts
+++ b/client/state/receipts/types.ts
@@ -36,7 +36,6 @@ export interface RawReceiptData {
 	price_integer: number;
 	currency: string;
 	purchases: Purchase[] | undefined | false;
-	is_gravatar_domain: boolean;
 }
 
 export interface ReceiptData {
@@ -47,7 +46,6 @@ export interface ReceiptData {
 	priceInteger: number;
 	purchases: ReceiptPurchase[];
 	failedPurchases: FailedReceiptPurchase[];
-	isGravatarDomain: boolean;
 }
 
 export interface ReceiptState {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -16,7 +16,6 @@ export type WPCOMTransactionEndpointResponseSuccess = {
 	price_integer: number;
 	price_float: number;
 	currency: string;
-	is_gravatar_domain: boolean;
 };
 
 export type WPCOMTransactionEndpointResponseFailed = {
@@ -32,7 +31,6 @@ export type WPCOMTransactionEndpointResponseFailed = {
 	price_integer: number;
 	price_float: number;
 	currency: string;
-	is_gravatar_domain: boolean;
 };
 
 export type WPCOMTransactionEndpointResponseRedirect = {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#91069