### PR TITLE
Jetpack Cloud Simple: Filter sites to only show Simple Classic

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -1,4 +1,4 @@
-import config, { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { omit } from 'lodash';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -91,19 +91,14 @@ export function requestSites() {
 			} )
 			.then( ( response ) => {
 				const jetpackCloudSites = response.sites.filter( ( site ) => {
-					// Filter Jetpack Cloud sites to exclude P2 & Simple not-classic sites by default.
+					// Filter Jetpack Cloud sites to exclude P2 and Simple non-Classic sites by default.
 					const isP2 = site?.options?.is_wpforteams_site;
-					let filterCondition = ! isP2;
+					const isSimpleClassic =
+						! site?.jetpack &&
+						! site?.is_wpcom_atomic &&
+						site?.options?.wpcom_admin_interface !== 'wp-admin';
 
-					// Filter out simple sites if feature flag is not enabled.
-					if ( ! isEnabled( 'jetpack/manage-simple-sites' ) ) {
-						const isSimpleClassic =
-							! site?.jetpack &&
-							! site?.is_wpcom_atomic &&
-							site?.options?.wpcom_admin_interface !== 'wp-admin';
-						filterCondition = ! isP2 && ! isSimpleClassic;
-					}
-					return filterCondition;
+					return ! isP2 && ! isSimpleClassic;
 				} );
 				dispatch( receiveSites( isJetpackCloud() ? jetpackCloudSites : response.sites ) );
 				dispatch( {

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -91,9 +91,14 @@ export function requestSites() {
 			} )
 			.then( ( response ) => {
 				const jetpackCloudSites = response.sites.filter( ( site ) => {
-					// Filter Jetpack Cloud sites to exclude P2 sites by default.
+					// Filter Jetpack Cloud sites to exclude P2 & Simple not-classic sites by default.
 					const isP2 = site?.options?.is_wpforteams_site;
-					let filterCondition = ! isP2;
+					const isSimpleClassic =
+						! site?.jetpack &&
+						! site?.is_wpcom_atomic &&
+						site?.options?.wpcom_admin_interface !== 'wp-admin';
+					let filterCondition = ! isP2 && ! isSimpleClassic;
+
 					// Filter out simple sites if feature flag is not enabled.
 					if ( ! isEnabled( 'jetpack/manage-simple-sites' ) ) {
 						const isSimple = ! site?.jetpack && ! site?.is_wpcom_atomic;

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -93,16 +93,15 @@ export function requestSites() {
 				const jetpackCloudSites = response.sites.filter( ( site ) => {
 					// Filter Jetpack Cloud sites to exclude P2 & Simple not-classic sites by default.
 					const isP2 = site?.options?.is_wpforteams_site;
-					const isSimpleClassic =
-						! site?.jetpack &&
-						! site?.is_wpcom_atomic &&
-						site?.options?.wpcom_admin_interface !== 'wp-admin';
-					let filterCondition = ! isP2 && ! isSimpleClassic;
+					let filterCondition = ! isP2;
 
 					// Filter out simple sites if feature flag is not enabled.
 					if ( ! isEnabled( 'jetpack/manage-simple-sites' ) ) {
-						const isSimple = ! site?.jetpack && ! site?.is_wpcom_atomic;
-						filterCondition = ! isP2 && ! isSimple;
+						const isSimpleClassic =
+							! site?.jetpack &&
+							! site?.is_wpcom_atomic &&
+							site?.options?.wpcom_admin_interface !== 'wp-admin';
+						filterCondition = ! isP2 && ! isSimpleClassic;
 					}
 					return filterCondition;
 				} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7592

## Proposed Changes

Jetpack Cloud should show Simple Classic sites with the flag `jetpack/manage-simple-sites` and not show Simple sites without Classic interface selected

## Testing Instructions

* Set a Simple Site to Classic Interface (wp-admin) 
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
```
* Go to http://jetpack.cloud.localhost:3000/
* Your site should appear
* Replace `wpcom_admin_interface` option with `calypso`
* Reload JP Cloud
* Your site should not appear
