### PR TITLE
Marketplace: Update styles of the section header

### DIFF
--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -8,6 +8,7 @@ import LinkCard from 'calypso/components/link-card';
 import Section, { SectionContainer } from 'calypso/components/section';
 import { preventWidows } from 'calypso/lib/formatting';
 import { addQueryArgs } from 'calypso/lib/route';
+import PluginsResultsHeader from 'calypso/my-sites/plugins/plugins-results-header';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { isUserLoggedIn, getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
@@ -147,61 +148,60 @@ const EducationFooter = () => {
 
 	return (
 		<EducationFooterContainer>
-			<Section
-				header={ __( 'Get started with plugins' ) }
-				subheader={ __( 'Our favorite how-to guides to get you started with plugins' ) }
-			>
-				<ThreeColumnContainer>
-					<LinkCard
-						external
-						target="_blank"
-						title={
-							<CardText color="var(--studio-gray-100)">
-								{ __( 'What Are WordPress Plugins and Themes? (A Beginner’s Guide)' ) }
-							</CardText>
-						}
-						titleMarginBottom="16px"
-						cta={ <ReadMoreLink /> }
-						url={ localizeUrl(
-							'https://wordpress.com/go/website-building/what-are-wordpress-plugins-and-themes-a-beginners-guide/'
-						) }
-						border="var(--studio-gray-5)"
-						onClick={ () => onClickLinkCard( 'website_building' ) }
-					/>
-					<LinkCard
-						external
-						target="_blank"
-						title={
-							<CardText color="var(--studio-gray-100)">
-								{ __( 'How to Use WordPress Plugins: The Complete Beginner’s Guide' ) }
-							</CardText>
-						}
-						titleMarginBottom="16px"
-						cta={ <ReadMoreLink /> }
-						url={ localizeUrl(
-							'https://wordpress.com/go/website-building/how-to-use-wordpress-plugins/'
-						) }
-						border="var(--studio-gray-5)"
-						onClick={ () => onClickLinkCard( 'customization' ) }
-					/>
-					<LinkCard
-						external
-						target="_blank"
-						title={
-							<CardText color="var(--studio-gray-100)">
-								{ __( '17 Must-Have WordPress Plugins (Useful For All Sites)' ) }
-							</CardText>
-						}
-						titleMarginBottom="16px"
-						cta={ <ReadMoreLink /> }
-						url={ localizeUrl(
-							'https://wordpress.com/go/website-building/17-must-have-wordpress-plugins-useful-for-all-sites/'
-						) }
-						border="var(--studio-gray-5)"
-						onClick={ () => onClickLinkCard( 'seo' ) }
-					/>
-				</ThreeColumnContainer>
-			</Section>
+			<PluginsResultsHeader
+				title={ __( 'Get started with plugins' ) }
+				subtitle={ __( 'Our favorite how-to guides to get you started with plugins' ) }
+			/>
+			<ThreeColumnContainer>
+				<LinkCard
+					external
+					target="_blank"
+					title={
+						<CardText color="var(--studio-gray-100)">
+							{ __( 'What Are WordPress Plugins and Themes? (A Beginner’s Guide)' ) }
+						</CardText>
+					}
+					titleMarginBottom="16px"
+					cta={ <ReadMoreLink /> }
+					url={ localizeUrl(
+						'https://wordpress.com/go/website-building/what-are-wordpress-plugins-and-themes-a-beginners-guide/'
+					) }
+					border="var(--studio-gray-5)"
+					onClick={ () => onClickLinkCard( 'website_building' ) }
+				/>
+				<LinkCard
+					external
+					target="_blank"
+					title={
+						<CardText color="var(--studio-gray-100)">
+							{ __( 'How to Use WordPress Plugins: The Complete Beginner’s Guide' ) }
+						</CardText>
+					}
+					titleMarginBottom="16px"
+					cta={ <ReadMoreLink /> }
+					url={ localizeUrl(
+						'https://wordpress.com/go/website-building/how-to-use-wordpress-plugins/'
+					) }
+					border="var(--studio-gray-5)"
+					onClick={ () => onClickLinkCard( 'customization' ) }
+				/>
+				<LinkCard
+					external
+					target="_blank"
+					title={
+						<CardText color="var(--studio-gray-100)">
+							{ __( '17 Must-Have WordPress Plugins (Useful For All Sites)' ) }
+						</CardText>
+					}
+					titleMarginBottom="16px"
+					cta={ <ReadMoreLink /> }
+					url={ localizeUrl(
+						'https://wordpress.com/go/website-building/17-must-have-wordpress-plugins-useful-for-all-sites/'
+					) }
+					border="var(--studio-gray-5)"
+					onClick={ () => onClickLinkCard( 'seo' ) }
+				/>
+			</ThreeColumnContainer>
 		</EducationFooterContainer>
 	);
 };

--- a/client/my-sites/plugins/plugins-results-header/index.tsx
+++ b/client/my-sites/plugins/plugins-results-header/index.tsx
@@ -19,7 +19,7 @@ export default function PluginsResultsHeader( {
 	subtitle: TranslateResult;
 	browseAllLink?: string;
 	resultCount?: string;
-	className: string;
+	className?: string;
 	listName?: string;
 } ) {
 	const { __ } = useI18n();

--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -7,16 +7,17 @@
 	column-gap: 12px;
 
 	.plugins-results-header__titles {
-		margin-bottom: 6px; // +18 from elements = 24 gap
-
 		.plugins-results-header__title {
-			@extend .wp-brand-font;
-			font-size: $font-title-medium;
+			font-size: $font-body;
 			font-weight: 500;
+			line-height: 24px;
 		}
 
 		.plugins-results-header__subtitle {
+			margin-top: 6.5px;
 			font-size: $font-body-small;
+			line-height: 20px;
+			color: var(--studio-gray-80);
 		}
 	}
 
@@ -26,7 +27,6 @@
 		align-items: center;
 		justify-content: space-between;
 		margin-top: auto;
-		margin-bottom: 6px; // +20 from elements = 26 gap
 
 		.plugins-results-header__action {
 			font-size: $font-body-small;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7538

## Proposed Changes

* Update styles of the section header on the marketplace page

| Before | After |
| - | - |
| <img width="1125" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/aec0e41b-80df-4e3d-909f-ede0651d6032"> | <img width="1051" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/64aa9ee0-1361-4826-8bc8-98d2ca27b883"> |
| <img width="1114" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/68e6b678-4424-4543-bea7-3a79e503af79"> | <img width="1043" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/e8c88fee-3033-4c40-918c-dd319dc298d5"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plugins
* Make sure the styles of the section header is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
