### PR TITLE
Global Sidebar: Update support session UI

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -516,31 +516,15 @@ body.has-global-sidebar.has-global-sidebar-collapsed .help-center .components-ca
 }
 
 body.has-global-sidebar .is-global-sidebar-visible.is-support-session {
-	&::before,
-	&::after {
+	&::before {
+		border: 2px solid var(--studio-orange);
+		bottom: 0;
 		content: "";
+		left: 0;
 		pointer-events: none;
 		position: fixed;
-		z-index: z-index("root", ".layout__secondary") + 1;
-	}
-
-	&::before {
-		border: 8px solid var(--studio-orange);
-		left: 0;
 		right: 0;
 		top: 0;
-		bottom: 0;
-	}
-
-	&::after {
-		background-color: var(--studio-orange);
-		border-radius: 0 0 2px 2px;
-		color: #fff;
-		content: "Support session";
-		font-size: $font-body-extra-small;
-		left: 50%;
-		padding: 4px 16px;
-		top: 0;
-		transform: translateX(-50%);
+		z-index: z-index("root", ".layout__secondary") + 1;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

See p1716982817900279-slack-C06DN6QQVAQ.

| Before | After |
| --- | --- |
| ![Screenshot 2024-05-30 at 9 05 44 AM](https://github.com/Automattic/wp-calypso/assets/797888/bc04f084-cad0-4181-aaf0-22f4807ca4df) | ![Screenshot 2024-05-30 at 9 06 09 AM](https://github.com/Automattic/wp-calypso/assets/797888/f8b9afc9-b7f8-4711-8e81-686a879e9e6a) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Update the UI to be less intrusive.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?