### PR TITLE
Command Palette: Change prompt icon to search icon on the command palette

### DIFF
--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import styled from '@emotion/styled';
 import { __experimentalHStack as HStack, Modal, TextHighlight } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
-import { chevronLeft as backIcon, Icon } from '@wordpress/icons';
+import { chevronLeft as backIcon, Icon, search as inputIcon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { cleanForSlug } from '@wordpress/url';
 import classnames from 'classnames';
@@ -13,7 +13,6 @@ import {
 	CommandPaletteContextProvider,
 	useCommandPaletteContext,
 } from './context';
-import { PromptIcon } from './icons/prompt';
 import { COMMAND_SEPARATOR, useCommandFilter } from './use-command-filter';
 import { useCommandPalette } from './use-command-palette';
 import { siteUsesWpAdminInterface } from './utils';
@@ -449,7 +448,7 @@ const CommandPalette = ( {
 									<Icon icon={ backIcon } />
 								</BackButton>
 							) : (
-								<PromptIcon />
+								<Icon icon={ inputIcon } />
 							) }
 							<CommandInput />
 						</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to
- https://github.com/Automattic/dotcom-forge/issues/7501

## Proposed Changes

* Reverting back to using the search icon instead of the prompt icon.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We think it makes more sense to have the search icon instead of the prompt icon for searching the command list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link
* Open the command palette with cmd+K
* You should see that the command palette's search box displays the magnifying glass icon.
* On `/sites` you should continue to see the prompt icon instead of the search icon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
