### PR TITLE
Help Center: Improve the a11y

### DIFF
--- a/client/blocks/inline-help/inline-help-search-card.tsx
+++ b/client/blocks/inline-help/inline-help-search-card.tsx
@@ -35,8 +35,7 @@ const InlineHelpSearchCard = ( {
 	// Focus in the input element.
 	useEffect( () => {
 		const inputElement = cardRef.current?.searchInput;
-		// Focuses only in the popover.
-		if ( location !== 'inline-help-popover' || ! inputElement || ! isVisible ) {
+		if ( ! inputElement || ! isVisible ) {
 			return;
 		}
 

--- a/client/layout/global-sidebar/menu-items/help-center/help-center.jsx
+++ b/client/layout/global-sidebar/menu-items/help-center/help-center.jsx
@@ -12,14 +12,23 @@ const HELP_CENTER_STORE = HelpCenter.register();
 
 const SidebarHelpCenter = ( { tooltip, onClick } ) => {
 	const helpIconRef = useRef();
-	const helpCenterVisible = useDateStoreSelect(
-		( select ) => select( HELP_CENTER_STORE ).isHelpCenterShown(),
-		[]
-	);
+	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE );
+		return {
+			show: store.isHelpCenterShown(),
+			isMinimized: store.getIsMinimized(),
+		};
+	}, [] );
+
 	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleToggleHelpCenter = () => {
-		setShowHelpCenter( ! helpCenterVisible );
+		if ( isMinimized ) {
+			setIsMinimized( false );
+		} else {
+			setShowHelpCenter( ! show );
+		}
 		onClick();
 	};
 
@@ -28,7 +37,7 @@ const SidebarHelpCenter = ( { tooltip, onClick } ) => {
 			<SidebarMenuItem
 				onClick={ handleToggleHelpCenter }
 				className={ clsx( 'sidebar__item-help', {
-					'is-active': helpCenterVisible,
+					'is-active': show,
 				} ) }
 				tooltip={ tooltip }
 				tooltipPlacement="top"

--- a/client/layout/global-sidebar/menu-items/help-center/help-center.jsx
+++ b/client/layout/global-sidebar/menu-items/help-center/help-center.jsx
@@ -20,8 +20,7 @@ const SidebarHelpCenter = ( { tooltip, onClick } ) => {
 		};
 	}, [] );
 
-	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
-	const { setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleToggleHelpCenter = () => {
 		if ( isMinimized ) {

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import { Icon, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
+import { useRef, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import '../styles.scss';
 
@@ -12,6 +13,7 @@ export const BackButton = ( { onClick, backToRoot = false, className }: Props ) 
 	const location = useLocation();
 	const navigate = useNavigate();
 	const buttonClassName = clsx( 'back-button__help-center', className );
+	const buttonRef = useRef();
 
 	function defaultOnClick() {
 		if ( backToRoot ) {
@@ -24,8 +26,13 @@ export const BackButton = ( { onClick, backToRoot = false, className }: Props ) 
 			navigate( -1 );
 		}
 	}
+
+	useEffect( () => {
+		buttonRef.current?.focus?.();
+	}, [] );
+
 	return (
-		<Button className={ buttonClassName } onClick={ onClick || defaultOnClick }>
+		<Button className={ buttonClassName } ref={ buttonRef } onClick={ onClick || defaultOnClick }>
 			<Icon icon={ chevronLeft } size={ 18 } />
 			{ __( 'Back', __i18n_text_domain__ ) }
 		</Button>

--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -2,7 +2,6 @@ import { Button } from '@wordpress/components';
 import { Icon, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { useRef, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import '../styles.scss';
 
@@ -13,7 +12,6 @@ export const BackButton = ( { onClick, backToRoot = false, className }: Props ) 
 	const location = useLocation();
 	const navigate = useNavigate();
 	const buttonClassName = clsx( 'back-button__help-center', className );
-	const buttonRef = useRef();
 
 	function defaultOnClick() {
 		if ( backToRoot ) {
@@ -27,12 +25,13 @@ export const BackButton = ( { onClick, backToRoot = false, className }: Props ) 
 		}
 	}
 
-	useEffect( () => {
-		buttonRef.current?.focus?.();
-	}, [] );
-
 	return (
-		<Button className={ buttonClassName } ref={ buttonRef } onClick={ onClick || defaultOnClick }>
+		<Button
+			className={ buttonClassName }
+			/* eslint-disable-next-line jsx-a11y/no-autofocus */
+			autoFocus
+			onClick={ onClick || defaultOnClick }
+		>
 			<Icon icon={ chevronLeft } size={ 18 } />
 			{ __( 'Back', __i18n_text_domain__ ) }
 		</Button>

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -4,6 +4,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
+import { useFocusReturn, useMergeRefs } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import clsx from 'clsx';
 import { useState, useRef, useEffect, useCallback, FC } from 'react';
@@ -73,6 +74,10 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 	// https://github.com/react-grid-layout/react-draggable/blob/781ef77c86be9486400da9837f43b96186166e38/README.md
 	const nodeRef = useRef( null );
 
+	const focusReturnRef = useFocusReturn();
+
+	const cardMergeRefs = useMergeRefs( [ nodeRef, focusReturnRef ] );
+
 	const shouldCloseOnEscapeRef = useRef( false );
 
 	shouldCloseOnEscapeRef.current = !! show && ! hidden && ! isMinimized;
@@ -103,7 +108,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, curr
 					handle=".help-center__container-header"
 					bounds="body"
 				>
-					<Card className={ classNames } { ...animationProps } ref={ nodeRef }>
+					<Card className={ classNames } { ...animationProps } ref={ cardMergeRefs }>
 						<HelpCenterHeader
 							isMinimized={ isMinimized }
 							onMinimize={ () => setIsMinimized( true ) }

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -4,7 +4,7 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import OdieAssistantProvider, { useSetOdieStorage } from '@automattic/odie-client';
-import { CardBody } from '@wordpress/components';
+import { CardBody, Disabled } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { useCallback, useState } from 'react';
@@ -83,44 +83,46 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 
 	return (
 		<CardBody ref={ containerRef } className="help-center__container-content">
-			<Routes>
-				<Route
-					path="/"
-					element={
-						<HelpCenterSearch onSearchChange={ setSearchTerm } currentRoute={ currentRoute } />
-					}
-				/>
-				<Route path="/post" element={ <HelpCenterEmbedResult /> } />
-				<Route path="/contact-options" element={ <HelpCenterContactPage /> } />
-				<Route
-					path="/contact-form"
-					element={ <HelpCenterContactForm onSubmit={ () => setOdieStorage( null ) } /> }
-				/>
-				<Route path="/success" element={ <SuccessScreen /> } />
-				<Route
-					path="/odie"
-					element={
-						<OdieAssistantProvider
-							botNameSlug="wpcom-support-chat"
-							botName="Wapuu"
-							enabled={ isWapuuEnabled }
-							isMinimized={ isMinimized }
-							initialUserMessage={ searchTerm }
-							logger={ trackEvent }
-							loggerEventNamePrefix="calypso_odie"
-							selectedSiteId={ selectedSiteId }
-							extraContactOptions={
-								<HelpCenterContactPage
-									hideHeaders
-									trackEventName="calypso_odie_extra_contact_option"
-								/>
-							}
-						>
-							<HelpCenterOdie />
-						</OdieAssistantProvider>
-					}
-				/>
-			</Routes>
+			<Disabled isDisabled={ isMinimized }>
+				<Routes>
+					<Route
+						path="/"
+						element={
+							<HelpCenterSearch onSearchChange={ setSearchTerm } currentRoute={ currentRoute } />
+						}
+					/>
+					<Route path="/post" element={ <HelpCenterEmbedResult /> } />
+					<Route path="/contact-options" element={ <HelpCenterContactPage /> } />
+					<Route
+						path="/contact-form"
+						element={ <HelpCenterContactForm onSubmit={ () => setOdieStorage( null ) } /> }
+					/>
+					<Route path="/success" element={ <SuccessScreen /> } />
+					<Route
+						path="/odie"
+						element={
+							<OdieAssistantProvider
+								botNameSlug="wpcom-support-chat"
+								botName="Wapuu"
+								enabled={ isWapuuEnabled }
+								isMinimized={ isMinimized }
+								initialUserMessage={ searchTerm }
+								logger={ trackEvent }
+								loggerEventNamePrefix="calypso_odie"
+								selectedSiteId={ selectedSiteId }
+								extraContactOptions={
+									<HelpCenterContactPage
+										hideHeaders
+										trackEventName="calypso_odie_extra_contact_option"
+									/>
+								}
+							>
+								<HelpCenterOdie />
+							</OdieAssistantProvider>
+						}
+					/>
+				</Routes>
+			</Disabled>
 		</CardBody>
 	);
 };

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -131,6 +131,7 @@
 					text-decoration: none;
 					color: var(--studio-gray-100);
 					font-size: $font-body-small;
+					border-radius: 2px;
 
 					svg:first-child {
 						margin-right: 15px;
@@ -230,6 +231,7 @@
 			.inline-help__resource-cell a,
 			.inline-help__resource-cell button {
 				display: flex;
+				border-radius: 2px;
 
 				svg:first-of-type {
 					margin-right: 15px;
@@ -293,8 +295,8 @@
 
 					&:active,
 					&:focus {
-						box-shadow: 0 0 0 1px var(--studio-blue-30), 0 0 2px 1px rgb(79 148 212 / 80%);
-						outline: 1px solid transparent;
+						box-shadow: none;
+						outline: var(--color-primary-light) solid 2px;
 					}
 				}
 
@@ -436,6 +438,7 @@
 
 				.help-center-search-results__cell a {
 					display: flex;
+					border-radius: 2px;
 
 					svg {
 						margin-right: 15px;
@@ -671,10 +674,9 @@
 		}
 
 		&:focus {
-			color: #043959;
-			box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba(79, 148, 212, 0.8);
-			outline: 1px solid transparent;
-			border-color: inherit;
+			border-color: transparent;
+			box-shadow: none;
+			outline: var(--color-primary-light) solid 2px;
 		}
 
 		svg {

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -28,11 +28,6 @@ $head-foot-height: 50px;
 			flex-direction: column;
 		}
 
-		// button.components-button:focus {
-		// 	box-shadow: none;
-		// 	outline: none;
-		// }
-
 		.help-center__container-header {
 			height: $head-foot-height;
 			padding: 16px 8px 16px 16px;
@@ -267,6 +262,11 @@ $head-foot-height: 50px;
 			justify-content: space-between;
 			padding: 16px;
 			box-sizing: border-box;
+
+			.odie-button-default:focus {
+				border-radius: 2px;
+				outline: var(--color-primary-light) solid 2px;
+			}
 		}
 	}
 

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -28,14 +28,22 @@ $head-foot-height: 50px;
 			flex-direction: column;
 		}
 
-		button.components-button:focus {
-			box-shadow: none;
-			outline: none;
-		}
+		// button.components-button:focus {
+		// 	box-shadow: none;
+		// 	outline: none;
+		// }
 
 		.help-center__container-header {
 			height: $head-foot-height;
 			padding: 16px 8px 16px 16px;
+
+			.help-center-header__maximize,
+			.help-center-header__minimize,
+			.help-center-header__close {
+				&:focus {
+					outline: var(--color-primary-light) solid 2px;
+				}
+			}
 
 			// This icon does not accept size prop due to a bug - https://github.com/WordPress/gutenberg/pull/40315
 			// We can remove this when the bug is fixed
@@ -67,6 +75,20 @@ $head-foot-height: 50px;
 		.help-center__container-content {
 			overflow-y: auto;
 			padding: 16px;
+
+			.search-card div.has-focus[role="search"] {
+				outline: var(--color-primary-light) solid 2px;
+				transition: none;
+			}
+
+			.help-center-search-results__results .help-center-search-results__item,
+			.inline-help__more-resources .inline-help__resource-item {
+				a:focus,
+				button:focus {
+					outline: var(--color-primary-light) solid 2px;
+					outline-offset: 2px;
+				}
+			}
 		}
 
 		.help-center__container-footer {
@@ -206,12 +228,12 @@ $head-foot-height: 50px;
 		display: flex;
 		color: #000;
 		font-size: $font-body-small;
-		padding: 0;
+		padding: 0 4px 0 0;
 
 		&:focus {
 			color: #043959;
-			box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba(79, 148, 212, 0.8);
-			outline: 1px solid transparent;
+			box-shadow: none;
+			outline: var(--color-primary-light) solid 2px;
 			border-color: inherit;
 		}
 

--- a/packages/odie-client/src/components/message/jump-to-recent.tsx
+++ b/packages/odie-client/src/components/message/jump-to-recent.tsx
@@ -37,7 +37,11 @@ export const JumpToRecent = ( {
 
 	return (
 		<div className={ className } style={ { bottom: bottomOffset - heightOffset } }>
-			<button className="odie-jump-to-recent-message-button" onClick={ jumpToRecent }>
+			<button
+				className="odie-jump-to-recent-message-button"
+				disabled={ ! enableJumpToRecent }
+				onClick={ jumpToRecent }
+			>
 				{ translate( 'Jump to recent', {
 					context:
 						'A dynamic button that appears on a chatbox, when the last message is not vissible',

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -266,6 +266,10 @@ $custom-border-corner-size: 16px;
 		opacity: 0;
 		bottom: 0 !important;
 		transition: opacity 0.3s ease, bottom 0.3s ease;
+
+		.odie-jump-to-recent-message-button {
+			pointer-events: none;
+		}
 	}
 
 	&.is-visible {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7550

## Proposed Changes

* Improve the tab behavior
  * Focus on the search input when it opens
  * Focus on the back button when the result page opens
  * Return the focus to the help center icon when it's minimized or closed
  * Currently, when the help center is minimized, the focus element will return to the help center icon, and the next focusable element is the command palette. If we keep focusing on the “Maximize” button, then the focusable element after the close button will be the browser URL bar. It seems to be a bit weird. Does it make sense?
* Improve the focus styles

https://github.com/Automattic/wp-calypso/assets/13596067/7a8f3dab-d26d-484a-b26e-77ff9b4c0552

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Use `tab` to navigate to the help center icon
* Use the keyboard to open the help center
* Use the keyboard to navigate
* Make sure the behavior is acceptable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
