### PR TITLE
Jetpack Visibility i1: Show jetpack scan history for atomic sites

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
@@ -4,6 +4,7 @@ export const JETPACK_MANAGE_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all
 export const JETPACK_MANAGE_SITES_LINK_FAVORITES = '/sites/favorites';
 export const JETPACK_MANAGE_PLUGINS_LINK = '/plugins/manage';
 export const JETPACK_CLOUD_ACTIVITY_LOG_LINK = '/activity-log';
+export const JETPACK_CLOUD_SCAN_HISTORY_LINK = '/scan/history';
 export const JETPACK_CLOUD_SEARCH_LINK = '/jetpack-search';
 export const JETPACK_CLOUD_SOCIAL_LINK = '/jetpack-social';
 export const JETPACK_CLOUD_SUBSCRIBERS_LINK = '/subscribers';

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -34,6 +34,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -41,6 +42,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import {
 	JETPACK_CLOUD_ACTIVITY_LOG_LINK,
 	JETPACK_CLOUD_MONETIZE_LINK,
+	JETPACK_CLOUD_SCAN_HISTORY_LINK,
 	JETPACK_CLOUD_SEARCH_LINK,
 	JETPACK_CLOUD_SOCIAL_LINK,
 	JETPACK_CLOUD_SUBSCRIBERS_LINK,
@@ -68,6 +70,8 @@ const useMenuItems = ( {
 	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 
 	const isWPForTeamsSite = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
+
+	const showScanHistory = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
 	const shouldShowSettings =
 		useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) ) &&
@@ -117,6 +121,15 @@ const useMenuItems = ( {
 					trackEventName: 'calypso_jetpack_sidebar_scan_clicked',
 					enabled: isAdmin && ! isWPCOM && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, scanPath( siteSlug ) ),
+				},
+				{
+					icon: shield,
+					path: '/',
+					link: `${ JETPACK_CLOUD_SCAN_HISTORY_LINK }/${ siteSlug }`,
+					title: translate( 'Scan' ),
+					trackEventName: 'calypso_jetpack_sidebar_scan_clicked',
+					enabled: isAdmin && showScanHistory && ! isWPForTeamsSite,
+					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SCAN_HISTORY_LINK }/${ siteSlug }` ),
 				},
 				{
 					icon: search,

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -122,12 +122,13 @@ const useMenuItems = ( {
 					enabled: isAdmin && ! isWPCOM && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, scanPath( siteSlug ) ),
 				},
+				// Scan history is mutually exclusive with the scan item above and should only be shown for atomic sites
 				{
 					icon: shield,
 					path: '/',
 					link: `${ JETPACK_CLOUD_SCAN_HISTORY_LINK }/${ siteSlug }`,
 					title: translate( 'Scan' ),
-					trackEventName: 'calypso_jetpack_sidebar_scan_clicked',
+					trackEventName: 'calypso_jetpack_sidebar_scan_history_clicked',
 					enabled: isAdmin && showScanHistory && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SCAN_HISTORY_LINK }/${ siteSlug }` ),
 				},

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -100,11 +100,9 @@ export function scan( context, next ) {
 export function scanHistory( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-	const doNotScanHistoryNavigation = ! isJetpackCloud() || ! isAtomicSite( state, siteId );
+	const showScanNavigation = ! isAtomicSite( state, siteId ) && isJetpackCloud();
 	const { filter } = context.params;
-	context.primary = (
-		<ScanHistoryPage filter={ filter } showNavigation={ doNotScanHistoryNavigation } />
-	);
+	context.primary = <ScanHistoryPage filter={ filter } showNavigation={ showScanNavigation } />;
 	next();
 }
 

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -100,9 +100,11 @@ export function scan( context, next ) {
 export function scanHistory( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-	const showNavigation = isJetpackCloud() || ! isAtomicSite( state, siteId );
+	const doNotScanHistoryNavigation = ! isJetpackCloud() || ! isAtomicSite( state, siteId );
 	const { filter } = context.params;
-	context.primary = <ScanHistoryPage filter={ filter } showNavigation={ showNavigation } />;
+	context.primary = (
+		<ScanHistoryPage filter={ filter } showNavigation={ doNotScanHistoryNavigation } />
+	);
 	next();
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Relates to https://github.com/Automattic/dotcom-forge/issues/7556 & https://github.com/Automattic/dotcom-forge/issues/7268

## Proposed Changes
This change enables the jetpack scan link in jetpack cloud for Atomic sites. 

* Show scan link in jetpack cloud that points to scan history.
* Hide scan navigation for atomic sites since we are only showing the history component.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To keep consistency with calypso since the jetpack scan link there only shows history page. It also keep the Untangling UI consistent where jetpack links redirects to JP Cloud and not calypso.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the JP Cloud link generated.
* Browse an Atomic site and verify the scan link is shown and redirects to history component
* Verify a simple site doesn't show the scan menu item


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
