### PR TITLE
Plans revert experiment: Refactor call to `getPlansListExperiment()`.

### DIFF
--- a/packages/calypso-products/src/plans.tsx
+++ b/packages/calypso-products/src/plans.tsx
@@ -6,52 +6,50 @@ import { getPlansListExperiment } from './experiments';
  * See: p7H4VZ-4S4-p2
  */
 
-const isPlanNameChangeTreatment =
-	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment';
 export const getPlanPersonalTitle = () =>
-	isPlanNameChangeTreatment
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
 		? // translators: Personal is a plan name
 		  i18n.translate( 'Personal' )
 		: // translators: Starter is a plan name
 		  i18n.translate( 'Starter' );
 
 export const getPlanPremiumTitle = () =>
-	isPlanNameChangeTreatment
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
 		? // translators: Premium is a plan name
 		  i18n.translate( 'Premium' )
 		: // translators: Explorer is a plan name
 		  i18n.translate( 'Explorer' );
 
 export const getPlanBusinessTitle = () =>
-	isPlanNameChangeTreatment
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
 		? // translators: Business is a plan name
 		  i18n.translate( 'Business' )
 		: // translators: Creator is a plan name
 		  i18n.translate( 'Creator' );
 
 export const getPlanEcommerceTitle = () =>
-	isPlanNameChangeTreatment
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
 		? // translators: Commerce is a plan name
 		  i18n.translate( 'Commerce' )
 		: // translators: Entrepreneur is a plan name
 		  i18n.translate( 'Entrepreneur' );
 
 export const getPlanBusinessTrialTitle = () =>
-	isPlanNameChangeTreatment
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
 		? // translators: Business Trial is a plan name
 		  i18n.translate( 'Business Trial' )
 		: // translators: Creator Trial is a plan name
 		  i18n.translate( 'Creator Trial' );
 
 export const getPlanBusinessTrialTagline = () =>
-	isPlanNameChangeTreatment
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
 		? // translators: Business is a plan name
 		  i18n.translate( 'Try all the features of our Business plan.' )
 		: // translators: Creator is a plan name
 		  i18n.translate( 'Try all the features of our Creator plan.' );
 
 export const getPlanCommerceTrialTitle = () =>
-	isPlanNameChangeTreatment
+	getPlansListExperiment( 'wpcom_plan_name_change_personal_premium_v1' ) === 'treatment'
 		? // translators: Commerce Trial is a plan name
 		  i18n.translate( 'Commerce Trial' )
 		: // translators: Entrepreneur Trial is a plan name


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* @claudiucelfilip reported [here](https://github.com/Automattic/wp-calypso/pull/91323/files#r1623818152) a bug with the call to getPlansListExperiment(). This PR fixes the issue.