### PR TITLE
Jetpack Cloud: Enable horizon/staging to load Simple Sites behind feature flag

### DIFF
--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -99,7 +99,7 @@
 		"scan": true,
 		"site-purchases": true
 	},
-	"site_filter": [ "jetpack", "atomic" ],
+	"site_filter": [ "jetpack", "atomic", "wpcom" ],
 	"theme": "jetpack-cloud",
 	"hotjar_enabled": true,
 	"theme_color": "#2fb41f"

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -103,7 +103,7 @@
 		"scan": true,
 		"site-purchases": true
 	},
-	"site_filter": [ "jetpack", "atomic" ],
+	"site_filter": [ "jetpack", "atomic", "wpcom" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7542

## Proposed Changes

* As part of making Jetpack Cloud available for Simple sites, we will start to query for simple sites
* Whether to show the Simple sites logic is gated behind the `jetpack/manage-simple-sites` feature flag

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow easier testing for Jetpack Cloud for Simple Sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link
* Check that by default it doesn't include SImple sites
* Apply feature flag by adding  `flags=jetpack/manage-simple-sites`
* Check that it includes Simple sites but doesn't show P2 sites
* You can also test the behavior on dev with `yarn start-jetpack-cloud` and accessing `jetpack.cloud.localhost:3000`, as the feature flag is on by default, you should be able to see simple sites and p2 sites are excluded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
