### PR TITLE
Hosting Overview: Add Backup and Support cards

### DIFF
--- a/client/hosting-overview/components/hosting-overview.tsx
+++ b/client/hosting-overview/components/hosting-overview.tsx
@@ -1,11 +1,16 @@
+import { WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ActiveDomainsCard from 'calypso/hosting-overview/components/active-domains-card';
 import PlanCard from 'calypso/hosting-overview/components/plan-card';
 import QuickActionsCard from 'calypso/hosting-overview/components/quick-actions-card';
+import SiteBackupCard from 'calypso/my-sites/hosting/site-backup-card';
+import SupportCard from 'calypso/my-sites/hosting/support-card';
 import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -13,6 +18,10 @@ import './style.scss';
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
 	const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
+	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, site.ID ?? null ) );
+	const hasAtomicFeature = useSelector( ( state ) =>
+		siteHasFeature( state, site.ID ?? null, WPCOM_FEATURES_ATOMIC )
+	);
 
 	const subtitle = isJetpackNotAtomic
 		? translate( 'Get a quick glance at your plans and upgrades.' )
@@ -27,6 +36,8 @@ const HostingOverview: FC = () => {
 			/>
 			<PlanCard />
 			<QuickActionsCard />
+			<SiteBackupCard disabled={ ! hasAtomicFeature || ! isSiteAtomic } />
+			<SupportCard />
 			<ActiveDomainsCard />
 		</div>
 	);

--- a/client/hosting-overview/components/hosting-overview.tsx
+++ b/client/hosting-overview/components/hosting-overview.tsx
@@ -18,9 +18,9 @@ import './style.scss';
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
 	const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
-	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, site?.ID ?? null ) );
+	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, site?.ID || -1 ) );
 	const hasAtomicFeature = useSelector( ( state ) =>
-		siteHasFeature( state, site?.ID ?? null, WPCOM_FEATURES_ATOMIC )
+		siteHasFeature( state, site?.ID || -1, WPCOM_FEATURES_ATOMIC )
 	);
 
 	const subtitle = isJetpackNotAtomic

--- a/client/hosting-overview/components/hosting-overview.tsx
+++ b/client/hosting-overview/components/hosting-overview.tsx
@@ -18,9 +18,9 @@ import './style.scss';
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
 	const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
-	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, site.ID ?? null ) );
+	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, site?.ID ?? null ) );
 	const hasAtomicFeature = useSelector( ( state ) =>
-		siteHasFeature( state, site.ID ?? null, WPCOM_FEATURES_ATOMIC )
+		siteHasFeature( state, site?.ID ?? null, WPCOM_FEATURES_ATOMIC )
 	);
 
 	const subtitle = isJetpackNotAtomic

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -18,28 +18,57 @@ $card-padding: 24px;
 
 .hosting-overview__navigation-header {
 	grid-column: 1 / -1;
-	grid-row: 1 / 2;
+	grid-row: 1;
 
 	&.navigation-header {
 		margin-bottom: 16px;
 	}
 }
 
-.hosting-overview__plan {
-	grid-column: 1 / 2;
-	grid-row: 2 / 3;
+.hosting-overview__plan,
+.hosting-overview__quick-actions {
+	grid-row: 2;
 }
 
-.hosting-overview__quick-actions {
-	grid-column: 2 / 3;
-	grid-row: 2 / 3;
-	padding-bottom: 10px;
+.hosting-card.site-backup-card,
+.hosting-card.support-card {
+	grid-row: 3;
 }
 
 .hosting-overview__active-domains {
-	grid-column: 1 / 3;
-	grid-row: 3 / 4;
+	grid-row: 4;
 	padding-bottom: 0;
+}
+
+.hosting-overview__navigation-header,
+.hosting-overview__active-domains {
+	grid-column: 1 / -1;
+}
+
+.hosting-overview__plan,
+.hosting-card.site-backup-card {
+	grid-column: 1 / 2;
+}
+
+.hosting-overview__quick-actions,
+.hosting-card.support-card {
+	grid-column: 2 / 2;
+}
+
+.hosting-overview__quick-actions {
+	padding-bottom: 10px;
+}
+
+.hosting-card.support-card {
+	.happiness-engineers-tray {
+		align-items: flex-start;
+		display: flex;
+		justify-content: flex-start;
+	}
+
+	.happiness-engineers-tray__gravatar {
+		margin-right: 16px;
+	}
 }
 
 @media ( max-width: $break-xlarge ) {
@@ -51,8 +80,10 @@ $card-padding: 24px;
 
 	.hosting-overview__plan,
 	.hosting-overview__quick-actions,
+	.hosting-card.site-backup-card,
+	.hosting-card.support-card,
 	.hosting-overview__active-domains {
-		grid-column: 1 / 2;
+		grid-column: 1;
 		grid-row: auto;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7512


## Proposed Changes

This PR adds the Backup and Support cards to Hosting Overview.

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-03 at 11 14 06 AM](https://github.com/Automattic/wp-calypso/assets/797888/31fe5e76-0259-4a69-826d-bb6646e8124a) | ![Screenshot 2024-06-03 at 11 14 26 AM](https://github.com/Automattic/wp-calypso/assets/797888/54079efa-c5cc-4f42-bf33-f4ae72b26c00) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Site Management Panel IA restructure.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the Site Management Panel's Overview tab now has the Backup and Support cards.
* Ensure that for Simple Sites, the Backup card says "There are no recent backups for your site"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
