### PR TITLE
Jetpack Cloud pricing | Replace Social plans with the new v1 plan

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon.ts
@@ -15,6 +15,7 @@ import {
 	JETPACK_MONITOR_PRODUCTS,
 	WOOCOMMERCE_PRODUCTS,
 	JETPACK_CREATOR_PRODUCTS,
+	JETPACK_SOCIAL_V1_PRODUCTS,
 } from '@automattic/calypso-products';
 import JetpackProductIconAILight from 'calypso/assets/images/jetpack/jetpack-product-icon-ai-light.svg';
 import JetpackProductIconAI from 'calypso/assets/images/jetpack/jetpack-product-icon-ai.svg';
@@ -90,6 +91,10 @@ const PRODUCT_ICON_MAP: Record< string, IconResource > = {
 		light: JetpackProductIconMonitorLight,
 	} ),
 	...setProductsIcon( JETPACK_SOCIAL_PRODUCTS, {
+		regular: JetpackProductIconSocial,
+		light: JetpackProductIconSocialLight,
+	} ),
+	...setProductsIcon( JETPACK_SOCIAL_V1_PRODUCTS, {
 		regular: JetpackProductIconSocial,
 		light: JetpackProductIconSocialLight,
 	} ),

--- a/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/get-sorted-displayable-products.ts
@@ -9,6 +9,7 @@ import {
 	JETPACK_VIDEOPRESS_PRODUCTS,
 	JETPACK_AI_PRODUCTS,
 	JETPACK_STATS_PRODUCTS,
+	JETPACK_SOCIAL_V1_PRODUCTS,
 } from '@automattic/calypso-products';
 import { SelectorProduct } from '../../types';
 
@@ -21,6 +22,7 @@ const DISPLAYABLE_PRODUCT_POSITION_MAP: Record< string, number > = {
 	...setProductsInPosition( JETPACK_BOOST_PRODUCTS, 3 ),
 	...setProductsInPosition( JETPACK_SCAN_PRODUCTS, 4 ),
 	...setProductsInPosition( JETPACK_SOCIAL_PRODUCTS, 5 ),
+	...setProductsInPosition( JETPACK_SOCIAL_V1_PRODUCTS, 5 ),
 	...setProductsInPosition( JETPACK_ANTI_SPAM_PRODUCTS, 6 ),
 	...setProductsInPosition( JETPACK_VIDEOPRESS_PRODUCTS, 7 ),
 	...setProductsInPosition( JETPACK_CRM_PRODUCTS, 8 ),

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	JETPACK_ANTI_SPAM_PRODUCTS,
 	PRODUCT_JETPACK_BACKUP_T0_YEARLY,
@@ -24,6 +25,7 @@ import {
 	getPlan,
 	PRODUCT_JETPACK_BACKUP_T1_BI_YEARLY,
 	JETPACK_CREATOR_PRODUCTS,
+	JETPACK_SOCIAL_V1_PRODUCTS,
 } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
 import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
@@ -147,28 +149,39 @@ const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
 		availableProducts = [ ...availableProducts, ...JETPACK_STATS_PRODUCTS ];
 	}
 
-	const socialProductsToShow: string[] = [];
+	if ( isEnabled( 'jetpack/social-plans-v1' ) ) {
+		// If Jetpack Social is directly or indirectly owned, continue, otherwise make it available.
+		if (
+			! ownedProducts.some( ( ownedProduct ) =>
+				( JETPACK_SOCIAL_V1_PRODUCTS as ReadonlyArray< string > ).includes( ownedProduct )
+			)
+		) {
+			availableProducts = [ ...availableProducts, ...JETPACK_SOCIAL_V1_PRODUCTS ];
+		}
+	} else {
+		const socialProductsToShow: string[] = [];
 
-	const ownsSocialBasic =
-		ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_BASIC_BI_YEARLY ) ||
-		ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_BASIC ) ||
-		ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY );
-	const ownsSocialAdvanced =
-		ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ) ||
-		ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_ADVANCED ) ||
-		ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY );
+		const ownsSocialBasic =
+			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_BASIC_BI_YEARLY ) ||
+			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_BASIC ) ||
+			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY );
+		const ownsSocialAdvanced =
+			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ) ||
+			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_ADVANCED ) ||
+			ownedProducts.includes( PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY );
 
