### PR TITLE
Remove deprecated default props on FormattedHeader component

### DIFF
--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -6,20 +6,20 @@ import { preventWidows } from 'calypso/lib/formatting';
 import './style.scss';
 
 function FormattedHeader( {
-	brandFont,
-	id,
+	brandFont = false,
+	id = '',
 	headerText,
 	subHeaderText,
 	tooltipText,
 	className,
-	compactOnMobile,
-	align,
-	subHeaderAlign,
-	isSecondary,
+	compactOnMobile = false,
+	align = 'center',
+	subHeaderAlign = null,
+	isSecondary = false,
 	hasScreenOptions,
 	subHeaderAs: SubHeaderAs = 'p',
 	children,
-	screenReader,
+	screenReader = null,
 } ) {
 	const classes = clsx( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
@@ -79,19 +79,6 @@ FormattedHeader.propTypes = {
 	hasScreenOptions: PropTypes.bool,
 	children: PropTypes.node,
 	screenReader: PropTypes.node,
-};
-
-FormattedHeader.defaultProps = {
-	id: '',
-	className: '',
-	brandFont: false,
-	subHeaderText: '',
-	tooltipText: '',
-	compactOnMobile: false,
-	isSecondary: false,
-	align: 'center',
-	subHeaderAlign: null,
-	screenReader: null,
 };
 
 export default FormattedHeader;

--- a/client/components/formatted-header/index.tsx
+++ b/client/components/formatted-header/index.tsx
@@ -1,11 +1,27 @@
 import clsx from 'clsx';
-import PropTypes from 'prop-types';
+import { ElementType, FC, PropsWithChildren, ReactNode } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
 import { preventWidows } from 'calypso/lib/formatting';
-
 import './style.scss';
 
-function FormattedHeader( {
+interface Props extends PropsWithChildren {
+	id: string;
+	className: string;
+	brandFont: boolean;
+	headerText: ReactNode;
+	subHeaderAs: ElementType;
+	subHeaderText: ReactNode;
+	tooltipText: ReactNode;
+	compactOnMobile: boolean;
+	isSecondary: boolean;
+	align: 'center' | 'left' | 'right';
+	subHeaderAlign?: 'center';
+	hasScreenOptions: boolean;
+	children: ReactNode;
+	screenReader: ReactNode;
+}
+
+const FormattedHeader: FC< Props > = ( {
 	brandFont = false,
 	id = '',
 	headerText,
@@ -14,13 +30,13 @@ function FormattedHeader( {
 	className,
 	compactOnMobile = false,
 	align = 'center',
-	subHeaderAlign = null,
+	subHeaderAlign,
 	isSecondary = false,
 	hasScreenOptions,
 	subHeaderAs: SubHeaderAs = 'p',
 	children,
 	screenReader = null,
-} ) {
+} ) => {
 	const classes = clsx( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
 		'is-compact-on-mobile': compactOnMobile,
@@ -62,23 +78,6 @@ function FormattedHeader( {
 			{ children }
 		</header>
 	);
-}
-
-FormattedHeader.propTypes = {
-	id: PropTypes.string,
-	className: PropTypes.string,
-	brandFont: PropTypes.bool,
-	headerText: PropTypes.node,
-	subHeaderAs: PropTypes.elementType,
-	subHeaderText: PropTypes.node,
-	tooltipText: PropTypes.node,
-	compactOnMobile: PropTypes.bool,
-	isSecondary: PropTypes.bool,
-	align: PropTypes.oneOf( [ 'center', 'left', 'right' ] ),
-	subHeaderAlign: PropTypes.oneOf( [ 'center', null ] ),
-	hasScreenOptions: PropTypes.bool,
-	children: PropTypes.node,
-	screenReader: PropTypes.node,
 };
 
 export default FormattedHeader;

--- a/client/components/formatted-header/index.tsx
+++ b/client/components/formatted-header/index.tsx
@@ -5,20 +5,20 @@ import { preventWidows } from 'calypso/lib/formatting';
 import './style.scss';
 
 interface Props extends PropsWithChildren {
-	id: string;
-	className: string;
-	brandFont: boolean;
+	id?: string;
+	className?: string;
+	brandFont?: boolean;
 	headerText: ReactNode;
-	subHeaderAs: ElementType;
-	subHeaderText: ReactNode;
-	tooltipText: ReactNode;
-	compactOnMobile: boolean;
-	isSecondary: boolean;
-	align: 'center' | 'left' | 'right';
+	subHeaderAs?: ElementType;
+	subHeaderText?: ReactNode;
+	tooltipText?: ReactNode;
+	compactOnMobile?: boolean;
+	isSecondary?: boolean;
+	align?: 'center' | 'left' | 'right';
 	subHeaderAlign?: 'center';
-	hasScreenOptions: boolean;
-	children: ReactNode;
-	screenReader: ReactNode;
+	hasScreenOptions?: boolean;
+	children?: ReactNode;
+	screenReader?: ReactNode;
 }
 
 const FormattedHeader: FC< Props > = ( {

--- a/client/components/formatted-header/index.tsx
+++ b/client/components/formatted-header/index.tsx
@@ -1,41 +1,40 @@
 import clsx from 'clsx';
-import { ElementType, FC, PropsWithChildren, ReactNode } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
 import { preventWidows } from 'calypso/lib/formatting';
+import type { ElementType, FC, PropsWithChildren, ReactNode } from 'react';
 import './style.scss';
 
 interface Props extends PropsWithChildren {
-	id?: string;
-	className?: string;
+	align?: 'center' | 'left' | 'right';
 	brandFont?: boolean;
+	className?: string;
+	compactOnMobile?: boolean;
+	hasScreenOptions?: boolean;
 	headerText: ReactNode;
+	id?: string;
+	isSecondary?: boolean;
+	screenReader?: ReactNode;
+	subHeaderAlign?: 'center';
 	subHeaderAs?: ElementType;
 	subHeaderText?: ReactNode;
 	tooltipText?: ReactNode;
-	compactOnMobile?: boolean;
-	isSecondary?: boolean;
-	align?: 'center' | 'left' | 'right';
-	subHeaderAlign?: 'center';
-	hasScreenOptions?: boolean;
-	children?: ReactNode;
-	screenReader?: ReactNode;
 }
 
 const FormattedHeader: FC< Props > = ( {
+	align = 'center',
 	brandFont = false,
-	id = '',
-	headerText,
-	subHeaderText,
-	tooltipText,
+	children,
 	className,
 	compactOnMobile = false,
-	align = 'center',
-	subHeaderAlign,
-	isSecondary = false,
 	hasScreenOptions,
-	subHeaderAs: SubHeaderAs = 'p',
-	children,
+	headerText,
+	id = '',
+	isSecondary = false,
 	screenReader = null,
+	subHeaderAlign,
+	subHeaderAs: SubHeaderAs = 'p',
+	subHeaderText,
+	tooltipText,
 } ) => {
 	const classes = clsx( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,

--- a/client/components/segmentation-survey/index.tsx
+++ b/client/components/segmentation-survey/index.tsx
@@ -32,7 +32,7 @@ type SegmentationSurveyProps = {
 	/**
 	 * The alignment of the header text.
 	 */
-	headerAlign?: string;
+	headerAlign?: 'center' | 'left' | 'right';
 	/**
 	 * The configuration for the questions.
 	 */

--- a/client/components/survey-container/components/question-step.tsx
+++ b/client/components/survey-container/components/question-step.tsx
@@ -23,7 +23,7 @@ type QuestionStepType = {
 	hideBack?: boolean;
 	hideContinue?: boolean;
 	hideSkip?: boolean;
-	headerAlign?: string;
+	headerAlign?: 'center' | 'left' | 'right';
 	questionComponentMap?: QuestionComponentMap;
 } & QuestionSelectionComponentProps;
 

--- a/client/components/survey-container/index.tsx
+++ b/client/components/survey-container/index.tsx
@@ -12,7 +12,7 @@ type SurveyContainerProps = {
 	onChange: ( questionKey: string, value: string[] ) => void;
 	hideBackOnFirstPage?: boolean;
 	disabled?: boolean;
-	headerAlign?: string;
+	headerAlign?: 'center' | 'left' | 'right';
 	questionConfiguration?: QuestionConfiguration;
 	questionComponentMap?: QuestionComponentMap;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -316,7 +316,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 				<FormattedHeader
 					id="domains-header"
 					align={ flow === HUNDRED_YEAR_PLAN_FLOW ? 'center' : 'left' }
-					subHeaderAlign={ flow === HUNDRED_YEAR_PLAN_FLOW ? 'center' : null }
+					subHeaderAlign={ flow === HUNDRED_YEAR_PLAN_FLOW ? 'center' : undefined }
 					headerText={ getHeaderText() }
 					subHeaderText={ getSubHeaderText() }
 				/>

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -75,7 +75,6 @@ const ImageSection = styled.div`
 	}
 `;
 
-// @ts-expect-error FormattedHeader is not typed and it's causing issues with the styled component
 const Header = styled( FormattedHeader )`
 	.formatted-header__title {
 		font-size: 2.25rem;
@@ -465,7 +464,6 @@ export default function DIFMLanding( {
 			) }
 			<Wrapper>
 				<ContentSection>
-					{ /* @ts-expect-error FormattedHeader is not typed and it's causing issues with the styled component */ }
 					<Header
 						brandFont
 						align="left"


### PR DESCRIPTION

## Proposed Changes
Remove the defaultProps definition.


## Why are these changes being made?
As explained [here](https://github.com/jsx-eslint/eslint-plugin-react/issues/2396), react is deprecating defaultProps on FunctionComponent. 

It is triggering warning message when a page with the component is rendered.

## Testing Instructions
* Access a step which uses the component like setup/design-first/new-or-existing-site
* Check there is no warning on the devtools

![default-props](https://github.com/Automattic/wp-calypso/assets/38718/593869bf-5cd5-454b-963c-a80c5bd87d06)

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
