### PR TITLE
Guided Onboarding: Plans step, add link for agencies

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -216,7 +216,7 @@ export class PlansStep extends Component {
 			);
 
 			return translate(
-				'Are you an agency? Get bulk discounts, revenue sharing, and premier support with {{link}}Automattic for Agencies{{/link}}.',
+				'Are you an agency? Get bulk discounts and premier support with {{link}}Automattic for Agencies{{/link}}.',
 				{ components: { link: a4aLinkButton } }
 			);
 		}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -203,20 +203,21 @@ export class PlansStep extends Component {
 			flowName === 'guided' ? getSegmentedIntent( segmentationSurveyAnswers ) : undefined;
 
 		if ( surveyedIntent === 'plans-guided-segment-developer-or-agency' ) {
-			const a4aLink = (
-				<a
+			const a4aLinkButton = (
+				<Button
 					href={ localizeUrl( 'https://automattic.com/for-agencies/' ) }
 					target="_blank"
 					rel="noopener noreferrer"
 					onClick={ () =>
 						this.props.recordTracksEvent( 'calypso_guided_onboarding_agency_link_click' )
 					}
+					borderless
 				/>
 			);
 
 			return translate(
 				'Are you an agency? Get the best of WordPress with {{link}}Automattic for Agencies{{/link}}',
-				{ components: { link: a4aLink } }
+				{ components: { link: a4aLinkButton } }
 			);
 		}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -195,7 +195,30 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderText() {
-		const { translate, useEmailOnboardingSubheader } = this.props;
+		const { translate, useEmailOnboardingSubheader, signupDependencies, flowName } = this.props;
+
+		const { segmentationSurveyAnswers } = signupDependencies;
+
+		const surveyedIntent =
+			flowName === 'guided' ? getSegmentedIntent( segmentationSurveyAnswers ) : undefined;
+
+		if ( surveyedIntent === 'plans-guided-segment-developer-or-agency' ) {
+			const a4aLink = (
+				<a
+					href={ localizeUrl( 'https://automattic.com/for-agencies/' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={ () =>
+						this.props.recordTracksEvent( 'calypso_guided_onboarding_agency_link_click' )
+					}
+				/>
+			);
+
+			return translate(
+				'Are you an agency? Get the best of WordPress with {{link}}Automattic for Agencies{{/link}}',
+				{ components: { link: a4aLink } }
+			);
+		}
 
 		const freePlanButton = (
 			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -198,12 +198,12 @@ export class PlansStep extends Component {
 		const { translate, useEmailOnboardingSubheader, signupDependencies, flowName } = this.props;
 
 		const { segmentationSurveyAnswers } = signupDependencies;
+		const { segmentSlug } = getSegmentedIntent( segmentationSurveyAnswers );
 
-		const surveyedIntent = isOnboardingGuidedFlow( flowName )
-			? getSegmentedIntent( segmentationSurveyAnswers )
-			: undefined;
-
-		if ( surveyedIntent === 'plans-guided-segment-developer-or-agency' ) {
+		if (
+			isOnboardingGuidedFlow( flowName ) &&
+			segmentSlug === 'plans-guided-segment-developer-or-agency'
+		) {
 			const a4aLinkButton = (
 				<Button
 					href="https://automattic.com/for-agencies/"

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -199,8 +199,9 @@ export class PlansStep extends Component {
 
 		const { segmentationSurveyAnswers } = signupDependencies;
 
-		const surveyedIntent =
-			flowName === 'guided' ? getSegmentedIntent( segmentationSurveyAnswers ) : undefined;
+		const surveyedIntent = isOnboardingGuidedFlow( flowName )
+			? getSegmentedIntent( segmentationSurveyAnswers )
+			: undefined;
 
 		if ( surveyedIntent === 'plans-guided-segment-developer-or-agency' ) {
 			const a4aLinkButton = (

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -216,7 +216,7 @@ export class PlansStep extends Component {
 			);
 
 			return translate(
-				'Are you an agency? Get the best of WordPress with {{link}}Automattic for Agencies{{/link}}',
+				'Are you an agency? Get bulk discounts, revenue sharing, and premier support with {{link}}Automattic for Agencies{{/link}}.',
 				{ components: { link: a4aLinkButton } }
 			);
 		}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -205,7 +205,7 @@ export class PlansStep extends Component {
 		if ( surveyedIntent === 'plans-guided-segment-developer-or-agency' ) {
 			const a4aLinkButton = (
 				<Button
-					href={ localizeUrl( 'https://automattic.com/for-agencies/' ) }
+					href="https://automattic.com/for-agencies/"
 					target="_blank"
 					rel="noopener noreferrer"
 					onClick={ () =>

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -53,6 +53,10 @@
 	font-weight: inherit;
 	line-height: inherit;
 	text-decoration: underline;
+
+	&:hover {
+		color: inherit;
+	}
 }
 
 .plans__loading {


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7434

## Proposed Changes

Show a link to A4A in the Plans page if agency segment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/guided`
* Choose `Create a site for a client`
* Reach the plans page
* Check that the subheader exists and the link works
* Ensure that `calypso_guided_onboarding_agency_link_click` is fired

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