-	// If neither Social Basic or Social Advanced backups are owned, then show Social Basic Plan.
-	// Otherwise the one owned will be displayed via purchasedProducts.
-	if ( ! ownsSocialBasic && ! ownsSocialAdvanced ) {
-		socialProductsToShow.push(
-			PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY,
-			PRODUCT_JETPACK_SOCIAL_ADVANCED,
-			PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY
-		);
+		// If neither Social Basic or Social Advanced backups are owned, then show Social Basic Plan.
+		// Otherwise the one owned will be displayed via purchasedProducts.
+		if ( ! ownsSocialBasic && ! ownsSocialAdvanced ) {
+			socialProductsToShow.push(
+				PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY,
+				PRODUCT_JETPACK_SOCIAL_ADVANCED,
+				PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY
+			);
+		}
+
+		availableProducts = [ ...availableProducts, ...socialProductsToShow ];
 	}
-
-	availableProducts = [ ...availableProducts, ...socialProductsToShow ];
 
 	// If the user does not own the AI product, include it in available products
 	if (

--- a/config/development.json
+++ b/config/development.json
@@ -104,6 +104,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": true,
 		"jetpack/simplify-pricing-structure": false,
+		"jetpack/social-plans-v1": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,
 		"jetpack/zendesk-chat-for-logged-in-users": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -63,6 +63,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
+		"jetpack/social-plans-v1": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -63,6 +63,7 @@
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
+		"jetpack/social-plans-v1": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/url-only-connection": true,
 		"jetpack/streamline-license-purchases": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -56,6 +56,7 @@
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
+		"jetpack/social-plans-v1": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/streamline-license-purchases": false,
 		"layout/app-banner": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -58,6 +58,7 @@
 		"jetpack/manage-sites-v2-menu": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
+		"jetpack/social-plans-v1": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/streamline-license-purchases": false,
 		"layout/app-banner": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -59,6 +59,7 @@
 		"jetpack/manage-simple-sites": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
+		"jetpack/social-plans-v1": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/url-only-connection": true,
 		"jetpack/streamline-license-purchases": false,

--- a/config/production.json
+++ b/config/production.json
@@ -78,6 +78,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
+		"jetpack/social-plans-v1": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -73,6 +73,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
+		"jetpack/social-plans-v1": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": true,
 		"jetpack/offer-complete-after-activation": false,

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -153,6 +153,9 @@ import {
 	PRODUCT_JETPACK_CREATOR_BI_YEARLY,
 	PRODUCT_JETPACK_CREATOR_YEARLY,
 	PRODUCT_JETPACK_CREATOR_MONTHLY,
+	PRODUCT_JETPACK_SOCIAL_V1_BI_YEARLY,
+	PRODUCT_JETPACK_SOCIAL_V1_YEARLY,
+	PRODUCT_JETPACK_SOCIAL_V1_MONTHLY,
 } from './constants';
 import type { FAQ, SelectorProductFeaturesItem } from './types';
 import type { TranslateResult } from 'i18n-calypso';
@@ -232,6 +235,9 @@ export const getJetpackProductsShortNames = (): Record< string, React.ReactEleme
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ]: 'Social',
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: 'Social',
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: 'Social',
+		[ PRODUCT_JETPACK_SOCIAL_V1_BI_YEARLY ]: 'Social',
+		[ PRODUCT_JETPACK_SOCIAL_V1_YEARLY ]: 'Social',
+		[ PRODUCT_JETPACK_SOCIAL_V1_MONTHLY ]: 'Social',
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: 'Stats',
 		[ PRODUCT_JETPACK_STATS_YEARLY ]: 'Stats',
 		[ PRODUCT_JETPACK_STATS_MONTHLY ]: 'Stats',
