### PR TITLE
Update site identification step Heading, SubTitle and CTA text

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -15,15 +15,16 @@ import type { OnInputChange, OnInputEnter } from './types';
 import type { FunctionComponent, ReactNode } from 'react';
 
 interface Props {
-	onInputEnter: OnInputEnter;
-	onInputChange?: OnInputChange;
-	onDontHaveSiteAddressClick?: () => void;
-	hasError?: boolean;
-	skipInitialChecking?: boolean;
-	label?: ReactNode;
-	placeholder?: string;
 	dontHaveSiteAddressLabel?: string;
+	hasError?: boolean;
 	hideImporterListLink?: boolean;
+	label?: ReactNode;
+	nextLabelText?: string;
+	onDontHaveSiteAddressClick?: () => void;
+	onInputChange?: OnInputChange;
+	onInputEnter: OnInputEnter;
+	placeholder?: string;
+	skipInitialChecking?: boolean;
 }
 const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const {
@@ -36,6 +37,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		placeholder = 'artfulbaker.blog',
 		dontHaveSiteAddressLabel,
 		hideImporterListLink = false,
+		nextLabelText,
 	} = props;
 
 	const translate = useTranslate();
@@ -124,7 +126,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 				</FormSettingExplanation>
 			</FormFieldset>
 
