### PR TITLE
Renovate: Update reviewer team

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -121,7 +121,7 @@
 
 	// --- Metadata settings for git ---
 	labels: [ 'Framework', '[Type] Task', 'dependencies' ],
-	reviewers: [ 'team:team-calypso' ],
+	reviewers: [ 'team:@automattic/calypso-dependency-updates' ],
 	branchPrefix: 'renovate/',
 	gitAuthor: 'Renovate Bot (self-hosted) <bot@renovateapp.com>',
 	platform: 'github',


### PR DESCRIPTION
## Proposed Changes

Change the team that receives the review requests for Renovate PRs.

## Why are these changes being made?

The team no longer maintains the Calypso dependencies.