### PR TITLE
Login: Fix suspicious mail back to enter email cycle

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -177,6 +177,7 @@ class Login extends Component {
 				twoFactorAuthType: 'link',
 				oauth2ClientId: this.props.currentQuery?.client_id,
 				redirectTo: this.props.currentQuery?.redirect_to,
+				usernameOnly: true,
 			} );
 
 			page( magicLoginUrl );

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -596,6 +596,10 @@ export class LoginForm extends Component {
 			return this.props.translate( 'Your email address or username' );
 		}
 
+		if ( this.props.currentQuery?.username_only === 'true' ) {
+			return this.props.translate( 'Your username' );
+		}
+
 		return this.isPasswordView() ? (
 			this.renderChangeUsername()
 		) : (

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -39,6 +39,7 @@ export function login( {
 	isPartnerSignup = undefined,
 	action = undefined,
 	lostpasswordFlow = undefined,
+	usernameOnly = undefined,
 } = {} ) {
 	let url = '/log-in';
 
@@ -104,6 +105,10 @@ export function login( {
 
 	if ( lostpasswordFlow ) {
 		url = addQueryArgs( { lostpassword_flow: true }, url );
+	}
+
+	if ( usernameOnly ) {
+		url = addQueryArgs( { username_only: true }, url );
 	}
 
 	return url;

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -26,10 +26,9 @@ import {
 	enhanceWithSiteType,
 } from 'calypso/state/analytics/actions';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
-import { getAuthAccountType } from 'calypso/state/login/actions';
 import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
 import { CHECK_YOUR_EMAIL_PAGE } from 'calypso/state/login/magic-login/constants';
-import { getLastCheckedUsernameOrEmail, getRequestError } from 'calypso/state/login/selectors';
+import { getLastCheckedUsernameOrEmail } from 'calypso/state/login/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -75,7 +74,6 @@ class MagicLogin extends Component {
 
 	componentDidMount() {
 		this.props.recordPageView( '/log-in/link', 'Login > Link' );
-		this.props.getAuthAccountType( this.state.usernameOrEmail );
 
 		if ( isGravPoweredOAuth2Client( this.props.oauth2Client ) ) {
 			this.props.recordTracksEvent( 'calypso_gravatar_powered_magic_login_email_form', {
@@ -130,14 +128,14 @@ class MagicLogin extends Component {
 			locale: this.props.locale,
 			emailAddress: this.props.query?.email_address,
 			signupUrl: this.props.query?.signup_url,
+			usernameOnly: true,
 		};
 
 		page( login( loginParameters ) );
 	};
 
 	renderLinks() {
-		const { isJetpackLogin, locale, showCheckYourEmail, translate, isWoo, loginRequestError } =
-			this.props;
+		const { isJetpackLogin, locale, showCheckYourEmail, translate, isWoo, query } = this.props;
 
 		if ( isWoo ) {
 			return null;
@@ -155,7 +153,7 @@ class MagicLogin extends Component {
 				/>
 			);
 		}
-		if ( this.props.query?.client_id ) {
+		if ( query?.client_id ) {
 			return null;
 		}
 
@@ -170,7 +168,7 @@ class MagicLogin extends Component {
 		};
 
 		let linkBack = translate( 'Enter a password instead' );
-		if ( loginRequestError?.code === 'email_login_not_allowed' ) {
+		if ( query?.username_only ) {
 			linkBack = translate( 'Use username and password instead' );
 		}
 
@@ -570,7 +568,6 @@ const mapState = ( state ) => ( {
 	showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 	isSendingEmail: isFetchingMagicLoginEmail( state ),
 	emailRequested: isMagicLoginEmailRequested( state ),
-	loginRequestError: getRequestError( state ),
 	isJetpackLogin: getCurrentRoute( state ) === '/log-in/jetpack/link',
 	oauth2Client: getCurrentOAuth2Client( state ),
 	userEmail:
@@ -586,7 +583,6 @@ const mapDispatch = {
 	sendEmailLogin,
 	recordPageView: withEnhancers( recordPageView, [ enhanceWithSiteType ] ),
 	recordTracksEvent: withEnhancers( recordTracksEvent, [ enhanceWithSiteType ] ),
-	getAuthAccountType,
 };
 
 export default connect( mapState, mapDispatch )( localize( MagicLogin ) );

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -168,7 +168,7 @@ class MagicLogin extends Component {
 		};
 
 		let linkBack = translate( 'Enter a password instead' );
-		if ( query?.username_only ) {
+		if ( query?.username_only === 'true' ) {
 			linkBack = translate( 'Use username and password instead' );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/91399

## Proposed Changes

Switch the `Enter a password instead` copy in magic-login to `Use username and password instead` instead in case of suspicious email.

<img width="454" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/8077950a-af9e-4076-a6d7-596b5fb75fe1">

When returning to the login page, show `Your username` as the label

<img width="890" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/dea78ab1-ea8f-4c8b-9ce7-ef2996195d81">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When redirecting to the magic-login page in case of suspicious emails, there was a link to `Enter a password instead`, but this is not correct in the case of suspicious email. That's because, when entering the email, we won't show the password field.

<img width="513" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/d7b22ae5-564a-4946-a0ab-909e05412657">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit login page
- Enter a suspicious email (you can try e.buccellitest@gmail.com)
- Check the change in copy and in the label when returning to login

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
