### PR TITLE
Marketplace: Change to 3 columns layout on the wide screen

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -126,6 +126,10 @@
 		@include break-large {
 			width: calc(50% - 9px); // 2 column grid with 18px gutter
 		}
+
+		@include break-wide {
+			width: calc(33% - 10px); // 3 column grid with 20px gutter
+		}
 	}
 
 	&.incompatible {

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -11,7 +11,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Module variables
  */
-export const SHORT_LIST_LENGTH = 4;
+export const SHORT_LIST_LENGTH = 6;
 
 const PLUGIN_SLUGS_BLOCKLIST = [];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7539

## Proposed Changes

* Change to 3 columns layout on the wide screen

| Before | After |
| - | - |
| <img width="1164" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/b22b8990-3efa-4d2b-a754-9ec32fee5da5"> | <img width="1165" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/9c363bdd-6431-434d-a127-ac32c4fd7aaa"> |

I think the 3 columns layout doesn't look good when the screen size is smaller than 1280px. For example, we might not be able to display the full name of the plugin. Any thoughts?

<img width="594" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/d4942b15-3b24-49be-a826-14ea14de18fd">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plugins
* Make sure it's 3 columns layout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
