### PR TITLE
Scheduled Updates: Hide update status text and frequency column when data is expanded

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-last-run-status.tsx
@@ -37,9 +37,10 @@ export function ScheduleListLastRunStatus( {
 						variant="link"
 						onClick={ () => onLogsClick && onLogsClick( schedule.schedule_id, site?.slug ) }
 					>
-						{ site.last_run_status === 'in-progress'
-							? translate( 'In progress' )
-							: site.last_run_timestamp && prepareDateTime( site.last_run_timestamp ) }
+						{ showStatusText &&
+							( site.last_run_status === 'in-progress'
+								? translate( 'In progress' )
+								: site.last_run_timestamp && prepareDateTime( site.last_run_timestamp ) ) }
 					</Button>
 				) }
 			</>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -120,6 +120,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 						<td>
 							<ScheduleListLastRunStatus
 								schedule={ schedule }
+								showStatusText={ isWideScreen }
 								site={ site }
 								onLogsClick={ onLogsClick }
 							/>

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row.tsx
@@ -125,7 +125,7 @@ export const ScheduleListTableRow = ( props: Props ) => {
 							/>
 						</td>
 						<td></td>
-						<td></td>
+						<td className="frequency"></td>
 
 						<td></td>
 						<td className="active">


### PR DESCRIPTION
## Proposed Changes

* Multisite context, expanded data:
  * Hide frequency column
  * Hide status text when

## Why are these changes being made?

* Missed use cases from the previous PR: https://github.com/Automattic/wp-calypso/pull/91396

## Testing Instructions

* Go to `/plugins/scheduled-updates`
* Expand data, click on the arrow button in the first column
* Resize the screen
* Check if the "Activation" toggle is in the same column

| Before | After |
|--------|--------|
| <img width="597" alt="Screenshot 2024-06-04 at 13 03 20" src="https://github.com/Automattic/wp-calypso/assets/1241413/46a4f572-9557-4f74-9c08-cba189ae3b1a"> | <img width="534" alt="Screenshot 2024-06-04 at 13 03 29" src="https://github.com/Automattic/wp-calypso/assets/1241413/9cb1696a-3a8d-44df-9f18-110e4ac667f7"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
