### PR TITLE
Guided onboarding: fix back button in domains step

### DIFF
--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -13,27 +13,50 @@ import { SKIP_ANSWER_KEY } from './constants';
 import useSegmentationSurveyNavigation from './hooks/use-segmentation-survey-navigation';
 
 type SegmentationSurveyProps = {
+	/**
+	 * The key of the survey to render.
+	 */
 	surveyKey: string;
+	/**
+	 * A function that will be called when the user navigates back.
+	 */
 	onBack?: () => void;
+	/**
+	 * A function that will be called when the user navigates forward.
+	 */
 	onNext?: ( questionKey: string, answerKeys: string[], isLastQuestion?: boolean ) => void;
+	/**
+	 * A function that determines whether to skip the next navigation.
+	 */
 	skipNextNavigation?: ( questionKey: string, answerKeys: string[] ) => boolean;
+	/**
+	 * The alignment of the header text.
+	 */
 	headerAlign?: string;
+	/**
+	 * The configuration for the questions.
+	 */
 	questionConfiguration?: QuestionConfiguration;
+	/**
+	 * A map of question types to components.
+	 */
 	questionComponentMap?: QuestionComponentMap;
+	/**
+	 * Whether to clear the answers after the last question.
+	 */
 	clearAnswersOnLastQuestion?: boolean;
+	/**
+	 * Requires `providedPage` prop. If you want to manage your own navigation, you can provide a function that navigates to a specific page.
+	 */
+	onGoToPage?: ( page: number ) => void;
+	/**
+	 * Requires `onGoToPage` prop. If you want to manage your own navigation, you can provide the current page number.
+	 */
+	providedPage?: number;
 };
 
 /**
  * A component that renders a segmentation survey.
- * @param {SegmentationSurveyProps} props
- * @param {string} props.surveyKey - The key of the survey to render.
- * @param {() => void} [props.onBack] - A function that navigates to the previous step.
- * @param {(questionKey: string, answerKeys: string[], isLastQuestion?: boolean) => void} [props.onNext] - A function that navigates to the next question/step.
- * @param {string} [props.headerAlign] - The alignment of the header text.
- * @param {QuestionConfiguration} [props.questionConfiguration] - The configuration for the questions.
- * @param {QuestionComponentMap} [props.questionComponentMap] - A map of question types to components.
- * @param {boolean} [props.clearAnswersOnLastQuestion] - Whether to clear the answers after the last question.
- * @returns {React.ReactComponentElement}
  */
 const SegmentationSurvey = ( {
 	surveyKey,
@@ -44,6 +67,8 @@ const SegmentationSurvey = ( {
 	questionConfiguration,
 	questionComponentMap,
 	clearAnswersOnLastQuestion = true,
+	onGoToPage,
+	providedPage,
 }: SegmentationSurveyProps ) => {
 	const { data: questions } = useSurveyStructureQuery( { surveyKey } );
 	const { mutateAsync, isPending } = useSaveAnswersMutation( { surveyKey } );
@@ -115,6 +140,8 @@ const SegmentationSurvey = ( {
 			questions,
 			surveyKey,
 			skipNextNavigation,
+			onGoToPage,
+			providedPage,
 		} );
 
 	if ( ! questions ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1414,6 +1414,8 @@ export class RenderDomainsStep extends Component {
 			backLabelText = translate( 'Back to themes' );
 		} else if ( 'plans-first' === flowName ) {
 			backUrl = getStepUrl( flowName, previousStepName );
+		} else if ( 'guided' === flowName ) {
+			backUrl = getStepUrl( flowName, previousStepName );
 		} else {
 			backUrl = getStepUrl( flowName, stepName, null, this.getLocale() );
 

--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -21,6 +21,7 @@ interface Props {
 			segmentationSurveyAnswers: Record< string, string[] >;
 		}
 	>;
+	progress: Record< string, any >;
 }
 
 const SURVEY_KEY = 'guided-onboarding-flow';
@@ -38,7 +39,8 @@ const QUESTION_CONFIGURATION: QuestionConfiguration = {
 };
 
 export default function InitialIntentStep( props: Props ) {
-	const { submitSignupStep, stepName, signupDependencies, flowName } = props;
+	const { submitSignupStep, stepName, signupDependencies, flowName, progress } = props;
+	const currentPage = progress[ stepName ]?.stepSectionName ?? 1;
 	const currentAnswers = signupDependencies.segmentationSurveyAnswers || {};
 	const translate = useTranslate();
 	const headerText = translate( 'What brings you to WordPress.com?' );
@@ -129,6 +131,10 @@ export default function InitialIntentStep( props: Props ) {
 					skipNextNavigation={ skipNextNavigation }
 					questionConfiguration={ QUESTION_CONFIGURATION }
 					questionComponentMap={ flowQuestionComponentMap }
+					onGoToPage={ ( stepSectionName: number ) =>
+						submitSignupStep( { flowName, stepName, stepSectionName }, {} )
+					}
+					providedPage={ currentPage }
 				/>
 			}
 			align="center"


### PR DESCRIPTION
## Proposed Changes

The guided onboarding flow is one of the handle signup flows in /start that don't start with the domain step, this adds the `guided` flow to the list of flows that have the generic "Back" button.

## Testing Instructions

1. Go to /start/guided.
2. Reach the domain step.
3. The Back button should say "Back".
4. Clicking it should take you back to the survey.

**Note**: there is another issue that the two segmentation survey steps count as one from the framework's perspective. So the back button will take you to the start of the survey. I'll send a separate PR for that.