### PR TITLE
A4A: remove Copy site button from sites flyout panel

### DIFF
--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -3,7 +3,6 @@ import { Button } from '@automattic/components';
 import { Tooltip } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { backupClonePath, backupMainPath } from 'calypso/my-sites/backup/paths';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -23,8 +22,8 @@ const BackupActionsToolbar: FunctionComponent< Props > = ( { siteId } ) => {
 	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 	const hasBackups = useSelector( ( state ) => siteHasBackups( state, siteId ) );
 
-	// Show the "Copy site" button if accessing on Jetpack Cloud or A4A
-	const showCopySiteButton = isJetpackCloud() || isA8CForAgencies();
+	// Show the "Copy site" button if accessing on Jetpack Cloud (A4A removed for now)
+	const showCopySiteButton = isJetpackCloud();
 
 	const copySite = (
 		<Tooltip

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -69,7 +69,7 @@ const ActivityLogV2: FunctionComponent = () => {
 				</div>
 			</div>
 			<div className="activity-log-v2__header-right">
-				{ ( isJetpackCloud() || isA8CForAgencies() ) && selectedSiteSlug && (
+				{ isJetpackCloud() && selectedSiteSlug && (
 					<Tooltip
 						text={ translate(
 							'To test your site changes, migrate or keep your data safe in another site'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/601

## Proposed Changes

Remove Copy site button as it needs to be re-assessed. 

<img width="1037" alt="Screenshot 2024-06-04 at 2 26 51 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/7bb69bcc-8e17-4e35-bf0f-e16907cfee0f">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use live link below and navigate to `/sites`
- If don't have one. Create a new JN site with Jetpack and purchase backup plan
- Open flyout panel for that site and observe that no `Copy site` button is present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
