### PR TITLE
Rename BlazePro into "Blaze Pro"

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -209,7 +209,7 @@ class Login extends Component {
 			! twoStepNonce &&
 			! socialConnect &&
 			! privateSite &&
-			// Show the continue as user flow WooCommerce and BlazePro but not for other OAuth2 clients
+			// Show the continue as user flow WooCommerce and Blaze Pro but not for other OAuth2 clients
 			! ( oauth2Client && ! ( isWoo && ! isPartnerSignup ) && ! isBlazePro ) &&
 			! isJetpackWooCommerceFlow &&
 			! isJetpack &&
@@ -572,7 +572,7 @@ class Login extends Component {
 			}
 
 			if ( isBlazeProOAuth2Client( oauth2Client ) ) {
-				headerText = <h3>{ translate( 'Log in to your BlazePro account' ) }</h3>;
+				headerText = <h3>{ translate( 'Log in to your Blaze Pro account' ) }</h3>;
 				const poweredByWpCom = (
 					<>
 						{ translate( 'Log in with your WordPress.com account.' ) }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -284,7 +284,7 @@ export class LoginForm extends Component {
 		const isWooAndNotPartnerSignup =
 			this.props.isWoo && ! this.props.isPartnerSignup && ! this.props.isWooPasswordless;
 
-		// Skip this step if we're in the ( ( Woo and not the partner ) or BlazePro ) signup flows, and hasAccountTypeLoaded.
+		// Skip this step if we're in the ( ( Woo and not the partner ) or Blaze Pro ) signup flows, and hasAccountTypeLoaded.
 		if (
 			! isWooAndNotPartnerSignup &&
 			! this.props.hasAccountTypeLoaded &&

--- a/client/layout/masterbar/blaze-pro.tsx
+++ b/client/layout/masterbar/blaze-pro.tsx
@@ -30,7 +30,7 @@ const BlazeProOauthMasterbar = () => {
 					<ul className="masterbar__blaze-pro-nav">
 						<li className="masterbar__blaze-pro-nav-item">
 							<a href={ config( 'blaze_pro_back_link' ) } className="masterbar__blaze-pro-link">
-								<img src={ BlazeProLogo } alt="BlazePro" width="40" />
+								<img src={ BlazeProLogo } alt="Blaze Pro" width="40" />
 							</a>
 						</li>
 						{ backNav }

--- a/client/signup/blaze-pro-processing-screen/index.jsx
+++ b/client/signup/blaze-pro-processing-screen/index.jsx
@@ -15,7 +15,7 @@ export default function BlazeProSignupProcessingScreen() {
 
 				<div className="blaze-pro-processing-screen__subtitle">
 					{ translate(
-						"Hang tight, we're almost there! You'll be redirected to BlazePro shortly"
+						"Hang tight, we're almost there! You'll be redirected to Blaze Pro shortly"
 					) }
 				</div>
 			</div>

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -98,17 +98,17 @@ export const initialClientsData = {
 	92099: {
 		id: 92099,
 		name: 'blaze-pro',
-		title: 'BlazePro',
+		title: 'Blaze Pro',
 	},
 	99370: {
 		id: 99370,
 		name: 'blaze-pro',
-		title: 'BlazePro',
+		title: 'Blaze Pro',
 	},
 	98166: {
 		id: 98166,
 		name: 'blaze-pro',
-		title: 'BlazePro',
+		title: 'Blaze Pro',
 	},
 };
 

--- a/client/state/selectors/get-is-blaze-pro.ts
+++ b/client/state/selectors/get-is-blaze-pro.ts
@@ -4,7 +4,7 @@ import { getCurrentOAuth2Client } from '../oauth2-clients/ui/selectors';
 import type { AppState } from 'calypso/types';
 
 /**
- * Return whether it's BlazePro authentication flow.
+ * Return whether it's Blaze Pro authentication flow.
  */
 export default function getIsBlazePro( state: AppState ): boolean {
 	return isBlazeProOAuth2Client( getCurrentOAuth2Client( state ) );


### PR DESCRIPTION
Related to A8C-DSP's 1636

## Proposed Changes
We want to change all BlazePro (without a space in between) to "Blaze Pro" (including a space character).

## Why are these changes being made?
For design/marketing purposes.

## Testing Instructions
Since we change only string constants and comments, doing a core review seems to be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
