### PR TITLE
Small fix to ToS in WPcom login

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -757,7 +757,7 @@ class Login extends Component {
 
 		const tos = translate(
 			'Just a little reminder that by continuing with any of the options below, ' +
-				'you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				'you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 			{
 				components: {
 					tosLink: (

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -756,8 +756,7 @@ class Login extends Component {
 		}
 
 		const tos = translate(
-			'Just a little reminder that by continuing with any of the options below, ' +
-				'you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+			'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 			{
 				components: {
 					tosLink: (

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -586,7 +586,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 	.is-social-first {
 		.login__form-subheader-terms {
 			display: block;
-			max-width: 420px;
+			max-width: 450px;
 			margin: 0 auto;
 
 			color: var(--studio-gray-50, #646970);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to this P2 comment from Legal: p4H3ND-1Cw-p2#comment-3589

## Proposed Changes

Changed `and` to `and have read our`.

|Before|After|
|---|---|
|<img width="430" alt="Screenshot 2024-05-31 at 17 19 42" src="https://github.com/Automattic/wp-calypso/assets/25607244/d63b5f64-6bbe-4402-b70a-1c6498c52c81">|<img width="485" alt="Screenshot 2024-05-31 at 17 20 00" src="https://github.com/Automattic/wp-calypso/assets/25607244/3df50361-638b-458a-8d87-9328d716fa8b">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Request from the legal team

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this branch
* Log out and visit `/log-in`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?