### PR TITLE
Add tracks event prop to upsell cards in Jetpack Cloud

### DIFF
--- a/client/components/jetpack/card/jetpack-rna-action-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-rna-action-card/index.tsx
@@ -2,9 +2,10 @@ import { Button } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { ReactNode } from 'react';
+import { useDispatch } from 'react-redux';
 import UpsellBackgroundImage from 'calypso/assets/images/jetpack/rna-card-bg.png';
 import DefaultImage from 'calypso/assets/images/jetpack/rna-image-default.png';
-
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
 interface RnaActionCardProps {
@@ -14,10 +15,13 @@ interface RnaActionCardProps {
 	onCtaButtonClick?: () => void;
 	ctaButtonURL?: string;
 	ctaButtonLabel: TranslateResult;
+	ctaTracksEvent?: string;
 	cardImage?: string;
 	cardImageAlt?: string;
 	isPlaceholder?: boolean;
 	secondaryCtaURL?: string;
+	secondaryCtaLabel?: string;
+	secondaryCtaTracksEvent?: string;
 }
 
 const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
@@ -27,12 +31,29 @@ const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
 	onCtaButtonClick,
 	ctaButtonURL,
 	ctaButtonLabel,
+	ctaTracksEvent,
 	cardImage = DefaultImage,
 	cardImageAlt,
 	isPlaceholder,
 	secondaryCtaURL,
+	secondaryCtaLabel,
+	secondaryCtaTracksEvent,
 } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const handleCtaButtonClick = () => {
+		if ( ctaTracksEvent ) {
+			dispatch( recordTracksEvent( ctaTracksEvent ) );
+		}
+		if ( onCtaButtonClick ) {
+			onCtaButtonClick();
+		}
+	};
+	const handleSecondaryCtaButtonClick = () => {
+		if ( secondaryCtaTracksEvent ) {
+			dispatch( recordTracksEvent( secondaryCtaTracksEvent ) );
+		}
+	};
 	return (
 		<div
 			className={ clsx( 'jetpack-rna-action-card', {
@@ -55,7 +76,7 @@ const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
 					<Button
 						primary
 						className="jetpack-rna-action-card__button"
-						onClick={ onCtaButtonClick && onCtaButtonClick }
+						onClick={ handleCtaButtonClick }
 						href={ ctaButtonURL ? ctaButtonURL : '#' }
 						disabled={ ! ctaButtonURL }
 					>
@@ -63,7 +84,9 @@ const JetpackRnaActionCard: React.FC< RnaActionCardProps > = ( {
 					</Button>
 					{ secondaryCtaURL && (
 						<div className="jetpack-rna-action-card__secondary-cta">
-							<a href={ secondaryCtaURL }>{ translate( 'See all plans' ) }</a>
+							<a href={ secondaryCtaURL } onClick={ handleSecondaryCtaButtonClick }>
+								{ secondaryCtaLabel }
+							</a>
 						</div>
 					) }
 				</div>

--- a/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
+++ b/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
@@ -158,9 +158,12 @@ export const UpsellProductWpcomPlanCard: React.FC< UpsellProductWpcomPlanCardPro
 				onCtaButtonClick={ onCtaButtonClick }
 				ctaButtonURL={ ctaButtonURL }
 				ctaButtonLabel={ ctaButtonLabel }
+				ctaTracksEvent="calypso_jetpack_upsell_product_wpcom_plan_cta_click"
 				cardImage={ upsellImageUrl }
 				cardImageAlt={ upsellImageAlt }
 				secondaryCtaURL={ secondaryCtaURL }
+				secondaryCtaLabel={ translate( 'See all plans' ) }
+				secondaryCtaTracksEvent="calypso_jetpack_upsell_product_wpcom_plan_see_all_plans_cta_click"
 			>
 				{ renderProductCardBody() }
 			</JetpackRnaActionCard>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7344#top

## Proposed Changes

* As a follow-up PR, we're adding the ability to add tracks event for the Upsell CTAs in Jetpack Cloud
* Made the secondary CTA more extensible in this PR

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that we have metrics for the clicks

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
```

* With a simple classic site, navigate to `jetpack.cloud.localhost:3000/jetpack-search/:site`
* Click on the CTAs and see if `calypso_jetpack_upsell_product_wpcom_plan_see_all_plans_cta_click` and `calypso_jetpack_upsell_product_wpcom_plan_cta_click` are triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
