### PR TITLE
Site Migrations: Add `from` ref to Scheduled Updates upsell nudge

### DIFF
--- a/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
@@ -67,6 +67,7 @@ const UpsellNudgeNotice = () => {
 		const href = addQueryArgs( `/setup/hosted-site-migration`, {
 			source: 'scheduled-updates-dashboard',
 			ref: 'scheduled-updates-dashboard',
+			from: siteSlug,
 		} );
 
 		return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90906

## Proposed Changes

* Make it easier for self-hosted Jetpack users to migrate your site from the Scheduled Updates upsell nudge by adding the `from` parameter auto-filled with the user's site slug.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pdtkmj-2GG-p2#comment-5101

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR or use calypso.live
* Go to `/plugins/scheduled-updates/siteSlug` on a self-hosted Jetpack site (you can use Jurassic Ninja)
* You should see the following upsell:

<img width="1236" alt="Screenshot 2024-05-21 at 9 59 18 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/8f45fdd2-f3f7-45a8-974d-cf5d0dc5695f">

* Clicking "Migrate" should take you to `/setup/hosted-site-migration/site-migration-identify?source=scheduled-updates-dashboard&ref=scheduled-updates-dashboard&from=siteslug`
* Landing in the site migration flow, the From URL should be automatically populated:

<img width="608" alt="Screenshot 2024-06-03 at 11 01 31 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/2bedc825-033c-42db-9dd8-52fc7147712d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?