### PR TITLE
Jetpack Backup: Add new Tracks events for download process

### DIFF
--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -63,7 +63,14 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 	const isRestoreDisabled =
 		doesRewindNeedCredentials || isRestoreInProgress || ( ! isAtomic && areCredentialsInvalid );
 
-	const onDownloadClick = () => dispatch( rewindRequestBackup( siteId, rewindId ) );
+	const onDownloadClick = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_actions_download_click', {
+				rewind_id: rewindId,
+			} )
+		);
+		dispatch( rewindRequestBackup( siteId, rewindId ) );
+	};
 
 	return (
 		<>

--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -1,10 +1,11 @@
 import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useCallback, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import QueryRewindBackupStatus from 'calypso/components/data/query-rewind-backup-status';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getRewindBackupProgress, rewindBackup } from 'calypso/state/activity-log/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getBackupProgress from 'calypso/state/selectors/get-backup-progress';
 import getRequest from 'calypso/state/selectors/get-request';
 import getRequestedBackup from 'calypso/state/selectors/get-requested-backup';
@@ -84,6 +85,12 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 		downloadRewindId !== rewindId || ( downloadId !== 0 && requestedBackup !== downloadId );
 	const isOtherDownloadInProgress = isOtherDownloadInfo && downloadProgress !== undefined;
 	const isDownloadURLNotReady = downloadUrl === undefined || downloadUrl === '';
+
+	useEffect( () => {
+		if ( ! isDownloadURLNotReady ) {
+			dispatch( recordTracksEvent( 'calypso_jetpack_backup_download_ready' ) );
+		}
+	}, [ isDownloadURLNotReady, dispatch ] );
 
 	const renderConfirm = () => (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/489

## Proposed Changes
Add the followings Tracks events to the download flow:
* `calypso_jetpack_backup_actions_download_click`: when a user clicks on `Download backup` in the actions' toolbar in the backup page or the activity log.
  ![CleanShot 2024-06-05 at 00 03 57@2x](https://github.com/Automattic/wp-calypso/assets/1488641/105a65a0-b0e5-40ca-a357-c9eaeef2fc30)
* `calypso_jetpack_backup_download_ready`: when a download is ready.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These specific Tracks events will help us validate the feature usage of the download feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> For brevity describing the test steps, when we say `validate the event X was triggered`, it means that you should see a request to `t.gif` with the described event name.

* Spin up a Jetpack Cloud live branch
* Open the Network tab in your developer tools
* Navigate to Jetpack Cloud > Backup
* On any available backup, click on `Actions (+)` and then `Download backup`
* Validate the event `calypso_jetpack_backup_actions_download_click` was triggered
* Initiate a download, and when it completes, validate the event `calypso_jetpack_backup_download_ready` was triggered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
