### PR TITLE
A4A: Add Partner Directory's Expertise form.

### DIFF
--- a/client/a8c-for-agencies/components/form/field/index.tsx
+++ b/client/a8c-for-agencies/components/form/field/index.tsx
@@ -4,14 +4,18 @@ import './style.scss';
 
 type Props = {
 	label: string;
+	sub?: string;
 	description?: string;
 	children: ReactNode;
 };
 
-export default function FormField( { label, children, description }: Props ) {
+export default function FormField( { label, sub, children, description }: Props ) {
 	return (
 		<div className="a4a-form__section-field">
-			<h3 className="a4a-form__section-field-label">{ label }</h3>
+			<div className="a4a-form__section-field-heading">
+				<h3 className="a4a-form__section-field-label">{ label }</h3>
+				{ sub && <p className="a4a-form__section-field-sub">{ sub }</p> }
+			</div>
 
 			{ children }
 

--- a/client/a8c-for-agencies/components/form/field/style.scss
+++ b/client/a8c-for-agencies/components/form/field/style.scss
@@ -5,6 +5,7 @@
 }
 
 .a4a-form__section-field-label,
+.a4a-form__section-field-sub,
 .a4a-form__section-field-description {
 	font-size: rem(14px);
 	line-height: 1.5;
@@ -14,6 +15,7 @@
 	font-weight: 500;
 }
 
+.a4a-form__section-field-sub,
 .a4a-form__section-field-description {
 	font-weight: 400;
 	color: var(--color-neutral-50);

--- a/client/a8c-for-agencies/components/form/style.scss
+++ b/client/a8c-for-agencies/components/form/style.scss
@@ -3,6 +3,9 @@
 	flex-direction: column;
 	gap: 48px;
 
+	max-width: 700px;
+	margin: 0 auto;
+
 	h1,
 	h2,
 	h3,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
@@ -1,0 +1,126 @@
+import { useCallback, useState } from 'react';
+import {
+	DIRECTORY_JETPACK,
+	DIRECTORY_PRESSABLE,
+	DIRECTORY_WOOCOMMERCE,
+	DIRECTORY_WPCOM,
+	EXPERTISE_FORM_FIELD_CUSTOMER_FEEDBACK_URL,
+	EXPERTISE_FORM_FIELD_DIRECTORIES,
+	EXPERTISE_FORM_FIELD_PRODUCTS,
+	EXPERTISE_FORM_FIELD_SERVICES,
+} from '../../constants';
+
+type Form = {
+	[ EXPERTISE_FORM_FIELD_SERVICES ]: string[];
+	[ EXPERTISE_FORM_FIELD_PRODUCTS ]: string[];
+	[ EXPERTISE_FORM_FIELD_CUSTOMER_FEEDBACK_URL ]: string;
+	[ EXPERTISE_FORM_FIELD_DIRECTORIES ]: Record< string, Directory >;
+};
+
+type Directory = {
+	selected: boolean;
+	samples: string[];
+};
+
+const DEFAULT_DIRECTORY_STATE: Directory = {
+	selected: false,
+	samples: [ '', '', '', '', '' ],
+};
+
+export default function useExpertiseForm() {
+	const [ formData, setFormData ] = useState< Form >( {
+		services: [],
+		products: [],
+		customerFeedbackURL: '',
+		directories: {
+			[ DIRECTORY_WPCOM ]: { ...DEFAULT_DIRECTORY_STATE },
+			[ DIRECTORY_WOOCOMMERCE ]: { ...DEFAULT_DIRECTORY_STATE },
+			[ DIRECTORY_JETPACK ]: { ...DEFAULT_DIRECTORY_STATE },
+			[ DIRECTORY_PRESSABLE ]: { ...DEFAULT_DIRECTORY_STATE },
+		},
+	} );
+
+	const getFormValue = useCallback(
+		( key: string ) => {
+			return formData[ key as keyof Form ];
+		},
+		[ formData ]
+	);
+
+	const setFormValue = useCallback(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( key: string, value: any ) => {
+			setFormData( {
+				...formData,
+				[ key as keyof Form ]: value,
+			} );
+		},
+		[ formData ]
+	);
+
+	const isDirectorySelected = useCallback(
+		( directory: string ) => {
+			return !! formData.directories[ directory ]?.selected;
+		},
+		[ formData ]
+	);
+
+	const setDirectorySelected = useCallback(
+		( directory: string, selected: boolean ) => {
+			setFormValue( EXPERTISE_FORM_FIELD_DIRECTORIES, {
+				...formData.directories,
+				[ directory ]: {
+					...formData.directories[ directory ],
+					selected,
+				},
+			} );
+		},
+		[ formData.directories, setFormValue ]
+	);
+
+	const getDirectories = useCallback( () => {
+		return Object.keys( formData.directories );
+	}, [ formData.directories ] );
+
+	const getSelectedDirectories = useCallback( () => {
+		return Object.keys( formData.directories ).filter( ( directory ) => {
+			return formData.directories[ directory ].selected;
+		} );
+	}, [ formData.directories ] );
+
+	const getDirectoryClientSamples = useCallback(
+		( directory: string ) => {
+			return formData.directories[ directory ]?.samples;
+		},
+		[ formData.directories ]
+	);
+
+	const setDirectorClientSample = useCallback(
+		( directory: string, index: number, value: string ) => {
+			setFormValue( EXPERTISE_FORM_FIELD_DIRECTORIES, {
+				...formData.directories,
+				[ directory ]: {
+					...formData.directories[ directory ],
+					samples: [
+						...formData.directories[ directory ].samples.slice( 0, index ),
+						value,
+						...formData.directories[ directory ].samples.slice( index + 1 ),
+					],
+				},
+			} );
+		},
+		[ formData.directories, setFormValue ]
+	);
+
+	return {
+		formData,
+		getFormValue,
+		setFormValue,
+		isDirectorySelected,
+		setDirectorySelected,
+		getDirectories,
+		getSelectedDirectories,
+		getDirectoryClientSamples,
+		setDirectorClientSample,
+	};
+}

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -1,8 +1,161 @@
-const AgencyExpertise = () => {
+import { CheckboxControl, FormTokenField, TextControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode } from 'react';
+import Form from 'calypso/a8c-for-agencies/components/form';
+import FormField from 'calypso/a8c-for-agencies/components/form/field';
+import FormSection from 'calypso/a8c-for-agencies/components/form/section';
+import {
+	EXPERTISE_FORM_FIELD_CUSTOMER_FEEDBACK_URL,
+	EXPERTISE_FORM_FIELD_PRODUCTS,
+	EXPERTISE_FORM_FIELD_SERVICES,
+} from '../constants';
+import { getPartnerDirectoryLabel } from '../utils/get-partner-directory-label';
+import useExpertiseForm from './hooks/use-expertise-form';
+
+import './style.scss';
+
+type DirectoryClientSamplesProps = {
+	label: string | ReactNode;
+	samples: string[];
+	onSampleChange: ( index: number, value: string ) => void;
+};
+
+const DirectoryClientSamples = ( {
+	label,
+	samples,
+	onSampleChange,
+}: DirectoryClientSamplesProps ) => {
+	const translate = useTranslate();
 	return (
-		<div>
-			<h2>Agency Expertise</h2>
+		<div className="partner-directory-agency-expertise__directory-client-site">
+			<h3 className="partner-directory-agency-expertise__client-samples-label">{ label }</h3>
+			<div className="partner-directory-agency-expertise__client-samples">
+				{ samples.map( ( sample, index ) => (
+					<TextControl
+						key={ `client-sample-${ index }` }
+						type="text"
+						placeholder={ translate( 'Enter URL' ) }
+						value={ sample }
+						onChange={ ( value ) => onSampleChange( index, value ) }
+					/>
+				) ) }
+			</div>
 		</div>
+	);
+};
+
+const AgencyExpertise = () => {
+	const translate = useTranslate();
+
+	const {
+		getFormValue,
+		setFormValue,
+		isDirectorySelected,
+		setDirectorySelected,
+		getDirectories,
+		getSelectedDirectories,
+		getDirectoryClientSamples,
+		setDirectorClientSample,
+	} = useExpertiseForm();
+
+	const selectedDirectories = getSelectedDirectories();
+
+	const directories = getDirectories();
+
+	return (
+		<Form
+			className="partner-directory-agency-expertise"
+			title={ translate( 'Share your expertise' ) }
+			description={ translate( "Pick your agency's specialties and choose your directories." ) }
+		>
+			<FormSection title={ translate( 'Product and Service' ) }>
+				<FormField
+					label={ translate( 'What services do you offer?' ) }
+					description={ translate(
+						'We allow each agency to offer up to five services to help you focus on what you do best.'
+					) }
+				>
+					<FormTokenField
+						label=""
+						value={ getFormValue( EXPERTISE_FORM_FIELD_SERVICES ) as string[] }
+						onChange={ ( value ) => setFormValue( EXPERTISE_FORM_FIELD_SERVICES, value ) }
+						__experimentalShowHowTo={ false }
+						__nextHasNoMarginBottom
+					/>
+				</FormField>
+
+				<FormField label={ translate( 'What products do you work with?' ) }>
+					<FormTokenField
+						label=""
+						value={ getFormValue( EXPERTISE_FORM_FIELD_PRODUCTS ) as string[] }
+						onChange={ ( value ) => setFormValue( EXPERTISE_FORM_FIELD_PRODUCTS, value ) }
+						__experimentalShowHowTo={ false }
+						__nextHasNoMarginBottom
+					/>
+				</FormField>
+			</FormSection>
+
+			<FormSection title={ translate( 'Partner Directories' ) }>
+				<FormField
+					label={ translate( 'Automattic Partner Directories' ) }
+					sub={ translate( 'Select the Automattic directories you would like to appear on.' ) }
+				>
+					<div className="partner-directory-agency-expertise__directory-options">
+						{ directories.map( ( directory ) => (
+							<CheckboxControl
+								key={ `directory-${ directory }` }
+								label={ getPartnerDirectoryLabel( directory ) }
+								checked={ isDirectorySelected( directory ) }
+								onChange={ ( value ) => setDirectorySelected( directory, value ) }
+							/>
+						) ) }
+					</div>
+				</FormField>
+
+				{ !! selectedDirectories.length && (
+					<FormField
+						label={ translate( 'Client sites' ) }
+						sub={ translate(
+							"For each directory you selected, provide URLs of 5 client sites you've worked on. This helps us gauge your expertise."
+						) }
+					>
+						<div className="partner-directory-agency-expertise__directory-client-sites">
+							{ selectedDirectories.map( ( directory ) => (
+								<DirectoryClientSamples
+									key={ `directory-samples-${ directory }` }
+									label={ translate( 'Relevant examples for %(directory)s', {
+										args: {
+											directory: getPartnerDirectoryLabel( directory ),
+										},
+										comment: '%(directory)s is the directory name, e.g. "WordPress.com"',
+									} ) }
+									samples={ getDirectoryClientSamples( directory ) }
+									onSampleChange={ ( index, value ) =>
+										setDirectorClientSample( directory, index, value )
+									}
+								/>
+							) ) }
+						</div>
+					</FormField>
+				) }
+
+				<FormField
+					label={ translate( 'Share customer feedback' ) }
+					description={ translate(
+						'Great support is key to our success. Share a link to your customer feedback from Google, Clutch, Facebook, etc., or testimonials featured on your website. If you don’t have online reviews, provide a link to client references or case studies.'
+					) }
+				>
+					<TextControl
+						type="text"
+						placeholder={ translate( 'Enter URL' ) }
+						value={ getFormValue( EXPERTISE_FORM_FIELD_CUSTOMER_FEEDBACK_URL ) as string }
+						onChange={ ( value ) =>
+							setFormValue( EXPERTISE_FORM_FIELD_CUSTOMER_FEEDBACK_URL, value )
+						}
+					/>
+				</FormField>
+			</FormSection>
+		</Form>
 	);
 };
 

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
@@ -14,7 +14,7 @@
 	gap: 8px;
 }
 
-.partner-directory-agency-expertise__client-samples-label {
+h3.partner-directory-agency-expertise__client-samples-label {
 	font-size: rem(14px);
 	line-height: 1.5;
 	font-weight: 500;

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
@@ -1,0 +1,20 @@
+.partner-directory-agency-expertise__directory-client-sites {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	row-gap: 16px;
+	column-gap: 32px;
+}
+
+.partner-directory-agency-expertise__client-site,
+.partner-directory-agency-expertise__client-samples {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.partner-directory-agency-expertise__client-samples-label {
+	font-size: rem(14px);
+	line-height: 1.5;
+	font-weight: 500;
+	margin-block-end: 8px;
+}

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
@@ -1,3 +1,4 @@
+
 .partner-directory-agency-expertise__directory-client-sites {
 	display: grid;
 	grid-template-columns: 1fr 1fr;

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
@@ -6,6 +6,7 @@
 }
 
 .partner-directory-agency-expertise__client-site,
+.partner-directory-agency-expertise__directory-options,
 .partner-directory-agency-expertise__client-samples {
 	display: flex;
 	flex-direction: column;

--- a/client/a8c-for-agencies/sections/partner-directory/constants.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/constants.ts
@@ -1,3 +1,13 @@
 export const PARTNER_DIRECTORY_DASHBOARD_SLUG = 'dashboard';
 export const PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG = 'agency-details';
 export const PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG = 'agency-expertise';
+
+export const EXPERTISE_FORM_FIELD_SERVICES = 'services';
+export const EXPERTISE_FORM_FIELD_PRODUCTS = 'products';
+export const EXPERTISE_FORM_FIELD_DIRECTORIES = 'directories';
+export const EXPERTISE_FORM_FIELD_CUSTOMER_FEEDBACK_URL = 'customerFeedbackURL';
+
+export const DIRECTORY_WPCOM = 'wpcom';
+export const DIRECTORY_WOOCOMMERCE = 'woocommerce';
+export const DIRECTORY_JETPACK = 'jetpack';
+export const DIRECTORY_PRESSABLE = 'pressable';

--- a/client/a8c-for-agencies/sections/partner-directory/constants.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/constants.ts
@@ -7,7 +7,7 @@ export const EXPERTISE_FORM_FIELD_PRODUCTS = 'products';
 export const EXPERTISE_FORM_FIELD_DIRECTORIES = 'directories';
 export const EXPERTISE_FORM_FIELD_CUSTOMER_FEEDBACK_URL = 'customerFeedbackURL';
 
-export const DIRECTORY_WPCOM = 'wpcom';
+export const DIRECTORY_WPCOM = 'wordpress';
 export const DIRECTORY_WOOCOMMERCE = 'woocommerce';
 export const DIRECTORY_JETPACK = 'jetpack';
 export const DIRECTORY_PRESSABLE = 'pressable';

--- a/client/a8c-for-agencies/sections/partner-directory/utils/get-partner-directory-label.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/get-partner-directory-label.ts
@@ -1,0 +1,17 @@
+import {
+	DIRECTORY_JETPACK,
+	DIRECTORY_PRESSABLE,
+	DIRECTORY_WOOCOMMERCE,
+	DIRECTORY_WPCOM,
+} from '../constants';
+
+export function getPartnerDirectoryLabel( directory: string ): string {
+	return (
+		{
+			[ DIRECTORY_WPCOM ]: 'WordPress.com',
+			[ DIRECTORY_WOOCOMMERCE ]: 'WooCommerce.com',
+			[ DIRECTORY_JETPACK ]: 'Jetpack.com',
+			[ DIRECTORY_PRESSABLE ]: 'Pressable.com',
+		}[ directory ] ?? ''
+	);
+}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -221,6 +221,7 @@
 
 	.components-checkbox-control__input {
 		border-radius: 4px;
+		border-color: var(--color-neutral-10);
 		margin: 0;
 	}
 
@@ -237,6 +238,10 @@
 	.components-checkbox-control__input[type="checkbox"]:focus {
 		box-shadow: none;
 		outline: none;
+
+		&:not(.components-checkbox-control__input[type="checkbox"]:checked) {
+			border-color: var(--color-neutral-10);
+		}
 	}
 
 	.components-checkbox-control__input[type="checkbox"]:focus-visible {
@@ -260,10 +265,10 @@
 		border-radius: 2px;
 		box-sizing: border-box;
 		color: var(--color-neutral-70);
-		font-size: 1rem;
+		font-size: rem(14px);
 		line-height: 1.5;
 		margin: 0;
-		padding: 7px 14px;
+		padding: 8px 12px;
 		transition: all 0.15s ease-in-out;
 		width: 100%;
 		min-height: 36px;
@@ -271,8 +276,22 @@
 		&.is-active,
 		&:focus {
 			border-color: var(--color-primary);
-			box-shadow: 0 0 0 2px var(--color-primary-10);
+			box-shadow: 0 0 0 2px var(--color-primary-5);
 			outline: none;
+		}
+	}
+
+	.components-form-token-field__input-container {
+		> * {
+			margin: 0;
+			padding: 0;
+		}
+
+		.components-form-token-field__token,
+		.components-form-token-field__token-text,
+		.components-form-token-field__remove-token.components-button {
+			background-color: var(--color-neutral-5);
+			border-radius: 4px;
 		}
 	}
 

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -229,6 +229,33 @@
 		color: var(--color-primary-60);
 	}
 
+	.components-base-control__field {
+		margin: 0;
+	}
+
+	.components-form-token-field__input-container,
+	.components-text-control__input {
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-neutral-10);
+		border-radius: 2px;
+		box-sizing: border-box;
+		color: var(--color-neutral-70);
+		font-size: 1rem;
+		line-height: 1.5;
+		margin: 0;
+		padding: 7px 14px;
+		transition: all 0.15s ease-in-out;
+		width: 100%;
+		min-height: 36px;
+
+		&.is-active,
+		&:focus {
+			border-color: var(--color-primary);
+			box-shadow: 0 0 0 2px var(--color-primary-10);
+			outline: none;
+		}
+	}
+
 	.button.is-borderless.is-primary.is-active,
 	.button.is-borderless.is-primary:active,
 	.button.is-borderless.is-primary:focus,

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -215,8 +215,8 @@
 	}
 
 	.components-form-toggle.is-checked .components-form-toggle__track {
-		background-color: var(--color-primary-60);
-		border-color: var(--color-primary-60);
+		background-color: var(--color-primary-50);
+		border-color: var(--color-primary-50);
 	}
 
 	.components-checkbox-control__input {

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -219,10 +219,30 @@
 		border-color: var(--color-primary-60);
 	}
 
+	.components-checkbox-control__input {
+		border-radius: 4px;
+		margin: 0;
+	}
+
+	.components-checkbox-control__input-container {
+		margin: 0 8px 0 0;
+	}
+
 	.components-checkbox-control__input[type="checkbox"]:checked,
 	.components-checkbox-control__input[type="checkbox"]:indeterminate {
 		background: var(--color-primary-60);
 		border-color: var(--color-primary-60);
+	}
+
+	.components-checkbox-control__input[type="checkbox"]:focus {
+		box-shadow: none;
+		outline: none;
+	}
+
+	.components-checkbox-control__input[type="checkbox"]:focus-visible {
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+		outline: none;
 	}
 
 	.components-button.is-tertiary {


### PR DESCRIPTION
This pull request includes the initial implementation of the Expertise form for the Partner directories. Please note that this is only for the user interface (presentation) and does not have functional capabilities. I will update the data model used for the form to match the actual data structure we are using on the Partner Directory in a separate pull request later. Additionally, the **services** and **products** field will be updated later to only accept predefined options.


<img width="1026" alt="Screenshot 2024-06-05 at 10 53 04 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/381e7ffd-40bc-4e4b-8fdc-6a4402a7fd6a">


Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/550

## Proposed Changes

* Add initial implementation of the Expertise form based on the i3 design.
* Update **FormField** component to include 'sub' props for additional subtitle content.

## Testing Instructions

* Use the A4A live link and go to /partner-directory/agency-expertise

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
