### PR TITLE
Site Profiler Menu: Show a proper distance from the section and sticky on mobile

### DIFF
--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -11,6 +11,7 @@ import './styles.scss';
 
 const Container = styled.div`
 	scroll-margin-top: ${ calculateMetricsSectionScrollOffset }px;
+	margin-bottom: 130px;
 `;
 
 const SubtitleIcon = styled( Gridicon )`

--- a/client/site-profiler/components/nav-menu/index.tsx
+++ b/client/site-profiler/components/nav-menu/index.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import './style.scss';
+import StickyPanel from 'calypso/components/sticky-panel';
 import { useIsMenuSectionVisible } from 'calypso/site-profiler/hooks/use-is-menu-section-visible';
+import './style.scss';
 
 interface NavMenuProps {
 	navItems: {
@@ -28,24 +29,26 @@ export const NavMenu = ( { navItems, domain, showMigrationCta = false }: NavMenu
 	const activeIndex = activeIndexes.indexOf( true );
 
 	return (
-		<nav className="site-profiler-nav-menu">
-			<ul>
-				{ navItems.map( ( navItem, index ) => (
-					<li>
-						<button
-							className={ clsx( { active: index === activeIndex } ) }
-							onClick={ () => executeScroll( navItem.ref ) }
-						>
-							0{ index + 1 }. { navItem.label }
-						</button>
-					</li>
-				) ) }
-				{ showMigrationCta && (
-					<li className="site-profiler-nav-menu__cta">
-						<a href={ migrateUrl }>{ translate( 'Request migration - It’s free' ) }</a>
-					</li>
-				) }
-			</ul>
-		</nav>
+		<StickyPanel minLimit={ 0 }>
+			<nav className="site-profiler-nav-menu">
+				<ul>
+					{ navItems.map( ( navItem, index ) => (
+						<li>
+							<button
+								className={ clsx( { active: index === activeIndex } ) }
+								onClick={ () => executeScroll( navItem.ref ) }
+							>
+								0{ index + 1 }. { navItem.label }
+							</button>
+						</li>
+					) ) }
+					{ showMigrationCta && (
+						<li className="site-profiler-nav-menu__cta">
+							<a href={ migrateUrl }>{ translate( 'Request migration - It’s free' ) }</a>
+						</li>
+					) }
+				</ul>
+			</nav>
+		</StickyPanel>
 	);
 };

--- a/client/site-profiler/components/nav-menu/style.scss
+++ b/client/site-profiler/components/nav-menu/style.scss
@@ -1,16 +1,8 @@
-
-.layout__content {
-	overflow: initial;
-}
-
 .site-profiler-nav-menu {
 	background-color: #101517;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 8px;
-	margin: 100px 0;
-	position: sticky;
-	top: 50px;
-	z-index: 99;
+	margin-top: 20px;
 
 	ul {
 		display: flex;

--- a/client/site-profiler/utils/calculate-metrics-section-scroll-offset.ts
+++ b/client/site-profiler/utils/calculate-metrics-section-scroll-offset.ts
@@ -1,7 +1,7 @@
 export function calculateMetricsSectionScrollOffset() {
 	let offset = 0;
 	const headerEl = document.getElementById( 'header' );
-	const menuHeight = 50;
+	const menuHeight = 92;
 
 	// Offset to account for Masterbar if it is fixed position
 	offset +=
@@ -12,7 +12,7 @@ export function calculateMetricsSectionScrollOffset() {
 	// Offset to account for the metrics menu navbar
 	offset += menuHeight;
 
-	const padding = 20;
+	const padding = 30;
 
 	return offset + padding;
 }


### PR DESCRIPTION


Related to https://github.com/Automattic/wp-calypso/pull/91459

## Proposed Changes

* Use StickyPanel to make the section stick
* Update the menu height on the calculate method

## Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/91459

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?