### PR TITLE
Overview support card: Overlap gravatars

### DIFF
--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -63,11 +63,21 @@ $card-padding: 24px;
 	.happiness-engineers-tray {
 		align-items: flex-start;
 		display: flex;
-		justify-content: flex-start;
+		/* Flipping the display order around so that the negative margin on gravatars
+		means that left overlaps right rather than vice versa */
+		justify-content: flex-end;
+		flex-direction: row-reverse;
+		height: 44px;
 	}
 
 	.happiness-engineers-tray__gravatar {
-		margin-right: 16px;
+		margin-left: -10px;
+		margin-right: 0;
+		border: 2px solid #fff;
+	}
+
+	:last-child {
+		margin-left: 0;
 	}
 }
 


### PR DESCRIPTION
Overlap the HE gravatars on the hosting overview support card so that it is similar to email templates and the overlapping gravatars on the home screen's daily prompt page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7618

## Proposed Changes

Make the HE gravatars overlap on the hosting overview support card

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Brings the HE gravatars in line with email templates and with the home screen's writing prompt gravatars.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Go to /overview/
3. Choose a site
4. Scroll down to the Support card

Before | After
-------|------
<img width="1381" alt="Screenshot 2024-06-05 at 19 36 05" src="https://github.com/Automattic/wp-calypso/assets/93301/49d814b4-d458-44cc-aa40-3c6bc7496c80"> | <img width="1381" alt="Screenshot 2024-06-05 at 19 34 46" src="https://github.com/Automattic/wp-calypso/assets/93301/09f2bdcd-0731-4e6e-b475-0c0ec6bc5829">


(chrome left, firefox right)

Note that the overlap order is different between firefox and chrome, I don't think this matters but I'll let @lucasmendes-design correct me. It's faster and simpler to change it to the chrome version - left on top of right.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
