### PR TITLE
Jetpack Cloud Classic: Point Start earning link to /monetize

### DIFF
--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -129,7 +129,7 @@ const GrowYourAudience = () => {
 							title={ translate( 'Start earning' ) }
 							tracksEventCta="earn"
 							ctaLabel={ translate( 'Learn more' ) }
-							url={ `https://wordpress.com/earn/${ selectedSiteSlug ?? '' }` }
+							url={ `/monetize/${ selectedSiteSlug ?? '' }` }
 						/>
 						<GrowYourAudienceCard
 							icon={ people }

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -5,6 +5,7 @@ import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { SectionContainer } from 'calypso/components/section';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { getSiteOption } from 'calypso/state/sites/selectors';
@@ -129,7 +130,11 @@ const GrowYourAudience = () => {
 							title={ translate( 'Start earning' ) }
 							tracksEventCta="earn"
 							ctaLabel={ translate( 'Learn more' ) }
-							url={ `/monetize/${ selectedSiteSlug ?? '' }` }
+							url={
+								isJetpackCloud()
+									? `/monetize/${ selectedSiteSlug ?? '' }`
+									: `/earn/${ selectedSiteSlug ?? '' }`
+							}
 						/>
 						<GrowYourAudienceCard
 							icon={ people }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7335

## Proposed Changes

* Point "Start earning" "Learn more" link to /monetize/:site

<img width="1720" alt="Screenshot 2024-05-31 at 4 06 58 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/be43937b-b29e-4364-a03f-92c1ac540c03">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Untangling Calypso

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Jetpack cloud live
* Select an Atomic site and go to /subscribers/:site
* Click on "Learn more" under "Start earning" and see that it goes to /monetize/:site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
