### PR TITLE
Revert "Domains: Remove CTAs from Gravatar flow"

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1724,7 +1724,6 @@ class RegisterDomainStep extends Component {
 		} = domainAvailability;
 
 		const { isSignupStep, includeOwnedDomainInSuggestions } = this.props;
-		const isGravatarFlow = this.props.flowName === 'domain-for-gravatar';
 
 		if (
 			( TRANSFERRABLE === error && this.state.lastDomainIsTransferrable ) ||
@@ -1738,7 +1737,7 @@ class RegisterDomainStep extends Component {
 		this.setState( {
 			showAvailabilityNotice: true,
 			availabilityError: error,
-			availabilityErrorData: isGravatarFlow ? { ...errorData, site: null } : errorData,
+			availabilityErrorData: errorData,
 			availabilityErrorDomain: domain,
 		} );
 	}

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -58,27 +58,25 @@ function getAvailabilityNotice(
 			);
 			break;
 		case domainAvailability.REGISTERED_SAME_SITE:
-			if ( site ) {
-				message = translate(
-					'{{strong}}%(domain)s{{/strong}} is already registered on this site. {{a}}Are you trying to make this the primary address for your site?{{/a}}',
-					{
-						args: { domain },
-						components: {
-							strong: <strong />,
-							a: (
-								<SetAsPrimaryLink
-									domainName={ domain }
-									siteIdOrSlug={ site }
-									additionalProperties={ {
-										clickOrigin: 'use-a-domain-i-own',
-									} }
-									onSuccess={ () => page( domainManagementList( domain ) ) }
-								/>
-							),
-						},
-					}
-				);
-			}
+			message = translate(
+				'{{strong}}%(domain)s{{/strong}} is already registered on this site. {{a}}Are you trying to make this the primary address for your site?{{/a}}',
+				{
+					args: { domain },
+					components: {
+						strong: <strong />,
+						a: (
+							<SetAsPrimaryLink
+								domainName={ domain }
+								siteIdOrSlug={ site }
+								additionalProperties={ {
+									clickOrigin: 'use-a-domain-i-own',
+								} }
+								onSuccess={ () => page( domainManagementList( domain ) ) }
+							/>
+						),
+					},
+				}
+			);
 			break;
 		case domainAvailability.REGISTERED_OTHER_SITE_SAME_USER:
 			if ( site ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#91029. 

Tests were failing, so I'm reverting this one to investigate it more.