### PR TITLE
Revert "Site Migrations: Update permissions check from owner to admin"

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -5,10 +5,10 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
+import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { addQueryArgs } from 'calypso/lib/url';
-import { useIsSiteAdmin } from '../hooks/use-is-site-admin';
 import { useSiteData } from '../hooks/use-site-data';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { useStartUrl } from '../hooks/use-start-url';
@@ -54,7 +54,7 @@ const siteMigration: Flow = {
 		const startUrl = useStartUrl( this.variantSlug ?? FLOW_NAME );
 
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
-		const { isAdmin } = useIsSiteAdmin();
+		const { isOwner } = useIsSiteOwner();
 
 		useEffect( () => {
 			if ( ! userIsLoggedIn ) {
@@ -64,10 +64,10 @@ const siteMigration: Flow = {
 		}, [ startUrl, userIsLoggedIn ] );
 
 		useEffect( () => {
-			if ( isAdmin === false ) {
+			if ( isOwner === false ) {
 				window.location.assign( '/start' );
 			}
-		}, [ isAdmin ] );
+		}, [ isOwner ] );
 
 		if ( ! userIsLoggedIn ) {
 			result = {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -6,7 +6,7 @@ import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selector
 import { waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
-import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
+import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { addQueryArgs } from '../../../../lib/url';
 import { goToCheckout } from '../../utils/checkout';
@@ -18,7 +18,7 @@ const originalLocation = window.location;
 
 jest.mock( '../../utils/checkout' );
 jest.mock( '@automattic/data-stores/src/user/selectors' );
-jest.mock( 'calypso/landing/stepper/hooks/use-is-site-admin' );
+jest.mock( 'calypso/landing/stepper/hooks/use-is-site-owner' );
 jest.mock( 'calypso/lib/guides/trigger-guides-for-step', () => ( {
 	triggerGuidesForStep: jest.fn(),
 } ) );
@@ -37,8 +37,8 @@ describe( 'Site Migration Flow', () => {
 	beforeEach( () => {
 		( window.location.assign as jest.Mock ).mockClear();
 		( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( true );
-		( useIsSiteAdmin as jest.Mock ).mockReturnValue( {
-			isAdmin: true,
+		( useIsSiteOwner as jest.Mock ).mockReturnValue( {
+			isOwner: true,
 		} );
 
 		const apiBaseUrl = 'https://public-api.wordpress.com';
@@ -78,9 +78,9 @@ describe( 'Site Migration Flow', () => {
 			expect( window.location.assign ).toHaveBeenCalledWith( '/start' );
 		} );
 
-		it( 'redirects the user to the start page when the user is not the site admin', () => {
+		it( 'redirects the user to the start page when the user is not the site owner', () => {
 			const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );
-			( useIsSiteAdmin as jest.Mock ).mockReturnValue( { isAdmin: false } );
+			( useIsSiteOwner as jest.Mock ).mockReturnValue( { isOwner: false } );
 
 			runUseAssertionCondition( {
 				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,


### PR DESCRIPTION
Just in case the tests weren't flaky after all.

Reverts Automattic/wp-calypso#91418