### PR TITLE
Remove English locale check from testimonials

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
@@ -1,6 +1,4 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useState } from '@wordpress/element';
-import { hasTranslation } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
@@ -16,7 +14,6 @@ import { UpgradePlanHostingDetailsTooltip } from './upgrade-plan-hosting-details
 
 export const UpgradePlanHostingDetails = () => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const [ activeTooltipId, setActiveTooltipId ] = useState( '' );
 	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
 	let importSiteHostName = '';
@@ -25,10 +22,6 @@ export const UpgradePlanHostingDetails = () => {
 		importSiteHostName = new URL( importSiteQueryParam )?.hostname;
 	} catch ( e ) {}
 
-	const headerMainText =
-		hasTranslation( 'Why should you host with us?' ) || isEnglishLocale
-			? translate( 'Why should you host with us?' )
-			: translate( 'Why you should host with us?' );
 	const { list: upgradePlanHostingDetailsList, isFetching } = useUpgradePlanHostingDetailsList();
 
 	const { data: urlData } = useAnalyzeUrlQuery( importSiteQueryParam, true );
@@ -87,7 +80,9 @@ export const UpgradePlanHostingDetails = () => {
 				} ) }
 			>
 				<div className="import__upgrade-plan-hosting-details-header">
-					<p className="import__upgrade-plan-hosting-details-header-main">{ headerMainText }</p>
+					<p className="import__upgrade-plan-hosting-details-header-main">
+						{ translate( 'Why should you host with us?' ) }
+					</p>
 					<p className="import__upgrade-plan-hosting-details-header-subtext">
 						{ translate(
 							'Google data shows that %(boostPercentage)d%% more WordPress.com sites have good Core Web Vitals as compared to other WordPress hosts.',

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
@@ -100,33 +100,31 @@ export const UpgradePlanHostingDetails = () => {
 				<div className="import__upgrade-plan-hosting-details-list">
 					<ul>{ hostingDetailsItems }</ul>
 				</div>
-				{ isEnglishLocale && (
-					<div className="import__upgrade-plan-hosting-details-testimonials-container">
-						<p>{ translate( '100% loved by our best customers' ) }</p>
-						<div className="import__upgrade-plan-hosting-details-testimonials">
-							{ UpgradePlanHostingTestimonials.map(
-								( { customerName, customerTestimonial, customerInfo, customerImage }, i ) => (
-									<UpgradePlanHostingDetailsTooltip
-										key={ i }
-										id={ `testimonial-${ i }` }
-										setActiveTooltipId={ setActiveTooltipId }
-										activeTooltipId={ activeTooltipId }
-										customerName={ customerName }
-										customerInfo={ customerInfo }
-										customerTestimonial={ customerTestimonial }
-										hideArrow={ false }
-									>
-										<img
-											className="import__upgrade-plan-hosting-details-testimonials-image"
-											src={ customerImage }
-											alt={ customerName }
-										/>
-									</UpgradePlanHostingDetailsTooltip>
-								)
-							) }
-						</div>
+				<div className="import__upgrade-plan-hosting-details-testimonials-container">
+					<p>{ translate( '100% loved by our best customers' ) }</p>
+					<div className="import__upgrade-plan-hosting-details-testimonials">
+						{ UpgradePlanHostingTestimonials.map(
+							( { customerName, customerTestimonial, customerInfo, customerImage }, i ) => (
+								<UpgradePlanHostingDetailsTooltip
+									key={ i }
+									id={ `testimonial-${ i }` }
+									setActiveTooltipId={ setActiveTooltipId }
+									activeTooltipId={ activeTooltipId }
+									customerName={ customerName }
+									customerInfo={ customerInfo }
+									customerTestimonial={ customerTestimonial }
+									hideArrow={ false }
+								>
+									<img
+										className="import__upgrade-plan-hosting-details-testimonials-image"
+										src={ customerImage }
+										alt={ customerName }
+									/>
+								</UpgradePlanHostingDetailsTooltip>
+							)
+						) }
 					</div>
-				) }
+				</div>
 			</div>
 			{ shouldDisplayHostIdentificationMessage && (
 				<div className="import__upgrade-plan-hosting-details-identified-host">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #89362

## Proposed Changes

* I just realized we are not displaying the testimonials to locales different than English. Based on [this PR](https://github.com/Automattic/wp-calypso/pull/89362) description, I think we just forgot it.
* I also took the opportunity to remove [this translation fallback](https://github.com/Automattic/wp-calypso/pull/91519/commits/d70515d4c101bf46b9462b1438b2699b329ab2ec) not needed anymore.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The testimonials are being displayed only to English locale.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your "Interface language" on https://wordpress.com/me/account to something different than English.
* Start a migration and navigate until the upgrade step: `/setup/site-migration/site-migration-upgrade-plan?siteSlug={SITE_SLUG}&siteId={SITE_ID}&from=https%3A%2F%2Fwww.mazdausa.com%2F`.
* Check that the testimonials are now displayed.

**Before:**

<img width="392" alt="Screenshot 2024-06-05 at 12 03 58" src="https://github.com/Automattic/wp-calypso/assets/876340/949872d1-fa04-4be7-aa30-a8aae47f6293">


**After:**

<img width="369" alt="Screenshot 2024-06-05 at 12 03 34" src="https://github.com/Automattic/wp-calypso/assets/876340/df4a5da3-4dd2-4e4c-bfad-8c67e53febfb">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
