### PR TITLE
DIFM: update list of optional pages

### DIFF
--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -1,4 +1,13 @@
-import { BLOG_PAGE, CONTACT_PAGE, CUSTOM_PAGE, SHOP_PAGE } from 'calypso/signup/difm/constants';
+import {
+	BLOG_PAGE,
+	CASE_STUDIES_PAGE,
+	CONTACT_PAGE,
+	CUSTOM_PAGE,
+	PHOTO_GALLERY_PAGE,
+	PORTFOLIO_PAGE,
+	SHOP_PAGE,
+	VIDEO_GALLERY_PAGE,
+} from 'calypso/signup/difm/constants';
 import {
 	ContactPageDetails,
 	CustomPageDetails,
@@ -89,6 +98,10 @@ const generateWebsiteContentSections = (
 		[ CONTACT_PAGE ]: true,
 		[ BLOG_PAGE ]: true,
 		[ SHOP_PAGE ]: true,
+		[ VIDEO_GALLERY_PAGE ]: true,
+		[ PHOTO_GALLERY_PAGE ]: true,
+		[ PORTFOLIO_PAGE ]: true,
+		[ CASE_STUDIES_PAGE ]: true,
 	};
 
 	const websiteContentSections = formValues.pages.map( ( page, index ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds `VIDEO_GALLERY_PAGE, PHOTO_GALLERY_PAGE, PORTFOLIO_PAGE` and `CASE_STUDIES_PAGE` to the list of optional pages in the DIFM content form.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These pages may not always have user content. Making these pages optional reduces the friction in this form.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing should not be necessary since this PR adds more values to an existing object.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
