### PR TITLE
Remove unused code added for Jetpack Cloud atomic

### DIFF
--- a/client/state/sites/selectors/get-jetpack-admin-url.js
+++ b/client/state/sites/selectors/get-jetpack-admin-url.js
@@ -1,5 +1,4 @@
 import { format as formatUrl, getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
-import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import getSiteAdminPage from './get-site-admin-page';
 import getSiteAdminUrl from './get-site-admin-url';
 
@@ -7,9 +6,6 @@ export default function getJetpackAdminUrl( state, siteId, productSlug ) {
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 	if ( siteAdminUrl === null ) {
 		return undefined;
-	}
-	if ( isSiteAtomic( state, siteId ) ) {
-		return siteAdminUrl;
 	}
 
 	const parts = getUrlParts( siteAdminUrl + 'admin.php' );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/87507

## Proposed Changes

* This removed code was introduced in https://github.com/Automattic/wp-calypso/pull/87507/files#diff-aa4cc97223acec7b1b48df2176da5c2220285eec94660bda6088cf1d28dba9dbR11-R13, but as we're now all pointing back to `/wp-admin` for all types of sites (https://github.com/Automattic/wp-calypso/pull/91234#top), the code is no longer needed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Remove unused code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The only other place the `getJetpackAdminUrl` function is used is in `client/my-sites/checkout/checkout-thank-you/use-get-jetpack-activation-confirmation-info.ts`

* Create a Jetpack site and connect it to Jetpack Cloud
* Go to the Jetpack Cloud live link and navigate to /pricing
* Pick a Jeptack product to checkout, I picked Social
* After checking out you'll notice you're on wordpress.com, swap the wordpress.com with the **Calypso** live link below
* Select a Jetpack site in the dropdown menu
* Click on Go to Dashboard and you should be directed to`/wp-admin/admin.php?page=my-jetpack`

Steps adapted from: https://github.com/Automattic/wp-calypso/pull/57708

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
