### PR TITLE
Guided Onboarding: Switch to site-migration

### DIFF
--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -1,4 +1,4 @@
-import { IMPORT_HOSTED_SITE_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
+import { HOSTED_SITE_MIGRATION_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import SegmentationSurvey from 'calypso/components/segmentation-survey';
@@ -57,23 +57,24 @@ export default function InitialIntentStep( props: Props ) {
 	}, [] );
 
 	const getRedirectForAnswers = ( _answerKeys: string[] ): string => {
+		const referrer = 'guided-onboarding';
+		let redirect = '';
+
 		if ( _answerKeys.includes( 'migrate-or-import-site' ) ) {
-			return `/setup/${ IMPORT_HOSTED_SITE_FLOW }`;
+			redirect = `/setup/${ HOSTED_SITE_MIGRATION_FLOW }`;
+		} else if ( _answerKeys.includes( 'newsletter' ) ) {
+			redirect = `/setup/${ NEWSLETTER_FLOW }/newsletterSetup`;
+		} else if ( _answerKeys.includes( 'sell' ) && _answerKeys.includes( 'difm' ) ) {
+			redirect = '/start/do-it-for-me-store';
+		} else if ( _answerKeys.includes( 'difm' ) ) {
+			redirect = '/start/do-it-for-me';
 		}
 
-		if ( _answerKeys.includes( 'newsletter' ) ) {
-			return `/setup/${ NEWSLETTER_FLOW }/newsletterSetup`;
+		if ( redirect ) {
+			return `${ redirect }?ref=${ referrer }`;
 		}
 
-		if ( _answerKeys.includes( 'sell' ) && _answerKeys.includes( 'difm' ) ) {
-			return '/start/do-it-for-me-store';
-		}
-
-		if ( _answerKeys.includes( 'difm' ) ) {
-			return '/start/do-it-for-me';
-		}
-
-		return '';
+		return redirect;
 	};
 
 	const shouldExitOnSkip = ( _questionKey: string, _answerKeys: string[] ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1717506835598629-slack-C02T4NVL4JJ
Related to https://github.com/Automattic/dotcom-forge/issues/7555

## Proposed Changes

Switch from `import-hosted-site`  flow to `hosted-site-migration`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The new flow is much more robust, and uses Migrate Guru, increasing a lot the migration success %

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to ´/setup/guided´
* Choose migration
* You should be correctly redirected
* Check that the correct `/ref` is appended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?