### PR TITLE
Entrepreneur Flow: Fix Signup `trialAcknowledge` step redirection

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -59,6 +59,7 @@ const entrepreneurFlow: Flow = {
 				variationName: flowName,
 				redirectTo,
 				locale,
+				customLoginPath: '/start/entrepreneur/user-social',
 			} );
 
 			return loginUrl;

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -50,6 +50,7 @@ export const getLoginUrl = ( {
 	redirectTo,
 	pageTitle,
 	locale,
+	customLoginPath,
 }: {
 	/**
 	 * Variation name is used to track the relevant login flow in the signup framework as explained in https://github.com/Automattic/wp-calypso/issues/67173
@@ -58,10 +59,12 @@ export const getLoginUrl = ( {
 	redirectTo?: string | null;
 	pageTitle?: string | null;
 	locale: string;
+	customLoginPath?: string | null;
 } ): string => {
-	const loginPath = `/start/account/${
+	const defaultLoginPath = `/start/account/${
 		isEnabled( 'signup/social-first' ) ? 'user-social' : 'user'
 	}`;
+	const loginPath = customLoginPath || defaultLoginPath;
 	const localizedLoginPath = locale && locale !== 'en' ? `${ loginPath }/${ locale }` : loginPath;
 
 	// Empty values are ignored down the call stack, so we don't need to check for them here.
@@ -78,6 +81,7 @@ export const useLoginUrl = ( {
 	redirectTo,
 	pageTitle,
 	locale,
+	customLoginPath,
 }: {
 	/**
 	 * Variation name is used to track the relevant login flow in the signup framework as explained in https://github.com/Automattic/wp-calypso/issues/67173
@@ -86,6 +90,7 @@ export const useLoginUrl = ( {
 	redirectTo?: string | null;
 	pageTitle?: string | null;
 	locale?: string;
+	customLoginPath?: string | null;
 } ): string => {
 	const currentLocale = useLocale();
 	return getLoginUrl( {
@@ -93,5 +98,6 @@ export const useLoginUrl = ( {
 		redirectTo,
 		pageTitle,
 		locale: locale ?? currentLocale,
+		customLoginPath,
 	} );
 };

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,4 +1,4 @@
-import { ACCOUNT_FLOW, HOSTING_LP_FLOW } from '@automattic/onboarding';
+import { ACCOUNT_FLOW, HOSTING_LP_FLOW, ENTREPRENEUR_FLOW } from '@automattic/onboarding';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -35,6 +35,7 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 			break;
 		case ACCOUNT_FLOW:
 		case HOSTING_LP_FLOW:
+		case ENTREPRENEUR_FLOW:
 			steps = [ { title: __( 'Creating your account' ) } ];
 			break;
 		case 'setup-site':


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7443.

## Proposed Changes

* allow `getLoginUrl` and `useLoginUrl` to accept optional `customLoginPath` parameter
* update `getEntrepreneurLoginUrl` to use `/start/entrepreneur/user-social` custom login path
* update signup reskinned processing screen messaging to display "Creating your account" message

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* this PR is the final piece of changes that fix the https://github.com/Automattic/dotcom-forge/issues/7443 issue

## Testing Instructions

1. Check out the PR and build it.
2. Make sure your GitHub account isn't linked with any WordPress.com account.
3. Open browser where you are not logged in into any WordPress.com account. Please don't use incognito browser window - there's some technical limitation related to local Calypso app and the login process won't finish.
4. Open any WordPress.com page, e.g. https://wordpress.com/ecommerce/?ref=woo-hosting-solutions-lp. This step is necessary for the `tk_ai` cookie to be available.
5. Navigate to http://calypso.localhost:3000/setup/entrepreneur/start/?ref=woo-hosting-solutions-lp (the local equivalent of CTA button at https://wordpress.com/ecommerce/?ref=woo-hosting-solutions-lp).
6. Go through the Segmentation Survey. Once you reach the "Create your account" screen, take a look at the address bar. It should include `entrepreneur` instead of `account` - as can be seen in the following screenshot:

![Markup on 2024-05-31 at 10:39:28](https://github.com/Automattic/wp-calypso/assets/25105483/253890c5-9597-4245-bf1b-4f98f24d7ef7)

7. Continue with the flow (sign in to GitHub). You should be directed back to WordPress.com and loading screen with "Creating your account" should display.
8. Once the account is created, you should reach the `trialAcknowledge` step and be able to follow through and have your customized in the CYS (Customize Your Store AI tool).
9. As next case you can try to go through the flow once again, but this time as a logged-in user: Simply go to http://calypso.localhost:3000/setup/entrepreneur/start/?ref=woo-hosting-solutions-lp again and you should be able to go through the whole flow without any issues. Second trial site should be created.
10. Feel free to test for potential regressions, e.g. trying other signup flow (email) or login flows (email or GitHub). Please note that Apple and Google SSOs won't work in local environment.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2