### PR TITLE
Site Migration: Remove Domains step migration card experiment code.

### DIFF
--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -101,12 +101,6 @@ class ReskinSideExplainer extends Component {
 				ctaText = translate( 'Use a domain I own' );
 				break;
 
-			case 'site-migration':
-				title = translate( 'Migrating an existing site?' );
-				subtitle = translate( 'We will get your site working on our infrastructure in no time!' );
-				ctaText = translate( 'Migrate my site' );
-				break;
-
 			case 'free-domain-only-explainer':
 				title = translate(
 					'Get a {{b}}free{{/b}} one-year domain registration with any paid annual plan.',

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -35,7 +35,6 @@ export const SIGNUP_DOMAIN_ORIGIN = {
 	FREE: 'free',
 	CUSTOM: 'custom',
 	NOT_SET: 'not-set',
-	SITE_MIGRATION: 'site-migration',
 };
 
 export function recordSignupComplete(

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -209,16 +209,6 @@ export function generateFlows( {
 			hideProgressIndicator: true,
 		},
 		{
-			name: 'site-migration',
-			steps: [ 'domains' ],
-			destination: getSignupDestination,
-			description: 'Take users to the site migration flow from the domains step.',
-			lastModified: '2024-05-09',
-			showRecaptcha: true,
-			hideProgressIndicator: true,
-			onEnterFlow: onEnterOnboarding,
-		},
-		{
 			name: 'onboarding-2023-pricing-grid',
 			steps: isEnabled( 'signup/professional-email-step' )
 				? [ userSocialStep, 'domains', 'emails', 'plans' ]

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -694,9 +694,6 @@ class Signup extends Component {
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToStep = ( stepName, stepSectionName, flowName = this.props.flowName ) => {
-		if ( flowName === 'site-migration' && ! stepName ) {
-			page( '/setup/migration-signup' );
-		}
 		// The `stepName` might be undefined after the user finish the last step but the value of
 		// `isEveryStepSubmitted` is still false. Thus, check the `stepName` here to avoid going
 		// to invalid step.

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -35,7 +35,6 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { Experiment } from 'calypso/lib/explat';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { getSitePropertyDefaults } from 'calypso/lib/signup/site-properties';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
@@ -323,18 +322,12 @@ export class RenderDomainsStep extends Component {
 		);
 	};
 
-	handleSkip = (
-		googleAppsCartItem,
-		shouldHideFreePlan = false,
-		signupDomainOrigin,
-		migrateSite = false
-	) => {
+	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false, signupDomainOrigin ) => {
 		const tracksProperties = Object.assign(
 			{
 				section: this.getAnalyticsSection(),
 				flow: this.props.flowName,
 				step: this.props.stepName,
-				is_migration: migrateSite,
 			},
 			this.isDependencyShouldHideFreePlanProvided()
 				? { should_hide_free_plan: shouldHideFreePlan }
@@ -352,25 +345,13 @@ export class RenderDomainsStep extends Component {
 		this.props.saveSignupStep( stepData );
 
 		defer( () => {
-			this.submitWithDomain( {
-				googleAppsCartItem,
-				shouldHideFreePlan,
-				signupDomainOrigin,
-				migrateSite,
-			} );
+			this.submitWithDomain( { googleAppsCartItem, shouldHideFreePlan, signupDomainOrigin } );
 		} );
 	};
 
 	handleDomainExplainerClick = () => {
 		const hideFreePlan = true;
 		this.handleSkip( undefined, hideFreePlan, SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER );
-	};
-
-	handleSiteMigrationClick = () => {
-		const hideFreePlan = true;
-		const migrateSite = true;
-
-		this.handleSkip( undefined, hideFreePlan, SIGNUP_DOMAIN_ORIGIN.SITE_MIGRATION, migrateSite );
 	};
 
 	handleUseYourDomainClick = () => {
@@ -389,12 +370,7 @@ export class RenderDomainsStep extends Component {
 		}
 	};
 
-	submitWithDomain = ( {
-		googleAppsCartItem,
-		shouldHideFreePlan = false,
-		signupDomainOrigin,
-		migrateSite = false,
-	} ) => {
+	submitWithDomain = ( { googleAppsCartItem, shouldHideFreePlan = false, signupDomainOrigin } ) => {
 		const { step } = this.props;
 		const { suggestion } = step;
 
@@ -485,11 +461,7 @@ export class RenderDomainsStep extends Component {
 			return;
 		}
 
-		if ( migrateSite ) {
-			this.props.goToNextStep( 'site-migration' );
-		} else {
-			this.props.goToNextStep();
-		}
+		this.props.goToNextStep();
 
 		// Start the username suggestion process.
 		siteUrl && this.props.fetchUsernameSuggestion( siteUrl.split( '.' )[ 0 ] );
@@ -966,19 +938,6 @@ export class RenderDomainsStep extends Component {
 
 		return (
 			<div className="domains__domain-side-content-container">
-				<Experiment
-					name="calypso_signup_domains_show_migrate_cta_2024"
-					defaultExperience={ null }
-					loadingExperience={ null }
-					treatmentExperience={
-						<div className="domains__domain-side-content domains__domain-site-migration">
-							<ReskinSideExplainer
-								type="site-migration"
-								onClick={ this.handleSiteMigrationClick }
-							/>
-						</div>
-					}
-				/>
 				{ domainsInCart.length > 0 || this.state.wpcomSubdomainSelected ? (
 					<DomainsMiniCart
 						domainsInCart={ domainsInCart }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -342,10 +342,6 @@ body.is-section-signup.is-white-signup {
 			@include break-medium {
 				width: 290px;
 				margin: 0 20px;
-
-				&.domains__domain-site-migration {
-					margin-right: 0;
-				}
 			}
 
 			@include break-large {


### PR DESCRIPTION
This reverts commit c5ef3981d30a6f0036fb1303745e1f9c089f1eb3.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90992

## Proposed Changes

This removes the code added in #90992 for the Domains step site migration experiment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The experiment has ended so we can remove the experiment code:

pbxNRc-3IH-p2#comment-5601

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection and comparison against #90992

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?