### PR TITLE
Dashboard v2 flyout list - increase size of search input.

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -591,7 +591,6 @@
 			margin-top: 0;
 			overflow: hidden;
 			padding-bottom: 0 !important;
-
 		}
 
 		.dataviews-wrapper {
@@ -604,6 +603,10 @@
 			.dataviews-view-list {
 				flex: 1;
 				max-height: none;
+			}
+
+			.components-base-control {
+				width: 85%;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#7621

## Proposed Changes

* Increase the width of the search input to take up unused space as design suggested.

BEFORE

<img width="413" alt="Screenshot 2024-06-05 at 12 57 59 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/11c99fc0-aeee-450f-b943-bf195e261845">


AFTER
<img width="415" alt="Screenshot 2024-06-05 at 12 57 41 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/958e1042-4e2d-46e3-ac9d-42e17b398220">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select a site at desktop view width
* verify the search input and icons take up the full space of the flyout panel.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
