### PR TITLE
Use plan purchase to render correct billing periods

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -65,6 +65,7 @@ const PricingSection: FC = () => {
 			components: {
 				span: <span />,
 			},
+			comment: 'billingPeriod e.g., every month, every year, every 3 years',
 		} );
 	};
 

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -40,13 +40,17 @@ const PricingSection: FC = () => {
 	} );
 	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
 	const isLoading = ! pricing || ! planData || planPurchaseLoading;
+	const billingPeriod = planPurchase?.billPeriodLabel;
 
 	const getBillingDetails = () => {
 		if ( isFreePlan ) {
 			return null;
 		}
+		if ( ! billingPeriod ) {
+			return null;
+		}
 
-		return translate( '{{span}}%(rawPrice)s{{/span}} billed annually, excludes taxes.', {
+		return translate( '{{span}}%(rawPrice)s{{/span}} billed %(billingPeriod)s, excludes taxes.', {
 			args: {
 				rawPrice: formatCurrency(
 					pricing?.[ planSlug ].originalPrice.full ?? 0,
@@ -56,6 +60,7 @@ const PricingSection: FC = () => {
 						isSmallestUnit: true,
 					}
 				),
+				billingPeriod,
 			},
 			components: {
 				span: <span />,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7609

## Proposed Changes

* Show the correct billing periods for the plans

![yearly](https://github.com/Automattic/wp-calypso/assets/6586048/e959cb53-9e44-46e2-b87b-33bf45677a29)
![monthly](https://github.com/Automattic/wp-calypso/assets/6586048/77a7bd57-06c0-4d0e-b6a6-9a7e733cc736)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently it's showing a hardcoded value, which is not correct

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites and check if the billing period is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
