### PR TITLE
Fix the logic of when to call renderPagesList so it doesn't cause infinite API loop

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -382,6 +382,7 @@ class Pages extends Component {
 		return (
 			<div id="pages" className="pages__page-list">
 				{ this.renderBlogPostsPage() }
+				{ this.renderVirtualHomePage() }
 				<div key="page-list-no-results">{ this.getNoContentMessage() }</div>
 			</div>
 		);
@@ -395,9 +396,7 @@ class Pages extends Component {
 			( loading || areBlockEditorSettingsLoading || isFSEActiveLoading ) && ! hasPage;
 
 		if ( ! isInitialLoad && hasSites ) {
-			return pages.length > 0 || this.showVirtualHomepage()
-				? this.renderPagesList( { pages } )
-				: this.renderNoContent();
+			return pages.length > 0 ? this.renderPagesList( { pages } ) : this.renderNoContent();
 		}
 
 		return this.renderLoading();


### PR DESCRIPTION
Fixes p1717004451771959/1716931381.473209-slack-C029GN3KD

## Proposed Changes

* Remove the effect of showVirtualHomepage to the rendering logic of whether to renderPagesList or renderNoContent

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This simplifies the logic on when to call renderPagesList
* Prevents the infinite API call loop mentioned in the Slack thread above

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Block the API request `https://public-api.wordpress.com/rest/v1.1/sites/:site/posts*` in browser dev tools
* Go to `/pages/:site` and see if it loads the empty state
* Test for sites with Home page that is a static page (usually FSE themes have this static page), and test for sites without the static page to check for regressions


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?