### PR TITLE
Site Management Panel: Fix the description on the pricing card

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -86,7 +86,7 @@ const PricingSection: FC = () => {
 				<div className="hosting-overview__plan-price-wrapper">
 					<PlanPrice
 						className="hosting-overview__plan-price"
-						currencyCode={ pricing?.[ planSlug ].currencyCode }
+						currencyCode={ pricing?.currencyCode }
 						isSmallestUnit
 						rawPrice={ pricing?.originalPrice.monthly }
 					/>

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -7,7 +7,7 @@ import {
 import { Button, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
-import { usePerMonthDescription } from '@automattic/plans-grid-next';
+import { usePlanBillingDescription } from '@automattic/plans-grid-next';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -46,7 +46,7 @@ const PricingSection: FC = () => {
 	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
 	const isLoading = ! pricing || ! planData || planPurchaseLoading;
 
-	const perMonthDescription = usePerMonthDescription( {
+	const planBillingDescription = usePlanBillingDescription( {
 		siteId: site?.ID,
 		planSlug,
 		pricing: pricing ?? null,
@@ -60,7 +60,7 @@ const PricingSection: FC = () => {
 			return null;
 		}
 
-		return <>{ perMonthDescription || getPlan( planSlug )?.getBillingTimeFrame?.() }.</>;
+		return <>{ planBillingDescription || getPlan( planSlug )?.getBillingTimeFrame?.() }.</>;
 	};
 
 	const getExpireDetails = () => {

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -60,7 +60,7 @@ const PricingSection: FC = () => {
 			return null;
 		}
 
-		return perMonthDescription || getPlan( planSlug )?.getBillingTimeFrame?.();
+		return <>{ perMonthDescription || getPlan( planSlug )?.getBillingTimeFrame?.() }.</>;
 	};
 
 	const getExpireDetails = () => {

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -60,27 +60,7 @@ const PricingSection: FC = () => {
 			return null;
 		}
 
-<<<<<<< HEAD
-		return translate( '{{span}}%(rawPrice)s{{/span}} billed %(billingPeriod)s, excludes taxes.', {
-			args: {
-				rawPrice: formatCurrency(
-					pricing?.[ planSlug ].originalPrice.full ?? 0,
-					pricing?.[ planSlug ].currencyCode ?? '',
-					{
-						stripZeros: true,
-						isSmallestUnit: true,
-					}
-				),
-				billingPeriod,
-			},
-			components: {
-				span: <span />,
-			},
-			comment: 'billingPeriod e.g., every month, every year, every 3 years',
-		} );
-=======
-		return perMonthDescription || getPlan( planSlug ).getBillingTimeFrame?.();
->>>>>>> 27ba959d95 (Site Management Panel: Introduce usePerMonthDescription hook to make the description of the plan consistent)
+		return perMonthDescription || getPlan( planSlug )?.getBillingTimeFrame?.();
 	};
 
 	const getExpireDetails = () => {

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -1,8 +1,13 @@
-import { PlanSlug, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import {
+	getPlan,
+	PlanSlug,
+	PRODUCT_1GB_SPACE,
+	PLAN_MONTHLY_PERIOD,
+} from '@automattic/calypso-products';
 import { Button, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { AddOns } from '@automattic/data-stores';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
-import { formatCurrency } from '@automattic/format-currency';
+import { usePerMonthDescription } from '@automattic/plans-grid-next';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -37,19 +42,25 @@ const PricingSection: FC = () => {
 		siteId: site?.ID,
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
-	} );
+	} )?.[ planSlug ];
 	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
 	const isLoading = ! pricing || ! planData || planPurchaseLoading;
-	const billingPeriod = planPurchase?.billPeriodLabel;
+
+	const perMonthDescription = usePerMonthDescription( {
+		siteId: site?.ID,
+		planSlug,
+		pricing: pricing ?? null,
+		isMonthlyPlan: pricing?.billingPeriod === PLAN_MONTHLY_PERIOD,
+		storageAddOnsForPlan: null,
+		useCheckPlanAvailabilityForPurchase,
+	} );
 
 	const getBillingDetails = () => {
 		if ( isFreePlan ) {
 			return null;
 		}
-		if ( ! billingPeriod ) {
-			return null;
-		}
 
+<<<<<<< HEAD
 		return translate( '{{span}}%(rawPrice)s{{/span}} billed %(billingPeriod)s, excludes taxes.', {
 			args: {
 				rawPrice: formatCurrency(
@@ -67,6 +78,9 @@ const PricingSection: FC = () => {
 			},
 			comment: 'billingPeriod e.g., every month, every year, every 3 years',
 		} );
+=======
+		return perMonthDescription || getPlan( planSlug ).getBillingTimeFrame?.();
+>>>>>>> 27ba959d95 (Site Management Panel: Introduce usePerMonthDescription hook to make the description of the plan consistent)
 	};
 
 	const getExpireDetails = () => {
@@ -94,7 +108,7 @@ const PricingSection: FC = () => {
 						className="hosting-overview__plan-price"
 						currencyCode={ pricing?.[ planSlug ].currencyCode }
 						isSmallestUnit
-						rawPrice={ pricing?.[ planSlug ].originalPrice.monthly }
+						rawPrice={ pricing?.originalPrice.monthly }
 					/>
 					<span className="hosting-overview__plan-price-term">
 						{ translate( '/mo', {

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -1,254 +1,15 @@
 import {
-	isWpComFreePlan,
 	isWpcomEnterpriseGridPlan,
-	PLAN_BIENNIAL_PERIOD,
-	PLAN_ANNUAL_PERIOD,
-	PLAN_TRIENNIAL_PERIOD,
 	PlanSlug,
-	getPlanSlugForTermVariant,
-	TERM_ANNUALLY,
 	isWooExpressPlan,
-	PLAN_HOSTING_TRIAL_MONTHLY,
 	isFreePlan,
 } from '@automattic/calypso-products';
-import { Plans } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
+import usePerMonthDescription from '../../../hooks/data-store/use-per-month-description';
 import type { GridPlan } from '../../../types';
-
-function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
-	const translate = useTranslate();
-	const { helpers, gridPlansIndex, coupon, siteId } = usePlansGridContext();
-	const {
-		isMonthlyPlan,
-		pricing: { currencyCode, originalPrice, discountedPrice, billingPeriod, introOffer },
-		storageAddOnsForPlan,
-	} = gridPlansIndex[ planSlug ];
-
-	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
-
-	const yearlyVariantPricing = Plans.usePricingMetaForGridPlans( {
-		planSlugs: yearlyVariantPlanSlug ? [ yearlyVariantPlanSlug ] : [],
-		storageAddOns: storageAddOnsForPlan,
-		coupon,
-		siteId,
-		useCheckPlanAvailabilityForPurchase: helpers?.useCheckPlanAvailabilityForPurchase,
-	} )?.[ yearlyVariantPlanSlug ?? '' ];
-
-	if (
-		isWpComFreePlan( planSlug ) ||
-		isWpcomEnterpriseGridPlan( planSlug ) ||
-		planSlug === PLAN_HOSTING_TRIAL_MONTHLY
-	) {
-		return null;
-	}
-
-	if (
-		isMonthlyPlan &&
-		originalPrice?.monthly &&
-		yearlyVariantPricing &&
-		( ! introOffer || introOffer.isOfferComplete )
-	) {
-		const yearlyVariantMaybeDiscountedPrice =
-			yearlyVariantPricing.discountedPrice?.monthly || yearlyVariantPricing.originalPrice?.monthly;
-
-		if (
-			yearlyVariantMaybeDiscountedPrice &&
-			yearlyVariantMaybeDiscountedPrice < originalPrice.monthly
-		) {
-			return translate( `Save %(discountRate)s%% by paying annually`, {
-				args: {
-					discountRate: Math.floor(
-						( 100 * ( originalPrice.monthly - yearlyVariantMaybeDiscountedPrice ) ) /
-							originalPrice.monthly
-					),
-				},
-			} );
-		}
-
-		return null;
-	}
-
-	const discountedPriceFullTermText =
-		currencyCode && discountedPrice?.full
-			? formatCurrency( discountedPrice.full, currencyCode, {
-					stripZeros: true,
-					isSmallestUnit: true,
-			  } )
-			: null;
-	const originalPriceFullTermText =
-		currencyCode && originalPrice?.full
-			? formatCurrency( originalPrice.full, currencyCode, {
-					stripZeros: true,
-					isSmallestUnit: true,
-			  } )
-			: null;
-
-	/*
-	 * The introOffer billing should fall below into the next block once experiment with Woo plans is finalized.
-	 *   1. We only expose introOffers to monthly & yearly plans for now (so no need to introduce more translations just yet)
-	 *   2. We only expose month & year based intervals for now (so no need to introduce more translations just yet)
-	 */
-	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
-		if ( originalPriceFullTermText ) {
-			if ( isMonthlyPlan ) {
-				if ( 1 === introOffer.intervalCount ) {
-					return translate(
-						'per month, for your first %(introOfferIntervalUnit)s,{{br/}}' +
-							'then %(rawPrice)s billed monthly, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalUnit: introOffer.intervalUnit,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-
-				if ( 'month' === introOffer.intervalUnit ) {
-					return translate(
-						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
-							'then %(rawPrice)s billed monthly, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalCount: introOffer.intervalCount,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-
-				if ( 'year' === introOffer.intervalUnit ) {
-					return translate(
-						'per month, for your first %(introOfferIntervalCount)s years,{{br/}}' +
-							'then %(rawPrice)s billed monthly, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalCount: introOffer.intervalCount,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-			}
-
-			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-				if ( 1 === introOffer.intervalCount ) {
-					return translate(
-						'per month, for your first %(introOfferIntervalUnit)s,{{br/}}' +
-							'then %(rawPrice)s billed annually, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalUnit: introOffer.intervalUnit,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-
-				if ( 'month' === introOffer.intervalUnit ) {
-					return translate(
-						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
-							'then %(rawPrice)s billed annually, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalCount: introOffer.intervalCount,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-
-				if ( 'year' === introOffer.intervalUnit ) {
-					return translate(
-						'per month, for your first %(introOfferIntervalCount)s years,{{br/}}' +
-							'then %(rawPrice)s billed annually, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalCount: introOffer.intervalCount,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-			}
-		}
-		/*
-		 * Early return here is for sanity. We don't want to show regular billing descriptions
-		 * if there is an introOffer (despite that will not be the case, unless some API-level bug happens)
-		 */
-		return null;
-	}
-
-	if ( discountedPriceFullTermText ) {
-		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-			return translate(
-				'per month, %(fullTermDiscountedPriceText)s for the first year, excl. taxes',
-				{
-					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
-					comment: 'Excl. Taxes is short for excluding taxes',
-				}
-			);
-		}
-
-		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-			return translate(
-				'per month, %(fullTermDiscountedPriceText)s for the first two years, excl. taxes',
-				{
-					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
-					comment: 'Excl. Taxes is short for excluding taxes',
-				}
-			);
-		}
-
-		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
-			return translate(
-				'per month, %(fullTermDiscountedPriceText)s for the first three years, excl. taxes',
-				{
-					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
-					comment: 'Excl. Taxes is short for excluding taxes',
-				}
-			);
-		}
-	} else if ( originalPriceFullTermText ) {
-		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, %(rawPrice)s billed annually, excl. taxes', {
-				args: { rawPrice: originalPriceFullTermText },
-				comment: 'Excl. Taxes is short for excluding taxes',
-			} );
-		}
-
-		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, %(rawPrice)s billed every two years, excl. taxes', {
-				args: { rawPrice: originalPriceFullTermText },
-				comment: 'Excl. Taxes is short for excluding taxes',
-			} );
-		}
-
-		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, %(rawPrice)s billed every three years, excl. taxes', {
-				args: { rawPrice: originalPriceFullTermText },
-				comment: 'Excl. Taxes is short for excluding taxes',
-			} );
-		}
-	}
-
-	return null;
-}
 
 const DiscountPromotion = styled.div`
 	text-transform: uppercase;
@@ -290,13 +51,20 @@ interface Props {
 
 const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 	const translate = useTranslate();
-	const { gridPlansIndex } = usePlansGridContext();
-	const {
+	const { helpers, gridPlansIndex, coupon, siteId } = usePlansGridContext();
+	const { isMonthlyPlan, billingTimeframe, pricing, storageAddOnsForPlan } =
+		gridPlansIndex[ planSlug ];
+
+	const { introOffer, billingPeriod } = pricing;
+	const perMonthDescription = usePerMonthDescription( {
+		siteId,
+		planSlug,
+		pricing,
 		isMonthlyPlan,
-		billingTimeframe,
-		pricing: { introOffer, billingPeriod },
-	} = gridPlansIndex[ planSlug ];
-	const perMonthDescription = usePerMonthDescription( { planSlug } );
+		storageAddOnsForPlan,
+		coupon,
+		useCheckPlanAvailabilityForPurchase: helpers.useCheckPlanAvailabilityForPurchase,
+	} );
 	const description = perMonthDescription || billingTimeframe;
 
 	if (

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -8,7 +8,7 @@ import { formatCurrency } from '@automattic/format-currency';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
-import usePerMonthDescription from '../../../hooks/data-store/use-per-month-description';
+import usePlanBillingDescription from '../../../hooks/data-store/use-plan-billing-description';
 import type { GridPlan } from '../../../types';
 
 const DiscountPromotion = styled.div`
@@ -56,7 +56,7 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 		gridPlansIndex[ planSlug ];
 
 	const { introOffer, billingPeriod } = pricing;
-	const perMonthDescription = usePerMonthDescription( {
+	const planBillingDescription = usePlanBillingDescription( {
 		siteId,
 		planSlug,
 		pricing,
@@ -65,7 +65,7 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 		coupon,
 		useCheckPlanAvailabilityForPurchase: helpers?.useCheckPlanAvailabilityForPurchase,
 	} );
-	const description = perMonthDescription || billingTimeframe;
+	const description = planBillingDescription || billingTimeframe;
 
 	if (
 		isWooExpressPlan( planSlug ) &&
@@ -75,7 +75,7 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 		return (
 			<div>
 				<div>{ billingTimeframe }</div>
-				<DiscountPromotion>{ perMonthDescription }</DiscountPromotion>
+				<DiscountPromotion>{ planBillingDescription }</DiscountPromotion>
 			</div>
 		);
 	}

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -63,7 +63,7 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 		isMonthlyPlan,
 		storageAddOnsForPlan,
 		coupon,
-		useCheckPlanAvailabilityForPurchase: helpers.useCheckPlanAvailabilityForPurchase,
+		useCheckPlanAvailabilityForPurchase: helpers?.useCheckPlanAvailabilityForPurchase,
 	} );
 	const description = perMonthDescription || billingTimeframe;
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-per-month-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-per-month-description.tsx
@@ -1,0 +1,264 @@
+import {
+	isWpComFreePlan,
+	isWpcomEnterpriseGridPlan,
+	PLAN_BIENNIAL_PERIOD,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
+	PlanSlug,
+	getPlanSlugForTermVariant,
+	TERM_ANNUALLY,
+	PLAN_HOSTING_TRIAL_MONTHLY,
+} from '@automattic/calypso-products';
+import { Plans } from '@automattic/data-stores';
+import { formatCurrency } from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import type { GridPlan } from '../../types';
+
+interface UsePerMonthDescriptionProps {
+	siteId?: number | null;
+	planSlug: PlanSlug;
+	pricing: GridPlan[ 'pricing' ] | null;
+	isMonthlyPlan?: boolean;
+	storageAddOnsForPlan: GridPlan[ 'storageAddOnsForPlan' ];
+	coupon?: string;
+	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase;
+}
+
+export default function usePerMonthDescription( {
+	siteId,
+	planSlug,
+	pricing,
+	storageAddOnsForPlan,
+	isMonthlyPlan,
+	coupon,
+	useCheckPlanAvailabilityForPurchase,
+}: UsePerMonthDescriptionProps ) {
+	const translate = useTranslate();
+	const { currencyCode, originalPrice, discountedPrice, billingPeriod, introOffer } = pricing || {};
+
+	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
+
+	const yearlyVariantPricing = Plans.usePricingMetaForGridPlans( {
+		planSlugs: yearlyVariantPlanSlug ? [ yearlyVariantPlanSlug ] : [],
+		storageAddOns: storageAddOnsForPlan,
+		coupon,
+		siteId,
+		useCheckPlanAvailabilityForPurchase,
+	} )?.[ yearlyVariantPlanSlug ?? '' ];
+
+	if ( ! pricing ) {
+		return null;
+	}
+
+	if (
+		isWpComFreePlan( planSlug ) ||
+		isWpcomEnterpriseGridPlan( planSlug ) ||
+		planSlug === PLAN_HOSTING_TRIAL_MONTHLY
+	) {
+		return null;
+	}
+
+	if (
+		isMonthlyPlan &&
+		originalPrice?.monthly &&
+		yearlyVariantPricing &&
+		( ! introOffer || introOffer.isOfferComplete )
+	) {
+		const yearlyVariantMaybeDiscountedPrice =
+			yearlyVariantPricing.discountedPrice?.monthly || yearlyVariantPricing.originalPrice?.monthly;
+
+		if (
+			yearlyVariantMaybeDiscountedPrice &&
+			yearlyVariantMaybeDiscountedPrice < originalPrice.monthly
+		) {
+			return translate( `Save %(discountRate)s%% by paying annually`, {
+				args: {
+					discountRate: Math.floor(
+						( 100 * ( originalPrice.monthly - yearlyVariantMaybeDiscountedPrice ) ) /
+							originalPrice.monthly
+					),
+				},
+			} );
+		}
+
+		return null;
+	}
+
+	const discountedPriceFullTermText =
+		currencyCode && discountedPrice?.full
+			? formatCurrency( discountedPrice.full, currencyCode, {
+					stripZeros: true,
+					isSmallestUnit: true,
+			  } )
+			: null;
+	const originalPriceFullTermText =
+		currencyCode && originalPrice?.full
+			? formatCurrency( originalPrice.full, currencyCode, {
+					stripZeros: true,
+					isSmallestUnit: true,
+			  } )
+			: null;
+
+	/*
+	 * The introOffer billing should fall below into the next block once experiment with Woo plans is finalized.
+	 *   1. We only expose introOffers to monthly & yearly plans for now (so no need to introduce more translations just yet)
+	 *   2. We only expose month & year based intervals for now (so no need to introduce more translations just yet)
+	 */
+	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
+		if ( originalPriceFullTermText ) {
+			if ( isMonthlyPlan ) {
+				if ( 1 === introOffer.intervalCount ) {
+					return translate(
+						'per month, for your first %(introOfferIntervalUnit)s,{{br/}}' +
+							'then %(rawPrice)s billed monthly, excl. taxes',
+						{
+							args: {
+								rawPrice: originalPriceFullTermText,
+								introOfferIntervalUnit: introOffer.intervalUnit,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
+
+				if ( 'month' === introOffer.intervalUnit ) {
+					return translate(
+						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
+							'then %(rawPrice)s billed monthly, excl. taxes',
+						{
+							args: {
+								rawPrice: originalPriceFullTermText,
+								introOfferIntervalCount: introOffer.intervalCount,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
+
+				if ( 'year' === introOffer.intervalUnit ) {
+					return translate(
+						'per month, for your first %(introOfferIntervalCount)s years,{{br/}}' +
+							'then %(rawPrice)s billed monthly, excl. taxes',
+						{
+							args: {
+								rawPrice: originalPriceFullTermText,
+								introOfferIntervalCount: introOffer.intervalCount,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
+			}
+
+			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
+				if ( 1 === introOffer.intervalCount ) {
+					return translate(
+						'per month, for your first %(introOfferIntervalUnit)s,{{br/}}' +
+							'then %(rawPrice)s billed annually, excl. taxes',
+						{
+							args: {
+								rawPrice: originalPriceFullTermText,
+								introOfferIntervalUnit: introOffer.intervalUnit,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
+
+				if ( 'month' === introOffer.intervalUnit ) {
+					return translate(
+						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
+							'then %(rawPrice)s billed annually, excl. taxes',
+						{
+							args: {
+								rawPrice: originalPriceFullTermText,
+								introOfferIntervalCount: introOffer.intervalCount,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
+
+				if ( 'year' === introOffer.intervalUnit ) {
+					return translate(
+						'per month, for your first %(introOfferIntervalCount)s years,{{br/}}' +
+							'then %(rawPrice)s billed annually, excl. taxes',
+						{
+							args: {
+								rawPrice: originalPriceFullTermText,
+								introOfferIntervalCount: introOffer.intervalCount,
+							},
+							components: { br: <br /> },
+							comment: 'excl. taxes is short for excluding taxes',
+						}
+					);
+				}
+			}
+		}
+		/*
+		 * Early return here is for sanity. We don't want to show regular billing descriptions
+		 * if there is an introOffer (despite that will not be the case, unless some API-level bug happens)
+		 */
+		return null;
+	}
+
+	if ( discountedPriceFullTermText ) {
+		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
+			return translate(
+				'per month, %(fullTermDiscountedPriceText)s for the first year, excl. taxes',
+				{
+					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
+					comment: 'Excl. Taxes is short for excluding taxes',
+				}
+			);
+		}
+
+		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
+			return translate(
+				'per month, %(fullTermDiscountedPriceText)s for the first two years, excl. taxes',
+				{
+					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
+					comment: 'Excl. Taxes is short for excluding taxes',
+				}
+			);
+		}
+
+		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
+			return translate(
+				'per month, %(fullTermDiscountedPriceText)s for the first three years, excl. taxes',
+				{
+					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
+					comment: 'Excl. Taxes is short for excluding taxes',
+				}
+			);
+		}
+	} else if ( originalPriceFullTermText ) {
+		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
+			return translate( 'per month, %(rawPrice)s billed annually, excl. taxes', {
+				args: { rawPrice: originalPriceFullTermText },
+				comment: 'Excl. Taxes is short for excluding taxes',
+			} );
+		}
+
+		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
+			return translate( 'per month, %(rawPrice)s billed every two years, excl. taxes', {
+				args: { rawPrice: originalPriceFullTermText },
+				comment: 'Excl. Taxes is short for excluding taxes',
+			} );
+		}
+
+		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
+			return translate( 'per month, %(rawPrice)s billed every three years, excl. taxes', {
+				args: { rawPrice: originalPriceFullTermText },
+				comment: 'Excl. Taxes is short for excluding taxes',
+			} );
+		}
+	}
+
+	return null;
+}

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -14,7 +14,7 @@ import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import type { GridPlan } from '../../types';
 
-interface UsePerMonthDescriptionProps {
+interface UsePlanBillingDescriptionProps {
 	siteId?: number | null;
 	planSlug: PlanSlug;
 	pricing: GridPlan[ 'pricing' ] | null;
@@ -24,7 +24,7 @@ interface UsePerMonthDescriptionProps {
 	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase;
 }
 
-export default function usePerMonthDescription( {
+export default function usePlanBillingDescription( {
 	siteId,
 	planSlug,
 	pricing,
@@ -32,7 +32,7 @@ export default function usePerMonthDescription( {
 	isMonthlyPlan,
 	coupon,
 	useCheckPlanAvailabilityForPurchase,
-}: UsePerMonthDescriptionProps ) {
+}: UsePlanBillingDescriptionProps ) {
 	const translate = useTranslate();
 	const { currencyCode, originalPrice, discountedPrice, billingPeriod, introOffer } = pricing || {};
 

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -10,6 +10,7 @@ import useGridPlanForSpotlight from './hooks/data-store/use-grid-plan-for-spotli
 import useGridPlans from './hooks/data-store/use-grid-plans';
 import useGridPlansForComparisonGrid from './hooks/data-store/use-grid-plans-for-comparison-grid';
 import useGridPlansForFeaturesGrid from './hooks/data-store/use-grid-plans-for-features-grid';
+import usePerMonthDescription from './hooks/data-store/use-per-month-description';
 import usePlanFeaturesForGridPlans from './hooks/data-store/use-plan-features-for-grid-plans';
 import useRestructuredPlanFeaturesForComparisonGrid from './hooks/data-store/use-restructured-plan-features-for-comparison-grid';
 import useGridSize from './hooks/use-grid-size';
@@ -173,6 +174,7 @@ export {
 	useGridPlansForFeaturesGrid,
 	useGridPlansForComparisonGrid,
 	useGridPlanForSpotlight,
+	usePerMonthDescription,
 	usePlanFeaturesForGridPlans,
 	useRestructuredPlanFeaturesForComparisonGrid,
 };

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -10,7 +10,7 @@ import useGridPlanForSpotlight from './hooks/data-store/use-grid-plan-for-spotli
 import useGridPlans from './hooks/data-store/use-grid-plans';
 import useGridPlansForComparisonGrid from './hooks/data-store/use-grid-plans-for-comparison-grid';
 import useGridPlansForFeaturesGrid from './hooks/data-store/use-grid-plans-for-features-grid';
-import usePerMonthDescription from './hooks/data-store/use-per-month-description';
+import usePlanBillingDescription from './hooks/data-store/use-plan-billing-description';
 import usePlanFeaturesForGridPlans from './hooks/data-store/use-plan-features-for-grid-plans';
 import useRestructuredPlanFeaturesForComparisonGrid from './hooks/data-store/use-restructured-plan-features-for-comparison-grid';
 import useGridSize from './hooks/use-grid-size';
@@ -174,7 +174,7 @@ export {
 	useGridPlansForFeaturesGrid,
 	useGridPlansForComparisonGrid,
 	useGridPlanForSpotlight,
-	usePerMonthDescription,
+	usePlanBillingDescription,
 	usePlanFeaturesForGridPlans,
 	useRestructuredPlanFeaturesForComparisonGrid,
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7634

## Proposed Changes

* Introduce the shared `usePerMonthDescription` hook, and use it to display the description of the current plan
* TODO: maybe remove the `per month,` on the plan card and I think it's fine 🤔

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/8bc43d8f-e560-4725-8a5e-ef654e70fe87) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/48101831-6d09-4dc6-997c-4ebc214b99a7) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/3fcb19b8-cd68-4576-9f22-f4cbbf1b99f8) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/527ae1fd-3b4c-4023-acc9-4a24cf55fb4a) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select a site with the monthly plan
* Make sure the description on the site card is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
