### PR TITLE
Site Profiler: Use the translate method to display milliseconds

### DIFF
--- a/client/data/site-profiler/metrics-dictionaries.ts
+++ b/client/data/site-profiler/metrics-dictionaries.ts
@@ -1,14 +1,5 @@
 import { Metrics, PerformanceCategories, PerformanceReport, Scores } from './types';
 
-export const BASIC_METRICS_UNITS: Record< Metrics, string > = {
-	cls: '',
-	fid: 'ms',
-	lcp: 'ms',
-	fcp: 'ms',
-	ttfb: 'ms',
-	inp: 'ms',
-};
-
 export const BASIC_METRICS_SCORES: Record< Metrics, [ number, number ] > = {
 	cls: [ 0.1, 0.25 ], // https://web.dev/articles/cls
 	fid: [ 100, 300 ], // https://web.dev/articles/fid

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ForwardedRef, forwardRef, useMemo } from 'react';
-import { BASIC_METRICS_UNITS } from 'calypso/data/site-profiler/metrics-dictionaries';
 import { calculateMetricsSectionScrollOffset } from 'calypso/site-profiler/utils/calculate-metrics-section-scroll-offset';
 import { CopiesReturnValueList, MetricsCopies, getCopies } from './copies';
 import type { BasicMetricsScored, Metrics, Scores } from 'calypso/data/site-profiler/types';
@@ -37,6 +36,7 @@ type BasicMetricProps = {
 };
 
 export const BasicMetric = ( { metric, basicMetrics, name, copies }: BasicMetricProps ) => {
+	const translate = useTranslate();
 	const { value, score } = basicMetrics[ metric ];
 	const showMetric = value !== undefined && value !== null;
 	const isPositiveScore = score === 'good';
@@ -50,8 +50,12 @@ export const BasicMetric = ( { metric, basicMetrics, name, copies }: BasicMetric
 						{ name }
 					</div>
 					<div className="basic-metrics__value">
-						{ value }
-						{ BASIC_METRICS_UNITS[ metric ] }
+						{ metric === 'cls'
+							? value
+							: translate( '%(ms)dms', {
+									comment: 'value to be displayed in millisecond',
+									args: { ms: value },
+							  } ) }
 					</div>
 				</div>
 				<h3>{ isPositiveScore ? copies.good.diagnostic : copies.poor.diagnostic }</h3>

--- a/client/site-profiler/components/metrics-insight/insight-table.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-table.tsx
@@ -105,7 +105,10 @@ function Cell( {
 			case 'ms':
 			case 'timespanMs':
 				// TODO: Implement a better visualization for ms values. Ex:  '1.2s' instead of '1200ms'
-				return translate( '%(ms)sms', { args: { ms: getFormattedNumber( data ) } } );
+				return translate( '%(ms)dms', {
+					comment: 'value to be displayed in milliseconds',
+					args: { ms: getFormattedNumber( data ) },
+				} );
 			case 'bytes':
 				return getFormattedSize( Number( data ) || 0 );
 			case 'numeric':


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7153


## Proposed Changes

Use the translate method to display the values in miliseconds.

## Why are these changes being made?

To allow this text to be internationalized.

## Testing Instructions

* Go to the `/site-profiler/:site`
* Check if the basic metrics are properly shown for all properties in `ms`
* Check if `CLS` is also show properly: unitless.

![CleanShot 2024-06-03 at 14 51 10@2x](https://github.com/Automattic/wp-calypso/assets/5039531/a3635702-d022-4110-8c2f-9af8356873e8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?