### PR TITLE
Site Migration: Increase to 5 minutes the time to wait for the plugin installation

### DIFF
--- a/client/landing/stepper/hooks/use-plugin-auto-installation.ts
+++ b/client/landing/stepper/hooks/use-plugin-auto-installation.ts
@@ -20,7 +20,7 @@ interface SiteMigrationStatus {
 }
 
 type Options = Pick< UseQueryOptions, 'enabled' | 'retry' >;
-const DEFAULT_RETRY = process.env.NODE_ENV !== 'production' ? 1 : 15;
+const DEFAULT_RETRY = process.env.NODE_ENV !== 'production' ? 1 : 100;
 const DEFAULT_RETRY_DELAY = process.env.NODE_ENV !== 'production' ? 300 : 3000;
 
 const fetchPluginsForSite = async ( siteId: number ): Promise< Response > =>


### PR DESCRIPTION
## Proposed Changes
Increase 100 the number of attempts to fetch the plugin list and install the plugin, totaling 5 minutes by operations.

## Why are these changes being made?
We still have a gap time between a site being transferred and being ready to return the list of plugins and install new ones. 


## Testing Instructions
* It is a react-query feature, so visual inspection should be enough.
* Manual instruction:
* Follow all site migration steps until the instructions page. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
