### PR TITLE
Calypso Notifications - fix bug with unseen indicator not present on load

### DIFF
--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -4,7 +4,9 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import SidebarMenuItem from 'calypso/layout/global-sidebar/menu-items/menu-item';
+import { setUnseenCount } from 'calypso/state/notifications/actions';
 import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
+import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import { BellIcon } from './icon';
@@ -18,13 +20,16 @@ class SidebarNotifications extends Component {
 		onClick: PropTypes.func,
 		//connected
 		isNotificationsOpen: PropTypes.bool,
+		hasUnseenNotifications: PropTypes.bool,
 		unseenCount: PropTypes.number,
 		tooltip: TranslatableString,
 	};
 
 	state = {
 		animationState: 0,
-		newNote: this.props.unseenCount > 0,
+		// unseenCount is null on initial load, so we use hasUnseenNotifications which checks user
+		// data as well.
+		newNote: this.props.hasUnseenNotifications,
 	};
 
 	componentDidUpdate( prevProps ) {
@@ -34,6 +39,9 @@ class SidebarNotifications extends Component {
 
 		if ( ! prevProps.isNotificationsOpen && this.props.isNotificationsOpen ) {
 			this.setNotesIndicator( 0 );
+			// Ensure we setUnseenCount when opening notes panel. The panel only calls this on
+			// APP_RENDER_NOTES which is not consistently called when opening the panel.
+			this.props.setUnseenCount( 0 );
 		}
 	}
 
@@ -108,10 +116,12 @@ const mapStateToProps = ( state ) => {
 		isActive: isPanelOpen || window.location.pathname === '/read/notifications',
 		isNotificationsOpen: isPanelOpen,
 		unseenCount: getUnseenCount( state ),
+		hasUnseenNotifications: hasUnseenNotifications( state ),
 	};
 };
 const mapDispatchToProps = {
 	toggleNotificationsPanel,
+	setUnseenCount,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( SidebarNotifications );

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -4,7 +4,9 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import { BellIcon } from 'calypso/layout/global-sidebar/menu-items/notifications/icon';
+import { setUnseenCount } from 'calypso/state/notifications/actions';
 import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
+import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import MasterbarItem from '../item';
@@ -18,12 +20,15 @@ class MasterbarItemNotifications extends Component {
 		tooltip: TranslatableString,
 		//connected
 		isNotificationsOpen: PropTypes.bool,
+		hasUnseenNotifications: PropTypes.bool,
 		unseenCount: PropTypes.number,
 	};
 
 	state = {
 		animationState: 0,
-		newNote: this.props.unseenCount > 0,
+		// unseenCount is null on initial load, so we use hasUnseenNotifications which checks user
+		// data as well.
+		newNote: this.props.hasUnseenNotifications,
 	};
 
 	componentDidUpdate( prevProps ) {
@@ -33,6 +38,9 @@ class MasterbarItemNotifications extends Component {
 
 		if ( ! prevProps.isNotificationsOpen && this.props.isNotificationsOpen ) {
 			this.setNotesIndicator( 0 );
+			// Ensure we setUnseenCount when opening notes panel. The panel only calls this on
+			// APP_RENDER_NOTES which is not consistently called when opening the panel.
+			this.props.setUnseenCount( 0 );
 		}
 	}
 
@@ -102,10 +110,12 @@ const mapStateToProps = ( state ) => {
 	return {
 		isNotificationsOpen: isNotificationsOpen( state ),
 		unseenCount: getUnseenCount( state ),
+		hasUnseenNotifications: hasUnseenNotifications( state ),
 	};
 };
 const mapDispatchToProps = {
 	toggleNotificationsPanel,
+	setUnseenCount,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( MasterbarItemNotifications );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7534 and a regression from https://github.com/Automattic/wp-calypso/pull/90683

## Proposed Changes

* Use the `hasUnseenNotifications` selector instead of simply checking `unseenCount > 0` to initialize the notifications unseen state. The selector is more robust to check user data if the unseenCount is not initialized, which is the case on load.
* call `setUnseenCount( 0 )` when opening the panel to ensure the unseen count is reset.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix 2 bugs noted on the issue:
1. The notifications dot is not present on load when there are unseen notifications. (a regression from a recent PR)
2. While the dot appears when if a notification arrives after load, it does not fully disappear until a hard reload.
    * Trigger a notification after loading calypso
    * See the unseen dot
    * Open the panel.
    * see the unseen dot is gone.
    * Go to another section of calypso (my home if you were in global state, of vice versa)
    * Notice the unseen dot has reappeared on the icon.

This PR resolves both of these issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch and open calypso.
* Trigger a new notification for yourself (comment on one of your posts in an incognito window, or use a handy wp CLI command on your sandbox).
* Verify the dot appears on the notification Icon.
* Reload the browser window. Verify the dot is still present.
* Open the panel, verify the dot disappears.
* Navigate to another section of calypso (my home if you were in global state, of vice versa), verify the dot does not reappear.
* Reload, verify the dot does not reappear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
