### PR TITLE
A4A: Add Form layout.

### DIFF
--- a/client/a8c-for-agencies/components/form/field/index.tsx
+++ b/client/a8c-for-agencies/components/form/field/index.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+import './style.scss';
+
+type Props = {
+	label: string;
+	description?: string;
+	children: ReactNode;
+};
+
+export default function FormField( { label, children, description }: Props ) {
+	return (
+		<div className="a4a-form__section-field">
+			<h3 className="a4a-form__section-field-label">{ label }</h3>
+
+			{ children }
+
+			{ description && <p className="a4a-form__section-field-description">{ description }</p> }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/form/field/style.scss
+++ b/client/a8c-for-agencies/components/form/field/style.scss
@@ -1,0 +1,20 @@
+.a4a-form__section-field {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.a4a-form__section-field-label,
+.a4a-form__section-field-description {
+	font-size: rem(14px);
+	line-height: 1.5;
+}
+
+.a4a-form__section-field-label {
+	font-weight: 500;
+}
+
+.a4a-form__section-field-description {
+	font-weight: 400;
+	color: var(--color-neutral-50);
+}

--- a/client/a8c-for-agencies/components/form/index.tsx
+++ b/client/a8c-for-agencies/components/form/index.tsx
@@ -1,0 +1,24 @@
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+
+import './style.scss';
+
+type Props = {
+	title?: string;
+	description?: string;
+	children: ReactNode;
+	className?: string;
+};
+
+export default function Form( { className, title, description, children }: Props ) {
+	return (
+		<form className={ clsx( 'a4a-form', className ) }>
+			<div className="a4a-form__heading">
+				{ title && <h1 className="a4a-form__heading-title">{ title }</h1> }
+				{ description && <p className="a4a-form__heading-description">{ description }</p> }
+			</div>
+
+			{ children }
+		</form>
+	);
+}

--- a/client/a8c-for-agencies/components/form/section/index.tsx
+++ b/client/a8c-for-agencies/components/form/section/index.tsx
@@ -5,14 +5,16 @@ import './style.scss';
 
 type Props = {
 	title?: string;
+	description?: string;
 	children: ReactNode;
 };
 
-export default function FormSection( { title, children }: Props ) {
+export default function FormSection( { title, description, children }: Props ) {
 	return (
 		<Card className="a4a-form__section" isRounded={ false }>
 			<div className="a4a-form__section-heading">
 				<h2 className="a4a-form__section-heading-title">{ title }</h2>
+				{ description && <p className="a4a-form__section-heading-description">{ description }</p> }
 			</div>
 
 			<div className="a4a-form__section-body">{ children }</div>

--- a/client/a8c-for-agencies/components/form/section/index.tsx
+++ b/client/a8c-for-agencies/components/form/section/index.tsx
@@ -1,0 +1,21 @@
+import { Card } from '@wordpress/components';
+import { ReactNode } from 'react';
+
+import './style.scss';
+
+type Props = {
+	title?: string;
+	children: ReactNode;
+};
+
+export default function FormSection( { title, children }: Props ) {
+	return (
+		<Card className="a4a-form__section" isRounded={ false }>
+			<div className="a4a-form__section-heading">
+				<h2 className="a4a-form__section-heading-title">{ title }</h2>
+			</div>
+
+			<div className="a4a-form__section-body">{ children }</div>
+		</Card>
+	);
+}

--- a/client/a8c-for-agencies/components/form/section/style.scss
+++ b/client/a8c-for-agencies/components/form/section/style.scss
@@ -10,8 +10,16 @@
 	font-weight: 500;
 }
 
+.a4a-form__section-heading-description {
+	font-size: rem(13px);
+	font-weight: 400;
+	color: var(--color-neutral-50);
+	line-height: 1.5;
+}
+
 .a4a-form__section-body {
 	display: flex;
 	flex-direction: column;
 	gap: 24px;
+	padding: 24px 0;
 }

--- a/client/a8c-for-agencies/components/form/section/style.scss
+++ b/client/a8c-for-agencies/components/form/section/style.scss
@@ -1,0 +1,17 @@
+
+.a4a-form__section {
+	padding: 16px 24px;
+	border-radius: 4px;
+}
+
+.a4a-form__section-heading-title {
+	font-size: rem(20px);
+	line-height: 1.3;
+	font-weight: 500;
+}
+
+.a4a-form__section-body {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}

--- a/client/a8c-for-agencies/components/form/style.scss
+++ b/client/a8c-for-agencies/components/form/style.scss
@@ -1,0 +1,25 @@
+.a4a-form {
+	display: flex;
+	flex-direction: column;
+	gap: 48px;
+
+	h1,
+	h2,
+	h3,
+	p {
+		margin: 0;
+		padding: 0;
+	}
+}
+
+.a4a-form__heading-title {
+	font-size: rem(24px);
+	line-height: 1.3;
+	font-weight: 600;
+}
+
+.a4a-form__heading-description {
+	font-size: rem(16px);
+	line-height: 1.5;
+	font-weight: 400;
+}


### PR DESCRIPTION
This pull request (PR) introduces a reusable form layout that can be utilized for form use cases.


## Proposed Changes

* Add the official A4A `Form,` `FormSection`, and `FormField` reusable components.

## Testing Instructions

* Spin up this branch locally.
* Consume the new Component. e.g. below

```
                <Form
			className="partner-directory-agency-expertise"
			title={ translate( 'Share your expertise' ) }
			description={ translate( "Pick your agency's specialties and choose your directories." ) }
		>
			<FormSection title={ translate( 'Product and Service' ) }>
				<FormField
					label={ translate( 'What services do you offer?' ) }
					description={ translate(
						'We allow each agency to offer up to five services to help you focus on what you do best.'
					) }
				>
					<FormTokenField
						label=""
						value={ services }
						onChange={ ( values ) => setServices( values as string[] ) }
						__experimentalShowHowTo={ false }
					/>
				</FormField>

				<FormField label={ translate( 'What products do you work with?' ) }>
					<FormTokenField
						label=""
						value={ products }
						onChange={ ( values ) => setProducts( values as string[] ) }
						__experimentalShowHowTo={ false }
					/>
				</FormField>
			</FormSection>

			<FormSection title={ translate( 'Partner Directories' ) }>test</FormSection>
		</Form>
```

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
