### PR TITLE
Calypso - Remove hosting overview menu option

### DIFF
--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -160,28 +160,12 @@ const useSiteMenuItems = () => {
 		return result.map( ( menu ) => {
 			if ( menu.slug === 'wpcom-hosting-menu' && Array.isArray( menu.children ) ) {
 				// Remove Hosting -> {Configuration, Monitoring}
-				let children = menu.children.filter(
+				const children = menu.children.filter(
 					( menuItem ) =>
 						! [ '/hosting-config/', '/site-monitoring' ].some( ( path ) =>
 							menuItem.url.startsWith( path )
 						)
 				);
-
-				// Insert Hosting -> Overview
-				const pos = 1;
-				if ( children.length > pos && ! children[ pos ].url.startsWith( '/hosting/' ) ) {
-					children = [
-						...children.splice( 0, pos ),
-						{
-							parent: menu.slug,
-							slug: 'hosting-overview',
-							title: translate( 'Overview' ),
-							type: 'submenu-item',
-							url: `/overview/${ siteDomain }`,
-						},
-						...children.splice( pos - 1 ),
-					];
-				}
 
 				return {
 					...menu,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/90562 https://github.com/Automattic/wpcomsh/pull/1897
Closes https://github.com/Automattic/dotcom-forge/issues/7588

## Proposed Changes

* Remove "Hosting > Overview" menu option from Calypso

|BEFORE|AFTER|
|-|-|
|<img width="161" alt="Screenshot 2567-06-04 at 12 06 45" src="https://github.com/Automattic/wp-calypso/assets/1881481/002ce4fe-cdfa-43f5-afbf-9b2c98fa7836">|<img width="161" alt="Screenshot 2567-06-04 at 12 06 08" src="https://github.com/Automattic/wp-calypso/assets/1881481/19b189c5-7d97-4d5e-9001-ac6f9bd8a6d9">|

>[!NOTE]
> The remaining logic that hides the options "Configuration" and "Monitoring" will not be necessary after we remove the proxy check in https://github.com/Automattic/wpcomsh/pull/1850, and should be migrated to jetpack-mu-wpcom. See: https://github.com/Automattic/dotcom-forge/issues/7066

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because we have the "Hosting Overview" button in the Site Management Panel card.

<img width="202" alt="Screenshot 2567-06-04 at 12 09 51" src="https://github.com/Automattic/wp-calypso/assets/1881481/10345cc6-2499-461d-8a5d-6f6aa35a0680">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/home/{ SITE }`
* Verify the option "Overview" has been removed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
