### PR TITLE
Stats: Restore download button on UTM summary page

### DIFF
--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -51,6 +51,7 @@ const StatsModuleUTMWrapper = ( { siteId, period, postId, query, summary, classN
 					isLoading={ isFetching ?? true }
 					hideSummaryLink={ hideSummaryLink }
 					postId={ postId }
+					summary={ summary }
 				/>
 			) }
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/49

## Proposed Changes

Fixes a regression with the UTM summary page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* n/a

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the Calypso Live link.
* Visit the Traffic page for any internal p2 site.
* Scroll down to the UTM module and click the "View details" link.
* Confirm the download button is present on the resulting summary page.

<img width="765" alt="SCR-20240604-phqt" src="https://github.com/Automattic/wp-calypso/assets/40267301/752a06d2-fe86-4a16-b025-72c0e06da2cb">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
