### PR TITLE
Site Migrations: Update permissions check from owner to admin

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -5,10 +5,10 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
-import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { addQueryArgs } from 'calypso/lib/url';
+import { useIsSiteAdmin } from '../hooks/use-is-site-admin';
 import { useSiteData } from '../hooks/use-site-data';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { useStartUrl } from '../hooks/use-start-url';
@@ -54,7 +54,7 @@ const siteMigration: Flow = {
 		const startUrl = useStartUrl( this.variantSlug ?? FLOW_NAME );
 
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
-		const { isOwner } = useIsSiteOwner();
+		const { isAdmin } = useIsSiteAdmin();
 
 		useEffect( () => {
 			if ( ! userIsLoggedIn ) {
@@ -64,10 +64,10 @@ const siteMigration: Flow = {
 		}, [ startUrl, userIsLoggedIn ] );
 
 		useEffect( () => {
-			if ( isOwner === false ) {
+			if ( isAdmin === false ) {
 				window.location.assign( '/start' );
 			}
-		}, [ isOwner ] );
+		}, [ isAdmin ] );
 
 		if ( ! userIsLoggedIn ) {
 			result = {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -6,7 +6,7 @@ import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selector
 import { waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
-import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
+import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { addQueryArgs } from '../../../../lib/url';
 import { goToCheckout } from '../../utils/checkout';
@@ -18,7 +18,7 @@ const originalLocation = window.location;
 
 jest.mock( '../../utils/checkout' );
 jest.mock( '@automattic/data-stores/src/user/selectors' );
-jest.mock( 'calypso/landing/stepper/hooks/use-is-site-owner' );
+jest.mock( 'calypso/landing/stepper/hooks/use-is-site-admin' );
 jest.mock( 'calypso/lib/guides/trigger-guides-for-step', () => ( {
 	triggerGuidesForStep: jest.fn(),
 } ) );
@@ -37,8 +37,8 @@ describe( 'Site Migration Flow', () => {
 	beforeEach( () => {
 		( window.location.assign as jest.Mock ).mockClear();
 		( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( true );
-		( useIsSiteOwner as jest.Mock ).mockReturnValue( {
-			isOwner: true,
+		( useIsSiteAdmin as jest.Mock ).mockReturnValue( {
+			isAdmin: true,
 		} );
 
 		const apiBaseUrl = 'https://public-api.wordpress.com';
@@ -78,9 +78,9 @@ describe( 'Site Migration Flow', () => {
 			expect( window.location.assign ).toHaveBeenCalledWith( '/start' );
 		} );
 
-		it( 'redirects the user to the start page when the user is not the site owner', () => {
+		it( 'redirects the user to the start page when the user is not the site admin', () => {
 			const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );
-			( useIsSiteOwner as jest.Mock ).mockReturnValue( { isOwner: false } );
+			( useIsSiteAdmin as jest.Mock ).mockReturnValue( { isAdmin: false } );
 
 			runUseAssertionCondition( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Administrators can do everything site owners can do on a site, so we don't need to restrict site migrations to just site owners; let's use site admin instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Discussed during sprint planning and noted that we were probably mistaken in checking isOwner rather than isAdmin in the first place paYKcK-4MQ-p2 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure tests pass: `yarn test-client wp-calypso/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx`
* Switch to this PR or use calypso.live
* Ensure you have a test site setup where there are three users -- one is an admin, one is the owner, and one is an Editor or lower. You can do this by going to Users -> Add New User and inviting the different roles, then accept the invitations in a separate browser.
* When logged in as the site admin (but not the owner), go to `/setup/site-migration?siteSlug=yourtestsite&siteId=yourtestsiteid`
* You should be allowed to proceed through the flow.
* When logged in as the site owner, you should be able to proceed through the flow.
* When logged in as the non-admin, you should be redirected to `/start`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?