### PR TITLE
Domains: Remove CTAs from Gravatar flow (2nd take)

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1724,6 +1724,7 @@ class RegisterDomainStep extends Component {
 		} = domainAvailability;
 
 		const { isSignupStep, includeOwnedDomainInSuggestions } = this.props;
+		const isGravatarFlow = this.props.flowName === 'domain-for-gravatar';
 
 		if (
 			( TRANSFERRABLE === error && this.state.lastDomainIsTransferrable ) ||
@@ -1737,7 +1738,7 @@ class RegisterDomainStep extends Component {
 		this.setState( {
 			showAvailabilityNotice: true,
 			availabilityError: error,
-			availabilityErrorData: errorData,
+			availabilityErrorData: isGravatarFlow ? { ...errorData, site: null } : errorData,
 			availabilityErrorDomain: domain,
 		} );
 	}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1721,6 +1721,7 @@ class RegisterDomainStep extends Component {
 			RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE,
 			SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE,
 			REGISTERED_OTHER_SITE_SAME_USER,
+			REGISTERED_SAME_SITE,
 		} = domainAvailability;
 
 		const { isSignupStep, includeOwnedDomainInSuggestions } = this.props;
@@ -1731,14 +1732,16 @@ class RegisterDomainStep extends Component {
 			RECENT_REGISTRATION_LOCK_NOT_TRANSFERRABLE === error ||
 			SERVER_TRANSFER_PROHIBITED_NOT_TRANSFERRABLE === error ||
 			( isSignupStep && DOTBLOG_SUBDOMAIN === error ) ||
-			( includeOwnedDomainInSuggestions && REGISTERED_OTHER_SITE_SAME_USER === error )
+			( includeOwnedDomainInSuggestions && REGISTERED_OTHER_SITE_SAME_USER === error ) ||
+			( isGravatarFlow &&
+				[ REGISTERED_OTHER_SITE_SAME_USER, REGISTERED_SAME_SITE ].includes( error ) )
 		) {
 			return;
 		}
 		this.setState( {
 			showAvailabilityNotice: true,
 			availabilityError: error,
-			availabilityErrorData: isGravatarFlow ? { ...errorData, site: null } : errorData,
+			availabilityErrorData: errorData,
 			availabilityErrorDomain: domain,
 		} );
 	}

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -58,27 +58,25 @@ function getAvailabilityNotice(
 			);
 			break;
 		case domainAvailability.REGISTERED_SAME_SITE:
-			if ( site ) {
-				message = translate(
-					'{{strong}}%(domain)s{{/strong}} is already registered on this site. {{a}}Are you trying to make this the primary address for your site?{{/a}}',
-					{
-						args: { domain },
-						components: {
-							strong: <strong />,
-							a: (
-								<SetAsPrimaryLink
-									domainName={ domain }
-									siteIdOrSlug={ site }
-									additionalProperties={ {
-										clickOrigin: 'use-a-domain-i-own',
-									} }
-									onSuccess={ () => page( domainManagementList( domain ) ) }
-								/>
-							),
-						},
-					}
-				);
-			}
+			message = translate(
+				'{{strong}}%(domain)s{{/strong}} is already registered on this site. {{a}}Are you trying to make this the primary address for your site?{{/a}}',
+				{
+					args: { domain },
+					components: {
+						strong: <strong />,
+						a: (
+							<SetAsPrimaryLink
+								domainName={ domain }
+								siteIdOrSlug={ site }
+								additionalProperties={ {
+									clickOrigin: 'use-a-domain-i-own',
+								} }
+								onSuccess={ () => page( domainManagementList( domain ) ) }
+							/>
+						),
+					},
+				}
+			);
 			break;
 		case domainAvailability.REGISTERED_OTHER_SITE_SAME_USER:
 			if ( site ) {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -58,25 +58,27 @@ function getAvailabilityNotice(
 			);
 			break;
 		case domainAvailability.REGISTERED_SAME_SITE:
-			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already registered on this site. {{a}}Are you trying to make this the primary address for your site?{{/a}}',
-				{
-					args: { domain },
-					components: {
-						strong: <strong />,
-						a: (
-							<SetAsPrimaryLink
-								domainName={ domain }
-								siteIdOrSlug={ site }
-								additionalProperties={ {
-									clickOrigin: 'use-a-domain-i-own',
-								} }
-								onSuccess={ () => page( domainManagementList( domain ) ) }
-							/>
-						),
-					},
-				}
-			);
+			if ( site ) {
+				message = translate(
+					'{{strong}}%(domain)s{{/strong}} is already registered on this site. {{a}}Are you trying to make this the primary address for your site?{{/a}}',
+					{
+						args: { domain },
+						components: {
+							strong: <strong />,
+							a: (
+								<SetAsPrimaryLink
+									domainName={ domain }
+									siteIdOrSlug={ site }
+									additionalProperties={ {
+										clickOrigin: 'use-a-domain-i-own',
+									} }
+									onSuccess={ () => page( domainManagementList( domain ) ) }
+								/>
+							),
+						},
+					}
+				);
+			}
 			break;
 		case domainAvailability.REGISTERED_OTHER_SITE_SAME_USER:
 			if ( site ) {


### PR DESCRIPTION
2nd take 😬 
Reverts Automattic/wp-calypso#91431 - adds back the PR deployed previously (#91029).

## Proposed Changes

Instead of removing the `site` parameter, we now opted to remove the message entirely - when searching for any of your domains in the Gravatar flow, you won't see the domain in the search results nor an error message.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of the Custom Domains on Gravatar project (pcYYhz-24z-p2).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the Calypso live page or build this branch locally;
- Go to `/start/domain-for-gravatar/domain-only?search=yes&new=your-test-domain.com`;
- Search for a WordPress.com domain of yours registered in another site;
- Try testing for both:
  - Search for a WordPress.com domain registration in a site you own;
  - Search for a standalone mapping in a WordPress.com site you own;
- Ensure you won't get error messages and the domain won't be displayed in the search list.
- Search for a WordPress.com domain mapped in a site you don't own and ensure you get the correct error message (`This domain is already mapped to a WordPress.com site.`)