### PR TITLE
Checkoutv2 tidying: Add prop to show Site Preview in checkout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -346,9 +346,7 @@ export default function CheckoutMainContent( {
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
 
-	/*
-	 * Only show the site preview for WPCOM domains that have a site connected to the site id
-	 * */
+	// Only show the site preview for WPCOM domains that have a site connected to the site id
 	const shouldShowSitePreview =
 		showSitePreview && selectedSiteData && wpcomDomain && ! isSignupCheckout && ! isDIFMInCart;
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -346,6 +346,12 @@ export default function CheckoutMainContent( {
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
 
+	/*
+	 * Only show the site preview for WPCOM domains that have a site connected to the site id
+	 * */
+	const shouldShowSitePreview =
+		showSitePreview && selectedSiteData && wpcomDomain && ! isSignupCheckout && ! isDIFMInCart;
+
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const reduxDispatch = useReduxDispatch();
 	usePresalesChat( getPresalesChatKey( responseCart ), responseCart?.products?.length > 0 );
@@ -537,20 +543,13 @@ export default function CheckoutMainContent( {
 								className="checkout__summary-body"
 								shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 							>
-								{ /*
-								 * Only show the site preview for WPCOM domains that have a site connected to the site id
-								 * */ }
-								{ showSitePreview &&
-									selectedSiteData &&
-									wpcomDomain &&
-									! isSignupCheckout &&
-									! isDIFMInCart && (
-										<div className="checkout-site-preview">
-											<SitePreviewWrapper>
-												<SitePreview showEditSite={ false } showSiteDetails={ false } />
-											</SitePreviewWrapper>
-										</div>
-									) }
+								{ shouldShowSitePreview && (
+									<div className="checkout-site-preview">
+										<SitePreviewWrapper>
+											<SitePreview showEditSite={ false } showSiteDetails={ false } />
+										</SitePreviewWrapper>
+									</div>
+								) }
 
 								<WPCheckoutOrderSummary
 									siteId={ siteId }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -346,7 +346,9 @@ export default function CheckoutMainContent( {
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
 
-	// Only show the site preview for WPCOM domains that have a site connected to the site id
+	// Only show the site preview for WPCOM domains that have 'showSitePreview' set to true
+	// and have a site connected to the site id
+	// NOTE - the implementer need to ensure correct styling for their specific use case
 	const shouldShowSitePreview =
 		showSitePreview && selectedSiteData && wpcomDomain && ! isSignupCheckout && ! isDIFMInCart;
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -346,10 +346,6 @@ export default function CheckoutMainContent( {
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
 
-	// Only show the site preview for WPCOM domains that have a site connected to the site id
-	const shouldShowSitePreview =
-		showSitePreview && selectedSiteData && wpcomDomain && ! isSignupCheckout && ! isDIFMInCart;
-
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const reduxDispatch = useReduxDispatch();
 	usePresalesChat( getPresalesChatKey( responseCart ), responseCart?.products?.length > 0 );
@@ -541,13 +537,20 @@ export default function CheckoutMainContent( {
 								className="checkout__summary-body"
 								shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 							>
-								{ shouldShowSitePreview && (
-									<div className="checkout-site-preview">
-										<SitePreviewWrapper>
-											<SitePreview showEditSite={ false } showSiteDetails={ false } />
-										</SitePreviewWrapper>
-									</div>
-								) }
+								{ /*
+								 * Only show the site preview for WPCOM domains that have a site connected to the site id
+								 * */ }
+								{ showSitePreview &&
+									selectedSiteData &&
+									wpcomDomain &&
+									! isSignupCheckout &&
+									! isDIFMInCart && (
+										<div className="checkout-site-preview">
+											<SitePreviewWrapper>
+												<SitePreview showEditSite={ false } showSiteDetails={ false } />
+											</SitePreviewWrapper>
+										</div>
+									) }
 
 								<WPCheckoutOrderSummary
 									siteId={ siteId }


### PR DESCRIPTION
Similar to https://github.com/Automattic/wp-calypso/pull/90534 this change adds a prop to the SitePreview component so developers can _opt-in_ to displaying it in checkout, by default it will be set to hidden.

| Hide | Show |
| ----- | ----- |
| <img width="1680" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/64700fcc-b665-49ec-a43c-ba6be8f2b6de"> | <img width="1687" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/a84cd7ef-e4a0-4d90-8684-83c0a0b381a0"> |

Related to this tidy up post pbOQVh-45k-p2#comment-5821

## Proposed Changes

* Add a showSitePreview prop to hide or show SitePreview in Checkout sidebar
* Remove instances of checkoutV2 hook

## Testing Instructions

*  Based on this line, `const shouldShowSitePreview = showSitePreview && selectedSiteData && wpcomDomain && ! isSignupCheckout && ! isDIFMInCart;` the site preview component should only display in Checkout when the showSitePreview prop is set to true, we have site data for the site the cart is generated for, the site is a WordPress.com site (not a Jetpack connected site), and we're not in a signup flow or purchasing a DIFM product.
* With that said, try a number of products such as Akismet, Jetpack, Dotcom plans, domains, onboarding, and see how they all work when `showSitePreview` is set to `true`.
* We are largely looking for styling issues or failure of the SitePreview iframe

> [!NOTE]  
> The SitePreview component relies on the implementer to provide styling for their specific use case

