### PR TITLE
Revert "explat-client: calypso-lib: Skip requests for E2E"

### DIFF
--- a/client/lib/explat/internals/fetch-experiment-assignment.ts
+++ b/client/lib/explat/internals/fetch-experiment-assignment.ts
@@ -1,4 +1,3 @@
-import { isE2ETest } from 'calypso/lib/e2e';
 import wpcom from 'calypso/lib/wp';
 
 // SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check
@@ -12,15 +11,6 @@ export default function fetchExperimentAssignment( {
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > {
-	if ( isE2ETest() ) {
-		return new Promise( () => ( {
-			variations: {
-				[ experimentName ]: null,
-			},
-			ttl: 60,
-		} ) );
-	}
-
 	return wpcom.req.get(
 		{
 			path: '/experiments/0.1.0/assignments/calypso',


### PR DESCRIPTION
Reverts Automattic/wp-calypso#91162