### PR TITLE
Revert "Update domain messaging in paid media flow"

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -135,7 +135,6 @@ class RegisterDomainStep extends Component {
 		otherManagedSubdomains: PropTypes.array,
 		forceExactSuggestion: PropTypes.bool,
 		checkDomainAvailabilityPromises: PropTypes.array,
-		useAlternateDomainMessaging: PropTypes.bool,
 
 		/**
 		 * If an override is not provided we generate 1 suggestion per 1 other subdomain
@@ -173,7 +172,6 @@ class RegisterDomainStep extends Component {
 		otherManagedSubdomains: null,
 		hasPendingRequests: false,
 		forceExactSuggestion: false,
-		useAlternateDomainMessaging: false,
 	};
 
 	constructor( props ) {
@@ -1436,42 +1434,11 @@ class RegisterDomainStep extends Component {
 	};
 
 	renderBestNamesPrompt() {
-		const { translate, promptText, useAlternateDomainMessaging } = this.props;
-		const icon = <Icon icon={ tip } size={ 20 } />;
-		const defaultPrompt = (
-			<>
-				{ icon }
-				{ translate( 'The best names are short and memorable' ) }
-			</>
-		);
-		let prompt = defaultPrompt;
-
-		if ( promptText ) {
-			prompt = (
-				<>
-					{ icon }
-					{ promptText }
-				</>
-			);
-		} else if ( useAlternateDomainMessaging ) {
-			prompt = translate(
-				'{{p}}{{icon/}}Think of your domain name as a welcome mat for your website. Choose from hundreds of top-level domains (e.g. .com or .net), and claim your corner of the web with a custom site address.{{/p}}{{p}}Your first year of domain registration is free when you choose an annual, 2-year, or 3-year plan.{{/p}}',
-				{
-					components: {
-						icon,
-						p: <p />,
-					},
-				}
-			);
-		}
-
+		const { translate, promptText } = this.props;
 		return (
-			<div
-				className={ classNames( 'register-domain-step__example-prompt', {
-					[ 'register-domain-step__example-prompt--stacked' ]: useAlternateDomainMessaging,
-				} ) }
-			>
-				{ prompt }
+			<div className="register-domain-step__example-prompt">
+				<Icon icon={ tip } size={ 20 } />
+				{ promptText ?? translate( 'The best names are short and memorable' ) }
 			</div>
 		);
 	}

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -161,15 +161,6 @@
 	@include break-xlarge {
 		margin: 0;
 	}
-
-	&--stacked {
-		flex-direction: column;
-		align-items: start;
-
-		svg {
-			float: left;
-		}
-	}
 }
 
 .register-domain-step__placeholder.empty-content {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -253,9 +253,6 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'coupon' ],
 			optionalDependenciesInQuery: [ 'coupon' ],
 			props: {
-				domains: {
-					useAlternateDomainMessaging: true,
-				},
 				plans: {
 					isCustomDomainAllowedOnFreePlan: true,
 					deemphasizeFreePlan: true,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -99,7 +99,6 @@ export class RenderDomainsStep extends Component {
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
 		isReskinned: PropTypes.bool,
-		useAlternateDomainMessaging: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -1118,7 +1117,6 @@ export class RenderDomainsStep extends Component {
 				forceExactSuggestion={ this.props?.queryObject?.source === 'general-settings' }
 				replaceDomainFailedMessage={ this.state.replaceDomainFailedMessage }
 				dismissReplaceDomainFailed={ this.dismissReplaceDomainFailed }
-				useAlternateDomainMessaging={ this.props.useAlternateDomainMessaging }
 			/>
 		);
 	};
@@ -1178,14 +1176,7 @@ export class RenderDomainsStep extends Component {
 	isHostingFlow = () => isHostingSignupFlow( this.props.flowName );
 
 	getSubHeaderText() {
-		const {
-			flowName,
-			isAllDomains,
-			useAlternateDomainMessaging,
-			isReskinned,
-			stepSectionName,
-			translate,
-		} = this.props;
+		const { flowName, isAllDomains, stepSectionName, isReskinned, translate } = this.props;
 
 		if ( isAllDomains ) {
 			return translate( 'Find the domain that defines you' );
@@ -1231,12 +1222,6 @@ export class RenderDomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( useAlternateDomainMessaging ) {
-				return translate(
-					"Find a unique web address that's easy to remember and even easier to share."
-				);
-			}
-
 			return (
 				! stepSectionName &&
 				'domain-transfer' !== flowName &&
@@ -1250,15 +1235,8 @@ export class RenderDomainsStep extends Component {
 	}
 
 	getHeaderText() {
-		const {
-			flowName,
-			headerText,
-			isAllDomains,
-			useAlternateDomainMessaging,
-			isReskinned,
-			stepSectionName,
-			translate,
-		} = this.props;
+		const { headerText, isAllDomains, isReskinned, stepSectionName, translate, flowName } =
+			this.props;
 
 		if ( stepSectionName === 'use-your-domain' || 'domain-transfer' === flowName ) {
 			return '';
@@ -1276,11 +1254,6 @@ export class RenderDomainsStep extends Component {
 			if ( shouldUseMultipleDomainsInCart( flowName ) ) {
 				return ! stepSectionName && translate( 'Choose your domains' );
 			}
-
-			if ( useAlternateDomainMessaging ) {
-				return translate( 'Claim your domain name' );
-			}
-
 			return ! stepSectionName && translate( 'Choose a domain' );
 		}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#88536

## Proposed Changes

A decision has been made (peP6yB-1YG-p2#comment-1106) to revert the original change as no improvement was detected.

| Before | After |
| -- | -- |
|![313053097-99ec3218-8744-4862-869a-9e514d7ac3ec](https://github.com/Automattic/wp-calypso/assets/69198925/40da4244-24f2-4fb6-816c-424217de7727)|![CleanShot 2024-06-03 at 12 34 28@2x](https://github.com/Automattic/wp-calypso/assets/69198925/8cfc8b83-9ea6-4207-bd12-9b5bbc95dd2c)|


## Testing Instructions

Visit `/start/onboarding-pm/domains` and verify that the messaging matches the 'After' screenshot above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?