### PR TITLE
Command palette: Add support for wildcard keywords 

### DIFF
--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -126,7 +126,7 @@ export function useCommands() {
 					_x( 'manage sites', 'Keyword for the View my sites command', __i18n_text_domain__ ),
 					_x( 'sites dashboard', 'Keyword for the View my sites command', __i18n_text_domain__ ),
 					'wp site', // WP-CLI command
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				icon: wordpressIcon,
 			},
 			switchSite: {
@@ -135,7 +135,7 @@ export function useCommands() {
 				searchLabel: [
 					_x( 'change site', 'Keyword for the Switch site command', __i18n_text_domain__ ),
 					_x( 'swap site', 'Keyword for the Switch site command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to switch to', __i18n_text_domain__ ),
 				callback: ( params ) => {
@@ -163,7 +163,7 @@ export function useCommands() {
 					_x( 'help center', 'Keyword for the Get help command', __i18n_text_domain__ ),
 					_x( 'send feedback', 'Keyword for the Get help command', __i18n_text_domain__ ),
 					'wp help', // WP-CLI command
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				icon: helpIcon,
 			},
 			clearCache: {
@@ -228,8 +228,8 @@ export function useCommands() {
 						'Keyword for the Manage cache settings command',
 						__i18n_text_domain__
 					),
-					'wp cache', // WP-CLI command
-				].join( ' ' ),
+					'wp cache*', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage cache settings', __i18n_text_domain__ ),
 				...siteFilters.hostingEnabled,
@@ -248,7 +248,7 @@ export function useCommands() {
 					_x( 'visit site', 'Keyword for the Visit site dashboard command', __i18n_text_domain__ ),
 					_x( 'see site', 'Keyword for the Visit site dashboard command', __i18n_text_domain__ ),
 					_x( 'browse site', 'Keyword for the Visit site dashboard command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/wp-admin', '/:site' ],
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to visit the homepage', __i18n_text_domain__ ),
@@ -270,7 +270,7 @@ export function useCommands() {
 					_x( 'admin', 'Keyword for the Open site dashboard command', __i18n_text_domain__ ),
 					_x( 'wp-admin', 'Keyword for the Open site dashboard command', __i18n_text_domain__ ),
 					'wp admin', // WP-CLI command
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/sites' ],
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open dashboard', __i18n_text_domain__ ),
@@ -343,8 +343,7 @@ export function useCommands() {
 						__i18n_text_domain__
 					),
 					'wp cli', // WP-CLI command
-					'wp db', // WP-CLI command
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/sites' ],
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open hosting configuration', __i18n_text_domain__ ),
@@ -379,7 +378,8 @@ export function useCommands() {
 						'Keyword for the Open database in phpMyAdmin command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+					'wp db*', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/sites' ],
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open phpMyAdmin', __i18n_text_domain__ ),
@@ -395,7 +395,7 @@ export function useCommands() {
 					_x( 'account', 'Keyword for the Open my profile command', __i18n_text_domain__ ),
 					_x( 'display name', 'Keyword for the Open my profile command', __i18n_text_domain__ ),
 					_x( 'gravatar', 'Keyword for the Open my profile command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/sites' ],
 				icon: profileIcon,
 			},
@@ -410,7 +410,7 @@ export function useCommands() {
 						__i18n_text_domain__
 					),
 					_x( 'profile', 'Keyword for the View developer features command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				icon: codeIcon,
 			},
 			openReader: {
@@ -442,7 +442,7 @@ export function useCommands() {
 						'Keyword for the Open My Jetpack command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/wp-admin/admin.php?page=my-jetpack' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open My Jetpack', __i18n_text_domain__ ),
@@ -480,7 +480,7 @@ export function useCommands() {
 						'Keyword for Add Jetpack to a self-hosted site command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				icon: <JetpackLogo size={ 18 } />,
 			},
 			manageJetpackModules: {
@@ -510,7 +510,7 @@ export function useCommands() {
 						'Keyword for Import site to WordPress.com command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				icon: downloadIcon,
 			},
 			addNewSite: {
@@ -521,7 +521,7 @@ export function useCommands() {
 					_x( 'add new site', 'Keyword for the Add new site command', __i18n_text_domain__ ),
 					_x( 'create site', 'Keyword for the Add new site command', __i18n_text_domain__ ),
 					'wp site create', // WP-CLI command
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/sites' ],
 				icon: plusIcon,
 			},
@@ -538,8 +538,8 @@ export function useCommands() {
 					_x( 'profile', 'Keyword for the Open account settings command', __i18n_text_domain__ ),
 					_x( 'email', 'Keyword for the Open account settings command', __i18n_text_domain__ ),
 					_x( 'language', 'Keyword for the Open account settings command', __i18n_text_domain__ ),
-					'wp language', // WP-CLI command
-				].join( ' ' ),
+					'wp language*', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				icon: profileIcon,
 			},
 			accessPurchases: {
@@ -570,7 +570,7 @@ export function useCommands() {
 					),
 					_x( 'subscriptions', 'Keyword for the View my purchases command', __i18n_text_domain__ ),
 					_x( 'upgrades', 'Keyword for the View my purchases command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/sites' ],
 				icon: creditCardIcon,
 			},
@@ -599,7 +599,7 @@ export function useCommands() {
 					_x( 'nameservers', 'Keyword for the Manage domains command', __i18n_text_domain__ ),
 					_x( 'subdomains', 'Keyword for the Manage domains command', __i18n_text_domain__ ),
 					_x( 'whois', 'Keyword for the Manage domains command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/sites' ],
 				icon: domainsIcon,
 			},
@@ -616,7 +616,7 @@ export function useCommands() {
 					_x( 'cname', 'Keyword for the Manage DNS records command', __i18n_text_domain__ ),
 					_x( 'mx', 'Keyword for the Manage DNS records command', __i18n_text_domain__ ),
 					_x( 'txt', 'Keyword for the Manage DNS records command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/sites' ],
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open DNS records', __i18n_text_domain__ ),
@@ -638,7 +638,7 @@ export function useCommands() {
 					_x( 'set up emails', 'Keyword for the Manage emails command', __i18n_text_domain__ ),
 					_x( 'manage email', 'Keyword for the Manage emails command', __i18n_text_domain__ ),
 					_x( 'manage emails', 'Keyword for the Manage emails command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage emails', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_OPTIONS,
@@ -724,7 +724,7 @@ export function useCommands() {
 						__i18n_text_domain__
 					),
 					_x( 'audit log', 'Keyword for the Open activity log command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						`${
@@ -776,7 +776,7 @@ export function useCommands() {
 					_x( 'open github deployments', 'Keyword for the Open GitHub Deployments command' ),
 					_x( 'github', 'Keyword for the Open GitHub Deployments command' ),
 					_x( 'deployments', 'Keyword for the Open GitHub Deployments command' ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open GitHub Deployments', __i18n_text_domain__ ),
 				...siteFilters.hostingEnabled,
@@ -814,7 +814,7 @@ export function useCommands() {
 					_x( 'fatal errors', 'Keyword for the Open PHP logs command', __i18n_text_domain__ ),
 					_x( 'php errors', 'Keyword for the Open PHP logs command', __i18n_text_domain__ ),
 					_x( 'php warnings', 'Keyword for the Open PHP logs command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/site-monitoring/:site/php' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open PHP logs', __i18n_text_domain__ ),
@@ -838,7 +838,7 @@ export function useCommands() {
 						'Keyword for the Open web server logs command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/site-monitoring/:site/web' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open web server logs', __i18n_text_domain__ ),
@@ -874,7 +874,7 @@ export function useCommands() {
 						'Keyword for the Manage staging sites command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/hosting-config/:site#staging-site' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage staging sites', __i18n_text_domain__ ),
@@ -904,7 +904,7 @@ export function useCommands() {
 						'Keyword for the Change admin interface style command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/hosting-config/:site#admin-interface-style' ),
 				siteSelector: true,
 				siteSelectorLabel: __(
@@ -922,7 +922,7 @@ export function useCommands() {
 					_x( 'create post', 'Keyword for the Add new post command', __i18n_text_domain__ ),
 					_x( 'write post', 'Keyword for the Add new post command', __i18n_text_domain__ ),
 					'wp post create', // WP-CLI command
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/posts', { path: '/wp-admin/edit.php', match: 'exact' } ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -972,7 +972,7 @@ export function useCommands() {
 					_x( 'edit category', 'Keyword for the Manage categories command', __i18n_text_domain__ ),
 					_x( 'add categories', 'Keyword for the Manage categories command', __i18n_text_domain__ ),
 					_x( 'add category', 'Keyword for the Manage categories command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/posts', { path: '/wp-admin/edit.php', match: 'exact' } ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -996,7 +996,7 @@ export function useCommands() {
 					_x( 'edit tag', 'Keyword for the Manage tags command', __i18n_text_domain__ ),
 					_x( 'add tags', 'Keyword for the Manage tags command', __i18n_text_domain__ ),
 					_x( 'add tag', 'Keyword for the Manage tags command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/posts', { path: '/wp-admin/edit.php', match: 'exact' } ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1024,8 +1024,8 @@ export function useCommands() {
 						'Keyword for the View media uploads command',
 						__i18n_text_domain__
 					),
-					'wp media', // WP-CLI command
-				].join( ' ' ),
+					'wp media*', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/upload.php' : '/media/:site'
@@ -1054,7 +1054,7 @@ export function useCommands() {
 					_x( 'manage pages', 'Keyword for the Manage pages command', __i18n_text_domain__ ),
 					_x( 'edit pages', 'Keyword for the Manage pages command', __i18n_text_domain__ ),
 					_x( 'delete pages', 'Keyword for the Manage pages command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site )
@@ -1073,7 +1073,7 @@ export function useCommands() {
 					_x( 'add new page', 'Keyword for the Add new page command', __i18n_text_domain__ ),
 					_x( 'create page', 'Keyword for the Add new page command', __i18n_text_domain__ ),
 					_x( 'write page', 'Keyword for the Add new page command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/pages', '/wp-admin/edit.php?post_type=page' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1093,8 +1093,8 @@ export function useCommands() {
 					_x( 'manage comments', 'Keyword for the Manage comments command', __i18n_text_domain__ ),
 					_x( 'edit comments', 'Keyword for the Manage comments command', __i18n_text_domain__ ),
 					_x( 'delete comments', 'Keyword for the Manage comments command', __i18n_text_domain__ ),
-					'wp comment', // WP-CLI command
-				].join( ' ' ),
+					'wp comment*', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site )
@@ -1111,7 +1111,7 @@ export function useCommands() {
 				label: __( 'View form responses', __i18n_text_domain__ ),
 				searchLabel: [
 					_x( 'feedback', 'Keyword for the View form responses command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/wp-admin/edit.php?post_type=feedback' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to view form responses', __i18n_text_domain__ ),
@@ -1159,7 +1159,7 @@ export function useCommands() {
 						'Keyword for the Open Crowdsignal command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/wp-admin/admin.php?page=polls' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open Crowdsignal', __i18n_text_domain__ ),
@@ -1173,7 +1173,7 @@ export function useCommands() {
 				label: __( 'View ratings', __i18n_text_domain__ ),
 				searchLabel: [
 					_x( 'feedback', 'Keyword for the View ratings command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/wp-admin/admin.php?page=ratings' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to view ratings', __i18n_text_domain__ ),
@@ -1190,8 +1190,8 @@ export function useCommands() {
 					_x( 'activate theme', 'Keyword for the Manage themes command', __i18n_text_domain__ ),
 					_x( 'install theme', 'Keyword for the Manage themes command', __i18n_text_domain__ ),
 					_x( 'delete theme', 'Keyword for the Manage themes command', __i18n_text_domain__ ),
-					'wp theme', // WP-CLI command
-				].join( ' ' ),
+					'wp theme*', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/themes.php' : '/themes/:site'
@@ -1209,7 +1209,8 @@ export function useCommands() {
 					_x( 'install theme', 'Keyword for the Install theme command', __i18n_text_domain__ ),
 					_x( 'add theme', 'Keyword for the Install theme command', __i18n_text_domain__ ),
 					_x( 'upload theme', 'Keyword for the Install theme command', __i18n_text_domain__ ),
-				].join( ' ' ),
+					'wp theme install', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site )
@@ -1228,7 +1229,7 @@ export function useCommands() {
 				searchLabel: [
 					_x( 'customize site', 'Keyword for the Open site editor command', __i18n_text_domain__ ),
 					_x( 'edit site', 'Keyword for the Open site editor command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/wp-admin/site-editor.php' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open site editor', __i18n_text_domain__ ),
@@ -1247,8 +1248,8 @@ export function useCommands() {
 					_x( 'install plugin', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
 					_x( 'delete plugin', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
 					_x( 'update plugin', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
-					'wp plugin', // WP-CLI command
-				].join( ' ' ),
+					'wp plugin*', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/plugins.php' : '/plugins/:site'
@@ -1267,7 +1268,7 @@ export function useCommands() {
 					_x( 'add plugin', 'Keyword for the Install plugin command', __i18n_text_domain__ ),
 					_x( 'upload plugin', 'Keyword for the Install plugin command', __i18n_text_domain__ ),
 					'wp plugin install', // WP-CLI command
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site )
@@ -1294,7 +1295,7 @@ export function useCommands() {
 						'Keyword for the Manage scheduled plugin updates command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/plugins/scheduled-updates/:site' ),
 				siteSelector: true,
 				siteSelectorLabel: __(
@@ -1312,7 +1313,7 @@ export function useCommands() {
 					_x( 'upgrade plan', 'Keyword for the Change site plan command', __i18n_text_domain__ ),
 					_x( 'change plan', 'Keyword for the Change site plan command', __i18n_text_domain__ ),
 					_x( 'add plan', 'Keyword for the Change site plan command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/plans/:site' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to change plan', __i18n_text_domain__ ),
@@ -1328,7 +1329,7 @@ export function useCommands() {
 					_x( 'upgrade plan', 'Keyword for the Manage site plan command', __i18n_text_domain__ ),
 					_x( 'manage plan', 'Keyword for the Manage site plan command', __i18n_text_domain__ ),
 					_x( 'plan features', 'Keyword for the Manage site plan command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/plans/my-plan/:site' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage your plan', __i18n_text_domain__ ),
@@ -1346,7 +1347,7 @@ export function useCommands() {
 					_x( 'buy add-ons', 'Keyword for the Buy add-ons command', __i18n_text_domain__ ),
 					_x( 'add extensions', 'Keyword for the Buy add-ons command', __i18n_text_domain__ ),
 					_x( 'expand plan', 'Keyword for the Buy add-ons command', __i18n_text_domain__ ),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: commandNavigation( '/add-ons/:site' ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage add-ons', __i18n_text_domain__ ),
@@ -1365,8 +1366,8 @@ export function useCommands() {
 					_x( 'edit user', 'Keyword for the Manage users command', __i18n_text_domain__ ),
 					_x( 'remove user', 'Keyword for the Manage users command', __i18n_text_domain__ ),
 					_x( 'update user', 'Keyword for the Manage users command', __i18n_text_domain__ ),
-					'wp user', // WP-CLI command
-				].join( ' ' ),
+					'wp user*', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/users.php' : '/people/team/:site'
@@ -1384,7 +1385,7 @@ export function useCommands() {
 					_x( 'create user', 'Keyword for the Add new user command', __i18n_text_domain__ ),
 					_x( 'invite user', 'Keyword for the Add new user command', __i18n_text_domain__ ),
 					'wp user create', // WP-CLI command
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/user-new.php' : '/people/new/:site'
@@ -1409,7 +1410,7 @@ export function useCommands() {
 						'Keyword for the Add subscribers command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						`${
@@ -1532,7 +1533,7 @@ export function useCommands() {
 						'Keyword for the Manage general settings command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1574,7 +1575,7 @@ export function useCommands() {
 						'Keyword for the Manage writing settings command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1616,7 +1617,7 @@ export function useCommands() {
 						'Keyword for the Manage reading settings command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1653,7 +1654,7 @@ export function useCommands() {
 						'Keyword for the Manage discussion settings command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1685,7 +1686,7 @@ export function useCommands() {
 						'Keyword for the Manage media settings command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: commandNavigation( '/wp-admin/options-media.php' ),
 				siteSelector: true,
@@ -1732,7 +1733,7 @@ export function useCommands() {
 						'Keyword for the Manage performance settings command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: ( params ) =>
 					commandNavigation(
@@ -1775,7 +1776,7 @@ export function useCommands() {
 						'Keyword for the Manage privacy settings command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: commandNavigation( '/wp-admin/options-privacy.php' ),
 				siteSelector: true,
@@ -1792,7 +1793,7 @@ export function useCommands() {
 						'Keyword for the Manage Crowdsignal settings command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: commandNavigation( '/wp-admin/options-general.php?page=crowdsignal-settings' ),
 				siteSelector: true,
@@ -1814,7 +1815,7 @@ export function useCommands() {
 						'Keyword for the Manage ratings settings command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
 				callback: commandNavigation( '/wp-admin/options-general.php?page=ratingsettings' ),
 				siteSelector: true,
@@ -1832,7 +1833,7 @@ export function useCommands() {
 						'Keyword for the Open marketing tools command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open marketing tools', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_OPTIONS,
@@ -1896,7 +1897,7 @@ export function useCommands() {
 						'Keyword for the Open monetization tools command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open monetization tools', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_OPTIONS,
@@ -1914,7 +1915,7 @@ export function useCommands() {
 						'Keyword for the Open theme file editor command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open theme file editor', __i18n_text_domain__ ),
 				siteType: SiteType.ATOMIC,
@@ -1931,7 +1932,7 @@ export function useCommands() {
 						'Keyword for the Open plugin file editor command',
 						__i18n_text_domain__
 					),
-				].join( ' ' ),
+				].join( KEYWORD_SEPARATOR ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to open plugin file editor', __i18n_text_domain__ ),
 				siteType: SiteType.ATOMIC,

--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -44,6 +44,7 @@ import {
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
+import { KEYWORD_SEPARATOR } from './use-command-filter';
 import { commandNavigation, siteUsesWpAdminInterface } from './utils';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -938,8 +939,8 @@ export function useCommands() {
 				searchLabel: [
 					_x( 'manage posts', 'Keyword for the Manage posts command', __i18n_text_domain__ ),
 					_x( 'edit posts', 'Keyword for the Manage posts command', __i18n_text_domain__ ),
-					'wp post', // WP-CLI command
-				].join( ' ' ),
+					'wp post*', // WP-CLI command
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/edit.php' : '/posts/:site'

--- a/packages/command-palette/src/use-command-filter.ts
+++ b/packages/command-palette/src/use-command-filter.ts
@@ -5,15 +5,15 @@ export const useCommandFilter = () => {
 		const lowercaseValue = value.toLowerCase();
 		const lowercaseSearch = search.toLowerCase().trim();
 
-		const [ beforeSeparator, afterSeparator ] = lowercaseValue.split( COMMAND_SEPARATOR );
+		const [ commandLabel, keywords ] = lowercaseValue.split( COMMAND_SEPARATOR );
 
 		// Check if the search matches the part before the separator
-		if ( beforeSeparator.includes( lowercaseSearch ) ) {
+		if ( commandLabel.includes( lowercaseSearch ) ) {
 			return 1;
 		}
 
 		// Check if there is an afterSeparator and the search matches it
-		if ( afterSeparator?.includes( lowercaseSearch ) ) {
+		if ( keywords?.includes( lowercaseSearch ) ) {
 			return 0.5;
 		}
 

--- a/packages/command-palette/src/use-command-filter.ts
+++ b/packages/command-palette/src/use-command-filter.ts
@@ -1,4 +1,5 @@
 export const COMMAND_SEPARATOR = '|~~~|';
+export const KEYWORD_SEPARATOR = '|~kw~|';
 
 export const useCommandFilter = () => {
 	const commandFilter = ( value: string, search: string ) => {
@@ -15,6 +16,16 @@ export const useCommandFilter = () => {
 		// Check if there is an afterSeparator and the search matches it
 		if ( keywords?.includes( lowercaseSearch ) ) {
 			return 0.5;
+		}
+
+		// Check if any of the keywords allow wildcards, this is indicated by a trailing *
+		const wildcardKeywords = ( keywords ?? '' )
+			.split( KEYWORD_SEPARATOR )
+			.filter( ( keyword ) => keyword.slice( -1 ) === '*' )
+			.map( ( keyword ) => keyword.slice( 0, -1 ) );
+
+		if ( wildcardKeywords.some( ( keyword ) => lowercaseSearch.startsWith( keyword ) ) ) {
+			return 0.4;
 		}
 
 		// No match

--- a/packages/command-palette/src/use-command-filter.ts
+++ b/packages/command-palette/src/use-command-filter.ts
@@ -1,6 +1,10 @@
 export const COMMAND_SEPARATOR = '|~~~|';
 export const KEYWORD_SEPARATOR = '|~kw~|';
 
+// Note that until we upgrade to cmdk@1 or above, the scoring system is only used for filtering.
+// Scores of zero are ommited from the results and scores above zero are all treated as equal.
+// See https://github.com/pacocoursey/cmdk/pull/182
+
 export const useCommandFilter = () => {
 	const commandFilter = ( value: string, search: string ) => {
 		const lowercaseValue = value.toLowerCase();

--- a/packages/command-palette/test/use-command-filter.tsx
+++ b/packages/command-palette/test/use-command-filter.tsx
@@ -1,4 +1,4 @@
-import { COMMAND_SEPARATOR, useCommandFilter } from '../src/use-command-filter';
+import { COMMAND_SEPARATOR, KEYWORD_SEPARATOR, useCommandFilter } from '../src/use-command-filter';
 
 describe( 'useCommandFilter', () => {
 	const commandFilter = useCommandFilter();
@@ -49,5 +49,21 @@ describe( 'useCommandFilter', () => {
 		const afterSeparator = 'hosting manage';
 		const value = beforeSeparator + COMMAND_SEPARATOR + afterSeparator;
 		expect( commandFilter( value, search ) ).toBe( 0 );
+	} );
+
+	test( 'Should return 0.5 for an exact match on a wildcard term', () => {
+		const search = 'wp post';
+		const beforeSeparator = 'Manage posts';
+		const value =
+			beforeSeparator + COMMAND_SEPARATOR + 'edit posts' + KEYWORD_SEPARATOR + 'wp post*';
+		expect( commandFilter( value, search ) ).toBe( 0.5 );
+	} );
+
+	test( 'Should return 0.4 where there is a wildcard match', () => {
+		const search = 'wp post get';
+		const beforeSeparator = 'Manage posts';
+		const value =
+			beforeSeparator + COMMAND_SEPARATOR + 'edit posts' + KEYWORD_SEPARATOR + 'wp post*';
+		expect( commandFilter( value, search ) ).toBe( 0.4 );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91281

## Proposed Changes

1. Enable the `searchLabel` substrings to be opted into being treated as a wildcard
2. Mark several wp-cli related commands as wildcard

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

So that a command search for `wp post get` will return a link to the manage posts command rather than nothing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Search for `wp post get`
3. Notice you get related commands in the command search results.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
