### PR TITLE
Site Dashboard: Always display all sites

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -57,29 +57,7 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 	const translate = useTranslate();
 	const scrollContainerRef = useRef< HTMLElement >();
 	const previousDataViewsState = usePrevious( data.dataViewsState );
-
-	// Until the DataViews package is updated to support the spinner, we need to manually add the (loading) spinner to the table wrapper for now.
-	// todo: The DataViews v0.9 has the spinner support. Remove this once we upgrade the package.
-	const SpinnerWrapper = () => {
-		return (
-			<div className="spinner-wrapper">
-				<Spinner />
-			</div>
-		);
-	};
 	const dataviewsWrapper = document.getElementsByClassName( 'dataviews-wrapper' )[ 0 ];
-	if ( dataviewsWrapper ) {
-		// Remove any existing spinner if present
-		const existingSpinner = dataviewsWrapper.querySelector( '.spinner-wrapper' );
-		if ( existingSpinner ) {
-			existingSpinner.remove();
-		}
-
-		const spinnerWrapper = dataviewsWrapper.appendChild( document.createElement( 'div' ) );
-		spinnerWrapper.classList.add( 'spinner-wrapper' );
-		// Render the SpinnerWrapper component inside the spinner wrapper
-		ReactDOM.hydrate( <SpinnerWrapper />, spinnerWrapper );
-	}
 
 	useLayoutEffect( () => {
 		if (
@@ -127,6 +105,17 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 				actions={ data.actions }
 				isLoading={ isLoading }
 			/>
+			{ dataviewsWrapper &&
+				ReactDOM.createPortal(
+					/**
+					 * Until the DataViews package is updated to support the spinner, we need to manually add the (loading) spinner to the table wrapper for now.
+					 * todo: The DataViews v0.9 has the spinner support. Remove this once we upgrade the package.
+					 */
+					<div className="spinner-wrapper">
+						<Spinner />
+					</div>,
+					dataviewsWrapper
+				) }
 		</div>
 	);
 };

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -184,6 +184,10 @@
 	.dataviews-view-table-wrapper {
 		height: 0 !important;
 	}
+
+	.dataviews-pagination {
+		display: none;
+	}
 }
 
 .dataviews-wrapper:has(.dataviews-no-results) {

--- a/client/components/route/index.js
+++ b/client/components/route/index.js
@@ -22,6 +22,11 @@ export function RouteProvider( {
 		() => ( { currentSection, currentRoute, currentQuery } ),
 		[ currentSection, currentRoute, currentQuery ]
 	);
+
+	if ( ! currentRoute ) {
+		return null;
+	}
+
 	return <RouteContext.Provider value={ currentRouteInfo }>{ children }</RouteContext.Provider>;
 }
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -404,8 +404,11 @@ class Layout extends Component {
 				/>
 				<HtmlIsIframeClassname />
 				<DocumentHead />
-				<QuerySites primaryAndRecent={ ! config.isEnabled( 'jetpack-cloud' ) } />
-				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }
+				{ this.props.shouldQueryAllSites ? (
+					<QuerySites allSites />
+				) : (
+					<QuerySites primaryAndRecent={ ! config.isEnabled( 'jetpack-cloud' ) } />
+				) }
 				<QueryPreferences />
 				<QuerySiteFeatures siteIds={ [ this.props.siteId ] } />
 				{ this.props.isUnifiedSiteSidebarVisible && (

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -528,6 +528,13 @@
 				position: relative;
 				width: 100%;
 			}
+
+			.spinner-wrapper {
+				position: absolute;
+				left: 50%;
+				top: 70px;
+				z-index: 2;
+			}
 		}
 	}
 }

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -8,7 +8,7 @@ import { GroupableSiteLaunchStatuses } from '@automattic/sites/src/use-sites-lis
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import GuidedTour from 'calypso/a8c-for-agencies/components/guided-tour';
 import {
 	DATAVIEWS_LIST,
@@ -93,7 +93,7 @@ const SitesDashboardV2 = ( {
 	selectedSiteFeaturePreview = undefined,
 }: SitesDashboardProps ) => {
 	const { __ } = useI18n();
-	const initialSortApplied = useRef( false );
+	const [ initialSortApplied, setInitialSortApplied ] = useState( false );
 
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
 
@@ -147,7 +147,7 @@ const SitesDashboardV2 = ( {
 	useEffect( () => {
 		// Ensure we set and check initialSortApplied to prevent infinite loops when changing sort
 		// values after initial sort.
-		if ( hasSitesSortingPreferenceLoaded && ! initialSortApplied.current ) {
+		if ( hasSitesSortingPreferenceLoaded && ! initialSortApplied ) {
 			const newSortField =
 				siteSortingKeys.find( ( key ) => key.sortKey === sitesSorting.sortKey )?.dataView || '';
 			const newSortDirection = sitesSorting.sortOrder;
@@ -160,9 +160,9 @@ const SitesDashboardV2 = ( {
 				},
 			} ) );
 
-			initialSortApplied.current = true;
+			setInitialSortApplied( true );
 		}
-	}, [ hasSitesSortingPreferenceLoaded, sitesSorting, dataViewsState.sort ] );
+	}, [ hasSitesSortingPreferenceLoaded, sitesSorting, dataViewsState.sort, initialSortApplied ] );
 
 	// Get the status group slug.
 	const statusSlug = useMemo( () => {
@@ -264,7 +264,7 @@ const SitesDashboardV2 = ( {
 					<DocumentHead title={ __( 'Sites' ) } />
 					<DotcomSitesDataViews
 						sites={ paginatedSites }
-						isLoading={ isLoading }
+						isLoading={ isLoading || ! initialSortApplied }
 						paginationInfo={ getSitesPagination( filteredSites, perPage ) }
 						dataViewsState={ dataViewsState }
 						setDataViewsState={ setDataViewsState }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7010

## Proposed Changes

* Query all sites instead of primary and recent sites to avoid only a couple of sites visible
* Ensure the sites are shown by the sorting method as much as possible so the order of the sites won't be changed after the first render.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clear the `calypso_store`
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/289925f3-0340-4070-b3c3-d2f4c8dc6e2e)
* Go to /sites?flags=force-sympathy
  * If you cannot reproduce the issue, you can block the `/me/sites` endpoint 
* Make sure you won't just see a couple of sites on the first render
* Make sure the order of sites won't be changed (it still has a chance...😓)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
