### PR TITLE
A4A: Improve agency signup form spacing on mobile

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-form/style.scss
@@ -1,6 +1,13 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .agency-signup-form {
 	max-width: 720px;
-	padding: 56px 68px 68px;
+	padding: 56px 32px 68px;
+
+	@include break-small {
+		padding: 56px 68px 68px;
+	}
 
 	.agency-signup-form__logo {
 		display: block;


### PR DESCRIPTION
## Proposed Changes

* A4A: Improve agency signup form spacing on mobile

## Why are these changes being made?

* p1717513345239179-slack-C06JY8QL0TU

## Testing Instructions

* Open up http://agencies.localhost:3000/signup and confirm the form layout looks good on all breakpoints.

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-04 at 18 22 23](https://github.com/Automattic/wp-calypso/assets/22746396/a9510e3d-1544-4848-a420-ce75d141a5d5) | ![Screenshot 2024-06-04 at 18 22 20](https://github.com/Automattic/wp-calypso/assets/22746396/415151af-a55a-4f00-b665-2f50ae507825) |


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?