### PR TITLE
Site Management Panel: Track the upgrade button

### DIFF
--- a/client/hosting-features/components/hosting-features.tsx
+++ b/client/hosting-features/components/hosting-features.tsx
@@ -95,6 +95,7 @@ const HostingFeatures = () => {
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showActivationButton = canSiteGoAtomic;
 	const handleTransfer = ( options: { geo_affinity?: string } ) => {
+		dispatch( recordTracksEvent( 'calypso_hosting_settings_activate_confirm' ) );
 		const params = new URLSearchParams( {
 			siteId: String( siteId ),
 			redirect_to: redirectUrl.current,
@@ -161,6 +162,7 @@ const HostingFeatures = () => {
 							className="hosting-features__button"
 							onClick={ () => {
 								if ( showActivationButton ) {
+									dispatch( recordTracksEvent( 'calypso_hosting_settings_activate_click' ) );
 									return setShowEligibility( true );
 								}
 							} }

--- a/client/hosting-features/components/hosting-features.tsx
+++ b/client/hosting-features/components/hosting-features.tsx
@@ -8,7 +8,8 @@ import { useRef, useState } from 'react';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import CardHeading from 'calypso/components/card-heading';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -34,6 +35,7 @@ const PromoCard = ( { title, text, supportContext }: PromoCardProps ) => (
 );
 
 const HostingFeatures = () => {
+	const dispatch = useDispatch();
 	const { searchParams } = new URL( document.location.toString() );
 	const showActivationModal = searchParams.get( 'activate' ) !== null;
 	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
@@ -185,7 +187,9 @@ const HostingFeatures = () => {
 					</>
 				) : (
 					<>
-						<Button variant="primary" className="hosting-features__button" href={ upgradeLink }>
+						<Button variant="primary" className="hosting-features__button" href={ upgradeLink } onClick={ () =>
+								dispatch( recordTracksEvent( 'calypso_hosting_settings_upgrade_plan_click' ) )
+							}>
 							{ translate( 'Upgrade now' ) }
 						</Button>
 					</>

--- a/client/hosting-features/components/hosting-features.tsx
+++ b/client/hosting-features/components/hosting-features.tsx
@@ -95,7 +95,7 @@ const HostingFeatures = () => {
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
 	const showActivationButton = canSiteGoAtomic;
 	const handleTransfer = ( options: { geo_affinity?: string } ) => {
-		dispatch( recordTracksEvent( 'calypso_hosting_settings_activate_confirm' ) );
+		dispatch( recordTracksEvent( 'calypso_hosting_features_activate_confirm' ) );
 		const params = new URLSearchParams( {
 			siteId: String( siteId ),
 			redirect_to: redirectUrl.current,
@@ -162,7 +162,7 @@ const HostingFeatures = () => {
 							className="hosting-features__button"
 							onClick={ () => {
 								if ( showActivationButton ) {
-									dispatch( recordTracksEvent( 'calypso_hosting_settings_activate_click' ) );
+									dispatch( recordTracksEvent( 'calypso_hosting_features_activate_click' ) );
 									return setShowEligibility( true );
 								}
 							} }
@@ -189,9 +189,14 @@ const HostingFeatures = () => {
 					</>
 				) : (
 					<>
-						<Button variant="primary" className="hosting-features__button" href={ upgradeLink } onClick={ () =>
-								dispatch( recordTracksEvent( 'calypso_hosting_settings_upgrade_plan_click' ) )
-							}>
+						<Button
+							variant="primary"
+							className="hosting-features__button"
+							href={ upgradeLink }
+							onClick={ () =>
+								dispatch( recordTracksEvent( 'calypso_hosting_features_upgrade_plan_click' ) )
+							}
+						>
 							{ translate( 'Upgrade now' ) }
 						</Button>
 					</>

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -11,7 +11,7 @@ import { usePlanBillingDescription } from '@automattic/plans-grid-next';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import PlanStorage from 'calypso/blocks/plan-storage';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import { HostingCard } from 'calypso/components/hosting-card';
@@ -21,6 +21,7 @@ import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { isStagingSite } from 'calypso/sites-dashboard/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -29,6 +30,7 @@ import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors
 
 const PricingSection: FC = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
 	const site = useSelector( getSelectedSite );
 	const planDetails = site?.plan;
@@ -121,7 +123,14 @@ const PricingSection: FC = () => {
 					{ getExpireDetails() }
 					<div className="hosting-overview__plan-cta">
 						{ isFreePlan && (
-							<Button primary compact href={ `/plans/${ site?.slug }` }>
+							<Button
+								primary
+								compact
+								href={ `/plans/${ site?.slug }` }
+								onClick={ () =>
+									dispatch( recordTracksEvent( 'calypso_hosting_overview_upgrade_plan_click' ) )
+								}
+							>
 								{ translate( 'Upgrade your plan' ) }
 							</Button>
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Track the upgrade button

| Overview | Hosting Settings |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/9a191ce5-28b8-41af-bfbb-7f35c1a58562) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/7ea3f3fa-a406-4929-a49c-636171de5b74) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/462dd2ec-8b08-4cfe-817e-4af4dac00d56) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e8ef7725-87e8-4bec-81b0-a0842269c9a8) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Select any free site
* Under the Overview tab, click the “Upgrade your plan”
* Make sure the event, `calypso_hosting_overview_upgrade_plan_click`, is sent correctly
* Navigate to the Hosting Settings and click the “Upgrade now”
* Make sure the event, `calypso_hosting_settings_upgrade_plan_click`, is sent correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
