### PR TITLE
Site Management Panel > Hosting Config: Update the IA

### DIFF
--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -51,6 +51,13 @@ const DevTools = () => {
 	const pluginsLink = `https://wordpress.com/plugins/${ encodeURIComponent( siteSlug ) }`;
 	const promoCards = [
 		{
+			title: translate( 'Deployments' ),
+			text: translate(
+				'Automate updates from GitHub to streamline workflows, reduce errors, and enable faster deployments.'
+			),
+			supportContext: 'github-deployments',
+		},
+		{
 			title: translate( 'Monitoring' ),
 			text: translate(
 				"Proactively monitor your site's performance, including requests per minute and average response time."
@@ -68,13 +75,6 @@ const DevTools = () => {
 				'Gain full visibility into server activity, helping you manage traffic and spot security issues early.'
 			),
 			supportContext: 'site-monitoring-logs',
-		},
-		{
-			title: translate( 'GitHub Deployments' ),
-			text: translate(
-				'Automate updates from GitHub to streamline workflows, reduce errors, and enable faster deployments.'
-			),
-			supportContext: 'github-deployments',
 		},
 		{
 			title: translate( 'Server Configuration' ),

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -51,13 +51,6 @@ const DevTools = () => {
 	const pluginsLink = `https://wordpress.com/plugins/${ encodeURIComponent( siteSlug ) }`;
 	const promoCards = [
 		{
-			title: translate( 'Hosting Configuration' ),
-			text: translate(
-				"Access your site's database and tailor your server settings to your specific needs."
-			),
-			supportContext: 'hosting-configuration',
-		},
-		{
 			title: translate( 'Monitoring' ),
 			text: translate(
 				"Proactively monitor your site's performance, including requests per minute and average response time."
@@ -82,6 +75,13 @@ const DevTools = () => {
 				'Automate updates from GitHub to streamline workflows, reduce errors, and enable faster deployments.'
 			),
 			supportContext: 'github-deployments',
+		},
+		{
+			title: translate( 'Server Configuration' ),
+			text: translate(
+				"Access your site's database and tailor your server settings to your specific needs."
+			),
+			supportContext: 'hosting-configuration',
 		},
 	];
 

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -186,14 +186,7 @@ const SidebarCards = ( { isBasicHostingDisabled } ) => {
 	return <ShowEnabledFeatureCards cards={ sidebarCards } availableTypes={ availableTypes } />;
 };
 
-const AllCards = ( {
-	hasStagingSitesFeature,
-	isAdvancedHostingDisabled,
-	isBasicHostingDisabled,
-	isWpcomStagingSite,
-	siteId,
-	siteSlug,
-} ) => {
+const AllCards = ( { isAdvancedHostingDisabled, isBasicHostingDisabled, siteId, siteSlug } ) => {
 	const { data, isLoading } = useCodeDeploymentsQuery( siteId );
 	const isCodeDeploymentsUnused = ! isLoading && data && ! data.length;
 
@@ -215,22 +208,6 @@ const AllCards = ( {
 			content: <PhpMyAdminCard disabled={ isAdvancedHostingDisabled } />,
 			type: 'advanced',
 		},
-		! isWpcomStagingSite && hasStagingSitesFeature
-			? {
-					feature: 'staging-site',
-					content: <StagingSiteCard disabled={ isAdvancedHostingDisabled } />,
-					type: 'advanced',
-			  }
-			: null,
-		isWpcomStagingSite && siteId
-			? {
-					feature: 'staging-production-site',
-					content: (
-						<StagingSiteProductionCard siteId={ siteId } disabled={ isAdvancedHostingDisabled } />
-					),
-					type: 'advanced',
-			  }
-			: null,
 		{
 			feature: 'web-server-settings',
 			content: <WebServerSettingsCard disabled={ isAdvancedHostingDisabled } />,
@@ -250,15 +227,6 @@ const AllCards = ( {
 			feature: 'wp-admin',
 			content: <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } isHosting />,
 			type: 'basic',
-		},
-		{
-			feature: 'site-backup',
-			content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
-			type: 'basic',
-		},
-		{
-			feature: 'support',
-			content: <SupportCard />,
 		},
 	].filter( ( card ) => card !== null );
 
@@ -373,11 +341,9 @@ const Hosting = ( props ) => {
 					<Layout className="hosting__layout">
 						{ isEnabled( 'layout/dotcom-nav-redesign-v2' ) ? (
 							<AllCards
-								hasStagingSitesFeature={ hasStagingSitesFeature }
 								isAdvancedHostingDisabled={ ! hasSftpFeature || ! isSiteAtomic }
 								isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
 								isBusinessTrial={ isBusinessTrial && ! hasTransfer }
-								isWpcomStagingSite={ isWpcomStagingSite }
 								siteId={ siteId }
 								siteSlug={ siteSlug }
 							/>
@@ -433,10 +399,20 @@ const Hosting = ( props ) => {
 				/>
 			) }
 			<PageViewTracker path="/hosting-config/:site" title="Hosting" />
-			<DocumentHead title={ translate( 'Hosting' ) } />
+			<DocumentHead
+				title={
+					isEnabled( 'layout/dotcom-nav-redesign-v2' )
+						? translate( 'Server Config' )
+						: translate( 'Hosting' )
+				}
+			/>
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ translate( 'Hosting Config' ) }
+				title={
+					isEnabled( 'layout/dotcom-nav-redesign-v2' )
+						? translate( 'Server Config' )
+						: translate( 'Hosting Config' )
+				}
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
 			{ ! showHostingActivationBanner && ! isTrialAcknowledgeModalOpen && (

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -50,11 +50,10 @@ $areas: github-deployments, sftp, site-backup, support, phpmyadmin, staging-site
 				grid-template-columns: 1fr 1fr;
 				grid-template-areas:
 					"github-deployments github-deployments"
-					"sftp site-backup"
-					"sftp support"
-					"phpmyadmin staging-site"
-					"restore-plan-software cache"
-					"web-server-settings admin-interface-style";
+					"sftp phpmyadmin"
+					"sftp cache"
+					"restore-plan-software web-server-settings"
+					"admin-interface-style web-server-settings";
 			}
 		}
 	}

--- a/client/my-sites/hosting/test/index.js
+++ b/client/my-sites/hosting/test/index.js
@@ -6,16 +6,6 @@ jest.mock( 'calypso/lib/analytics/page-view-tracker', () => 'page-view-tracker' 
 jest.mock( 'calypso/components/feature-example', () => ( { children } ) => {
 	return <div data-testid="feature-example-wrapper">{ children }</div>;
 } );
-jest.mock( '../staging-site-card', () => () => (
-	<div data-testid="staging-site-card">
-		<span>Staging site</span>
-	</div>
-) );
-jest.mock( '../staging-site-card/staging-site-production-card', () => () => (
-	<div data-testid="staging-site-production-card">
-		<span>Staging site</span>
-	</div>
-) );
 jest.mock( 'calypso/lib/wp', () => ( {
 	req: {
 		get: jest.fn(),
@@ -161,10 +151,6 @@ const getExpectedStringsForTestConfig = ( testConfig, { enabledOnly = false } = 
 		}
 	} else {
 		expectedStrings = stringsForAllAtomicFeatureCards;
-	}
-
-	if ( testConfig.siteFeatures.includes( FEATURE_SITE_STAGING_SITES ) ) {
-		expectedStrings.push( 'Staging site' );
 	}
 
 	return expectedStrings;
@@ -343,28 +329,6 @@ describe( 'Hosting Configuration', () => {
 				expect( elementForString ).toBeVisible();
 				expect( mainFeatureExampleElement ).not.toContainElement( elementForString );
 			} );
-		} );
-	} );
-
-	describe( 'Staging site', () => {
-		it( 'should show the primary site card and not show the upsell nudge', async () => {
-			const testConfig = getTestConfig( {
-				isAtomicSite: true,
-				isWpcomStagingSite: true,
-				planSlug: PLAN_BUSINESS_MONTHLY,
-				siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SFTP, FEATURE_SITE_STAGING_SITES ],
-				transferStatus: transferStates.COMPLETE,
-			} );
-
-			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
-			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
-
-			expect(
-				screen.queryByText( 'Upgrade to the Creator plan to access all hosting features:' )
-			).toBeNull();
-			expect( screen.queryByText( 'Upgrade to Creator Plan' ) ).toBeNull();
-
-			expect( screen.getByTestId( 'staging-site-production-card' ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -65,8 +65,8 @@ const DotcomPreviewPane = ( {
 				selectedSiteFeaturePreview
 			),
 			createFeaturePreview(
-				DOTCOM_HOSTING_CONFIG,
-				__( 'Hosting Config' ),
+				DOTCOM_GITHUB_DEPLOYMENTS,
+				__( 'Deployments' ),
 				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
@@ -89,16 +89,16 @@ const DotcomPreviewPane = ( {
 				selectedSiteFeaturePreview
 			),
 			createFeaturePreview(
-				DOTCOM_GITHUB_DEPLOYMENTS,
-				__( 'GitHub Deployments' ),
+				DOTCOM_STAGING_SITE,
+				__( 'Staging Site' ),
 				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
 				selectedSiteFeaturePreview
 			),
 			createFeaturePreview(
-				DOTCOM_STAGING_SITE,
-				__( 'Staging Site' ),
+				DOTCOM_HOSTING_CONFIG,
+				__( 'Server Config' ),
 				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7515

## Proposed Changes

This PR makes the following changes:

- Updates the title of the page to Server Config under the flag `layout/dotcom-nav-redesign-v2`.
- Moves the tab Server Config to be the last tab in the Site Management Panel, for Atomic sites.
- Removes the following cards from the page:
  - Backup https://github.com/Automattic/dotcom-forge/issues/7512
  - Support https://github.com/Automattic/dotcom-forge/issues/7512
  - Staging site https://github.com/Automattic/dotcom-forge/issues/7513
- Updates unit tests that checks for the existence of the Stating site card.

| Before | After |
| --- | --- |
| ![Screenshot 2024-05-30 at 3 23 08 PM](https://github.com/Automattic/wp-calypso/assets/797888/0725abb1-7fed-4cf6-8a32-be3c6065747d) | ![Screenshot 2024-05-30 at 3 22 40 PM](https://github.com/Automattic/wp-calypso/assets/797888/0a431a70-bb11-49fd-8861-203341076539) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

With the Nav Redesign v2 project, the settings above are moved to other pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Select any Atomic site (except P2).
* Ensure that the Hosting Config tab is renamed to Server Config, and moved to the end of the tab list.
* Ensure that the cards listed above are no longer present in the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
