### PR TITLE
Redirect to Jetpack Cloud for Subscribers View Details in Stats

### DIFF
--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isAdminInterfaceWPAdmin, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
@@ -70,6 +70,7 @@ class StatModuleFollowers extends Component {
 			isAtomic,
 			isJetpack,
 			className,
+			isAdminInterface,
 		} = this.props;
 		const isLoading = requestingWpcomFollowers || requestingEmailFollowers;
 		const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
@@ -80,11 +81,14 @@ class StatModuleFollowers extends Component {
 		const summaryPageSlug = siteSlug || '';
 		// email-followers is no longer available, so fallback to the new subscribers URL.
 		// Old, non-functional path: '/people/email-followers/' + summaryPageSlug.
-		// If the site is Atomic or Jetpack self-hosted, it links to Jetpack cloud.
-		// For all other cases, turn to the WP.com URL since Odyssey Stats doesn't have the Followers page.
+		// If the site is Atomic, Simple Classic or Jetpack self-hosted, it links to Jetpack Cloud.
+		// jetpack/manage-simple-sites is the feature flag for allowing Simple sites in Jetpack Cloud.
 		const jetpackCloudLink = `https://cloud.jetpack.com/subscribers/${ summaryPageSlug }`;
 		const wpcomLink = `https://wordpress.com/people/subscribers/${ summaryPageSlug }`;
-		const summaryPageLink = isAtomic || isJetpack ? jetpackCloudLink : wpcomLink;
+		const summaryPageLink =
+			isAtomic || isJetpack || ( isEnabled( 'jetpack/manage-simple-sites' ) && isAdminInterface )
+				? jetpackCloudLink
+				: wpcomLink;
 
 		// Combine data sets, sort by recency, and limit to 10.
 		const data = [ ...( wpcomData?.subscribers ?? [] ), ...( emailData?.subscribers ?? [] ) ]
@@ -188,6 +192,7 @@ const connectComponent = connect(
 			isOdysseyStats: config.isEnabled( 'is_running_in_jetpack_site' ),
 			isAtomic: isAtomicSite( state, siteId ),
 			isJetpack: isJetpackSite( state, siteId ),
+			isAdminInterface: isAdminInterfaceWPAdmin( state, siteId ),
 		};
 	},
 	{ recordGoogleEvent }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6466

## Proposed Changes

* When `jetpack/manage-simple-sites` flag is enabled, point users to Jetpack Cloud

![stats](https://github.com/Automattic/wp-calypso/assets/6586048/3bd70b16-b787-48b8-97b1-0183e1412927)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We have moved the subscribers feature to Jetpack Cloud
* Jetpack Cloud is available for Simple Sites behind the feature flag

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```

* Make sure you have at least one subscriber for the site
* From the directory `wp-calypso/apps/odyssey-stats/`
* Sync the code to your sandbox `NODE_ENV=production yarn dev --sync`
* Sandbox `widgets.wp.com`
* On the Simple Classic site, navigate to Jetpack > Stats
* Click on the Subscribers tab
* Click on View details, should be directed to `/people/subscribers/:site` in Calypso
* Enable the flag `flags=jetpack/manage-simple-sites`
* Click on View details, should be directed to `/subscribers/:site` in Jetpack Cloud, as the flag is not enabled by default for staging, you can add `flags=jetpack/manage-simple-sites` to the redirected link to see the data for the simple site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
