### PR TITLE
A4A: Add Partner Directory interfaces: AgencyDetails AgencyApplication

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/types.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/types.ts
@@ -1,0 +1,31 @@
+export interface AgencyDirectoryApplication {
+	status: 'pending' | 'in_progress' | 'completed';
+	products: string[];
+	services: string[];
+	directories: DirectoryApplication[];
+	feedback_url: string;
+}
+
+interface DirectoryApplication {
+	directory: 'WordPress' | 'Jetpack' | 'WooCommerce' | 'Pressable';
+	published: boolean;
+	status: 'pending' | 'approved' | 'rejected' | 'closed';
+	urls: string[];
+	note: string;
+}
+
+export interface AgencyDetails {
+	name: string;
+	email: string;
+	website: string;
+	bio_description: string;
+	logo_url: string;
+	landing_page_url: string;
+	country: string;
+	is_available: boolean;
+	industry: string;
+	services: string[];
+	products: string[];
+	languages_spoken: string[];
+	budget_lower_range: number;
+}

--- a/client/a8c-for-agencies/sections/partner-directory/types.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/types.ts
@@ -1,5 +1,5 @@
 export interface AgencyDirectoryApplication {
-	status: 'pending' | 'in_progress' | 'completed';
+	status: 'pending' | 'in-progress' | 'completed';
 	products: string[];
 	services: string[];
 	directories: DirectoryApplication[];
@@ -7,7 +7,7 @@ export interface AgencyDirectoryApplication {
 }
 
 interface DirectoryApplication {
-	directory: 'WordPress' | 'Jetpack' | 'WooCommerce' | 'Pressable';
+	directory: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable';
 	published: boolean;
 	status: 'pending' | 'approved' | 'rejected' | 'closed';
 	urls: string[];


### PR DESCRIPTION
Resolve: https://github.com/Automattic/automattic-for-agencies-dev/issues/627

## Proposed Changes

This PR adds the required Partner Directory interfaces:

- AgencyDetails
- AgencyDirectoryApplication
- DirectoryApplication

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code and ensure that they have all the required fields with their types.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