-			<NextButton type="submit">{ translate( 'Continue' ) }</NextButton>
+			<NextButton type="submit">{ nextLabelText ?? translate( 'Continue' ) }</NextButton>
 
 			<div className="action-buttons__importer-list">
 				{ ! hideImporterListLink &&

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -75,4 +75,14 @@ describe( 'CaptureInput', () => {
 
 		expect( mockedRecordTracksEvent.mock.calls.length ).toBe( 1 );
 	} );
+
+	it( 'shows a custom CTA label', async () => {
+		render(
+			<MemoryRouter>
+				<CaptureInput onInputEnter={ jest.fn() } label="A custom label text" nextLabelText="XYZ" />
+			</MemoryRouter>
+		);
+
+		expect( screen.getByRole( 'button', { name: /XYZ/ } ) ).toBeInTheDocument();
+	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -39,6 +39,12 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 	const subtitleInUse =
 		isEnglishLocale || isTranslationAvailableForNewSubtitle ? newSubtitle : oldSubtitle;
 
+	// TODO: Remove extra steps for non-English locales once we have translations.
+	const oldTitle = translate( 'Let’s import your content' );
+	const newTitle = translate( 'Let’s find your site' );
+	const isTranslationAvailableForNewTitle = hasTranslation( 'Let’s find your site' );
+	const titleInUse = isTranslationAvailableForNewTitle ? newTitle : oldTitle;
+
 	const {
 		data: siteInfo,
 		isError: hasError,
@@ -59,7 +65,7 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 	return (
 		<div>
 			<div className="import__heading import__heading-center">
-				<Title>{ translate( 'Let’s import your content' ) }</Title>
+				<Title>{ titleInUse }</Title>
 				<SubTitle>{ subtitleInUse }</SubTitle>
 			</div>
 			<div className="import__capture-container">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,4 +1,6 @@
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, useEffect, useState, useCallback } from 'react';
 import CaptureInput from 'calypso/blocks/import/capture/capture-input';
@@ -23,7 +25,19 @@ interface Props {
 
 export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
+
+	// TODO: Remove extra steps for non-English locales once we have translations.
+	const oldSubtitle = translate( 'Drop your current site address below to get started.' );
+	const newSubtitle = translate(
+		"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
+	);
+	const isTranslationAvailableForNewSubtitle = hasTranslation(
+		"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
+	);
+	const subtitleInUse =
+		isEnglishLocale || isTranslationAvailableForNewSubtitle ? newSubtitle : oldSubtitle;
 
 	const {
 		data: siteInfo,
@@ -46,7 +60,7 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		<div>
 			<div className="import__heading import__heading-center">
 				<Title>{ translate( 'Let’s import your content' ) }</Title>
-				<SubTitle>{ translate( 'Drop your current site address below to get started.' ) }</SubTitle>
+				<SubTitle>{ subtitleInUse }</SubTitle>
 			</div>
 			<div className="import__capture-container">
 				<CaptureInput

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,6 +1,5 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
-import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, useEffect, useState, useCallback } from 'react';
 import CaptureInput from 'calypso/blocks/import/capture/capture-input';
@@ -25,25 +24,26 @@ interface Props {
 
 export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
+	const hasEnTranslation = useHasEnTranslation();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
 
-	// TODO: Remove extra steps for non-English locales once we have translations.
-	const oldSubtitle = translate( 'Drop your current site address below to get started.' );
-	const newSubtitle = translate(
-		"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
-	);
-	const isTranslationAvailableForNewSubtitle = hasTranslation(
-		"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
-	);
-	const subtitleInUse =
-		isEnglishLocale || isTranslationAvailableForNewSubtitle ? newSubtitle : oldSubtitle;
+	// TODO: Remove extra steps for non-English locales once we have translations -- title.
+	const titleInUse = hasEnTranslation( 'Let’s find your site' )
+		? translate( 'Let’s find your site' )
+		: translate( 'Let’s import your content' );
 
-	// TODO: Remove extra steps for non-English locales once we have translations.
-	const oldTitle = translate( 'Let’s import your content' );
-	const newTitle = translate( 'Let’s find your site' );
-	const isTranslationAvailableForNewTitle = hasTranslation( 'Let’s find your site' );
-	const titleInUse = isTranslationAvailableForNewTitle ? newTitle : oldTitle;
+	// TODO: Remove extra steps for non-English locales once we have translations -- subtitle.
+	const subtitleInUse = hasEnTranslation(
+		"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
+	)
+		? translate(
+				"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
+		  )
+		: translate( 'Drop your current site address below to get started.' );
+
+	// TODO: Remove extra steps for non-English locales once we have translations -- CTA text.
+	const nextLabelText = hasEnTranslation( 'Check my site' ) ? translate( 'Check my site' ) : false;
+	const nextLabelProp = nextLabelText ? { nextLabelText } : {}; // If we don't pass anything, the default label 'Continue' will be used.
 
 	const {
 		data: siteInfo,
@@ -81,6 +81,7 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 						'Or <button>pick your current platform from a list</button>'
 					) }
 					hideImporterListLink={ hideImporterListLink }
+					{ ...nextLabelProp }
 				/>
 			</div>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -67,7 +67,7 @@ describe( 'SiteMigrationIdentify', () => {
 
 		await userEvent.type( getInput(), 'https://example.com' );
 
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Check my site/ } ) );
 
 		await waitFor( () => {
 			expect( submit ).toHaveBeenCalledWith(
@@ -91,7 +91,7 @@ describe( 'SiteMigrationIdentify', () => {
 
 		await userEvent.type( getInput(), 'https://example.com' );
 
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Check my site/ } ) );
 
 		await waitFor( () =>
 			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { platform: 'unknown' } ) )
@@ -124,7 +124,7 @@ describe( 'SiteMigrationIdentify', () => {
 
 		await userEvent.type( getInput(), 'https://example.com' );
 
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Check my site/ } ) );
 
 		await waitFor( () =>
 			expect( screen.getByText( /Please enter a valid website / ) ).toBeVisible()
@@ -149,7 +149,7 @@ describe( 'SiteMigrationIdentify', () => {
 			.query( { site_url: 'https://existent-site.com' } )
 			.reply( 200, API_RESPONSE_WITH_OTHER_PLATFORM );
 
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Check my site/ } ) );
 		await waitFor( () =>
 			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { platform: 'unknown' } ) )
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91477, https://github.com/Automattic/wp-calypso/issues/91478, https://github.com/Automattic/wp-calypso/issues/91542

## Proposed Changes

We've updated the -
- Heading of the site identification page from "`Let’s import your content`" to "`Let’s find your site`"
- The subtitle from "`Drop your current site address below to get started.`" to "`Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration.`"
- The CTA from "Continue" to "Check my site"

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Previously we only said 'what', now we are also adding the 'why' to explain the need and benefit of putting the URL in the input field

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- First, switch to `trunk`
- Go to `https://wordpress.com/me/account`
- Switch to any language other than English
- In the migration flow (take any migration path, for example `http://calypso.localhost:3000/start`), navigate to the Site Identification step (screenshot attached below in case you're not sure which page)
- Check the header, subtitle, and CTA text on that page (screenshot is marked to point out which parts)
- Copy-paste them somewhere so that you can verify them later
- Now switch to this branch, and after rebuilding, open the site identification tab and reload
- Make sure all of those three texts are still looking the same as before in your selected language (you can verify using your copy)
- Now go to the `https://wordpress.com/me/account` page and switch the language to English.
- Get back to the  Site Identification page
- Make sure you see the updated texts in English
 
<img width="1045" alt="Screenshot 2024-06-06 at 6 47 03 AM" src="https://github.com/Automattic/wp-calypso/assets/6820724/f215abef-51ad-41a7-a0a1-ec78c8079584">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?