### PR TITLE
Notifications: Focus the first element when opening

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -268,6 +268,11 @@ $with-sidebar-min-page-width: 1114px;
 			color: var(--color-neutral-70);
 		}
 
+		&:focus {
+			outline: var(--color-primary-light) solid 2px;
+			outline-offset: -2px;
+		}
+
 		&:first-of-type {
 			border-top-left-radius: 4px;
 			border-bottom-left-radius: 4px;
@@ -450,6 +455,7 @@ $with-sidebar-min-page-width: 1114px;
 			border-style: solid;
 		}
 
+		.wpnc__note:focus,
 		.wpnc__selected-note {
 			box-shadow: inset 4px 0 0 var(--color-primary);
 
@@ -519,6 +525,7 @@ $with-sidebar-min-page-width: 1114px;
 			.gridicons-cog {
 				cursor: pointer;
 				align-self: center;
+				border-radius: 2px;
 				margin-left: auto;
 				margin-right: $wpnc__padding-small;
 			}
@@ -534,6 +541,10 @@ $with-sidebar-min-page-width: 1114px;
 			.wpnc__settings {
 				display: flex;
 				flex-grow: 1;
+
+				&:focus svg {
+					outline: var(--color-primary-light) solid 2px;
+				}
 			}
 		}
 	}

