### PR TITLE
Guided Onboarding: deemphasize free plan for paid domains

### DIFF
--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -101,11 +101,13 @@ const PlansPageSubheader = ( {
 	isDisplayingPlansNeededForFeature,
 	deemphasizeFreePlan,
 	showPlanBenefits,
+	offeringFreePlan,
 	onFreePlanCTAClick,
 }: {
 	siteSlug?: string | null;
 	isDisplayingPlansNeededForFeature: boolean;
 	deemphasizeFreePlan?: boolean;
+	offeringFreePlan?: boolean;
 	showPlanBenefits?: boolean;
 	onFreePlanCTAClick: () => void;
 } ) => {
@@ -113,7 +115,7 @@ const PlansPageSubheader = ( {
 
 	return (
 		<>
-			{ deemphasizeFreePlan && (
+			{ deemphasizeFreePlan && offeringFreePlan ? (
 				<Subheader>
 					{ translate(
 						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
@@ -124,8 +126,9 @@ const PlansPageSubheader = ( {
 						}
 					) }
 				</Subheader>
+			) : (
+				showPlanBenefits && <PlanBenefitHeader />
 			) }
-			{ ! deemphasizeFreePlan && showPlanBenefits && <PlanBenefitHeader /> }
 			{ isDisplayingPlansNeededForFeature && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
 		</>
 	);

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -439,7 +439,7 @@ const PlansFeaturesMain = ( {
 	);
 
 	// In some cases, the free plan is not an option at all. Make sure not to offer it in the subheader.
-	const offeringFreePlan = gridPlansForFeaturesGrid?.some(
+	const offeringFreePlan = gridPlansForFeaturesGridRaw?.some(
 		( { planSlug } ) => planSlug === PLAN_FREE
 	);
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -438,6 +438,11 @@ const PlansFeaturesMain = ( {
 		[ gridPlansForFeaturesGridRaw, deemphasizeFreePlan ]
 	);
 
+	// In some cases, the free plan is not an option at all. Make sure not to offer it in the subheader.
+	const offeringFreePlan = gridPlansForFeaturesGrid?.some(
+		( { planSlug } ) => planSlug === PLAN_FREE
+	);
+
 	let hidePlanSelector = false;
 	// In the "purchase a plan and free domain" flow we do not want to show
 	// monthly plans because monthly plans do not come with a free domain.
@@ -725,6 +730,7 @@ const PlansFeaturesMain = ( {
 				<PlansPageSubheader
 					siteSlug={ siteSlug }
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
+					offeringFreePlan={ offeringFreePlan }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
 					onFreePlanCTAClick={ onFreePlanCTAClick }
 					showPlanBenefits={ isInSignup && isTrailMapAny }

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -700,9 +700,11 @@ export function generateFlows( {
 			lastModified: '2024-05-15',
 			showRecaptcha: true,
 			hideProgressIndicator: true,
-			plans: {
-				isCustomDomainAllowedOnFreePlan: true,
-				deemphasizeFreePlan: true,
+			props: {
+				plans: {
+					isCustomDomainAllowedOnFreePlan: true,
+					deemphasizeFreePlan: true,
+				},
 			},
 		},
 		{

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -700,12 +700,6 @@ export function generateFlows( {
 			lastModified: '2024-05-15',
 			showRecaptcha: true,
 			hideProgressIndicator: true,
-			props: {
-				plans: {
-					isCustomDomainAllowedOnFreePlan: true,
-					deemphasizeFreePlan: true,
-				},
-			},
 		},
 		{
 			name: 'entrepreneur',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -700,6 +700,10 @@ export function generateFlows( {
 			lastModified: '2024-05-15',
 			showRecaptcha: true,
 			hideProgressIndicator: true,
+			plans: {
+				isCustomDomainAllowedOnFreePlan: true,
+				deemphasizeFreePlan: true,
+			},
 		},
 		{
 			name: 'entrepreneur',

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -129,7 +129,7 @@ export class PlansStep extends Component {
 			freeWPComSubdomain = siteUrl;
 		}
 
-		// De-emphasize the Free plan as a CTA link on the main onboarding flow when a paid domain is picked.
+		// De-emphasize the Free plan as a CTA link on the main onboarding flow, and the guided flow, when a paid domain is picked.
 		// More context can be found in p2-p5uIfZ-f5p
 		const deemphasizeFreePlan =
 			( [ 'onboarding', 'guided' ].includes( flowName ) && paidDomainName != null ) ||

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -132,7 +132,8 @@ export class PlansStep extends Component {
 		// De-emphasize the Free plan as a CTA link on the main onboarding flow when a paid domain is picked.
 		// More context can be found in p2-p5uIfZ-f5p
 		const deemphasizeFreePlan =
-			( flowName === 'onboarding' && paidDomainName != null ) || deemphasizeFreePlanFromProps;
+			( [ 'onboarding', 'guided' ].includes( flowName ) && paidDomainName != null ) ||
+			deemphasizeFreePlanFromProps;
 
 		return (
 			<div>


### PR DESCRIPTION
## Proposed Changes

This changes the guided flow to behave like the onboarding flow in deemphasizing the free plan when a paid domain is selected.

## Testing steps
1. Go to /start/guided.
2. Choose the first option "Creating a site for myself, a business, or a friend".
3. Choose "Publish a blog".
4. Choose a free domain.
5. The Free plan should be a card.
6. Go back and pick a paid domain.
7. The free plan should be a subheader.


