### PR TITLE
A4A: Remove beta from the A4A Overview page's title

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/index.tsx
@@ -10,7 +10,7 @@ const Card1 = () => {
 	const translate = useTranslate();
 	return (
 		<>
-			<h1>{ translate( 'Welcome to the Automattic for Agencies beta' ) }</h1>
+			<h1>{ translate( 'Welcome to the Automattic for Agencies' ) }</h1>
 			<p>
 				{ translate(
 					'Automattic for Agencies is a new agency program that brings together all of Automattic’s brands under one roof, enabling you to get the best deals on our products and services. We’ll also provide you with tooling to help you be more efficient in your work and grow your business.'

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -16,7 +16,7 @@ import './style.scss';
 
 export default function Overview() {
 	const translate = useTranslate();
-	const title = translate( 'Agency HQ Overview' );
+	const title = translate( 'Agency Overview' );
 
 	return (
 		<Layout title={ title } wide>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/629.

## Proposed Changes

* Remove the word `beta` from the main card title.
* Remove the word `HQ` from the page title.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We launched the program today, so we are not in beta anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a Live Branch.
* Visit the Overview page.
* Verify that the word `beta` is no longer present.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="773" alt="Google Chrome 2024-06-05 11 06 07" src="https://github.com/Automattic/wp-calypso/assets/3418513/a38b6b68-54da-41a5-9463-f033278dc5f6">
</td>
<td>
<img width="773" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/96a59a79-1627-47ff-b7e1-26e1b220c91a">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
