### PR TITLE
A4A: remove hubspot script loading for signup finish page

### DIFF
--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/index.tsx
@@ -1,6 +1,5 @@
 import page from '@automattic/calypso-router';
 import { APIError } from '@automattic/data-stores';
-import { loadScript } from '@automattic/load-script';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import A4ALogo, { LOGO_COLOR_SECONDARY_ALT } from 'calypso/a8c-for-agencies/components/a4a-logo';
@@ -48,13 +47,12 @@ export default function AgencySignupFinish() {
 	}, [ agency ] );
 
 	useEffect( () => {
-		async function createAgencyHandler() {
+		function createAgencyHandler() {
 			// Added to prevent typescript errors and for additional safety
 			if ( ! userLoggedIn || ! signupData ) {
 				page.redirect( A4A_SIGNUP_LINK );
 				return;
 			}
-			await loadScript( '//js.hs-scripts.com/45522507.js' );
 
 			createAgency.mutate( signupData );
 			dispatch(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1717606999934649/1717601085.331669-slack-C06JY8QL0TU

## Proposed Changes

Remove hubspot script as it's not necessary there.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using this branch check the `signup` flow works smoothly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?