### PR TITLE
Jetpack Backup: Add new Tracks events for the copy to staging process

### DIFF
--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -576,6 +576,12 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) );
 	const isFinished = inProgressRewindStatus !== null && inProgressRewindStatus === 'finished';
 
+	useEffect( () => {
+		if ( isFinished ) {
+			dispatch( recordTracksEvent( 'calypso_jetpack_clone_flow_completed' ) );
+		}
+	}, [ dispatch, isFinished ] );
+
 	const render = () => {
 		if ( loading ) {
 			return <Loading />;

--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -238,6 +238,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 		dispatch( setValidFrom( 'restore', Date.now() ) );
 		setUserHasRequestedRestore( true );
 		requestClone();
+		dispatch( recordTracksEvent( 'calypso_jetpack_clone_flow_confirm' ) );
 	}, [ dispatch, setUserHasRequestedRestore, requestClone ] );
 
 	// Takes a destination as a vault role or blog id
@@ -536,6 +537,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 				<Button
 					primary
 					href={ getDestinationUrl() }
+					target="_blank"
 					onClick={ () =>
 						dispatch( recordTracksEvent( 'calypso_jetpack_clone_flow_finished_view_site' ) )
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/489

## Proposed Changes
* Add the followings Tracks events to the copy to staging / clone flow:
  * `calypso_jetpack_clone_flow_confirm`: when the user confirms to initiate the clone flow.
  * `calypso_jetpack_clone_flow_completed`: when the clone flow completes.
* Add a `target="_blank"` to the `View your website` button on the successful restore view. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These specific Tracks events will help us validate the feature usage of the copy to staging feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> For brevity describing the test steps, when we say `validate the event X was triggered`, it means that you should see a request to `t.gif` with the described event name.

* Spin up a Jetpack Cloud live branch
* Open the Network tab in your developer tools
* Click on `Copy site` at the top right of the page
* Navigate to Jetpack Cloud > Backup

Assuming you already have a staging site configured:
* Search for a site that has been previously configured as a staging site
* Select the backup point
* Click on `Confirm configuration` and validate the event `calypso_jetpack_clone_flow_confirm` was triggered.
* Once the restore completes successfully, validate the event `calypso_jetpack_clone_flow_completed` was triggered.
* Ensure that clicking on `View your website` opens in a new tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
