### PR TITLE
Jetpack Cloud: Change the copy to include Atomic when there're no sites

### DIFF
--- a/client/components/jetpack/no-jetpack-sites-message/index.tsx
+++ b/client/components/jetpack/no-jetpack-sites-message/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
@@ -20,18 +19,6 @@ export const NoJetpackSitesMessage = ( { siteSlug }: { siteSlug: string | undefi
 					) }
 				</p>
 			) }
-			<p>
-				{ translate(
-					'This area is only for Jetpack customers with self-hosted WordPress sites and WordPress.com-hosted sites using our {{a}}advanced hosting features{{/a}}.',
-					{
-						components: {
-							a: (
-								<a href={ localizeUrl( 'https://wordpress.com/support/hosting-configuration/' ) } />
-							),
-						},
-					}
-				) }
-			</p>
 			<Button primary href="https://wordpress.com" rel="noopener noreferrer">
 				{ translate( 'Visit Dashboard' ) }
 			</Button>

--- a/client/components/jetpack/no-jetpack-sites-message/index.tsx
+++ b/client/components/jetpack/no-jetpack-sites-message/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
@@ -20,7 +21,16 @@ export const NoJetpackSitesMessage = ( { siteSlug }: { siteSlug: string | undefi
 				</p>
 			) }
 			<p>
-				{ translate( 'This area is only for Jetpack customers with self-hosted WordPress sites.' ) }
+				{ translate(
+					'This area is only for Jetpack customers with self-hosted WordPress sites and WordPress.com-hosted sites using our {{a}}advanced hosting features{{/a}}.',
+					{
+						components: {
+							a: (
+								<a href={ localizeUrl( 'https://wordpress.com/support/hosting-configuration/' ) } />
+							),
+						},
+					}
+				) }
 			</p>
 			<Button primary href="https://wordpress.com" rel="noopener noreferrer">
 				{ translate( 'Visit Dashboard' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

Fix https://github.com/Automattic/dotcom-forge/issues/7391

This PR removes the copy when there are no sites, as Atomic is already supported, and Simple will be soon. 
https://github.com/Automattic/wp-calypso/pull/91501#issuecomment-2149133468

| before | after |
|--------|--------|
|<img width="785" alt="Screenshot 2024-06-05 at 14 54 15" src="https://github.com/Automattic/wp-calypso/assets/5287479/fa04ba40-7067-49ea-9b18-1c4e7b606672"> | <img width="800" alt="Screenshot 2024-06-06 at 10 34 19" src="https://github.com/Automattic/wp-calypso/assets/5287479/e38df6d5-93fd-44cc-b83b-4c23a66ea895"> | 

<details><summary>previous approach</summary>
<p>

This PR changes the copy when there are no sites.
Changed it to include Atomic, as it's already supported.

| before | after |
|--------|--------|
| <img width="785" alt="Screenshot 2024-06-05 at 14 54 15" src="https://github.com/Automattic/wp-calypso/assets/5287479/fa04ba40-7067-49ea-9b18-1c4e7b606672"> | <img width="757" alt="Screenshot 2024-06-05 at 14 54 09" src="https://github.com/Automattic/wp-calypso/assets/5287479/d2d569ec-31cc-466b-b02f-e05563d23acb"> | 


</p>
</details> 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As we already support Atomic sites in Jetpack Cloud.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare an account without Atomic sites
* Open Jetpack Cloud live https://github.com/Automattic/wp-calypso/pull/91501#issuecomment-2148913408

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
