### PR TITLE
Untangling: Remove temporary code that hides Hosting menu options

### DIFF
--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -150,32 +150,7 @@ const useSiteMenuItems = () => {
 		showSiteMonitoring: isAtomic,
 	};
 
-	const result = menuItemsWithNewsletterSettings ?? buildFallbackResponse( fallbackDataOverrides );
-
-	if ( isEnabled( 'layout/dotcom-nav-redesign-v2' ) ) {
-		// TODO: After the flag is enabled, the following logic can be reimplemented in jetpack-mu-wpcom
-		// and removed from Calypso.
-		// See: https://github.com/Automattic/dotcom-forge/issues/7066
-
-		return result.map( ( menu ) => {
-			if ( menu.slug === 'wpcom-hosting-menu' && Array.isArray( menu.children ) ) {
-				// Remove Hosting -> {Configuration, Monitoring}
-				const children = menu.children.filter(
-					( menuItem ) =>
-						! [ '/hosting-config/', '/site-monitoring' ].some( ( path ) =>
-							menuItem.url.startsWith( path )
-						)
-				);
-
-				return {
-					...menu,
-					children,
-				};
-			}
-			return menu;
-		} );
-	}
-	return result;
+	return menuItemsWithNewsletterSettings ?? buildFallbackResponse( fallbackDataOverrides );
 };
 
 export default useSiteMenuItems;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7066

## Proposed Changes

- Remove temporary code that hides Hosting menu options

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  This code is no longer required. See https://github.com/Automattic/wp-calypso/pull/89981

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/wp-admin/`
* Verify there are no changes on the Hosting menu

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
