### PR TITLE
Site Profiler: Avoid queuing advance tests when its not required

### DIFF
--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -25,7 +25,7 @@ function mapScores( response: UrlBasicMetricsQueryResponse ) {
 	return { ...response, success: basic.success, basic: basicMetricsScored };
 }
 
-export const useUrlBasicMetricsQuery = ( url?: string ) => {
+export const useUrlBasicMetricsQuery = ( url?: string, advance = false ) => {
 	return useQuery( {
 		queryKey: [ 'url-', url ],
 		queryFn: (): Promise< UrlBasicMetricsQueryResponse > =>
@@ -34,7 +34,7 @@ export const useUrlBasicMetricsQuery = ( url?: string ) => {
 					path: '/site-profiler/metrics/basic',
 					apiNamespace: 'wpcom/v2',
 				},
-				{ url, advance: '1' }
+				{ url, ...( advance ? { advance: '1' } : {} ) }
 			),
 		select: mapScores,
 		meta: {

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -92,7 +92,7 @@ export default function SiteProfilerV2( props: Props ) {
 		data: basicMetrics,
 		error: errorBasicMetrics,
 		isFetching: isFetchingBasicMetrics,
-	} = useUrlBasicMetricsQuery( url );
+	} = useUrlBasicMetricsQuery( url, true );
 
 	const showBasicMetrics =
 		basicMetrics && basicMetrics.success && ! isFetchingBasicMetrics && ! errorBasicMetrics;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add default param function to avoid queuing site profiler advance tests when they are not required.
* Update function calls to queue advance tests when they are needed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, this function is used by `use-get-upgrade-plan-site-metrics.tsx#L2` to get basic metrics. However, this also enqueues the site profiler tests that are not required. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/site-profiler?flags=-site-profiler/metrics` to disable flag
* Open network tab on browser console
* Run profiler any URL
* Confirm basic metrics endpoint is called but without the `advance=1` query param. 
![CleanShot 2024-06-06 at 12 26 10@2x](https://github.com/Automattic/wp-calypso/assets/86406124/71eca485-0aff-4696-9f45-99992228d24c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
