### PR TITLE
Help Center: Bring back calypso_inlinehelp_contact_submit event to chat and change `kayako` to `email`.

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -379,7 +379,7 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 					} )
 						.then( () => {
 							recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
-								support_variation: 'kayako',
+								support_variation: 'email',
 								force_site_id: true,
 								location: 'help-center',
 								section: sectionName,

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -179,6 +179,13 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 		const handleOnClick = () => {
 			contactOptionsEventMap.chat();
 
+			recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
+				support_variation: 'messaging',
+				force_site_id: true,
+				location: 'help-center',
+				section: sectionName,
+			} );
+
 			recordTracksEvent( 'calypso_help_live_chat_begin', {
 				site_plan_product_id: productId,
 				is_automated_transfer: currentSite?.is_wpcom_atomic,


### PR DESCRIPTION
Context: pflv1o-ko-p2#comment-394

The event was removed with the contact form since there was no actual submission. This brings it back, and now it fires for every contact option (chat, email, or forums). 

And rename `kayako` variation to `email`.