### PR TITLE
Add function to get a translation or a fallback

### DIFF
--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -82,6 +82,22 @@ export function translationExists( phrase: string ) {
 }
 
 /**
+ * Get the first translated phrase if it is available in the user locale,
+ * otherwise returns the fallback.
+ * @param {string} phrase The text to check if translation is available.
+ * @param {string} translatedPhrase The translated phrase.
+ * @param {string} phraseFallback The fallback phrase.
+ * @returns {string} The translation if available, otherwise the fallback.
+ */
+export function getTranslationOrFallback(
+	phrase: string,
+	translatedPhrase: string,
+	phraseFallback: string
+) {
+	return translationExists( phrase ) ? translatedPhrase : phraseFallback;
+}
+
+/**
  * Return a list of all supported language slugs
  * @returns {Array} A list of all supported language slugs
  */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

I started working on a function to simplify getting a fallback text if a translation is not ready. But after talking w/ @donnapep, she mentioned something @Imran92 found (p1717612302615999/1717588786.354879-slack-C02NWDZBL0H) and I had not seen yet. So it's probably not worth it anymore.

The initial plan would be something similar to `fixme__` on JavaScript side, but to make it simpler (not adding a new translation function because of `gettext` and lint rules), I was implementing something to work like this:

```js
	getTranslationOrFallback(
		'Why should you host with us?',
		translate( 'Why should you host with us?' ),
		translate( 'Why you should host with us?' )
	);
```

So given we found the hook `useHasEnTranslation`, I'm not working on it anymore.
I just opened this PR and I'm closing it to keep it registered in case we want to use in the future for any reason.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?