### PR TITLE
A4A > Partner Directory: Implement popover for the `Not Approved` badge on the Partner Directory

### DIFF
--- a/client/a8c-for-agencies/components/a4a-popover/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-popover/index.tsx
@@ -1,0 +1,40 @@
+import { Popover } from '@wordpress/components';
+
+import './style.scss';
+
+interface Props {
+	noArrow?: boolean;
+	offset?: number;
+	position?: React.ComponentProps< typeof Popover >[ 'position' ];
+	wrapperRef: React.MutableRefObject< HTMLElement | null >;
+	title: string;
+	onFocusOutside: ( event: React.SyntheticEvent ) => void;
+	children: React.ReactNode;
+}
+
+export default function A4APopover( {
+	noArrow = false,
+	offset = 0,
+	position = 'bottom',
+	wrapperRef,
+	title,
+	onFocusOutside,
+	children,
+}: Props ) {
+	return (
+		<Popover
+			isVisible
+			noArrow={ noArrow }
+			offset={ offset }
+			className="a4a-popover"
+			context={ wrapperRef.current }
+			position={ position }
+			onFocusOutside={ onFocusOutside }
+		>
+			<div className="a4a-popover__content">
+				<div className="a4a-popover__title">{ title }</div>
+				{ children }
+			</div>
+		</Popover>
+	);
+}

--- a/client/a8c-for-agencies/components/a4a-popover/style.scss
+++ b/client/a8c-for-agencies/components/a4a-popover/style.scss
@@ -1,0 +1,22 @@
+.a4a-popover__content {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	border-radius: 4px;
+	width: 300px;
+
+	.button {
+		margin-inline-end: 8px;
+	}
+
+	.a4a-popover__title {
+		font-size: rem(14px);
+		color: var(--color-accent-60);
+	}
+}
+
+.a4a-popover {
+	.components-popover__content {
+		padding: 16px;
+	}
+}

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -7,8 +7,8 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import StepSection from '../../referrals/common/step-section';
 import StepSectionItem from '../../referrals/common/step-section-item';
-import StatusBadge from '../../referrals/common/step-section-item/status-badge';
 import { getBrandMeta } from '../lib/get-brand-meta';
+import DashboardStatusBadge from './status-badge';
 
 import './style.scss';
 
@@ -85,6 +85,8 @@ export default function PartnerDirectoryDashboard() {
 		</StepSection>
 	);
 
