### PR TITLE
A4A: fix bulk bundle purchases

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-issue-license-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-issue-license-mutation.ts
@@ -7,12 +7,14 @@ import { APIError, APILicense } from 'calypso/state/partner-portal/types';
 export interface MutationIssueLicenseVariables {
 	product: string;
 	quantity: number;
+	isBundle?: boolean;
 }
 
 function mutationIssueLicense( {
 	product,
 	quantity,
 	agencyId,
+	isBundle = false,
 }: MutationIssueLicenseVariables & { agencyId?: number } ): Promise< APILicense[] > {
 	if ( ! agencyId ) {
 		throw new Error( 'Agency ID is required to issue a license' );
@@ -20,7 +22,7 @@ function mutationIssueLicense( {
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: '/jetpack-licensing/licenses',
-		body: { product, quantity, agency_id: agencyId, bundle: false },
+		body: { product, quantity, agency_id: agencyId, bundle: isBundle },
 	} );
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-licenses.tsx
@@ -1,5 +1,9 @@
 import usePaymentMethod from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method';
-import { APIError, APILicense } from 'calypso/state/partner-portal/types';
+import {
+	APIError,
+	APILicense,
+	APIProductFamilyProductBundlePrice,
+} from 'calypso/state/partner-portal/types';
 import useIssueLicenseMutation from '../../hooks/use-issue-license-mutation';
 
 const NO_OP = () => {
@@ -9,6 +13,7 @@ const NO_OP = () => {
 export type IssueLicenseRequest = {
 	slug: string;
 	quantity: number;
+	supported_bundles?: APIProductFamilyProductBundlePrice[];
 };
 
 export type FulfilledIssueLicenseResult = {
@@ -50,12 +55,14 @@ const useIssueLicenses = ( options: UseIssueLicensesOptions = {} ) => {
 		selectedLicenses: IssueLicenseRequest[]
 	): Promise< IssueLicenseResult[] > => {
 		const requests: Promise< IssueLicenseResult >[] = selectedLicenses.map(
-			( { slug, quantity } ) =>
-				mutateAsync( { product: slug, quantity } )
+			( { slug, quantity, supported_bundles = [] } ) => {
+				const isBundle = supported_bundles.some( ( bundle ) => bundle.quantity === quantity );
+				return mutateAsync( { product: slug, quantity, isBundle } )
 					.then( ( value ): FulfilledIssueLicenseResult => {
 						return { slug, status: 'fulfilled', licenses: value };
 					} )
-					.catch( (): RejectedIssueLicenseResult => ( { slug, status: 'rejected' } ) )
+					.catch( (): RejectedIssueLicenseResult => ( { slug, status: 'rejected' } ) );
+			}
 		);
 
 		return Promise.all( requests );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/625

## Proposed Changes

We need to check if the product in the cart is `bundle` and send it as parameter when purchasing `licenses`

<img width="663" alt="Screenshot 2024-06-04 at 11 54 45 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/30eb4318-27da-4be2-86a9-c5433245788f">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using this branch (or live link below) navigate to `/marketplace`.
- Add different items and some bulk items to the cart
- Add some hosting options
- Navigate to checkout and purchase.
- Bulk licenses should be purchased as bulk (verify in dev console) and should be represented in `/purchases/licenses` accordingly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
