### PR TITLE
Jetpack Cloud Simple: Add copy and a see all plans link to match the design.

### DIFF
--- a/client/components/jetpack/card/jetpack-rna-action-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-rna-action-card/index.tsx
@@ -17,6 +17,8 @@ interface RnaActionCardProps {
 	cardImage?: string;
 	cardImageAlt?: string;
 	isPlaceholder?: boolean;
+	secondaryCtaURL?: string;
+	secondaryCtaLabel?: string;
 }
 
 const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
@@ -29,6 +31,8 @@ const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
 	cardImage = DefaultImage,
 	cardImageAlt,
 	isPlaceholder,
+	secondaryCtaURL,
+	secondaryCtaLabel,
 } ) => {
 	const translate = useTranslate();
 	return (
@@ -59,6 +63,11 @@ const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
 					>
 						{ ctaButtonLabel }
 					</Button>
+					{ secondaryCtaURL ? (
+						<div className="jetpack-rna-action-card__secondary-cta">
+							<a href={ secondaryCtaURL }>{ secondaryCtaLabel || translate( 'Learn more' ) }</a>
+						</div>
+					) : null }
 				</div>
 			</div>
 			<div className="jetpack-rna-action-card__footer">

--- a/client/components/jetpack/card/jetpack-rna-action-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-rna-action-card/index.tsx
@@ -18,7 +18,6 @@ interface RnaActionCardProps {
 	cardImageAlt?: string;
 	isPlaceholder?: boolean;
 	secondaryCtaURL?: string;
-	secondaryCtaLabel?: string;
 }
 
 const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
@@ -32,7 +31,6 @@ const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
 	cardImageAlt,
 	isPlaceholder,
 	secondaryCtaURL,
-	secondaryCtaLabel,
 } ) => {
 	const translate = useTranslate();
 	return (
@@ -63,11 +61,11 @@ const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
 					>
 						{ ctaButtonLabel }
 					</Button>
-					{ secondaryCtaURL ? (
+					{ secondaryCtaURL && (
 						<div className="jetpack-rna-action-card__secondary-cta">
-							<a href={ secondaryCtaURL }>{ secondaryCtaLabel || translate( 'Learn more' ) }</a>
+							<a href={ secondaryCtaURL }>{ translate( 'See all plans' ) }</a>
 						</div>
-					) : null }
+					) }
 				</div>
 			</div>
 			<div className="jetpack-rna-action-card__footer">

--- a/client/components/jetpack/card/jetpack-rna-action-card/style.scss
+++ b/client/components/jetpack/card/jetpack-rna-action-card/style.scss
@@ -118,10 +118,15 @@
 			margin-left: 28px;
 
 			a,
-			a:active,
-			a:focus,
 			a:visited {
 				color: var(--studio-gray-80);
+			}
+
+			a:hover,
+			a:focus,
+			a:active,
+			a.is_active {
+				color: var(--studio-jetpack-green-50);
 			}
 		}
 	}

--- a/client/components/jetpack/card/jetpack-rna-action-card/style.scss
+++ b/client/components/jetpack/card/jetpack-rna-action-card/style.scss
@@ -108,4 +108,21 @@
 		padding-bottom: 85%;
 		@include placeholder( --studio-gray-5 );
 	}
+
+	&__secondary-cta {
+		display: none;
+
+		@include break-medium {
+			display: block;
+			align-self: center;
+			margin-left: 28px;
+
+			a,
+			a:active,
+			a:focus,
+			a:visited {
+				color: var(--studio-gray-80);
+			}
+		}
+	}
 }

--- a/client/components/jetpack/card/jetpack-rna-action-card/style.scss
+++ b/client/components/jetpack/card/jetpack-rna-action-card/style.scss
@@ -42,6 +42,7 @@
 		align-items: flex-end;
 		margin-top: 24px;
 		flex: 1;
+		flex-wrap: wrap;
 	}
 
 	&__button {
@@ -50,6 +51,12 @@
 			padding: 8px 32px;
 			width: 100%;
 			@include break-medium {
+				width: auto;
+			}
+			@include break-large {
+				width: 100%;
+			}
+			@include break-wide {
 				width: auto;
 			}
 			.is-placeholder & {
@@ -110,24 +117,36 @@
 	}
 
 	&__secondary-cta {
-		display: none;
+		text-align: center;
+		margin: 25px auto 0;
+
+		a,
+		a:visited {
+			color: var(--studio-gray-80);
+		}
+
+		a:hover,
+		a:focus,
+		a:active,
+		a.is_active {
+			color: var(--studio-jetpack-green-50);
+		}
 
 		@include break-medium {
-			display: block;
+			text-align: left;
 			align-self: center;
-			margin-left: 28px;
+			margin: 0 0 0 28px;
+		}
 
-			a,
-			a:visited {
-				color: var(--studio-gray-80);
-			}
+		@include break-large {
+			text-align: center;
+			margin: 25px auto 0;
+		}
 
-			a:hover,
-			a:focus,
-			a:active,
-			a.is_active {
-				color: var(--studio-jetpack-green-50);
-			}
+		@include break-wide {
+			text-align: left;
+			align-self: center;
+			margin: 0 0 0 28px;
 		}
 	}
 }

