### PR TITLE
Site Dashboard: Add See all backups link to the backup card

### DIFF
--- a/client/my-sites/hosting/site-backup-card/index.js
+++ b/client/my-sites/hosting/site-backup-card/index.js
@@ -1,20 +1,28 @@
+import { Button } from '@automattic/components';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { HostingCard } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useSelector } from 'calypso/state';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import getLastGoodRewindBackup from 'calypso/state/selectors/get-last-good-rewind-backup';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId } ) => {
+const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId, siteSlug } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 
 	const hasRetrievedLastBackup = lastGoodBackup !== null;
 	const [ isLoading, setIsLoading ] = useState( false );
+	const wpcomAdminInterface = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	);
 
 	useEffect( () => {
 		const shouldRequestLastBackup = ! disabled && ! hasRetrievedLastBackup && ! isLoading;
@@ -47,6 +55,17 @@ const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId } ) 
 							"If you restore your site using this backup, you'll lose any changes made after that date."
 						) }
 					</p>
+					<Button
+						className={ clsx( 'site-backup-card__button', 'hosting-overview__link-button' ) }
+						plain
+						href={
+							wpcomAdminInterface === 'wp-admin'
+								? `https://cloud.jetpack.com/backup/${ siteSlug }`
+								: `/backup/${ siteSlug }`
+						}
+					>
+						{ translate( 'See all backups' ) }
+					</Button>
 				</>
 			) }
 			{ ( ( hasRetrievedLastBackup && ! lastGoodBackup && ! isLoading ) || disabled ) && (
@@ -69,6 +88,7 @@ export default connect(
 		return {
 			lastGoodBackup: getLastGoodRewindBackup( state, siteId ),
 			siteId,
+			siteSlug: getSiteSlug( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/hosting/site-backup-card/style.scss
+++ b/client/my-sites/hosting/site-backup-card/style.scss
@@ -10,7 +10,7 @@
 	&__warning {
 		color: var(--color-text-subtle);
 		font-size: $font-body-small;
-		margin-bottom: 0;
+		margin-bottom: 16px;
 	}
 
 	&__placeholder {
@@ -25,6 +25,10 @@
 		&:last-child {
 			margin-bottom: 0;
 		}
+	}
+
+	&__button.hosting-overview__link-button {
+		font-size: $font-body;
 	}
 
 	&.is-disabled {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7594

## Proposed Changes

* Add `See all backups` link to the backup card

![image](https://github.com/Automattic/wp-calypso/assets/13596067/a0cf6ac9-b6f9-4d95-bf6f-5c17350902e3)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select a atomic site
* Make sure you can see the `See all backups` link on the backup card
* Click the link
* Make sure it opens the correct page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
