### PR TITLE
Site Profiler: Use overall score from advanced performance endpoint

### DIFF
--- a/client/data/site-profiler/metrics-dictionaries.ts
+++ b/client/data/site-profiler/metrics-dictionaries.ts
@@ -1,5 +1,4 @@
-import { UrlData } from 'calypso/blocks/import/types';
-import { BasicMetricsScored, Metrics, PerformanceCategories, Scores } from './types';
+import { Metrics, PerformanceCategories, PerformanceReport, Scores } from './types';
 
 export const BASIC_METRICS_UNITS: Record< Metrics, string > = {
 	cls: '',
@@ -38,19 +37,17 @@ export function getScore( metric: Metrics, value: number ): Scores {
 }
 
 /**
- * Get the overall score of the site based on the scores of the basic metrics.
- * It will return poor if more then 2 metrics are poor, good otherwise.
- * Defaults to good if no metrics are provided.
+ * Get the overall score of the site based on the advanced performance
+ * report. If the performance is greater than 0.9, the score is good,
  * @param metrics A record of metrics with their scores
  * @returns The overall score of the site
  */
-function getOveralScore( metrics?: BasicMetricsScored ): Scores {
+function getOveralScore( metrics?: PerformanceReport ): Scores {
 	if ( ! metrics ) {
 		return 'good';
 	}
 
-	const poorMetrics = Object.values( metrics ).filter( ( metric ) => metric?.score === 'poor' );
-	return poorMetrics.length > 2 ? 'poor' : 'good';
+	return metrics.performance >= 0.9 ? 'good' : 'poor';
 }
 
 /**
@@ -62,18 +59,15 @@ function isScoreGood( score: Scores ): boolean {
 	return score === 'good';
 }
 
-export function getPerformanceCategory(
-	metrics?: BasicMetricsScored,
-	urlData?: UrlData
-): PerformanceCategories {
+export function getPerformanceCategory( metrics?: PerformanceReport ): PerformanceCategories {
 	const overallScore = getOveralScore( metrics );
-	if ( isScoreGood( overallScore ) && urlData?.platform_data?.is_wpcom ) {
+	if ( isScoreGood( overallScore ) && metrics?.is_wpcom ) {
 		return 'wpcom-high-performer';
 	}
-	if ( isScoreGood( overallScore ) && ! urlData?.platform_data?.is_wpcom ) {
+	if ( isScoreGood( overallScore ) && ! metrics?.is_wpcom ) {
 		return 'non-wpcom-high-performer';
 	}
-	if ( ! isScoreGood( overallScore ) && urlData?.platform_data?.is_wpcom ) {
+	if ( ! isScoreGood( overallScore ) && metrics?.is_wpcom ) {
 		return 'wpcom-low-performer';
 	}
 	return 'non-wpcom-low-performer';

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -116,16 +116,19 @@ export interface UrlSecurityMetricsQueryResponse {
 	};
 }
 
+export interface PerformanceReport {
+	audits: {
+		health: PerformanceMetricsDataQueryResponse;
+		performance: PerformanceMetricsDataQueryResponse;
+	};
+	performance: number;
+	overall_score: number;
+	is_wpcom: boolean;
+}
+
 export interface UrlPerformanceMetricsQueryResponse {
 	webtestpage_org: {
-		report: {
-			audits: {
-				health: PerformanceMetricsDataQueryResponse;
-				performance: PerformanceMetricsDataQueryResponse;
-			};
-			performance: number;
-			overall_score: number;
-		};
+		report: PerformanceReport;
 		status: string;
 	};
 }

--- a/client/site-profiler/components/results-header/index.tsx
+++ b/client/site-profiler/components/results-header/index.tsx
@@ -2,7 +2,6 @@ import { Button, Gridicon } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import nonWpComSiteIcon from 'calypso/assets/images/site-profiler/non-wpcom-site.svg';
 import wpComSiteIcon from 'calypso/assets/images/site-profiler/wpcom-site.svg';
-import { UrlData } from 'calypso/blocks/import/types';
 import { PerformanceCategories } from 'calypso/data/site-profiler/types';
 
 import './styles.scss';
@@ -10,19 +9,19 @@ import './styles.scss';
 type Props = {
 	domain: string;
 	performanceCategory: PerformanceCategories;
-	urlData?: UrlData;
+	isWpCom: boolean;
 	onGetReport: () => void;
 };
 
-function getIcon( urlData?: UrlData ) {
-	if ( urlData?.platform_data?.is_wpcom ) {
+function getIcon( isWpCom?: boolean ) {
+	if ( isWpCom ) {
 		return <img src={ wpComSiteIcon } alt={ translate( 'WordPress.com site' ) } />;
 	}
 	return <img src={ nonWpComSiteIcon } alt={ translate( 'Non WordPress.com site' ) } />;
 }
 
-function getIsWpComSiteMessage( urlData?: UrlData ) {
-	if ( urlData?.platform_data?.is_wpcom ) {
+function getIsWpComSiteMessage( isWpCom?: boolean ) {
+	if ( isWpCom ) {
 		return translate( 'This site is hosted on WordPress.com' );
 	}
 	return translate( 'This site is not hosted on WordPress.com' );
@@ -41,13 +40,13 @@ function getTitleMessage( performanceCategory: PerformanceCategories ) {
 	return translate( 'Room for growth! Let’s optimize your site.' );
 }
 
-export const ResultsHeader = ( { domain, performanceCategory, urlData, onGetReport }: Props ) => {
+export const ResultsHeader = ( { domain, performanceCategory, isWpCom, onGetReport }: Props ) => {
 	return (
 		<div className="results-header--container">
 			<div className="results-header--domain-container">
 				<span className="domain-title">{ domain }</span>
-				{ getIcon( urlData ) }
-				<span className="domain-message">{ getIsWpComSiteMessage( urlData ) }</span>
+				{ getIcon( isWpCom ) }
+				<span className="domain-message">{ getIsWpComSiteMessage( isWpCom ) }</span>
 			</div>
 			<h1>{ getTitleMessage( performanceCategory ) }</h1>
 			<div className="results-header--button-container">

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -107,12 +107,12 @@ export default function SiteProfilerV2( props: Props ) {
 
 	const showGetReportForm = !! showBasicMetrics && !! url && isGetReportFormOpen;
 
-	const performanceCategory = getPerformanceCategory( basicMetrics?.basic, urlData );
-
 	const { data: performanceMetrics } = useUrlPerformanceMetricsQuery(
 		basicMetrics?.final_url,
 		basicMetrics?.token
 	);
+
+	const performanceCategory = getPerformanceCategory( performanceMetrics );
 
 	const updateDomainRouteParam = ( value: string ) => {
 		// Update the domain param;
@@ -120,7 +120,7 @@ export default function SiteProfilerV2( props: Props ) {
 		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
 	};
 
-	const isWpCom = !! urlData?.platform_data?.is_wpcom;
+	const isWpCom = !! performanceMetrics?.is_wpcom;
 
 	return (
 		<div id="site-profiler-v2">
@@ -152,7 +152,7 @@ export default function SiteProfilerV2( props: Props ) {
 							<ResultsHeader
 								domain={ domain }
 								performanceCategory={ performanceCategory }
-								urlData={ urlData }
+								isWpCom={ isWpCom }
 								onGetReport={ () => setIsGetReportFormOpen( true ) }
 							/>
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/7552

## Proposed Changes

* Use the `performance` value from the `advanced` endpoint to establish the overall score that decides the background color. When it is more than 0.9, the performance is `good` as per Google documentation https://developer.chrome.com/docs/lighthouse/performance/performance-scoring

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because that performance is more accurate than the previous Proof of Concept version

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Navigate to the site profiler for the following 4 sites that have different categories: 34a1c-pb/#plain
* Make sure that for each category you see the correct title and the correct background color

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
~~- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~