### PR TITLE
Hosting Overview: Get purchase currency code to match purchase price.

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -50,7 +50,7 @@ const PricingSection: FC = () => {
 			args: {
 				rawPrice: formatCurrency(
 					pricing?.[ planSlug ].originalPrice.full ?? 0,
-					planData?.currencyCode ?? '',
+					pricing?.[ planSlug ].purchaseCurrencyCode ?? '',
 					{
 						stripZeros: true,
 						isSmallestUnit: true,

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -86,7 +86,7 @@ const PricingSection: FC = () => {
 				<div className="hosting-overview__plan-price-wrapper">
 					<PlanPrice
 						className="hosting-overview__plan-price"
-						currencyCode={ planData?.currencyCode }
+						currencyCode={ pricing?.[ planSlug ].purchaseCurrencyCode }
 						isSmallestUnit
 						rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
 					/>

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -230,6 +230,7 @@ const usePricingMetaForGridPlans = ( {
 					billingPeriod: plans.data?.[ planSlug ]?.pricing?.billPeriod,
 					// TODO clk: the condition on `.pricing` here needs investigation. There should be a pricing object for all returned API plans.
 					currencyCode: plans.data?.[ planSlug ]?.pricing?.currencyCode,
+					purchaseCurrencyCode: purchasedPlan?.currencyCode,
 					expiry: sitePlans.data?.[ planSlug ]?.expiry,
 					introOffer: introOffers?.[ planSlug ],
 				},

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -105,6 +105,7 @@ export interface SitePlanPricing extends Omit< PlanPricing, 'billPeriod' > {}
 export interface PricingMetaForGridPlan {
 	billingPeriod?: PlanPricing[ 'billPeriod' ];
 	currencyCode?: PlanPricing[ 'currencyCode' ];
+	purchaseCurrencyCode?: PlanPricing[ 'currencyCode' ];
 	originalPrice: PlanPricing[ 'originalPrice' ];
 	/**
 	 * If discounted prices are provided (not null), they will take precedence over originalPrice.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7628

## Proposed Changes

* Get the purchase currency code to match the purchase price we're displaying.

Before | After
---- | ----
<img width="662" alt="Screen Shot 2024-06-05 at 3 05 43 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/8630fb62-86b2-420d-b73d-80c7808b5283"> | <img width="662" alt="Screen Shot 2024-06-05 at 3 04 38 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/30fabdfd-63b1-4e07-91de-e918606e49f8">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change a test user's currency to a different one than your main user, like PHP or JPY.
* As the test user, create a site with a paid plan.
* Add your main user as an admin on the new site.
* As your main user, go to /overview for the new site. You'll see a currency symbol that doesn't match the amount.
* Open /overview on this branch. You should see both the monthly and annual price in the test user's currency. The amount and the symbol should be in the same currency.
* Regression: the price of the plan for a site you've created as your main user still shows up correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
