### PR TITLE
Replace "chat with us" references

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
@@ -59,7 +59,7 @@ const PrecancellationChatButton: FC< Props > = ( {
 			onClick={ handleClick }
 		>
 			{ icon && <MaterialIcon icon={ icon } /> }
-			{ __( 'Need help? Chat with us' ) }
+			{ __( 'Need help? Contact us' ) }
 		</ChatButton>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -55,7 +55,7 @@ const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 					withHelpCenter={ false }
 				>
 					<MaterialIcon icon="chat_bubble" />
-					{ __( 'Need help? Chat with us' ) }
+					{ __( 'Need help? Contact us' ) }
 				</ChatButton>
 			}
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -56,7 +56,7 @@ const Intro: Step = function Intro( { navigation, variantSlug } ) {
 					withHelpCenter={ false }
 				>
 					<MaterialIcon icon="chat_bubble" />
-					{ __( 'Need help? Chat with us' ) }
+					{ __( 'Need help? Contact us' ) }
 				</ChatButton>
 			}
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
@@ -185,7 +185,7 @@ const ConfirmationModal = ( {
 					</List>
 					<Footer>
 						<HelpLink>
-							{ translate( 'Need help? {{ChatLink}}Chat with us{{/ChatLink}}', {
+							{ translate( 'Need help? {{ChatLink}}Contact us{{/ChatLink}}', {
 								components: {
 									ChatLink: <Button variant="link" onClick={ openChat } />,
 								},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-5Yj-p2

## Proposed Changes

* Renames "Need help? Chat with us" to "Need help? Contact us"

<img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/2d8fef70-edff-42e7-bb11-587529114448">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pau2Xa-5Yj-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR only contains string changes with no changes in functionality. To view one instance of the new string, you can go to `/setup/domain-transfer/intro`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?