### PR TITLE
Continue with GitHub: Update GithubSocialButton's `redirectUri` to respect current `pathname` during signup flows

### DIFF
--- a/client/blocks/authentication/social/index.tsx
+++ b/client/blocks/authentication/social/index.tsx
@@ -132,7 +132,7 @@ const SocialAuthenticationForm = ( {
 
 						<GithubSocialButton
 							socialServiceResponse={ socialService === 'github' ? socialServiceResponse : null }
-							redirectUri={ isLogin ? getRedirectUri( 'github' ) : window?.location?.pathname }
+							redirectUri={ getRedirectUri( 'github' ) }
 							responseHandler={ handleGitHubResponse }
 							onClick={ () => {
 								trackLoginAndRememberRedirect( 'github' );

--- a/client/blocks/authentication/social/index.tsx
+++ b/client/blocks/authentication/social/index.tsx
@@ -132,7 +132,7 @@ const SocialAuthenticationForm = ( {
 
 						<GithubSocialButton
 							socialServiceResponse={ socialService === 'github' ? socialServiceResponse : null }
-							redirectUri={ getRedirectUri( 'github' ) }
+							redirectUri={ isLogin ? getRedirectUri( 'github' ) : window?.location?.pathname }
 							responseHandler={ handleGitHubResponse }
 							onClick={ () => {
 								trackLoginAndRememberRedirect( 'github' );

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -100,11 +100,18 @@ class SocialSignupForm extends Component {
 
 	getRedirectUri = ( socialService ) => {
 		const origin = typeof window !== 'undefined' && window.location.origin;
+		const pathname = typeof window !== 'undefined' && window.location.pathname;
 
 		// If the user is in the WPCC flow, we want to redirect user to login callback so that we can automatically log them in.
-		return isWpccFlow( this.props.flowName )
-			? `${ origin + login( { socialService } ) }`
-			: `${ origin }/start/user`;
+		if ( isWpccFlow( this.props.flowName ) ) {
+			return `${ origin + login( { socialService } ) }`;
+		}
+
+		if ( socialService === 'github' ) {
+			return `${ origin }${ pathname }`;
+		}
+
+		return `${ origin }/start/user`;
 	};
 
 	trackLoginAndRememberRedirect = ( service ) => {


### PR DESCRIPTION
⚠️ Please do not merge until we are ready. If merged without necessary backend updates (D150510-code), the deploy is breaking production. ⚠️

---

Fixes https://github.com/Automattic/dotcom-forge/issues/7443.

Todos:

- [x] rebase after https://github.com/Automattic/wp-calypso/pull/91228 is merged
- [x] update description, test instructions (and logic potentially: https://github.com/Automattic/wp-calypso/pull/91283#discussion_r1620462052) once related backend logic change patch is ready for review

## Proposed Changes

*  update GithubSocialButton's `redirectUri` to respect current `pathname` during signup flows

Related discussion: p1716997343523629/1716809850.368589-slack-C02TCEHP3HA

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* this PR is one of the steps in resolving https://github.com/Automattic/dotcom-forge/issues/7443

## Testing Instructions

1. Apply the related patch (D150510-code) to your sandbox and sandbox `public-api.wordpress.com`.
2. Test signup flows using GitHub SSO (_Continue with GitHub_), e.g.:
  - Hosting trial flow: http://calypso.localhost:3000/start/hosting?ref=developer-lp&flow=new-hosted-site (CTA at https://developer.wordpress.com/)
  - Entrepreneur / eCommerce trial flow: http://calypso.localhost:3000/setup/entrepreneur/start/?ref=woo-hosting-solutions-lp (CTA at https://wordpress.com/ecommerce/?ref=woo-hosting-solutions-lp)
3. You should be guided through the whole flow correctly. For the Entrepreneur flow, you should go through the `/setup/entrepreneur/trialAcknowledge` step; for the Hosting flow, you should go through the `hosting-decider` step. In other words, none of these two flows should end up on the domain selection page.
4. Test for regressions (e.g. GitHub login flows). Other SSO options, i.e. Google / Apple will be testable once the PR is in staging environment. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?