### PR TITLE
A4A > Partner Directory: Implement Welcome View for the Dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -1,9 +1,98 @@
-const PartnerDirectoryDashboard = () => {
-	return (
-		<div>
-			<h2>Partner Directory Dashboard</h2>
-		</div>
-	);
-};
+import { Button } from '@automattic/components';
+import { Icon, external } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import StepSection from '../../referrals/common/step-section';
+import StepSectionItem from '../../referrals/common/step-section-item';
 
-export default PartnerDirectoryDashboard;
+import './style.scss';
+
+export default function PartnerDirectoryDashboard() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onApplyNowClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_apply_now_click' ) );
+	}, [ dispatch ] );
+
+	const onFinishProfileClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_finish_profile_click' ) );
+	}, [ dispatch ] );
+
+	return (
+		<>
+			<div className="partner-directory-dashboard__heading">
+				{ translate( `Boost your agency's visibility across Automattic platforms.` ) }
+			</div>
+
+			<div className="partner-directory-dashboard__subtitle">
+				{ translate(
+					'List your agency in our partner directories. Showcase your skills, attract clients, and grow your business.'
+				) }
+			</div>
+			<StepSection heading={ translate( 'How do I start?' ) }>
+				<StepSectionItem
+					isNewLayout
+					stepNumber={ 1 }
+					heading={ translate( 'Share your expertise' ) }
+					description={ translate(
+						`Pick your agency's specialties and choose your directories. We'll review your application.`
+					) }
+					buttonProps={ {
+						children: translate( 'Apply now' ),
+						href: '/partner-directory/agency-expertise',
+						onClick: onApplyNowClick,
+						primary: true,
+						compact: true,
+					} }
+				/>
+				<StepSectionItem
+					isNewLayout
+					stepNumber={ 2 }
+					heading={ translate( 'Finish adding details to your public profile' ) }
+					description={ translate(
+						`When approved, add details to your agency's public profile for clients to see.`
+					) }
+					buttonProps={ {
+						children: translate( 'Finish profile' ),
+						href: '/partner-directory/agency-details',
+						onClick: onFinishProfileClick,
+						primary: false,
+						disabled: true,
+						compact: true,
+					} }
+				/>
+				<StepSectionItem
+					isNewLayout
+					stepNumber={ 3 }
+					heading={ translate( 'New clients will find you' ) }
+					description={ translate(
+						'Your agency will appear in the partner directories you select and get approved for, including WordPress.com, Woo.com, Pressable.com, and Jetpack.com.'
+					) }
+				/>
+			</StepSection>
+			<StepSection
+				className="partner-directory-dashboard__learn-more-section"
+				heading={ translate( 'Learn more about the program' ) }
+			>
+				{
+					// FIXME: Add link
+					<Button className="a8c-blue-link" borderless href="#">
+						{ translate( 'How does the approval process work?' ) }
+						<Icon icon={ external } size={ 18 } />
+					</Button>
+				}
+				<br />
+				{
+					// FIXME: Add link
+					<Button className="a8c-blue-link" borderless href="#">
+						{ translate( 'What can I put on my public profile?' ) }
+						<Icon icon={ external } size={ 18 } />
+					</Button>
+				}
+			</StepSection>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
@@ -1,0 +1,33 @@
+.partner-directory__dashboard {
+	.a4a-layout__body-wrapper {
+		max-width: 700px;
+	}
+}
+
+.partner-directory-dashboard__heading {
+	margin-block-start: 32px;
+	font-size: rem(24px);
+	margin-block-end: 8px;
+	font-weight: 600;
+}
+.partner-directory-dashboard__subtitle {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	font-size: rem(14px);
+	font-weight: 400;
+	margin-block-end: 48px;
+	color: var(--color-neutral-50);
+}
+
+.partner-directory-dashboard__learn-more-section {
+	margin-block-start: 40px;
+
+	a.button {
+		padding-block: 4px;
+	}
+
+	.step-section__header {
+		margin-block-end: 0;
+	}
+}

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useMemo } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -26,6 +27,7 @@ type Props = {
 interface Section {
 	content: ReactNode;
 	breadcrumbItems: BreadcrumbItem[];
+	className?: string;
 }
 
 export default function PartnerDirectory( { selectedSection }: Props ) {
@@ -44,6 +46,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 					href: A4A_PARTNER_DIRECTORY_LINK,
 				},
 			],
