### PR TITLE
Fire a track event for Big Sky choice view

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -49,6 +49,14 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 		submit?.( { destination } );
 	};
 
+	const recordBigSkyView = () => {
+		recordTracksEvent( 'calypso_big_sky_view_choice', {
+			flow,
+			step: stepName,
+		} );
+		return true;
+	};
+
 	return (
 		<>
 			<DocumentHead title={ headerText } />
@@ -75,7 +83,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 								destination="pattern-assembler"
 								onSelect={ handleSubmit }
 							/>
-							{ isBigSkyEligible && (
+							{ isBigSkyEligible && recordBigSkyView() && (
 								<DesignChoice
 									className="design-choices__try-big-sky"
 									title={ translate( 'Try Big Sky' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90287 

## Proposed Changes

Fires a dedicated event when the Big Sky card is viewed on the /design-choices page. I could not find any existing props that are tracking it. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Need to determine the start of the funnel. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Head to `/setup/site-setup/design-choices?siteSlug=YOURSITE.wordpress.com` (replace the siteSlug with one of your Premium/Explorer sites)
- Submit `localStorage.setItem('debug', 'calypso:analytics');` to your browser console. 
- Refresh the page
- Observe the console logs. Should see the event come through
- Now use a `siteSlug` that does not have premium/explorer. When the card is not showing, the event should not fire. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
