### PR TITLE
A4A: add referral toggle to pressable overview

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -20,6 +20,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingOverview from '../common/hosting-overview';
+import ReferralToggle from '../common/referral-toggle';
 import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
@@ -86,8 +87,9 @@ function PressableOverview() {
 						] }
 					/>
 
-					<Actions>
+					<Actions className="a4a-marketplace__header-actions">
 						<MobileSidebarNavigation />
+						<ReferralToggle />
 						<ShoppingCart
 							showCart={ showCart }
 							setShowCart={ setShowCart }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { MarketplaceTypeContext } from '../../context';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
 import useExistingPressablePlan from '../hooks/use-existing-pressable-plan';
 import PlanSelectionDetails from './details';
@@ -16,7 +17,10 @@ type Props = {
 export default function PressableOverviewPlanSelection( { onAddToCart }: Props ) {
 	const dispatch = useDispatch();
 
-	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const referralMode = marketplaceType === 'referral';
+
+	const [ stateSelectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
 
 	const onSelectPlan = useCallback(
 		( plan: APIProductFamilyProduct | null ) => {
@@ -29,6 +33,8 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 		selectedSite: null,
 		productSearchQuery: '',
 	} );
+
+	const selectedPlan = referralMode ? pressablePlans[ 0 ] : stateSelectedPlan;
 
 	const { existingPlan, isReady: isExistingPlanFetched } = useExistingPressablePlan( {
 		plans: pressablePlans,
@@ -53,13 +59,15 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 
 	return (
 		<div className="pressable-overview-plan-selection">
-			<PlanSelectionFilter
-				selectedPlan={ selectedPlan }
-				plans={ pressablePlans }
-				onSelectPlan={ onSelectPlan }
-				existingPlan={ existingPlan }
-				isLoading={ ! isExistingPlanFetched }
-			/>
+			{ ! referralMode && (
+				<PlanSelectionFilter
+					selectedPlan={ selectedPlan }
+					plans={ pressablePlans }
+					onSelectPlan={ onSelectPlan }
+					existingPlan={ existingPlan }
+					isLoading={ ! isExistingPlanFetched }
+				/>
+			) }
 
 			<PlanSelectionDetails
 				selectedPlan={ selectedPlan }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -1,7 +1,5 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Button, Gridicon } from '@automattic/components';
-import { ToggleControl } from '@wordpress/components';
+import { Button } from '@automattic/components';
 import {
 	Icon,
 	blockMeta,
@@ -33,6 +31,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingOverview from '../common/hosting-overview';
 import HostingOverviewFeatures from '../common/hosting-overview-features';
+import ReferralToggle from '../common/referral-toggle';
 import { MarketplaceTypeContext } from '../context';
 import withMarketplaceType from '../hoc/with-marketplace-type';
 import useProductAndPlans from '../hooks/use-product-and-plans';
@@ -50,8 +49,7 @@ function WpcomOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
-	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const referralMode = marketplaceType === 'referral';
 
 	const {
@@ -139,17 +137,7 @@ function WpcomOverview() {
 
 					<Actions className="a4a-marketplace__header-actions">
 						<MobileSidebarNavigation />
-						{ isAutomatedReferrals && (
-							<div className="a4a-marketplace__toggle-marketplace-type">
-								<ToggleControl
-									onChange={ toggleMarketplaceType }
-									checked={ marketplaceType === 'referral' }
-									id="a4a-marketplace__toggle-marketplace-type"
-									label={ translate( 'Refer products' ) }
-								/>
-								<Gridicon icon="info-outline" size={ 16 } />
-							</div>
-						) }
+						<ReferralToggle />
 						<ShoppingCart
 							showCart={ showCart }
 							setShowCart={ setShowCart }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/363

## Proposed Changes

Adds Referral toggle to Pressable overview page. In Referral mode removed plan selection.

<img width="1235" alt="Screenshot 2024-05-31 at 11 50 56 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/60eaefd1-dd58-4891-9552-fc9eda9837b1">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/marketplace/hosting/pressable` .
- Check referral toggle behavior in the top right corner of the screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
