### PR TITLE
(Take 2) explat-client: calypso-lib: Skip requests for E2E 

### DIFF
--- a/client/lib/explat/internals/fetch-experiment-assignment.ts
+++ b/client/lib/explat/internals/fetch-experiment-assignment.ts
@@ -1,3 +1,4 @@
+import { isE2ETest } from 'calypso/lib/e2e';
 import wpcom from 'calypso/lib/wp';
 
 // SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check
@@ -11,6 +12,17 @@ export default function fetchExperimentAssignment( {
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > {
+	if ( isE2ETest() ) {
+		return new Promise( ( resolve ) => {
+			resolve( {
+				variations: {
+					[ experimentName ]: null,
+				},
+				ttl: 60,
+			} );
+		} );
+	}
+
 	return wpcom.req.get(
 		{
 			path: '/experiments/0.1.0/assignments/calypso',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Take 2 of https://github.com/Automattic/wp-calypso/pull/91162 which had to be reverted due to a failing test (check p1717157824185699-slack-C02DQP0FP).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To prevent timeouts from E2E tests from plan name change experiments, reported in pbmo2S-2yX-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as https://github.com/Automattic/wp-calypso/pull/91162.