### PR TITLE
Revert update webpack packages

### DIFF
--- a/apps/blaze-dashboard/package.json
+++ b/apps/blaze-dashboard/package.json
@@ -57,7 +57,7 @@
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
 		"@automattic/webpack-inline-constant-exports-plugin": "workspace:^",
 		"@automattic/wp-babel-makepot": "workspace:^",
-		"@wordpress/dependency-extraction-webpack-plugin": "^6.0.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
 		"autoprefixer": "^10.2.5",
 		"gettext-parser": "^6.0.0",
 		"html-webpack-plugin": "^5.6.0",

--- a/apps/command-palette-wp-admin/package.json
+++ b/apps/command-palette-wp-admin/package.json
@@ -43,7 +43,7 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@automattic/wp-babel-makepot": "workspace:^",
-		"@wordpress/dependency-extraction-webpack-plugin": "^6.0.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
 		"gettext-parser": "^6.0.0",
 		"lodash": "^4.17.21",
 		"mkdirp": "^1.0.4",

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -81,7 +81,7 @@
 		"@wordpress/data": "^10.0.0",
 		"@wordpress/data-controls": "^4.0.0",
 		"@wordpress/date": "^5.0.0",
-		"@wordpress/dependency-extraction-webpack-plugin": "^6.0.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
 		"@wordpress/dom-ready": "^4.0.0",
 		"@wordpress/edit-post": "^8.0.0",
 		"@wordpress/element": "^6.0.0",

--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -62,7 +62,7 @@
 		"@automattic/wp-babel-makepot": "workspace:^",
 		"@babel/core": "^7.24.5",
 		"@size-limit/file": "^8.2.6",
-		"@wordpress/dependency-extraction-webpack-plugin": "^6.0.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
 		"autoprefixer": "^10.2.5",
 		"babel-jest": "^29.6.1",
 		"gettext-parser": "^6.0.0",

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -57,7 +57,7 @@
 		"@automattic/calypso-apps-builder": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
-		"@wordpress/dependency-extraction-webpack-plugin": "^6.0.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.4.5",
 		"webpack": "^5.91.0",

--- a/package.json
+++ b/package.json
@@ -344,7 +344,7 @@
 		"@wordpress/data": "^10.0.0",
 		"@wordpress/dataviews": "0.4.1",
 		"@wordpress/date": "5.0.0",
-		"@wordpress/dependency-extraction-webpack-plugin": "6.0.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "5.9.0",
 		"@wordpress/deprecated": "4.0.0",
 		"@wordpress/docgen": "2.0.0",
 		"@wordpress/dom-ready": "4.0.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -41,7 +41,7 @@
 		"@babel/core": "^7.24.5",
 		"@types/webpack-env": "^1.18.5",
 		"@wordpress/browserslist-config": "^6.0.0",
-		"@wordpress/dependency-extraction-webpack-plugin": "^6.0.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
 		"autoprefixer": "^10.2.5",
 		"babel-loader": "^8.2.3",
 		"browserslist": "^4.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,7 +150,7 @@ __metadata:
     "@automattic/wp-babel-makepot": "workspace:^"
     "@tanstack/react-query": "npm:^5.15.5"
     "@wordpress/data": "npm:^10.0.0"
-    "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.0.0"
+    "@wordpress/dependency-extraction-webpack-plugin": "npm:^5.9.0"
     autoprefixer: "npm:^10.2.5"
     calypso: "workspace:^"
     clsx: "npm:^2.1.1"
@@ -282,7 +282,7 @@ __metadata:
     "@babel/core": "npm:^7.24.5"
     "@types/webpack-env": "npm:^1.18.5"
     "@wordpress/browserslist-config": "npm:^6.0.0"
-    "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.0.0"
+    "@wordpress/dependency-extraction-webpack-plugin": "npm:^5.9.0"
     autoprefixer: "npm:^10.2.5"
     babel-loader: "npm:^8.2.3"
     browserslist: "npm:^4.8.2"
