### PR TITLE
Make loading screen animation slower

### DIFF
--- a/client/site-profiler/components/loading-screen/index.tsx
+++ b/client/site-profiler/components/loading-screen/index.tsx
@@ -32,9 +32,7 @@ export const LoadingScreen = () => {
 
 	useEffect( () => {
 		setTimeout( () => {
-			if ( progress >= 100 ) {
-				setProgress( 0 );
-			} else {
+			if ( progress < 90 ) {
 				setProgress( progress + ( 100 - progress ) / 5 );
 			}
 		}, 3000 );

--- a/client/site-profiler/components/loading-screen/index.tsx
+++ b/client/site-profiler/components/loading-screen/index.tsx
@@ -35,16 +35,16 @@ export const LoadingScreen = () => {
 			if ( progress >= 100 ) {
 				setProgress( 0 );
 			} else {
-				setProgress( progress + 3 );
+				setProgress( progress + ( 100 - progress ) / 5 );
 			}
-		}, 1000 );
+		}, 3000 );
 	}, [ progress ] );
 
 	return (
 		<LayoutBlock className="landing-page-header-block" width="medium">
 			<StyledLoadingScreen>
 				<h2>{ progressHeadings[ Math.floor( ( progress / 101 ) * progressHeadings.length ) ] }</h2>
-				<Progress value={ progress } total={ 100 } canGoBackwards />
+				<Progress value={ progress } total={ 100 } />
 			</StyledLoadingScreen>
 		</LayoutBlock>
 	);

--- a/client/site-profiler/components/loading-screen/index.tsx
+++ b/client/site-profiler/components/loading-screen/index.tsx
@@ -29,14 +29,17 @@ export const LoadingScreen = () => {
 	];
 
 	const [ progress, setProgress ] = useState( 0 );
+	const [ tick, setTick ] = useState( 0 );
 
 	useEffect( () => {
-		setTimeout( () => {
-			if ( progress < 90 ) {
-				setProgress( progress + ( 100 - progress ) / 5 );
-			}
-		}, 3000 );
-	}, [ progress ] );
+		const timeoutId = setTimeout( () => {
+			const newProgress = 100 * ( 1 - Math.pow( 1.07, -tick ) );
+			setProgress( newProgress );
+			setTick( tick + 1 );
+		}, 1000 );
+
+		return () => clearTimeout( timeoutId );
+	}, [ progress, tick ] );
 
 	return (
 		<LayoutBlock className="landing-page-header-block" width="medium">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7572

## Proposed Changes

* update progress bar every 3 seconds
* step forward by 1/5th of the remaining progress
* disable the progress bar resetting to zero

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This issue addresses CFT feedback for the Site Profiler project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the `/site-profiler/:url` and enter a site URL
- Check that the progress bar fills up slower than before (~70 sec)

https://github.com/Automattic/wp-calypso/assets/11555574/7c7f761e-bfba-44d8-99b3-653e5db99cdb

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
