### PR TITLE
A4A: update Referral guide modal wording

### DIFF
--- a/client/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide.tsx
+++ b/client/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide.tsx
@@ -14,16 +14,16 @@ function useReferralsGuide() {
 	const steps = useMemo(
 		() => [
 			{
-				title: translate( 'Welcome to Refer products mode' ),
+				title: translate( 'Welcome to product referral mode' ),
 				description: translate(
-					'Check out the quick steps you’ll take to refer products to your client so that you get paid commissions.'
+					`Manage your clients' products without the burden of managing the billing. Assemble a cart of products, send a request for payment to your clients, and make commissions based on what you sell.`
 				),
 				preview: <img src={ step1 } alt="" />,
 			},
 			{
-				title: translate( 'Add the needed products for your client' ),
+				title: translate( 'Add the products your client needs' ),
 				description: translate(
-					'Just add the products to the cart like you would in any other e-commerce page.'
+					'Ensure "Refer products" is toggled on, and add any mix of products to your cart.'
 				),
 				preview: (
 					<video
@@ -37,9 +37,9 @@ function useReferralsGuide() {
 				),
 			},
 			{
-				title: translate( 'Proceed to checkout as normal' ),
+				title: translate( 'Review your selection during checkout' ),
 				description: translate(
-					'All done? Just click Checkout to fill in the details for your client.'
+					`During checkout, add your clients' email address and a note about the invoice for the selected products.`
 				),
 				preview: (
 					<video
@@ -53,9 +53,9 @@ function useReferralsGuide() {
 				),
 			},
 			{
-				title: translate( 'Send a payment to your client with a note' ),
+				title: translate( 'Send your client the payment request' ),
 				description: translate(
-					'At checkout, instead of paying yourself, send a payment request to your client with a note.'
+					`Once sent, your client will get the invoice delivered to their inbox. After they pay, you'll be able to assign the products to their site.`
 				),
 				preview: (
 					<video
@@ -69,9 +69,9 @@ function useReferralsGuide() {
 				),
 			},
 			{
-				title: translate( 'Get paid commissions' ),
+				title: translate( 'Get paid real commissions' ),
 				description: translate(
-					'Your client will pay for the subscriptions. You will get commissions when they pay each month. You’ll have access to the licenses so that you can configure the products and hosting for your client.'
+					`Clients will be billed at the end of every month for their products. When they pay, you'll make commissions on those products, which you'll be able to manage under the Referrals section, soon.`
 				),
 				preview: <img src={ step5 } alt="" />,
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/614

## Proposed Changes

Update wording as requested

<img width="421" alt="Screenshot 2024-06-04 at 9 36 45 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/2779b914-f276-495b-8f6e-a4ab56b0faba">

<img width="416" alt="Screenshot 2024-06-04 at 9 36 52 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/b62bdda9-3ef4-400d-a81c-94ce37a6c5ef">

<img width="410" alt="Screenshot 2024-06-04 at 9 36 58 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/ee4a2deb-d7b5-4587-9a63-53c956892519">

<img width="414" alt="Screenshot 2024-06-04 at 9 37 04 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/3c104798-98a5-47e2-87a6-890b387d0eec">

<img width="411" alt="Screenshot 2024-06-04 at 9 37 11 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/026856b5-2fb4-4901-b92e-116a88284049">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using Automattic for Agencies live link below navigate to `/markerplace/products?purchase_type=referral`.
- In the top right, on referral toggle hit `i` button and open Modal.
- Compare wording with the task.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
