### PR TITLE
Site Profiler: Align background to right for all widths

### DIFF
--- a/client/site-profiler/components/styles-v2.scss
+++ b/client/site-profiler/components/styles-v2.scss
@@ -207,12 +207,6 @@
 		background: url(calypso/assets/images/site-profiler/background-landing-header.svg) no-repeat left bottom;
 		padding-bottom: 240px;
 
-		// Huge screens and bigger
-		@media (min-width: $break-huge) {
-			background-position-x: center;
-		}
-
-
 		// Small screens
 		@media (max-width: $break-small ) {
 			padding-top: 6rem;
@@ -226,17 +220,9 @@
 
 		&.poor {
 			background: url(calypso/assets/images/site-profiler/background-results-bad.svg) no-repeat right top;
-			// Huge screens and bigger
-			@media (min-width: $break-huge) {
-				background-position-x: center;
-			}
 		}
 		&.good {
 			background: url(calypso/assets/images/site-profiler/background-results-good.svg) no-repeat right top;
-			// Huge screens and bigger
-			@media (min-width: $break-huge) {
-				background-position-x: center;
-			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Align the background to the right for all screen widths

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To better adapt to the design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Navigate to `/site-profiler`
* Check the background is aligned to the right for all the widths of screen
* Add a site with a good performance, e.g. `wordpress.com`
* Check the background is aligned to the right for all the widths of screen
* Add a site with poor performance, e.g. `www.atliq.com`
* Check the background is aligned to the right for all the widths of screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