@@ -565,7 +565,7 @@ __metadata:
     "@automattic/wp-babel-makepot": "workspace:^"
     "@tanstack/react-query": "npm:^5.15.5"
     "@wordpress/data": "npm:^10.0.0"
-    "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.0.0"
+    "@wordpress/dependency-extraction-webpack-plugin": "npm:^5.9.0"
     "@wordpress/dom-ready": "npm:^4.0.0"
     "@wordpress/i18n": "npm:^5.0.0"
     calypso: "workspace:^"
@@ -1460,7 +1460,7 @@ __metadata:
     "@tanstack/react-query": "npm:^5.15.5"
     "@wordpress/base-styles": "npm:^5.0.0"
     "@wordpress/data": "npm:^10.0.0"
-    "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.0.0"
+    "@wordpress/dependency-extraction-webpack-plugin": "npm:^5.9.0"
     "@wordpress/icons": "npm:^10.0.0"
     autoprefixer: "npm:^10.2.5"
     babel-jest: "npm:^29.6.1"
@@ -2102,7 +2102,7 @@ __metadata:
     "@wordpress/components": "npm:^28.0.0"
     "@wordpress/compose": "npm:^7.0.0"
     "@wordpress/data": "npm:^10.0.0"
-    "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.0.0"
+    "@wordpress/dependency-extraction-webpack-plugin": "npm:^5.9.0"
     "@wordpress/dom-ready": "npm:^4.0.0"
     "@wordpress/edit-post": "npm:^8.0.0"
     "@wordpress/edit-site": "npm:^6.0.0"
@@ -2207,7 +2207,7 @@ __metadata:
     "@wordpress/data": "npm:^10.0.0"
     "@wordpress/data-controls": "npm:^4.0.0"
     "@wordpress/date": "npm:^5.0.0"
-    "@wordpress/dependency-extraction-webpack-plugin": "npm:^6.0.0"
+    "@wordpress/dependency-extraction-webpack-plugin": "npm:^5.9.0"
     "@wordpress/dom-ready": "npm:^4.0.0"
     "@wordpress/edit-post": "npm:^8.0.0"
     "@wordpress/element": "npm:^6.0.0"
@@ -9479,14 +9479,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dependency-extraction-webpack-plugin@npm:6.0.0":
-  version: 6.0.0
-  resolution: "@wordpress/dependency-extraction-webpack-plugin@npm:6.0.0"
+"@wordpress/dependency-extraction-webpack-plugin@npm:5.9.0":
+  version: 5.9.0
+  resolution: "@wordpress/dependency-extraction-webpack-plugin@npm:5.9.0"
   dependencies:
     json2php: "npm:^0.0.7"
   peerDependencies:
     webpack: ^5.0.0
-  checksum: f052343a2a0fe6cdc745bed68741bb591b8c7a8c0ac6ca0df4efff4d61e00fcfb0e3e541c42876ff96a9f0ad7c34082ffe142d0a3cf3f907af042c88f4d41f37
+  checksum: de26747649fe096736bbd443b657947abc8965a14dc298a5566dcae31b0fdb232e7bd283c1f263c99a89d0884a279260013abbf88535fb4e04cc62ef5ba947ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

Partially reverts https://github.com/Automattic/wp-calypso/pull/91367 because it was breaking the `command-palette-wp-admin` app (unsure if it was breaking other apps too).

## Why are these changes being made?

To fix the `command-palette-wp-admin` app 

## Testing Instructions

- In your sandbox run `install-plugin.sh command-palette-wp-admin trunk`
- Sandbox `widgets.wp.com` and a simple site
- Go to `/wp-admin` on your sandboxed site
- Open the command palette (⌘ + K)
- Observe the JS error: `build.min.js?ver=20240604:6 Uncaught TypeError: Cannot read properties of undefined (reading 'jsx')`
- Apply now changes from this PR: `install-plugin.sh command-palette-wp-admin revert/webpack-packages-updates`
- Reload `/wp-admin` and open the command palette
- Make sure it works as expected without any JS error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
