### PR TITLE
E2E: Update editor-header-settings locator

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -311,17 +311,10 @@ export class EditorToolbarComponent {
 	async openSettings( target: EditorToolbarSettingsButton ): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		let headerSettingsClassname;
-		if ( ! envVariables.TEST_ON_ATOMIC || ! envVariables.COBLOCKS_EDGE ) {
-			headerSettingsClassname = '.editor-header__settings';
-		} else {
-			headerSettingsClassname = '.edit-post-header__settings';
-		}
-
 		// To support i18n tests.
 		const translatedTargetName = await this.translateFromPage( target );
 		const button = editorParent
-			.locator( headerSettingsClassname )
+			.locator( '.editor-header__settings, .edit-post-header__settings' )
 			.getByLabel( translatedTargetName );
 
 		if ( await this.targetIsOpen( button ) ) {

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -312,7 +312,7 @@ export class EditorToolbarComponent {
 		const editorParent = await this.editor.parent();
 
 		let headerSettingsClassname;
-		if ( ! envVariables.TEST_ON_ATOMIC ) {
+		if ( ! envVariables.TEST_ON_ATOMIC || ! envVariables.COBLOCKS_EDGE ) {
 			headerSettingsClassname = '.editor-header__settings';
 		} else {
 			headerSettingsClassname = '.edit-post-header__settings';

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -314,8 +314,8 @@ export class EditorToolbarComponent {
 		// To support i18n tests.
 		const translatedTargetName = await this.translateFromPage( target );
 		const button = editorParent
-			.locator( '.editor-header__settings' )
-			.getByRole( 'button', { name: translatedTargetName, exact: true } );
+			.locator( '.edit-post-header__settings' )
+			.getByLabel( translatedTargetName );
 
 		if ( await this.targetIsOpen( button ) ) {
 			return;

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -311,10 +311,17 @@ export class EditorToolbarComponent {
 	async openSettings( target: EditorToolbarSettingsButton ): Promise< void > {
 		const editorParent = await this.editor.parent();
 
+		let headerSettingsClassname;
+		if ( ! envVariables.TEST_ON_ATOMIC ) {
+			headerSettingsClassname = '.editor-header__settings';
+		} else {
+			headerSettingsClassname = '.edit-post-header__settings';
+		}
+
 		// To support i18n tests.
 		const translatedTargetName = await this.translateFromPage( target );
 		const button = editorParent
-			.locator( '.edit-post-header__settings' )
+			.locator( headerSettingsClassname )
 			.getByLabel( translatedTargetName );
 
 		if ( await this.targetIsOpen( button ) ) {


### PR DESCRIPTION
## Proposed Changes

Fixes the settings header selector for e2e tests on Atomic sites.

## Why are these changes being made?
Some e2e tests are failing since the header changed the class from `editor-header__settings` to `edit-post-header__settings`
