### PR TITLE
Command Palette: Add "Open hosting overview" command to wp-admin app

### DIFF
--- a/packages/command-palette/package.json
+++ b/packages/command-palette/package.json
@@ -39,7 +39,6 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/command-palette#readme",
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",
-		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { JetpackLogo, WooCommerceWooLogo } from '@automattic/components';
 import { SiteCapabilities } from '@automattic/data-stores';
 import {
@@ -275,20 +274,18 @@ export function useCommands() {
 				siteSelectorLabel: __( 'Select site to open dashboard', __i18n_text_domain__ ),
 				icon: dashboardIcon,
 			},
-			...( isEnabled( 'layout/dotcom-nav-redesign-v2' ) && {
-				openHostingOverview: {
-					name: 'openHostingOverview',
-					label: __( 'Open hosting overview', __i18n_text_domain__ ),
-					callback: commandNavigation( '/overview/:site' ),
-					context: [ '/sites' ],
-					siteSelector: true,
-					siteSelectorLabel: __( 'Select site to open hosting overview', __i18n_text_domain__ ),
-					capability: SiteCapabilities.MANAGE_OPTIONS,
-					filterP2: true,
-					filterSelfHosted: true,
-					icon: hostingIcon,
-				},
-			} ),
+			openHostingOverview: {
+				name: 'openHostingOverview',
+				label: __( 'Open hosting overview', __i18n_text_domain__ ),
+				callback: commandNavigation( '/overview/:site' ),
+				context: [ '/sites' ],
+				siteSelector: true,
+				siteSelectorLabel: __( 'Select site to open hosting overview', __i18n_text_domain__ ),
+				capability: SiteCapabilities.MANAGE_OPTIONS,
+				filterP2: true,
+				filterSelfHosted: true,
+				icon: hostingIcon,
+			},
 			openHostingConfiguration: {
 				name: 'openHostingConfiguration',
 				label: __( 'Open hosting configuration', __i18n_text_domain__ ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,7 +589,6 @@ __metadata:
   resolution: "@automattic/command-palette@workspace:packages/command-palette"
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
-    "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/wp-calypso/pull/91289

## Proposed Changes

Now that the Nav Redesign project has been launched to production, we no longer need the feature flag check that was preventing the "Open hosting overview" command to be available on wp-admin.

## Why are these changes being made?

To ensure we have the same set of commands across Calypso and WP Admin

## Testing Instructions

- Run `install-plugin.sh command-palette update/hosting-overview-command` in your sandbox
- Sandbox `widgets.wp.com` and a Simple site
- Go to wp-admin on your sandboxed site
- Open the command palette
- Make sure the "Open hosting overview" command is available 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