@@ -526,6 +532,9 @@ export const getJetpackProductsTaglines = (): Record<
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ]: { default: socialAdvancedTagLine },
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: { default: socialAdvancedTagLine },
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: { default: socialAdvancedTagLine },
+		[ PRODUCT_JETPACK_SOCIAL_V1_BI_YEARLY ]: { default: socialTagLine },
+		[ PRODUCT_JETPACK_SOCIAL_V1_YEARLY ]: { default: socialTagLine },
+		[ PRODUCT_JETPACK_SOCIAL_V1_MONTHLY ]: { default: socialTagLine },
 		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_10GB_MONTHLY ]: {
 			default: backupAddonTagLine,
 			owned: backupAddonOwnedTagLine,
@@ -702,6 +711,9 @@ export const getJetpackProductsDescriptions = (): Record< string, TranslateResul
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ]: socialAdvancedDescription,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedDescription,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedDescription,
+		[ PRODUCT_JETPACK_SOCIAL_V1_BI_YEARLY ]: socialDescription,
+		[ PRODUCT_JETPACK_SOCIAL_V1_YEARLY ]: socialDescription,
+		[ PRODUCT_JETPACK_SOCIAL_V1_MONTHLY ]: socialDescription,
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: statsCommercialDescription,
 		[ PRODUCT_JETPACK_STATS_YEARLY ]: statsCommercialDescription,
 		[ PRODUCT_JETPACK_STATS_MONTHLY ]: statsCommercialDescription,
@@ -788,6 +800,9 @@ export const getJetpackProductsShortDescriptions = (): Record< string, Translate
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ]: socialAdvancedShortDescription,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedShortDescription,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedShortDescription,
+		[ PRODUCT_JETPACK_SOCIAL_V1_BI_YEARLY ]: socialShortDescription,
+		[ PRODUCT_JETPACK_SOCIAL_V1_YEARLY ]: socialShortDescription,
+		[ PRODUCT_JETPACK_SOCIAL_V1_MONTHLY ]: socialShortDescription,
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: statsCommercialShortDescription,
 		[ PRODUCT_JETPACK_STATS_YEARLY ]: statsCommercialShortDescription,
 		[ PRODUCT_JETPACK_STATS_MONTHLY ]: statsCommercialShortDescription,
@@ -876,6 +891,9 @@ export const getJetpackProductsFeaturedDescription = (): Record< string, Transla
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ]: socialAdvancedFeaturedText,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedFeaturedText,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedFeaturedText,
+		[ PRODUCT_JETPACK_SOCIAL_V1_BI_YEARLY ]: socialFeaturedText,
+		[ PRODUCT_JETPACK_SOCIAL_V1_YEARLY ]: socialFeaturedText,
+		[ PRODUCT_JETPACK_SOCIAL_V1_MONTHLY ]: socialFeaturedText,
 		[ PRODUCT_JETPACK_MONITOR_YEARLY ]: monitorFeaturedText,
 		[ PRODUCT_JETPACK_MONITOR_MONTHLY ]: monitorFeaturedText,
 	};
@@ -1097,6 +1115,9 @@ export const getJetpackProductsLightboxDescription = (): Record< string, Transla
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ]: socialAdvancedLightboxDescription,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedLightboxDescription,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedLightboxDescription,
+		[ PRODUCT_JETPACK_SOCIAL_V1_BI_YEARLY ]: socialLightboxDescription,
+		[ PRODUCT_JETPACK_SOCIAL_V1_YEARLY ]: socialLightboxDescription,
+		[ PRODUCT_JETPACK_SOCIAL_V1_MONTHLY ]: socialLightboxDescription,
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: statsLightboxDescription,
 		[ PRODUCT_JETPACK_STATS_YEARLY ]: statsLightboxDescription,
 		[ PRODUCT_JETPACK_STATS_MONTHLY ]: statsLightboxDescription,
@@ -1348,6 +1369,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Recycle content' ),
 		translate( 'Image generator' ),
 	];
+	const socialIncludesInfo = socialAdvancedIncludesInfo;
 	const statsCommercialIncludesInfo = [
 		translate( 'Real-time data on visitors' ),
 		translate( 'Traffic stats and trends for posts and pages' ),
@@ -1610,6 +1632,9 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ]: socialAdvancedIncludesInfo,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedIncludesInfo,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedIncludesInfo,
+		[ PRODUCT_JETPACK_SOCIAL_V1_BI_YEARLY ]: socialIncludesInfo,
+		[ PRODUCT_JETPACK_SOCIAL_V1_YEARLY ]: socialIncludesInfo,
+		[ PRODUCT_JETPACK_SOCIAL_V1_MONTHLY ]: socialIncludesInfo,
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: [
 			translate( '10K site views (upgradeable)' ),
 			...statsCommercialIncludesInfo,
@@ -1800,7 +1825,7 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 		translate( 'Best-in-class support from WordPress experts' ),
 	];
 