--- a/apps/notifications/src/panel/templates/filter-bar.jsx
+++ b/apps/notifications/src/panel/templates/filter-bar.jsx
@@ -1,11 +1,57 @@
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { Component } from 'react';
+import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import getFilterName from '../state/selectors/get-filter-name';
 import Filters from './filters';
 
 export class FilterBar extends Component {
+	filterListRef = createRef();
+
+	timerId = null;
+
+	componentDidMount() {
+		if ( this.props.isPanelOpen ) {
+			this.focusOnSelectedTab();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( ! prevProps.isPanelOpen && this.props.isPanelOpen ) {
+			this.focusOnSelectedTab();
+		}
+	}
+
+	componentWillUnmount() {
+		if ( this.timerId ) {
+			window.clearTimeout( this.timerId );
+		}
+	}
+
+	getFilterItems = () => {
+		if ( ! this.filterItems ) {
+			this.filterItems = Object.keys( Filters )
+				.map( ( name ) => Filters[ name ]() )
+				.sort( ( a, b ) => a.index - b.index );
+		}
+
+		return this.filterItems;
+	};
+
+	focusOnSelectedTab() {
+		if ( ! this.props.autoFocus ) {
+			return;
+		}
+
+		const selectedFilter = this.filterListRef.current?.querySelector(
+			'.wpnc__filter--segmented-control-item[aria-selected="true"]'
+		);
+		if ( selectedFilter ) {
+			// It might be focused immediately when the panel is opening because of the pointer-events is none.
+			this.timerId = window.setTimeout( () => selectedFilter.focus(), 300 );
+		}
+	}
+
 	selectFilter = ( event ) => {
 		if ( event ) {
 			event.stopPropagation();
@@ -16,12 +62,27 @@ export class FilterBar extends Component {
 		this.props.controller.selectFilter( filterName );
 	};
 
+	handleKeydown = ( event ) => {
+		let direction;
+		if ( event.key === 'ArrowRight' ) {
+			direction = 1;
+		} else if ( event.key === 'ArrowLeft' ) {
+			direction = -1;
+		}
+
+		if ( ! direction ) {
+			return;
+		}
+		event.stopPropagation();
+		const filterItems = this.getFilterItems();
+		const currentIndex = filterItems.findIndex( ( { name } ) => name === this.props.filterName );
+		const nextIndex = ( currentIndex + direction + filterItems.length ) % filterItems.length;
+		this.props.controller.selectFilter( filterItems[ nextIndex ].name );
+	};
+
 	render() {
 		const { filterName, translate } = this.props;
-
-		const filterItems = Object.keys( Filters )
-			.map( ( name ) => Filters[ name ]() )
-			.sort( ( a, b ) => a.index - b.index );
+		const filterItems = this.getFilterItems();
 
 		return (
 			<div className="wpnc__filter">
@@ -29,28 +90,33 @@ export class FilterBar extends Component {
 					className="wpnc__filter--segmented-control"
 					role="tablist"
 					aria-label={ translate( 'Filter notifications' ) }
+					ref={ this.filterListRef }
+					onKeyDown={ this.handleKeydown }
 				>
-					{ filterItems.map( ( { label, name } ) => (
-						<li
-							key={ name }
-							data-filter-name={ name }
-							className={ clsx( 'wpnc__filter--segmented-control-item', {
-								selected: name === filterName,
-							} ) }
-							onClick={ this.selectFilter }
-							onKeyDown={ ( e ) => {
-								if ( e.key === 'Enter' ) {
-									this.selectFilter( e );
-								}
-							} }
-							role="tab"
-							aria-selected={ name === filterName }
-							aria-controls="wpnc__note-list"
-							tabIndex={ 0 }
-						>
-							{ label }
-						</li>
-					) ) }
+					{ filterItems.map( ( { label, name } ) => {
+						const isSelected = name === filterName;
+						return (
+							<li
+								key={ name }
+								data-filter-name={ name }
+								className={ clsx( 'wpnc__filter--segmented-control-item', {
+									selected: isSelected,
+								} ) }
+								onClick={ this.selectFilter }
+								onKeyDown={ ( e ) => {
+									if ( e.key === 'Enter' ) {
+										this.selectFilter( e );
+									}
+								} }
+								role="tab"
+								aria-selected={ isSelected }
+								aria-controls="wpnc__note-list"
+								tabIndex={ isSelected ? 0 : -1 }
+							>
+								{ label }
+							</li>
+						);
+					} ) }
 				</ul>
 			</div>
 		);

--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { modifierKeyIsActive } from '../helpers/input';
 import actions from '../state/actions';
 import getAllNotes from '../state/selectors/get-all-notes';
+import getIsLoading from '../state/selectors/get-is-loading';
 import getIsNoteHidden from '../state/selectors/get-is-note-hidden';
 import getIsPanelOpen from '../state/selectors/get-is-panel-open';
 import getKeyboardShortcutsEnabled from '../state/selectors/get-keyboard-shortcuts-enabled';
@@ -16,6 +17,7 @@ import NavButton from './nav-button';
 import Note from './note';
 import NoteList from './note-list';
 
+const KEY_TAB = 9;
 const KEY_ENTER = 13;
 const KEY_ESC = 27;
 const KEY_LEFT = 37;
@@ -152,7 +154,17 @@ class Layout extends Component {
 		}
 	}
 
-	componentDidUpdate() {
+	componentDidUpdate( prevProps ) {
+		if (
+			this.noteList &&
+			( ( ! prevProps.isPanelOpen && this.props.isPanelOpen ) ||
+				( prevProps.isLoading && ! this.props.isLoading ) ) &&
+			this.state.lastSelectedIndex === 0 &&
+			! this.state.selectedNote
+		) {
+			this.navigateToNextNote();
+		}
+
 		if ( ! this.detailView ) {
 			return;
 		}
@@ -378,6 +390,15 @@ class Layout extends Component {
 				activateKeyboard();
 				this.navigateToPrevNote();
 				break;
+			case KEY_TAB:
+				stopEvent();
+				activateKeyboard();
+				if ( event.shiftKey ) {
+					this.navigateToPrevNote();
+				} else {
+					this.navigateToNextNote();
+				}
+				break;
 			case KEY_N:
 				this.props.closePanel();
 				stopEvent();
@@ -526,6 +547,7 @@ const mapStateToProps = ( state ) => ( {
 	notes: getAllNotes( state ),
 	selectedNoteId: getSelectedNoteId( state ),
 	keyboardShortcutsAreEnabled: getKeyboardShortcutsEnabled( state ),
+	isLoading: getIsLoading( state ),
 } );
 
 const mapDispatchToProps = {

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -249,6 +249,7 @@ export class NoteList extends Component {
 						global={ this.props.global }
 						currentNote={ this.props.selectedNoteId }
 						selectedNote={ this.props.selectedNote }
+						isShowing={ this.props.isPanelOpen }
 					/>
 				);
 			}

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -250,6 +250,7 @@ export class NoteList extends Component {
 						currentNote={ this.props.selectedNoteId }
 						selectedNote={ this.props.selectedNote }
 						isShowing={ this.props.isPanelOpen }
+						handleFocus={ this.props.navigateToNoteById }
 					/>
 				);
 			}
@@ -350,8 +351,13 @@ export class NoteList extends Component {
 		return (
 			<>
 				{ /* Keep the wpnc__note-list as the first child of the Fragment to ensure the ReactDOM.findDOMNode returns the list element */ }
-				<div className={ classes } id="wpnc__note-list">
-					<FilterBar controller={ this.props.filterController } />
+				<div className={ classes } id="wpnc__note-list" ref={ this.props.listElementRef }>
+					<FilterBar
+						controller={ this.props.filterController }
+						isPanelOpen={ this.props.isPanelOpen }
+						/* eslint-disable-next-line jsx-a11y/no-autofocus */
+						autoFocus={ ! this.props.selectedNote }
+					/>
 					<button className="screen-reader-text" onClick={ this.props.closePanel }>
 						{ this.props.translate( 'Close notifications' ) }
 					</button>

--- a/apps/notifications/src/panel/templates/note.jsx
+++ b/apps/notifications/src/panel/templates/note.jsx
@@ -14,8 +14,17 @@ const hasBadge = ( body ) =>
 	body.some( ( { media } ) => media && media.some( ( { type } ) => 'badge' === type ) );
 
 export const Note = React.forwardRef( ( props, ref ) => {
-	const { currentNote, detailView, global, isApproved, isRead, note, selectedNote, unselectNote } =
-		props;
+	const {
+		currentNote,
+		detailView,
+		global,
+		isApproved,
+		isRead,
+		note,
+		selectedNote,
+		unselectNote,
+		isShowing,
+	} = props;
 	const translate = useTranslate();
 
 	let hasCommentReply = false;
@@ -37,6 +46,8 @@ export const Note = React.forwardRef( ( props, ref ) => {
 		}
 	}
 
+	const isSelected = parseInt( selectedNote, 10 ) === parseInt( note.id, 10 );
+
 	const classes = clsx( 'wpnc__note', `wpnc__${ note.type }`, {
 		'comment-reply': hasCommentReply,
 		read: isRead,
@@ -44,10 +55,27 @@ export const Note = React.forwardRef( ( props, ref ) => {
 		wpnc__badge: hasBadge( note.body ),
 		'wpnc__comment-unapproved': hasUnapprovedComment,
 		wpnc__current: detailView,
-		'wpnc__selected-note': parseInt( selectedNote, 10 ) === parseInt( note.id, 10 ),
+		'wpnc__selected-note': isSelected,
 	} );
 
+	const noteContainerRef = React.useRef();
 	const noteBodyRef = React.useRef( null );
+
+	const setContainerRef = React.useCallback( ( currentRef ) => {
+		noteContainerRef.current = currentRef;
+		if ( typeof ref === 'function' ) {
+			ref( currentRef );
+		} else {
+			ref = currentRef;
+		}
+	}, [] );
+
+	React.useEffect( () => {
+		if ( isShowing && isSelected ) {
+			// Make sure it gets focused when re-opening the panel.
+			window.setTimeout( () => noteContainerRef.current?.focus(), 300 );
+		}
+	}, [ isShowing, isSelected ] );
 
 	React.useEffect( () => {
 		if ( detailView && noteBodyRef.current ) {
@@ -59,11 +87,11 @@ export const Note = React.forwardRef( ( props, ref ) => {
 		<li
 			id={ detailView ? 'note-details-' + note.id : 'note-' + note.id }
 			className={ classes }
-			ref={ ref }
+			ref={ setContainerRef }
 			tabIndex={ detailView ? -1 : 0 }
 			role={ detailView ? 'article' : 'listitem' }
 			aria-controls={ detailView ? null : 'note-details-' + note.id }
-			aria-selected={ detailView ? null : currentNote === note.id }
+			aria-selected={ detailView ? null : isSelected }
 		>
 			{ ! detailView && (
 				<SummaryInList

--- a/apps/notifications/src/panel/templates/note.jsx
+++ b/apps/notifications/src/panel/templates/note.jsx
@@ -24,6 +24,7 @@ export const Note = React.forwardRef( ( props, ref ) => {
 		selectedNote,
 		unselectNote,
 		isShowing,
+		handleFocus,
 	} = props;
 	const translate = useTranslate();
 
@@ -71,11 +72,21 @@ export const Note = React.forwardRef( ( props, ref ) => {
 	}, [] );
 
 	React.useEffect( () => {
-		if ( isShowing && isSelected ) {
-			// Make sure it gets focused when re-opening the panel.
-			window.setTimeout( () => noteContainerRef.current?.focus(), 300 );
+		let timerId;
+		if ( isShowing && isSelected && ! currentNote && noteContainerRef.current ) {
+			noteContainerRef.current.focus();
+			// It might not be focused immediately when the panel is opening because of the pointer-events is none.
+			if ( document.activeElement !== noteContainerRef.current ) {
+				timerId = window.setTimeout( () => noteContainerRef.current.focus(), 300 );
+			}
 		}
-	}, [ isShowing, isSelected ] );
+
+		return () => {
+			if ( timerId ) {
+				window.clearTimeout( timerId );
+			}
+		};
+	}, [ isShowing, isSelected, currentNote ] );
 
 	React.useEffect( () => {
 		if ( detailView && noteBodyRef.current ) {
@@ -92,6 +103,7 @@ export const Note = React.forwardRef( ( props, ref ) => {
 			role={ detailView ? 'article' : 'listitem' }
 			aria-controls={ detailView ? null : 'note-details-' + note.id }
 			aria-selected={ detailView ? null : isSelected }
+			onFocus={ () => handleFocus( note.id ) }
 		>
 			{ ! detailView && (
 				<SummaryInList

--- a/client/layout/global-notifications/index.tsx
+++ b/client/layout/global-notifications/index.tsx
@@ -68,15 +68,6 @@ const GlobalNotifications = () => {
 		}
 	}, [ prevIsNotificationsOpen, isNotificationsOpen, unseenCount, dispatch ] );
 
-	/**
-	 * Focus on main window if we just closed the notes panel
-	 */
-	useEffect( () => {
-		if ( prevIsNotificationsOpen && ! isNotificationsOpen ) {
-			containerRef.current?.ownerDocument.body.focus();
-		}
-	}, [ prevIsNotificationsOpen, isNotificationsOpen, dispatch ] );
-
 	return (
 		<div className="global-notifications" ref={ containerRef }>
 			<AsyncLoad

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -57,9 +57,15 @@ export class Notifications extends Component {
 		isVisible: isDesktop ? true : getIsVisible(),
 	};
 
+	focusedElementBeforeOpen = null;
+
 	componentDidMount() {
 		document.addEventListener( 'click', this.props.checkToggle );
 		document.addEventListener( 'keydown', this.handleKeyPress );
+
+		if ( this.props.isShowing ) {
+			this.focusedElementBeforeOpen = document.activeElement;
+		}
 
 		if ( typeof document.hidden !== 'undefined' ) {
 			document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
@@ -74,6 +80,18 @@ export class Notifications extends Component {
 				this.receiveServiceWorkerMessage
 			);
 			this.postServiceWorkerMessage( { action: 'sendQueuedMessages' } );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.isShowing === this.props.isShowing ) {
+			return;
+		}
+
+		if ( ! prevProps.isShowing && this.props.isShowing ) {
+			this.focusedElementBeforeOpen = document.activeElement;
+		} else {
+			this.focusedElementBeforeOpen?.focus();
 		}
 	}
 

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -190,18 +190,19 @@ div.reader-notifications__panel {
 				border-bottom-left-radius: 8px; /* stylelint-disable-line scales/radii */
 			}
 		}
-		.wpnc__list-view .wpnc__selected-note {
-			box-shadow: inset -4px 0 0 var(--color-primary);
+		.wpnc__list-view {
+			border: none;
+			border-right: 1px solid var(--color-neutral-0);
+
+			.wpnc__note:focus,
+			.wpnc__selected-note {
+				box-shadow: inset -4px 0 0 var(--color-primary);
+			}
 		}
 
 		&.wpnc__note-list {
 			right: auto;
 			left: 0;
-		}
-
-		.wpnc__list-view {
-			border: none;
-			border-right: 1px solid var(--color-neutral-0);
 		}
 
 		.wpnc__single-view {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7551

## Proposed Changes

* Focus on the first tab of the notification when the panel opens
* You can use `<-` or `->` to navigate the tab
* You can use `tab` to focus on each notification
* You can use `esc` to close the detail view
* Focus on the last active element when the panel is closed

https://github.com/Automattic/wp-calypso/assets/13596067/72e7f032-f069-4ff2-91b7-fec17ffbe716

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Use the `tab` to navigate to the notification icon
* Press `enter` to open the notification panel
* Make sure the first tab is focused
* Use `<-` or `->` to navigate the tab
* Use `tab` to focus on each notification
* Press `enter` to open the detail view
* Press `enter` again or `esc` to close the detail view
* Press `esc` again to make close the notification panel
* Make sure the notification icon is focused
* Press `enter` to open the panel again
* Make sure the last selected notification is focused

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
