### PR TITLE
Subscriptions: Add the Subscribe block navigation placement toggle

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/SubscribeNavigationSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeNavigationSetting.tsx
@@ -46,7 +46,7 @@ export const SubscribeNavigationSetting = ( {
 			disabled={ disabled }
 			label={
 				<>
-					{ translate( 'Add the Subscribe block to the navigation.' ) }{ ' ' }
+					{ translate( 'Add the Subscribe Block to the navigation.' ) }{ ' ' }
 					<ExternalLink href={ getEditUrl() } onClick={ onEditClick }>
 						{ translate( 'Preview and edit' ) }
 					</ExternalLink>

--- a/client/my-sites/site-settings/settings-newsletter/SubscribeNavigationSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeNavigationSetting.tsx
@@ -1,0 +1,57 @@
+import { ExternalLink, ToggleControl } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const SUBSCRIBE_NAVIGATION_OPTION = 'jetpack_subscriptions_subscribe_navigation_enabled';
+
+interface SubscribeNavigationSettingProps {
+	value?: boolean;
+	handleToggle: ( field: string ) => ( value: boolean ) => void;
+	disabled?: boolean;
+}
+
+export const SubscribeNavigationSetting = ( {
+	value = false,
+	handleToggle,
+	disabled,
+}: SubscribeNavigationSettingProps ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+
+	const siteEditorUrl = useSelector( ( state: object ) => getSiteEditorUrl( state, siteId ) );
+	const { data: activeThemeData } = useActiveThemeQuery( siteId, true );
+
+	const getEditUrl = () => {
+		const themeSlug = activeThemeData?.[ 0 ]?.stylesheet;
+
+		return addQueryArgs( siteEditorUrl, {
+			postType: 'wp_template',
+			postId: `${ themeSlug }//index`,
+		} );
+	};
+
+	const onEditClick = () => {
+		recordTracksEvent( 'calypso_settings_subscribe_navigation_edit_click' );
+	};
+
+	return (
+		<ToggleControl
+			checked={ !! value }
+			onChange={ handleToggle( SUBSCRIBE_NAVIGATION_OPTION ) }
+			disabled={ disabled }
+			label={
+				<>
+					{ translate( 'Add the Subscribe block to the navigation.' ) }{ ' ' }
+					<ExternalLink href={ getEditUrl() } onClick={ onEditClick }>
+						{ translate( 'Preview and edit' ) }
+					</ExternalLink>
+				</>
+			}
+		/>
+	);
+};

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -20,6 +20,7 @@ import { ReplyToSetting } from './ReplyToSetting';
 import { SenderNameSetting } from './SenderNameSetting';
 import { SubscribeModalOnCommentSetting } from './SubscribeModalOnCommentSetting';
 import { SubscribeModalSetting } from './SubscribeModalSetting';
+import { SubscribeNavigationSetting } from './SubscribeNavigationSetting';
 import { SubscribeOverlaySetting } from './SubscribeOverlaySetting';
 import { SubscribePostEndSetting } from './SubscribePostEndSetting';
 import { SubscriberLoginNavigationSetting } from './SubscriberLoginNavigationSetting';
@@ -44,6 +45,7 @@ type Fields = {
 	sm_enabled?: boolean;
 	jetpack_subscribe_overlay_enabled?: boolean;
 	jetpack_subscriptions_subscribe_post_end_enabled?: boolean;
+	jetpack_subscriptions_subscribe_navigation_enabled?: boolean;
 	jetpack_subscriptions_login_navigation_enabled?: boolean;
 	jetpack_verbum_subscription_modal?: boolean;
 };
@@ -64,6 +66,7 @@ const getFormSettings = ( settings?: Fields ) => {
 		sm_enabled,
 		jetpack_subscribe_overlay_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled,
+		jetpack_subscriptions_subscribe_navigation_enabled,
 		jetpack_subscriptions_login_navigation_enabled,
 		jetpack_verbum_subscription_modal,
 	} = settings;
@@ -80,6 +83,8 @@ const getFormSettings = ( settings?: Fields ) => {
 		jetpack_subscribe_overlay_enabled: !! jetpack_subscribe_overlay_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled:
 			!! jetpack_subscriptions_subscribe_post_end_enabled,
+		jetpack_subscriptions_subscribe_navigation_enabled:
+			!! jetpack_subscriptions_subscribe_navigation_enabled,
 		jetpack_subscriptions_login_navigation_enabled:
 			!! jetpack_subscriptions_login_navigation_enabled,
 		jetpack_verbum_subscription_modal: !! jetpack_verbum_subscription_modal,
@@ -117,6 +122,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		sm_enabled,
 		jetpack_subscribe_overlay_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled,
+		jetpack_subscriptions_subscribe_navigation_enabled,
 		jetpack_subscriptions_login_navigation_enabled,
 		jetpack_verbum_subscription_modal,
 	} = fields;
@@ -190,6 +196,11 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 						value={ jetpack_verbum_subscription_modal }
 					/>
 				) }
+				<SubscribeNavigationSetting
+					disabled={ disabled }
+					handleToggle={ handleToggle }
+					value={ jetpack_subscriptions_subscribe_navigation_enabled }
+				/>
 				<SubscriberLoginNavigationSetting
 					disabled={ disabled }
 					handleToggle={ handleToggle }

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -39,6 +39,7 @@ type Fields = {
 	sm_enabled?: boolean;
 	jetpack_subscribe_overlay_enabled?: boolean;
 	jetpack_subscriptions_subscribe_post_end_enabled?: boolean;
+	jetpack_subscriptions_subscribe_navigation_enabled?: boolean;
 	jetpack_subscriptions_login_navigation_enabled?: boolean;
 	date_format?: string;
 	timezone_string?: string;
@@ -68,6 +69,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		sm_enabled,
 		jetpack_subscribe_overlay_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled,
+		jetpack_subscriptions_subscribe_navigation_enabled,
 		jetpack_subscriptions_login_navigation_enabled,
 		date_format,
 		timezone_string,
@@ -93,6 +95,8 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		jetpack_subscribe_overlay_enabled: !! jetpack_subscribe_overlay_enabled,
 		jetpack_subscriptions_subscribe_post_end_enabled:
 			!! jetpack_subscriptions_subscribe_post_end_enabled,
+		jetpack_subscriptions_subscribe_navigation_enabled:
+			!! jetpack_subscriptions_subscribe_navigation_enabled,
 		jetpack_subscriptions_login_navigation_enabled:
 			!! jetpack_subscriptions_login_navigation_enabled,
 		date_format: date_format,

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -216,6 +216,12 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 							path,
 						} );
 						break;
+					case 'jetpack_subscriptions_subscribe_navigation_enabled':
+						trackTracksEvent( 'calypso_settings_subscribe_navigation_updated', {
+							value: fields.jetpack_subscriptions_subscribe_navigation_enabled,
+							path,
+						} );
+						break;
 					case 'jetpack_subscriptions_login_navigation_enabled':
 						trackTracksEvent( 'calypso_settings_subscriber_login_navigation_updated', {
 							value: fields.jetpack_subscriptions_login_navigation_enabled,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to peKye1-EA-p2

## Proposed Changes

It adds the Subscribe block navigation placement toggle to Newsletter settings.

<img width="739" alt="Screenshot 2024-06-03 at 11 10 52" src="https://github.com/Automattic/wp-calypso/assets/4068554/14051f00-639b-43c7-a1d5-b6ffdcb4cbc9">

## Testing Instructions

1. Go to Newsletter settings
2. Make sure the "Add the Subscribe block to the navigation" toggle works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?