### PR TITLE
Site Profiler Performance: Update title and links for each case

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -106,6 +106,7 @@ export interface UrlPerformanceMetricsQueryResponse {
 				health: PerformanceMetricsDataQueryResponse;
 				performance: PerformanceMetricsDataQueryResponse;
 			};
+			performance: number;
 		};
 	};
 }
@@ -113,6 +114,7 @@ export interface UrlPerformanceMetricsQueryResponse {
 export interface PerformanceMetricsDataQueryResponse {
 	diagnostic: Record< string, PerformanceMetricsItemQueryResponse >;
 	pass: Record< string, PerformanceMetricsItemQueryResponse >;
+	truncated: boolean;
 }
 
 export interface PerformanceMetricsItemQueryResponse {

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -99,6 +99,20 @@ export interface UrlBasicMetricsQueryResponse {
 	token: string;
 }
 
+export interface UrlSecurityMetricsQueryResponse {
+	wpscan: {
+		report: {
+			audits: {
+				pass: Record< string, PerformanceMetricsItemQueryResponse >;
+				fail: Record< string, PerformanceMetricsItemQueryResponse >;
+				truncated: boolean;
+			};
+			ovc: number;
+		};
+		errors: Record< string, Array< string > >;
+	};
+}
+
 export interface UrlPerformanceMetricsQueryResponse {
 	webtestpage_org: {
 		report: {
@@ -107,6 +121,7 @@ export interface UrlPerformanceMetricsQueryResponse {
 				performance: PerformanceMetricsDataQueryResponse;
 			};
 			performance: number;
+			overall_score: number;
 		};
 	};
 }

--- a/client/data/site-profiler/use-url-performance-metrics-query.ts
+++ b/client/data/site-profiler/use-url-performance-metrics-query.ts
@@ -3,7 +3,7 @@ import wp from 'calypso/lib/wp';
 import { UrlPerformanceMetricsQueryResponse } from './types';
 
 function mapResult( response: UrlPerformanceMetricsQueryResponse ) {
-	return response.webtestpage_org.report.audits;
+	return response.webtestpage_org.report;
 }
 
 export const useUrlPerformanceMetricsQuery = ( url?: string, hash?: string ) => {

--- a/client/data/site-profiler/use-url-performance-metrics-query.ts
+++ b/client/data/site-profiler/use-url-performance-metrics-query.ts
@@ -8,7 +8,7 @@ function mapResult( response: UrlPerformanceMetricsQueryResponse ) {
 
 export const useUrlPerformanceMetricsQuery = ( url?: string, hash?: string ) => {
 	return useQuery( {
-		queryKey: [ 'url-', url, hash ],
+		queryKey: [ 'url', 'performance', url, hash ],
 		queryFn: () =>
 			wp.req.get(
 				{

--- a/client/data/site-profiler/use-url-security-metrics-query.ts
+++ b/client/data/site-profiler/use-url-security-metrics-query.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { UrlSecurityMetricsQueryResponse } from './types';
+
+function mapResult( response: UrlSecurityMetricsQueryResponse ) {
+	return response.wpscan;
+}
+
+export const useUrlSecurityMetricsQuery = ( url?: string, hash?: string ) => {
+	return useQuery( {
+		queryKey: [ 'url', 'security', url, hash ],
+		queryFn: () =>
+			wp.req.get(
+				{
+					path: '/site-profiler/metrics/advanced/security',
+					apiNamespace: 'wpcom/v2',
+				},
+				{ url, hash }
+			),
+		meta: {
+			persist: false,
+		},
+		select: mapResult,
+		enabled: !! url,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};

--- a/client/site-profiler/components/health-section/index.tsx
+++ b/client/site-profiler/components/health-section/index.tsx
@@ -9,66 +9,66 @@ import { InsightHeader } from 'calypso/site-profiler/components/metrics-insight/
 import { MetricsSection } from 'calypso/site-profiler/components/metrics-section';
 import { getTitleTranslateOptions } from 'calypso/site-profiler/utils/get-title-translate-options';
 
-interface PerformanceSectionProps {
+interface HealthSectionProps {
 	url?: string;
 	hash?: string;
 	hostingProvider?: HostingProvider;
-	performanceMetricsRef: React.RefObject< HTMLObjectElement >;
+	healthMetricsRef: React.RefObject< HTMLObjectElement >;
 	setIsGetReportFormOpen?: ( isOpen: boolean ) => void;
 }
 
-const PERFORMANCE_THRESHOLD = 0.9;
+const OVERALL_SCORE_THRESHOLD = 0.8;
 
-export const PerformanceSection: React.FC< PerformanceSectionProps > = ( props ) => {
+export const HealthSection: React.FC< HealthSectionProps > = ( props ) => {
 	const translate = useTranslate();
-	const { url, hash, hostingProvider, performanceMetricsRef, setIsGetReportFormOpen } = props;
+	const { url, hash, hostingProvider, healthMetricsRef, setIsGetReportFormOpen } = props;
 	const { data } = useUrlPerformanceMetricsQuery( url, hash );
-	const { truncated, diagnostic: performanceData = {} } = data?.audits.performance ?? {};
+	const { truncated, diagnostic: healthData = {} } = data?.audits.health ?? {};
 
 	const isWPcom = hostingProvider?.slug?.toLowerCase() === 'automattic';
 
-	const performanceScore = data?.performance ?? 0;
-	const isPerformanceGood = performanceScore >= PERFORMANCE_THRESHOLD;
+	const healthScore = data?.overall_score ?? 0;
+	const isHealthGood = healthScore >= OVERALL_SCORE_THRESHOLD;
 
 	const title = useMemo( () => {
-		if ( ! isPerformanceGood && ! isWPcom ) {
+		if ( ! isHealthGood && ! isWPcom ) {
 			return translate(
-				"Your site's performance could be better. Migrate to WordPress.com for significant improvements in {{poor}}speed and reliability.{{/poor}}",
+				"Your site's health scores need attention to prevent {{poor}}low performance{{/poor}}. Improve with WordPress.com's tools for better performance.",
 				getTitleTranslateOptions()
 			);
 		}
 
-		if ( isPerformanceGood && ! isWPcom ) {
+		if ( isHealthGood && ! isWPcom ) {
 			return translate(
-				"Your site {{good}}performs well{{/good}}, but there's room for improvement. Migrate to WordPress.com for even better performance.",
+				"Your site's {{good}}health scores are strong{{/good}}, but there's room for improvement. Optimize further with WordPress.com's tools.",
 				getTitleTranslateOptions()
 			);
 		}
 
-		if ( isPerformanceGood && isWPcom ) {
+		if ( isHealthGood && isWPcom ) {
 			return translate(
-				"Your site's {{good}}performance is outstanding{{/good}}. Keep up the great work and explore advanced features to stay ahead.",
+				"Your site's {{good}}health scores are strong{{/good}}, indicating well-maintained performance and user experience. Keep monitoring and optimizing for the best results.",
 				getTitleTranslateOptions()
 			);
 		}
 
 		return translate(
-			'Your site performs well, but there are {{poor}}areas for improvement{{/poor}}.',
+			"Your site's health scores are decent, but critical areas need attention to prevent {{poor}}low performance{{/poor}} and ensure stability",
 			getTitleTranslateOptions()
 		);
-	}, [ isPerformanceGood, isWPcom, translate ] );
+	}, [ isHealthGood, isWPcom, translate ] );
 
 	return (
 		<MetricsSection
-			name={ translate( 'Performance Metrics' ) }
+			name={ translate( 'Health Scores' ) }
 			title={ title }
-			subtitle={ ! isWPcom ? translate( "Boost your site's performance" ) : null }
+			subtitle={ ! isWPcom ? translate( 'Boost Site Health Now' ) : null }
 			subtitleOnClick={ () =>
 				page( `/setup/hosted-site-migration?ref=site-profiler&from=${ url }` )
 			}
-			ref={ performanceMetricsRef }
+			ref={ healthMetricsRef }
 		>
-			{ Object.values( performanceData ).map( ( metric ) => (
+			{ Object.values( healthData ).map( ( metric ) => (
 				<MetricsInsight
 					key={ `insight-${ metric.id }` }
 					insight={ {

--- a/client/site-profiler/components/metrics-insight/insight-table.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-table.tsx
@@ -49,6 +49,15 @@ function Cell( {
 						</pre>
 					</div>
 				);
+
+			case 'code':
+				return (
+					<div>
+						<pre>
+							<code>{ data?.value }</code>
+						</pre>
+					</div>
+				);
 			case 'numeric':
 				return getFormattedNumber( data.value );
 			case 'url':

--- a/client/site-profiler/components/performance-section/index.tsx
+++ b/client/site-profiler/components/performance-section/index.tsx
@@ -1,4 +1,7 @@
+import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { HostingProvider } from 'calypso/data/site-profiler/types';
 import { useUrlPerformanceMetricsQuery } from 'calypso/data/site-profiler/use-url-performance-metrics-query';
 import { MetricsInsight } from 'calypso/site-profiler/components/metrics-insight';
 import { InsightContent } from 'calypso/site-profiler/components/metrics-insight/insight-content';
@@ -9,24 +12,60 @@ import { getTitleTranslateOptions } from 'calypso/site-profiler/utils/get-title-
 interface PerformanceSectionProps {
 	url?: string;
 	hash?: string;
+	hostingProvider?: HostingProvider;
 	performanceMetricsRef: React.RefObject< HTMLObjectElement >;
 	setIsGetReportFormOpen?: ( isOpen: boolean ) => void;
 }
 
+const PERFORMANCE_THRESHOLD = 0.9;
+
 export const PerformanceSection: React.FC< PerformanceSectionProps > = ( props ) => {
 	const translate = useTranslate();
-	const { url, hash, performanceMetricsRef, setIsGetReportFormOpen } = props;
+	const { url, hash, hostingProvider, performanceMetricsRef, setIsGetReportFormOpen } = props;
 	const { data } = useUrlPerformanceMetricsQuery( url, hash );
-	const performanceData = data?.performance?.diagnostic ?? {};
+	const { truncated, diagnostic: performanceData = {} } = data?.audits.performance ?? {};
+
+	const isWPcom = hostingProvider?.slug?.toLowerCase() === 'automattic';
+
+	const performanceScore = data?.performance ?? 0;
+	const isPerformanceGood = performanceScore >= PERFORMANCE_THRESHOLD;
+
+	const title = useMemo( () => {
+		if ( ! isPerformanceGood && ! isWPcom ) {
+			return translate(
+				"Your site's performance could be better. Migrate to WordPress.com for significant improvements in {{poor}}speed and reliability.{{/poor}}",
+				getTitleTranslateOptions()
+			);
+		}
+
+		if ( isPerformanceGood && ! isWPcom ) {
+			return translate(
+				"Your site {{good}}performs well{{/good}}, but there's room for improvement. Migrate to WordPress.com for even better performance.",
+				getTitleTranslateOptions()
+			);
+		}
+
+		if ( isPerformanceGood && isWPcom ) {
+			return translate(
+				"Your site's {{good}}performance is outstanding{{/good}}. Keep up the great work and explore advanced features to stay ahead.",
+				getTitleTranslateOptions()
+			);
+		}
+
+		return translate(
+			'Your site performs well, but there are {{poor}}areas for improvement{{/poor}}.',
+			getTitleTranslateOptions()
+		);
+	}, [ isPerformanceGood, isWPcom, translate ] );
 
 	return (
 		<MetricsSection
 			name={ translate( 'Performance Metrics' ) }
-			title={ translate(
-				"Your site {{good}}performs well{{/good}}, but there's always room to be faster and smoother for your visitors.",
-				getTitleTranslateOptions()
-			) }
-			subtitle={ translate( "Boost your site's performance" ) }
+			title={ title }
+			subtitle={ ! isWPcom ? translate( "Boost your site's performance" ) : null }
+			subtitleOnClick={ () =>
+				page( `/setup/hosted-site-migration?ref=site-profiler&from=${ url }` )
+			}
 			ref={ performanceMetricsRef }
 		>
 			{ Object.values( performanceData ).map( ( metric ) => (
@@ -39,15 +78,16 @@ export const PerformanceSection: React.FC< PerformanceSectionProps > = ( props )
 				/>
 			) ) }
 
-			{ Array( 5 )
-				.fill( {} )
-				.map( ( _, index ) => (
-					<MetricsInsight
-						key={ `locked-${ index }` }
-						locked
-						onClick={ () => setIsGetReportFormOpen?.( true ) }
-					/>
-				) ) }
+			{ truncated &&
+				Array( 10 )
+					.fill( {} )
+					.map( ( _, index ) => (
+						<MetricsInsight
+							key={ `locked-${ index }` }
+							locked
+							onClick={ () => setIsGetReportFormOpen?.( true ) }
+						/>
+					) ) }
 		</MetricsSection>
 	);
 };

--- a/client/site-profiler/components/security-section/index.tsx
+++ b/client/site-profiler/components/security-section/index.tsx
@@ -1,0 +1,98 @@
+import page from '@automattic/calypso-router';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { HostingProvider } from 'calypso/data/site-profiler/types';
+import { useUrlSecurityMetricsQuery } from 'calypso/data/site-profiler/use-url-security-metrics-query';
+import { MetricsInsight } from 'calypso/site-profiler/components/metrics-insight';
+import { InsightContent } from 'calypso/site-profiler/components/metrics-insight/insight-content';
+import { InsightHeader } from 'calypso/site-profiler/components/metrics-insight/insight-header';
+import { MetricsSection } from 'calypso/site-profiler/components/metrics-section';
+import { getTitleTranslateOptions } from 'calypso/site-profiler/utils/get-title-translate-options';
+
+interface SecuritySectionProps {
+	url?: string;
+	hash?: string;
+	hostingProvider?: HostingProvider;
+	securityMetricsRef: React.RefObject< HTMLObjectElement >;
+	setIsGetReportFormOpen?: ( isOpen: boolean ) => void;
+}
+
+export const SecuritySection: React.FC< SecuritySectionProps > = ( props ) => {
+	const translate = useTranslate();
+	const { url, hash, hostingProvider, securityMetricsRef, setIsGetReportFormOpen } = props;
+	const { data } = useUrlSecurityMetricsQuery( url, hash );
+	const { truncated, fail: securityData = {} } = data?.report?.audits ?? {};
+	const overallVulnerabilities = data?.report?.ovc ?? 0;
+
+	const { errors = {} } = data ?? {};
+	const noWordPressFound = Object.keys( errors ).find( ( error ) => error === 'no_wordpress' );
+
+	const isWPcom = hostingProvider?.slug?.toLowerCase() === 'automattic';
+
+	const isSecurityGood = overallVulnerabilities === 0;
+
+	const title = useMemo( () => {
+		if ( ! isSecurityGood && ! isWPcom ) {
+			return translate(
+				'Security vulnerabilities are {{poor}}exposing your site to risks{{/poor}}. Migrate to WordPress.com for robust security measures.',
+				getTitleTranslateOptions()
+			);
+		}
+
+		if ( isSecurityGood && ! isWPcom ) {
+			return translate(
+				'Your site is well-secured, but enhancing it further will {{good}}protect your data more effectively{{/good}}. Continue improving security for optimal protection.',
+				getTitleTranslateOptions()
+			);
+		}
+
+		if ( isSecurityGood && isWPcom ) {
+			return translate(
+				'Your site is well-secured, effectively {{good}}protecting against risks{{/good}} and maintaining its integrity. Continue to enhance security measures for optimal protection.',
+				getTitleTranslateOptions()
+			);
+		}
+
+		return translate(
+			'Your site has some {{poor}}security vulnerabilities{{/poor}} that could expose it to risks. Strengthen your site further with our advanced protection.',
+			getTitleTranslateOptions()
+		);
+	}, [ isSecurityGood, isWPcom, translate ] );
+
+	if ( noWordPressFound ) {
+		return;
+	}
+
+	return (
+		<MetricsSection
+			name={ translate( 'Security' ) }
+			title={ title }
+			subtitle={ ! isWPcom ? translate( 'Migrate for Better Security' ) : null }
+			subtitleOnClick={ () =>
+				page( `/setup/hosted-site-migration?ref=site-profiler&from=${ url }` )
+			}
+			ref={ securityMetricsRef }
+		>
+			{ Object.values( securityData ).map( ( metric ) => (
+				<MetricsInsight
+					key={ `insight-${ metric.id }` }
+					insight={ {
+						header: <InsightHeader data={ metric } />,
+						description: <InsightContent data={ metric } />,
+					} }
+				/>
+			) ) }
+
+			{ truncated &&
+				Array( 10 )
+					.fill( {} )
+					.map( ( _, index ) => (
+						<MetricsInsight
+							key={ `locked-${ index }` }
+							locked
+							onClick={ () => setIsGetReportFormOpen?.( true ) }
+						/>
+					) ) }
+		</MetricsSection>
+	);
+};

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -163,8 +163,9 @@ export default function SiteProfilerV2( props: Props ) {
 								/>
 
 								<PerformanceSection
-									url={ url }
+									url={ basicMetrics?.final_url }
 									hash={ hash ?? basicMetrics?.token }
+									hostingProvider={ hostingProviderData?.hosting_provider }
 									performanceMetricsRef={ perfomanceMetricsRef }
 									setIsGetReportFormOpen={ setIsGetReportFormOpen }
 								/>

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -20,12 +20,14 @@ import { normalizeWhoisField } from '../utils/normalize-whois-entry';
 import { BasicMetrics } from './basic-metrics';
 import { DomainSection } from './domain-section';
 import { GetReportForm } from './get-report-form';
+import { HealthSection } from './health-section';
 import { HostingSection } from './hosting-section';
 import { LandingPageHeader } from './landing-page-header';
 import { MigrationBanner } from './migration-banner';
 import { MigrationBannerBig } from './migration-banner-big';
 import { PerformanceSection } from './performance-section';
 import { ResultsHeader } from './results-header';
+import { SecuritySection } from './security-section';
 import './styles-v2.scss';
 
 const debug = debugFactory( 'apps:site-profiler' );
@@ -40,6 +42,8 @@ export default function SiteProfilerV2( props: Props ) {
 	const hostingRef = useRef( null );
 	const domainRef = useRef( null );
 	const perfomanceMetricsRef = useRef( null );
+	const healthMetricsRef = useRef( null );
+	const securityMetricsRef = useRef( null );
 	const [ isGetReportFormOpen, setIsGetReportFormOpen ] = useState( false );
 
 	const {
@@ -167,6 +171,22 @@ export default function SiteProfilerV2( props: Props ) {
 									hash={ hash ?? basicMetrics?.token }
 									hostingProvider={ hostingProviderData?.hosting_provider }
 									performanceMetricsRef={ perfomanceMetricsRef }
+									setIsGetReportFormOpen={ setIsGetReportFormOpen }
+								/>
+
+								<HealthSection
+									url={ basicMetrics?.final_url }
+									hash={ hash ?? basicMetrics?.token }
+									hostingProvider={ hostingProviderData?.hosting_provider }
+									healthMetricsRef={ healthMetricsRef }
+									setIsGetReportFormOpen={ setIsGetReportFormOpen }
+								/>
+
+								<SecuritySection
+									url={ basicMetrics?.final_url }
+									hash={ hash ?? basicMetrics?.token }
+									hostingProvider={ hostingProviderData?.hosting_provider }
+									securityMetricsRef={ securityMetricsRef }
 									setIsGetReportFormOpen={ setIsGetReportFormOpen }
 								/>
 							</>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7304

## Proposed Changes

* Update the title according hosting and performance
* Use the final url data from the basic metrics request to send to performance endpoint.
* Redirect the page to the import flow when the site is not on WP.com yet.

---
* Add the Health and Security Sections (https://github.com/Automattic/wp-calypso/pull/91312)

## Why are these changes being made?

To match the [figma layout](https://www.figma.com/design/P7Jjk4nbUTahUk8aHkG6NQ/Performance-Tool?m=dev&node-id=1126-6311) for Site Profiler V2.

## Testing Instructions

* Go to `/site-profiler/:url` with a WP.com site. Ex: `/site-profiler/wordpress.com`
* Go to the Performance section and check if the layout matches the ones below
* Go to `/site-profiler/:url` with a WP.com site. Ex: `/site-profiler/example.com`
* Go to the Performance section and check if the layout matches the ones below

| WP.com good  | WP.com poor | non-WP.com good | non-WP.com poor|
| ------------- | ------------- |------------- | ------------- |
|![CleanShot 2024-05-30 at 12 42 26@2x](https://github.com/Automattic/wp-calypso/assets/5039531/b82613c8-0157-4e09-b4ad-69d4761ec44f)|![CleanShot 2024-05-30 at 12 45 58@2x](https://github.com/Automattic/wp-calypso/assets/5039531/e5a72c5f-27af-4032-8e79-3e8659a12e4d)|![CleanShot 2024-05-30 at 12 38 23@2x](https://github.com/Automattic/wp-calypso/assets/5039531/27eb529c-646c-4269-b63c-eb54c1985bce)|![CleanShot 2024-05-30 at 12 33 25@2x](https://github.com/Automattic/wp-calypso/assets/5039531/8c8ae1ae-4eb7-49fb-9864-7faedf1a466e)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?