### PR TITLE
DIFM Content Form: enable filler content for all locales

### DIFF
--- a/client/signup/steps/website-content/section-types/custom-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/custom-page-details.tsx
@@ -1,4 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import {
@@ -31,7 +30,6 @@ export function CustomPageDetails( {
 	const translate = useTranslate();
 	const site = useSelector( getSelectedSite );
 	const description = useTranslatedPageDescriptions( page.id, context );
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const { onCheckboxChanged, onFieldChanged } = useChangeHandlers( {
 		pageId: page.id,
@@ -55,7 +53,7 @@ export function CustomPageDetails( {
 				error={ formErrors[ 'content' ] }
 				label={ description }
 				disabled={ !! page.useFillerContent }
-				hasFillerContentCheckbox={ isEnglishLocale }
+				hasFillerContentCheckbox
 				characterLimit={ CHARACTER_LIMIT }
 				characterLimitError={ translate(
 					"Please shorten your text to under %(characterLimit)s characters for optimal formatting. If it remains over this limit, we'll optimize it with AI when building your site.",
@@ -67,18 +65,16 @@ export function CustomPageDetails( {
 					}
 				) }
 			/>
-			{ isEnglishLocale && (
-				<CheckboxField
-					name="useFillerContent"
-					checked={ page.useFillerContent || false }
-					value="true"
-					onChange={ onCheckboxChanged }
-					label={ translate( 'Build this page with AI-generated text.' ) }
-					helpText={ translate(
-						'When building your site, we will use AI to generate copy based on the search phrases you have provided. The copy can be edited later with the WordPress editor.'
-					) }
-				/>
-			) }
+			<CheckboxField
+				name="useFillerContent"
+				checked={ page.useFillerContent || false }
+				value="true"
+				onChange={ onCheckboxChanged }
+				label={ translate( 'Build this page with AI-generated text.' ) }
+				helpText={ translate(
+					'When building your site, we will use AI to generate copy based on the search phrases you have provided. The copy can be edited later with the WordPress editor.'
+				) }
+			/>
 			{ site && <MediaUpload page={ page } site={ site } onChangeField={ onChangeField } /> }
 		</>
 	);

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -1,4 +1,3 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { TextAreaField, CheckboxField } from 'calypso/signup/accordion-form/form-components';
@@ -28,7 +27,6 @@ export function DefaultPageDetails( {
 
 	const site = useSelector( getSelectedSite );
 	const description = useTranslatedPageDescriptions( page.id, context );
-	const isEnglishLocale = useIsEnglishLocale();
 	const { onCheckboxChanged, onFieldChanged } = useChangeHandlers( {
 		pageId: page.id,
 		onChangeField,
@@ -43,7 +41,7 @@ export function DefaultPageDetails( {
 				error={ formErrors[ 'content' ] }
 				label={ description }
 				disabled={ !! page.useFillerContent }
-				hasFillerContentCheckbox={ isEnglishLocale }
+				hasFillerContentCheckbox
 				characterLimit={ CHARACTER_LIMIT }
 				characterLimitError={ translate(
 					"Please shorten your text to under %(characterLimit)s characters for optimal formatting. If it remains over this limit, we'll optimize it with AI when building your site.",
@@ -55,18 +53,16 @@ export function DefaultPageDetails( {
 					}
 				) }
 			/>
-			{ isEnglishLocale && (
-				<CheckboxField
-					name="useFillerContent"
-					checked={ page.useFillerContent || false }
-					value="true"
-					onChange={ onCheckboxChanged }
-					label={ translate( 'Build this page with AI-generated text.' ) }
-					helpText={ translate(
-						'When building your site, we will use AI to generate copy based on the search phrases you have provided. The copy can be edited later with the WordPress editor.'
-					) }
-				/>
-			) }
+			<CheckboxField
+				name="useFillerContent"
+				checked={ page.useFillerContent || false }
+				value="true"
+				onChange={ onCheckboxChanged }
+				label={ translate( 'Build this page with AI-generated text.' ) }
+				helpText={ translate(
+					'When building your site, we will use AI to generate copy based on the search phrases you have provided. The copy can be edited later with the WordPress editor.'
+				) }
+			/>
 			{ site && <MediaUpload page={ page } site={ site } onChangeField={ onChangeField } /> }
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Removes the EN-only restriction for showing the AI-content checkbox.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p1717166065460949-slack-C02KVCAL7GX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to any locale other than English.
* Go to `/start/do-it-for-me` and complete the purchase.
* On the website content form, open each page section and confirm that the checkbox with the label `Build this page with AI-generated text.`
* Confirm that the AI checkbox is present.

<img width="850" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/9e2395f8-7b6a-49f0-99b0-63b01162223c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?