### PR TITLE
Scheduled Updates: Hide subtitle in the multisite context (fix regression)

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -53,6 +53,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 						<ScheduleList
 							compact
 							previewMode="card"
+							showSubtitle={ false }
 							showNewScheduleBtn={ context === 'edit' }
 							selectedScheduleId={ selectedSchedule?.schedule_id }
 							onCreateNewSchedule={ onCreateNewSchedule }

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -22,6 +22,7 @@ import './styles.scss';
 type Props = {
 	compact?: boolean;
 	previewMode: 'table' | 'card';
+	showSubtitle?: boolean;
 	showNewScheduleBtn?: boolean;
 	selectedScheduleId?: string;
 	onEditSchedule: ( id: string ) => void;
@@ -33,6 +34,7 @@ export const ScheduleList = ( props: Props ) => {
 	const {
 		compact,
 		previewMode,
+		showSubtitle = true,
 		showNewScheduleBtn = true,
 		selectedScheduleId: initSelectedScheduleId,
 		onEditSchedule,
@@ -125,11 +127,13 @@ export const ScheduleList = ( props: Props ) => {
 			<div className="plugins-update-manager-multisite__header">
 				<div className="plugins-update-manager-multisite__header-main">
 					<h1>{ translate( 'Scheduled Updates' ) }</h1>
-					<p>
-						{ translate(
-							'Streamline your workflow with scheduled updates, timed to suit your needs.'
-						) }
-					</p>
+					{ showSubtitle && (
+						<p>
+							{ translate(
+								'Streamline your workflow with scheduled updates, timed to suit your needs.'
+							) }
+						</p>
+					) }
 				</div>
 				{ showNewScheduleBtn && ! isScheduleEmpty && (
 					<Button


### PR DESCRIPTION
## Proposed Changes

* Go to `/plugins/scheduled-updates`
* Click on any schedule
* Check if there is a subtitle in the left column (schedule list)

## Testing Instructions

| Before | After |
|--------|--------|
| <img width="869" alt="Screenshot 2024-05-31 at 13 09 23" src="https://github.com/Automattic/wp-calypso/assets/1241413/f9061db5-1afd-4d38-882f-6fc49bf0dcc4"> | <img width="872" alt="Screenshot 2024-05-31 at 13 09 34" src="https://github.com/Automattic/wp-calypso/assets/1241413/2ecaa251-e9bf-420f-94de-d86e44912b63"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
