### PR TITLE
Segmentation Survey: Fix Invalid Data issue when saving answers for previously skipped questions

### DIFF
--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -125,7 +125,7 @@ const SegmentationSurvey = ( {
 
 	const onSkip = useCallback(
 		async ( currentQuestion: Question ) => {
-			onChangeAnswer( currentQuestion.key, [ SKIP_ANSWER_KEY ] );
+			onChangeAnswer( currentQuestion.key, [] );
 			await handleSave( currentQuestion, [ SKIP_ANSWER_KEY ] );
 		},
 		[ handleSave, onChangeAnswer ]


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/7603

## Proposed Changes

* This PR fixes Invalid Data issue when saving answers for previously skipped questions.

## Why are these changes being made?

* To fix a regression on the Segmentation Survey.

## Testing Instructions

1. Go to http://calypso.localhost:3000/setup/entrepreneur/start
2. Open the Network tab
3. Skip one of the questions
4. Return to the same question using the Back button
5. Now select one or more options and click Continue
6. Check the save request, the answers should be successfully saved

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
