### PR TITLE
Command Palette: Add specific keywords for common settings

### DIFF
--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -1363,6 +1363,43 @@ export function useCommands() {
 			manageSettingsGeneral: {
 				name: 'manageSettingsGeneral',
 				label: __( 'Manage general settings', __i18n_text_domain__ ),
+				searchLabel: [
+					_x(
+						'change site title',
+						'Keyword for the Manage general settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change tagline',
+						'Keyword for the Manage general settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change site icon',
+						'Keyword for the Manage general settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change site language',
+						'Keyword for the Manage general settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change timezone',
+						'Keyword for the Manage general settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change date format',
+						'Keyword for the Manage general settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change time format',
+						'Keyword for the Manage general settings command',
+						__i18n_text_domain__
+					),
+				].join( ' ' ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1378,6 +1415,33 @@ export function useCommands() {
 			manageSettingsWriting: {
 				name: 'manageSettingsWriting',
 				label: __( 'Manage writing settings', __i18n_text_domain__ ),
+				searchLabel: [
+					_x(
+						'change default post category',
+						'Keyword for the Manage writing settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change default post format',
+						'Keyword for the Manage writing settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'configure post via email',
+						'Keyword for the Manage writing settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'enable custom content types',
+						'Keyword for the Manage writing settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'enable CPTs',
+						'Keyword for the Manage writing settings command',
+						__i18n_text_domain__
+					),
+				].join( ' ' ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1393,6 +1457,33 @@ export function useCommands() {
 			manageSettingsReading: {
 				name: 'manageSettingsReading',
 				label: __( 'Manage reading settings', __i18n_text_domain__ ),
+				searchLabel: [
+					_x(
+						'change homepage behavior',
+						'Keyword for the Manage reading settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change blog pagination',
+						'Keyword for the Manage reading settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change feed content',
+						'Keyword for the Manage reading settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'change site visibility',
+						'Keyword for the Manage reading settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'manage related posts settings',
+						'Keyword for the Manage reading settings command',
+						__i18n_text_domain__
+					),
+				].join( ' ' ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1408,6 +1499,28 @@ export function useCommands() {
 			manageSettingsDiscussion: {
 				name: 'manageSettingsDiscussion',
 				label: __( 'Manage discussion settings', __i18n_text_domain__ ),
+				searchLabel: [
+					_x(
+						'manage default post settings',
+						'Keyword for the Manage discussion settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'manage comment settings',
+						'Keyword for the Manage discussion settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'manage email notifications',
+						'Keyword for the Manage discussion settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'manage avatar settings',
+						'Keyword for the Manage discussion settings command',
+						__i18n_text_domain__
+					),
+				].join( ' ' ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1423,6 +1536,23 @@ export function useCommands() {
 			manageSettingsMedia: {
 				name: 'manageSettingsMedia',
 				label: __( 'Manage media settings', __i18n_text_domain__ ),
+				searchLabel: [
+					_x(
+						'set max image size',
+						'Keyword for the Manage media settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'set maximum image dimensions',
+						'Keyword for the Manage media settings command',
+						__i18n_text_domain__
+					),
+					_x(
+						'manage image gallery settings',
+						'Keyword for the Manage media settings command',
+						__i18n_text_domain__
+					),
+				].join( ' ' ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: commandNavigation( '/wp-admin/options-media.php' ),
 				siteSelector: true,


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/7510

## Proposed Changes

Adds some common settings as specific keywords for the relevant manage settings commands. Some examples:
- "change site title" highlights "Manage general settings".
- "enable custom content types" highlights "Manage writing settings".
- "change homepage behavior" highlights "Manage reading settings".
- etc

## Why are these changes being made?

To improve the discoverability of the manage settings commands

## Testing Instructions

- Check the code and make sure that the added keywords make sense
- Use the Calypso live link below
- Open the command palette
- Enter any of the new keywords
- Make sure the relevant manage settings command appears in the results

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
