### PR TITLE
Render Agency Managed Plan in sites overview

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -38,7 +38,7 @@ const PricingSection: FC = () => {
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );
-	const planPurchaseLoading = planPurchase === null;
+	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
 	const isLoading = ! pricing || ! planData || planPurchaseLoading;
 
 	const getBillingDetails = () => {
@@ -166,7 +166,7 @@ const PlanCard: FC = () => {
 	const planName = isAgencyPurchase
 		? purchaseType( planPurchase )
 		: planDetails?.product_name_short ?? '';
-	const planPurchaseLoading = planPurchase === null;
+	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
 	const isLoading = ! planDetails || planPurchaseLoading;
 
 	// Check for storage addons available for purchase.

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -12,6 +12,7 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import { HostingCard } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PlanStorageBar from 'calypso/hosting-overview/components/plan-storage-bar';
+import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { isStagingSite } from 'calypso/sites-dashboard/utils';
@@ -19,7 +20,7 @@ import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-p
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
 
 const PricingSection: FC = () => {
 	const translate = useTranslate();
@@ -29,6 +30,7 @@ const PricingSection: FC = () => {
 	const planSlug = ( planDetails?.product_slug || '' ) as PlanSlug;
 	const planData = useSelector( ( state ) => getCurrentPlan( state, site?.ID ) );
 	const isFreePlan = planDetails?.is_free;
+	const planPurchase = useSelector( getSelectedPurchase );
 	const pricing = usePricingMetaForGridPlans( {
 		coupon: undefined,
 		planSlugs: [ planSlug ],
@@ -36,12 +38,14 @@ const PricingSection: FC = () => {
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );
-	const isLoading = ! pricing || ! planData;
+	const planPurchaseLoading = planPurchase === null;
+	const isLoading = ! pricing || ! planData || planPurchaseLoading;
 
 	const getBillingDetails = () => {
 		if ( isFreePlan ) {
 			return null;
 		}
+
 		return translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
 			args: {
 				rawPrice: formatCurrency(
@@ -147,7 +151,6 @@ const PlanCard: FC = () => {
 	const translate = useTranslate();
 	const site = useSelector( getSelectedSite );
 	const planDetails = site?.plan;
-	const planName = planDetails?.product_name_short ?? '';
 	const isFreePlan = planDetails?.is_free;
 	const isJetpack = useSelector( ( state ) =>
 		isJetpackSite( state, site?.ID, { treatAtomicAsJetpackSite: false } )
@@ -157,6 +160,14 @@ const PlanCard: FC = () => {
 	const planPurchaseId = useSelector( ( state: IAppState ) =>
 		getCurrentPlanPurchaseId( state, site?.ID ?? 0 )
 	);
+	const planPurchase = useSelector( getSelectedPurchase );
+	const isAgencyPurchase = planPurchase && isPartnerPurchase( planPurchase );
+	// Show that this is an Agency Managed plan for agency purchases.
+	const planName = isAgencyPurchase
+		? purchaseType( planPurchase )
+		: planDetails?.product_name_short ?? '';
+	const planPurchaseLoading = planPurchase === null;
+	const isLoading = ! planDetails || planPurchaseLoading;
 
 	// Check for storage addons available for purchase.
 	const addOns = AddOns.useAddOns( { selectedSiteId: site?.ID } );
@@ -164,7 +175,7 @@ const PlanCard: FC = () => {
 		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE && ! addOn?.exceedsSiteStorageLimits
 	);
 	const renderManageButton = () => {
-		if ( isJetpack || ! site || isStaging ) {
+		if ( isJetpack || ! site || isStaging || isAgencyPurchase ) {
 			return false;
 		}
 		if ( isFreePlan ) {
@@ -202,12 +213,18 @@ const PlanCard: FC = () => {
 			<QuerySitePlans siteId={ site?.ID } />
 			<HostingCard className="hosting-overview__plan">
 				<div className="hosting-overview__plan-card-header">
-					<h3 className="hosting-overview__plan-card-title">
-						{ isStaging ? translate( 'Staging site' ) : planName }
-					</h3>
-					{ renderManageButton() }
+					{ isLoading ? (
+						<LoadingPlaceholder width="100px" height="16px" />
+					) : (
+						<>
+							<h3 className="hosting-overview__plan-card-title">
+								{ isStaging ? translate( 'Staging site' ) : planName }
+							</h3>
+							{ renderManageButton() }
+						</>
+					) }
 				</div>
-				{ ! isStaging && (
+				{ ! isStaging && ! isAgencyPurchase && (
 					<>
 						<PricingSection />
 						<PlanStorage


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7585

## Proposed Changes

* Render "Agency Managed Plan" in sites overview for Creator Plans purchased through A4A

> [!NOTE]  
> Other known issues are mentioned p1717502139334549-slack-C06DN6QQVAQ

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The original screen attached in the issue is weird

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites dashboard for an A4A site, I used the Agency demo account to test

![agency](https://github.com/Automattic/wp-calypso/assets/6586048/dcc21c37-d376-4977-b41b-91017b769365)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?