### PR TITLE
Guided Onboarding: Skip q2 if user choose Client

### DIFF
--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -70,6 +70,7 @@ export default function InitialIntentStep( props: Props ) {
 
 	const skipNextNavigation = ( _questionKey: string, _answerKeys: string[] ) => {
 		return (
+			_answerKeys.includes( 'client' ) ||
 			Boolean( getRedirectForAnswers( _answerKeys ) ) ||
 			shouldExitOnSkip( _questionKey, _answerKeys )
 		);
@@ -83,7 +84,11 @@ export default function InitialIntentStep( props: Props ) {
 			return window.location.assign( redirect );
 		}
 
-		if ( isLastQuestion || shouldExitOnSkip( _questionKey, _answerKeys ) ) {
+		if (
+			_answerKeys.includes( 'client' ) ||
+			isLastQuestion ||
+			shouldExitOnSkip( _questionKey, _answerKeys )
+		) {
 			recordCompleteEvent();
 			props.goToNextStep();
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7519

## Proposed Changes

* Skip q2 if q1 answer is `Create a site for a client`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

![image](https://github.com/Automattic/wp-calypso/assets/52076348/4185bc8f-52d2-4b07-86d0-1e32f8abb5ee)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/guided`
* Choose `Create a site for a client`
* You should get to domains
* Check that all the rest is still working

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
