### PR TITLE
Remove hardcoded plan name strings

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -3,7 +3,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useHasEnTranslation, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
@@ -30,6 +30,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
 	const plan = getPlan( PLAN_BUSINESS );
+	const hasEnTranslation = useHasEnTranslation();
 	const {
 		site,
 		navigateToVerifyEmailStep,
@@ -116,6 +117,21 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		);
 	};
 
+	const upgradeCtaCopy = hasEnTranslation(
+		'Migrations are exclusive to the %(planName)s plan. Check out all its benefits, and upgrade to get started.'
+	)
+		? translate(
+				'Migrations are exclusive to the %(planName)s plan. Check out all its benefits, and upgrade to get started.',
+				{
+					args: {
+						planName: plan?.getTitle() ?? '',
+					},
+				}
+		  )
+		: translate(
+				'Migrations are exclusive to the Creator plan. Check out all its benefits, and upgrade to get started.'
+		  );
+
 	return (
 		<div className="import__upgrade-plan">
 			{ ! hideTitleAndSubTitle && (
@@ -127,9 +143,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 					</Title>
 					<SubTitle className="onboarding-subtitle--full-width">
 						{ subTitleText || isEnglishLocale
-							? translate(
-									'Migrations are exclusive to the Creator plan. Check out all its benefits, and upgrade to get started.'
-							  )
+							? upgradeCtaCopy
 							: translate(
 									'Migrating themes, plugins, users, and settings requires a %(plan)s plan.',
 									{

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -1,6 +1,7 @@
-import { FEATURE_SFTP } from '@automattic/calypso-products';
+import { FEATURE_SFTP, getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card, Dialog } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -42,6 +43,7 @@ const DevTools = () => {
 		isSiteAtomic: isSiteWpcomAtomic( state, siteId as number ),
 		hasSftpFeature: siteHasFeature( state, siteId, FEATURE_SFTP ),
 	} ) );
+	const hasEnTranslation = useHasEnTranslation();
 
 	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
 	const pluginsLink = `https://wordpress.com/plugins/${ encodeURIComponent( siteSlug ) }`;
@@ -100,6 +102,19 @@ const DevTools = () => {
 		return;
 	}
 
+	const upgradeCtaCopy = hasEnTranslation(
+		'Upgrade to the %(planName)s plan or higher to get access to all developer tools'
+	)
+		? translate(
+				'Upgrade to the %(planName)s plan or higher to get access to all developer tools',
+				{
+					args: {
+						planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+					},
+				}
+		  )
+		: translate( 'Upgrade to the Creator plan or higher to get access to all developer tools' );
+
 	return (
 		<div className="dev-tools">
 			<div className="dev-tools__hero">
@@ -113,9 +128,7 @@ const DevTools = () => {
 						? translate(
 								'Your plan includes all the developer tools listed below. Click "Activate Now" to begin.'
 						  )
-						: translate(
-								'Upgrade to the Creator plan or higher to get access to all developer tools'
-						  ) }
+						: upgradeCtaCopy }
 				</p>
 				{ showActivationButton ? (
 					<>

--- a/client/landing/stepper/declarative-flow/internals/components/migration-assistance-modal/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/migration-assistance-modal/index.tsx
@@ -1,4 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
@@ -46,6 +48,8 @@ export const MigrationAssistanceModal: React.FunctionComponent< MigrationAssista
 		} );
 	}, [ importSiteHostName ] );
 
+	const hasEnTranslation = useHasEnTranslation();
+
 	return (
 		<ConfirmModal
 			compact={ false }
@@ -56,14 +60,26 @@ export const MigrationAssistanceModal: React.FunctionComponent< MigrationAssista
 			onConfirm={ acceptMigrationAssistance }
 		>
 			<p>
-				{ translate(
-					`Subscribe to the Creator plan now, and get a complimentary migration service (normally $500) to move %(importSiteHostName)s to WordPress.com.`,
-					{
-						args: {
-							importSiteHostName,
-						},
-					}
-				) }
+				{ hasEnTranslation(
+					'Subscribe to the %(planName)s plan now, and get a complimentary migration service (normally $500) to move %(importSiteHostName)s to WordPress.com.'
+				)
+					? translate(
+							'Subscribe to the %(planName)s plan now, and get a complimentary migration service (normally $500) to move %(importSiteHostName)s to WordPress.com.',
+							{
+								args: {
+									importSiteHostName,
+									planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+								},
+							}
+					  )
+					: translate(
+							`Subscribe to the Creator plan now, and get a complimentary migration service (normally $500) to move %(importSiteHostName)s to WordPress.com.`,
+							{
+								args: {
+									importSiteHostName,
+								},
+							}
+					  ) }
 			</p>
 			<p>
 				{ translate(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -1,3 +1,5 @@
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import {
 	NextButton,
 	StepContainer,
@@ -18,9 +20,14 @@ type SubmitDestination = 'import' | 'migrate' | 'upgrade';
 const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 	const translate = useTranslate();
 	const site = useSite();
+	const hasEnTranslation = useHasEnTranslation();
 	const options = [
 		{
-			label: translate( 'Everything (requires a Creator Plan)' ),
+			label: hasEnTranslation( 'Everything (requires a %(planName)s Plan)' )
+				? translate( 'Everything (requires a %(planName)s Plan)', {
+						args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+				  } )
+				: translate( 'Everything (requires a Creator Plan)' ),
 			description: translate(
 				"All your site's content, themes, plugins, users, and customizations."
 			),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -4,6 +4,7 @@ import {
 	getPlan,
 	getPlanByPathSlug,
 } from '@automattic/calypso-products';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { UpgradePlan } from 'calypso/blocks/importer/wordpress/upgrade-plan';
@@ -21,6 +22,7 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 	const siteItem = useSite();
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const queryParams = useQuery();
 	const hideFreeMigrationTrialForNonVerifiedEmail =
 		( data?.hideFreeMigrationTrialForNonVerifiedEmail as boolean | undefined ) ?? true;
@@ -96,9 +98,22 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 					<FormattedHeader
 						id="site-migration-instructions-header"
 						headerText={ translate( 'Take your site to the next level' ) }
-						subHeaderText={ translate(
-							'Migrations are exclusive to the Creator plan. Check out all its benefits, and upgrade to get started.'
-						) }
+						subHeaderText={
+							hasEnTranslation(
+								'Migrations are exclusive to the %(planName)s plan. Check out all its benefits, and upgrade to get started.'
+							)
+								? translate(
+										'Migrations are exclusive to the %(planName)s plan. Check out all its benefits, and upgrade to get started.',
+										{
+											args: {
+												planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+											},
+										}
+								  )
+								: translate(
+										'Migrations are exclusive to the Creator plan. Check out all its benefits, and upgrade to get started.'
+								  )
+						}
 						align="center"
 						subHeaderAlign="center"
 					/>

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -466,6 +466,9 @@ import {
 	getPlanEcommerceTitle,
 	getPlanPersonalTitle,
 	getPlanPremiumTitle,
+	getPlanBusinessTrialTitle,
+	getPlanCommerceTrialTitle,
+	getPlanBusinessTrialTagline,
 } from './plans';
 import type {
 	BillingTerm,
@@ -4089,8 +4092,8 @@ PLANS_LIST[ PLAN_ECOMMERCE_TRIAL_MONTHLY ] = {
 	term: TERM_MONTHLY,
 	getBillingTimeFrame: () => i18n.translate( 'free trial' ),
 	getStoreSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	getTitle: () => i18n.translate( 'Entrepreneur free trial' ),
-	getDescription: () => i18n.translate( 'Entrepreneur free trial' ),
+	getTitle: getPlanCommerceTrialTitle,
+	getDescription: getPlanCommerceTrialTitle,
 	getTagline: () => i18n.translate( 'Get a taste of the world’s most popular eCommerce software.' ),
 };
 
@@ -4104,13 +4107,13 @@ if ( isEnabled( 'plans/migration-trial' ) ) {
 		term: TERM_MONTHLY,
 		getBillingTimeFrame: () => i18n.translate( 'free trial' ),
 		getStoreSlug: () => PLAN_MIGRATION_TRIAL_MONTHLY,
-		getTitle: () => i18n.translate( 'Creator Trial' ),
+		getTitle: getPlanBusinessTrialTitle,
 	};
 }
 
 PLANS_LIST[ PLAN_HOSTING_TRIAL_MONTHLY ] = {
 	...getPlanBusinessDetails(),
-	getPlanTagline: () => i18n.translate( 'Try all the features of our Creator plan.' ),
+	getPlanTagline: getPlanBusinessTrialTagline,
 	type: TYPE_BUSINESS,
 	group: GROUP_WPCOM,
 	getProductId: () => 1058,
@@ -4118,7 +4121,7 @@ PLANS_LIST[ PLAN_HOSTING_TRIAL_MONTHLY ] = {
 	term: TERM_MONTHLY,
 	getBillingTimeFrame: () => i18n.translate( 'Try it for 3 days' ),
 	getStoreSlug: () => PLAN_HOSTING_TRIAL_MONTHLY,
-	getTitle: () => i18n.translate( 'Creator Trial' ),
+	getTitle: getPlanBusinessTrialTitle,
 	getDescription: () => i18n.translate( 'Hosting free trial' ),
 	getTagline: () => i18n.translate( 'Get a taste of unlimited performance and unbeatable uptime' ),
 };

--- a/packages/calypso-products/src/plans.tsx
+++ b/packages/calypso-products/src/plans.tsx
@@ -6,30 +6,53 @@ import { getPlansListExperiment } from './experiments';
  * See: p7H4VZ-4S4-p2
  */
 
+const isPlanNameChangeTreatment =
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment';
 export const getPlanPersonalTitle = () =>
-	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
+	isPlanNameChangeTreatment
 		? // translators: Personal is a plan name
 		  i18n.translate( 'Personal' )
 		: // translators: Starter is a plan name
 		  i18n.translate( 'Starter' );
 
 export const getPlanPremiumTitle = () =>
-	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
+	isPlanNameChangeTreatment
 		? // translators: Premium is a plan name
 		  i18n.translate( 'Premium' )
 		: // translators: Explorer is a plan name
 		  i18n.translate( 'Explorer' );
 
 export const getPlanBusinessTitle = () =>
-	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
+	isPlanNameChangeTreatment
 		? // translators: Business is a plan name
 		  i18n.translate( 'Business' )
 		: // translators: Creator is a plan name
 		  i18n.translate( 'Creator' );
 
 export const getPlanEcommerceTitle = () =>
-	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
+	isPlanNameChangeTreatment
 		? // translators: Commerce is a plan name
 		  i18n.translate( 'Commerce' )
 		: // translators: Entrepreneur is a plan name
 		  i18n.translate( 'Entrepreneur' );
+
+export const getPlanBusinessTrialTitle = () =>
+	isPlanNameChangeTreatment
+		? // translators: Business Trial is a plan name
+		  i18n.translate( 'Business Trial' )
+		: // translators: Creator Trial is a plan name
+		  i18n.translate( 'Creator Trial' );
+
+export const getPlanBusinessTrialTagline = () =>
+	isPlanNameChangeTreatment
+		? // translators: Business is a plan name
+		  i18n.translate( 'Try all the features of our Business plan.' )
+		: // translators: Creator is a plan name
+		  i18n.translate( 'Try all the features of our Creator plan.' );
+
+export const getPlanCommerceTrialTitle = () =>
+	isPlanNameChangeTreatment
+		? // translators: Commerce Trial is a plan name
+		  i18n.translate( 'Commerce Trial' )
+		: // translators: Entrepreneur Trial is a plan name
+		  i18n.translate( 'Entrepreneur Trial' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove hardcoded plan name strings since these will interfere with plan name change experiments.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because they will interfere with the plan name change experiment (check pbxNRc-3Kh-p2).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify in all the places that these strings appear that the strings continue to render as before. 

