### PR TITLE
A4A: Product marketplace filtering improvements

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/product-filter.ts
@@ -43,13 +43,15 @@ export type SelectedFilters = {
 };
 
 export function hasSelectedFilter( selectedFilters: SelectedFilters ) {
-	return Object.keys( selectedFilters )
-		.filter( ( key ) => key !== PRODUCT_FILTER_KEY_BRAND )
-		.some( ( key ) => {
-			return Object.values( selectedFilters[ key as keyof SelectedFilters ] ).some(
-				( selected ) => selected
-			);
-		} );
+	return [
+		selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ],
+		selectedFilters[ PRODUCT_FILTER_KEY_TYPES ],
+		selectedFilters[ PRODUCT_FILTER_KEY_PRICES ],
+	].some( ( filters ) => hasSelectedFilterByType( filters ) );
+}
+
+export function hasSelectedFilterByType( filters: Record< string, boolean > ) {
+	return Object.values( filters ).some( ( selected ) => selected );
 }
 
 export function filterProductsAndPlans(

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.ts
@@ -49,7 +49,7 @@ export default function useProductFilterOptions() {
 			{ key: PRODUCT_TYPE_EXTENSION, label: translate( 'Extension' ) },
 			{ key: PRODUCT_TYPE_PLAN, label: translate( 'Plan' ) },
 			{ key: PRODUCT_TYPE_PRODUCT, label: translate( 'Product' ) },
-			{ key: PRODUCT_TYPE_ADDON, label: translate( 'Addon' ) },
+			{ key: PRODUCT_TYPE_ADDON, label: translate( 'Add-on' ) },
 		],
 		[ PRODUCT_FILTER_KEY_PRICES ]: [
 			{ key: PRODUCT_PRICE_FREE, label: translate( 'Free' ) },

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
@@ -1,4 +1,4 @@
-import { SubmenuPopover, useSubmenuPopoverProps } from '@automattic/components';
+import { Button, SubmenuPopover, useSubmenuPopoverProps } from '@automattic/components';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { Icon, chevronRight, funnel, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -8,7 +8,7 @@ import {
 	PRODUCT_FILTER_KEY_PRICES,
 	PRODUCT_FILTER_KEY_TYPES,
 } from '../../constants';
-import { SelectedFilters } from '../../lib/product-filter';
+import { SelectedFilters, hasSelectedFilter } from '../../lib/product-filter';
 import useOnScreen from './hooks/use-on-screen';
 import useProductFilterOptions from './hooks/use-product-filter-options';
 
@@ -54,9 +54,14 @@ export function ProductFilterItem( {
 type Props = {
 	selectedFilters: SelectedFilters;
 	setSelectedFilters: ( selectedFilters: SelectedFilters ) => void;
+	resetFilters: () => void;
 };
 
-export default function ProductFilter( { selectedFilters, setSelectedFilters }: Props ) {
+export default function ProductFilter( {
+	selectedFilters,
+	setSelectedFilters,
+	resetFilters,
+}: Props ) {
 	const translate = useTranslate();
 
 	const [ openDropdown, setOpenDropdown ] = useState< boolean >( false );
@@ -91,39 +96,51 @@ export default function ProductFilter( { selectedFilters, setSelectedFilters }: 
 		}
 	}, [ isVisible, openDropdown ] );
 
+	const hasSelections = hasSelectedFilter( selectedFilters );
+
 	return (
-		<div ref={ ref }>
-			<DropdownMenu
-				className="product-filter"
-				label={ translate( 'Filter' ) }
-				icon={ funnel }
-				variant="product-filter"
-				open={ openDropdown }
-				onToggle={ () => setOpenDropdown( ! openDropdown ) }
-			>
-				{ () => (
-					<MenuGroup className="product-filter__group">
-						<ProductFilterItem
-							label={ translate( 'Category' ) }
-							options={ categories }
-							selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
-							onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option ) }
-						/>
-						<ProductFilterItem
-							label={ translate( 'Type' ) }
-							options={ types }
-							selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
-							onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
-						/>
-						<ProductFilterItem
-							label={ translate( 'Price' ) }
-							options={ prices }
-							selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
-							onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
-						/>
-					</MenuGroup>
-				) }
-			</DropdownMenu>
+		<div className="product-filter-container">
+			<div ref={ ref }>
+				<DropdownMenu
+					className="product-filter"
+					label={ translate( 'Filter' ) }
+					icon={ funnel }
+					variant="product-filter"
+					open={ openDropdown }
+					onToggle={ () => setOpenDropdown( ! openDropdown ) }
+				>
+					{ () => (
+						<MenuGroup className="product-filter__group">
+							<ProductFilterItem
+								label={ translate( 'Category' ) }
+								options={ categories }
+								selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
+								onOptionClick={ ( option ) =>
+									updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option )
+								}
+							/>
+							<ProductFilterItem
+								label={ translate( 'Type' ) }
+								options={ types }
+								selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
+								onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
+							/>
+							<ProductFilterItem
+								label={ translate( 'Price' ) }
+								options={ prices }
+								selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
+								onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
+							/>
+						</MenuGroup>
+					) }
+				</DropdownMenu>
+			</div>
+
+			{ hasSelections && (
+				<Button className="product-filter-button" plain onClick={ resetFilters }>
+					{ translate( 'Reset filter' ) }
+				</Button>
+			) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/index.tsx
@@ -1,6 +1,6 @@
-import { Button, SubmenuPopover, useSubmenuPopoverProps } from '@automattic/components';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
-import { Icon, chevronRight, funnel, check } from '@wordpress/icons';
+import { Button } from '@automattic/components';
+import { DropdownMenu, MenuGroup } from '@wordpress/components';
+import { funnel } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import {
@@ -8,48 +8,17 @@ import {
 	PRODUCT_FILTER_KEY_PRICES,
 	PRODUCT_FILTER_KEY_TYPES,
 } from '../../constants';
-import { SelectedFilters, hasSelectedFilter } from '../../lib/product-filter';
+import {
+	SelectedFilters,
+	hasSelectedFilter,
+	hasSelectedFilterByType,
+} from '../../lib/product-filter';
 import useOnScreen from './hooks/use-on-screen';
 import useProductFilterOptions from './hooks/use-product-filter-options';
+import { ProductFilterItem } from './product-filter-item';
+import { ProductFilterSelect } from './product-filter-select';
 
 import './style.scss';
-
-type ProductFilterItemProps = {
-	label: string;
-	options: { key: string; label: string }[];
-	selectedOptions: { [ key: string ]: boolean };
-	onOptionClick?: ( option: string ) => void;
-};
-
-export function ProductFilterItem( {
-	label,
-	options,
-	selectedOptions,
-	onOptionClick,
-}: ProductFilterItemProps ) {
-	const submenu = useSubmenuPopoverProps< HTMLDivElement >( {
-		flip: false,
-	} );
-
-	return (
-		<div { ...submenu.parent }>
-			<MenuItem icon={ chevronRight }>{ label }</MenuItem>
-			<SubmenuPopover { ...submenu.submenu } className="components-popover is-product-filter">
-				<MenuGroup className="product-filter__group">
-					{ options.map( ( option ) => (
-						<MenuItem key={ option.key } onClick={ () => onOptionClick?.( option.key ) }>
-							<Icon
-								icon={ check }
-								style={ { visibility: selectedOptions[ option.key ] ? 'visible' : 'hidden' } } // We need to hide the check icon but still keep the space for it
-							/>
-							{ option.label }
-						</MenuItem>
-					) ) }
-				</MenuGroup>
-			</SubmenuPopover>
-		</div>
-	);
-}
 
 type Props = {
 	selectedFilters: SelectedFilters;
@@ -135,6 +104,33 @@ export default function ProductFilter( {
 					) }
 				</DropdownMenu>
 			</div>
+
+			{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] ) && (
+				<ProductFilterSelect
+					label={ translate( 'Category' ) }
+					options={ categories }
+					selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_CATEGORIES ] }
+					onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_CATEGORIES, option ) }
+				/>
+			) }
+
+			{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] ) && (
+				<ProductFilterSelect
+					label={ translate( 'Type' ) }
+					options={ types }
+					selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_TYPES ] }
+					onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_TYPES, option ) }
+				/>
+			) }
+
+			{ hasSelectedFilterByType( selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] ) && (
+				<ProductFilterSelect
+					label={ translate( 'Price' ) }
+					options={ prices }
+					selectedOptions={ selectedFilters[ PRODUCT_FILTER_KEY_PRICES ] }
+					onOptionClick={ ( option ) => updateFilter( PRODUCT_FILTER_KEY_PRICES, option ) }
+				/>
+			) }
 
 			{ hasSelections && (
 				<Button className="product-filter-button" plain onClick={ resetFilters }>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/product-filter-item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/product-filter-item.tsx
@@ -1,0 +1,35 @@
+import { SubmenuPopover, useSubmenuPopoverProps } from '@automattic/components';
+import { MenuGroup, MenuItem } from '@wordpress/components';
+import { Icon, chevronRight, check } from '@wordpress/icons';
+
+type Props = {
+	label: string;
+	options: { key: string; label: string }[];
+	selectedOptions: { [ key: string ]: boolean };
+	onOptionClick?: ( option: string ) => void;
+};
+
+export function ProductFilterItem( { label, options, selectedOptions, onOptionClick }: Props ) {
+	const submenu = useSubmenuPopoverProps< HTMLDivElement >( {
+		flip: false,
+	} );
+
+	return (
+		<div { ...submenu.parent }>
+			<MenuItem icon={ chevronRight }>{ label }</MenuItem>
+			<SubmenuPopover { ...submenu.submenu } className="components-popover is-product-filter">
+				<MenuGroup className="product-filter__group">
+					{ options.map( ( option ) => (
+						<MenuItem key={ option.key } onClick={ () => onOptionClick?.( option.key ) }>
+							<Icon
+								icon={ check }
+								style={ { visibility: selectedOptions[ option.key ] ? 'visible' : 'hidden' } } // We need to hide the check icon but still keep the space for it
+							/>
+							{ option.label }
+						</MenuItem>
+					) ) }
+				</MenuGroup>
+			</SubmenuPopover>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/product-filter-select.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/product-filter-select.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@automattic/components';
 import { Icon, check, chevronDown } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import useOnScreen from './hooks/use-on-screen';
 
 type Props = {
 	label: string;
@@ -14,6 +15,7 @@ type Props = {
 
 export function ProductFilterSelect( { label, options, selectedOptions, onOptionClick }: Props ) {
 	const buttonRef = useRef< HTMLButtonElement | null >( null );
+	const isVisible = useOnScreen( buttonRef );
 
 	const [ openDropdown, setOpenDropdown ] = useState< boolean >( false );
 
@@ -30,8 +32,15 @@ export function ProductFilterSelect( { label, options, selectedOptions, onOption
 			'%(filterLabel)s is the filter label and %(filterCount)d is the number of selected filters',
 	} );
 
+	useEffect( () => {
+		// Dropdown doesn't play well with our layout when scrolling. We need to close it when the Select button is not visible to avoid overlapping issues.
+		if ( openDropdown && ! isVisible ) {
+			setOpenDropdown( false );
+		}
+	}, [ isVisible, openDropdown ] );
+
 	return (
-		<>
+		<div className="product-filter-select">
 			<Button
 				ref={ buttonRef }
 				className="product-filter-button"
@@ -58,6 +67,6 @@ export function ProductFilterSelect( { label, options, selectedOptions, onOption
 					</PopoverMenuItem>
 				) ) }
 			</PopoverMenu>
-		</>
+		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/product-filter-select.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/product-filter-select.tsx
@@ -1,0 +1,63 @@
+import { Button } from '@automattic/components';
+import { Icon, check, chevronDown } from '@wordpress/icons';
+import { translate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+type Props = {
+	label: string;
+	options: { key: string; label: string }[];
+	selectedOptions: { [ key: string ]: boolean };
+	onOptionClick?: ( option: string ) => void;
+};
+
+export function ProductFilterSelect( { label, options, selectedOptions, onOptionClick }: Props ) {
+	const buttonRef = useRef< HTMLButtonElement | null >( null );
+
+	const [ openDropdown, setOpenDropdown ] = useState< boolean >( false );
+
+	const selectedOptionsCount = Object.values( selectedOptions ).filter(
+		( isSelected ) => isSelected
+	).length;
+
+	const buttonText = translate( '%(filterLabel)s (%(filterCount)d)', {
+		args: {
+			filterLabel: label,
+			filterCount: selectedOptionsCount,
+		},
+		comment:
+			'%(filterLabel)s is the filter label and %(filterCount)d is the number of selected filters',
+	} );
+
+	return (
+		<>
+			<Button
+				ref={ buttonRef }
+				className="product-filter-button"
+				plain
+				onClick={ () => setOpenDropdown( true ) }
+			>
+				{ buttonText } <Icon icon={ chevronDown } />
+			</Button>
+
+			<PopoverMenu
+				context={ buttonRef.current }
+				isVisible={ openDropdown }
+				onClose={ () => setOpenDropdown( false ) }
+				position="bottom right"
+			>
+				{ options.map( ( option ) => (
+					<PopoverMenuItem key={ option.key } onClick={ () => onOptionClick?.( option.key ) }>
+						<Icon
+							className="gridicon"
+							icon={ check }
+							style={ { visibility: selectedOptions[ option.key ] ? 'visible' : 'hidden' } } // We need to hide the check icon but still keep the space for it
+						/>
+						{ option.label }
+					</PopoverMenuItem>
+				) ) }
+			</PopoverMenu>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -3,6 +3,12 @@
 	max-width: 33px;
 }
 
+.product-filter-container {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+}
+
 .components-popover.is-product-filter {
 	border-radius: 4px;
 	border: 1px solid var(--color-neutral-5);
@@ -30,4 +36,25 @@
 .product-filter__group .components-menu-item__item {
 	display: flex;
 	gap: 8px;
+}
+
+.product-filter-button {
+	white-space: nowrap;
+	max-height: 36px;
+	font-size: rem(13px);
+	cursor: pointer;
+	color: var(--color-primary-60);
+	padding: 8px 12px;
+	border-radius: 4px;
+
+	&:focus-visible {
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		outline: 3px solid transparent;
+	}
+
+	&:hover {
+		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
+		color: var(--color-accent-60);
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -32,9 +32,10 @@
 	&:hover:not(:disabled) {
 		border: none;
 		box-shadow: none;
-		background: var(--wp-components-color-accent);
-		color: var(--color-text-inverted);
-		fill: var(--color-text-inverted);
+	}
+
+	&:hover:not(:disabled) {
+		background-color: var(--color-neutral-0);
 	}
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -29,7 +29,9 @@
 	&:hover:not(:disabled) {
 		border: none;
 		box-shadow: none;
-		background-color: var(--color-neutral-0);
+		background: var(--wp-components-color-accent);
+		color: var(--color-text-inverted);
+		fill: var(--color-text-inverted);
 	}
 }
 
@@ -44,8 +46,14 @@
 	font-size: rem(13px);
 	cursor: pointer;
 	color: var(--color-primary-60);
+	fill: var(--color-primary-60);
 	padding: 8px 12px;
 	border-radius: 4px;
+
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
 
 	&:focus-visible {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
@@ -55,6 +63,7 @@
 	&:hover {
 		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
 		color: var(--color-accent-60);
+		fill: var(--color-accent-60);
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .product-filter {
 	max-height: 33px;
 	max-width: 33px;
@@ -65,5 +68,13 @@
 		color: var(--color-accent-60);
 		fill: var(--color-accent-60);
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+	}
+}
+
+.product-filter-select {
+	display: none;
+
+	@include break-wide {
+		display: block;
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/empty-result-message.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/empty-result-message.tsx
@@ -7,7 +7,7 @@ export default function EmptyResultMessage() {
 	return (
 		<Card className="product-listing__empty-result-message">
 			<div className="product-listing__empty-result-message-heading">
-				{ translate( 'Sorry, no result found.' ) }
+				{ translate( 'Sorry, no results found.' ) }
 			</div>
 
 			<div className="product-listing__empty-result-message-description">

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/empty-result-message.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/empty-result-message.tsx
@@ -1,0 +1,20 @@
+import { Card } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+export default function EmptyResultMessage() {
+	const translate = useTranslate();
+
+	return (
+		<Card className="product-listing__empty-result-message">
+			<div className="product-listing__empty-result-message-heading">
+				{ translate( 'Sorry, no result found.' ) }
+			</div>
+
+			<div className="product-listing__empty-result-message-description">
+				{ translate(
+					"Please try refining your search and filtering to find what you're looking for."
+				) }
+			</div>
+		</Card>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-selected-product-filters.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/hooks/use-selected-product-filters.tsx
@@ -5,7 +5,7 @@ import {
 	PRODUCT_FILTER_KEY_PRICES,
 	PRODUCT_FILTER_KEY_TYPES,
 } from '../../../constants';
-import { SelectedFilters, hasSelectedFilter } from '../../../lib/product-filter';
+import { SelectedFilters } from '../../../lib/product-filter';
 
 const DEFAULT_SELECTED_FILTERS = {
 	[ PRODUCT_FILTER_KEY_BRAND ]: '',
@@ -43,7 +43,6 @@ export default function useSelectedProductFilters( { productBrand }: Props ) {
 			selectedFilters,
 			setSelectedFilters,
 			resetFilters,
-			hasSelected: hasSelectedFilter( selectedFilters ),
 		} ),
 		[ resetFilters, selectedFilters ]
 	);

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -1,4 +1,4 @@
-import { Button, JetpackLogo, WooLogo } from '@automattic/components';
+import { JetpackLogo, WooLogo } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
@@ -54,12 +54,9 @@ export default function ProductListing( {
 		setSelectedSize: setSelectedBundleSize,
 	} = useProductBundleSize();
 
-	const {
-		selectedFilters,
-		setSelectedFilters,
-		resetFilters,
-		hasSelected: shouldShowResetButton,
-	} = useSelectedProductFilters( { productBrand } );
+	const { selectedFilters, setSelectedFilters, resetFilters } = useSelectedProductFilters( {
+		productBrand,
+	} );
 
 	const quantity = useMemo(
 		() => ( isReferingProducts ? 1 : selectedBundleSize ),
@@ -314,13 +311,8 @@ export default function ProductListing( {
 					<ProductFilter
 						selectedFilters={ selectedFilters }
 						setSelectedFilters={ setSelectedFilters }
+						resetFilters={ resetFilters }
 					/>
-
-					{ shouldShowResetButton && (
-						<Button className="product-listing__reset-filter-button" plain onClick={ resetFilters }>
-							{ translate( 'Reset filter' ) }
-						</Button>
-					) }
 				</div>
 
 				{ ! isReferingProducts && availableBundleSizes.length > 1 && (

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -303,7 +303,7 @@ export default function ProductListing( {
 			<div className="product-listing__actions">
 				<div className="product-listing__actions-search-and-filter">
 					<FilterSearch
-						label={ translate( 'Search' ) }
+						label={ translate( 'Search products' ) }
 						onSearch={ onProductSearch }
 						onClick={ trackClickCallback( 'search' ) }
 					/>

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -17,6 +17,7 @@ import ListingSection from '../../listing-section';
 import MultiProductCard from '../multi-product-card';
 import ProductCard from '../product-card';
 import ProductFilter from '../product-filter';
+import EmptyResultMessage from './empty-result-message';
 import { getSupportedBundleSizes, useProductBundleSize } from './hooks/use-product-bundle-size';
 import useSelectedProductFilters from './hooks/use-selected-product-filters';
 import useSubmitForm from './hooks/use-submit-form';
@@ -80,6 +81,8 @@ export default function ProductListing( {
 		selectedProductFilters: selectedFilters,
 		productSearchQuery,
 	} );
+
+	const isEmptyList = ! filteredProductsAndBundles.length;
 
 	// Create a ref for `filteredProductsAndBundles` to prevent unnecessary re-renders caused by the `useEffect` hook.
 	const filteredProductsAndBundlesRef = useRef( filteredProductsAndBundles );
@@ -328,6 +331,12 @@ export default function ProductListing( {
 					/>
 				) }
 			</div>
+
+			{ isEmptyList && (
+				<div className="product-listing">
+					<EmptyResultMessage />
+				</div>
+			) }
 
 			{ wooExtensions.length > 0 && (
 				<ListingSection

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -116,3 +116,21 @@ p.product-listing__description {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 	}
 }
+
+.product-listing__empty-result-message {
+	text-align: center;
+	padding: 16px;
+	border-radius: 4px;
+	max-width: 800px;
+	margin: 64px auto 0;
+}
+
+.product-listing__empty-result-message-heading {
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.product-listing__empty-result-message-description {
+	font-size: rem(14px);
+	color: var(--color-neutral-50);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -96,27 +96,6 @@ p.product-listing__description {
 	gap: 8px;
 }
 
-.product-listing__reset-filter-button {
-	white-space: nowrap;
-	max-height: 36px;
-	font-size: rem(13px);
-	cursor: pointer;
-	color: var(--color-primary-60);
-	padding: 8px 12px;
-	border-radius: 4px;
-
-	&:focus-visible {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
-		outline: 3px solid transparent;
-	}
-
-	&:hover {
-		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
-		color: var(--color-accent-60);
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-	}
-}
-
 .product-listing__empty-result-message {
 	text-align: center;
 	padding: 16px;


### PR DESCRIPTION
This pull request makes several improvements to the product marketplace filtering capabilities based on previous feedback.

Follow up on https://github.com/Automattic/wp-calypso/pull/91085
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/590

## Proposed Changes

* Change the 'Search' label to 'Search products'.

| Before | After |
|--------|--------|
| <img width="201" alt="Screenshot 2024-05-30 at 8 57 56 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/02c38b96-c0c5-40fc-b736-76402585a59c"> | <img width="216" alt="Screenshot 2024-05-30 at 8 56 49 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8994931b-c3bc-4f82-a228-c385bf8f58f2"> |

* Correct the 'Addon' type label to 'Add-on'.

| Before | After |
|--------|--------|
| <img width="508" alt="Screenshot 2024-05-30 at 8 59 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7025b0f6-5be5-4f46-8bcf-600b834d400b"> | <img width="479" alt="Screenshot 2024-05-30 at 9 03 12 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b2afe128-3a5b-4c3b-ab3d-c0dd627d0ca8"> | 

* Show an empty result message when no product matches.
   <img width="1579" alt="Screenshot 2024-05-30 at 9 04 30 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/26741ee1-5c0d-45a0-ad77-5c451eda258d">
* Show filtering dropdown shortcuts when there is active filter.
   <img width="657" alt="Screenshot 2024-05-30 at 9 04 52 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b8634d6a-bb30-4058-8b93-0efd7529b083">

## Testing Instructions


* Use the A4A live link and go to `/marketplace/products`
* Confirm that the 'Search products' label is visible in the Search component.
* Click the Filter icon and hover on Type.
* Confirm that the 'Add-on' label is correct.
* Select some filters for category, type, and price.
* Confirm that a dropdown shortcut is visible.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
