### PR TITLE
Tweak page layouts heading in Pattern Library

### DIFF
--- a/client/my-sites/patterns/components/pattern-library/index.tsx
+++ b/client/my-sites/patterns/components/pattern-library/index.tsx
@@ -1,6 +1,10 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import { useLocale, addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
+import {
+	useLocale,
+	addLocaleToPathLocaleInFront,
+	useHasEnTranslation,
+} from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Icon, category as iconCategory } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -77,6 +81,7 @@ export const PatternLibrary = ( {
 }: PatternLibraryProps ) => {
 	const locale = useLocale();
 	const translate = useTranslate();
+	const hasTranslation = useHasEnTranslation();
 	const navRef = useRef< HTMLDivElement >( null );
 
 	const { recordPatternsEvent } = useRecordPatternsEvent();
@@ -219,6 +224,18 @@ export const PatternLibrary = ( {
 		} );
 	}
 
+	const pageLayoutsHeading = hasTranslation( 'Beautiful, curated page layouts' )
+		? translate( 'Beautiful, curated page layouts', {
+				comment:
+					'Heading text for a section in the Pattern Library with links to block pattern categories containing page layouts',
+				textOnly: true,
+		  } )
+		: translate( 'Beautifully curated page layouts', {
+				comment:
+					'Heading text for a section in the Pattern Library with links to block pattern categories containing page layouts',
+				textOnly: true,
+		  } );
+
 	return (
 		<>
 			{ isHomePage ? (
@@ -344,11 +361,7 @@ export const PatternLibrary = ( {
 
 				{ isHomePage && (
 					<CategoryGallery
-						title={ translate( 'Beautifully curated page layouts', {
-							comment:
-								'Heading text for a section in the Pattern Library with links to block pattern categories containing page layouts',
-							textOnly: true,
-						} ) }
+						title={ pageLayoutsHeading }
 						description={ translate(
 							'Start even faster with ready-to-use pages and preassembled patterns. Then tweak the design until it’s just right.'
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1717076684003709/1717024845.301409-slack-C048CUFRGFQ

## Proposed Changes

Tweak the page layouts heading on wordpress.com/patterns (because it sounds weird currently).

| Before | After |
| - | - |
| ![wordpress com_patterns_(Medium laptop)](https://github.com/Automattic/wp-calypso/assets/1101677/d7205624-089b-4b5a-863a-0dee43c77c88) | ![calypso localhost_3000_patterns(Medium laptop)](https://github.com/Automattic/wp-calypso/assets/1101677/f2b4ef96-1a03-461d-aa78-87b5ac8edaf6) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice