### PR TITLE
Add translations for WP Blaze Campaign Goals feature

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -9,13 +9,9 @@ const BlazePressStrings = () => {
 	translate( 'The campaign cannot be created. Please {{a}}contact our support team{{/a}}.' );
 	translate( 'Go to my campaigns' );
 	translate( 'All set!' );
-	translate(
-		'The ad has been submitted for approval. We’ll send you a confirmation email once it’s approved and running.'
-	);
+	translate( 'The ad has been submitted for approval. We’ll send you a confirmation email once it’s approved and running.' );
 	translate( 'Skip and go to my campaigns next time.' );
-	translate(
-		'Learn more about the {{linkAdvertisingPolicy}}Advertising Policy{{/linkAdvertisingPolicy}}.'
-	);
+	translate( 'Learn more about the {{linkAdvertisingPolicy}}Advertising Policy{{/linkAdvertisingPolicy}}.' );
 	translate( 'Creating campaign…' );
 	translate( 'Make the most of your Blaze campaign' );
 	translate( 'Choose an eye-catching image for your ad' );
@@ -23,24 +19,28 @@ const BlazePressStrings = () => {
 	translate( 'Pick the right audience, budget and duration' );
 	translate( 'Get started' );
 	translate( 'Learn more' );
-	translate( "Don't show me this step again." );
+	translate( 'Don\'t show me this step again.' );
+	translate( 'Uploading images...' );
 	translate( 'Checking payment information…' );
 	translate( 'Fetching pages…' );
+	translate( 'Fetching products…' );
 	translate( 'Fetching posts…' );
 	translate( 'Fetching more pages…' );
+	translate( 'Fetching more products…' );
 	translate( 'Fetching more posts…' );
 	translate( 'No pages found.' );
+	translate( 'No products found.' );
 	translate( 'No posts found.' );
 	translate( 'Select post to promote' );
 	translate( 'Post' );
 	translate( 'Type' );
+	translate( 'SKU' );
+	translate( 'Price' );
 	translate( 'Publish date' );
 	translate( 'Visitors' );
 	translate( 'Likes' );
 	translate( 'Comments' );
-	translate(
-		'Cannot create subscription. Please {{supportLink}}contact support{{/supportLink}} or try again later.'
-	);
+	translate( 'Cannot create subscription. Please {{supportLink}}contact support{{/supportLink}} or try again later.' );
 	translate( 'Advanced Settings' );
 	translate( 'Targeted Devices' );
 	translate( 'Destination URL' );
@@ -51,20 +51,16 @@ const BlazePressStrings = () => {
 	translate( 'URL parameters' );
 	translate( 'key1=value1&key2=value2&key3=value3' );
 	translate( 'URL parameters are invalid' );
-	translate( '%(charactersLeft)s character remaining', '%(charactersLeft)s characters remaining', {
-		count: 1,
-	} );
+	translate( '%(charactersLeft)s character remaining', '%(charactersLeft)s characters remaining', { count: 1 } );
 	translate( 'Appearance' );
 	translate( 'Ad creative' );
-	translate( "Use post's media" );
+	translate( 'Use post\'s media' );
 	translate( 'Site title' );
+	translate( 'Loading page title...' );
 	translate( 'Page title' );
 	translate( 'Snippet' );
-	translate(
-		'%(snippetCharactersLeft)s character remaining',
-		'%(snippetCharactersLeft)s characters remaining',
-		{ count: 1 }
-	);
+	translate( '%(snippetCharactersLeft)s character remaining', '%(snippetCharactersLeft)s characters remaining', { count: 1 } );
+	translate( 'Loading ad text....' );
 	translate( 'Ad text' );
 	translate( 'Use + / - or simply drag the image to adjust it' );
 	translate( 'Apply' );
@@ -79,11 +75,7 @@ const BlazePressStrings = () => {
 	translate( 'Drop images to upload' );
 	translate( 'Use selected' );
 	translate( 'Load More' );
-	translate(
-		'Showing %(found)s of %(found)s media item',
-		'Showing %(found)s of %(found)s media items',
-		{ count: 1 }
-	);
+	translate( 'Showing %(found)s of %(found)s media item', 'Showing %(found)s of %(found)s media items', { count: 1 } );
 	translate( 'Search images' );
 	translate( 'Search' );
 	translate( 'Select' );
@@ -93,56 +85,70 @@ const BlazePressStrings = () => {
 	translate( 'Click or drag an image here to upload.' );
 	translate( 'Upload an image file, or pick one from your media library.' );
 	translate( 'Audience' );
-	translate(
-		'Not enough reach to create a campaign with the current audience configuration. Please, expand your reach by changing or removing some of the audience settings'
-	);
+	translate( 'Not enough reach to create a campaign with the current audience configuration. Please, expand your reach by changing or removing some of the audience settings' );
+	translate( 'Language' );
 	translate( 'Location' );
 	translate( 'All languages' );
-	translate(
-		'Based on the language of your site we suggest targeting %(lang)s speaking users to ensure the ad is seen by the right audience and to increase its effectiveness.'
-	);
-	translate( 'Language' );
+	translate( 'Based on the language of your site we suggest targeting %(lang)s speaking users to ensure the ad is seen by the right audience and to increase its effectiveness.' );
 	translate( 'All topics' );
 	translate( 'Interests' );
 	translate( 'Budget and duration' );
-	translate( 'Total' );
-	translate(
-		'Daily spend for %(durationDays)s-day duration',
-		'Daily spend for %(durationDays)s-day duration',
-		{ count: 1 }
-	);
-	translate( 'Estimated people reached per day' );
+	translate( 'Schedule' );
+	translate( 'Run until I stop it. ' );
+	translate( 'Specify the duration.' );
 	translate( 'Start date' );
+	translate( 'Please select a valid range' );
 	translate( 'Duration (days)' );
+	translate( 'Weekly Total' );
+	translate( 'Total' );
+	translate( 'Daily spend for %(durationDays)s-day duration', 'Daily spend for %(durationDays)s day duration', { count: 1 } );
+	translate( 'Estimated people reached per day' );
 	translate( 'days' );
 	translate( 'Credits will be automatically applied to your order when available.' );
 	translate( 'Credits: %(creditsUsed)s (%(remainingCredit)s remain)' );
 	translate( 'Review your campaign' );
-	translate(
-		'We created this campaign to deliver the most valuable traffic, yet you can still make changes before submitting it.'
-	);
+	translate( 'We created this campaign to deliver the most valuable traffic, yet you can still make changes before submitting it.' );
+	translate( 'Campaign Objective' );
+	translate( 'Change' );
+	translate( 'Start Date' );
 	translate( 'Duration' );
 	translate( 'Budget' );
 	translate( 'day' );
-	translate( 'Estimated impressions' );
+	translate( ' impressions' );
+	translate( 'Impressions are estimated' );
 	translate( 'Payment' );
 	translate( 'Loading' );
 	translate( 'Start typing country, state or city to see available options' );
 	translate( 'No results found' );
 	translate( 'Search for locations' );
+	translate( 'Good for: ' );
+	translate( 'Traffic' );
+	translate( 'Aims to drive more visitors and increase page views.' );
+	translate( 'E-commerce sites, content-driven websites, startups.' );
+	translate( 'Sales' );
+	translate( 'Converts potential customers into buyers by encouraging purchase.' );
+	translate( 'E-commerce, retailers, subscription services.' );
+	translate( 'Awareness' );
+	translate( 'Focuses on increasing brand recognition and visibility.' );
+	translate( 'New businesses, brands launching new products.' );
+	translate( 'Engagement' );
+	translate( 'Encourages your audience to interact and connect with your brand.' );
+	translate( 'Influencers and community builders looking for followers of the same interest.' );
+	translate( 'Choose campaign objective' );
+	translate( 'Continue' );
+	translate( 'Save my selection for future campaigns' );
+	translate( 'Cancel' );
+	translate( 'Good for:' );
 	translate( 'You won’t be charged until the ad is approved and starts running.' );
 	translate( 'You can pause spending at any time.' );
 	translate( 'Could not retrieve countries. Please try again later.' );
+	translate( 'Could not connect to payment provider. Please try again later.' );
+	translate( 'Error setting up payment. Please try again later' );
 	translate( 'Error submitting payment. Please check payment information.' );
-	translate(
-		'There was an error with the address. Please verify that all the required data is valid'
-	);
-	translate(
-		'There was an error with the address. The province, state or region should be filled'
-	);
-	translate(
-		'There was an error with the address. Please, check that the Zip code exists, is valid for the country, and corresponds for the given address'
-	);
+	translate( 'Error fetching payment method. Please try again later.' );
+	translate( 'There was an error with the address. Please verify that all the required data is valid' );
+	translate( 'There was an error with the address. The province, state or region should be filled' );
+	translate( 'There was an error with the address. Please, check that the Zip code exists, is valid for the country, and corresponds for the given address' );
 	translate( 'Use saved card' );
 	translate( 'First Name' );
 	translate( 'Last Name' );
@@ -162,9 +168,7 @@ const BlazePressStrings = () => {
 	translate( 'Untitled' );
 	translate( 'View' );
 	translate( 'Promote' );
-	translate(
-		'By clicking "Submit campaign" you agree to the {{linkTos}}Terms of Service{{externalLinkIcon/}}{{/linkTos}} and {{linkAdvertisingPolicy}}Advertising Policy{{externalLinkIcon/}}{{/linkAdvertisingPolicy}}, and authorize your payment method to be charged for the budget and duration you chose. {{linkMoreAboutAds}}Learn more{{externalLinkIcon/}}{{/linkMoreAboutAds}} about how budgets and payments for Promoted Posts work.'
-	);
+	translate( 'By clicking \"Submit campaign\" you agree to the {{linkTos}}Terms of Service{{externalLinkIcon/}}{{/linkTos}} and {{linkAdvertisingPolicy}}Advertising Policy{{externalLinkIcon/}}{{/linkAdvertisingPolicy}}, and authorize your payment method to be charged for the budget and duration you chose. {{linkMoreAboutAds}}Learn more{{externalLinkIcon/}}{{/linkMoreAboutAds}} about how budgets and payments for Promoted Posts work.' );
 	translate( 'Creating campaign' );
 	translate( 'Submit campaign' );
 	translate( 'Make changes' );
@@ -173,10 +177,12 @@ const BlazePressStrings = () => {
 	translate( 'Tablet' );
 	translate( 'Desktop' );
 	translate( 'Everywhere' );
+	translate( 'Weekly total' );
 	translate( 'Summary' );
 	translate( 'Preview' );
 	translate( 'Depending on the platform, the ad may look different from the preview.' );
 	translate( 'Estimated Impressions' );
+	translate( 'Weekly Budget' );
 	translate( 'Max Budget' );
 	translate( 'Languages' );
 	translate( 'Devices' );
@@ -186,11 +192,8 @@ const BlazePressStrings = () => {
 	translate( 'Oops, something went wrong' );
 	translate( 'Loading site…' );
 	translate( 'Fetching subscriptions…' );
-	translate(
-		'There was a problem getting the necessary information to create your campaign. Please try again soon or {{a}}contact our support team{{/a}} for help.'
-	);
+	translate( 'There was a problem getting the necessary information to create your campaign. Please try again soon or {{a}}contact our support team{{/a}} for help.' );
 	translate( 'Preparing the wizard…' );
-	translate( 'Fetching the AI suggestions…' );
 	translate( 'Drop image here' );
 	translate( 'Click or Drag an image here' );
 	translate( '%(field)s is required.' );

--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -9,9 +9,13 @@ const BlazePressStrings = () => {
 	translate( 'The campaign cannot be created. Please {{a}}contact our support team{{/a}}.' );
 	translate( 'Go to my campaigns' );
 	translate( 'All set!' );
-	translate( 'The ad has been submitted for approval. We’ll send you a confirmation email once it’s approved and running.' );
+	translate(
+		'The ad has been submitted for approval. We’ll send you a confirmation email once it’s approved and running.'
+	);
 	translate( 'Skip and go to my campaigns next time.' );
-	translate( 'Learn more about the {{linkAdvertisingPolicy}}Advertising Policy{{/linkAdvertisingPolicy}}.' );
+	translate(
+		'Learn more about the {{linkAdvertisingPolicy}}Advertising Policy{{/linkAdvertisingPolicy}}.'
+	);
 	translate( 'Creating campaign…' );
 	translate( 'Make the most of your Blaze campaign' );
 	translate( 'Choose an eye-catching image for your ad' );
@@ -19,7 +23,7 @@ const BlazePressStrings = () => {
 	translate( 'Pick the right audience, budget and duration' );
 	translate( 'Get started' );
 	translate( 'Learn more' );
-	translate( 'Don\'t show me this step again.' );
+	translate( "Don't show me this step again." );
 	translate( 'Uploading images...' );
 	translate( 'Checking payment information…' );
 	translate( 'Fetching pages…' );
@@ -40,7 +44,9 @@ const BlazePressStrings = () => {
 	translate( 'Visitors' );
 	translate( 'Likes' );
 	translate( 'Comments' );
-	translate( 'Cannot create subscription. Please {{supportLink}}contact support{{/supportLink}} or try again later.' );
+	translate(
+		'Cannot create subscription. Please {{supportLink}}contact support{{/supportLink}} or try again later.'
+	);
 	translate( 'Advanced Settings' );
 	translate( 'Targeted Devices' );
 	translate( 'Destination URL' );
@@ -51,16 +57,22 @@ const BlazePressStrings = () => {
 	translate( 'URL parameters' );
 	translate( 'key1=value1&key2=value2&key3=value3' );
 	translate( 'URL parameters are invalid' );
-	translate( '%(charactersLeft)s character remaining', '%(charactersLeft)s characters remaining', { count: 1 } );
+	translate( '%(charactersLeft)s character remaining', '%(charactersLeft)s characters remaining', {
+		count: 1,
+	} );
 	translate( 'Appearance' );
 	translate( 'Ad creative' );
-	translate( 'Use post\'s media' );
+	translate( "Use post's media" );
 	translate( 'Site title' );
 	translate( 'Loading page title...' );
 	translate( 'Page title' );
 	translate( 'Snippet' );
-	translate( '%(snippetCharactersLeft)s character remaining', '%(snippetCharactersLeft)s characters remaining', { count: 1 } );
-	translate( 'Loading ad text....' );
+	translate(
+		'%(snippetCharactersLeft)s character remaining',
+		'%(snippetCharactersLeft)s characters remaining',
+		{ count: 1 }
+	);
+	translate( 'Loading ad text…' );
 	translate( 'Ad text' );
 	translate( 'Use + / - or simply drag the image to adjust it' );
 	translate( 'Apply' );
@@ -75,7 +87,11 @@ const BlazePressStrings = () => {
 	translate( 'Drop images to upload' );
 	translate( 'Use selected' );
 	translate( 'Load More' );
-	translate( 'Showing %(found)s of %(found)s media item', 'Showing %(found)s of %(found)s media items', { count: 1 } );
+	translate(
+		'Showing %(found)s of %(found)s media item',
+		'Showing %(found)s of %(found)s media items',
+		{ count: 1 }
+	);
 	translate( 'Search images' );
 	translate( 'Search' );
 	translate( 'Select' );
@@ -85,11 +101,15 @@ const BlazePressStrings = () => {
 	translate( 'Click or drag an image here to upload.' );
 	translate( 'Upload an image file, or pick one from your media library.' );
 	translate( 'Audience' );
-	translate( 'Not enough reach to create a campaign with the current audience configuration. Please, expand your reach by changing or removing some of the audience settings' );
+	translate(
+		'Not enough reach to create a campaign with the current audience configuration. Please, expand your reach by changing or removing some of the audience settings'
+	);
 	translate( 'Language' );
 	translate( 'Location' );
 	translate( 'All languages' );
-	translate( 'Based on the language of your site we suggest targeting %(lang)s speaking users to ensure the ad is seen by the right audience and to increase its effectiveness.' );
+	translate(
+		'Based on the language of your site we suggest targeting %(lang)s speaking users to ensure the ad is seen by the right audience and to increase its effectiveness.'
+	);
 	translate( 'All topics' );
 	translate( 'Interests' );
 	translate( 'Budget and duration' );
@@ -101,13 +121,19 @@ const BlazePressStrings = () => {
 	translate( 'Duration (days)' );
 	translate( 'Weekly Total' );
 	translate( 'Total' );
-	translate( 'Daily spend for %(durationDays)s-day duration', 'Daily spend for %(durationDays)s day duration', { count: 1 } );
+	translate(
+		'Daily spend for %(durationDays)s-day duration',
+		'Daily spend for %(durationDays)s day duration',
+		{ count: 1 }
+	);
 	translate( 'Estimated people reached per day' );
 	translate( 'days' );
 	translate( 'Credits will be automatically applied to your order when available.' );
 	translate( 'Credits: %(creditsUsed)s (%(remainingCredit)s remain)' );
 	translate( 'Review your campaign' );
-	translate( 'We created this campaign to deliver the most valuable traffic, yet you can still make changes before submitting it.' );
+	translate(
+		'We created this campaign to deliver the most valuable traffic, yet you can still make changes before submitting it.'
+	);
 	translate( 'Campaign Objective' );
 	translate( 'Change' );
 	translate( 'Start Date' );
@@ -146,9 +172,15 @@ const BlazePressStrings = () => {
 	translate( 'Error setting up payment. Please try again later' );
 	translate( 'Error submitting payment. Please check payment information.' );
 	translate( 'Error fetching payment method. Please try again later.' );
-	translate( 'There was an error with the address. Please verify that all the required data is valid' );
-	translate( 'There was an error with the address. The province, state or region should be filled' );
-	translate( 'There was an error with the address. Please, check that the Zip code exists, is valid for the country, and corresponds for the given address' );
+	translate(
+		'There was an error with the address. Please verify that all the required data is valid'
+	);
+	translate(
+		'There was an error with the address. The province, state or region should be filled'
+	);
+	translate(
+		'There was an error with the address. Please, check that the Zip code exists, is valid for the country, and corresponds for the given address'
+	);
 	translate( 'Use saved card' );
 	translate( 'First Name' );
 	translate( 'Last Name' );
@@ -168,7 +200,9 @@ const BlazePressStrings = () => {
 	translate( 'Untitled' );
 	translate( 'View' );
 	translate( 'Promote' );
-	translate( 'By clicking \"Submit campaign\" you agree to the {{linkTos}}Terms of Service{{externalLinkIcon/}}{{/linkTos}} and {{linkAdvertisingPolicy}}Advertising Policy{{externalLinkIcon/}}{{/linkAdvertisingPolicy}}, and authorize your payment method to be charged for the budget and duration you chose. {{linkMoreAboutAds}}Learn more{{externalLinkIcon/}}{{/linkMoreAboutAds}} about how budgets and payments for Promoted Posts work.' );
+	translate(
+		'By clicking "Submit campaign" you agree to the {{linkTos}}Terms of Service{{externalLinkIcon/}}{{/linkTos}} and {{linkAdvertisingPolicy}}Advertising Policy{{externalLinkIcon/}}{{/linkAdvertisingPolicy}}, and authorize your payment method to be charged for the budget and duration you chose. {{linkMoreAboutAds}}Learn more{{externalLinkIcon/}}{{/linkMoreAboutAds}} about how budgets and payments for Promoted Posts work.'
+	);
 	translate( 'Creating campaign' );
 	translate( 'Submit campaign' );
 	translate( 'Make changes' );
@@ -192,7 +226,9 @@ const BlazePressStrings = () => {
 	translate( 'Oops, something went wrong' );
 	translate( 'Loading site…' );
 	translate( 'Fetching subscriptions…' );
-	translate( 'There was a problem getting the necessary information to create your campaign. Please try again soon or {{a}}contact our support team{{/a}} for help.' );
+	translate(
+		'There was a problem getting the necessary information to create your campaign. Please try again soon or {{a}}contact our support team{{/a}} for help.'
+	);
 	translate( 'Preparing the wizard…' );
 	translate( 'Drop image here' );
 	translate( 'Click or Drag an image here' );


### PR DESCRIPTION
Related to #

## Proposed Changes

* New translations. Generated the file through the DSP

<img width="835" alt="Screenshot 2024-06-04 at 11 12 07 PM" src="https://github.com/Automattic/wp-calypso/assets/3519324/ccebc45e-cc82-4fc7-8d8e-3a349a64a23d">

<img width="844" alt="Screenshot 2024-06-04 at 11 12 10 PM" src="https://github.com/Automattic/wp-calypso/assets/3519324/9758a667-ca82-469f-be82-ea9f7e45041d">

<img width="646" alt="Screenshot 2024-06-05 at 3 25 40 PM" src="https://github.com/Automattic/wp-calypso/assets/3519324/25d9e0fb-5412-405b-ae0c-f555d875d95d">

<img width="677" alt="Screenshot 2024-06-05 at 3 27 08 PM" src="https://github.com/Automattic/wp-calypso/assets/3519324/5cea27e4-170a-4c5c-afa7-91ce448a89c1">

<img width="769" alt="Screenshot 2024-06-05 at 3 25 49 PM" src="https://github.com/Automattic/wp-calypso/assets/3519324/ecbc9594-4ea4-4f29-8f3d-5c7f75fd10b9">




## Testing Instructions


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
