### PR TITLE
Update the Plugins link in /sites Ellipses menu

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -34,7 +34,6 @@ import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/laun
 import { getSiteOption, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import {
 	getHostingConfigUrl,
-	getManagePluginsUrl,
 	getPluginsUrl,
 	getSettingsUrl,
 	getSiteMonitoringUrl,
@@ -126,14 +125,10 @@ const ManagePluginsItem = ( {
 		useSelector( ( state: AppState ) =>
 			siteHasFeature( state, site.ID, WPCOM_FEATURES_MANAGE_PLUGINS )
 		) || isNotAtomicJetpack( site );
-	// If the site can't manage plugins then go to the main plugins page instead
-	// because it shows an upsell message.
-	const [ href, label ] = hasManagePluginsFeature
-		? [
-				isWpAdminInterface ? `${ wpAdminUrl }plugins.php` : getManagePluginsUrl( site.slug ),
-				__( 'Manage plugins' ),
-		  ]
-		: [ getPluginsUrl( site.slug ), __( 'Plugins' ) ];
+	const [ href, label ] = [
+		isWpAdminInterface ? `${ wpAdminUrl }plugins.php` : getPluginsUrl( site.slug ),
+		__( 'Plugins' ),
+	];
 	const upsellPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6563

## Proposed Changes

* Update the Plugins link in /sites Ellipses menu
* We no longer point to /manage/plugins/:site because it's not exposed elsewhere. Instead, we point to /plugins/:site to match the Site Admin Menu.
* Due to the above, the copy is changed from "Manage Plugins" to "Plugins" again to match the Site Admin Menu.
* Classic sites always point to /wp-admin/plugins.php and Default sites always point to /plugins/:site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To create consistency between the /sites Ellipses menu and Site Admin Menu for the Plugins link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR using Calypso live
* The Plugins link the /sites Ellipses menu should point to the same place as the Site Admin Menu.

/sites Ellipses | Site Admin Menu
--|--
<img width="268" alt="Screenshot 2024-06-04 at 5 00 12 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/ac09102e-d921-4224-8570-68b2b0213795">  | <img width="335" alt="336044403-83939981-f4a0-4c59-b155-10f0352f77a4" src="https://github.com/Automattic/wp-calypso/assets/140841/b8db1a7c-aa4e-4b30-ad79-4d910911fc45">





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
