### PR TITLE
Stats: Fix Subscriber Stats highlights section loading state

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import useSubscribersOverview from 'calypso/my-sites/stats/hooks/use-subscribers-overview';
 import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import './style.scss';
 import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 
@@ -114,6 +115,11 @@ export default function SubscribersHighlightSection( { siteId }: { siteId: numbe
 		comment: 'Heading for Subscribers page highlights section',
 	} );
 
+	const isJetpackNotAtomic = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, {
+			treatAtomicAsJetpackSite: false,
+		} )
+	);
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	// Check if the site has any paid subscription products added.
@@ -122,8 +128,8 @@ export default function SubscribersHighlightSection( { siteId }: { siteId: numbe
 
 	// Odyssey Stats doesn't support the membership API endpoint yet.
 	// Products with an undefined value rather than an empty array means the API call has not been completed yet.
-	const isPaidSubscriptionProductsLoading = ! isOdysseyStats && ! products;
-	const hasAddedPaidSubscriptionProduct = ! isOdysseyStats && products && products.length > 0;
+	const isPaidSubscriptionProductsLoading = ! isJetpackNotAtomic && ! products;
+	const hasAddedPaidSubscriptionProduct = ! isJetpackNotAtomic && products && products.length > 0;
 
 	const highlights = useSubscriberHighlights( siteId, hasAddedPaidSubscriptionProduct );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Enforce the Subscriber Stats highlights loading state to _**true**_ for `Jetpack sites` because membership products fetch always fails.

|Before|After|
|-|-|
|<img width="1293" alt="截圖 2024-05-31 上午1 38 13" src="https://github.com/Automattic/wp-calypso/assets/6869813/502e45df-6ffe-4770-844e-6fc4a7c2a9b0">|<img width="1277" alt="截圖 2024-05-31 上午1 38 59" src="https://github.com/Automattic/wp-calypso/assets/6869813/a6e9cc6a-0442-4f3d-be0b-2f489de777dd">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The API endpoint `/memberships/products` fetching on Calypso for Jetpack sites also fails, which would cause the forever loading state.

<img width="710" alt="截圖 2024-06-06 上午1 27 47" src="https://github.com/Automattic/wp-calypso/assets/6869813/06def8a9-3db8-4316-bce4-9e8f8022cce7">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Subscribers page with a Jetpack site.
* Ensure the highlights section works well without always loading state.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
