### PR TITLE
Stats: Remove "checkout-flows-v2" feature flag

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import i18n from 'i18n-calypso';
 import { find, pick } from 'lodash';
@@ -16,8 +15,6 @@ import StatsSite from './site';
 import StatsEmailDetail from './stats-email-detail';
 import StatsEmailSummary from './stats-email-summary';
 import LoadStatsPage from './stats-redirect/load-stats-page';
-
-const isPurchaseFlowEnabled = config.isEnabled( 'stats/checkout-flows-v2' );
 
 function getNumPeriodAgo( momentSiteZone, date, period ) {
 	const endOfCurrentPeriod = momentSiteZone.endOf( period );
@@ -143,7 +140,7 @@ export function overview( context, next ) {
 	const siteId = getSelectedSiteId( context.store.getState() );
 
 	context.primary =
-		isPurchaseFlowEnabled && siteId !== null ? (
+		siteId !== null ? (
 			<LoadStatsPage>
 				<AsyncLoad
 					require="calypso/my-sites/stats/overview"
@@ -204,7 +201,7 @@ export function site( context, next ) {
 	const validTabs = [ 'views', 'visitors', 'likes', 'comments' ];
 	const chartTab = validTabs.includes( queryOptions.tab ) ? queryOptions.tab : 'views';
 
-	context.primary = isPurchaseFlowEnabled ? (
+	context.primary = (
 		<LoadStatsPage>
 			<StatsSite
 				path={ context.pathname }
@@ -214,14 +211,6 @@ export function site( context, next ) {
 				period={ rangeOfPeriod( activeFilter.period, date ) }
 			/>
 		</LoadStatsPage>
-	) : (
-		<StatsSite
-			path={ context.pathname }
-			date={ date }
-			chartTab={ chartTab }
-			context={ context }
-			period={ rangeOfPeriod( activeFilter.period, date ) }
-		/>
 	);
 
 	next();
@@ -296,7 +285,7 @@ export function summary( context, next ) {
 		statsQueryOptions.period = 'day';
 	}
 
-	context.primary = isPurchaseFlowEnabled ? (
+	context.primary = (
 		<LoadStatsPage>
 			<AsyncLoad
 				require="calypso/my-sites/stats/summary"
@@ -309,17 +298,6 @@ export function summary( context, next ) {
 				{ ...extraProps }
 			/>
 		</LoadStatsPage>
-	) : (
-		<AsyncLoad
-			require="calypso/my-sites/stats/summary"
-			placeholder={ PageLoading }
-			path={ context.pathname }
-			statsQueryOptions={ statsQueryOptions }
-			date={ date }
-			context={ context }
-			period={ period }
-			{ ...extraProps }
-		/>
 	);
 
 	next();
@@ -336,7 +314,7 @@ export function post( context, next ) {
 		return next();
 	}
 
-	context.primary = isPurchaseFlowEnabled ? (
+	context.primary = (
 		<LoadStatsPage>
 			<AsyncLoad
 				require="calypso/my-sites/stats/stats-post-detail"
@@ -346,14 +324,6 @@ export function post( context, next ) {
 				context={ context }
 			/>
 		</LoadStatsPage>
-	) : (
-		<AsyncLoad
-			require="calypso/my-sites/stats/stats-post-detail"
-			placeholder={ PageLoading }
-			path={ context.path }
-			postId={ postId }
-			context={ context }
-		/>
 	);
 
 	next();
@@ -382,7 +352,7 @@ export function follows( context, next ) {
 		pageNum = 1;
 	}
 
-	context.primary = isPurchaseFlowEnabled ? (
+	context.primary = (
 		<LoadStatsPage>
 			<AsyncLoad
 				require="calypso/my-sites/stats/comment-follows"
@@ -395,17 +365,6 @@ export function follows( context, next ) {
 				siteId={ siteId }
 			/>
 		</LoadStatsPage>
-	) : (
-		<AsyncLoad
-			require="calypso/my-sites/stats/comment-follows"
-			placeholder={ PageLoading }
-			path={ context.path }
-			page={ pageNum }
-			perPage="20"
-			total="10"
-			domain={ siteDomain }
-			siteId={ siteId }
-		/>
 	);
 
 	next();

--- a/client/my-sites/stats/pages/insights/controller.tsx
+++ b/client/my-sites/stats/pages/insights/controller.tsx
@@ -1,18 +1,13 @@
-import config from '@automattic/calypso-config';
 import AsyncLoad from 'calypso/components/async-load';
 import LoadStatsPage from '../../stats-redirect/load-stats-page';
 import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
 
-const isPurchaseFlowEnabled = config.isEnabled( 'stats/checkout-flows-v2' );
-
 function insights( context: Context, next: () => void ) {
-	context.primary = isPurchaseFlowEnabled ? (
+	context.primary = (
 		<LoadStatsPage>
 			<AsyncLoad require="calypso/my-sites/stats/pages/insights" placeholder={ PageLoading } />
 		</LoadStatsPage>
-	) : (
-		<AsyncLoad require="calypso/my-sites/stats/pages/insights" placeholder={ PageLoading } />
 	);
 	next();
 }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-notice.jsx
@@ -108,7 +108,7 @@ const StatsFreeOwnedNotice = ( { siteId, siteSlug } ) => {
 	};
 
 	return (
-		<StatsSingleItemPagePurchaseFrame isFree>
+		<StatsSingleItemPagePurchaseFrame>
 			<h1>{ translate( 'You already have a free license for Jetpack Stats.' ) }</h1>
 			<p>
 				{ translate(

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -31,7 +31,6 @@ interface PersonalPurchaseProps {
 	adminUrl: string;
 	redirectUri: string;
 	from: string;
-	isStandalone?: boolean;
 }
 
 const PersonalPurchase = ( {
@@ -46,7 +45,6 @@ const PersonalPurchase = ( {
 	adminUrl,
 	redirectUri,
 	from,
-	isStandalone,
 }: PersonalPurchaseProps ) => {
 	const translate = useTranslate();
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
@@ -63,7 +61,6 @@ const PersonalPurchase = ( {
 	} = sliderSettings;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
-	const isNewPurchaseFlowEnabled = config.isEnabled( 'stats/checkout-flows-v2' );
 
 	const sliderLabel = ( ( props, state ) => {
 		let emoji;
@@ -98,13 +95,7 @@ const PersonalPurchase = ( {
 	// TODO: Remove old slider code paths.
 	const showOldSlider = ! isTierUpgradeSliderEnabled;
 
-	let continueButtonText = isStandalone
-		? translate( 'Get Stats' )
-		: translate( 'Get Jetpack Stats' );
-
-	if ( isNewPurchaseFlowEnabled ) {
-		continueButtonText = translate( 'Contribute now and continue' );
-	}
+	const continueButtonText = translate( 'Contribute now and continue' );
 	const { refetch: refetchNotices } = useNoticeVisibilityQuery( siteId, 'focus_jetpack_purchase' );
 	const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
 		siteId,
@@ -280,16 +271,14 @@ const PersonalPurchase = ( {
 						{ continueButtonText }
 					</ButtonComponent>
 
-					{ isNewPurchaseFlowEnabled && (
-						<ButtonComponent
-							variant="secondary"
-							isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
-							busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />
-							onClick={ handleCheckoutPostponed }
-						>
-							{ translate( 'I will do it later' ) }
-						</ButtonComponent>
-					) }
+					<ButtonComponent
+						variant="secondary"
+						isBusy={ isWPCOMSite ? undefined : isPostponeBusy } // for <Button />
+						busy={ isWPCOMSite ? isPostponeBusy : undefined } // for <CalypsoButton />
+						onClick={ handleCheckoutPostponed }
+					>
+						{ translate( 'I will do it later' ) }
+					</ButtonComponent>
 				</div>
 			) }
 		</div>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Popover } from '@automattic/components';
 import { getCurrencyObject } from '@automattic/format-currency';
 import { Card } from '@wordpress/components';
@@ -6,9 +5,7 @@ import { Icon, info } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
-import statsPurchaseBackgroundSVG from 'calypso/assets/images/stats/purchase-background.svg';
 import StatsPurchasePreviewImage from './stats-purchase-preview-image';
-import StatsPurchaseSVG from './stats-purchase-svg';
 import { COMPONENT_CLASS_NAME } from './stats-purchase-wizard';
 
 interface StatsCommercialPriceDisplayProps {
@@ -18,7 +15,6 @@ interface StatsCommercialPriceDisplayProps {
 
 interface StatsSingleItemPagePurchaseFrameProps {
 	children: React.ReactNode;
-	isFree?: boolean;
 }
 
 const StatsCommercialPriceDisplay = ( {
@@ -265,24 +261,14 @@ const StatsBenefitsFree = () => {
 
 const StatsSingleItemPagePurchaseFrame = ( {
 	children,
-	isFree = false,
 }: StatsSingleItemPagePurchaseFrameProps ) => {
-	const useNewPreviewImage = config.isEnabled( 'stats/checkout-flows-v2' );
 	return (
 		<div className={ clsx( COMPONENT_CLASS_NAME, `${ COMPONENT_CLASS_NAME }--single` ) }>
 			<Card className={ `${ COMPONENT_CLASS_NAME }__card-parent` }>
 				<div className={ `${ COMPONENT_CLASS_NAME }__card` }>
 					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--left` }>{ children }</div>
 					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right` }>
-						{ useNewPreviewImage && <StatsPurchasePreviewImage /> }
-						{ ! useNewPreviewImage && (
-							<>
-								<StatsPurchaseSVG isFree={ isFree } hasHighlight={ false } extraMessage={ false } />
-								<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right-background` }>
-									<img src={ statsPurchaseBackgroundSVG } alt="Blurred background" />
-								</div>
-							</>
-						) }
+						<StatsPurchasePreviewImage />
 					</div>
 				</div>
 			</Card>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -287,7 +287,6 @@ const StatsPersonalPurchase = ( {
 				adminUrl={ adminUrl }
 				redirectUri={ redirectUri }
 				from={ from }
-				isStandalone
 			/>
 		</>
 	);

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -49,11 +49,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 	const { isNewSite, shouldShowPaywall } = useSiteCompulsoryPlanSelectionQualifiedCheck( siteId );
 	// to redirect the user can't have a plan purached and can't have the flag true, if either is true the user either has a plan or is postponing
 	const redirectToPurchase =
-		config.isEnabled( 'stats/checkout-flows-v2' ) &&
-		isSiteJetpackNotAtomic &&
-		! hasAnyPlan &&
-		purchaseNotPostponed &&
-		shouldShowPaywall;
+		isSiteJetpackNotAtomic && ! hasAnyPlan && purchaseNotPostponed && shouldShowPaywall;
 
 	// TODO: If notices are not used by class components, we don't have any reasons to launch any of those actions anymore. If we do need them, we should consider refactoring them to another component.
 	const dispatch = useDispatch();

--- a/config/client.json
+++ b/config/client.json
@@ -22,7 +22,6 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
-	"stats/checkout-flows-v2",
 	"stats/date-control",
 	"stats/devices",
 	"stats/paid-wpcom-stats",

--- a/config/development.json
+++ b/config/development.json
@@ -206,7 +206,6 @@
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": false,
-		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -131,7 +131,6 @@
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
-		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,

--- a/config/production.json
+++ b/config/production.json
@@ -177,7 +177,6 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -170,7 +170,6 @@
 		"site-indicator": true,
 		"site-profiler/metrics": false,
 		"ssr/prefetch-timebox": true,
-		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,

--- a/config/test.json
+++ b/config/test.json
@@ -113,7 +113,6 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -167,7 +167,6 @@
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
-		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/45

## Proposed Changes

Fully removes the `stats/checkout-flows-v2` flag now that the feature has been released.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of our regular maintenance work to keep tech debt low.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The code changes are pretty straight-forward but it touches a bunch of our controller logic. Please test that the various Stats top-level tabs (Traffic, Insights, etc.) load correctly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
