### PR TITLE
Update description on staging site card

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import SiteIcon from 'calypso/blocks/site-icon';
@@ -103,6 +104,7 @@ export const ManageStagingSiteCardContent = ( {
 }: CardContentProps ) => {
 	{
 		const translate = useTranslate();
+		const hasEnTranslation = useHasEnTranslation();
 		const productionSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 
 		const ConfirmationDeleteButton = () => {
@@ -151,14 +153,29 @@ export const ManageStagingSiteCardContent = ( {
 		return (
 			<>
 				<p>
-					{ translate(
-						'Your staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
-						{
-							components: {
-								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
-							},
-						}
-					) }
+					{ hasEnTranslation(
+						'Preview and troubleshoot changes before updating your production site. {{a}}Learn more{{/a}}.'
+					)
+						? translate(
+								'Preview and troubleshoot changes before updating your production site. {{a}}Learn more{{/a}}.',
+								{
+									components: {
+										a: (
+											<InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />
+										),
+									},
+								}
+						  )
+						: translate(
+								'Your staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
+								{
+									components: {
+										a: (
+											<InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />
+										),
+									},
+								}
+						  ) }
 				</p>
 				<BorderedContainer>
 					<SiteRow>

--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -24,10 +24,10 @@ export const NewStagingSiteCardContent = ( {
 			<>
 				<HostingCardDescription>
 					{ hasEnTranslation(
-						'Preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.'
+						'Preview and troubleshoot changes before updating your production site. {{a}}Learn more{{/a}}.'
 					)
 						? translate(
-								'Preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
+								'Preview and troubleshoot changes before updating your production site. {{a}}Learn more{{/a}}.',
 								{
 									components: {
 										a: (

--- a/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { HostingCardDescription } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -17,17 +18,34 @@ export const NewStagingSiteCardContent = ( {
 }: CardContentProps ) => {
 	{
 		const translate = useTranslate();
+		const hasEnTranslation = useHasEnTranslation();
+
 		return (
 			<>
 				<HostingCardDescription>
-					{ translate(
-						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
-						{
-							components: {
-								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
-							},
-						}
-					) }
+					{ hasEnTranslation(
+						'Preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.'
+					)
+						? translate(
+								'Preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
+								{
+									components: {
+										a: (
+											<InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />
+										),
+									},
+								}
+						  )
+						: translate(
+								'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
+								{
+									components: {
+										a: (
+											<InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />
+										),
+									},
+								}
+						  ) }
 				</HostingCardDescription>
 				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
 					<span>{ translate( 'Add staging site' ) }</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7597

## Proposed Changes

* Shortens the description on the staging site card for both 'create' and 'manage' card versions.

BEFORE
<img width="918" alt="Screenshot 2024-06-04 at 4 56 12 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/b184b9cf-48e9-4f95-b7b4-006588e9b9f1">


AFTER
<img width="917" alt="Screenshot 2024-06-05 at 8 50 12 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/3433675c-1b41-44b1-9573-3a29cacc37a2">


<img width="895" alt="Screenshot 2024-06-05 at 8 53 07 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/163030c2-d10e-4e5a-9357-413f9a724726">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Automattic/dotcom-forge#7597 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select an atomic site, visit the "staging site" tab.
* verify the description is shortened.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
