### PR TITLE
tweak: small copy change to social tos not requiring agreement

### DIFF
--- a/client/blocks/authentication/social/social-tos.jsx
+++ b/client/blocks/authentication/social/social-tos.jsx
@@ -32,7 +32,7 @@ function SocialAuthToS( props ) {
 	if ( props.isWooPasswordless ) {
 		return getToSComponent(
 			props.translate(
-				'By continuing with any of the options above, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				'By continuing with any of the options above, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 				toSLinks
 			)
 		);
@@ -41,7 +41,7 @@ function SocialAuthToS( props ) {
 	if ( props.isBlazePro ) {
 		return getToSComponent(
 			props.translate(
-				'By continuing with any of the options above you agree to our {{tosLink}}Terms of Service{{/tosLink}} and {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				'By continuing with any of the options above you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 				toSLinks
 			)
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/91349


## Proposed Changes

* Small change to TOS text for WooCommerce and Blaze Pro logins

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- p4H3ND-1Cw-p2#comment-3589
* We don't actually require the users to agree to the privacy policy, just to have read it

@timur987 I also made this similar change for the BlazePro login since it's adjacent and I think it makes sense to have the same wording. Let me know if you think otherwise and I'll revert that!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn start` (or use calypso live)
* Go to an incognito window (so that you're not logged in) and go to woocommerce.com
* Click on the login button
* Replace https://wordpress.com/ in the URL with either http://calypso.localhost:3000/ or the calypso live URL
* Should see this:

<img width="1274" alt="image" src="https://github.com/Automattic/wp-calypso/assets/27843274/321361b2-0948-4f53-a4ca-15ab00f89031">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?