### PR TITLE
Site management panel: Combine log tabs

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-table/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-table/style.scss
@@ -33,7 +33,7 @@ $border-color:#eeeeee; /* stylelint-disable-line color-hex-length */
 
 /* Remove padding on the left for the first item in the row */
 .site-logs-table tr td:first-child {
-	padding-left: 0;
+	padding-inline-start: 0 !important;
 }
 
 /* Remove padding on the right for the last item in the row */

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -187,7 +187,7 @@ export const SiteLogsToolbar = ( {
 				{ logType === 'web' && (
 					<>
 						<div className="site-logs-toolbar-filter-element">
-							<label htmlFor="site-logs-request-type">{ translate( 'Request Type' ) }</label>
+							<label htmlFor="site-logs-request-type">{ translate( 'Request type' ) }</label>
 							<SelectDropdown
 								id="site-logs-request-type"
 								className="site-logs-toolbar-filter-request-type"

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -276,10 +276,6 @@ div.is-section-site-monitoring:not(.is-global-sidebar-visible) {
 	}
 }
 
-.site-logs__navigation-header.navigation-header {
-	margin-bottom: 32px;
-}
-
 .site-logs-container {
 	@media (max-width: $break-small) {
 		margin-top: -12px !important;

--- a/client/sections.js
+++ b/client/sections.js
@@ -705,8 +705,14 @@ const sections = [
 	},
 	{
 		name: 'site-monitoring',
-		paths: [ '/site-monitoring', '/site-logs' ],
+		paths: [ '/site-monitoring' ],
 		module: 'calypso/site-monitoring',
+		group: 'sites',
+	},
+	{
+		name: 'site-logs',
+		paths: [ '/site-logs' ],
+		module: 'calypso/site-logs',
 		group: 'sites',
 	},
 	{

--- a/client/site-logs/components/logs-header/index.tsx
+++ b/client/site-logs/components/logs-header/index.tsx
@@ -1,0 +1,57 @@
+import { SegmentedControl } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { navigate } from 'calypso/lib/navigate';
+
+import './style.scss';
+
+export function LogsHeader( { logType }: { logType: string } ) {
+	const options = [
+		{
+			value: 'php',
+			label: translate( 'PHP error logs' ),
+		},
+		{
+			value: 'web',
+			label: translate( 'HTTP request logs' ),
+		},
+	];
+
+	const switchType = ( newType: string ) => {
+		navigate( window.location.pathname.replace( /\/[^/]+$/, '/' + newType ) );
+	};
+
+	return (
+		<div className="logs-header">
+			<NavigationHeader
+				title={ translate( 'Logs' ) }
+				subtitle={ translate(
+					'View and download various server logs. {{link}}Learn more.{{/link}}',
+					{
+						components: {
+							link: <InlineSupportLink supportContext="site-monitoring-logs" showIcon={ false } />,
+						},
+					}
+				) }
+			/>
+			<div className="logs-header__selector-container">
+				<div className="logs-header__selector-heading">{ translate( 'Log type' ) }</div>
+				<SegmentedControl primary className="logs-header__selector-controls">
+					{ options.map( ( option ) => {
+						return (
+							<SegmentedControl.Item
+								key={ option.value }
+								value={ option.value }
+								selected={ option.value === logType }
+								onClick={ () => switchType( option.value ) }
+							>
+								{ option.label }
+							</SegmentedControl.Item>
+						);
+					} ) }
+				</SegmentedControl>
+			</div>
+		</div>
+	);
+}

--- a/client/site-logs/components/logs-header/index.tsx
+++ b/client/site-logs/components/logs-header/index.tsx
@@ -10,11 +10,11 @@ export function LogsHeader( { logType }: { logType: string } ) {
 	const options = [
 		{
 			value: 'php',
-			label: translate( 'PHP error logs' ),
+			label: translate( 'PHP error' ),
 		},
 		{
 			value: 'web',
-			label: translate( 'HTTP request logs' ),
+			label: translate( 'Web server' ),
 		},
 	];
 

--- a/client/site-logs/components/logs-header/style.scss
+++ b/client/site-logs/components/logs-header/style.scss
@@ -1,0 +1,61 @@
+
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.logs-header {
+	display: flex;
+	gap: 24px;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 16px;
+
+	.navigation-header {
+		width: auto;
+		padding-bottom: 0;
+		margin-bottom: 16px;
+
+		@media (max-width: $break-medium) {
+			margin-bottom: 8px;
+		}
+	}
+}
+
+.logs-header__selector-container {
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+	justify-content: flex-end;
+	align-self: flex-start;
+	gap: 10px;
+
+	@include break-medium {
+		flex-direction: row;
+		align-items: center;
+	}
+
+	@media (max-width: $break-medium) {
+		width: 100%;
+	}
+}
+
+.logs-header__selector-heading {
+	font-weight: 400;
+	font-size: 0.875rem;
+	line-height: 20px;
+}
+
+.logs-header__selector-controls {
+	flex-grow: 1;
+	&.segmented-control .segmented-control__item:first-of-type .segmented-control__link {
+		border-top-left-radius: 4px;
+		border-bottom-left-radius: 4px;
+	}
+	&.segmented-control .segmented-control__item:last-of-type .segmented-control__link {
+		border-top-right-radius: 4px;
+		border-bottom-right-radius: 4px;
+	}
+	@include break-medium {
+		max-width: 329px;
+	}
+}

--- a/client/site-logs/controller.tsx
+++ b/client/site-logs/controller.tsx
@@ -18,7 +18,7 @@ export function phpErrorLogs( context: PageJSContext, next: () => void ) {
 export function httpRequestLogs( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<>
-			<PageViewTracker path="/site-logs/:site/web" title="HTTP Request Logs" />
+			<PageViewTracker path="/site-logs/:site/web" title="Web Server Logs" />
 			<LogsHeader logType="web" />
 			<LogsTab logType="web" />
 		</>

--- a/client/site-logs/controller.tsx
+++ b/client/site-logs/controller.tsx
@@ -1,0 +1,28 @@
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { LogsTab } from 'calypso/my-sites/site-monitoring/logs-tab';
+import { LogsHeader } from './components/logs-header';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+export function phpErrorLogs( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<>
+			<PageViewTracker path="/site-logs/:site/php" title="PHP Error Logs" />
+			<LogsHeader logType="php" />
+			<LogsTab logType="php" />
+		</>
+	);
+
+	next();
+}
+
+export function httpRequestLogs( context: PageJSContext, next: () => void ) {
+	context.primary = (
+		<>
+			<PageViewTracker path="/site-logs/:site/web" title="HTTP Request Logs" />
+			<LogsHeader logType="web" />
+			<LogsTab logType="web" />
+		</>
+	);
+
+	next();
+}

--- a/client/site-logs/index.tsx
+++ b/client/site-logs/index.tsx
@@ -1,0 +1,43 @@
+import page, { type Callback } from '@automattic/calypso-router';
+import {
+	makeLayout,
+	render as clientRender,
+	redirectToDevToolsPromoIfNotAtomic,
+} from 'calypso/controller';
+import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
+import { redirectHomeIfIneligible } from 'calypso/my-sites/site-monitoring/controller';
+import { siteDashboard } from 'calypso/sites-dashboard-v2/controller';
+import { DOTCOM_LOGS } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
+import { httpRequestLogs, phpErrorLogs } from './controller';
+
+export default function () {
+	page( '/site-logs', siteSelection, sites, makeLayout, clientRender );
+
+	const redirectSiteLogsToPhp: Callback = ( context ) => {
+		context.page.replace( `/site-logs/${ context.params.site }/php` );
+	};
+	page( '/site-logs/:site', redirectSiteLogsToPhp );
+
+	page(
+		'/site-logs/:site/php',
+		siteSelection,
+		redirectToDevToolsPromoIfNotAtomic,
+		redirectHomeIfIneligible,
+		navigation,
+		phpErrorLogs,
+		siteDashboard( DOTCOM_LOGS ),
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/site-logs/:site/web',
+		siteSelection,
+		redirectToDevToolsPromoIfNotAtomic,
+		redirectHomeIfIneligible,
+		navigation,
+		httpRequestLogs,
+		siteDashboard( DOTCOM_LOGS ),
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/site-monitoring/controller.tsx
+++ b/client/site-monitoring/controller.tsx
@@ -1,59 +1,12 @@
-import { translate } from 'i18n-calypso';
-import InlineSupportLink from 'calypso/components/inline-support-link';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { LogsTab } from 'calypso/my-sites/site-monitoring/logs-tab';
 import { MetricsTab } from 'calypso/my-sites/site-monitoring/metrics-tab';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
-export function siteMonitoringOverview( context: PageJSContext, next: () => void ) {
+export function siteMonitoring( context: PageJSContext, next: () => void ) {
 	context.primary = (
 		<>
 			<PageViewTracker path="/site-monitoring/:site" title="Site Monitoring" />
 			<MetricsTab />
-		</>
-	);
-
-	next();
-}
-
-export function siteMonitoringPhpLogs( context: PageJSContext, next: () => void ) {
-	context.primary = (
-		<>
-			<PageViewTracker path="/site-monitoring/:site/php" title="Site Monitoring" />
-			<NavigationHeader
-				className="site-logs__navigation-header"
-				title={ translate( 'PHP Logs' ) }
-				subtitle={ translate( 'View and download PHP error logs. {{link}}Learn more.{{/link}}', {
-					components: {
-						link: <InlineSupportLink supportContext="site-monitoring-logs" showIcon={ false } />,
-					},
-				} ) }
-			/>
-			<LogsTab logType="php" />
-		</>
-	);
-
-	next();
-}
-
-export function siteMonitoringServerLogs( context: PageJSContext, next: () => void ) {
-	context.primary = (
-		<>
-			<PageViewTracker path="/site-monitoring/:site/web" title="Site Monitoring" />
-			<NavigationHeader
-				className="site-logs__navigation-header"
-				title={ translate( 'Server Logs' ) }
-				subtitle={ translate(
-					'Gain full visibility into server activity. {{link}}Learn more.{{/link}}',
-					{
-						components: {
-							link: <InlineSupportLink supportContext="site-monitoring-logs" showIcon={ false } />,
-						},
-					}
-				) }
-			/>
-			<LogsTab logType="web" />
 		</>
 	);
 

--- a/client/site-monitoring/index.tsx
+++ b/client/site-monitoring/index.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import page, { type Callback } from '@automattic/calypso-router';
+import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
@@ -8,16 +8,8 @@ import {
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { redirectHomeIfIneligible, siteMetrics } from 'calypso/my-sites/site-monitoring/controller';
 import { siteDashboard } from 'calypso/sites-dashboard-v2/controller';
-import {
-	DOTCOM_MONITORING,
-	DOTCOM_PHP_LOGS,
-	DOTCOM_SERVER_LOGS,
-} from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
-import {
-	siteMonitoringOverview,
-	siteMonitoringPhpLogs,
-	siteMonitoringServerLogs,
-} from './controller';
+import { DOTCOM_MONITORING } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
+import { siteMonitoring } from './controller';
 
 export default function () {
 	page( '/site-monitoring', siteSelection, sites, makeLayout, clientRender );
@@ -29,30 +21,8 @@ export default function () {
 			redirectToDevToolsPromoIfNotAtomic,
 			redirectHomeIfIneligible,
 			navigation,
-			siteMonitoringOverview,
+			siteMonitoring,
 			siteDashboard( DOTCOM_MONITORING ),
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/site-monitoring/:site/php',
-			siteSelection,
-			redirectToDevToolsPromoIfNotAtomic,
-			redirectHomeIfIneligible,
-			navigation,
-			siteMonitoringPhpLogs,
-			siteDashboard( DOTCOM_PHP_LOGS ),
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/site-monitoring/:site/web',
-			siteSelection,
-			redirectToDevToolsPromoIfNotAtomic,
-			redirectHomeIfIneligible,
-			navigation,
-			siteMonitoringServerLogs,
-			siteDashboard( DOTCOM_SERVER_LOGS ),
 			makeLayout,
 			clientRender
 		);
@@ -68,16 +38,4 @@ export default function () {
 			clientRender
 		);
 	}
-
-	// Legacy redirect for Site Logs.
-	const redirectSiteLogsToMonitoring: Callback = ( context ) => {
-		if ( context.params?.siteId ) {
-			context.page.replace( `/site-monitoring/${ context.params.siteId }` );
-		} else {
-			context.page.replace( `/site-monitoring` );
-		}
-		return;
-	};
-	page( '/site-logs', redirectSiteLogsToMonitoring );
-	page( '/site-logs/:siteId', redirectSiteLogsToMonitoring );
 }

--- a/client/sites-dashboard-v2/hooks/use-sync-selected-site-feature.ts
+++ b/client/sites-dashboard-v2/hooks/use-sync-selected-site-feature.ts
@@ -47,8 +47,15 @@ export function useSyncSelectedSiteFeature( {
 		}
 	};
 
-	// Update URL when a new feature is selected.
+	// Update URL when a new site or feature is selected.
 	useEffect( () => {
+		if (
+			selectedSite?.slug === dataViewsState.selectedItem?.slug &&
+			selectedSiteFeature === initialSiteFeature
+		) {
+			return;
+		}
+
 		// Whether the left sidebar should animate (grow or collapse)
 		const shouldAnimate = Boolean( selectedSite ) !== Boolean( dataViewsState.selectedItem?.slug );
 

--- a/client/sites-dashboard-v2/site-preview-pane/constants.ts
+++ b/client/sites-dashboard-v2/site-preview-pane/constants.ts
@@ -1,7 +1,6 @@
 export const DOTCOM_OVERVIEW = 'dotcom-hosting';
 export const DOTCOM_MONITORING = 'dotcom-site-monitoring';
-export const DOTCOM_PHP_LOGS = 'dotcom-site-monitoring-php';
-export const DOTCOM_SERVER_LOGS = 'dotcom-site-monitoring-web';
+export const DOTCOM_LOGS = 'dotcom-site-logs';
 export const DOTCOM_GITHUB_DEPLOYMENTS = 'dotcom-github-deployments';
 export const DOTCOM_HOSTING_CONFIG = 'dotcom-hosting-config';
 export const DOTCOM_DEVELOPER_TOOLS = 'dotcom-developer-tools';
@@ -10,8 +9,7 @@ export const DOTCOM_STAGING_SITE = 'dotcom-staging-site';
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_OVERVIEW ]: 'overview/:site',
 	[ DOTCOM_MONITORING ]: 'site-monitoring/:site',
-	[ DOTCOM_PHP_LOGS ]: 'site-monitoring/:site/php',
-	[ DOTCOM_SERVER_LOGS ]: 'site-monitoring/:site/web',
+	[ DOTCOM_LOGS ]: 'site-logs/:site/php',
 	[ DOTCOM_GITHUB_DEPLOYMENTS ]: 'github-deployments/:site',
 	[ DOTCOM_HOSTING_CONFIG ]: 'hosting-config/:site',
 	[ DOTCOM_DEVELOPER_TOOLS ]: 'dev-tools/:site',

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -10,8 +10,7 @@ import {
 	DOTCOM_HOSTING_CONFIG,
 	DOTCOM_OVERVIEW,
 	DOTCOM_MONITORING,
-	DOTCOM_PHP_LOGS,
-	DOTCOM_SERVER_LOGS,
+	DOTCOM_LOGS,
 	DOTCOM_GITHUB_DEPLOYMENTS,
 	DOTCOM_DEVELOPER_TOOLS,
 	DOTCOM_STAGING_SITE,
@@ -82,16 +81,8 @@ const DotcomPreviewPane = ( {
 				selectedSiteFeaturePreview
 			),
 			createFeaturePreview(
-				DOTCOM_PHP_LOGS,
-				__( 'PHP Logs' ),
-				isAtomicSite && ! isPlanExpired,
-				selectedSiteFeature,
-				setSelectedSiteFeature,
-				selectedSiteFeaturePreview
-			),
-			createFeaturePreview(
-				DOTCOM_SERVER_LOGS,
-				__( 'Server Logs' ),
+				DOTCOM_LOGS,
+				__( 'Logs' ),
 				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -15,6 +15,7 @@ const GLOBAL_SITE_DASHBOARD_ROUTES = {
 	hosting: '/hosting-config/',
 	'github-deployments': '/github-deployments/',
 	'site-monitoring': '/site-monitoring/',
+	'site-logs': '/site-logs/',
 	'dev-tools': '/dev-tools/',
 	'staging-site': '/staging-site',
 };


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/7514

## Proposed Changes

This PR combines the `PHP Logs` and `Server Logs` tabs into one single Logs tab:

|Before|After|
|-|-|
|PHP<br><img width="1357" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/92fbaf6e-6076-4b1c-bc54-17ce69ba9ab1"><br><br>Web<br><img width="1357" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/51795977-5ef0-4d8e-8580-5dd13b0a778c">|PHP<br><img width="1356" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/a57959a8-8072-4cac-a4a8-321749c5fba2"><br><br>Web<br><img width="1356" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/998e71fe-d703-4785-b165-889fe2dcb7a3">|

> [!NOTE]
> I am reusing the old `/site-logs/` route, which is now unused. Seems perfect for this job.

> [!NOTE]
> Here, I improvise the subtab naming based on my suggestion in the [issue](https://github.com/Automattic/dotcom-forge/issues/7514). Feel free to suggest otherwise, or we can iterate later.

## Why are these changes being made?

We want to refine the information architecture of the site management panel.

## Testing Instructions

1. Go to `/sites`.
2. Select an atomic site.
3. Click Logs tab.
4. Play around with the PHP subtab; verify that the functionality works.
5. Click the HTTP request subtab.
6. Play around with the HTTP request subtab; verify that the functionality works.

Regression testing

1. Visit `/site-monitoring/:site/php?flags=-layout/dotcom-nav-redesign-v2` and verify that it still works.
1. Visit `/site-monitoring/:site/web?flags=-layout/dotcom-nav-redesign-v2` and verify that it still works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
