### PR TITLE
Fixes the signup oauth flor for Blaze Pro

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -291,7 +291,7 @@ class SignupForm extends Component {
 		const fieldsForValidation = filter( [
 			'email',
 			this.props.isPasswordless === false && 'password', // Remove password from validation if passwordless
-			this.props.displayUsernameInput && 'username',
+			this.displayUsernameInput() && 'username',
 			this.props.displayNameInput && 'firstName',
 			this.props.displayNameInput && 'lastName',
 		] );
@@ -573,7 +573,7 @@ class SignupForm extends Component {
 			};
 		}
 
-		if ( this.props.displayUsernameInput ) {
+		if ( this.displayUsernameInput() ) {
 			userData.username = formState.getFieldValue( this.state.form, 'username' );
 		} else {
 			userData.extra = {


### PR DESCRIPTION
There is a bug in the OAuth signup flow for the Blaze Pro App. The problem happens because we are sending a blank username, and the `signups/validation` endpoint complains about that. 

## Proposed Changes

* Changed to use the `displayUsernameInput` function instead of the value from the props, so it starts checking the `isBlazePro` flag.

## Why are these changes being made?

* Users can't complete a signup flow. This PR fixes that problem

## Testing Instructions

Same testing instructions as the base OAuth [Blaze Pro PR](https://github.com/Automattic/wp-calypso/pull/91095)

* Generate a signup link running this script with node locally:
```
function generateState() {
  const crypto = require('crypto');
  const hmac = crypto.createHmac('sha256', 'secret' );
  const data = hmac.update(new Date().getTime().toString());
  const state = data.digest('hex');
  return state;
}

const redirectUri = 'http://blaze.pro:3005/auth/connected&blog_id=0&wpcom_connect=1&calypso_env=development&scope=global&from-calypso=1';
const getLoginLink = () =>
	`https://public-api.wordpress.com/oauth2/authorize?response_type=code&client_id=92099&state=${generateState()}&redirect_uri=${encodeURIComponent(redirectUri)}`;

const signInLink = `http://calypso.localhost:3000/log-in?client_id=92099&redirect_to=${encodeURIComponent(getLoginLink())}`;

const signUpLink = `http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=92099&oauth2_redirect=${encodeURIComponent(getLoginLink())}`;

console.log('Login URL:');
console.log(signInLink);
console.log('');
console.log('Sign Up URL:');
console.log(signUpLink);
```
* Checkout this branch and start Calypso server
* Open the Sign Up URL from the script result in the console
* Verify that the Blaze Pro signup page is shown
![Screenshot 2024-06-05 at 6 59 15 PM](https://github.com/Automattic/wp-calypso/assets/1258162/e301bf7b-f68d-4cbd-9db4-a48c2d20662a)
* Complete the form and click `Create your account`
* Verify that the you are moved to the next step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
