### PR TITLE
Update hosting check because it was depending on translations

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
@@ -32,10 +32,11 @@ export const UpgradePlanHostingDetails = () => {
 		urlData
 	);
 
+	const hostingProviderSlug = hostingProviderData?.hosting_provider?.slug;
 	const shouldDisplayHostIdentificationMessage =
-		hostingProviderName &&
-		hostingProviderName !== 'Unknown' &&
-		hostingProviderName !== 'WordPress.com';
+		hostingProviderSlug &&
+		hostingProviderSlug !== 'unknown' &&
+		hostingProviderSlug !== 'automattic';
 
 	let hostingDetailsItems = null;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Instead of checking the host based on its name, it now checks based on the host slug. The reason is that some issues happened with `Unknown` host being translated.

Steps to reproduce the issue on `trunk`:

* Change your "Interface language" on https://wordpress.com/me/account to something different than English.
* Start a migration. When asked the site to import, click on "pick your current platform from a list" and select WordPress.
* Navigate until the upgrade step.
* Check that you see the unknown hosting, while it should not be displayed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There's an issue in the check because of the `Unknown` translation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test what is described above under _"Steps to reproduce the issue on `trunk`"_ and make sure you don't see the "unknown" host message (in the language you selected).
* Also test importing from another WPCOM site (test28837.wordpress.com is one I created for test, for example). This also shouldn't show the hosting message.
* Now test with a site that should display the hosting name and make sure it continues working. Example: https://www.mazdausa.com/

Before:

![Screenshot 2024-06-05 at 18 04 08](https://github.com/Automattic/wp-calypso/assets/876340/19af9daa-4b6f-4070-8036-25c976369cd9)

After:

![Screenshot 2024-06-05 at 18 04 54](https://github.com/Automattic/wp-calypso/assets/876340/c09a59db-305e-4dc1-9594-a96cee7c93eb)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
