### PR TITLE
Global Sidebar: Support url param 'from'

### DIFF
--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -23,6 +23,8 @@ const GlobalSidebar = ( {
 	path = '',
 	...props
 } ) => {
+	const urlSearchParams = new URLSearchParams( window.location.search );
+	const urlFrom = urlSearchParams.get( 'from' ) || '';
 	const wrapperRef = useRef( null );
 	const bodyRef = useRef( null );
 	const menuItems = useSiteMenuItems();
@@ -71,7 +73,7 @@ const GlobalSidebar = ( {
 	}
 
 	const { requireBackLink, siteTitle, backLinkHref, ...sidebarProps } = props;
-	const sidebarBackLinkHref = backLinkHref || previousLink || '/sites';
+	const sidebarBackLinkHref = urlFrom || backLinkHref || previousLink || '/sites';
 
 	return (
 		<div className="global-sidebar" ref={ wrapperRef }>

--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -23,8 +23,6 @@ const GlobalSidebar = ( {
 	path = '',
 	...props
 } ) => {
-	const urlSearchParams = new URLSearchParams( window.location.search );
-	const urlFrom = urlSearchParams.get( 'from' ) || '';
 	const wrapperRef = useRef( null );
 	const bodyRef = useRef( null );
 	const menuItems = useSiteMenuItems();
@@ -46,6 +44,14 @@ const GlobalSidebar = ( {
 
 	const handleBackLinkClick = () => {
 		recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.MENU_BACK_CLICK, { path } );
+	};
+
+	const getBackLinkFromURL = () => {
+		const searchParams = new URLSearchParams( window.location.search );
+		const url = searchParams.get( 'from' ) || '';
+
+		// Only accept internal links for security purposes.
+		return url.startsWith( '/' ) ? url : '';
 	};
 
 	useEffect( () => {
@@ -73,7 +79,7 @@ const GlobalSidebar = ( {
 	}
 
 	const { requireBackLink, siteTitle, backLinkHref, ...sidebarProps } = props;
-	const sidebarBackLinkHref = urlFrom || backLinkHref || previousLink || '/sites';
+	const sidebarBackLinkHref = getBackLinkFromURL() || backLinkHref || previousLink || '/sites';
 
 	return (
 		<div className="global-sidebar" ref={ wrapperRef }>

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -1,10 +1,12 @@
 import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { CONTACT, SUPPORT_ROOT } from '@automattic/urls';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import { login } from 'calypso/lib/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import CoursesComponent from './help-courses';
 import HelpComponent from './main';
 
@@ -55,6 +57,8 @@ export function courses( context, next ) {
 	next();
 }
 
-export function contactRedirect() {
-	page.redirect( '/help' );
+export function contactRedirect( context ) {
+	const state = context.store.getState();
+	const previousRoute = getPreviousRoute( state );
+	page.redirect( addQueryArgs( '/help', { from: previousRoute } ) );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7564

## Proposed Changes

This PR adds support to the URL param `from` to the Global Sidebar. The URL in `&from=` will serve as the back button link. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Address issue with router redirects.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Open the Site Management Panel of any site.
* Click on the Contact us button from the Support card in the Overview tab.
* Expect to land in `/help`.
* Ensure that the URL contains `&from`.
* Ensure that clicking the Back button of the Global Sidebar takes you back to the `&from` URL.
* Test the Global Sidebar's Back button in other contexts (i.e.: /read, /plugins, /me), and ensure they still work as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