+	const showFinishProfileButton = brandStatuses.some( ( { status } ) => status === 'Approved' );
+
 	if ( isCompleted ) {
 		return (
 			<div className="partner-directory-dashboard__completed-section">
@@ -100,6 +102,8 @@ export default function PartnerDirectoryDashboard() {
 				{ brandStatuses.length > 0 &&
 					brandStatuses.map( ( { brand, status, type } ) => {
 						const brandMeta = getBrandMeta( brand );
+						const showPopoverOnLoad =
+							brandStatuses.filter( ( { status } ) => status === 'Not approved' ).length === 1;
 						return (
 							<StepSectionItem
 								isNewLayout
@@ -126,11 +130,12 @@ export default function PartnerDirectoryDashboard() {
 											</Button>
 										</>
 									) : (
-										<StatusBadge
+										<DashboardStatusBadge
 											statusProps={ {
-												children: status,
+												status,
 												type,
 											} }
+											showPopoverOnLoad={ showPopoverOnLoad }
 										/>
 									)
 								}
@@ -185,17 +190,23 @@ export default function PartnerDirectoryDashboard() {
 					description={
 						isSubmitted && brandStatuses.length > 0 ? (
 							<div className="partner-directory-dashboard__brand-status-section">
-								{ brandStatuses.map( ( { brand, status, type } ) => (
-									<div key={ brand }>
-										<StatusBadge
-											statusProps={ {
-												children: status,
-												type,
-											} }
-										/>
-										<span>{ brand }</span>
-									</div>
-								) ) }
+								{ brandStatuses.map( ( { brand, status, type } ) => {
+									const showPopoverOnLoad =
+										brandStatuses.filter( ( { status } ) => status === 'Not approved' ).length ===
+										1;
+									return (
+										<div key={ brand }>
+											<DashboardStatusBadge
+												statusProps={ {
+													status,
+													type,
+												} }
+												showPopoverOnLoad={ showPopoverOnLoad }
+											/>
+											<span>{ brand }</span>
+										</div>
+									);
+								} ) }
 							</div>
 						) : (
 							translate(
@@ -223,7 +234,7 @@ export default function PartnerDirectoryDashboard() {
 						href: '/partner-directory/agency-details',
 						onClick: onFinishProfileClick,
 						primary: isSubmitted,
-						disabled: ! isSubmitted,
+						disabled: ! isSubmitted || ! showFinishProfileButton,
 						compact: true,
 					} }
 				/>

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/status-badge.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/status-badge.tsx
@@ -1,0 +1,110 @@
+import { BadgeType, Button, Badge } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useRef, useState, useCallback, useEffect } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import A4APopover from '../../../components/a4a-popover';
+
+interface Props {
+	statusProps: {
+		status: string;
+		type: BadgeType;
+	};
+	showPopoverOnLoad: boolean;
+}
+
+const PREFERENCE_NAME = 'a4a-partner-directory-dashboard-not-approved-popover';
+
+export default function DashboardStatusBadge( { statusProps, showPopoverOnLoad }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ showPopover, setShowPopover ] = useState( false );
+	const popoverShown = useSelector( ( state ) => getPreference( state, PREFERENCE_NAME ) );
+
+	const onUpdateExpertiseClick = useCallback( () => {
+		setShowPopover( false );
+		dispatch( savePreference( PREFERENCE_NAME, true ) );
+		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_update_expertise_click' ) );
+	}, [ dispatch ] );
+
+	const onClickDoItLater = useCallback( () => {
+		setShowPopover( false );
+		dispatch( savePreference( PREFERENCE_NAME, true ) );
+		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_do_it_later_click' ) );
+	}, [ dispatch ] );
+
+	useEffect( () => {
+		if ( showPopoverOnLoad && ! popoverShown ) {
+			setShowPopover( true );
+		}
+	}, [ showPopoverOnLoad, popoverShown ] );
+
+	const popoverContent =
+		statusProps.status === 'Not approved' ? (
+			<div>
+				<Button
+					compact
+					primary
+					href="/partner-directory/agency-expertise"
+					onClick={ onUpdateExpertiseClick }
+				>
+					{ translate( 'Update my expertise' ) }
+				</Button>
+				{ ! popoverShown && (
+					<Button compact onClick={ onClickDoItLater }>
+						{ translate( `I'll do it later` ) }
+					</Button>
+				) }
+			</div>
+		) : undefined;
+
+	const wrapperRef = useRef< HTMLDivElement | null >( null );
+
+	if ( ! popoverContent ) {
+		return (
+			<span>
+				<Badge
+					className="step-section-item__status"
+					children={ statusProps.status }
+					type={ statusProps.type }
+				/>
+			</span>
+		);
+	}
+
+	const handleShowPopover = ( show: boolean ) => {
+		if ( ! showPopoverOnLoad || popoverShown ) {
+			setShowPopover( show );
+		}
+	};
+
+	return (
+		<span
+			onMouseEnter={ () => handleShowPopover( true ) }
+			role="button"
+			tabIndex={ 0 }
+			ref={ wrapperRef }
+		>
+			<Badge
+				className="step-section-item__status"
+				children={ statusProps.status }
+				type={ statusProps.type }
+			/>
+			{ showPopover && popoverContent && (
+				<A4APopover
+					title={ translate(
+						"Your agency wasn't approved. Please check your email for feedback from our review team."
+					) }
+					offset={ 12 }
+					wrapperRef={ wrapperRef }
+					onFocusOutside={ () => handleShowPopover( false ) }
+				>
+					{ popoverContent }
+				</A4APopover>
+			) }
+		</span>
+	);
+}

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
@@ -100,3 +100,26 @@
 		margin-inline-end: 8px;
 	}
 }
+
+.partner-directory-dashboard__popover-content {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	border-radius: 4px;
+	width: 300px;
+
+	.button {
+		margin-inline-end: 8px;
+	}
+
+	.partner-directory-dashboard__popover-content-title {
+		font-size: rem(14px);
+		color: var(--color-accent-60);
+	}
+}
+
+.partner-directory-dashboard__popover {
+	.components-popover__content {
+		padding: 16px;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/620

## Proposed Changes

This PR implements a popover for the `Not Approved` badge on the Partner Directory. This PR also creates a reusable popover that can be used for A4A.

We are currently hardcoding all the values. The API changes will be done in another PR.

NOTE: 

- [Design](https://www.figma.com/design/fp9lBFMcpB15H7czSIthPW/Partner-Directories?node-id=7025-23772&m=dev)
- The popover won't be shown when there are more than 2 `Not approved` badges.

## Testing Instructions

1. Open the A4A live link.
2. Go to Partner Directory - Dashboard > Verify the Popover is shown as below

<img width="849" alt="Screenshot 2024-06-06 at 9 57 00 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/584a5f48-75af-4984-bf75-3a8ee04079f4">

3. Click on any button on the popover and verify that it appears only when hovered. Please note: To make the popover interactive, we will hide it only when clicked outside.

<img width="849" alt="Screenshot 2024-06-06 at 9 57 05 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7a485fed-41b6-438e-8dc5-12e932389141">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
