### PR TITLE
Launch the treatment variation of the de-emphasize free plan experiment as the new default

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
@@ -1,21 +1,5 @@
-import { useExperiment } from 'calypso/lib/explat';
-import type { DataResponse } from '@automattic/plans-grid-next';
-
-function useDeemphasizeFreePlan(
-	flowName?: string | null,
-	paidDomainName?: string
-): DataResponse< boolean > {
-	const [ isLoading, experimentAssignment ] = useExperiment(
-		'calypso_signup_onboarding_deemphasize_free_plan',
-		{
-			isEligible: flowName === 'onboarding',
-		}
-	);
-
-	return {
-		isLoading,
-		result: experimentAssignment?.variationName === 'treatment' && paidDomainName != null,
-	};
+function useDeemphasizeFreePlan( flowName?: string | null, paidDomainName?: string ): boolean {
+	return flowName === 'onboarding' && paidDomainName != null;
 }
 
 export default useDeemphasizeFreePlan;

--- a/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
@@ -1,4 +1,5 @@
 function useDeemphasizeFreePlan( flowName?: string | null, paidDomainName?: string ): boolean {
+	// De-emphasize the Free plan as a CTA link on the main onboarding flow when a paid domain is picked. More context can be found in p2-p5uIfZ-f5p
 	return flowName === 'onboarding' && paidDomainName != null;
 }
 

--- a/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
+++ b/client/my-sites/plans-features-main/hooks/use-deemphasize-free-plan.ts
@@ -1,6 +1,0 @@
-function useDeemphasizeFreePlan( flowName?: string | null, paidDomainName?: string ): boolean {
-	// De-emphasize the Free plan as a CTA link on the main onboarding flow when a paid domain is picked. More context can be found in p2-p5uIfZ-f5p
-	return flowName === 'onboarding' && paidDomainName != null;
-}
-
-export default useDeemphasizeFreePlan;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -378,11 +378,8 @@ const PlansFeaturesMain = ( {
 		hideEnterprisePlan,
 	};
 
-	// The hook is introduced temporarily to alter the value dynamically according to the ExPlat variant loaded.
-	// Once the experiment concludes, we will clean it up and simply use the prop value.
-	// For more details, please refer to peP6yB-23n-p2
-	const resolvedDeemphasizeFreePlan = useDeemphasizeFreePlan( flowName, paidDomainName );
-	const deemphasizeFreePlan = deemphasizeFreePlanFromProps || resolvedDeemphasizeFreePlan.result;
+	const deemphasizeFreePlan =
+		useDeemphasizeFreePlan( flowName, paidDomainName ) || deemphasizeFreePlanFromProps;
 
 	// we need all the plans that are available to pick for comparison grid (these should extend into plans-ui data store selectors)
 	const gridPlansForComparisonGrid = useGridPlansForComparisonGrid( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -71,7 +71,6 @@ import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
 import PlansPageSubheader from './components/plans-page-subheader';
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
-import useDeemphasizeFreePlan from './hooks/use-deemphasize-free-plan';
 import useExperimentForTrailMap from './hooks/use-experiment-for-trail-map';
 import useFilteredDisplayedIntervals from './hooks/use-filtered-displayed-intervals';
 import useGenerateActionHook from './hooks/use-generate-action-hook';
@@ -215,7 +214,7 @@ const PlansFeaturesMain = ( {
 	isStepperUpgradeFlow = false,
 	isLaunchPage = false,
 	showLegacyStorageFeature = false,
-	deemphasizeFreePlan: deemphasizeFreePlanFromProps,
+	deemphasizeFreePlan,
 	isSpotlightOnCurrentPlan,
 	renderSiblingWhenLoaded,
 	showPlanTypeSelectorDropdown = false,
@@ -377,9 +376,6 @@ const PlansFeaturesMain = ( {
 		hideEcommercePlan,
 		hideEnterprisePlan,
 	};
-
-	const deemphasizeFreePlan =
-		useDeemphasizeFreePlan( flowName, paidDomainName ) || deemphasizeFreePlanFromProps;
 
 	// we need all the plans that are available to pick for comparison grid (these should extend into plans-ui data store selectors)
 	const gridPlansForComparisonGrid = useGridPlansForComparisonGrid( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -644,10 +644,7 @@ const PlansFeaturesMain = ( {
 			isExperimentLoading ||
 			isTrailMapExperimentLoading
 	);
-	const isPlansGridReady =
-		! isLoadingGridPlans &&
-		! resolvedSubdomainName.isLoading &&
-		! resolvedDeemphasizeFreePlan.isLoading;
+	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
 
 	const isMobile = useMobileBreakpoint();
 	const enablePlanTypeSelectorStickyBehavior = isMobile && showPlanTypeSelectorDropdown;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -95,7 +95,7 @@ export class PlansStep extends Component {
 	plansFeaturesList() {
 		const {
 			disableBloggerPlanWithNonBlogDomain,
-			deemphasizeFreePlan,
+			deemphasizeFreePlan: deemphasizeFreePlanFromProps,
 			hideFreePlan,
 			isLaunchPage,
 			selectedSite,
@@ -122,6 +122,12 @@ export class PlansStep extends Component {
 		if ( typeof siteUrl === 'string' && siteUrl.includes( '.wordpress.com' ) ) {
 			freeWPComSubdomain = siteUrl;
 		}
+
+		// De-emphasize the Free plan as a CTA link on the main onboarding flow when a paid domain is picked.
+		// More context can be found in p2-p5uIfZ-f5p
+		const deemphasizeFreePlan =
+			( flowName === 'onboarding' && paidDomainName != null ) || deemphasizeFreePlanFromProps;
+
 		return (
 			<div>
 				{ errorDisplay }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2791

## Proposed Changes

Now that we've confirmed the treatment variation wins, this PR launches the behavior as the new default.

We can't use the flow level prop like [the onboarding-pm flow does](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/config/flows-pure.js#L260) since it's a dynamic value depending on whether a paid domain name is picked. 

One thing that might worth considering is being able to pass in a function instead of a static value for the flow-level props so it doesn't have to be derived in the plans step component, but that might be too far fetched for now.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

See p2-p5uIfZ-f5p

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For /start:

* Pick a free domain at the domain step, and make sure the Free plan shows as a plan card along side the other plans.
* Pick a paid domain at the domain step, and make sure it shows as a CTA link under the header.

For /start/onboarding-pm: (we'd want to check this case since it uses a flow-level prop to enable the de-emphasizing free plan functionality)
* Make sure the free plan is always a CTA link irrespect to the domain selection.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
