### PR TITLE
Help Center: Pass slug to feedback form

### DIFF
--- a/packages/help-center/src/components/help-center-article-content.tsx
+++ b/packages/help-center/src/components/help-center-article-content.tsx
@@ -13,6 +13,7 @@ interface ArticleContentProps {
 	isLoading?: boolean;
 	postId: number;
 	blogId?: string | null;
+	slug?: string;
 }
 
 const ArticleContent = ( {
@@ -22,6 +23,7 @@ const ArticleContent = ( {
 	postId,
 	blogId,
 	isLoading = false,
+	slug,
 }: ArticleContentProps ) => {
 	const post = { title: title, url: link };
 	return (
@@ -37,7 +39,7 @@ const ArticleContent = ( {
 							// eslint-disable-next-line react/no-danger
 							dangerouslySetInnerHTML={ { __html: content } }
 						/>
-						<HelpCenterFeedbackForm postId={ postId } blogId={ blogId } />
+						<HelpCenterFeedbackForm postId={ postId } blogId={ blogId } slug={ slug } />
 					</EmbedContainer>
 				</>
 			) }

--- a/packages/help-center/src/components/help-center-article-fetching-content.tsx
+++ b/packages/help-center/src/components/help-center-article-fetching-content.tsx
@@ -72,6 +72,7 @@ const ArticleFetchingContent = ( { postId, blogId, articleUrl }: ArticleFetching
 				isLoading={ isLoading }
 				postId={ postId }
 				blogId={ blogId }
+				slug={ post?.slug }
 			/>
 		</>
 	);

--- a/packages/help-center/src/components/help-center-feedback-form.tsx
+++ b/packages/help-center/src/components/help-center-feedback-form.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
 import React, { useState } from 'react';
 import { ThumbsDownIcon, ThumbsUpIcon } from '../icons/thumbs';
 import './help-center-feedback-form.scss';
@@ -43,6 +44,16 @@ const HelpCenterFeedbackForm = ( { postId, blogId, slug }: HelpCenterFeedbackFor
 		</>
 	);
 
+	const feedbackFormUrl = addQueryArgs(
+		'https://wordpressdotcom.survey.fm/helpcenter-articles-feedback',
+		{
+			q_1_choice: answerValue,
+			guide: slug,
+			postId,
+			blogId,
+		}
+	);
+
 	const FeedbackTextArea = () => (
 		<>
 			<p>{ __( 'How we can improve?' ) }</p>
@@ -51,7 +62,7 @@ const HelpCenterFeedbackForm = ( { postId, blogId, slug }: HelpCenterFeedbackFor
 				// This is the URL of the feedback form,
 				// `answerValue` is either 1 or 2 and it is used to skip the first question since we are already asking it here.
 				// it is necessary to help crowd signal to `skip` ( display none with css ) the first question and save the correct value.
-				src={ `https://wordpressdotcom.survey.fm/helpcenter-articles-feedback?q_1_choice=${ answerValue }&guide=${ slug }&postId=${ postId }&blogId=${ blogId }` }
+				src={ feedbackFormUrl }
 			></iframe>
 		</>
 	);

--- a/packages/help-center/src/components/help-center-feedback-form.tsx
+++ b/packages/help-center/src/components/help-center-feedback-form.tsx
@@ -6,8 +6,9 @@ import './help-center-feedback-form.scss';
 interface HelpCenterFeedbackFormProps {
 	postId: number;
 	blogId?: string | null;
+	slug?: string;
 }
-const HelpCenterFeedbackForm = ( { postId, blogId }: HelpCenterFeedbackFormProps ) => {
+const HelpCenterFeedbackForm = ( { postId, blogId, slug }: HelpCenterFeedbackFormProps ) => {
 	const { __ } = useI18n();
 	const [ startedFeedback, setStartedFeedback ] = useState< boolean | null >( null );
 	const [ answerValue, setAnswerValue ] = useState< number | null >( null );
@@ -50,7 +51,7 @@ const HelpCenterFeedbackForm = ( { postId, blogId }: HelpCenterFeedbackFormProps
 				// This is the URL of the feedback form,
 				// `answerValue` is either 1 or 2 and it is used to skip the first question since we are already asking it here.
 				// it is necessary to help crowd signal to `skip` ( display none with css ) the first question and save the correct value.
-				src={ `https://wordpressdotcom.survey.fm/helpcenter-articles-feedback?q_1_choice=${ answerValue }&postId=${ postId }&blogId=${ blogId }` }
+				src={ `https://wordpressdotcom.survey.fm/helpcenter-articles-feedback?q_1_choice=${ answerValue }&guide=${ slug }&postId=${ postId }&blogId=${ blogId }` }
 			></iframe>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p2rHU0-13K-p2#comment-4054

## Proposed Changes

Add a slug parameter in the feedback form in the Help Center articles.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Read the `Related to`: The field "Tag Value" in the excel in CrowdSignal shows an id, while on Support it shows the slug of the article. We want to show the slug in the Help Center too.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Sync Help Center
* Visit an article, click on thumb up and inspect the form. The url will have guide= the slug of the article

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?