### PR TITLE
Jetpack Backup: Add new Tracks events for the restore process

### DIFF
--- a/client/my-sites/backup/rewind-flow/error.tsx
+++ b/client/my-sites/backup/rewind-flow/error.tsx
@@ -28,6 +28,10 @@ const RewindFlowError: FunctionComponent< Props > = ( {
 		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_failed' ) );
 	}, [ dispatch ] );
 
+	const handleContactSupportClick = () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_failed_contact_support_click' ) );
+	};
+
 	return (
 		<>
 			<div className="rewind-flow__header">
@@ -41,6 +45,7 @@ const RewindFlowError: FunctionComponent< Props > = ( {
 				primary
 				rel="noopener noreferrer"
 				target="_blank"
+				onClick={ handleContactSupportClick }
 			>
 				{ translate( 'Contact support {{externalIcon/}}', {
 					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },

--- a/client/my-sites/backup/rewind-flow/error.tsx
+++ b/client/my-sites/backup/rewind-flow/error.tsx
@@ -1,8 +1,10 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 import downloadFailureImage from 'calypso/assets/images/illustrations/jetpack-cloud-download-failure.svg';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
 	imgSrc?: string;
@@ -20,6 +22,12 @@ const RewindFlowError: FunctionComponent< Props > = ( {
 	imgAlt = 'jetpack cloud error',
 } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_failed' ) );
+	}, [ dispatch ] );
+
 	return (
 		<>
 			<div className="rewind-flow__header">

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -515,8 +515,20 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<Button primary href={ siteUrl } className="rewind-flow__primary-button">
-				{ translate( 'View your website' ) }
+			<Button
+				primary
+				href={ siteUrl }
+				target="_blank"
+				className="rewind-flow__primary-button"
+				onClick={ () =>
+					dispatch(
+						recordTracksEvent( 'calypso_jetpack_backup_granular_restore_complete_view_site' )
+					)
+				}
+			>
+				{ translate( 'View your website {{externalIcon/}}', {
+					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
+				} ) }
 			</Button>
 		</>
 	);

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -515,20 +515,8 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<Button
-				primary
-				href={ siteUrl }
-				target="_blank"
-				className="rewind-flow__primary-button"
-				onClick={ () =>
-					dispatch(
-						recordTracksEvent( 'calypso_jetpack_backup_granular_restore_complete_view_site' )
-					)
-				}
-			>
-				{ translate( 'View your website {{externalIcon/}}', {
-					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
-				} ) }
+			<Button primary href={ siteUrl } className="rewind-flow__primary-button">
+				{ translate( 'View your website' ) }
 			</Button>
 		</>
 	);

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -154,6 +154,10 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		refetchPreflightStatus,
 	] );
 
+	const onGoBack = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_goback' ) );
+	}, [ dispatch ] );
+
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	const loading = rewindState.state === 'uninitialized';
@@ -201,7 +205,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				) }
 			</>
 			<div className="rewind-flow__btn-group">
-				<Button className="rewind-flow__back-button" href={ backupMainPath( siteSlug ) }>
+				<Button
+					className="rewind-flow__back-button"
+					href={ backupMainPath( siteSlug ) }
+					onClick={ onGoBack }
+				>
 					{ translate( 'Go back' ) }
 				</Button>
 				<Button

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -286,7 +286,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				target="_blank"
 				className="rewind-flow__primary-button"
 				onClick={ () =>
-					dispatch( recordTracksEvent( 'calypso_jetpack_restore_complete_view_site' ) )
+					dispatch( recordTracksEvent( 'calypso_jetpack_restore_completed_view_site' ) )
 				}
 			>
 				{ translate( 'View your website {{externalIcon/}}', {

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -316,10 +316,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 
 	useEffect( () => {
 		if ( isFinished ) {
+			dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_completed' ) );
 			setRestoreInitiated( false );
 			setUserHasRequestedRestore( false );
 		}
-	}, [ isFinished ] );
+	}, [ dispatch, isFinished ] );
 
 	const render = () => {
 		if ( loading ) {

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -280,7 +280,15 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<Button primary href={ siteUrl } target="_blank" className="rewind-flow__primary-button">
+			<Button
+				primary
+				href={ siteUrl }
+				target="_blank"
+				className="rewind-flow__primary-button"
+				onClick={ () =>
+					dispatch( recordTracksEvent( 'calypso_jetpack_restore_complete_view_site' ) )
+				}
+			>
 				{ translate( 'View your website {{externalIcon/}}', {
 					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
 				} ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/489

## Proposed Changes

Add the followings Tracks events to the restore flow:
* `calypso_jetpack_backup_restore_goback`: when a user clicks on `Go back` button on the restore confirmation page.
* `calypso_jetpack_backup_restore_completed`: when a restore completes successfully.
* `calypso_jetpack_restore_completed_view_site`: when the user clicks on `View your website` after a successful restore.
* `calypso_jetpack_backup_restore_failed`: when a restore fails.
* `calypso_jetpack_backup_restore_failed_contact_support_click`: when a user clicks on `Contact support` after a failed restore.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These specific Tracks events will help us validate the feature usage of the restore feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
> [!NOTE]
> For brevity describing the test steps, when we say `validate the event X was triggered`, it means that you should see a request to `t.gif` with the described event name.

* Spin up a Jetpack Cloud live branch
* Open the Network tab in your developer tools
* Navigate to Jetpack Cloud > Backup
* On any available backup, click on `Restore to this point` to start the restore process.
* Click on `Go back` and validate the event `calypso_jetpack_backup_restore_goback` was triggered.
* Click again on `Restore to this point` to return to the confirmation page.
* Select all items you want to restore (you can try restoring only the themes to make it quicker if you want) and click on `Restore now`.
* When the restore completes, validate the event `calypso_jetpack_backup_restore_completed` was triggered.
* Click on `View your website` and validate the event `calypso_jetpack_restore_completed_view_site` was triggered.
* Now try a restore with a different restore point and make it fail. You can try setting 555 permissions to your WordPress installation path, or just turn off the web server.
* When the restore fails, validate the event `calypso_jetpack_backup_restore_failed` was triggered.
* Click on `Contact support` and validate the event `calypso_jetpack_backup_restore_failed_contact_support_click` was triggered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
