### PR TITLE
Hosting Config: Allow PHP 8.3 to be selected as the PHP version

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -224,6 +224,10 @@ const WebServerSettingsCard = ( {
 				label: '8.2',
 				value: '8.2',
 			},
+			{
+				label: '8.3',
+				value: '8.3',
+			},
 		];
 	};
 


### PR DESCRIPTION
## Proposed Changes

Allows PHP 8.3 to be selected as the PHP version:

![CleanShot 2024-05-30 at 04 53 38@2x](https://github.com/Automattic/wp-calypso/assets/36432/cd989d9a-eb28-4edb-b6b9-d898eb03ef0a)

## Why are these changes being made?

PHP 8.3 is available on the Atomic platform, so we'd like our users to be able to switch to it.

## Testing Instructions

1. Navigate to hosting settings.
2. Verify a site can be switched to PHP 8.3 and then back again.