### PR TITLE
Nav redesign - fix dev tools redirect

### DIFF
--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -38,13 +38,17 @@ const DevTools = () => {
 	const showActivationModal = searchParams.get( 'activate' ) !== null;
 	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
 	const siteId = useSelector( getSelectedSiteId );
-	// The ref is required to persist the value of redirect_to after renders
-	const redirectUrl = useRef( searchParams.get( 'redirect_to' ) ?? `/hosting-config/${ siteId }` );
 	const { siteSlug, isSiteAtomic, hasSftpFeature } = useSelector( ( state ) => ( {
 		siteSlug: getSiteSlug( state, siteId ) || '',
 		isSiteAtomic: isSiteWpcomAtomic( state, siteId as number ),
 		hasSftpFeature: siteHasFeature( state, siteId, FEATURE_SFTP ),
 	} ) );
+	// The ref is required to persist the value of redirect_to after renders
+	const redirectUrl = useRef(
+		searchParams.get( 'redirect_to' ) ?? hasSftpFeature
+			? `/hosting-config/${ siteId }`
+			: `/overview/${ siteId }`
+	);
 	const hasEnTranslation = useHasEnTranslation();
 
 	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
@@ -98,7 +102,7 @@ const DevTools = () => {
 		page( `/setup/transferring-hosted-site?${ params }` );
 	};
 
-	if ( isSiteAtomic && hasSftpFeature ) {
+	if ( isSiteAtomic ) {
 		page.replace( redirectUrl.current );
 		return;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7535

The dev tools redirect is broken when going from a simple site dev tools panel and then selecting an atomic site. The reason for this is the redirect only happens if that atomic site has the SFTP feature setup where it redirects to the atomic sites host config panel. We need to update this to fallback to redirect to the overview panel when SFTP feature is not set.

## Before

https://github.com/Automattic/wp-calypso/assets/5560595/00887852-9304-4b23-9571-542317d8e005

## After

https://github.com/Automattic/wp-calypso/assets/5560595/028b6cb9-0bd5-4bdd-abc2-90e51aa2f7ea

## Proposed Changes

* Updates redirect on dev tools for all atomic sites, if SFTP setup then goes to hosting config, otherwise it goes to overview.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Broken UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites` and switch between a simple site dev tools panel and an atomic site (with SFTP not setup)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
