### PR TITLE
Site Profiler: Add new content type visualizations

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -145,11 +145,12 @@ export interface PerformanceMetricsItemQueryResponse {
 }
 
 export interface PerformanceMetricsDetailsQueryResponse {
-	type: 'table' | 'opportunity' | 'list';
+	type: 'table' | 'opportunity' | 'list' | 'criticalrequestchain';
 	headings?: Array< { key: string; label: string; valueType: string } >;
 	items?: Array< {
 		[ key: string ]: string | number | { [ key: string ]: any };
 	} >;
+	chains?: Array< { [ key: string ]: any } >;
 }
 
 export interface BasicMetricsResult extends Omit< UrlBasicMetricsQueryResponse, 'basic' > {

--- a/client/site-profiler/components/metrics-insight/insight-detailed-content.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-detailed-content.tsx
@@ -1,5 +1,6 @@
 import { PerformanceMetricsDetailsQueryResponse } from 'calypso/data/site-profiler/types';
 import { InsightTable } from './insight-table';
+import { InsightTree } from './insight-tree';
 
 export interface InsightDetailedContentProps {
 	data: PerformanceMetricsDetailsQueryResponse;
@@ -16,6 +17,10 @@ export const InsightDetailedContent: React.FC< InsightDetailedContentProps > = (
 		const tables = data.items ?? [];
 
 		return tables.map( ( item, index ) => <InsightTable key={ index } data={ item as any } /> );
+	}
+
+	if ( data.type === 'criticalrequestchain' ) {
+		return <InsightTree { ...props } />;
 	}
 
 	return null;

--- a/client/site-profiler/components/metrics-insight/insight-table.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-table.tsx
@@ -25,7 +25,9 @@ export function InsightTable( { data }: { data: PerformanceMetricsDetailsQueryRe
 								</td>
 							) ) }
 						</tr>
-						{ item.subItems && <SubRows items={ item.subItems?.items } headings={ headings } /> }
+						{ item.subItems && typeof item.subItems === 'object' && (
+							<SubRows items={ item.subItems?.items } headings={ headings } />
+						) }
 					</>
 				) ) }
 			</tbody>

--- a/client/site-profiler/components/metrics-insight/insight-table.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-table.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import Markdown from 'react-markdown';
 import { PerformanceMetricsDetailsQueryResponse } from 'calypso/data/site-profiler/types';
