### PR TITLE
Site Profiler: Fix the error for trying to render an object

### DIFF
--- a/client/site-profiler/components/metrics-insight/insight-table.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-table.tsx
@@ -20,13 +20,17 @@ export function InsightTable( { data }: { data: PerformanceMetricsDetailsQueryRe
 					<>
 						<tr key={ `tr-${ index }` }>
 							{ headings.map( ( heading ) => (
-								<td>
+								<td key={ `td-${ index }-${ heading.key }` }>
 									<Cell data={ item[ heading.key ] } headingValueType={ heading.valueType } />
 								</td>
 							) ) }
 						</tr>
 						{ item.subItems && typeof item.subItems === 'object' && (
-							<SubRows items={ item.subItems?.items } headings={ headings } />
+							<SubRows
+								items={ item.subItems?.items }
+								headings={ headings }
+								key={ `subrows-${ index }` }
+							/>
 						) }
 					</>
 				) ) }
@@ -38,11 +42,11 @@ export function InsightTable( { data }: { data: PerformanceMetricsDetailsQueryRe
 function SubRows( { items, headings }: { items: any[]; headings: any[] } ) {
 	return items.map( ( subItem, subIndex ) => (
 		<tr key={ `sub-${ subIndex }` } className="sub">
-			{ headings.map( ( heading ) => {
+			{ headings.map( ( heading, index ) => {
 				const { subItemsHeading } = heading;
 
 				return (
-					<td>
+					<td key={ `subrow-${ index }` }>
 						<Cell
 							data={ subItem[ subItemsHeading?.key ] }
 							headingValueType={ subItemsHeading?.valueType }
@@ -90,8 +94,10 @@ function Cell( {
 				if ( data?.location ) {
 					return `${ data.location.url }:${ data.location.line }:${ data.location.column }`;
 				}
-				return data?.url || data;
+				return data?.url;
 		}
+
+		return data?.value;
 	}
 
 	if ( typeof data === 'string' || typeof data === 'number' ) {


### PR DESCRIPTION
## Proposed Changes

Fix the error for trying to render an object.


## Why are these changes being made?

p1717181053930009-slack-C02JPCHEKDY

## Testing Instructions

* Go to  `/site-profiler/indicaexpress.co`
* Check if the site still working as expected
* In production this should show a blank screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?