### PR TITLE
A8C For Agencies: Fix empty and disabled states for site tags and add copy

### DIFF
--- a/client/a8c-for-agencies/components/agency-site-tags/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tags/index.tsx
@@ -29,8 +29,15 @@ export default function AgencySiteTags( { tags, isLoading, onAddTags, onRemoveTa
 		}
 	};
 
+	const isTagsSubmitDisabled = tagsInput === '' || ! tagsInput;
+
 	return (
 		<div className="agency-site-tags">
+			<p>
+				{ translate(
+					'Add tags to categorize your sites and easily filter through them on your Sites dashboard.'
+				) }
+			</p>
 			<Card className="agency-site-tags__controls">
 				<FormTextInput
 					disabled={ isLoading }
@@ -46,19 +53,22 @@ export default function AgencySiteTags( { tags, isLoading, onAddTags, onRemoveTa
 					primary
 					compact
 					busy={ isLoading }
+					disabled={ isTagsSubmitDisabled }
 					onClick={ handleAddTags }
 					className="agency-site-tags__button"
 				>
 					{ translate( 'Add' ) }
 				</Button>
 			</Card>
-			<Card tagName="ul" className="agency-site-tags__list">
-				{ tags.map( ( tag ) => (
-					<li>
-						<AgencySiteTag key={ tag } tag={ tag } onRemoveTag={ onRemoveTag } />
-					</li>
-				) ) }
-			</Card>
+			{ tags.length ? (
+				<Card tagName="ul" className="agency-site-tags__list">
+					{ tags.map( ( tag ) => (
+						<li>
+							<AgencySiteTag key={ tag } tag={ tag } onRemoveTag={ onRemoveTag } />
+						</li>
+					) ) }
+				</Card>
+			) : null }
 		</div>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* https://github.com/Automattic/automattic-for-agencies-dev/issues/600

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix empty and disabled states for site tags and add copy


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open agencies.localhost:3000/sites
* Select a site
* Got to 'Details'
* You should see no empty list of tags below the input field
* Submit button must be on disabled state if the tag input field is empty
* There should be an explanatory copy about the tags feature

Reference image below:
![image](https://github.com/Automattic/wp-calypso/assets/5550190/2326eef8-8996-4ae3-be7c-35735faf876d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