+import { getFormattedNumber, getFormattedSize } from 'calypso/site-profiler/utils/formatting-data';
 
 export function InsightTable( { data }: { data: PerformanceMetricsDetailsQueryResponse } ) {
 	const { headings = [], items = [] } = data ?? {};
@@ -16,17 +17,39 @@ export function InsightTable( { data }: { data: PerformanceMetricsDetailsQueryRe
 			</thead>
 			<tbody>
 				{ items.map( ( item, index ) => (
-					<tr key={ `tr-${ index }` }>
-						{ headings.map( ( heading ) => (
-							<td>
-								<Cell data={ item[ heading.key ] } headingValueType={ heading.valueType } />
-							</td>
-						) ) }
-					</tr>
+					<>
+						<tr key={ `tr-${ index }` }>
+							{ headings.map( ( heading ) => (
+								<td>
+									<Cell data={ item[ heading.key ] } headingValueType={ heading.valueType } />
+								</td>
+							) ) }
+						</tr>
+						{ item.subItems && <SubRows items={ item.subItems?.items } headings={ headings } /> }
+					</>
 				) ) }
 			</tbody>
 		</table>
 	);
+}
+
+function SubRows( { items, headings }: { items: any[]; headings: any[] } ) {
+	return items.map( ( subItem, subIndex ) => (
+		<tr key={ `sub-${ subIndex }` } className="sub">
+			{ headings.map( ( heading ) => {
+				const { subItemsHeading } = heading;
+
+				return (
+					<td>
+						<Cell
+							data={ subItem[ subItemsHeading?.key ] }
+							headingValueType={ subItemsHeading?.valueType }
+						/>
+					</td>
+				);
+			} ) }
+		</tr>
+	) );
 }
 
 function Cell( {
@@ -82,24 +105,15 @@ function Cell( {
 			case 'link':
 				return <Markdown>{ data.toString() }</Markdown>;
 			case 'score':
-				<span className={ `score ${ Number( data ) > 6 ? 'dangerous' : 'alert' } ` }>
-					{ data }
-				</span>;
+				return (
+					<span className={ `score ${ Number( data ) > 6 ? 'dangerous' : 'alert' } ` }>
+						{ data }
+					</span>
+				);
 			default:
 				return data;
 		}
 	}
 
 	return data;
-}
-
-function getFormattedNumber( value: number | string, dec = 2 ) {
-	return Number( Number( value ?? 0 ).toFixed( dec ) );
-}
-
-function getFormattedSize( size: number ) {
-	const i = size === 0 ? 0 : Math.floor( Math.log( size ) / Math.log( 1024 ) );
-	return (
-		+( size / Math.pow( 1024, i ) ).toFixed( 2 ) * 1 + ' ' + [ 'B', 'kB', 'MB', 'GB', 'TB' ][ i ]
-	);
 }

--- a/client/site-profiler/components/metrics-insight/insight-tree.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-tree.tsx
@@ -8,9 +8,9 @@ interface InsightTreeProps {
 
 export const InsightTree: React.FC< InsightTreeProps > = ( { data } ) => {
 	const translate = useTranslate();
-	const { chains } = data ?? {};
+	const chains: { [ key: string ]: any } = data?.chains ?? {};
 
-	return Object.keys( chains ).map( ( item, index ) => {
+	return Object.keys( chains ).map( ( item: string, index ) => {
 		const request = chains[ item ];
 		const children = chains[ item ][ 'children' ];
 

--- a/client/site-profiler/components/metrics-insight/insight-tree.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-tree.tsx
@@ -1,0 +1,58 @@
+import { useTranslate } from 'i18n-calypso';
+import { PerformanceMetricsDetailsQueryResponse } from 'calypso/data/site-profiler/types';
+import { getFormattedNumber, getFormattedSize } from 'calypso/site-profiler/utils/formatting-data';
+
+interface InsightTreeProps {
+	data: PerformanceMetricsDetailsQueryResponse;
+}
+
+export const InsightTree: React.FC< InsightTreeProps > = ( { data } ) => {
+	const translate = useTranslate();
+	const { chains } = data ?? {};
+
+	return Object.keys( chains ).map( ( item, index ) => {
+		const request = chains[ item ];
+		const children = chains[ item ][ 'children' ];
+
+		return (
+			<ul className="tree" key={ index }>
+				{ translate( 'Initial Request' ) }
+				<li>
+					<details open>
+						<summary>
+							<Request request={ request } />
+						</summary>
+						<ul>
+							{ Object.keys( children ).map( ( item, index ) => {
+								const childRequest = children[ item ];
+								return (
+									<li key={ index }>
+										<Request request={ childRequest } />
+									</li>
+								);
+							} ) }
+						</ul>
+					</details>
+				</li>
+			</ul>
+		);
+	} );
+};
+
+function Request( { request }: { request: any } ) {
+	const translate = useTranslate();
+	const { url, responseReceivedTime, transferSize } = request.request;
+
+	return (
+		<span>
+			{ translate( '%(url)s - {{b}}%(ms)sms{{/b}}, %(size)s', {
+				args: {
+					url,
+					ms: getFormattedNumber( responseReceivedTime ),
+					size: getFormattedSize( transferSize ),
+				},
+				components: { b: <b /> },
+			} ) }
+		</span>
+	);
+}

--- a/client/site-profiler/components/styles-v2.scss
+++ b/client/site-profiler/components/styles-v2.scss
@@ -328,6 +328,11 @@
 						font-size: $font-body-small;
 					}
 
+					tr.sub {
+						padding-left: 40px;
+						background: var(--studio-gray-70);
+					}
+
 					tbody {
 						background: var(--studio-gray-90);
 					}
@@ -341,6 +346,91 @@
 					$blueberry-color: #3858e9;
 					code {
 						color: $blueberry-color;
+					}
+
+					.score {
+						font-weight: bold;
+						display: inline-block;
+						width: 40px;
+						height: 25px;
+						line-height: 25px;
+						text-align: center;
+						border-radius: 4px;
+
+						&.dangerous {
+							color: var(--studio-red-60);
+							background: var(--studio-red-10);
+						}
+
+						&.alert {
+							color: var(--studio-yellow-60);
+							background: var(--studio-yellow-10);
+						}
+					}
+				}
+
+				.tree {
+					--spacing: 1.5rem;
+					--radius: 10px; /* stylelint-disable-line scales/radii */
+					margin: 0;
+					padding: 0;
+
+					li {
+						margin: 0;
+						display: block;
+						position: relative;
+						padding-left: calc(2 * var(--spacing) - var(--radius) - 2px);
+						line-height: 30px;
+					}
+
+					ul {
+						margin-left: calc(var(--radius) - var(--spacing));
+						padding-left: 0;
+
+						li {
+							border-left: 2px solid #ddd;
+
+							&:last-child {
+								border-color: transparent;
+							}
+
+							&::before {
+								content: "";
+								display: block;
+								position: absolute;
+								top: calc(var(--spacing) / -2);
+								left: -2px;
+								width: calc(var(--spacing) + 2px);
+								height: calc(var(--spacing) + 1px);
+								border: solid #ddd;
+								border-width: 0 0 2px 2px;
+							}
+						}
+					}
+
+					summary {
+						display: block;
+						cursor: pointer;
+
+						&::marker,
+						&::-webkit-details-marker {
+							display: none;
+						}
+
+						&:focus {
+							outline: none;
+						}
+
+						&:focus-visible {
+							outline: 1px dotted #000;
+						}
+
+						&::before {
+							z-index: 1;
+						}
+					}
+					details[open] > summary::before {
+						background-position: calc(-2 * var(--radius)) 0;
 					}
 				}
 			}

--- a/client/site-profiler/utils/formatting-data.ts
+++ b/client/site-profiler/utils/formatting-data.ts
@@ -1,0 +1,10 @@
+export function getFormattedNumber( value: number | string, dec = 2 ) {
+	return Number( Number( value ?? 0 ).toFixed( dec ) );
+}
+
+export function getFormattedSize( size: number ) {
+	const i = size === 0 ? 0 : Math.floor( Math.log( size ) / Math.log( 1024 ) );
+	return (
+		+( size / Math.pow( 1024, i ) ).toFixed( 2 ) * 1 + ' ' + [ 'B', 'kB', 'MB', 'GB', 'TB' ][ i ]
+	);
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7448

## Proposed Changes

Properly render 3 new visualization types:
* Tree (or chain)
* Table with sub rows
* Scores

| Tree  | Table with subrows | score|
| ------------- | ------------- | ------------- |
|![CleanShot 2024-05-31 at 12 46 37@2x](https://github.com/Automattic/wp-calypso/assets/5039531/2119831b-4d74-45f1-a399-deb153d8ac53)|![CleanShot 2024-05-31 at 13 07 38@2x](https://github.com/Automattic/wp-calypso/assets/5039531/6d8ec3ab-70d7-439e-b199-7012a19d2244)|![CleanShot 2024-05-31 at 12 46 46@2x](https://github.com/Automattic/wp-calypso/assets/5039531/b1bd01c9-d47f-4481-ad5c-999a61b81810)|

PS: There are some TS errors to be fixed before the merge

## Why are these changes being made?
To render those types that will come from the API

## Testing Instructions


* Go to `/site-profiler/:url`. Ex: `/site-profiler/wordpress.com`
* Check if all items are properly render on all the sections: Performance, Health and Security
* To better test those 3 types, go to `/site-profiler/www.atliq.com`
* Search for `Avoid serving legacy JavaScript to modern browsers` on `Performance` to see the table with subrows type
* Search for `Avoid chaining critical requests` on `Performance` to see the Tree
* Go to the `Security` section and you will be presented with scores on every item

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?