### PR TITLE
Site Profiler Performance: Show tables for the 'list' type

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -126,7 +126,9 @@ export interface PerformanceMetricsItemQueryResponse {
 export interface PerformanceMetricsDetailsQueryResponse {
 	type: 'table' | 'opportunity' | 'list';
 	headings?: Array< { key: string; label: string; valueType: string } >;
-	items?: Array< { [ key: string ]: string | number | { [ key: string ]: any } } >;
+	items?: Array< {
+		[ key: string ]: string | number | { [ key: string ]: any };
+	} >;
 }
 
 export interface BasicMetricsResult extends Omit< UrlBasicMetricsQueryResponse, 'basic' > {

--- a/client/site-profiler/components/metrics-insight/insight-detailed-content.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-detailed-content.tsx
@@ -12,5 +12,11 @@ export const InsightDetailedContent: React.FC< InsightDetailedContentProps > = (
 		return <InsightTable { ...props } />;
 	}
 
+	if ( data.type === 'list' ) {
+		const tables = data.items ?? [];
+
+		return tables.map( ( item, index ) => <InsightTable key={ index } data={ item as any } /> );
+	}
+
 	return null;
 };

--- a/client/site-profiler/components/metrics-insight/insight-table.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-table.tsx
@@ -3,7 +3,7 @@ import Markdown from 'react-markdown';
 import { PerformanceMetricsDetailsQueryResponse } from 'calypso/data/site-profiler/types';
 
 export function InsightTable( { data }: { data: PerformanceMetricsDetailsQueryResponse } ) {
-	const { headings = [], items = [] } = data;
+	const { headings = [], items = [] } = data ?? {};
 
 	return (
 		<table>
@@ -15,11 +15,11 @@ export function InsightTable( { data }: { data: PerformanceMetricsDetailsQueryRe
 				</tr>
 			</thead>
 			<tbody>
-				{ items.map( ( row, index ) => (
+				{ items.map( ( item, index ) => (
 					<tr key={ `tr-${ index }` }>
 						{ headings.map( ( heading ) => (
 							<td>
-								<Cell data={ row[ heading.key ] } headingValueType={ heading.valueType } />
+								<Cell data={ item[ heading.key ] } headingValueType={ heading.valueType } />
 							</td>
 						) ) }
 					</tr>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7531
Depends on https://github.com/Automattic/wp-calypso/pull/91265

## Proposed Changes

Display the detailed content for "list"  tests. This is a list of tables that should use the `InsightTable` component that is already existent.



## Why are these changes being made?

To match the [figma layout](https://www.figma.com/design/P7Jjk4nbUTahUk8aHkG6NQ/Performance-Tool?m=dev&node-id=1126-6311) for Site Profiler V2.

## Testing Instructions

* Go to `/site-profiler/:url`. Ex: `/site-profiler/wordpress.com`
* Go to the Performance section and check if the items of the type "list" are being rendered as a list of tables
* Check if the layout is similar to the one in figma
* 
![CleanShot 2024-05-29 at 21 23 35@2x](https://github.com/Automattic/wp-calypso/assets/5039531/4d214214-65f9-4310-9109-decebc24cc43)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?