### PR TITLE
Issue template: Remove team Calypso ping from GB upgrade

### DIFF
--- a/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
+++ b/.github/ISSUE_TEMPLATE/gutenberg-plugin-upgrade.md
@@ -41,7 +41,6 @@ As you complete the tasks in this list, please update the relevant lines with di
 
 **Publish internal announcements**
 
-- [ ] Slack: #team-calypso
 - [ ] Slack: #wpcom-happy-announce
 - [ ] P2: wpcomhappy
 


### PR DESCRIPTION
## Proposed Changes

In the issue template, remove the ping to Team Calypso in Slack after a GB upgrade

## Why are these changes being made?

Team Calypso no longer does the GB releases