### PR TITLE
Site Migration: Remove new migration flow feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -1,7 +1,5 @@
-import config from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { useLocale, englishLocales } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import type { Goal } from './types';
 
@@ -48,22 +46,11 @@ const useBBEGoal = () => {
 
 export const useGoals = (): Goal[] => {
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
 	const locale = useLocale();
 	const builtByExpressGoalDisplayText = useBBEGoal();
 
 	const importDisplayText = () => {
-		// New copy waiting on translation.
-		if (
-			config.isEnabled( 'onboarding/new-migration-flow' ) &&
-			( englishLocales.includes( translate?.localeSlug || '' ) ||
-				hasTranslation( 'Import existing content or website' ) )
-		) {
-			return translate( 'Import existing content or website' );
-		}
-
-		// Original copy
-		return translate( 'Import my existing website content' );
+		return translate( 'Import existing content or website' );
 	};
 
 	const goals = [

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -147,6 +147,10 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ MIGRATION_SIGNUP_FLOW ]: () =>
 		import( /* webpackChunkName: "migration-signup" */ '../declarative-flow/migration-signup' ),
+	[ SITE_MIGRATION_FLOW ]: () =>
+		import(
+			/* webpackChunkName: "site-migration-flow" */ '../declarative-flow/site-migration-flow'
+		),
 };
 
 const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(
@@ -164,17 +168,6 @@ const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = 
 	  }
 	: {};
 
-const siteMigrationFlow: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(
-	'onboarding/new-migration-flow'
-)
-	? {
-			[ SITE_MIGRATION_FLOW ]: () =>
-				import(
-					/* webpackChunkName: "site-migration-flow" */ '../declarative-flow/site-migration-flow'
-				),
-	  }
-	: {};
-
 const hostedSiteMigrationFlow: Record< string, () => Promise< { default: Flow } > > = {
 	[ HOSTED_SITE_MIGRATION_FLOW ]: () =>
 		import(
@@ -185,6 +178,5 @@ const hostedSiteMigrationFlow: Record< string, () => Promise< { default: Flow } 
 export default {
 	...availableFlows,
 	...videoPressTvFlows,
-	...siteMigrationFlow,
 	...hostedSiteMigrationFlow,
 };

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -337,13 +337,8 @@ const siteSetupFlow: Flow = {
 
 					switch ( intent ) {
 						case SiteIntent.Import:
-							if ( isEnabled( 'onboarding/new-migration-flow' ) ) {
-								return exitFlow(
-									`/setup/site-migration?siteSlug=${ siteSlug }&flags=onboarding/new-migration-flow`
-								);
-							}
+							return exitFlow( `/setup/site-migration?siteSlug=${ siteSlug }&ref=goals` );
 
-							return navigate( 'import' );
 						case SiteIntent.DIFM:
 							return navigate( 'difmStartingPoint' );
 						case SiteIntent.Write:

--- a/config/development.json
+++ b/config/development.json
@@ -214,7 +214,6 @@
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -138,7 +138,6 @@
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -184,7 +184,6 @@
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -177,7 +177,6 @@
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/test.json
+++ b/config/test.json
@@ -122,7 +122,6 @@
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -176,7 +176,6 @@
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
-		"onboarding/new-migration-flow": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,


### PR DESCRIPTION
## Proposed Changes
* Remove all references to the feature flag `onboarding/new-migration-flow`

## Why are these changes being made?
This feature has been enabled for months, so the removal helps us to maintain the codebase more safely, reducing complexity.

## Testing Instructions
* Run the migration (happy path should be enough) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
