### PR TITLE
Sites Dashboard: Remove "View all sites" tooltip

### DIFF
--- a/client/layout/global-sidebar/header.tsx
+++ b/client/layout/global-sidebar/header.tsx
@@ -16,8 +16,6 @@ export const GlobalSidebarHeader = () => {
 			<SidebarMenuItem
 				url="/sites"
 				className="link-logo"
-				tooltip={ translate( 'View all sites' ) }
-				tooltipPlacement="bottom"
 				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.ALLSITES_CLICK ) }
 				icon={ <span className="dotcom"></span> }
 			/>

--- a/client/layout/global-sidebar/menu-items/menu-item.tsx
+++ b/client/layout/global-sidebar/menu-items/menu-item.tsx
@@ -10,8 +10,8 @@ interface Props {
 	url?: string;
 	tipTarget?: string;
 	onClick: () => void;
-	tooltip: string;
-	tooltipPlacement: 'bottom' | 'top' | 'right';
+	tooltip?: string;
+	tooltipPlacement?: 'bottom' | 'top' | 'right';
 	icon?: ReactNode;
 	className: string;
 	isActive?: boolean;


### PR DESCRIPTION
## Proposed Changes

Removes the "View all sites" tooltip:

![CleanShot 2024-05-30 at 06 30 59@2x](https://github.com/Automattic/wp-calypso/assets/36432/552ee817-37c7-4caf-a585-06d50bb8b709)

See p1717073503209319-slack-C06DN6QQVAQ

## Why are these changes being made?

The tooltip is unnecessary.

## Testing Instructions

1. Navigate to `/sites`.
2. Hover over the WordPress.com logo.
3. Verify that no tooltip appears.