### PR TITLE
A4A > Referrals: Referrals page cleanup for the launch

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -62,6 +62,7 @@
 		font-size: rem(16px);
 		font-weight: 400;
 		line-height: 1.5;
+		max-width: 850px;
 	}
 
 	.a4a-migration-offer__details-button {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -24,9 +24,6 @@ export default function PricingSummary( { items, onRemoveItem, isAutomatedReferr
 
 	const { discountedCost, actualCost } = getTotalInvoiceValue( userProducts, items );
 
-	// FIXME: we should update the magic numbers here with values when backend part is finished.
-	const commissionAmount = Math.floor( discountedCost * 0.5 );
-
 	const currency = items[ 0 ]?.currency ?? 'USD'; // FIXME: Fix if multiple currencies are supported
 
 	const learnMoreLink = ''; //FIXME: Add link for A4A;
@@ -77,19 +74,6 @@ export default function PricingSummary( { items, onRemoveItem, isAutomatedReferr
 					} ) }
 				</span>
 			</div>
-
-			{ isAutomatedReferrals && (
-				<div className="shopping-cart__menu-commission">
-					<span>{ translate( 'Your estimated commision:' ) }</span>
-					<span>
-						{ translate( '%(total)s/mo', {
-							args: {
-								total: formatCurrency( commissionAmount, items[ 0 ]?.currency ?? 'USD' ),
-							},
-						} ) }
-					</span>
-				</div>
-			) }
 
 			{ ! isAutomatedReferrals && (
 				<div className="checkout__summary-notice">

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -51,13 +51,11 @@ export const marketplaceHostingContext: Callback = ( context, next ) => {
 };
 
 export const marketplacePressableContext: Callback = ( context, next ) => {
-	const { purchase_type } = context.query;
-	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Hosting > Pressable" path={ context.path } />
-			<PressableOverview defaultMarketplaceType={ purchaseType } />
+			<PressableOverview />
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -2,13 +2,14 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useContext } from 'react';
 import { useSelector } from 'react-redux';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { APIProductFamily } from 'calypso/state/partner-portal/types';
 import SimpleList from '../../common/simple-list';
+import { MarketplaceTypeContext } from '../../context';
 import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { getCheapestPlan, getWPCOMCreatorPlan } from '../../lib/hosting';
 import ListingSection from '../../listing-section';
@@ -26,6 +27,12 @@ export default function HostingList( { selectedSite }: Props ) {
 	const activeAgency = useSelector( getActiveAgency );
 
 	const { data } = useProductsQuery( false, true );
+
+	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+
+	// Hide the section if it's automated referrals marketplace
+	const hideSection = marketplaceType === 'referral' && isAutomatedReferrals;
 
 	const wpcomProducts = data
 		? ( data.find(
@@ -131,7 +138,7 @@ export default function HostingList( { selectedSite }: Props ) {
 					/>
 				) }
 
-				{ cheapestPressablePlan && (
+				{ cheapestPressablePlan && ! hideSection && (
 					<HostingCard
 						plan={ cheapestPressablePlan }
 						pressableOwnership={ pressableOwnership }
@@ -148,7 +155,7 @@ export default function HostingList( { selectedSite }: Props ) {
 					/>
 				) }
 			</ListingSection>
-			{ isWPCOMOptionEnabled && (
+			{ isWPCOMOptionEnabled && ! hideSection && (
 				<Card className="hosting-list__features">
 					<h3 className="hosting-list__features-heading">
 						{ translate( 'Included with Standard & Premier hosting' ) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useContext, useEffect } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -20,6 +20,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingOverview from '../common/hosting-overview';
+import { MarketplaceTypeContext } from '../context';
 import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
@@ -40,6 +41,14 @@ function PressableOverview() {
 		setShowCart,
 		toggleCart,
 	} = useShoppingCart();
+
+	const { setMarketplaceType } = useContext( MarketplaceTypeContext );
+
+	// Set the marketplace type to regular when the component mounts
+	// since we are not using the referral marketplace for Pressable.
+	useEffect( () => {
+		setMarketplaceType( 'regular' );
+	}, [ setMarketplaceType ] );
 
 	const onAddToCart = useCallback(
 		( item: APIProductFamilyProduct ) => {

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -27,8 +27,6 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 	const { getTotalInvoiceValue } = useTotalInvoiceValue();
 	const { discountedCost } = getTotalInvoiceValue( userProducts, items );
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
-	// FIXME: we should update the magic numbers here with values when backend part is finished.
-	const commissionAmount = Math.floor( discountedCost * 0.5 );
 
 	return (
 		<Popover
@@ -75,18 +73,6 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 							} ) }
 						</span>
 					</div>
-					{ marketplaceType === 'referral' && (
-						<div className="shopping-cart__menu-commission">
-							<span>{ translate( 'Your estimated commision:' ) }</span>
-							<span>
-								{ translate( '%(total)s/mo', {
-									args: {
-										total: formatCurrency( commissionAmount, items[ 0 ]?.currency ?? 'USD' ),
-									},
-								} ) }
-							</span>
-						</div>
-					) }
 
 					<Button
 						className="shopping-cart__menu-checkout-button"

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -28,7 +28,6 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import StepSection from '../../common/step-section';
 import StepSectionItem from '../../common/step-section-item';
-import ConsolidatedViews from '../../consolidated-view';
 import { getAccountStatus } from '../../lib/get-account-status';
 import tipaltiLogo from '../../lib/tipalti-logo';
 import ReferralList from '../../referrals-list';
@@ -116,7 +115,6 @@ export default function LayoutBodyContent( {
 	if ( isAutomatedReferral && referrals?.length ) {
 		return (
 			<>
-				{ ! dataViewsState.selectedItem && <ConsolidatedViews referrals={ referrals } /> }
 				<ReferralList
 					referrals={ referrals }
 					dataViewsState={ dataViewsState }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -4,7 +4,6 @@ import ItemPreviewPane, {
 	createFeaturePreview,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import SubscriptionStatus from '../referrals-list/subscription-status';
-import ReferralCommissions from './commissions';
 import ReferralPurchases from './purchases';
 import type { Referral } from '../types';
 import type { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
@@ -17,8 +16,6 @@ interface Props {
 import './style.scss';
 
 const REFERRAL_PURCHASES_ID = 'referral-purchases';
-const REFERRAL_COMMISSIONS_ID = 'referral-commissions';
-const REFERRAL_ACITIVTY_ID = 'referral-activity';
 
 export default function ReferralDetails( { referral, closeSitePreviewPane }: Props ) {
 	const translate = useTranslate();
@@ -52,22 +49,6 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				selectedReferralTab,
 				setSelectedReferralTab,
 				<ReferralPurchases purchases={ referral.purchases } />
-			),
-			createFeaturePreview(
-				REFERRAL_COMMISSIONS_ID,
-				translate( 'Commissions' ),
-				true,
-				selectedReferralTab,
-				setSelectedReferralTab,
-				<ReferralCommissions referral={ referral } />
-			),
-			createFeaturePreview(
-				REFERRAL_ACITIVTY_ID,
-				translate( 'Activity' ),
-				true,
-				selectedReferralTab,
-				setSelectedReferralTab,
-				'Activity tab content'
 			),
 		],
 		[ referral, selectedReferralTab, translate ]

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback, ReactNode } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
@@ -14,6 +15,7 @@ interface Props {
 }
 
 export default function ReferralList( { referrals, dataViewsState, setDataViewsState }: Props ) {
+	const isDesktop = useDesktopBreakpoint();
 	const translate = useTranslate();
 
 	const openSitePreviewPane = useCallback(
@@ -29,7 +31,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 
 	const fields = useMemo(
 		() =>
-			dataViewsState.selectedItem
+			dataViewsState.selectedItem || ! isDesktop
 				? [
 						{
 							id: 'client',
@@ -78,16 +80,6 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							enableSorting: false,
 						},
 						{
-							id: 'commissions',
-							header: translate( 'Commissions' ).toUpperCase(),
-							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => {
-								return `$${ item.commissions }`;
-							},
-							enableHiding: false,
-							enableSorting: false,
-						},
-						{
 							id: 'subscription-status',
 							header: translate( 'Subscription Status' ).toUpperCase(),
 							getValue: () => '-',
@@ -113,7 +105,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							enableSorting: false,
 						},
 				  ],
-		[ dataViewsState.selectedItem, openSitePreviewPane, translate ]
+		[ dataViewsState.selectedItem, isDesktop, openSitePreviewPane, translate ]
 	);
 
 	return (
@@ -125,7 +117,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 						totalItems: 1,
 						totalPages: 1,
 					},
-					searchLabel: translate( 'Search referrals' ),
+					enableSearch: false,
 					fields: fields,
 					actions: [],
 					setDataViewsState: setDataViewsState,


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/378

## Proposed Changes

This PR makes some cleanup for the launch to the Referrals page.

NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)
- There are some UI enhancement & mobile fixes that will be done in another PR, so please ignore those for now.

## Testing Instructions

1. Open the A4A live link.
2. Go to  Referrals > Dashboard.
3. Use the below API endpoint manually to create a referral if you don't have some. Create a couple of them

POST https://public-api.wordpress.com/wpcom/v2/agency/230591090/referrals?client_email={client_email}&client_message={your_message}&product_ids={product_id,products_2}

4. Patch D149816
5. Now visit the  Referrals - Dashboard & refresh the page > Verify that looks like below:

<img width="1726" alt="Screenshot 2024-06-06 at 10 54 14 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b9f00fe8-2441-4c8f-adc4-2180532c9b49">

6. Click on the details of any referral and verify that you can now see on the Purchases:

<img width="1050" alt="Screenshot 2024-06-06 at 10 58 50 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/850b56f6-2558-40b0-b5b1-2d0efd57ad64">


7. Click the `New Referral` button > Click the Cart > Go to Checkout and verify the commission info is removed

<img width="579" alt="Screenshot 2024-06-06 at 10 55 31 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/46c648f5-dbad-4a6c-a956-00376cd75d77">
<img width="594" alt="Screenshot 2024-06-06 at 10 55 35 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5192536d-cd78-492b-8e38-ce526dec623a">

8. Visit http://agencies.localhost:3000/marketplace/hosting > Verift the pressable & the comparisons section is hidden when the Refer products mode is on 

<img width="1343" alt="Screenshot 2024-06-10 at 9 19 57 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/95b8c014-d01a-4e71-b8e5-03978caa4d95">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
