### PR TITLE
A4A > Partner Directory: Implement Partner Directory Success view

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -89,7 +89,13 @@ export default function PartnerDirectoryDashboard() {
 		return (
 			<div className="partner-directory-dashboard__completed-section">
 				<div className="partner-directory-dashboard__heading">
-					{ translate( 'Congratulations! Your agency is now listed in our partner directories.' ) }
+					{ translate(
+						'Congratulations! Your agency is now listed in our partner directory.',
+						'Congratulations! Your agency is now listed in our partner directories.',
+						{
+							count: brandStatuses.filter( ( { status } ) => status === 'Approved' ).length,
+						}
+					) }
 				</div>
 				{ brandStatuses.length > 0 &&
 					brandStatuses.map( ( { brand, status, type } ) => {

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -1,5 +1,6 @@
 import { BadgeType, Button } from '@automattic/components';
 import { Icon, external, check } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'calypso/state';
@@ -7,6 +8,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import StepSection from '../../referrals/common/step-section';
 import StepSectionItem from '../../referrals/common/step-section-item';
 import StatusBadge from '../../referrals/common/step-section-item/status-badge';
+import { getBrandMeta } from '../lib/get-brand-meta';
 
 import './style.scss';
 
@@ -22,6 +24,18 @@ export default function PartnerDirectoryDashboard() {
 		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_finish_profile_click' ) );
 	}, [ dispatch ] );
 
+	const onEditExpertiseClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_edit_expertise_click' ) );
+	}, [ dispatch ] );
+
+	const onEditProfileClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_edit_profile_click' ) );
+	}, [ dispatch ] );
+
+	const onAgencyProfileClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_agency_profile_click' ) );
+	}, [ dispatch ] );
+
 	const isSubmitted = true; // FIXME: Replace with actual value
 	const brandStatuses = [
 		{
@@ -30,9 +44,9 @@ export default function PartnerDirectoryDashboard() {
 			type: 'success',
 		},
 		{
-			brand: 'Woocommerce.com',
-			status: 'Pending',
-			type: 'warning',
+			brand: 'WooCommerce.com',
+			status: 'Not approved',
+			type: 'error',
 		},
 		{
 			brand: 'Pressable.com',
@@ -45,6 +59,104 @@ export default function PartnerDirectoryDashboard() {
 			type: 'warning',
 		},
 	] as { brand: string; status: string; type: BadgeType }[]; // FIXME: Replace with actual value
+
+	const isCompleted = true; // FIXME: Replace with actual value
+
+	const programLinks = (
+		<StepSection
+			className="partner-directory-dashboard__learn-more-section"
+			heading={ translate( 'Learn more about the program' ) }
+		>
+			{
+				// FIXME: Add link
+				<Button className="a8c-blue-link" borderless href="#">
+					{ translate( 'How does the approval process work?' ) }
+					<Icon icon={ external } size={ 18 } />
+				</Button>
+			}
+			<br />
+			{
+				// FIXME: Add link
+				<Button className="a8c-blue-link" borderless href="#">
+					{ translate( 'What can I put on my public profile?' ) }
+					<Icon icon={ external } size={ 18 } />
+				</Button>
+			}
+		</StepSection>
+	);
+
+	if ( isCompleted ) {
+		return (
+			<div className="partner-directory-dashboard__completed-section">
+				<div className="partner-directory-dashboard__heading">
+					{ translate( 'Congratulations! Your agency is now listed in our partner directories.' ) }
+				</div>
+				{ brandStatuses.length > 0 &&
+					brandStatuses.map( ( { brand, status, type } ) => {
+						const brandMeta = getBrandMeta( brand );
+						return (
+							<StepSectionItem
+								isNewLayout
+								iconClassName={ clsx( brandMeta.className ) }
+								icon={ brandMeta.icon }
+								heading={ brand }
+								description={
+									// FIXME: Add links to all the buttons
+									status === 'Approved' ? (
+										<>
+											<Button className="a8c-blue-link" borderless href="#">
+												{ translate( '%(brand)s Partner Directory', {
+													args: { brand },
+												} ) }
+											</Button>
+											<br />
+											<Button
+												className="a8c-blue-link"
+												onClick={ onAgencyProfileClick }
+												href="/partner-directory/agency-details"
+												borderless
+											>
+												{ translate( `Your agency's profile` ) }
+											</Button>
+										</>
+									) : (
+										<StatusBadge
+											statusProps={ {
+												children: status,
+												type,
+											} }
+										/>
+									)
+								}
+							/>
+						);
+					} ) }
+				<StepSection
+					className="partner-directory-dashboard__edit-section"
+					heading={ translate( `Edit your agency's information` ) }
+				>
+					<div className="partner-directory-dashboard__subtitle">
+						{ translate(
+							`Expand to more Automattic directories by adding products or updating your agency's profile.`
+						) }
+					</div>
+					<div>
+						<Button
+							onClick={ onEditExpertiseClick }
+							href="/partner-directory/agency-expertise"
+							compact
+						>
+							{ translate( 'Edit expertise' ) }
+						</Button>
+						<Button onClick={ onEditProfileClick } href="/partner-directory/agency-details" compact>
+							{ translate( 'Edit profile' ) }
+						</Button>
+					</div>
+				</StepSection>
+				{ programLinks }
+			</div>
+		);
+	}
 
 	return (
 		<>
@@ -60,6 +172,7 @@ export default function PartnerDirectoryDashboard() {
 			<StepSection heading={ translate( 'How do I start?' ) }>
 				<StepSectionItem
 					isNewLayout
+					className="partner-directory-dashboard__apply-now-section"
 					icon={ check }
 					stepNumber={ isSubmitted ? undefined : 1 }
 					heading={ translate( 'Share your expertise' ) }
@@ -68,7 +181,12 @@ export default function PartnerDirectoryDashboard() {
 							<div className="partner-directory-dashboard__brand-status-section">
 								{ brandStatuses.map( ( { brand, status, type } ) => (
 									<div key={ brand }>
-										<StatusBadge statusProps={ { children: status, type } } />
+										<StatusBadge
+											statusProps={ {
+												children: status,
+												type,
+											} }
+										/>
 										<span>{ brand }</span>
 									</div>
 								) ) }
@@ -112,26 +230,7 @@ export default function PartnerDirectoryDashboard() {
 					) }
 				/>
 			</StepSection>
-			<StepSection
-				className="partner-directory-dashboard__learn-more-section"
-				heading={ translate( 'Learn more about the program' ) }
-			>
-				{
-					// FIXME: Add link
-					<Button className="a8c-blue-link" borderless href="#">
-						{ translate( 'How does the approval process work?' ) }
-						<Icon icon={ external } size={ 18 } />
-					</Button>
-				}
-				<br />
-				{
-					// FIXME: Add link
-					<Button className="a8c-blue-link" borderless href="#">
-						{ translate( 'What can I put on my public profile?' ) }
-						<Icon icon={ external } size={ 18 } />
-					</Button>
-				}
-			</StepSection>
+			{ programLinks }
 		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
@@ -3,7 +3,7 @@
 		max-width: 700px;
 	}
 
-	svg.sidebar__menu-icon {
+	.partner-directory-dashboard__apply-now-section svg.sidebar__menu-icon {
 		width: 20px;
 		height: 20px;
 		padding: 2px;
@@ -48,12 +48,55 @@
 	gap: 8px;
 
 	.badge {
-		min-width: 80px;
+		min-width: 100px;
 		margin-inline-end: 8px;
 		text-align: center;
 	}
 
 	span {
 		color: var(--color-text-black);
+	}
+}
+
+.partner-directory-dashboard__completed-section {
+	.partner-directory-dashboard__heading {
+		margin-block-end: 32px;
+	}
+	.step-section-item__status {
+		margin-block-start: 4px;
+	}
+
+	.a8c-blue-link {
+		padding-block: 2px;
+	}
+
+	.sidebar__menu-icon {
+		width: 33px;
+		height: 33px;
+	}
+
+	.partner-directory-dashboard__woo-icon {
+		.sidebar__menu-icon {
+			width: 38px;
+			height: 38px;
+			position: relative;
+			left: -3px;
+		}
+	}
+}
+
+.partner-directory-dashboard__edit-section {
+	margin-block-start: 40px;
+
+	.step-section__header {
+		margin-block-end: 4px;
+	}
+
+	.partner-directory-dashboard__subtitle {
+		margin-block-end: 24px;
+	}
+
+	.button {
+		margin-inline-end: 8px;
 	}
 }

--- a/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
@@ -1,0 +1,26 @@
+import { WooLogo, WordPressLogo, JetpackLogo } from '@automattic/components';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+
+export const getBrandMeta = ( brand: string ) => {
+	let className = '';
+	let icon = undefined;
+	switch ( brand ) {
+		case 'WordPress.com':
+			icon = <WordPressLogo />;
+			break;
+		case 'WooCommerce.com':
+			icon = <WooLogo />;
+			className = 'partner-directory-dashboard__woo-icon';
+			break;
+		case 'Pressable.com':
+			icon = <img src={ pressableIcon } alt="" />;
+			break;
+		case 'Jetpack.com':
+			icon = <JetpackLogo />;
+			break;
+		default:
+			icon = undefined;
+			break;
+	}
+	return { className, icon };
+};


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/551

## Proposed Changes

This PR implements the success view for the dashboard on the Partner Directory.

We are currently hardcoding all the values. The API changes will be done in another PR.

NOTE: 

- [Design](https://www.figma.com/design/fp9lBFMcpB15H7czSIthPW/Partner-Directories?node-id=7025-23772&m=dev)

## Testing Instructions

1. Open the A4A live link.
2. Go to Partner Directory - Dashboard > Verify the UI looks as below. 

<img width="1409" alt="Screenshot 2024-06-05 at 10 17 41 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/1c02b030-77ed-4052-86e9-91936354429c">


<img width="1409" alt="Screenshot 2024-06-05 at 11 09 48 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/220c795a-3cf5-49be-99da-600e243c9109">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