-	const socialBenefits = [
+	const socialBasicBenefits = [
 		translate( 'Save time by sharing your posts automatically' ),
 		translate( 'Unlock your growth potential by building a following on social media' ),
 		translate( 'Easy-to-use interface' ),
@@ -1818,6 +1843,8 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 		translate( 'Automatically create custom images, saving you hours of tedious work' ),
 		translate( 'Repurpose, reuse or republish already published content' ),
 	];
+
+	const socialBenefits = socialAdvancedBenefits;
 
 	const statsCommercialBenefits = [
 		translate( 'Better understand your audience' ),
@@ -1993,12 +2020,15 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 		[ PRODUCT_JETPACK_BOOST_BI_YEARLY ]: boostBenefits,
 		[ PRODUCT_JETPACK_BOOST ]: boostBenefits,
 		[ PRODUCT_JETPACK_BOOST_MONTHLY ]: boostBenefits,
-		[ PRODUCT_JETPACK_SOCIAL_BASIC_BI_YEARLY ]: socialBenefits,
-		[ PRODUCT_JETPACK_SOCIAL_BASIC ]: socialBenefits,
-		[ PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY ]: socialBenefits,
+		[ PRODUCT_JETPACK_SOCIAL_BASIC_BI_YEARLY ]: socialBasicBenefits,
+		[ PRODUCT_JETPACK_SOCIAL_BASIC ]: socialBasicBenefits,
+		[ PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY ]: socialBasicBenefits,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_BI_YEARLY ]: socialAdvancedBenefits,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedBenefits,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedBenefits,
+		[ PRODUCT_JETPACK_SOCIAL_V1_BI_YEARLY ]: socialBenefits,
+		[ PRODUCT_JETPACK_SOCIAL_V1_YEARLY ]: socialBenefits,
+		[ PRODUCT_JETPACK_SOCIAL_V1_MONTHLY ]: socialBenefits,
 		[ PRODUCT_JETPACK_STATS_BI_YEARLY ]: statsCommercialBenefits,
 		[ PRODUCT_JETPACK_STATS_YEARLY ]: statsCommercialBenefits,
 		[ PRODUCT_JETPACK_STATS_MONTHLY ]: statsCommercialBenefits,


### PR DESCRIPTION
## Proposed Changes

* Add feature flag `jetpack/social-plans-v1` to use for conditionally displaying the UIs
* Update Jetpack Cloud pricing to display Social V1 pricing/product

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The reason for this change is to replace Advanced and Basic plans for Jetpack Social with a unified plan named Social (V1) - pdrWKz-1Du-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Do any one of these
    * Click on Jetpack Cloud live link below and wait for the redirect to complete, then goto `/pricing?flags=jetpack/social-plans-v1`
    * or boot up this PR 
        * Run `git fetch && git checkout update/jetpack-pricing-to-show-social-v1`
        * Run `yarn start-jetpack-cloud`
        * Goto [http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/social-plans-v1](http://jetpack.cloud.localhost:3000/pricing?flags=jetpack/social-plans-v1)
2. Confirm that you see the new Social product in the list.
3. Click on "More about Social" link
4. Confirm that the modal opens with correct details
5. Confirm that you don't see the Advanced and Basic plan
6. Goto the same page with a site context - `/pricing/:site/?flags=...`
7. Confirm that the above works fine
8. Goto Calypso plans page for the site - `http://calypso.localhost:3000/plans/:site?flags=jetpack/social-plans-v1`
9. Confirm that the plans show up correctly for the site
10. Complete the purchase for Social
11. Confirm that the checkout and the pricing are correct
12. Now visit the above pricing pages with site context again
13. Confirm that now you see the "Manage Subscription" button instead of "Get" or "Add to cart"
14. Remove the `flags` param
15. Confirm that everything works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


Calypso plans - `/plans/:site`
<img width="1131" alt="Screenshot 2024-06-04 at 10 44 29 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/9f58d17f-c8ba-4362-b1e9-90da750bbf93">

Jetpack Cloud pricing with site context - `/pricing/:site`
<img width="1176" alt="Screenshot 2024-06-04 at 10 45 23 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/16209c33-a84d-4eec-82ec-d97823c0e26a">

Jetpack Cloud pricing without site context - `/pricing/`
<img width="1179" alt="Screenshot 2024-06-04 at 10 45 56 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/c99796d8-38c4-447f-8169-809ca3f6a3c2">


<img width="579" alt="Screenshot 2024-06-04 at 10 46 07 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/27c9ccd8-70b6-4975-bc38-17552455b893">
