### PR TITLE
Help center - don't show whats new menu item if there are no announcements.

### DIFF
--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -3,7 +3,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
-import WhatsNewGuide from '@automattic/whats-new';
+import WhatsNewGuide, { useWhatsNewAnnouncementsQuery } from '@automattic/whats-new';
 import { Button, SVG, Circle } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -36,6 +36,9 @@ export const HelpCenterMoreResources = () => {
 		purchaseSlugs &&
 		( purchaseSlugs.some( isWpComBusinessPlan ) || purchaseSlugs.some( isWpComEcommercePlan ) )
 	);
+	const { data } = useWhatsNewAnnouncementsQuery( siteId?.toString() );
+
+	const showWhatsNewItem = data && data.length > 0;
 
 	const { hasSeenWhatsNewModal, doneLoading } = useSelect(
 		( select ) => ( {
@@ -136,21 +139,23 @@ export const HelpCenterMoreResources = () => {
 						</a>
 					</div>
 				</li>
-				<li className="inline-help__resource-item">
-					<div className="inline-help__resource-cell">
-						<Button
-							variant="link"
-							onClick={ handleWhatsNewClick }
-							className="inline-help__new-releases"
-						>
-							<Icon icon={ <NewReleases /> } size={ 24 } />
-							<span>{ __( "What's New", __i18n_text_domain__ ) }</span>
-							{ showWhatsNewDot && (
-								<Icon className="inline-help__new-releases_dot" icon={ circle } size={ 16 } />
-							) }
-						</Button>
-					</div>
-				</li>
+				{ showWhatsNewItem && (
+					<li className="inline-help__resource-item">
+						<div className="inline-help__resource-cell">
+							<Button
+								variant="link"
+								onClick={ handleWhatsNewClick }
+								className="inline-help__new-releases"
+							>
+								<Icon icon={ <NewReleases /> } size={ 24 } />
+								<span>{ __( "What's New", __i18n_text_domain__ ) }</span>
+								{ showWhatsNewDot && (
+									<Icon className="inline-help__new-releases_dot" icon={ circle } size={ 16 } />
+								) }
+							</Button>
+						</div>
+					</li>
+				) }
 			</ul>
 			{ showGuide && (
 				<WhatsNewGuide


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # kind of related to Automattic/dotcom-forge#7368, and @davemart-in noticing that the "Whats new" item in help center is still present when there are no active whats new announcements. 
## Proposed Changes

* Hide the "Whats new" menu link when there are no active whats new messages.
* Ideally we should strive to always have an announcement active, which should make this code unnecessary. But sometimes all messaged get deactivated, etc. and this seems like good future proofing.

With NO ACTIVE whats new announcements available:


BEFORE

<img width="405" alt="Screenshot 2024-06-03 at 1 34 31 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/bc783c4d-8de9-4607-8391-44cf876a04b9">


AFTER

<img width="405" alt="Screenshot 2024-06-03 at 1 34 07 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/19483990-338a-4283-b718-2a7a72c462e0">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The whats new menu item does nothing if there are no active whats new announcements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Verify whats new is still available in the help center. (There are 2 inactive announcements, which show up for a12s).
* Log into a non-a8c test account.
* Open help center, verify there is no whats new item.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
