### PR TITLE
Site sort component (dotcom and a4a) - Add a11y focus styles.

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/site-sort/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/site-sort/style.scss
@@ -36,7 +36,7 @@
 	border-radius: 2px;
 	.accessible-focus &:focus {
 		outline-style: solid;
-		outline-color: var(--color-accent);
+		outline-color: var(--color-primary-light);
 		outline-width: 2px;
 		outline-offset: 2px;
 	}

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/site-sort/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/site-sort/style.scss
@@ -29,4 +29,15 @@
 
 .site-sort__clickable {
 	cursor: pointer;
+	// Inline block to ensure focus outline is rectangular.
+	display: inline-block;
+	// 5px right padding so focus border doesnt overlap icon.
+	padding-right: 5px;
+	border-radius: 2px;
+	.accessible-focus &:focus {
+		outline-style: solid;
+		outline-color: var(--color-accent);
+		outline-width: 2px;
+		outline-offset: 2px;
+	}
 }

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -400,7 +400,7 @@ $brand-text: "SF Pro Text", $sans;
 .accessible-focus div.global-sidebar {
 	*:focus {
 		outline-style: solid;
-		outline-color: var(--color-sidebar-menu-selected-background);
+		outline-color: var(--color-primary-light);
 		outline-width: 2px;
 		outline-offset: 2px;
 	}

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -108,7 +108,7 @@
 	border-radius: 2px;
 	.accessible-focus &:focus {
 		outline-style: solid;
-		outline-color: var(--color-accent);
+		outline-color: var(--color-primary-light);
 		outline-width: 2px;
 		outline-offset: 2px;
 	}

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -98,3 +98,18 @@
 		margin: 0;
 	}
 }
+
+.site-sort__clickable {
+	cursor: pointer;
+	// Inline block to ensure focus outline is rectangular.
+	display: inline-block;
+	// 5px right padding so focus border doesnt overlap icon.
+	padding-right: 5px;
+	border-radius: 2px;
+	.accessible-focus &:focus {
+		outline-style: solid;
+		outline-color: var(--color-accent);
+		outline-width: 2px;
+		outline-offset: 2px;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#7549 and Automattic/dotcom-forge#7548

## Proposed Changes

* Adds a11y focus styles for the site-sort components used in the sites dashboards for dotcom and a4a.
    * Updates these to also have inline-block display and 5px of right padding so the outlines are rectangular (non-jagged) and surround the corresponding icon as well.
* Updates the var used for a11y focus styles in the global sidebar to match everything else.

BEFORE:
No a11y focus styles on site sort components.

Global sidebar a11y focus color:
<img width="317" alt="Screenshot 2024-05-31 at 12 24 37 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/1d4eb856-4cf4-4611-9ca5-2a80ee7b1eb1">



AFTER:

Global sidebar
<img width="306" alt="Screenshot 2024-05-31 at 12 21 02 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/e5036f0d-9d36-4645-a561-8f07e6276685">
<img width="124" alt="Screenshot 2024-05-31 at 12 21 07 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/729fa8a2-830d-4d11-92fb-e03e17892fdb">

Site sort (dotcom)
<img width="96" alt="Screenshot 2024-05-31 at 12 21 22 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/b13c5fda-42ea-4223-a079-e5b832eb72c5">
<img width="150" alt="Screenshot 2024-05-31 at 12 21 28 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/7bde3e46-3de0-44c3-bbc7-14b47d9140e7">

Site sort (a4a)
<img width="94" alt="Screenshot 2024-05-31 at 12 25 53 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/0aa28893-aec2-41e1-9f95-9ffb061f0196">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* because we care about a11y

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Go to /sites
* navigate with the keyboard.
* Verify the global sidebar a11y focus outline color is now the same blue as a11y focus styles elsewhere on the page.
* In the sites table, verify the site sort component now shows an outline when you navigate to it via keyboard.

* Test this on the a4a link as well.
* Verify the site sort component has an outline that corresponds to the other a11y focus outline colors on the page when navigated to via keyboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
