### PR TITLE
Site Management Panel: Update tab names

### DIFF
--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -52,7 +52,6 @@ const DevTools = () => {
 	const hasEnTranslation = useHasEnTranslation();
 
 	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
-	const pluginsLink = `https://wordpress.com/plugins/${ encodeURIComponent( siteSlug ) }`;
 	const promoCards = [
 		{
 			title: translate( 'Deployments' ),
@@ -81,7 +80,9 @@ const DevTools = () => {
 			supportContext: 'site-monitoring-logs',
 		},
 		{
-			title: translate( 'Server Configuration' ),
+			title: hasEnTranslation
+				? translate( 'Server Settings' )
+				: translate( 'Server Configuration' ),
 			text: translate(
 				"Access your site's database and tailor your server settings to your specific needs."
 			),
@@ -169,9 +170,6 @@ const DevTools = () => {
 					</>
 				) : (
 					<>
-						<Button variant="secondary" className="dev-tools__button" href={ pluginsLink }>
-							{ translate( 'Browse plugins' ) }
-						</Button>
 						<Button variant="primary" className="dev-tools__button" href={ upgradeLink }>
 							{ translate( 'Upgrade now' ) }
 						</Button>

--- a/client/dev-tools/components/dev-tools.tsx
+++ b/client/dev-tools/components/dev-tools.tsx
@@ -80,7 +80,7 @@ const DevTools = () => {
 			supportContext: 'site-monitoring-logs',
 		},
 		{
-			title: hasEnTranslation
+			title: hasEnTranslation( 'Server Settings' )
 				? translate( 'Server Settings' )
 				: translate( 'Server Configuration' ),
 			text: translate(

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -299,7 +299,9 @@ const Hosting = ( props ) => {
 
 	const getPageTitle = () => {
 		if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-			return hasEnTranslation ? translate( 'Server Settings' ) : translate( 'Server Config' );
+			return hasEnTranslation( 'Server Settings' )
+				? translate( 'Server Settings' )
+				: translate( 'Server Config' );
 		}
 
 		return translate( 'Hosting' );

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -6,6 +6,7 @@ import {
 	WPCOM_FEATURES_ATOMIC,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { Fragment, useState, useCallback } from 'react';
@@ -258,6 +259,7 @@ const Hosting = ( props ) => {
 		transferState,
 	} = props;
 
+	const hasEnTranslation = useHasEnTranslation();
 	const [ isTrialAcknowledgeModalOpen, setIsTrialAcknowledgeModalOpen ] = useState( false );
 	const [ hasTransfer, setHasTransferring ] = useState(
 		transferState &&
@@ -294,6 +296,14 @@ const Hosting = ( props ) => {
 		},
 		[ hasTransfer ]
 	);
+
+	const getPageTitle = () => {
+		if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
+			return hasEnTranslation ? translate( 'Server Settings' ) : translate( 'Server Config' );
+		}
+
+		return translate( 'Hosting' );
+	};
 
 	const getUpgradeBanner = () => {
 		if ( hasTransfer ) {
@@ -399,20 +409,10 @@ const Hosting = ( props ) => {
 				/>
 			) }
 			<PageViewTracker path="/hosting-config/:site" title="Hosting" />
-			<DocumentHead
-				title={
-					isEnabled( 'layout/dotcom-nav-redesign-v2' )
-						? translate( 'Server Config' )
-						: translate( 'Hosting' )
-				}
-			/>
+			<DocumentHead title={ getPageTitle() } />
 			<NavigationHeader
 				navigationItems={ [] }
-				title={
-					isEnabled( 'layout/dotcom-nav-redesign-v2' )
-						? translate( 'Server Config' )
-						: translate( 'Hosting Config' )
-				}
+				title={ getPageTitle() }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
 			{ ! showHostingActivationBanner && ! isTrialAcknowledgeModalOpen && (

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useMemo, useEffect } from 'react';
@@ -39,6 +40,7 @@ const DotcomPreviewPane = ( {
 	closeSitePreviewPane,
 }: Props ) => {
 	const { __ } = useI18n();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const isAtomicSite = !! site.is_wpcom_atomic || !! site.is_wpcom_staging_site;
 	const isSimpleSite = ! site.jetpack;
@@ -57,7 +59,8 @@ const DotcomPreviewPane = ( {
 			createFeaturePreview(
 				DOTCOM_DEVELOPER_TOOLS,
 				<span>
-					{ __( 'Dev Tools' ) } <DevToolsIcon />
+					{ hasEnTranslation ? __( 'Hosting Settings' ) : __( 'Dev Tools' ) }
+					<DevToolsIcon />
 				</span>,
 				isSimpleSite || isPlanExpired,
 				selectedSiteFeature,
@@ -98,7 +101,7 @@ const DotcomPreviewPane = ( {
 			),
 			createFeaturePreview(
 				DOTCOM_HOSTING_CONFIG,
-				__( 'Server Config' ),
+				hasEnTranslation ? __( 'Server Settings' ) : __( 'Server Config' ),
 				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -59,7 +59,7 @@ const DotcomPreviewPane = ( {
 			createFeaturePreview(
 				DOTCOM_DEVELOPER_TOOLS,
 				<span>
-					{ hasEnTranslation ? __( 'Hosting Settings' ) : __( 'Dev Tools' ) }
+					{ hasEnTranslation( 'Hosting Settings' ) ? __( 'Hosting Settings' ) : __( 'Dev Tools' ) }
 					<DevToolsIcon />
 				</span>,
 				isSimpleSite || isPlanExpired,
@@ -101,7 +101,7 @@ const DotcomPreviewPane = ( {
 			),
 			createFeaturePreview(
 				DOTCOM_HOSTING_CONFIG,
-				hasEnTranslation ? __( 'Server Settings' ) : __( 'Server Config' ),
+				hasEnTranslation( 'Server Settings' ) ? __( 'Server Settings' ) : __( 'Server Config' ),
 				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,
 				setSelectedSiteFeature,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7587
Fixes https://github.com/Automattic/dotcom-forge/issues/7590
Fixes https://github.com/Automattic/dotcom-forge/issues/7591

## Proposed Changes

This PR does three things:

Renames Dev Tools to Hosting Settings, and removes the "Browse Plugins" button.

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-04 at 9 36 08 AM](https://github.com/Automattic/wp-calypso/assets/797888/018ddc36-3380-494c-8e1a-f782b433fd68) | ![Screenshot 2024-06-04 at 9 35 49 AM](https://github.com/Automattic/wp-calypso/assets/797888/b0cc17d0-a31a-4d70-ae52-6573aba62e0d)| 

Renames Server Config to Server Settings.

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-04 at 9 38 09 AM](https://github.com/Automattic/wp-calypso/assets/797888/7b7e05bb-34f9-4321-8b7b-b8f7a303c1ff) | ![Screenshot 2024-06-04 at 9 37 54 AM](https://github.com/Automattic/wp-calypso/assets/797888/bc6f9948-3dd0-46e5-898c-96912a0897bf) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Address walkthrough feedback.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the SMP is updated as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
