### PR TITLE
Subscribers: Include Social Followers Count

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-list-container/style.scss
@@ -13,6 +13,12 @@
 			color: $studio-gray-100;
 		}
 
+		.subscriber-list-container__social-count {
+			color: var(--color-text-subtle);
+			font-size: $font-body-small;
+			margin-right: 4px;
+		}
+
 		.subscriber-list-container__subscriber-count {
 			font-weight: 500;
 			color: $studio-gray-40;

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -1,6 +1,7 @@
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import { getLocaleSlug, translate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import InfoPopover from 'calypso/components/info-popover';
 import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { NoSearchResults } from 'calypso/my-sites/subscribers/components/no-search-results';
@@ -11,7 +12,7 @@ import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subs
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { isSimpleSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isSimpleSite } from 'calypso/state/sites/selectors';
 import { useRecordSearch } from '../../tracks';
 import { GrowYourAudience } from '../grow-your-audience';
 import './style.scss';
@@ -32,6 +33,7 @@ const SubscriberListContainer = ( {
 	const {
 		grandTotal,
 		total,
+		socialTotal,
 		perPage,
 		page,
 		pageChangeCallback,
@@ -43,6 +45,7 @@ const SubscriberListContainer = ( {
 	} = useSubscribersPage();
 	useRecordSearch();
 
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
@@ -73,12 +76,42 @@ const SubscriberListContainer = ( {
 							}` }
 							title={
 								total > 1000
-									? formatNumber( total, getLocaleSlug() || undefined, { notation: 'standard' } )
+									? formatNumber( socialTotal, getLocaleSlug() || undefined, {
+											notation: 'standard',
+									  } )
 									: undefined
 							}
 						>
 							{ formatNumber( total, getLocaleSlug() || undefined ) }
 						</span>
+						{ socialTotal > 0 && (
+							<div>
+								<span className="subscriber-list-container__social-count">
+									{ translate(
+										'You also have %(socialTotal)s social follower.',
+										'You also have %(socialTotal)s social followers.',
+										{
+											count: socialTotal,
+											args: {
+												socialTotal: formatNumber( socialTotal, getLocaleSlug() || undefined ),
+											},
+										}
+									) }
+								</span>
+								<InfoPopover position="top right" iconSize={ 14 }>
+									<span>
+										{ translate(
+											'Social followers receive your posts on social media via {{a}}auto-sharing{{/a}}.',
+											{
+												components: {
+													a: <a href={ '/marketing/connections/' + siteSlug } />,
+												},
+											}
+										) }
+									</span>
+								</InfoPopover>
+							</div>
+						) }
 					</div>
 
 					<SubscriberListActionsBar />

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -37,6 +37,7 @@ type SubscribersPageContextProps = {
 	subscribers: Subscriber[];
 	total: number;
 	grandTotal: number;
+	socialTotal: number;
 	pageChangeCallback: ( page: number ) => void;
 	sortTerm: SubscribersSortBy;
 	setSortTerm: ( term: SubscribersSortBy ) => void;
@@ -122,6 +123,7 @@ export const SubscribersPageProvider = ( {
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId );
 
 	const grandTotal = subscribersTotals?.email_subscribers ?? 0;
+	const socialTotal = subscribersTotals?.social_followers ?? 0;
 
 	const { pageChangeCallback } = usePagination(
 		pageNumber,
@@ -215,6 +217,7 @@ export const SubscribersPageProvider = ( {
 				page: pageNumber,
 				grandTotal,
 				total,
+				socialTotal,
 				perPage,
 				setPerPage,
 				subscribers,


### PR DESCRIPTION
## Proposed Changes

Include the Social Followers count under My Sites > Users > Subscribers. 

## Why are these changes being made?

It's become a very regular occurrence for those in Support to handle tickets asking about why there is a discrepancy between the Subscribe block/widget and the subscriber count shown in Calypso. The discrepancy arises because the Subscribe block includes Social Followers: https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/#settings

In contrast, the Social Follower count cannot be found anywhere in Calypso. By including this count, the user is at least able to deduce why the two do not match. 

(Sample tickets: 8260141-zen; 8215037-zen; p1717136974941409-slack-C03TY6J1A)

## Testing Instructions

Go to My Sites > Users > Subscribers and verify that the Social Followers count appears. It should not appear if the site has no Social Followers at all. 

<img width="1098" alt="Screenshot 2024-06-01 at 11 55 01" src="https://github.com/Automattic/wp-calypso/assets/43215253/69b18420-f25e-4a7b-84bc-b71a4d7ee3fe">

cc @simison, @JuanLucha, @pkuliga 