### PR TITLE
Notifications: use absolute widgets.wp.com links in iframe HTML

### DIFF
--- a/apps/notifications/src/index.ejs
+++ b/apps/notifications/src/index.ejs
@@ -7,16 +7,13 @@
 	<title>Notifications</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<meta name="mobile-web-app-capable" content="yes">
-	<meta name="node-platform" content="<%= htmlWebpackPlugin.options.nodePlatform %>">
-	<meta name="node-version" content="<%= htmlWebpackPlugin.options.nodeVersion %>">
-	<meta name="git-describe" content="<%= htmlWebpackPlugin.options.gitDescribe %>">
-    <% htmlWebpackPlugin.files.css.forEach( function( style ) { if ( style.includes( 'rtl' ) && htmlWebpackPlugin.options.isRTL ) { %><link rel="stylesheet" href="<%= style %>"><% } else if ( ! ( style.includes( 'rtl' ) || htmlWebpackPlugin.options.isRTL ) ) { %><link rel="stylesheet" href="<%= style %>"><% } } ) %>
+  <%= htmlWebpackPlugin.tags.headTags.filter( ( tag ) => tag.tagName !== 'link' || htmlWebpackPlugin.options.includeStyle( tag.attributes.href ) ) %>
 </head>
 
 <body class="wpnc">
 	<div class="wpnc__main"></div>
 	<script charset="UTF-8" src="https://stats.wp.com/w.js?67"></script>
-	<% htmlWebpackPlugin.files.js.forEach( function( script ) { %><script charset="UTF-8" src="<%= script %>"></script><% } ) %>
+	<%= htmlWebpackPlugin.tags.bodyTags %>
 </body>
 
 </html>

--- a/apps/notifications/webpack.config.js
+++ b/apps/notifications/webpack.config.js
@@ -53,9 +53,7 @@ function getWebpackConfig(
 	).slice( 0, 11 );
 
 	const pageMeta = {
-		nodePlatform: process.platform,
-		nodeVersion: process.version,
-		gitDescribe,
+		'git-describe': gitDescribe,
 	};
 
 	return {
@@ -79,20 +77,22 @@ function getWebpackConfig(
 			new HtmlWebpackPlugin( {
 				filename: path.join( outputPath, 'index.html' ),
 				template: path.join( __dirname, 'src', 'index.ejs' ),
-				title: 'Notifications',
+				publicPath: 'https://widgets.wp.com/notifications/',
 				hash: true,
 				inject: false,
-				isRTL: false,
-				...pageMeta,
+				scriptLoading: 'blocking',
+				meta: pageMeta,
+				includeStyle: ( href ) => ! href.includes( '.rtl.css' ),
 			} ),
 			new HtmlWebpackPlugin( {
 				filename: path.join( outputPath, 'rtl.html' ),
 				template: path.join( __dirname, 'src', 'index.ejs' ),
-				title: 'Notifications',
+				publicPath: 'https://widgets.wp.com/notifications/',
 				hash: true,
 				inject: false,
-				isRTL: true,
-				...pageMeta,
+				scriptLoading: 'blocking',
+				meta: pageMeta,
+				includeStyle: ( href ) => href.includes( '.rtl.css' ),
 			} ),
 			shouldEmitStats &&
 				new BundleAnalyzerPlugin( {


### PR DESCRIPTION
When the build of `apps/notifications` generates the HTML file for the notifications iframe, it will now insert absolute links that start with `https://widgets.wp.com/...`. This way the HTML document can be in another location (like `wordpress.com/widgets`) and will load the CSS/JS assets from the right location.

I'm also removing the `node-platform` and `node-version` meta headers, there's no reason why this info should be public.

The HTML plugin also doesn't need the `title` option, the title is hardcoded in the template.

**How to test:**
Go to `apps/notifications` and run `yarn build`. Verify that the `dist/index.html` and `dist/rtl.html` files contain correct links to CSS and JS. In the right location in the document, the right URLs. And there should be only one stylesheet, either the LTR or the RTL one.