### PR TITLE
Dashboard v2 - hide a4a banner in collapsed flyout sidebar

### DIFF
--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -632,6 +632,10 @@
 				max-height: none;
 			}
 		}
+
+		.sites-a8c-for-agencies-banner-container {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1717608722785249-slack-C06DN6QQVAQ

## Proposed Changes

* Hides the a4a banner in /sites list when a site is selected.
* We hide this via css. At first I tried hiding it via a `selectedSite` condition in JS, which works, but the banner doesnt disappear until after the collapse animation and it looks weird in that animation process and has a bit of a jump disappearing when done. So hiding via css selectors seems more fitting.

BEFORE
<img width="711" alt="Screenshot 2024-06-05 at 1 45 36 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/f840d079-24e9-4be1-8ee5-9589e878fb8c">



AFTER

<img width="620" alt="Screenshot 2024-06-05 at 1 45 22 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/f8b007ee-aedb-4277-a011-fa0cf2cb8b1a">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The banner takes up too much space in this context and has already been visible in order to get here.
* The banner also looks broken, we could clean it up but it will inevitably still take up a lot of real estate in this situation.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso.
* Visit /sites. Verify the a4a banner is visible.
* Select a site to see the collapsed site list sidebar, verify the banner is not visible.
* If you have already dismissed the banner, you can reset the preference in your dev tools in the bottom right. It is the preference named `dismissible-card-dismissible-card-a8c-for-agencies-sites`
<img width="601" alt="Screenshot 2024-06-05 at 2 35 55 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/3a468f0e-d058-41c4-a462-035e06ea9aa2">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?