### PR TITLE
Scheduled Updates: Wrap the single site context with the Card component

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -98,7 +98,8 @@ $brand-display: "SF Pro Display", sans-serif;
 			padding: 0.5rem 0.125rem;
 			vertical-align: middle;
 
-			&.last-update {
+			&.last-update,
+			&.next-update {
 				min-width: 200px;
 			}
 
@@ -116,17 +117,23 @@ $brand-display: "SF Pro Display", sans-serif;
 			}
 
 			&.name {
-				width: 300px;
+				min-width: 150px;
 			}
 
 			&.sites {
-				width: 80px;
+				min-width: 80px;
 			}
 
 			&.menu {
 				text-align: center;
 			}
 		}
+
+	}
+
+	.schedule-list--card .components-card__body,
+	.plugins-update-manager-multisite-table-container {
+		overflow-x: scroll;
 	}
 
 	.schedule-form {

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -111,7 +111,7 @@ $brand-display: "SF Pro Display", sans-serif;
 
 			&.last-update,
 			&.next-update {
-				min-width: 200px;
+				min-width: 210px;
 			}
 
 			.badge-component {

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -144,7 +144,7 @@ $brand-display: "SF Pro Display", sans-serif;
 
 	.plugins-update-manager-multisite-table-container,
 	.schedule-list--card__single-site .components-card__body {
-		overflow-x: scroll;
+		overflow-x: auto;
 	}
 
 	.schedule-form {

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -3,6 +3,12 @@
 
 $brand-display: "SF Pro Display", sans-serif;
 
+.plugins-update-manager:not(.plugins-update-manager-multisite) {
+	.empty-state {
+		max-width: 80%;
+	}
+}
+
 .plugins-update-manager,
 .plugins-update-manager-multisite {
 	@media screen and (max-width: $break-small) {
@@ -71,6 +77,11 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		p {
 			text-align: center;
+		}
+
+		button {
+			display: flex;
+			margin: auto;
 		}
 	}
 

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -142,8 +142,8 @@ $brand-display: "SF Pro Display", sans-serif;
 
 	}
 
-	.schedule-list--card .components-card__body,
-	.plugins-update-manager-multisite-table-container {
+	.plugins-update-manager-multisite-table-container,
+	.schedule-list--card__single-site .components-card__body {
 		overflow-x: scroll;
 	}
 

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -128,7 +128,7 @@ $brand-display: "SF Pro Display", sans-serif;
 			}
 
 			&.name {
-				min-width: 150px;
+				min-width: 180px;
 			}
 
 			&.sites {

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -66,7 +66,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 				<td className="last-update">
 					<ScheduleListLastRunStatus schedule={ schedule } />
 				</td>
-				<td>{ prepareDateTime( schedule.timestamp ) }</td>
+				<td className="next-update">{ prepareDateTime( schedule.timestamp ) }</td>
 
 				<td>
 					{

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table.tsx
@@ -16,45 +16,47 @@ export const ScheduleListTable = ( props: Props ) => {
 	const translate = useTranslate();
 
 	return (
-		<table className="plugins-update-manager-multisite-table">
-			<thead>
-				<tr>
-					<th className="expand"></th>
-					<th>{ translate( 'Name' ) }</th>
-					<th>{ translate( 'Sites' ) }</th>
-					<th>{ translate( 'Last update' ) }</th>
-					<th>{ translate( 'Next update' ) }</th>
-					<th>{ translate( 'Frequency' ) }</th>
-					<th>{ translate( 'Plugins' ) }</th>
-					<th>{ translate( 'Active' ) }</th>
-					<th></th>
-				</tr>
-			</thead>
-			<tbody>
-				{ schedules.map( ( schedule ) => (
-					<ScheduleListTableRow
-						schedule={ schedule }
-						onEditClick={ onEditClick }
-						onRemoveClick={ onRemoveClick }
-						onLogsClick={ onLogsClick }
-						key={ schedule.id }
-					/>
-				) ) }
-
-				{ schedules.length === 0 && (
+		<div className="plugins-update-manager-multisite-table-container">
+			<table className="plugins-update-manager-multisite-table">
+				<thead>
 					<tr>
-						<td colSpan={ 9 }>
-							<div className="empty-state empty-state__center">
-								<p>
-									{ translate(
-										"Oops! We couldn't find any schedules based on your search criteria. You might want to check your search terms and try again."
-									) }
-								</p>
-							</div>
-						</td>
+						<th className="expand"></th>
+						<th>{ translate( 'Name' ) }</th>
+						<th>{ translate( 'Sites' ) }</th>
+						<th>{ translate( 'Last update' ) }</th>
+						<th>{ translate( 'Next update' ) }</th>
+						<th>{ translate( 'Frequency' ) }</th>
+						<th>{ translate( 'Plugins' ) }</th>
+						<th>{ translate( 'Active' ) }</th>
+						<th></th>
 					</tr>
-				) }
-			</tbody>
-		</table>
+				</thead>
+				<tbody>
+					{ schedules.map( ( schedule ) => (
+						<ScheduleListTableRow
+							schedule={ schedule }
+							onEditClick={ onEditClick }
+							onRemoveClick={ onRemoveClick }
+							onLogsClick={ onLogsClick }
+							key={ schedule.id }
+						/>
+					) ) }
+
+					{ schedules.length === 0 && (
+						<tr>
+							<td colSpan={ 9 }>
+								<div className="empty-state empty-state__center">
+									<p>
+										{ translate(
+											"Oops! We couldn't find any schedules based on your search criteria. You might want to check your search terms and try again."
+										) }
+									</p>
+								</div>
+							</td>
+						</tr>
+					) }
+				</tbody>
+			</table>
+		</div>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -94,7 +94,6 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		edit: {
 			component: <ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />,
 			title: translate( 'Edit schedule' ),
-			showClose: true,
 		},
 		notifications: {
 			component: <NotificationSettings onNavBack={ onNavBack } />,

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -115,42 +114,32 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 					subtitle={ translate(
 						'Streamline your workflow with scheduled updates, timed to suit your needs.'
 					) }
-				/>
-				<div
-					className={ classnames(
-						'plugins-update-manager__header',
-						context !== 'list' ? 'no-border' : null
-					) }
 				>
-					<div className="buttons">
-						{ context === 'list' && (
-							<>
-								{ onNotificationManagement && (
-									<Button
-										__next40pxDefaultSize
-										variant="secondary"
-										onClick={ onNotificationManagement }
-									>
-										{ translate( 'Notification settings' ) }
-									</Button>
-								) }
+					{ context === 'list' && (
+						<>
+							{ onNotificationManagement && (
+								<Button
+									__next40pxDefaultSize
+									variant="secondary"
+									onClick={ onNotificationManagement }
+								>
+									{ translate( 'Notification settings' ) }
+								</Button>
+							) }
 
-								{ onCreateNewSchedule && ! hideCreateButton && (
-									<Button
-										__next40pxDefaultSize
-										variant={
-											canCreateSchedules && siteHasEligiblePlugins ? 'primary' : 'secondary'
-										}
-										onClick={ onCreateNewSchedule }
-										disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
-									>
-										{ translate( 'New Schedule' ) }
-									</Button>
-								) }
-							</>
-						) }
-					</div>
-				</div>
+							{ onCreateNewSchedule && ! hideCreateButton && (
+								<Button
+									__next40pxDefaultSize
+									variant={ canCreateSchedules && siteHasEligiblePlugins ? 'primary' : 'secondary' }
+									onClick={ onCreateNewSchedule }
+									disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
+								>
+									{ translate( 'New Schedule' ) }
+								</Button>
+							) }
+						</>
+					) }
+				</NavigationHeader>
 				<ScheduledUpdatesGate siteId={ siteId as number }>{ component }</ScheduledUpdatesGate>
 			</MainComponent>
 		</PluginUpdateManagerContextProvider>

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -99,7 +99,6 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		notifications: {
 			component: <NotificationSettings onNavBack={ onNavBack } />,
 			title: translate( 'Notification settings' ),
-			showClose: true,
 		},
 	}[ context ];
 

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -5,6 +5,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import MainComponent from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ScheduledUpdatesGate from 'calypso/components/scheduled-updates/scheduled-updates-gate';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -60,7 +62,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		} );
 	}, [ context, siteSlug ] );
 
-	const [ navigationTitle, setNavigationTitle ] = useState< string | null >( null );
+	const [ , setNavigationTitle ] = useState< string | null >( null );
 
 	const { component, title, showClose } = {
 		logs: {
@@ -88,7 +90,6 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		create: {
 			component: <ScheduleCreate onNavBack={ onNavBack } />,
 			title: translate( 'New schedule' ),
-			showClose: true,
 		},
 		edit: {
 			component: <ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />,
@@ -110,14 +111,21 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		<PluginUpdateManagerContextProvider siteSlug={ siteSlug }>
 			<DocumentHead title={ title } />
 			{ ! isSitePlansLoaded && <QuerySitePlans siteId={ siteId } /> }
-			<div className="plugins-update-manager">
+			<MainComponent wideLayout>
+				<NavigationHeader
+					className="plugins-update-manager-header"
+					navigationItems={ [] }
+					title={ translate( 'Plugin Update Manager' ) }
+					subtitle={ translate(
+						'Streamline your workflow with scheduled updates, timed to suit your needs.'
+					) }
+				/>
 				<div
 					className={ classnames(
 						'plugins-update-manager__header',
 						context !== 'list' ? 'no-border' : null
 					) }
 				>
-					<h1>{ navigationTitle }</h1>
 					<div className="buttons">
 						{ context === 'list' && (
 							<>
@@ -153,7 +161,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 					</div>
 				</div>
 				<ScheduledUpdatesGate siteId={ siteId as number }>{ component }</ScheduledUpdatesGate>
-			</div>
+			</MainComponent>
 		</PluginUpdateManagerContextProvider>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { close, Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -64,7 +63,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 
 	const [ , setNavigationTitle ] = useState< string | null >( null );
 
-	const { component, title, showClose } = {
+	const { component, title } = {
 		logs: {
 			component: (
 				<ScheduleLogs
@@ -74,7 +73,6 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 				/>
 			),
 			title: translate( 'Scheduled Updates Logs' ),
-			showClose: true,
 		},
 		list: {
 			component: (
@@ -150,11 +148,6 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 									</Button>
 								) }
 							</>
-						) }
-						{ showClose && (
-							<Button onClick={ onNavBack }>
-								<Icon icon={ close } />
-							</Button>
 						) }
 					</div>
 				</div>

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -111,7 +111,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 		<PluginUpdateManagerContextProvider siteSlug={ siteSlug }>
 			<DocumentHead title={ title } />
 			{ ! isSitePlansLoaded && <QuerySitePlans siteId={ siteId } /> }
-			<MainComponent wideLayout>
+			<MainComponent wideLayout className="plugins-update-manager">
 				<NavigationHeader
 					className="plugins-update-manager-header"
 					navigationItems={ [] }

--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -1,4 +1,13 @@
-import { __experimentalText as Text, CheckboxControl, Button } from '@wordpress/components';
+import {
+	__experimentalText as Text,
+	CheckboxControl,
+	Button,
+	Card,
+	CardHeader,
+	CardBody,
+	CardFooter,
+} from '@wordpress/components';
+import { arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import { useScheduledUpdatesNotificationSettingsMutation } from 'calypso/data/plugins/use-scheduled-updates-notification-settings-mutation';
@@ -73,47 +82,63 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 	}, [ formValues, updateNotificationSettings ] );
 
 	return (
-		<form className="notification-settings-form">
-			<label>{ translate( 'Email me' ) }</label>
-			<Text className="info-msg">
-				{ translate(
-					'Receive email notifications to stay informed about the performance of the plugin updates.'
-				) }
-			</Text>
-
-			<div className="form-field">
-				<CheckboxControl
-					label={ translate( 'On successful updates' ) }
-					checked={ formValues.success }
-					onChange={ handleCheckboxChange( 'success' ) }
-					disabled={ ! isFetched || hasGlobalNotificationsDisabled }
-				/>
-			</div>
-			<div className="form-field">
-				<CheckboxControl
-					label={ translate( 'On failed updates' ) }
-					checked={ formValues.failure }
-					onChange={ handleCheckboxChange( 'failure' ) }
-					disabled={ ! isFetched || hasGlobalNotificationsDisabled }
-				/>
-			</div>
-
-			{ hasGlobalNotificationsDisabled && (
-				<Text className="info-msg">
-					{ translate(
-						"You've opted out of WordPress.com's scheduled update notifications. Head to {{notificationSettingsLink}}Notification Settings{{/notificationSettingsLink}} to re-enable them.",
-						{
-							components: {
-								notificationSettingsLink: <a href="/me/notifications/updates" />,
-							},
-						}
+		<Card>
+			<CardHeader size="extraSmall">
+				<div className="ch-placeholder">
+					{ onNavBack && (
+						<Button icon={ arrowLeft } onClick={ onNavBack }>
+							{ translate( 'Back' ) }
+						</Button>
 					) }
-				</Text>
-			) }
+				</div>
+				<Text>{ translate( 'Notification Settings' ) }</Text>
+				<div className="ch-placeholder"></div>
+			</CardHeader>
+			<CardBody className="notification-settings-form">
+				<form>
+					<label>{ translate( 'Email me' ) }</label>
+					<Text className="info-msg">
+						{ translate(
+							'Receive email notifications to stay informed about the performance of the plugin updates.'
+						) }
+					</Text>
 
-			<Button variant="primary" disabled={ isSaving } onClick={ onSave }>
-				{ translate( 'Save' ) }
-			</Button>
-		</form>
+					<div className="form-field">
+						<CheckboxControl
+							label={ translate( 'On successful updates' ) }
+							checked={ formValues.success }
+							onChange={ handleCheckboxChange( 'success' ) }
+							disabled={ ! isFetched || hasGlobalNotificationsDisabled }
+						/>
+					</div>
+					<div className="form-field">
+						<CheckboxControl
+							label={ translate( 'On failed updates' ) }
+							checked={ formValues.failure }
+							onChange={ handleCheckboxChange( 'failure' ) }
+							disabled={ ! isFetched || hasGlobalNotificationsDisabled }
+						/>
+					</div>
+
+					{ hasGlobalNotificationsDisabled && (
+						<Text className="info-msg">
+							{ translate(
+								"You've opted out of WordPress.com's scheduled update notifications. Head to {{notificationSettingsLink}}Notification Settings{{/notificationSettingsLink}} to re-enable them.",
+								{
+									components: {
+										notificationSettingsLink: <a href="/me/notifications/updates" />,
+									},
+								}
+							) }
+						</Text>
+					) }
+				</form>
+			</CardBody>
+			<CardFooter>
+				<Button variant="primary" disabled={ isSaving } onClick={ onSave }>
+					{ translate( 'Save' ) }
+				</Button>
+			</CardFooter>
+		</Card>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/notification-settings.tsx
+++ b/client/blocks/plugins-scheduled-updates/notification-settings.tsx
@@ -82,7 +82,7 @@ export const NotificationSettings = ( { onNavBack }: Props ) => {
 	}, [ formValues, updateNotificationSettings ] );
 
 	return (
-		<Card>
+		<Card className="plugins-update-manager">
 			<CardHeader size="extraSmall">
 				<div className="ch-placeholder">
 					{ onNavBack && (

--- a/client/blocks/plugins-scheduled-updates/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-create.tsx
@@ -83,7 +83,7 @@ export const ScheduleCreate = ( props: Props ) => {
 					} }
 				/>
 			) }
-			<Card>
+			<Card className="plugins-update-manager">
 				<CardHeader size="extraSmall">
 					<div className="ch-placeholder">
 						{ onNavBack && (

--- a/client/blocks/plugins-scheduled-updates/schedule-create.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-create.tsx
@@ -1,8 +1,16 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { useMutationState } from '@tanstack/react-query';
-import { __experimentalText as Text, Button, Icon } from '@wordpress/components';
-import { info } from '@wordpress/icons';
+import {
+	__experimentalText as Text,
+	Button,
+	Icon,
+	Card,
+	CardHeader,
+	CardBody,
+	CardFooter,
+} from '@wordpress/components';
+import { info, arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { Banner } from 'calypso/components/banner';
@@ -75,26 +83,41 @@ export const ScheduleCreate = ( props: Props ) => {
 					} }
 				/>
 			) }
-
-			<ScheduleForm onSyncSuccess={ onSyncSuccess } onSyncError={ setSyncError } />
-
-			<Button
-				form="schedule"
-				type="submit"
-				variant={ canCreateSchedules ? 'primary' : 'secondary' }
-				disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
-				isBusy={ isBusy }
-				className="schedule-form-button"
-			>
-				{ translate( 'Create' ) }
-			</Button>
-			{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
-				<Text as="p" className="validation-msg">
-					<Icon className="icon-info" icon={ info } size={ 16 } />
-					{ ( eligibilityCheckErrors?.length && eligibilityCheckErrors[ 0 ].message ) || '' }
-					{ syncError }
-				</Text>
-			) }
+			<Card>
+				<CardHeader size="extraSmall">
+					<div className="ch-placeholder">
+						{ onNavBack && (
+							<Button icon={ arrowLeft } onClick={ onNavBack }>
+								{ translate( 'Back' ) }
+							</Button>
+						) }
+					</div>
+					<Text>{ translate( 'New Schedule' ) }</Text>
+					<div className="ch-placeholder"></div>
+				</CardHeader>
+				<CardBody>
+					<ScheduleForm onSyncSuccess={ onSyncSuccess } onSyncError={ setSyncError } />
+				</CardBody>
+				<CardFooter>
+					<Button
+						form="schedule"
+						type="submit"
+						variant={ canCreateSchedules ? 'primary' : 'secondary' }
+						disabled={ ! canCreateSchedules || ! siteHasEligiblePlugins }
+						isBusy={ isBusy }
+						className="schedule-form-button"
+					>
+						{ translate( 'Create' ) }
+					</Button>
+					{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
+						<Text as="p" className="validation-msg">
+							<Icon className="icon-info" icon={ info } size={ 16 } />
+							{ ( eligibilityCheckErrors?.length && eligibilityCheckErrors[ 0 ].message ) || '' }
+							{ syncError }
+						</Text>
+					) }
+				</CardFooter>
+			</Card>
 		</>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-edit.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-edit.tsx
@@ -1,7 +1,15 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutationState } from '@tanstack/react-query';
-import { __experimentalText as Text, Button, Icon } from '@wordpress/components';
-import { info } from '@wordpress/icons';
+import {
+	__experimentalText as Text,
+	Button,
+	Icon,
+	Card,
+	CardHeader,
+	CardBody,
+	CardFooter,
+} from '@wordpress/components';
+import { info, arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
@@ -59,32 +67,46 @@ export const ScheduleEdit = ( props: Props ) => {
 	};
 
 	return (
-		<>
-			{ schedule && (
-				<ScheduleForm
-					scheduleForEdit={ schedule }
-					onSyncSuccess={ onSyncSuccess }
-					onSyncError={ setSyncError }
-				/>
-			) }
-
-			<Button
-				form="schedule"
-				type="submit"
-				variant={ canCreateSchedules ? 'primary' : 'secondary' }
-				isBusy={ isBusy }
-				disabled={ ! canCreateSchedules }
-				className="schedule-form-button"
-			>
-				{ translate( 'Save' ) }
-			</Button>
-			{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
-				<Text as="p" className="validation-msg">
-					<Icon className="icon-info" icon={ info } size={ 16 } />
-					{ ( eligibilityCheckErrors?.length && eligibilityCheckErrors[ 0 ].message ) || '' }
-					{ syncError }
-				</Text>
-			) }
-		</>
+		<Card className="plugins-update-manager">
+			<CardHeader size="extraSmall">
+				<div className="ch-placeholder">
+					{ onNavBack && (
+						<Button icon={ arrowLeft } onClick={ onNavBack }>
+							{ translate( 'Back' ) }
+						</Button>
+					) }
+				</div>
+				<Text>{ translate( 'Edit Schedule' ) }</Text>
+				<div className="ch-placeholder"></div>
+			</CardHeader>
+			<CardBody>
+				{ schedule && (
+					<ScheduleForm
+						scheduleForEdit={ schedule }
+						onSyncSuccess={ onSyncSuccess }
+						onSyncError={ setSyncError }
+					/>
+				) }
+			</CardBody>
+			<CardFooter>
+				<Button
+					form="schedule"
+					type="submit"
+					variant={ canCreateSchedules ? 'primary' : 'secondary' }
+					isBusy={ isBusy }
+					disabled={ ! canCreateSchedules }
+					className="schedule-form-button"
+				>
+					{ translate( 'Save' ) }
+				</Button>
+				{ ( ( ! canCreateSchedules && eligibilityCheckErrors?.length ) || syncError ) && (
+					<Text as="p" className="validation-msg">
+						<Icon className="icon-info" icon={ info } size={ 16 } />
+						{ ( eligibilityCheckErrors?.length && eligibilityCheckErrors[ 0 ].message ) || '' }
+						{ syncError }
+					</Text>
+				) }
+			</CardFooter>
+		</Card>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-empty.tsx
@@ -15,7 +15,7 @@ export const ScheduleListEmpty = ( props: Props ) => {
 	const { siteHasEligiblePlugins } = useSiteHasEligiblePlugins();
 
 	return (
-		<div className="empty-state">
+		<div className="empty-state empty-state__center">
 			<Text as="p">
 				{ ( () => {
 					if ( ! siteHasEligiblePlugins && canCreateSchedules ) {

--- a/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list-table.tsx
@@ -80,7 +80,7 @@ export const ScheduleListTable = ( props: Props ) => {
 
 							{ ! schedule.last_run_status && ! schedule.last_run_timestamp && '-' }
 						</td>
-						<td>{ prepareDateTime( schedule.timestamp ) }</td>
+						<td className="next-update">{ prepareDateTime( schedule.timestamp ) }</td>
 						<td>
 							{
 								{

--- a/client/blocks/plugins-scheduled-updates/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list.tsx
@@ -1,3 +1,4 @@
+import { DESKTOP_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import {
 	__experimentalText as Text,
@@ -37,7 +38,7 @@ interface Props {
 export const ScheduleList = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
-	const isSmallScreen = useBreakpoint( '<660px' );
+	const isDesktopScreen = useBreakpoint( DESKTOP_BREAKPOINT );
 	const { isEligibleForFeature, loading: isEligibleForFeatureLoading } = useIsEligibleForFeature();
 	const { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading } =
 		useSiteHasEligiblePlugins();
@@ -112,7 +113,7 @@ export const ScheduleList = ( props: Props ) => {
 			>
 				{ translate( 'Are you sure you want to delete this schedule?' ) }
 			</ConfirmDialog>
-			<Card className="plugins-update-manager">
+			<Card className="plugins-update-manager schedule-list--card__single-site">
 				<CardHeader size="extraSmall">
 					<div className="ch-placeholder">
 						{ onNavBack && (
@@ -143,7 +144,7 @@ export const ScheduleList = ( props: Props ) => {
 						schedules.length > 0 &&
 						canCreateSchedules && (
 							<>
-								{ isSmallScreen ? (
+								{ ! isDesktopScreen ? (
 									<ScheduleListCards
 										onRemoveClick={ openRemoveDialog }
 										onEditClick={ onEditSchedule }

--- a/client/blocks/plugins-scheduled-updates/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-list.tsx
@@ -1,5 +1,14 @@
 import { useBreakpoint } from '@automattic/viewport-react';
-import { __experimentalConfirmDialog as ConfirmDialog, Spinner } from '@wordpress/components';
+import {
+	__experimentalText as Text,
+	__experimentalConfirmDialog as ConfirmDialog,
+	Spinner,
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+} from '@wordpress/components';
+import { arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
@@ -20,6 +29,7 @@ import { ScheduleListTable } from './schedule-list-table';
 
 interface Props {
 	siteId: number | null;
+	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
 	onEditSchedule: ( id: string ) => void;
 	onShowLogs: ( id: string ) => void;
@@ -32,7 +42,7 @@ export const ScheduleList = ( props: Props ) => {
 	const { siteHasEligiblePlugins, loading: siteHasEligiblePluginsLoading } =
 		useSiteHasEligiblePlugins();
 
-	const { siteId, onCreateNewSchedule, onEditSchedule, onShowLogs } = props;
+	const { siteId, onNavBack, onCreateNewSchedule, onEditSchedule, onShowLogs } = props;
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< undefined | string >();
 
@@ -102,40 +112,54 @@ export const ScheduleList = ( props: Props ) => {
 			>
 				{ translate( 'Are you sure you want to delete this schedule?' ) }
 			</ConfirmDialog>
-
-			{ schedules.length === 0 && isLoading && <Spinner /> }
-			{ ! isLoading && showScheduleListEmpty && (
-				<ScheduleListEmpty
-					pluginsUrl={
-						isGlobalSiteViewEnabled
-							? `${ siteAdminUrl }plugin-install.php`
-							: `/plugins/${ siteSlug }`
-					}
-					onCreateNewSchedule={ onCreateNewSchedule }
-					canCreateSchedules={ canCreateSchedules }
-				/>
-			) }
-			{ isFetched &&
-				! isLoadingCanCreateSchedules &&
-				siteHasEligiblePlugins &&
-				schedules.length > 0 &&
-				canCreateSchedules && (
-					<>
-						{ isSmallScreen ? (
-							<ScheduleListCards
-								onRemoveClick={ openRemoveDialog }
-								onEditClick={ onEditSchedule }
-								onShowLogs={ onShowLogs }
-							/>
-						) : (
-							<ScheduleListTable
-								onRemoveClick={ openRemoveDialog }
-								onEditClick={ onEditSchedule }
-								onShowLogs={ onShowLogs }
-							/>
+			<Card className="plugins-update-manager">
+				<CardHeader size="extraSmall">
+					<div className="ch-placeholder">
+						{ onNavBack && (
+							<Button icon={ arrowLeft } onClick={ onNavBack }>
+								{ translate( 'Back' ) }
+							</Button>
 						) }
-					</>
-				) }
+					</div>
+					<Text>{ translate( 'Schedules' ) }</Text>
+					<div className="ch-placeholder"></div>
+				</CardHeader>
+				<CardBody>
+					{ schedules.length === 0 && isLoading && <Spinner /> }
+					{ ! isLoading && showScheduleListEmpty && (
+						<ScheduleListEmpty
+							pluginsUrl={
+								isGlobalSiteViewEnabled
+									? `${ siteAdminUrl }plugin-install.php`
+									: `/plugins/${ siteSlug }`
+							}
+							onCreateNewSchedule={ onCreateNewSchedule }
+							canCreateSchedules={ canCreateSchedules }
+						/>
+					) }
+					{ isFetched &&
+						! isLoadingCanCreateSchedules &&
+						siteHasEligiblePlugins &&
+						schedules.length > 0 &&
+						canCreateSchedules && (
+							<>
+								{ isSmallScreen ? (
+									<ScheduleListCards
+										onRemoveClick={ openRemoveDialog }
+										onEditClick={ onEditSchedule }
+										onShowLogs={ onShowLogs }
+									/>
+								) : (
+									<ScheduleListTable
+										onRemoveClick={ openRemoveDialog }
+										onEditClick={ onEditSchedule }
+										onShowLogs={ onShowLogs }
+									/>
+								) }
+							</>
+						) }
+				</CardBody>
+			</Card>
 		</>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/schedule-logs.tsx
+++ b/client/blocks/plugins-scheduled-updates/schedule-logs.tsx
@@ -1,5 +1,13 @@
-import { __experimentalText as Text, Tooltip, Spinner } from '@wordpress/components';
-import { Icon, info } from '@wordpress/icons';
+import {
+	__experimentalText as Text,
+	Tooltip,
+	Spinner,
+	Button,
+	Card,
+	CardHeader,
+	CardBody,
+} from '@wordpress/components';
+import { Icon, info, arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 import Timeline from 'calypso/components/timeline';
@@ -80,8 +88,18 @@ export const ScheduleLogs = ( props: Props ) => {
 	}
 
 	return (
-		<>
-			<div>
+		<Card className="plugins-update-manager">
+			<CardHeader size="extraSmall">
+				<div className="ch-placeholder">
+					{ onNavBack && (
+						<Button icon={ arrowLeft } onClick={ onNavBack }>
+							{ translate( 'Back' ) }
+						</Button>
+					) }
+				</div>
+				<Text>
+					{ translate( 'Logs' ) } - { prepareScheduleName( schedule as ScheduleUpdates ) }
+				</Text>
 				<div className="ch-placeholder">
 					<Text isBlock align="end" lineHeight={ 2.5 }>
 						{ translate( '%(pluginsNumber)d plugin', '%(pluginsNumber)d plugins', {
@@ -101,13 +119,15 @@ export const ScheduleLogs = ( props: Props ) => {
 						) }
 					</Text>
 				</div>
-			</div>
-			{ isPendingLogs && <Spinner /> }
-			{ ! isPendingLogs && ! scheduleLogs.length && (
-				<div className="empty-state">
-					<Text align="center">{ translate( 'No logs available at the moment.' ) }</Text>
-				</div>
-			) }
+			</CardHeader>
+			<CardBody>
+				{ isPendingLogs && <Spinner /> }
+				{ ! isPendingLogs && ! scheduleLogs.length && (
+					<div className="empty-state">
+						<Text align="center">{ translate( 'No logs available at the moment.' ) }</Text>
+					</div>
+				) }
+			</CardBody>
 			{ scheduleLogs.map( ( logs, i ) => (
 				<Timeline key={ i }>
 					{ logs.reverse().map( ( log, j ) => (
@@ -136,6 +156,6 @@ export const ScheduleLogs = ( props: Props ) => {
 					) ) }
 				</Timeline>
 			) ) }
-		</>
+		</Card>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -6,6 +6,9 @@
 }
 
 .plugins-update-manager {
+	&.components-card {
+		margin-bottom: 1rem;
+	}
 
 	.ch-placeholder {
 		min-width: 60px;

--- a/client/blocks/plugins-scheduled-updates/styles.scss
+++ b/client/blocks/plugins-scheduled-updates/styles.scss
@@ -107,14 +107,8 @@
 		td {
 			vertical-align: middle;
 
-			&.last-update {
-				min-width: 200px;
-
-			}
-
 			.badge-component {
 				line-height: 2;
-
 			}
 		}
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -54,7 +54,7 @@ body.is-section-plugins {
 			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
 			height: calc(100vh - 32px);
 			max-width: none;
-			overflow-y: scroll;
+			overflow-y: auto;
 		}
 	}
 
@@ -76,7 +76,7 @@ body.is-section-plugins {
 	}
 
 	.a4a-layout-column {
-		overflow: scroll;
+		overflow: auto;
 	}
 
 	.a4a-layout-column.scheduled-updates-list-compact {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/91285

## Proposed Changes

* Wrap the single site context with the Card component
* Update style to support smaller resolutions

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/{ATOMIC_SLUG}`
* Check if there is the Card parent component for the `list`, `create`, `edit`, `logs`, and `notifications` screens.

List:
<img width="1015" alt="Screenshot 2024-05-31 at 00 00 29" src="https://github.com/Automattic/wp-calypso/assets/1241413/965ab0a4-cfe1-42e5-afc6-555a75615f92">

New Schedule:
<img width="1013" alt="Screenshot 2024-05-31 at 00 00 41" src="https://github.com/Automattic/wp-calypso/assets/1241413/f71bad5b-e0a5-43dd-b564-a69b7ab130aa">

Edit Schedule:
<img width="1002" alt="Screenshot 2024-05-31 at 00 00 53" src="https://github.com/Automattic/wp-calypso/assets/1241413/1ed2b1b9-a2cb-4dcb-95df-9f5fb7e4012b">

Logs:
<img width="1017" alt="Screenshot 2024-05-31 at 00 01 03" src="https://github.com/Automattic/wp-calypso/assets/1241413/201ba7d7-c0ff-47a3-a819-9641dbf22cdd">

Notifications:
<img width="1024" alt="Screenshot 2024-05-31 at 00 01 22" src="https://github.com/Automattic/wp-calypso/assets/1241413/e2149c35-8ef2-43d9-8879-29392fb279b9">


Empty state:
| Multisite | Single |
|--------|--------|
| <img width="1170" alt="Screenshot 2024-05-30 at 23 54 29" src="https://github.com/Automattic/wp-calypso/assets/1241413/8bf109bc-fc33-4284-aa1b-b9f4a63563c9"> | <img width="1728" alt="Screenshot 2024-05-30 at 23 54 47" src="https://github.com/Automattic/wp-calypso/assets/1241413/020bda4e-f359-47b7-8ee6-5cb78231ea83"> |

Smaller resolution:
![Screen Capture on 2024-05-31 at 00-11-10](https://github.com/Automattic/wp-calypso/assets/1241413/6681127a-be8a-4bcf-bfaf-d493946d80ae)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
