### PR TITLE
Site Profiler Performance: Add the Table for the "table" and "opportunity" data type

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -124,7 +124,9 @@ export interface PerformanceMetricsItemQueryResponse {
 }
 
 export interface PerformanceMetricsDetailsQueryResponse {
-	type: 'table' | 'oppurtunity' | 'list';
+	type: 'table' | 'opportunity' | 'list';
+	headings?: Array< { key: string; label: string; valueType: string } >;
+	items?: Array< { [ key: string ]: string | number | { [ key: string ]: any } } >;
 }
 
 export interface BasicMetricsResult extends Omit< UrlBasicMetricsQueryResponse, 'basic' > {

--- a/client/site-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-content.tsx
@@ -1,5 +1,6 @@
 import Markdown from 'react-markdown';
 import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
+import { InsightDetailedContent } from './insight-detailed-content';
 
 interface InsightContentProps {
 	data: PerformanceMetricsItemQueryResponse;
@@ -10,7 +11,7 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 	const { description = '' } = data ?? {};
 
 	return (
-		<div className="metrics-insigh-content">
+		<div className="metrics-insight-content">
 			<Markdown
 				components={ {
 					a( props ) {
@@ -20,6 +21,11 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 			>
 				{ description }
 			</Markdown>
+			{ data.details?.type && (
+				<div className="metrics-insight-detailed-content">
+					<InsightDetailedContent data={ data.details } />
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/site-profiler/components/metrics-insight/insight-detailed-content.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-detailed-content.tsx
@@ -1,0 +1,16 @@
+import { PerformanceMetricsDetailsQueryResponse } from 'calypso/data/site-profiler/types';
+import { InsightTable } from './insight-table';
+
+export interface InsightDetailedContentProps {
+	data: PerformanceMetricsDetailsQueryResponse;
+}
+
+export const InsightDetailedContent: React.FC< InsightDetailedContentProps > = ( props ) => {
+	const { data } = props;
+
+	if ( data.type === 'table' || data.type === 'opportunity' ) {
+		return <InsightTable { ...props } />;
+	}
+
+	return null;
+};

--- a/client/site-profiler/components/metrics-insight/insight-table.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-table.tsx
@@ -1,0 +1,96 @@
+import { useTranslate } from 'i18n-calypso';
+import Markdown from 'react-markdown';
+import { PerformanceMetricsDetailsQueryResponse } from 'calypso/data/site-profiler/types';
+
+export function InsightTable( { data }: { data: PerformanceMetricsDetailsQueryResponse } ) {
+	const { headings = [], items = [] } = data;
+
+	return (
+		<table>
+			<thead>
+				<tr>
+					{ headings.map( ( heading, index ) => (
+						<th key={ `th-${ index }` }>{ heading.label }</th>
+					) ) }
+				</tr>
+			</thead>
+			<tbody>
+				{ items.map( ( row, index ) => (
+					<tr key={ `tr-${ index }` }>
+						{ headings.map( ( heading ) => (
+							<td>
+								<Cell data={ row[ heading.key ] } headingValueType={ heading.valueType } />
+							</td>
+						) ) }
+					</tr>
+				) ) }
+			</tbody>
+		</table>
+	);
+}
+
+function Cell( {
+	data,
+	headingValueType,
+}: {
+	data: string | number | { [ key: string ]: any };
+	headingValueType: string;
+} ) {
+	const translate = useTranslate();
+
+	if ( typeof data === 'object' ) {
+		switch ( data?.type ) {
+			case 'node':
+				return (
+					<div>
+						<p>{ data?.nodeLabel }</p>
+						<pre>
+							<code>{ data?.snippet }</code>
+						</pre>
+					</div>
+				);
+			case 'numeric':
+				return getFormattedNumber( data.value );
+			case 'url':
+			case 'source-location':
+				if ( data?.location ) {
+					return `${ data.location.url }:${ data.location.line }:${ data.location.column }`;
+				}
+				return data?.url || data;
+		}
+	}
+
+	if ( typeof data === 'string' || typeof data === 'number' ) {
+		switch ( headingValueType ) {
+			case 'ms':
+			case 'timespanMs':
+				// TODO: Implement a better visualization for ms values. Ex:  '1.2s' instead of '1200ms'
+				return translate( '%(ms)sms', { args: { ms: getFormattedNumber( data ) } } );
+			case 'bytes':
+				return getFormattedSize( Number( data ) || 0 );
+			case 'numeric':
+				return getFormattedNumber( data, 2 );
+			case 'link':
+				return <Markdown>{ data.toString() }</Markdown>;
+			case 'score':
+				<span className={ `score ${ Number( data ) > 6 ? 'dangerous' : 'alert' } ` }>
+					{ data }
+				</span>;
+			default:
+				return data;
+		}
+	}
+
+	return data;
+}
+
+function getFormattedNumber( value: number | string, dec = 2 ) {
+	return Number( Number( value ?? 0 ).toFixed( dec ) );
+}
+
+function getFormattedSize( size: number ) {
+	const i = size === 0 ? 0 : Math.floor( Math.log( size ) / Math.log( 1024 ) );
+	return (
+		+( size / Math.pow( 1024, i ) ).toFixed( 2 ) * 1 + ' ' + [ 'B', 'kB', 'MB', 'GB', 'TB' ][ i ]
+	);
+}

--- a/client/site-profiler/components/styles-v2.scss
+++ b/client/site-profiler/components/styles-v2.scss
@@ -323,6 +323,41 @@
 					color: #fff;
 				}
 			}
+
+			.metrics-insight-detailed-content {
+				margin-top: 42px;
+
+				table {
+					table-layout: fixed;
+					width: 100%;
+
+					thead {
+						background: var(--studio-gray-80);
+					}
+
+					th,
+					td {
+						padding: 24px 30px;
+						word-break: break-word;
+						font-size: $font-body-small;
+					}
+
+					tbody {
+						background: var(--studio-gray-90);
+					}
+
+					pre {
+						background: none;
+						padding: 14px 0 0;
+						margin-bottom: 0;
+					}
+
+					$blueberry-color: #3858e9;
+					code {
+						color: $blueberry-color;
+					}
+				}
+			}
 		}
 
 		&:last-child {
@@ -332,6 +367,7 @@
 		&.is-expanded {
 			.foldable-card__content {
 				border-top: none;
+				max-height: none;
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7529
Fixes https://github.com/Automattic/dotcom-forge/issues/7530

## Proposed Changes

Display the detailed content for "table" and "opportunity" tests.



## Why are these changes being made?

To match the [figma layout](https://www.figma.com/design/P7Jjk4nbUTahUk8aHkG6NQ/Performance-Tool?m=dev&node-id=1126-6311) for Site Profiler V2.

## Testing Instructions

* Go to `/site-profiler/:url`. Ex: `/site-profiler/wordpress.com`
* Go to the Performance section and check if the items of the type "table" and opportunity are being rendered as a table
* Check if the layout is similar to the one in figma

![CleanShot 2024-05-29 at 20 35 09@2x](https://github.com/Automattic/wp-calypso/assets/5039531/32371c78-c0cd-47c3-83f1-ecaf67417166)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?