### PR TITLE
A8C For Agencies: Agency HQ Overview: Hide "Explore Pressable" when Agency already has a Pressable subscription

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -5,15 +5,11 @@ import { useCallback } from 'react';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
 import Offering from 'calypso/a8c-for-agencies/components/offering';
 import { OfferingItemProps } from 'calypso/a8c-for-agencies/components/offering/types';
-import {
-	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
-	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import { A4A_MARKETPLACE_HOSTING_WPCOM_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-
 import './styles.scss';
+import PressableOffering from './pressable-oferring';
 
 const OverviewBodyHosting = () => {
 	const translate = useTranslate();
@@ -30,30 +26,6 @@ const OverviewBodyHosting = () => {
 		},
 		[ dispatch ]
 	);
-
-	const pressable: OfferingItemProps = {
-		//translators: Title for the action card
-		title: translate( 'Pressable' ),
-		titleIcon: <img src={ pressableIcon } alt="Pressable" />,
-		description: translate(
-			'Pressable offers world-class managed WordPress hosting for agencies with award-winning support, powerful site management, and flexible plans that scale with your business.'
-		),
-		highlights: [
-			translate( 'Git integration, WP-CLI, SSH, and staging.' ),
-			translate( 'Lightning-fast performance.' ),
-			translate( '100% uptime SLA.' ),
-			translate( 'Smart, managed plugin updates.' ),
-			translate( 'Comprehensive WP security with Jetpack.' ),
-			translate( '24/7 support from WordPress experts.' ),
-		],
-		// translators: Button navigating to A4A Marketplace
-		buttonTitle: translate( 'Explore Pressable' ),
-		expanded: true,
-		actionHandler: () => {
-			actionHandlerCallback( 'hosting', 'pressable' );
-			page( A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK );
-		},
-	};
 
 	const wpcom: OfferingItemProps = {
 		//translators: Title for the action card
@@ -92,9 +64,10 @@ const OverviewBodyHosting = () => {
 			description={ translate(
 				'Choose the hosting that suits your needs from our best-in-class offerings.'
 			) }
-			items={ [ pressable, wpcom ] }
+			items={ [ wpcom ] }
 		>
 			{ migrationOffer }
+			<PressableOffering />
 		</Offering>
 	);
 };

--- a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-oferring.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-oferring.tsx
@@ -1,0 +1,94 @@
+import page from '@automattic/calypso-router';
+import { Badge, Button, FoldableCard, Gridicon } from '@automattic/components';
+import { Icon, external } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'react-redux';
+import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+
+const pressableUrl = 'https://my.pressable.com/agency/auth';
+
+const PressableOffering = () => {
+	const translate = useTranslate();
+	const agency = useSelector( getActiveAgency );
+	const dispatch = useDispatch();
+	const isPressableRegular =
+		null === agency?.third_party?.pressable?.a4a_id && agency?.third_party.pressable.pressable_id;
+
+	const highlights = [
+		translate( 'Git integration, WP-CLI, SSH, and staging.' ),
+		translate( 'Lightning-fast performance.' ),
+		translate( '100% uptime SLA.' ),
+		translate( 'Smart, managed plugin updates.' ),
+		translate( 'Comprehensive WP security with Jetpack.' ),
+		translate( '24/7 support from WordPress experts.' ),
+	];
+
+	const handleActionButtonClick = () => {
+		page( A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK );
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_overview_click_open_marketplace', {
+				section: 'hosting',
+				product: 'pressable',
+			} )
+		);
+	};
+
+	const header = (
+		<div className="a4a-offering-item__title-container">
+			<img src={ pressableIcon } alt="Pressable" />
+			<div className="a4a-overview-pressable-offering-header-title">
+				<h3 className="a4a-offering-item__title">
+					{ translate( 'Pressale' ) }
+					{ isPressableRegular && (
+						<Badge type="success">{ translate( "You're signed up!" ) }</Badge>
+					) }
+				</h3>
+			</div>
+		</div>
+	);
+
+	return (
+		<FoldableCard
+			className="a4a-oferring-item-pressable a4a-offering-item__card"
+			header={ header }
+			expanded
+		>
+			<p className="a4a-offering-item__description">
+				{ translate(
+					'Pressable offers world-class managed WordPress hosting for agencies with award-winning support, powerful site management, and flexible plans that scale with your business.'
+				) }
+			</p>
+			<ul className="a4a-offering-item__card-list">
+				{ highlights.map( ( highlightItemText ) => (
+					<li className="a4a-offering-item__card-list-item" key={ highlightItemText }>
+						<div className="a4a-offering-item__icon-container">
+							<Gridicon className="a4a-offering-item__gridicon" icon="checkmark" size={ 18 } />
+						</div>
+						<span className="a4a-offering-item__text">{ highlightItemText }</span>
+					</li>
+				) ) }
+			</ul>
+			{ ! isPressableRegular ? (
+				<Button className="a4a-offering-item__button" onClick={ handleActionButtonClick } primary>
+					{ translate( 'Explore Pressable' ) }
+				</Button>
+			) : (
+				<Button
+					className="a4a-offering-item__button"
+					primary
+					target="_blank"
+					rel="norefferer nooppener"
+					href={ pressableUrl }
+				>
+					{ translate( 'View your dashboard' ) }
+					<Icon icon={ external } size={ 18 } />
+				</Button>
+			) }
+		</FoldableCard>
+	);
+};
+
+export default PressableOffering;

--- a/client/a8c-for-agencies/sections/overview/body/hosting/styles.scss
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/styles.scss
@@ -2,3 +2,22 @@
 	fill: var(--color-primary-50);
 	margin: 0;
 }
+
+.a4a-overview-pressable-offering-header-title {
+	.badge {
+		margin-left: 12px;
+	}
+
+	.badge--success {
+		background: var(--studio-green-5);
+		color: var(--studio-green-50);
+	}
+	.badge--warning {
+		background: var(--studio-yellow-5);
+		color: var(--studio-yellow-70);
+	}
+	.badge--error {
+		background: var(--studio-red-5);
+		color: var(--studio-red-70);
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This "Pressable" card should be changed for agencies that already have a Pressable account, as it gives access to a page where they can acquire Pressable licenses, leading their account to a broken state of having multiple Pressable subscriptions. Pressable regulars need to be directed to Pressable dashboard.

![image](https://github.com/Automattic/wp-calypso/assets/5550190/2e2e55d8-291f-46b4-8761-379938148da3)


- How it should be for Pressable Regulars
![image](https://github.com/Automattic/wp-calypso/assets/5550190/ea92bb6d-eaeb-453a-9654-173accd7e0ef)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Having a regular Pressable account registered with the same email used for your A4A account, access the Agency HQ Overview ( http://agencies.localhost:3000/overview )
* You should see the Pressable card on the hosing offers like above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
