### PR TITLE
Jetpack Cloud Classic: Update Activity log upsells for wpcom

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -168,6 +168,7 @@ class ActivityCardList extends Component {
 			availableActions,
 			onClickClone,
 			siteSlug,
+			siteHasFullActivityLog,
 		} = this.props;
 
 		const today = ( applySiteOffset ?? moment )();
@@ -189,9 +190,13 @@ class ActivityCardList extends Component {
 				<>
 					<EmptyContent
 						title={ translate( 'No matching events found.' ) }
-						line={ translate( 'Try adjusting your date range or activity type filters' ) }
-						action={ translate( 'Remove all filters' ) }
-						actionURL={ '/activity-log/' + siteSlug }
+						line={
+							siteHasFullActivityLog
+								? translate( 'Try adjusting your date range or activity type filters' )
+								: null
+						}
+						action={ siteHasFullActivityLog ? translate( 'Remove all filters' ) : null }
+						actionURL={ siteHasFullActivityLog ? '/activity-log/' + siteSlug : null }
 					/>
 				</>
 			);

--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -28,11 +28,10 @@ import getRewindPoliciesRequestStatus from 'calypso/state/rewind/selectors/get-r
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import VisibleDaysLimitUpsell from './visible-days-limit-upsell';
-
 import './style.scss';
 
 class ActivityCardList extends Component {
@@ -263,7 +262,7 @@ class ActivityCardList extends Component {
 			pageSize,
 			showPagination,
 			siteHasFullActivityLog,
-			isSimple,
+			isWPCOMSite,
 		} = this.props;
 
 		const visibleLimitCutoffDate = Number.isFinite( visibleDays )
@@ -300,7 +299,7 @@ class ActivityCardList extends Component {
 						total={ visibleLogs.length }
 					/>
 				) }
-				{ ! siteHasFullActivityLog && isSimple && this.renderPlanUpsell( pageLogs ) }
+				{ ! siteHasFullActivityLog && isWPCOMSite && this.renderPlanUpsell( pageLogs ) }
 				{ this.renderLogs( pageLogs ) }
 				{ showLimitUpsell && (
 					<VisibleDaysLimitUpsell cardClassName="activity-card-list__primary-card-with-more" />
@@ -409,7 +408,7 @@ const mapStateToProps = ( state ) => {
 	const rewindPoliciesRequestStatus = getRewindPoliciesRequestStatus( state, siteId );
 
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
-	const isSimple = isSimpleSite( state, siteId );
+	const isWPCOMSite = getIsSiteWPCOM( state, siteId );
 	const requestingSiteFeatures = isRequestingSiteFeatures( state, siteId );
 	const siteHasFullActivityLog =
 		siteId && siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG );
@@ -423,7 +422,7 @@ const mapStateToProps = ( state ) => {
 		siteSlug,
 		userLocale,
 		isAtomic,
-		isSimple,
+		isWPCOMSite,
 		isRequestingSiteFeatures: requestingSiteFeatures,
 		siteHasFullActivityLog,
 	};

--- a/client/components/activity-card/plan-upsell.tsx
+++ b/client/components/activity-card/plan-upsell.tsx
@@ -2,11 +2,12 @@ import { Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import ActivityActor from 'calypso/components/activity-card/activity-actor';
+import Button from 'calypso/components/forms/form-button';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { useSelector } from 'calypso/state';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { Activity } from './types';
 
 import './style.scss';
@@ -26,6 +27,7 @@ type Props = OwnProps & {
 
 const PlanUpsellCard: React.FC< Props > = ( { upsellPlanName } ) => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
+	const siteSlug = useSelector( getSelectedSiteSlug );
 	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
 	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
 	const currentDateDisplay = applySiteOffset( Date.now(), { gmtOffset, timezone } ).format( 'LT' );
@@ -62,12 +64,13 @@ const PlanUpsellCard: React.FC< Props > = ( { upsellPlanName } ) => {
 										}
 									) }
 								</p>
-								<button
+								<Button
 									type="button"
 									className="button activity-card__activity-overlay-button is-primary"
+									href={ `https://wordpress.com/plans/${ siteSlug }` }
 								>
 									{ translate( 'Upgrade' ) }
-								</button>
+								</Button>
 							</div>
 						</div>
 					</Card>

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -24,6 +24,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -37,6 +38,7 @@ const ActivityLogV2: FunctionComponent = () => {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
+	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
 	const { data: logs } = useActivityLogQuery( siteId, filter );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
@@ -124,7 +126,7 @@ const ActivityLogV2: FunctionComponent = () => {
 			{ isJetpackCloud() && <SidebarNavigation /> }
 			<PageViewTracker path="/activity-log/:site" title="Activity log" />
 			{ settingsUrl && <TimeMismatchWarning siteId={ siteId } settingsUrl={ settingsUrl } /> }
-			{ isJetpackCloud() || isA8CForAgencies() ? (
+			{ ( isJetpackCloud() || isA8CForAgencies() ) && ! isWPCOMSite ? (
 				jetpackCloudHeader
 			) : (
 				<NavigationHeader


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7336

## Proposed Changes

* Remove the top "Activity Log" upsell for all WPCOM sites, both Simple and Atomic. It's specific to Jetpack self-hosted and not relevent to WPCOM sites.

<img width="300" alt="Screenshot 2024-05-31 at 5 05 24 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/098a4d21-3de1-4252-ad0d-425ad19e6633">

* Include the "Upgrade to Starter plan or higher" upsell on all WPCOM sites (both Simple and Atomic) that do not have the `WPCOM_FEATURES_FULL_ACTIVITY_LOG` feature.

<img width="300" alt="Screenshot 2024-05-31 at 5 05 49 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/8ce9461f-0ff7-48ab-825c-ddb76fa89ba6">

* Add a link to the "Upgrade" button in the upsell mentioned above to https://wordpress.com/plans/:site
* Do not show the "clear filter" CTA on empty activity logs that do not have the `WPCOM_FEATURES_FULL_ACTIVITY_LOG` feature and, therefore, can not filter or clear their filter.

Before | After
--|--
 <img width="1711" alt="Screenshot 2024-05-31 at 5 34 05 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/0b66a6c5-0aa1-42fa-abd0-5b0e37b116fe"> | <img width="1719" alt="Screenshot 2024-05-31 at 5 33 08 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/c65f3478-852f-4442-b7d3-032b060a1510">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Jetpack upsells are not available to WCPOM sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using this PR on http://jetpack.cloud.localhost:3000. If you'd like to use the live link, add `flags=jetpack/manage-simple-sites` to show simple sites.
* Visit http://jetpack.cloud.localhost:3000/activity-log/ on Simple and Atomic sites.
* None of these sites should contain the "Top upsell" referencing "Jetpack VaultPress Backup or Jetpack Security"
* Free Simple and Atomic sites should contain the "Upgrade to Starter plan or higher" upsell.
* Free sites with no events should not include a CTA to "Remove all filters"
* The "Upgrade" button on the upsell should work.

Test self-hosted Jetpack sites for regressions. You can compare production to this PR. There should be no difference.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
