### PR TITLE
Github Deployments: Always show deployments survey 

### DIFF
--- a/client/my-sites/github-deployments/components/deployments-survey/index.tsx
+++ b/client/my-sites/github-deployments/components/deployments-survey/index.tsx
@@ -1,21 +1,13 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import surveyImage from 'calypso/assets/images/illustrations/github-deployments.svg';
 import SurveyModal from 'calypso/components/survey-modal';
-import { maybeSetDeploymentDone, shouldShowDeploymentSurvey } from './utils';
 
 export const GitHubDeploymentSurvey = () => {
 	const localeSlug = useLocale();
-	const [ showSurvey, setShowSurvey ] = useState( false );
 
-	useEffect( () => {
-		maybeSetDeploymentDone();
-		setShowSurvey( shouldShowDeploymentSurvey() );
-	}, [] );
-
-	if ( localeSlug !== 'en' || ! showSurvey ) {
+	if ( localeSlug !== 'en' ) {
 		return null;
 	}
 

--- a/client/my-sites/github-deployments/deployments/index.tsx
+++ b/client/my-sites/github-deployments/deployments/index.tsx
@@ -28,7 +28,6 @@ export function GitHubDeployments() {
 			return (
 				<>
 					<GitHubDeploymentsList deployments={ deployments } />
-					<GitHubDeploymentSurvey />
 				</>
 			);
 		}
@@ -66,6 +65,7 @@ export function GitHubDeployments() {
 			}
 		>
 			{ renderContent() }
+			<GitHubDeploymentSurvey />
 		</PageShell>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Slack discussion  p1717516862404769-slack-C04H4NY6STW

## Proposed Changes
Currently the Github deployments survey is only shown 7 days after first deployment. We want to change that to always show it to increase engagement with the survey.

* Show Github deployments survey at all times.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These changes are made to try and increase survey engagement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* browse `/github-deployments/atomic-site`
* Verify the survey is shown

![image](https://github.com/Automattic/wp-calypso/assets/47489215/175330ad-e70b-436b-8658-ca7f961c6027)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?