### PR TITLE
A4A > Partner Directory: Implement Partner Directory In-Progress view

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -1,11 +1,12 @@
-import { Button } from '@automattic/components';
-import { Icon, external } from '@wordpress/icons';
+import { BadgeType, Button } from '@automattic/components';
+import { Icon, external, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import StepSection from '../../referrals/common/step-section';
 import StepSectionItem from '../../referrals/common/step-section-item';
+import StatusBadge from '../../referrals/common/step-section-item/status-badge';
 
 import './style.scss';
 
@@ -21,6 +22,30 @@ export default function PartnerDirectoryDashboard() {
 		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_finish_profile_click' ) );
 	}, [ dispatch ] );
 
+	const isSubmitted = true; // FIXME: Replace with actual value
+	const brandStatuses = [
+		{
+			brand: 'WordPress.com',
+			status: 'Approved',
+			type: 'success',
+		},
+		{
+			brand: 'Woocommerce.com',
+			status: 'Pending',
+			type: 'warning',
+		},
+		{
+			brand: 'Pressable.com',
+			status: 'Pending',
+			type: 'warning',
+		},
+		{
+			brand: 'Jetpack.com',
+			status: 'Pending',
+			type: 'warning',
+		},
+	] as { brand: string; status: string; type: BadgeType }[]; // FIXME: Replace with actual value
+
 	return (
 		<>
 			<div className="partner-directory-dashboard__heading">
@@ -35,16 +60,30 @@ export default function PartnerDirectoryDashboard() {
 			<StepSection heading={ translate( 'How do I start?' ) }>
 				<StepSectionItem
 					isNewLayout
-					stepNumber={ 1 }
+					icon={ check }
+					stepNumber={ isSubmitted ? undefined : 1 }
 					heading={ translate( 'Share your expertise' ) }
-					description={ translate(
-						`Pick your agency's specialties and choose your directories. We'll review your application.`
-					) }
+					description={
+						isSubmitted && brandStatuses.length > 0 ? (
+							<div className="partner-directory-dashboard__brand-status-section">
+								{ brandStatuses.map( ( { brand, status, type } ) => (
+									<div key={ brand }>
+										<StatusBadge statusProps={ { children: status, type } } />
+										<span>{ brand }</span>
+									</div>
+								) ) }
+							</div>
+						) : (
+							translate(
+								`Pick your agency's specialties and choose your directories. We'll review your application.`
+							)
+						)
+					}
 					buttonProps={ {
-						children: translate( 'Apply now' ),
+						children: isSubmitted ? translate( 'Edit expertise' ) : translate( 'Apply now' ),
 						href: '/partner-directory/agency-expertise',
 						onClick: onApplyNowClick,
-						primary: true,
+						primary: ! isSubmitted,
 						compact: true,
 					} }
 				/>
@@ -59,8 +98,8 @@ export default function PartnerDirectoryDashboard() {
 						children: translate( 'Finish profile' ),
 						href: '/partner-directory/agency-details',
 						onClick: onFinishProfileClick,
-						primary: false,
-						disabled: true,
+						primary: isSubmitted,
+						disabled: ! isSubmitted,
 						compact: true,
 					} }
 				/>

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
@@ -2,6 +2,15 @@
 	.a4a-layout__body-wrapper {
 		max-width: 700px;
 	}
+
+	svg.sidebar__menu-icon {
+		width: 20px;
+		height: 20px;
+		padding: 2px;
+		background: var(--color-success-50);
+		border-radius: 50%;
+		fill: var(--color-text-white);
+	}
 }
 
 .partner-directory-dashboard__heading {
@@ -29,5 +38,22 @@
 
 	.step-section__header {
 		margin-block-end: 0;
+	}
+}
+
+.partner-directory-dashboard__brand-status-section {
+	margin-block-start: 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+
+	.badge {
+		min-width: 80px;
+		margin-inline-end: 8px;
+		text-align: center;
+	}
+
+	span {
+		color: var(--color-text-black);
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/index.tsx
@@ -48,12 +48,7 @@ export default function StepSectionItem( {
 		<div className={ clsx( 'step-section-item', className ) }>
 			{ icon && (
 				<div className={ clsx( 'step-section-item__icon', iconClassName ) }>
-					<Icon
-						className="sidebar__menu-icon"
-						style={ { fill: 'currentcolor' } }
-						icon={ icon }
-						size={ ICON_SIZE }
-					/>
+					<Icon className="sidebar__menu-icon" icon={ icon } size={ ICON_SIZE } />
 				</div>
 			) }
 			{ stepNumber && <span className="step-section-item__step-number">{ stepNumber }</span> }

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -15,6 +15,7 @@
 	.step-section-item__icon {
 		display: none;
 
+
 		@include break-large {
 			display: block;
 		}
@@ -139,4 +140,8 @@
 		align-items: center;
 		justify-content: center;
 	}
+}
+
+.sidebar__menu-icon {
+	fill: currentColor;
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/552

## Proposed Changes

This PR implements the in-progress view for the dashboard on the Partner Directory

NOTE: 

- [Design](https://www.figma.com/design/fp9lBFMcpB15H7czSIthPW/Partner-Directories?node-id=6644-77865&m=dev)

## Testing Instructions

1. Open the A4A live link.
2. Append the /referrals URL as /referrals?flags=-a4a-automated-referrals, and verify that the above changes are not reflected and that the Referrals page matches the production.
3. Go to Partner Directory - Dashboard > Verify the UI looks as below. 

<img width="1409" alt="Screenshot 2024-06-04 at 2 37 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4eaf3798-8012-4e70-975f-280cf7909b5b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
