### PR TITLE
Site Profiler: Hide migration banner for WP.com sites

### DIFF
--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -209,7 +209,7 @@ export default function SiteProfilerV2( props: Props ) {
 							</>
 						) }
 					</LayoutBlock>
-					<MigrationBannerBig />
+					{ ! isWpCom && <MigrationBannerBig /> }
 				</>
 			) }
 			<FootNote />


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7570

## Proposed Changes

Hide migration banner for WP.com sites

## Why are these changes being made?

Because a WP.com site cannot be migrated

## Testing Instructions


* Go to `/site-profiler/:site` on a non-WP.com site. Ex: `/site-profiler/quintoandar.com.br`
* Scroll down and check the if the migration banner is present 
* Go to `/site-profiler/:site` on a WP.com site. Ex: `/site-profilerr/wordpress.com`
* Scroll down and check the if the migration banner is NOT present 

| non WP.com  | WP.com |
| ------------- | ------------- |
|![CleanShot 2024-06-03 at 16 48 16@2x](https://github.com/Automattic/wp-calypso/assets/5039531/70c7fc9f-1319-4fa6-b245-6efc2cd5c59d)|![CleanShot 2024-06-03 at 16 47 04@2x](https://github.com/Automattic/wp-calypso/assets/5039531/cc3be8f8-8ecc-4841-b3ae-468296bf6e10)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?