### PR TITLE
Proxy content via public-api, even when we're on a simple site.

### DIFF
--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -15,8 +15,7 @@ import {
 	isImageEditorImageLoaded,
 } from 'calypso/state/editor/image-editor/selectors';
 import getImageEditorIsGreaterThanMinimumDimensions from 'calypso/state/selectors/get-image-editor-is-greater-than-minimum-dimensions';
-import isPrivateSite from 'calypso/state/selectors/is-private-site';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import ImageEditorCrop from './image-editor-crop';
@@ -100,9 +99,9 @@ export class ImageEditorCanvas extends Component {
 	}
 
 	fetchImageBlob( src ) {
-		const { siteSlug, isPrivateAtomic } = this.props;
+		const { siteSlug, isJetpackNonAtomic } = this.props;
 		const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-		const useProxy = isPrivateAtomic && filePath && isRelativeToSiteRoot;
+		const useProxy = ! isJetpackNonAtomic && !! filePath && isRelativeToSiteRoot;
 
 		if ( useProxy ) {
 			return getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, { query } );
@@ -293,8 +292,7 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSelectedSiteSlug( state );
-		const isPrivateAtomic =
-			isPrivateSite( state, siteId ) && isSiteAutomatedTransfer( state, siteId );
+		const isJetpackNonAtomic = isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } );
 
 		const transform = getImageEditorTransform( state );
 		const { src, mimeType } = getImageEditorFileInfo( state );
@@ -304,7 +302,7 @@ export default connect(
 
 		return {
 			siteSlug,
-			isPrivateAtomic,
+			isJetpackNonAtomic,
 			src,
 			mimeType,
 			transform,

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { mediaURLToProxyConfig } from 'calypso/lib/media/utils';
-import isPrivateSite from 'calypso/state/selectors/is-private-site';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { IAppState } from 'calypso/state/types';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
@@ -55,10 +54,10 @@ const MediaFile: React.FC< MediaFileProps > = function MediaFile( {
 export default connect( ( state: IAppState, { src }: Pick< MediaFileProps, 'src' > ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state ) as string;
-	const isAtomic = !! isSiteAutomatedTransfer( state, siteId as number );
-	const isPrivate = !! isPrivateSite( state, siteId ?? 0 );
 	const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-	const useProxy = Boolean( isAtomic && isPrivate && filePath && isRelativeToSiteRoot );
+	const isJetpackNonAtomic =
+		siteId && isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } );
+	const useProxy = ! isJetpackNonAtomic && !! filePath && isRelativeToSiteRoot;
 
 	return {
 		query,


### PR DESCRIPTION
This reapplies the change from #90895 - there have been some changes to public-api.wordpress.com that resolved the problem that caused that MR to get reverted (D150124-wpcom).  This change ultimately causes all links in the media library to be proxied via public-api.wordpress.com, which ensures that they are accessible even in the case of broken primary domains.