### PR TITLE
Hosting Settings: Remove GitHub banner

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -188,17 +188,7 @@ const SidebarCards = ( { isBasicHostingDisabled } ) => {
 };
 
 const AllCards = ( { isAdvancedHostingDisabled, isBasicHostingDisabled, siteId, siteSlug } ) => {
-	const { data, isLoading } = useCodeDeploymentsQuery( siteId );
-	const isCodeDeploymentsUnused = ! isLoading && data && ! data.length;
-
 	const allCards = [
-		isCodeDeploymentsUnused
-			? {
-					feature: 'github-deployments',
-					content: <GitHubDeploymentsCard />,
-					type: 'advanced',
-			  }
-			: null,
 		{
 			feature: 'sftp',
 			content: <SFTPCard disabled={ isAdvancedHostingDisabled } />,

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -1,6 +1,6 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 
-$areas: github-deployments, sftp, site-backup, support, phpmyadmin, staging-site, restore-plan-software, cache, web-server-settings, admin-interface-style;
+$areas: sftp, site-backup, support, phpmyadmin, staging-site, restore-plan-software, cache, web-server-settings, admin-interface-style;
 
 .hosting {
 	/* Rely on the standard spacing for the underlying elements. */
@@ -49,7 +49,6 @@ $areas: github-deployments, sftp, site-backup, support, phpmyadmin, staging-site
 				display: grid;
 				grid-template-columns: 1fr 1fr;
 				grid-template-areas:
-					"github-deployments github-deployments"
 					"sftp phpmyadmin"
 					"sftp cache"
 					"restore-plan-software web-server-settings"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7626

## Proposed Changes

This PR removes the GitHub banner in the Hosting Settings page.

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-06 at 9 18 00 AM](https://github.com/Automattic/wp-calypso/assets/797888/353ea382-7c44-4f24-a211-bd9fb574f002) | ![Screenshot 2024-06-06 at 9 17 41 AM](https://github.com/Automattic/wp-calypso/assets/797888/44a91fce-72d1-4292-9d85-0ccafc17ca4b) |



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Site Management Panel already has a Deployment tab.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Open the SMP of any atomic site.
* Ensure that the GitHub banner no longer shows up.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
