### PR TITLE
Scheduled Updates: Only load the component if it's not loading

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -157,14 +157,16 @@ export const ScheduleList = ( props: Props ) => {
 			{ ! isScheduleEmpty && ScheduleListComponent ? (
 				<>
 					<ScheduleListFilter />
-					<ScheduleListComponent
-						compact={ compact }
-						schedules={ filteredSchedules }
-						selectedScheduleId={ selectedScheduleId }
-						onRemoveClick={ openRemoveDialog }
-						onEditClick={ onEditSchedule }
-						onLogsClick={ onShowLogs }
-					/>
+					{ ! isLoadingSchedules && (
+						<ScheduleListComponent
+							compact={ compact }
+							schedules={ filteredSchedules }
+							selectedScheduleId={ selectedScheduleId }
+							onRemoveClick={ openRemoveDialog }
+							onEditClick={ onEditSchedule }
+							onLogsClick={ onShowLogs }
+						/>
+					) }
 				</>
 			) : null }
 			{ schedules.length === 0 && isLoading && <Spinner /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91393

## Proposed Changes

* On the multisite level screen, when you create a schedule, it returns back to the list view, but it shows the `Oops! We couldn't find any schedules based on your search criteria. You might want to check your search terms and try again.` when the page is still loading. In the PR, we add a condition to prevent the empty message from showing while the page is still loading.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates`
* Try to create or update an existing schedule and click Save.
* Once it's back to the list view, you shouldn't see `Oops! We couldn't find any schedules based on your search criteria. You might want to check your search terms and try again.` while it's loading.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
