### PR TITLE
Jetpack Backup: Add new Tracks events for the granular restore process

### DIFF
--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -515,8 +515,20 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<Button primary href={ siteUrl } className="rewind-flow__primary-button">
-				{ translate( 'View your website' ) }
+			<Button
+				primary
+				target="_blank"
+				href={ siteUrl }
+				className="rewind-flow__primary-button"
+				onClick={ () =>
+					dispatch(
+						recordTracksEvent( 'calypso_jetpack_backup_granular_restore_complete_view_site' )
+					)
+				}
+			>
+				{ translate( 'View your website {{externalIcon/}}', {
+					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
+				} ) }
 			</Button>
 		</>
 	);

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -556,9 +556,10 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 		}
 
 		if ( isFinished ) {
+			dispatch( recordTracksEvent( 'calypso_jetpack_backup_granular_restore_completed' ) );
 			setUserHasRequestedRestore( false );
 		}
-	}, [ inProgressRewindStatus, isFinished, isInProgress, userHasRequestedRestore ] );
+	}, [ dispatch, inProgressRewindStatus, isFinished, isInProgress, userHasRequestedRestore ] );
 
 	const render = () => {
 		if ( loading ) {

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -567,7 +567,7 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 			setUserHasRequestedRestore( true );
 		}
 
-		if ( isFinished ) {
+		if ( isFinished && userHasRequestedRestore ) {
 			dispatch( recordTracksEvent( 'calypso_jetpack_backup_granular_restore_completed' ) );
 			setUserHasRequestedRestore( false );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/489

## Proposed Changes
* Add the followings Tracks events to the restore flow:
  * `calypso_jetpack_backup_granular_restore_completed`
  * `calypso_jetpack_backup_granular_restore_complete_view_site`
* Add an external icon and `target="_blank"` to the `View your website` button

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These specific Tracks events will help us validate the feature usage of the granular feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch
* Open the Network tab in your developer tools
* Navigate to Jetpack Cloud > Backup
* On any available backup, click on `Actions (+)`, then on `View files` to access the backup browser.
* Try checking at least one file, and then click on `Restore selected files`
* Confirm clicking on `Restore now`
* Once the restore completes, validate the event `calypso_jetpack_backup_granular_restore_completed` was triggered.
* Now click on `View your website` and:
  * Ensure it opens in a new tab 
  * Validate the event`calypso_jetpack_backup_granular_restore_complete_view_site` was triggered.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?