### PR TITLE
clsx: consistent import names

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -7,7 +7,7 @@ import { useMediaQuery } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
-import cx from 'clsx';
+import clsx from 'clsx';
 import { useSelector } from 'react-redux';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import { whatsNewQueryClient } from '../../common/what-new-query-client';
@@ -45,7 +45,7 @@ function HelpCenterContent() {
 	const content = (
 		<>
 			<Button
-				className={ cx( 'entry-point-button', 'help-center', { 'is-active': show } ) }
+				className={ clsx( 'entry-point-button', 'help-center', { 'is-active': show } ) }
 				onClick={ handleToggleHelpCenter }
 				icon={
 					<HelpIcon

--- a/client/components/marketing-message/index.tsx
+++ b/client/components/marketing-message/index.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
-import cx from 'clsx';
+import clsx from 'clsx';
 import { useEffect } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import { useMarketingMessage } from './use-marketing-message';
@@ -122,7 +122,7 @@ export default function MarketingMessage( { siteId, useMockData, ...props }: Nud
 		return null;
 	}
 
-	const classNames = cx( 'nudge-container', props.className, `is-${ slugify( props.path ) }` );
+	const classNames = clsx( 'nudge-container', props.className, `is-${ slugify( props.path ) }` );
 
 	return (
 		<Container path={ props.path } className={ classNames } role="status">

--- a/packages/design-carousel/src/item.tsx
+++ b/packages/design-carousel/src/item.tsx
@@ -2,7 +2,7 @@
 import './styles.scss';
 import { getDesignPreviewUrl } from '@automattic/design-picker';
 import { MShotsImage, MShotsOptions } from '@automattic/onboarding';
-import cx from 'clsx';
+import clsx from 'clsx';
 
 type Props = {
 	className?: string;
@@ -13,7 +13,7 @@ type Props = {
 
 export function Item( { style, design, className, options }: Props ) {
 	return (
-		<div style={ style } className={ cx( 'design-carousel__item', className ) }>
+		<div style={ style } className={ clsx( 'design-carousel__item', className ) }>
 			<MShotsImage
 				url={ getDesignPreviewUrl( design, {
 					use_screenshot_overrides: true,

--- a/packages/site-picker/src/index.tsx
+++ b/packages/site-picker/src/index.tsx
@@ -2,7 +2,7 @@
 import { useFocusTrap } from '@automattic/tour-kit';
 import { __ } from '@wordpress/i18n';
 import { globe, Icon, chevronUp, chevronDown } from '@wordpress/icons';
-import cx from 'clsx';
+import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import { useArrowNavigation } from './hooks';
 import type { FC } from 'react';
@@ -43,7 +43,7 @@ const SitePickerItem: FC< ItemProps > = ( {
 }: ItemProps ) => {
 	return (
 		<button
-			className={ cx( 'site-picker__site-item', { 'main-item': mainItem, selected, enabled } ) }
+			className={ clsx( 'site-picker__site-item', { 'main-item': mainItem, selected, enabled } ) }
 			onClick={ onClick }
 			// eslint-disable-next-line jsx-a11y/no-autofocus
 			autoFocus={ selected }
@@ -116,7 +116,7 @@ export const SitePickerDropDown: FC< Props > = ( {
 					? __( 'Select a site', __i18n_text_domain__ )
 					: __( 'Site', __i18n_text_domain__ ) }
 			</label>
-			<div className={ cx( 'site-picker__site-dropdown', { open } ) }>
+			<div className={ clsx( 'site-picker__site-dropdown', { open } ) }>
 				<SitePickerItem
 					host={ selectedSite?.URL?.replace( 'https://', '' ) ?? '' }
 					enabled={ enabled }

--- a/packages/social-previews/src/nextdoor-preview/post-preview.tsx
+++ b/packages/social-previews/src/nextdoor-preview/post-preview.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import cx from 'clsx';
+import clsx from 'clsx';
 import {
 	baseDomain,
 	formatNextdoorDate,
@@ -83,7 +83,7 @@ export function NextdoorPostPreview( {
 						) : null }
 
 						<article
-							className={ cx( 'nextdoor-preview__card', {
+							className={ clsx( 'nextdoor-preview__card', {
 								'small-preview': ! image || hasMedia,
 							} ) }
 						>


### PR DESCRIPTION
## Proposed Changes

Following up on @DaniGuardiola's [review](https://github.com/Automattic/wp-calypso/pull/91408#pullrequestreview-2093909549) to address his comments.

## Why are these changes being made?

To import `clsx` with the same import name for consistency across the Calypso codebase.

## Testing Instructions

Verify all checks are green