### PR TITLE
Switch support check point back to `is_user_eligible`

### DIFF
--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -18,7 +18,7 @@ export default function useChatStatus(
 
 	// All paying customers are eligible for chat.
 	// See: pdDR7T-1vN-p2
-	const isEligibleForChat = Boolean( chatStatus?.is_paying_customer );
+	const isEligibleForChat = Boolean( chatStatus?.is_user_eligible );
 
 	const { data: supportActivity, isInitialLoading: isLoadingSupportActivity } =
 		useSupportActivity( isEligibleForChat );

--- a/packages/help-center/src/hooks/use-should-render-email-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-email-option.tsx
@@ -4,9 +4,9 @@ export function useShouldRenderEmailOption() {
 	const { data: supportAvailability, isFetching } = useSupportAvailability();
 
 	// Domain only customers should always see the email option
-	// Domain only users have this combination of support level === free, and paying customer status.
+	// Domain only users have this combination of support level === free, and is_user_eligible === true.
 	const isDomainOnlyUser =
-		supportAvailability?.is_paying_customer && supportAvailability?.supportLevel === 'free';
+		supportAvailability?.is_user_eligible && supportAvailability?.supportLevel === 'free';
 
 	return {
 		isLoading: isFetching,

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -17,7 +17,7 @@ export function isWapuuFlagSetInURL(): boolean {
 export function useStillNeedHelpURL() {
 	const { data: supportAvailability, isLoading } = useSupportAvailability();
 	const isWapuuEnabled = useIsWapuuEnabled() || isWapuuFlagSetInURL();
-	const isFreeUser = ! supportAvailability?.is_paying_customer;
+	const isFreeUser = ! supportAvailability?.is_user_eligible;
 
 	if ( ! isFreeUser ) {
 		const url = isWapuuEnabled ? '/odie' : '/contact-options';

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -86,13 +86,7 @@ interface Availability {
 
 export interface ChatAvailability {
 	locale: string;
-	/**
-	 * @deprecated
-	 *
-	 * DO NOT USE THIS VALUE. We no longer use eligibility checks for chat. All paid users are eligible for chat.
-	 */
 	is_user_eligible: boolean;
-	is_paying_customer: boolean;
 	supportLevel:
 		| 'free'
 		| 'personal'


### PR DESCRIPTION
## Proposed Changes
After D151217-code, the `is_user_eligible` now has the correct checks. Before, it only returned true if the user had certain plans. Now it should return true for all paid customers and users who are admins in paid sites. 

## Testing Instructions
1. Open the Help Center from a paid user.
2. You should have access to chat.
3. Open the Help Center in a free user.
4. You shouldn't.