### PR TITLE
Site Migrations: Fix `has_source_site` tracks param

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -48,7 +48,7 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 
 	const customTracksEventProps = {
 		from: migrateFrom,
-		has_source_site: migrateFrom !== '',
+		has_source_site: migrateFrom !== '' && migrateFrom !== null,
 	};
 
 	const stepContent = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/91071

## Proposed Changes

* Noticed a bug in the recently deployed change to Tracks events on the site migration upgrades step; you can have an empty `from` parameter but `has_source_site` will be `true` because it's not checking for null:

<img width="533" alt="Screenshot 2024-05-30 at 8 59 50 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/34ab055a-d18b-4e6e-8d37-2c321d2b56db">

* Fix the comparison to check for `null` values as well as empty strings.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR and ensure you can see Tracks events in the console/Tracks Vigilante
* Navigate to `/start`
* At the goals step select Import
* Enter your URL
* Choose Everything
* At the upgrade step, you should see the following Tracks event fire with the following properties:

<img width="818" alt="Screenshot 2024-05-30 at 9 15 35 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/20429836-621e-48ec-aa4b-6c7b6addb746">

* Now go back to the URL entry step; don't check out or start the migration.
* Instead of putting in a URL, choose "pick your current platform from a list"
* Choose WordPress
* Choose Everything
* At the upgrade step, you should see the following Tracks event fire with the following properties:

<img width="815" alt="Screenshot 2024-05-30 at 9 16 20 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/75d50782-3686-4c3c-8cb6-da82f54d0115">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
