### PR TITLE
Site Migration: hide import list link via query arg

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -23,6 +23,7 @@ interface Props {
 	label?: ReactNode;
 	placeholder?: string;
 	dontHaveSiteAddressLabel?: string;
+	hideImporterListLink?: boolean;
 }
 const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const {
@@ -34,6 +35,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		label,
 		placeholder = 'artfulbaker.blog',
 		dontHaveSiteAddressLabel,
+		hideImporterListLink = false,
 	} = props;
 
 	const translate = useTranslate();
@@ -125,7 +127,8 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 			<NextButton type="submit">{ translate( 'Continue' ) }</NextButton>
 
 			<div className="action-buttons__importer-list">
-				{ onDontHaveSiteAddressClick &&
+				{ ! hideImporterListLink &&
+					onDontHaveSiteAddressClick &&
 					createInterpolateElement(
 						dontHaveSiteAddressLabel ??
 							translate( 'Or <button>choose a content platform</button>' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -18,9 +18,10 @@ interface Props {
 	hasError?: boolean;
 	onComplete: ( siteInfo: UrlData ) => void;
 	onSkip: () => void;
+	hideImporterListLink: boolean;
 }
 
-export const Analyzer: FC< Props > = ( { onComplete, onSkip } ) => {
+export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
 	const translate = useTranslate();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
 
@@ -59,6 +60,7 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip } ) => {
 					dontHaveSiteAddressLabel={ translate(
 						'Or <button>pick your current platform from a list</button>'
 					) }
+					hideImporterListLink={ hideImporterListLink }
 				/>
 			</div>
 		</div>
@@ -124,6 +126,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 						onComplete={ ( { platform, url } ) =>
 							handleSubmit( 'continue', { platform, from: url } )
 						}
+						hideImporterListLink={ urlQueryParams.get( 'hide_importer_link' ) === 'true' }
 						onSkip={ () => {
 							handleSubmit( 'skip_platform_identification' );
 						} }


### PR DESCRIPTION
In some cases, the source platform has already been chosen. In those cases we need to hide the platform link in the Analyzer step to avoid confusion.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

A query arg called `hide_importer_link` is added. When its value is `true`, the link is not shown.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It was reported in this thread: p1717082302516469-slack-C02FMH4G8 that some users were clicking on' Choose content platform' on the Analyzer step when coming from `Tools > Import`. In that case, the decision has already been made, so we need to hide the link to avoid confusion.

More context: paYKcK-4MY-p2
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or use the calypso.live link below.
* Navigate to a site migration flow, either `/start` and picking Import intent or direct nav to `/setup/hosted-site-migration` should work.
* Verify that the Analyzer step is rendered as always.
* Add the `hide_importer_link=true` query arg.
* Verify the `pick your current platform from a list` link disappears. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?