### PR TITLE
Replace references to email support

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description.ts
@@ -23,7 +23,7 @@ export default function useWPCOMPlanDescription( slug: string ) {
 		];
 
 		features2 = [
-			translate( 'Expert live chat & email support' ),
+			translate( 'Priority support 24/7' ),
 			translate( 'DDOS mitigation' ),
 			translate( 'Free staging environment' ),
 			translate( 'Isolated site infrastructure' ),

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_BUSINESS, PLAN_PERSONAL, getPlan } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
@@ -15,12 +15,19 @@ import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/s
 import { isAtomicSiteWithoutBusinessPlan } from './utils';
 
 // Mapping eligibility holds to messages that will be shown to the user
-function getHoldMessages(
-	context: string | null,
-	translate: LocalizeProps[ 'translate' ],
-	billingPeriod?: string,
-	isMarketplace?: boolean
-) {
+function getHoldMessages( {
+	context,
+	translate,
+	billingPeriod,
+	isMarketplace,
+	hasEnTranslation,
+}: {
+	context: string | null;
+	translate: LocalizeProps[ 'translate' ];
+	billingPeriod?: string;
+	isMarketplace?: boolean;
+	hasEnTranslation: ( arg: string ) => boolean;
+} ) {
 	return {
 		NO_BUSINESS_PLAN: {
 			title: ( function () {
@@ -36,26 +43,46 @@ function getHoldMessages(
 			} )(),
 			description: ( function () {
 				if ( context === 'themes' ) {
-					return translate(
-						"You'll also get to install custom plugins, have more storage, and access live support."
-					);
+					return hasEnTranslation(
+						"You'll also get to install custom plugins, have more storage, and access priority 24/7 support."
+					)
+						? translate(
+								"You'll also get to install custom plugins, have more storage, and access priority 24/7 support."
+						  )
+						: translate(
+								"You'll also get to install custom plugins, have more storage, and access live support."
+						  );
 				}
 
 				if ( isMarketplace && isEnabled( 'marketplace-personal-premium' ) ) {
-					return translate(
-						"You'll also get a free domain for one year, and access email support."
-					);
+					return hasEnTranslation(
+						"You'll also get a free domain for one year, and access fast support."
+					)
+						? translate( "You'll also get a free domain for one year, and access fast support." )
+						: translate( "You'll also get a free domain for one year, and access email support." );
 				}
 
 				if ( billingPeriod === IntervalLength.MONTHLY ) {
-					return translate(
-						"You'll also get to install custom themes, have more storage, and access email support."
-					);
+					return hasEnTranslation(
+						"You'll also get to install custom themes, have more storage, and access fast support."
+					)
+						? translate(
+								"You'll also get to install custom themes, have more storage, and access fast support."
+						  )
+						: translate(
+								"You'll also get to install custom themes, have more storage, and access email support."
+						  );
 				}
 
-				return translate(
-					"You'll also get to install custom themes, have more storage, and access live support."
-				);
+				return hasEnTranslation(
+					"You'll also get to install custom themes, have more storage, and access priority 24/7 support."
+				)
+					? translate(
+							"You'll also get to install custom themes, have more storage, and access priority 24/7 support."
+					  )
+					: translate(
+							"You'll also get to install custom themes, have more storage, and access live support."
+					  );
 			} )(),
 			supportUrl: null,
 		},
@@ -225,8 +252,16 @@ export const HardBlockingNotice = ( {
 };
 
 export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, translate }: Props ) => {
+	const hasEnTranslation = useHasEnTranslation();
+
 	const billingPeriod = useSelector( getBillingInterval );
-	const holdMessages = getHoldMessages( context, translate, billingPeriod, isMarketplace );
+	const holdMessages = getHoldMessages( {
+		context,
+		translate,
+		billingPeriod,
+		isMarketplace,
+		hasEnTranslation,
+	} );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( ( h ) => isHardBlockingHoldType( h, blockingMessages ) );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -276,15 +276,22 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 					image={ imgSwitchPlan }
 				>
 					<>
-						{
-							/* translators: %(plan)s is WordPress.com Personal or another plan */
-							translate(
-								'%(plan)s still gives you access to customer support via email, removal of ads, and more — and for 50% of the cost of your current plan.',
-								{
-									args: { plan: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
-								}
-							)
-						}{ ' ' }
+						{ hasEnTranslation(
+							'%(plan)s still gives you access to fast support, removal of ads, and more — and for 50% of the cost of your current plan.'
+						)
+							? translate(
+									'%(plan)s still gives you access to fast support, removal of ads, and more — and for 50% of the cost of your current plan.',
+									{
+										args: { plan: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+										comment: '%(plan)s is WordPress.com Personal or another plan',
+									}
+							  )
+							: translate(
+									'%(plan)s still gives you access to customer support via email, removal of ads, and more — and for 50% of the cost of your current plan.',
+									{
+										args: { plan: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+									}
+							  ) }{ ' ' }
 						{ refundAmount &&
 							translate(
 								'You can downgrade and get a partial refund of %(amount)s or ' +

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -522,7 +522,7 @@ export function CheckoutSummaryFeaturesList( props: {
 			{ ! hasPlanInCart && hasEmailInCart && (
 				<CheckoutSummaryFeaturesListItem>
 					<WPCheckoutCheckIcon id="features-list-support-email" />
-					{ translate( '24/7 support via email' ) }
+					{ translate( 'Fast support' ) }
 				</CheckoutSummaryFeaturesListItem>
 			) }
 

--- a/client/my-sites/checkout/src/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/src/lib/get-plan-features.ts
@@ -59,8 +59,12 @@ export default function getPlanFeatures(
 		}
 	}
 
-	const emailSupport = String( translate( 'Customer support via email' ) );
-	const liveChatSupport = String( translate( 'Live chat support' ) );
+	/**
+	 * For WPCOM plans, the feature list for new purchases is returned by the above function.
+	 * The following is used to return the feature list for manual renewals.
+	 */
+	const fastSupport = String( translate( 'Fast support' ) );
+	const prioritySupport = String( translate( 'Priority support 24/7' ) );
 	const freeOneYearDomain = showFreeDomainFeature
 		? String( translate( 'Free domain for one year' ) )
 		: undefined;
@@ -69,7 +73,7 @@ export default function getPlanFeatures(
 	if ( isWpComPersonalPlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
-			emailSupport,
+			fastSupport,
 			String( translate( 'Best-in-class hosting' ) ),
 			String( translate( 'Dozens of Free Themes' ) ),
 			String( translate( 'Ad-free experience' ) ),
@@ -79,7 +83,7 @@ export default function getPlanFeatures(
 	if ( isStarterPlan( productSlug ) ) {
 		return [
 			freeOneYearDomain,
-			emailSupport,
+			fastSupport,
 			String( translate( 'Best-in-class hosting' ) ),
 			String( translate( 'Dozens of Free Themes' ) ),
 			String( translate( 'Track your stats with Google Analytics' ) ),
@@ -89,8 +93,8 @@ export default function getPlanFeatures(
 	if ( isWpComPremiumPlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
-			isMonthlyPlan && emailSupport,
-			! isMonthlyPlan && liveChatSupport,
+			isMonthlyPlan && fastSupport,
+			! isMonthlyPlan && prioritySupport,
 			isEnabled( 'themes/premium' )
 				? String( translate( 'Unlimited access to our library of Premium Themes' ) )
 				: null,
@@ -104,8 +108,8 @@ export default function getPlanFeatures(
 	if ( isWpComBusinessPlan( productSlug ) || isWpComProPlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
-			isMonthlyPlan && emailSupport,
-			! isMonthlyPlan && liveChatSupport,
+			isMonthlyPlan && fastSupport,
+			! isMonthlyPlan && prioritySupport,
 			String( translate( 'Install custom plugins and themes' ) ),
 			String( translate( 'Drive traffic to your site with our advanced SEO tools' ) ),
 			String( translate( 'Track your stats with Google Analytics' ) ),
@@ -116,8 +120,8 @@ export default function getPlanFeatures(
 	if ( isWpComEcommercePlan( productSlug ) || isWooExpressPlan( productSlug ) ) {
 		return [
 			! isMonthlyPlan && freeOneYearDomain,
-			isMonthlyPlan && emailSupport,
-			! isMonthlyPlan && liveChatSupport,
+			isMonthlyPlan && fastSupport,
+			! isMonthlyPlan && prioritySupport,
 			String( translate( 'Install custom plugins and themes' ) ),
 			String( translate( 'Accept payments in 60+ countries' ) ),
 			String( translate( 'Integrations with top shipping carriers' ) ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-5Yj-p2

## Proposed Changes

* Replaces references to email support with the appropriate replacement string.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pau2Xa-5Yj-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
These are direct replacements by an already-translated string. No testing is required.
* `client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description.ts`
* `client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx`
* `client/my-sites/checkout/src/lib/get-plan-features.ts`

* `client/blocks/eligibility-warnings/hold-list.tsx`: 
  * Go to `/plugins/upload/<site slug>` for a site on the free plan. Confirm that the page matches the screenshot:
  * <img width="733" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/15eb8254-c2b4-4aa5-953b-3b1c17adc446">
  * Go to the plugins page, select any plugin and then select "Annually" near the purchase CTA. Go to `/plugins/upload/<site slug>` for a site on the free plan. Confirm that the page matches the screenshot:
  * <img width="713" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/c6456e67-03a1-4880-9d61-a4381bbfc700">
* `client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx`:
  * Proceed to cancel the subscription for an Explorer plan. In the pre-cancellation survey, enter "Price/budget" and "It's too expensive". Confirm that the page matches the screenshot:
  * <img width="616" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/26e2493b-cda4-4d19-b990-c8acb078c7c7">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?