+			className: 'partner-directory__dashboard',
 		};
 
 		sections[ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ] = {
@@ -75,7 +78,12 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 	const section: Section = sections[ selectedSection ];
 
 	return (
-		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+		<Layout
+			className={ clsx( section.className ) }
+			title={ title }
+			wide
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+		>
 			<LayoutTop>
 				<LayoutHeader>
 					{ section.breadcrumbItems.length === 1 ? (

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
@@ -10,14 +10,15 @@ import './style.scss';
 const ICON_SIZE = 24;
 
 interface StepSectionItemProps {
-	icon: JSX.Element;
+	icon?: JSX.Element;
 	heading: string;
 	description: TranslateResult;
 	buttonProps?: React.ComponentProps< typeof Button >;
 	statusProps?: React.ComponentProps< typeof Badge > & { tooltip?: string };
 	className?: string;
 	iconClassName?: string;
-	isAutomatedReferral?: boolean;
+	isNewLayout?: boolean;
+	stepNumber?: number;
 }
 
 export default function StepSectionItem( {
@@ -28,7 +29,8 @@ export default function StepSectionItem( {
 	statusProps,
 	className,
 	iconClassName,
-	isAutomatedReferral = false,
+	isNewLayout = false,
+	stepNumber,
 }: StepSectionItemProps ) {
 	const status = <StatusBadge statusProps={ statusProps } />;
 
@@ -44,25 +46,28 @@ export default function StepSectionItem( {
 
 	return (
 		<div className={ clsx( 'step-section-item', className ) }>
-			<div className={ clsx( 'step-section-item__icon', iconClassName ) }>
-				<Icon
-					className="sidebar__menu-icon"
-					style={ { fill: 'currentcolor' } }
-					icon={ icon }
-					size={ ICON_SIZE }
-				/>
-			</div>
+			{ icon && (
+				<div className={ clsx( 'step-section-item__icon', iconClassName ) }>
+					<Icon
+						className="sidebar__menu-icon"
+						style={ { fill: 'currentcolor' } }
+						icon={ icon }
+						size={ ICON_SIZE }
+					/>
+				</div>
+			) }
+			{ stepNumber && <span className="step-section-item__step-number">{ stepNumber }</span> }
 			<div className="step-section-item__content">
 				{ statusProps && (
 					<div className="step-section-item__status is-small-screen">{ status }</div>
 				) }
 				<div className="step-section-item__heading">
-					{ heading } { isAutomatedReferral && statusContent }
+					{ heading } { isNewLayout && statusContent }
 				</div>
 				<div className="step-section-item__description">{ description }</div>
-				{ ! isAutomatedReferral && buttonContent }
+				{ ! isNewLayout && buttonContent }
 			</div>
-			{ isAutomatedReferral ? buttonContent : statusContent }
+			{ isNewLayout ? buttonContent : statusContent }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -121,3 +121,14 @@
 
 	}
 }
+
+.step-section-item__step-number {
+	color: var(--color-accent);
+	font-size: rem(16px);
+	font-weight: 600;
+	text-align: center;
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	border: 2px solid var(--color-accent);
+}

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -41,6 +41,7 @@
 			height: 40px;
 
 			@include break-large {
+				min-width: 100px;
 				width: auto;
 				height: inherit;
 			}
@@ -123,12 +124,19 @@
 }
 
 .step-section-item__step-number {
+	display: none;
 	color: var(--color-accent);
-	font-size: rem(16px);
+	font-size: rem(12px);
 	font-weight: 600;
 	text-align: center;
-	width: 24px;
-	height: 24px;
+	width: 20px;
+	height: 20px;
 	border-radius: 50%;
 	border: 2px solid var(--color-accent);
+
+	@include break-large {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -203,7 +203,7 @@ export default function LayoutBodyContent( {
 							}
 						>
 							<StepSectionItem
-								isAutomatedReferral={ isAutomatedReferral }
+								isNewLayout={ isAutomatedReferral }
 								icon={ tipaltiLogo }
 								heading={
 									isAutomatedReferral
@@ -250,7 +250,7 @@ export default function LayoutBodyContent( {
 							{ isAutomatedReferral ? (
 								<StepSectionItem
 									iconClassName="referrals-overview__opacity-70-percent"
-									isAutomatedReferral
+									isNewLayout
 									icon={ reusableBlock }
 									heading={ translate( 'Refer products and hosting' ) }
 									description={ translate( 'Receive up to a 50% commission.' ) }
@@ -279,7 +279,7 @@ export default function LayoutBodyContent( {
 								/>
 							) }
 							<StepSectionItem
-								isAutomatedReferral={ isAutomatedReferral }
+								isNewLayout={ isAutomatedReferral }
 								className="referrals-overview__step-section-woo-payments"
 								icon={ <WooLogo /> }
 								heading={

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -201,6 +201,11 @@
 		&.a8c-blue-link {
 			color: var(--color-primary-50);
 			text-decoration: underline;
+
+			svg {
+				fill: var(--color-primary-50);
+				margin-inline-start: 4px;
+			}
 		}
 	}
 
@@ -249,6 +254,7 @@
 	.button.disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+		pointer-events: none;
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/560

## Proposed Changes

This PR implements the welcome view for the dashboard

NOTE: 

- [Design](https://www.figma.com/design/fp9lBFMcpB15H7czSIthPW/Partner-Directories?node-id=6644-76437&m=dev)
- The links will be updated later in a different PR.

## Testing Instructions

1. Open the A4A live link.
2. Append the /referrals URL as /referrals?flags=-a4a-automated-referrals, and verify that the above changes are not reflected and that the Referrals page matches the production.
3. Go to Partner Directory - Dashboard > Verify the UI looks as below. 

<img width="1430" alt="Screenshot 2024-06-04 at 12 53 21 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c5ab9e59-65e2-482a-8972-0a1ca48c9d04">

<img width="313" alt="Screenshot 2024-06-04 at 12 53 59 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b89bcbff-f616-4efb-ab85-d98366b92b8a">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
