### PR TITLE
Site Profiler: Fix scroll for get report form on Mobile

### DIFF
--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -8,7 +8,7 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
-	z-index: 10;
+	z-index: 185;
 	background-color: var(--studio-gray-0);
 	border: 1px solid #cbcbcb;
 	padding: 0 1.5rem;
@@ -16,10 +16,6 @@
 
 	&--hidden {
 		transform: translateY(100%);
-	}
-
-	@media (max-width: $break-mobile) {
-		bottom: -36px;
 	}
 }
 .get-report-form__container {

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -19,7 +19,6 @@
 	}
 
 	@media (max-width: $break-mobile) {
-		height: 100dvh;
 		bottom: -36px;
 	}
 }
@@ -33,6 +32,12 @@
 	gap: 36px;
 	margin: 0 auto;
 	max-width: 1224px;
+
+	@media (max-width: $break-mobile) {
+		height: 100vh;
+		height: 100svh;
+		overflow-y: auto;
+	}
 
 	@media (max-width: $break-large) {
 		.get-report-form__body {

--- a/client/site-profiler/components/get-report-form/styles.scss
+++ b/client/site-profiler/components/get-report-form/styles.scss
@@ -34,8 +34,7 @@
 	max-width: 1224px;
 
 	@media (max-width: $break-mobile) {
-		height: 100vh;
-		height: 100svh;
+		height: 100dvh;
 		overflow-y: auto;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/7568

## Proposed Changes

* Add a height to the get report form container for mobile view
* Add `overflow-y` to add scroll


https://github.com/Automattic/wp-calypso/assets/3519124/71ba2c3c-e628-429b-85da-f7f285bb0347



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The submit button was not reachable for certain sizes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Navigate to a site profiler and analyze a site
* Open developer tools and select a small Mobile device, e.g. `IPhone SE`
* Click on the `Access full report` CTA to display the form
* Check the Submit button can be accessed by Scrolling

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
~~- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
~~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~