### PR TITLE
Reader - Removed background color from Reader cards

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -35,7 +35,6 @@
 	margin: 0;
 	margin-bottom: 24px;
 	position: relative;
-	background: #FAFAFA; /* stylelint-disable color-hex-case */
 
 	@include breakpoint-deprecated( "<660px" ) {
 		background: none;


### PR DESCRIPTION
## Description

@crisbusquets and I had discussed removing the background color from cards in the reader. This PR does just that.

## Before

![CleanShot 2024-06-04 at 12 37 17@2x](https://github.com/Automattic/wp-calypso/assets/5634774/e52b60dd-e612-477f-a89b-3890e90b71d4)

## After

![CleanShot 2024-06-04 at 12 37 37@2x](https://github.com/Automattic/wp-calypso/assets/5634774/a92682ef-643e-44ac-9f90-68235f170b26)

## Testing notes

- Apply this PR
- Go to reader
- Click around in the various pages and make sure that the background has been removed from all cards.