### PR TITLE
Replace references to live chat

### DIFF
--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -5,6 +5,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -18,11 +19,15 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export const UpgradeToPremiumNudgePure = ( props ) => {
 	const { price, planSlug, translate, userCurrency, canUserUpgrade } = props;
 
+	const hasEnTranslation = useHasEnTranslation();
+
 	const featureList = [
 		translate( 'Share posts that have already been published.' ),
 		translate( 'Schedule your social messages in advance.' ),
 		translate( 'Remove all advertising from your site.' ),
-		translate( 'Enjoy live chat support.' ),
+		hasEnTranslation( 'Enjoy fast support.' )
+			? translate( 'Enjoy fast support.' )
+			: translate( 'Enjoy live chat support.' ),
 		translate( 'Easy monetization options' ),
 	];
 

--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -143,7 +143,7 @@ const ChatButton: FC< Props > = ( {
 			primary={ primary }
 			borderless={ borderless }
 			onClick={ handleClick }
-			title={ __( 'Support Chat' ) }
+			title={ __( 'Contact us' ) }
 		>
 			{ getChildren() }
 		</Button>

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isDomainRegistration, isPlan } from '@automattic/calypso-products';
 import { MaterialIcon } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import ChatButton from 'calypso/components/chat-button';
@@ -27,6 +28,7 @@ const PrecancellationChatButton: FC< Props > = ( {
 	className,
 } ) => {
 	const { __ } = useI18n();
+	const hasEnTranslation = useHasEnTranslation();
 	const siteUrl =
 		useSelector( ( state ) => getSiteUrl( state, purchase.siteId ) ) || 'Unknown site';
 
@@ -59,7 +61,9 @@ const PrecancellationChatButton: FC< Props > = ( {
 			onClick={ handleClick }
 		>
 			{ icon && <MaterialIcon icon={ icon } /> }
-			{ __( 'Need help? Chat with us' ) }
+			{ hasEnTranslation( 'Need help? Contact us' )
+				? __( 'Need help? Contact us' )
+				: __( 'Need help? Chat with us' ) }
 		</ChatButton>
 	);
 };

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { MaterialIcon } from '@automattic/components';
 import { useChatWidget } from '@automattic/help-center/src/hooks';
-import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { useHasEnTranslation, useLocalizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -72,6 +72,7 @@ type StepProps = {
 
 export default function EducationalCotnentStep( { type, site, ...props }: StepProps ) {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const localizeUrl = useLocalizeUrl();
 	const { isOpeningChatWidget, openChatWidget } = useChatWidget();
 
@@ -236,37 +237,71 @@ export default function EducationalCotnentStep( { type, site, ...props }: StepPr
 							) }
 						</li>
 						<li>
-							{ translate(
-								'Read more about domain connection {{link}}here{{/link}} or {{chat}}chat with a real person{{/chat}} right now.',
-								{
-									components: {
-										link: (
-											<Button
-												href={ localizeUrl(
-													'https://wordpress.com/support/domains/connect-existing-domain/'
-												) }
-												variant="link"
-											/>
-										),
-										chat: (
-											<Button
-												isBusy={ isOpeningChatWidget }
-												disabled={ isOpeningChatWidget }
-												onClick={ () => {
-													page( `/domains/manage/${ site.slug }` );
-													openChatWidget( {
-														message:
-															"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
-															props.cancellationReason,
-														siteUrl: site.URL,
-													} );
-												} }
-												variant="link"
-											/>
-										),
-									},
-								}
-							) }
+							{ hasEnTranslation(
+								'Read more about domain connection {{link}}here{{/link}} or {{chat}}contact us{{/chat}} right now.'
+							)
+								? translate(
+										'Read more about domain connection {{link}}here{{/link}} or {{chat}}contact us{{/chat}} right now.',
+										{
+											components: {
+												link: (
+													<Button
+														href={ localizeUrl(
+															'https://wordpress.com/support/domains/connect-existing-domain/'
+														) }
+														variant="link"
+													/>
+												),
+												chat: (
+													<Button
+														isBusy={ isOpeningChatWidget }
+														disabled={ isOpeningChatWidget }
+														onClick={ () => {
+															page( `/domains/manage/${ site.slug }` );
+															openChatWidget( {
+																message:
+																	"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
+																	props.cancellationReason,
+																siteUrl: site.URL,
+															} );
+														} }
+														variant="link"
+													/>
+												),
+											},
+										}
+								  )
+								: translate(
+										'Read more about domain connection {{link}}here{{/link}} or {{chat}}chat with a real person{{/chat}} right now.',
+										{
+											components: {
+												link: (
+													<Button
+														href={ localizeUrl(
+															'https://wordpress.com/support/domains/connect-existing-domain/'
+														) }
+														variant="link"
+													/>
+												),
+												chat: (
+													<Button
+														isBusy={ isOpeningChatWidget }
+														disabled={ isOpeningChatWidget }
+														onClick={ () => {
+															page( `/domains/manage/${ site.slug }` );
+															openChatWidget( {
+																message:
+																	"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
+																	props.cancellationReason,
+																siteUrl: site.URL,
+															} );
+														} }
+														variant="link"
+													/>
+												),
+											},
+										}
+								  ) }
 						</li>
 					</ul>
 				</Content>

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -1,5 +1,6 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 
 interface Props {
@@ -8,6 +9,7 @@ interface Props {
 
 const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: Props ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const plans = Plans.usePlans( { coupon: undefined } );
 	const planTitle = plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '';
 
@@ -15,7 +17,9 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 		<strong>{ translate( 'Free domain for one year' ) }</strong>,
 		<strong>{ translate( 'Premium themes' ) }</strong>,
 		translate( 'Style customization' ),
-		translate( 'Live chat support' ),
+		hasEnTranslation( 'Fast support' )
+			? translate( 'Fast support' )
+			: translate( 'Live chat support' ),
 		translate( 'Ad-free experience' ),
 		translate( 'Earn with WordAds' ),
 	];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx
@@ -1,4 +1,5 @@
 import { MaterialIcon } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import ChatButton from 'calypso/components/chat-button';
@@ -13,6 +14,7 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 	const { submit, goBack } = navigation;
 	const { __ } = useI18n();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const handleSubmit = () => {
 		submit?.();
@@ -55,7 +57,9 @@ const Intro: Step = function Intro( { navigation, flow, variantSlug } ) {
 					withHelpCenter={ false }
 				>
 					<MaterialIcon icon="chat_bubble" />
-					{ __( 'Need help? Chat with us' ) }
+					{ hasEnTranslation( 'Need help? Contact us' )
+						? __( 'Need help? Contact us' )
+						: __( 'Need help? Chat with us' ) }
 				</ChatButton>
 			}
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/index.tsx
@@ -1,4 +1,5 @@
 import { MaterialIcon } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { GOOGLE_TRANSFER } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
@@ -13,6 +14,7 @@ import './styles.scss';
 const Intro: Step = function Intro( { navigation, variantSlug } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const handleSubmit = () => {
 		submit?.();
@@ -56,7 +58,9 @@ const Intro: Step = function Intro( { navigation, variantSlug } ) {
 					withHelpCenter={ false }
 				>
 					<MaterialIcon icon="chat_bubble" />
-					{ __( 'Need help? Chat with us' ) }
+					{ hasEnTranslation( 'Need help? Contact us' )
+						? __( 'Need help? Contact us' )
+						: __( 'Need help? Chat with us' ) }
 				</ChatButton>
 			}
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx
@@ -1,5 +1,6 @@
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Button, Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -132,6 +133,7 @@ const ConfirmationModal = ( {
 	closeModal: () => void;
 } ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const { openChat } = usePresalesChat( 'wpcom' );
 
@@ -185,11 +187,17 @@ const ConfirmationModal = ( {
 					</List>
 					<Footer>
 						<HelpLink>
-							{ translate( 'Need help? {{ChatLink}}Chat with us{{/ChatLink}}', {
-								components: {
-									ChatLink: <Button variant="link" onClick={ openChat } />,
-								},
-							} ) }
+							{ hasEnTranslation( 'Need help? {{ChatLink}}Contact us{{/ChatLink}}' )
+								? translate( 'Need help? {{ChatLink}}Contact us{{/ChatLink}}', {
+										components: {
+											ChatLink: <Button variant="link" onClick={ openChat } />,
+										},
+								  } )
+								: translate( 'Need help? {{ChatLink}}Chat with us{{/ChatLink}}', {
+										components: {
+											ChatLink: <Button variant="link" onClick={ openChat } />,
+										},
+								  } ) }
 						</HelpLink>
 						<ButtonsContainer>
 							<StyledButton variant="secondary" onClick={ closeModal }>

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
+import i18n, { localize, getLocaleSlug } from 'i18n-calypso';
 import { map } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -208,16 +208,32 @@ class AccountSettingsClose extends Component {
 									) }
 								</p>
 								<p className="account-close__body-copy">
-									{ translate(
+									{ getLocaleSlug().startsWith( 'en' ) ||
+									i18n.hasTranslation(
 										'If you have any questions at all about what happens when you close an account, ' +
-											'please {{a}}chat with someone from our support team{{/a}} first. ' +
-											"They'll explain the ramifications and help you explore alternatives. ",
-										{
-											components: {
-												a: <ActionPanelLink href="/help/contact" />,
-											},
-										}
-									) }
+											'please {{a}}contact someone from our support team{{/a}} first. ' +
+											"They'll explain the ramifications and help you explore alternatives. "
+									)
+										? translate(
+												'If you have any questions at all about what happens when you close an account, ' +
+													'please {{a}}contact someone from our support team{{/a}} first. ' +
+													"They'll explain the ramifications and help you explore alternatives. ",
+												{
+													components: {
+														a: <ActionPanelLink href="/help/contact" />,
+													},
+												}
+										  )
+										: translate(
+												'If you have any questions at all about what happens when you close an account, ' +
+													'please {{a}}chat with someone from our support team{{/a}} first. ' +
+													"They'll explain the ramifications and help you explore alternatives. ",
+												{
+													components: {
+														a: <ActionPanelLink href="/help/contact" />,
+													},
+												}
+										  ) }
 								</p>
 								<p className="account-close__body-copy">
 									{ translate( 'When you\'re ready to proceed, use the "Close account" button.' ) }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -1,5 +1,6 @@
 import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Gridicon, LoadingPlaceholder } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { PlanButton } from '@automattic/plans-grid-next';
 import styled from '@emotion/styled';
 import { useEffect } from '@wordpress/element';
@@ -94,6 +95,7 @@ export function FreePlanFreeDomainDialog( {
 	onPlanSelected,
 }: DomainPlanDialogProps ) {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const basicPlanUpsellInfo = usePlanUpsellInfo( { planSlug: PLAN_PERSONAL } );
 	const advancePlanUpsellInfo = usePlanUpsellInfo( { planSlug: PLAN_PREMIUM } );
 	const buttonDisabled = generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result;
@@ -153,19 +155,35 @@ export function FreePlanFreeDomainDialog( {
 				) }
 			</TextBox>
 			<TextBox>
-				{ translate(
-					'{{strong}}Need premium themes, live chat support, and advanced design tools?{{/strong}}{{break}}{{/break}}Go with our %(planTitle)s plan, starting at just %(planPrice)s/month. All annual plans come with a 14-day money-back guarantee.',
-					{
-						args: {
-							planTitle: advancePlanUpsellInfo.title,
-							planPrice: advancePlanUpsellInfo.formattedPriceMonthly,
-						},
-						components: {
-							strong: <strong></strong>,
-							break: <br />,
-						},
-					}
-				) }
+				{ hasEnTranslation(
+					'{{strong}}Need premium themes, fast support, and advanced design tools?{{/strong}}{{break}}{{/break}}Go with our %(planTitle)s plan, starting at just %(planPrice)s/month. All annual plans come with a 14-day money-back guarantee.'
+				)
+					? translate(
+							'{{strong}}Need premium themes, fast support, and advanced design tools?{{/strong}}{{break}}{{/break}}Go with our %(planTitle)s plan, starting at just %(planPrice)s/month. All annual plans come with a 14-day money-back guarantee.',
+							{
+								args: {
+									planTitle: advancePlanUpsellInfo.title,
+									planPrice: advancePlanUpsellInfo.formattedPriceMonthly,
+								},
+								components: {
+									strong: <strong></strong>,
+									break: <br />,
+								},
+							}
+					  )
+					: translate(
+							'{{strong}}Need premium themes, live chat support, and advanced design tools?{{/strong}}{{break}}{{/break}}Go with our %(planTitle)s plan, starting at just %(planPrice)s/month. All annual plans come with a 14-day money-back guarantee.',
+							{
+								args: {
+									planTitle: advancePlanUpsellInfo.title,
+									planPrice: advancePlanUpsellInfo.formattedPriceMonthly,
+								},
+								components: {
+									strong: <strong></strong>,
+									break: <br />,
+								},
+							}
+					  ) }
 			</TextBox>
 
 			<ButtonRow>

--- a/client/my-sites/plans/ecommerce-trial/wx-medium-features.ts
+++ b/client/my-sites/plans/ecommerce-trial/wx-medium-features.ts
@@ -20,7 +20,6 @@ type WooExpressMediumFeatureSetProps = {
 
 export const getWooExpressMediumFeatureSets = ( {
 	translate,
-	interval,
 }: WooExpressMediumFeatureSetProps ): WooExpressMediumPlanFeatureSet[] => {
 	return [
 		{
@@ -43,10 +42,7 @@ export const getWooExpressMediumFeatureSets = ( {
 				},
 				{
 					title: translate( 'Get support 24/7', { textOnly: true } ),
-					subtitle:
-						interval === 'yearly'
-							? translate( 'Need help? Reach out anytime via email or chat.' )
-							: translate( 'Need help? Reach out anytime via email.' ),
+					subtitle: translate( 'Need help? Reach out anytime.' ),
 				},
 				{
 					title: translate( 'Have unlimited admin accounts', { textOnly: true } ),
@@ -258,9 +254,7 @@ export const getExpiredTrialWooExpressMediumFeatureSets = ( {
 				},
 				{
 					title: translate( 'Priority support 24/7', { textOnly: true } ),
-					subtitle: translate(
-						'Need help? Reach out to our Woo specialists anytime via email or chat.'
-					),
+					subtitle: translate( 'Need help? Reach out to our Woo specialists anytime.' ),
 				},
 				{
 					title: translate( 'Get unlimited admin accounts', { textOnly: true } ),

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import ActionCard from 'calypso/components/action-card';
@@ -23,6 +24,7 @@ import './style.scss';
 
 const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const selectedSite = useSelector( getSelectedSite );
 	const dispatch = useDispatch();
@@ -119,14 +121,27 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 			<ActionCard
 				classNames="plugin-plans"
 				headerText=""
-				mainText={ translate(
-					'Need some help? Let us help you find the perfect plan for your site. {{a}}Chat now{{/a}} or {{a}}contact our support{{/a}}.',
-					{
-						components: {
-							a: <ActionPanelLink href="/help/contact" />,
-						},
-					}
-				) }
+				mainText={
+					hasEnTranslation(
+						'Need some help? Let us help you find the perfect plan for your site. {{a}}Contact our support now{{/a}}.'
+					)
+						? translate(
+								'Need some help? Let us help you find the perfect plan for your site. {{a}}Contact our support now{{/a}}.',
+								{
+									components: {
+										a: <ActionPanelLink href="/help/contact" />,
+									},
+								}
+						  )
+						: translate(
+								'Need some help? Let us help you find the perfect plan for your site. {{a}}Chat now{{/a}} or {{a}}contact our support{{/a}}.',
+								{
+									components: {
+										a: <ActionPanelLink href="/help/contact" />,
+									},
+								}
+						  )
+				}
 				buttonText={
 					translate( 'Upgrade to %(planName)s', {
 						args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },

--- a/client/my-sites/plugins/use-plugins-support-text/index.js
+++ b/client/my-sites/plugins/use-plugins-support-text/index.js
@@ -1,6 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
-import { hasOrIntendsToBuyLiveSupport } from 'calypso/state/marketplace/selectors';
 
 /*
  * Gets text used to describe the support level a user will receive
@@ -27,10 +25,5 @@ import { hasOrIntendsToBuyLiveSupport } from 'calypso/state/marketplace/selector
  */
 export default function usePluginsSupportText() {
 	const translate = useTranslate();
-	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
-	const supportTextNonPro = isLiveSupport
-		? translate( 'Live chat support' )
-		: translate( 'Unlimited email support' );
-	const supportText = supportTextNonPro;
-	return supportText;
+	return translate( '24/7 expert support' );
 }

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -225,10 +225,19 @@ class DeleteSite extends Component {
 						) }
 					</p>
 					<p>
-						{ translate(
+						{ getLocaleSlug().startsWith( 'en' ) ||
+						i18n.hasTranslation(
 							"If you're unsure about what deletion means or have any other questions, " +
-								'please chat with someone from our support team before proceeding.'
-						) }
+								'please contact our support team before proceeding.'
+						)
+							? translate(
+									"If you're unsure about what deletion means or have any other questions, " +
+										'please contact our support team before proceeding.'
+							  )
+							: translate(
+									"If you're unsure about what deletion means or have any other questions, " +
+										'please chat with someone from our support team before proceeding.'
+							  ) }
 					</p>
 					<p>
 						<a

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -7,7 +7,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
-import ActionPanelFigure from 'calypso/components/action-panel/figure';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import HeaderCake from 'calypso/components/header-cake';
@@ -156,67 +155,12 @@ class DeleteSite extends Component {
 	}
 
 	renderBody() {
-		if (
-			getLocaleSlug() === 'en' ||
-			getLocaleSlug() === 'en-gb' ||
-			i18n.hasTranslation(
-				'Deletion is {{strong}}irreversible and will permanently remove all site content{{/strong}} — posts, pages, media, users, authors, domains, purchased upgrades, and premium themes.'
-			)
-		) {
-			return (
-				<>
-					<div>
-						<p>
-							{ translate(
-								'Deletion is {{strong}}irreversible and will permanently remove all site content{{/strong}} — posts, pages, media, users, authors, domains, purchased upgrades, and premium themes.',
-								{
-									components: {
-										strong: <strong />,
-									},
-								}
-							) }
-						</p>
-						<p>
-							{ translate(
-								'Once deleted, your domain {{strong}}%(siteDomain)s{{/strong}} will also become unavailable.',
-								{
-									components: {
-										strong: <strong />,
-									},
-									args: {
-										siteDomain: this.props.siteDomain,
-									},
-								}
-							) }
-						</p>
-					</div>
-				</>
-			);
-		}
-
 		return (
 			<>
-				<ActionPanelFigure>
-					<h3 className="delete-site__content-list-header">
-						{ translate( 'These items will be deleted' ) }
-					</h3>
-					<ul className="delete-site__content-list">
-						<li className="delete-site__content-list-item">{ translate( 'Posts' ) }</li>
-						<li className="delete-site__content-list-item">{ translate( 'Pages' ) }</li>
-						<li className="delete-site__content-list-item">{ translate( 'Media' ) }</li>
-						<li className="delete-site__content-list-item">{ translate( 'Users & Authors' ) }</li>
-						<li className="delete-site__content-list-item">{ translate( 'Domains' ) }</li>
-						<li className="delete-site__content-list-item">
-							{ translate( 'Purchased Upgrades' ) }
-						</li>
-						<li className="delete-site__content-list-item">{ translate( 'Premium Themes' ) }</li>
-					</ul>
-				</ActionPanelFigure>
 				<div>
 					<p>
 						{ translate(
-							'Deletion {{strong}}can not{{/strong}} be undone, ' +
-								'and will remove all content, contributors, domains, themes and upgrades from this site.',
+							'Deletion is {{strong}}irreversible and will permanently remove all site content{{/strong}} — posts, pages, media, users, authors, domains, purchased upgrades, and premium themes.',
 							{
 								components: {
 									strong: <strong />,
@@ -225,27 +169,17 @@ class DeleteSite extends Component {
 						) }
 					</p>
 					<p>
-						{ getLocaleSlug().startsWith( 'en' ) ||
-						i18n.hasTranslation(
-							"If you're unsure about what deletion means or have any other questions, " +
-								'please contact our support team before proceeding.'
-						)
-							? translate(
-									"If you're unsure about what deletion means or have any other questions, " +
-										'please contact our support team before proceeding.'
-							  )
-							: translate(
-									"If you're unsure about what deletion means or have any other questions, " +
-										'please chat with someone from our support team before proceeding.'
-							  ) }
-					</p>
-					<p>
-						<a
-							className="delete-site__body-text-link action-panel__body-text-link"
-							href="/help/contact"
-						>
-							{ translate( 'Contact support' ) }
-						</a>
+						{ translate(
+							'Once deleted, your domain {{strong}}%(siteDomain)s{{/strong}} will also become unavailable.',
+							{
+								components: {
+									strong: <strong />,
+								},
+								args: {
+									siteDomain: this.props.siteDomain,
+								},
+							}
+						) }
 					</p>
 				</div>
 			</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-5Yj-p2

## Proposed Changes

* Replaces references to live chat with context-appropriate copy.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pau2Xa-5Yj-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `client/components/chat-button/index.tsx`:
  * Go to `/setup/domain-transfer/intro`. Confirm that the button in the top right corner matches the screenshot. 
  * <img width="249" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/05438c4f-7dd1-4e28-8011-f5ac99c7db8e">
* `client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx`:
  * Proceed to cancel a paid plan. In the cancellation survey, confirm that the button in the top right corner matches the screenshot. 
  * <img width="249" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/05438c4f-7dd1-4e28-8011-f5ac99c7db8e">
* `client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx`:
  * Proceed to cancel a paid plan. In the cancellation survey, select "Domain" and "Problem connecting my domain". Confirm that it matches the screenshot.
  * <img width="710" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/f7f4387c-0c02-4607-9e19-97c0b7ca1d32">
* `client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx`:
  * Follow the test instructions in #81019
  * <img width="356" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/2781c967-1533-46d9-8b4a-3c5e70a59cf2">
* `client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/index.tsx`:
  * Go to `/setup/domain-transfer/intro`. Confirm that the button in the top right corner matches the screenshot. 
  * <img width="249" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/05438c4f-7dd1-4e28-8011-f5ac99c7db8e">
* `client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-site-picker/index.tsx`:
  * Go to `/setup/hundred-year-plan/site-picker`. Select a site. Confirm that the dialog matches the screenshot:
  * <img width="597" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/455a3c93-9bbf-4102-8478-6add66fb6d60">
* `client/me/account-close/main.jsx`:
  *  Go to `/me/account/close` for an account without any active purchases. Confirm that the screen matches the screenshot:
  * <img width="1018" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/e04778d6-b46d-46d5-87b6-23adfc080290">
* `client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx`:
  * Go to `/start/onboarding-pm` and select a free domain with a free plan. Confirm that the dialog matches the screenshot:
  * <img width="817" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/d72a98bd-0745-4fe1-99fa-635b9dbf9c3e">
* `client/my-sites/plugins/plans/index.tsx`:
  * Go to `/plugins/plans/woocommerce/yearly/<siteslug>?flags=plugins-plans-page` for a site on the free plan. Scroll down and confirm that it matches the screenshot:
  * <img width="1164" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/a87d65fc-c2d7-44ae-b7ef-c7372b9337b5">
* `client/my-sites/plugins/use-plugins-support-text/index.js`:
  * Go to `/plugins/plans/woocommerce/yearly/<siteslug>?flags=plugins-plans-page` for a site on the free plan. Scroll down and confirm that it matches the screenshot:
  * <img width="296" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/78ef59d7-7b67-469f-838f-ba76278f3e93">
* `client/my-sites/site-settings/delete-site/index.jsx`: Removes old translations. Check the code diff for more details.

There are some changes for which I could not reach without test instructions:
 
* `client/blocks/post-share/nudges.jsx`
* `client/my-sites/plans/ecommerce-trial/wx-medium-features.ts`




 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?