### PR TITLE
A4A: When first entering referral modal modal should be shown

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
@@ -2,17 +2,31 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import useReferralsGuide from 'calypso/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide';
+import { useDispatch, useSelector } from 'calypso/state';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
 import { MarketplaceTypeContext } from '../../context';
 
 import './style.scss';
 
+const PREFERENCE_NAME = 'a4a-marketplace-referral-guide-seen';
+
 const ReferralToggle = () => {
 	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
 	const { guideModal, openGuide } = useReferralsGuide();
+
+	const guideModalSeen = useSelector( ( state ) => getPreference( state, PREFERENCE_NAME ) );
+	useEffect( () => {
+		if ( marketplaceType === 'referral' && ! guideModalSeen ) {
+			dispatch( savePreference( PREFERENCE_NAME, true ) );
+			openGuide();
+		}
+	}, [ dispatch, guideModalSeen, marketplaceType, openGuide ] );
 
 	if ( ! isAutomatedReferrals ) {
 		return null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/355

## Proposed Changes

Final PR to complete Referral Modal guide. It should show the modal whenever we are triggering the referral mode for the first time.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to `/marketplace/hosting?purchase_type=referral` 
- First time the Modal should be shown.
- All following times there should be no Modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
