### PR TITLE
Deployment Tab: Update title

### DIFF
--- a/client/my-sites/github-deployments/components/page-shell/index.tsx
+++ b/client/my-sites/github-deployments/components/page-shell/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { Fragment, ReactNode, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -66,7 +67,11 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 			<DocumentHead title={ pageTitle } />
 			<NavigationHeader
 				compactBreadcrumb
-				title={ translate( 'GitHub Deployments' ) }
+				title={
+					isEnabled( 'layout/dotcom-nav-redesign-v2' )
+						? translate( 'Deployments' )
+						: translate( 'GitHub Deployments' )
+				}
 				subtitle={ translate(
 					'Automate updates from GitHub to streamline workflows. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{

--- a/client/my-sites/github-deployments/deployments/index.tsx
+++ b/client/my-sites/github-deployments/deployments/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useI18n } from '@wordpress/react-i18n';
 import ActionPanel from 'calypso/components/action-panel';
@@ -48,7 +49,11 @@ export function GitHubDeployments() {
 
 	return (
 		<PageShell
-			pageTitle={ __( 'GitHub Deployments' ) }
+			pageTitle={
+				isEnabled( 'layout/dotcom-nav-redesign-v2' )
+					? __( 'Deployments' )
+					: __( 'GitHub Deployments' )
+			}
 			topRightButton={
 				deployments &&
 				deployments?.length > 0 && (


### PR DESCRIPTION
## Proposed Changes

This PR updates the page title from "GitHub Deployments" to "Deployments".

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Consistency with the tab title.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the Deployments page title is updated to "Deployments".

| Before | After | 
| --- | --- |
| ![Screenshot 2024-05-31 at 5 54 28 PM](https://github.com/Automattic/wp-calypso/assets/797888/8b09fef2-0966-4839-a646-128bd6f0d46e) | ![Screenshot 2024-05-31 at 5 54 12 PM](https://github.com/Automattic/wp-calypso/assets/797888/6dcb564e-c267-4ff0-963b-a5de3182bb40) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
