### PR TITLE
Remove hardcoded Entrepreneur plan name

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
@@ -3,6 +3,7 @@ import {
 	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_ECOMMERCE_3_YEARS,
 	PLAN_ECOMMERCE_MONTHLY,
+	getPlan,
 	getPlans,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
@@ -196,11 +197,25 @@ export function EntrepreneurPlan( props: EntrepreneurPlanProps ) {
 			<Card>
 				<div className="plan-wrapper">
 					<div className="plan-description">
-						<h3 className="entrepreneur-trial-plan__plan-title">{ translate( 'Entrepreneur' ) }</h3>
+						<h3 className="entrepreneur-trial-plan__plan-title">
+							{ getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '' }
+						</h3>
 						<p className="card-text">
-							{ translate(
-								"Secure the full benefits of the Entrepreneur plan. Purchase today and maximize your store's potential!"
-							) }
+							{ isEnglish ||
+							hasTranslation(
+								"Secure the full benefits of the %(planName)s plan. Purchase today and maximize your store's potential!"
+							)
+								? translate(
+										"Secure the full benefits of the %(planName)s plan. Purchase today and maximize your store's potential!",
+										{
+											args: {
+												planName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+											},
+										}
+								  )
+								: translate(
+										"Secure the full benefits of the Entrepreneur plan. Purchase today and maximize your store's potential!"
+								  ) }
 						</p>
 					</div>
 					<div className="price-block">

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -4,6 +4,7 @@ import {
 	getIntervalTypeForTerm,
 	getPlan,
 	isFreePlanProduct,
+	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_FREE,
 	PLAN_HOSTING_TRIAL_MONTHLY,
@@ -401,15 +402,19 @@ class Plans extends Component {
 		);
 
 		const hasEntrepreneurTrialSubHeaderTextTranslation = hasTranslation(
-			"Discover what's available in your Entrepreneur plan."
+			"Discover what's available in your %(planName)s plan."
 		);
 
 		const isEnglishLocale = englishLocales.includes( this.props.locale );
 
 		const entrepreneurTrialSubHeaderText =
 			isEnglishLocale || hasEntrepreneurTrialSubHeaderTextTranslation
-				? translate( "Discover what's available in your Entrepreneur plan." )
-				: translate( "Discover what's available in your Entrepreneur plan" );
+				? translate( "Discover what's available in your %(planName)s plan.", {
+						args: {
+							planName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+						},
+				  } )
+				: translate( "Discover what's available in your Entrepreneur plan." );
 
 		const isWooExpressTrial = purchase?.isWooExpressTrial;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove hardcoded plan names introduced in https://github.com/Automattic/wp-calypso/pull/90816 and https://github.com/Automattic/wp-calypso/pull/89575.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because the hardcoded plan names will interfere with plan name change experiments. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The pages displaying these strings should continue to show the same strings with no changes, and translations preserved.