--- a/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
+++ b/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
@@ -56,7 +56,7 @@ export const UpsellProductWpcomPlanCard: React.FC< UpsellProductWpcomPlanCardPro
 	const ctaButtonURL: string = `https://wordpress.com/checkout/${ selectedSiteSlug }/${ planSlug }?redirect_to=${ encodeURIComponent(
 		window.location.href
 	) }`;
-	const secondaryCtaURL: string = `https://wordpress.com/plans/${ selectedSiteSlug }) }`;
+	const secondaryCtaURL: string = `https://wordpress.com/plans/${ selectedSiteSlug }`;
 	const isFetchingPrices: boolean = ! siteProduct;
 	const originalPrice: number = siteProduct?.cost_smallest_unit ?? 0;
 	const displayPrice: number = siteProduct?.cost / 12 ?? 0;

--- a/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
+++ b/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
@@ -161,7 +161,6 @@ export const UpsellProductWpcomPlanCard: React.FC< UpsellProductWpcomPlanCardPro
 				cardImage={ upsellImageUrl }
 				cardImageAlt={ upsellImageAlt }
 				secondaryCtaURL={ secondaryCtaURL }
-				secondaryCtaLabel={ translate( 'See all plans' ) }
 			>
 				{ renderProductCardBody() }
 			</JetpackRnaActionCard>

--- a/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
+++ b/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
@@ -56,6 +56,7 @@ export const UpsellProductWpcomPlanCard: React.FC< UpsellProductWpcomPlanCardPro
 	const ctaButtonURL: string = `https://wordpress.com/checkout/${ selectedSiteSlug }/${ planSlug }?redirect_to=${ encodeURIComponent(
 		window.location.href
 	) }`;
+	const secondaryCtaURL: string = `https://wordpress.com/plans/${ selectedSiteSlug }) }`;
 	const isFetchingPrices: boolean = ! siteProduct;
 	const originalPrice: number = siteProduct?.cost_smallest_unit ?? 0;
 	const displayPrice: number = siteProduct?.cost / 12 ?? 0;
@@ -129,7 +130,7 @@ export const UpsellProductWpcomPlanCard: React.FC< UpsellProductWpcomPlanCardPro
 					/>
 				</div>
 				<div className="upsell-product-card__included" aria-hidden="true">
-					{ translate( 'Included with %(planName)s plan:', {
+					{ translate( 'Included with the %(planName)s plan:', {
 						args: {
 							planName: plan.getTitle(),
 						},
@@ -159,6 +160,8 @@ export const UpsellProductWpcomPlanCard: React.FC< UpsellProductWpcomPlanCardPro
 				ctaButtonLabel={ ctaButtonLabel }
 				cardImage={ upsellImageUrl }
 				cardImageAlt={ upsellImageAlt }
+				secondaryCtaURL={ secondaryCtaURL }
+				secondaryCtaLabel={ translate( 'See all plans' ) }
 			>
 				{ renderProductCardBody() }
 			</JetpackRnaActionCard>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7344

## Proposed Changes

* Add "the" to "Included with..." plan sentence.
* Add "See all plans" next to button.

<img width="1027" alt="Screen Shot 2024-06-03 at 3 35 16 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/7a19901d-9919-46d9-9452-ec2ed4aeb489">
<img width="1032" alt="Screen Shot 2024-06-03 at 3 35 08 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/f9a6cb31-e9ea-49e3-a26e-40180c83ae1b">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align the Jetpack Cloud Simple Site upsells with the provided design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On Jetpack Cloud with these changes applied, click into the Backup and Search pages with 1) a Simple site, 2) an Atomic site, 3) a Jetpack site.
   * Check that "See all plans" only shows up for Simple sites.
   * Check that both the button CTA and the "See all plans" CTA work.
   * Check the CTAs at different screen sizes.
* Regression test the other Jetpack Cloud upsells for the different site types (Activity Log, Scan, Purchases).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
