### PR TITLE
Update TOS wording for Blaze Pro authentication

### DIFF
--- a/client/blocks/authentication/social/social-tos.jsx
+++ b/client/blocks/authentication/social/social-tos.jsx
@@ -41,7 +41,7 @@ function SocialAuthToS( props ) {
 	if ( props.isBlazePro ) {
 		return getToSComponent(
 			props.translate(
-				'By continuing with any of the options above you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				'By continuing with any of the options above, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and acknowledge you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 				toSLinks
 			)
 		);

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -920,6 +920,13 @@ class SignupForm extends Component {
 			);
 		}
 
+		if ( this.props.isBlazePro ) {
+			tosText = this.props.translate(
+				'By creating an account, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and acknowledge you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+				options
+			);
+		}
+
 		return <p className="signup-form__terms-of-service-link">{ tosText }</p>;
 	};
 


### PR DESCRIPTION
Related to PR 1762 from A8C-DSP repo

## Proposed Changes
* Adjust wording related to Blaze Pro's authentication flow in WPCOM

## Why are these changes being made?
2 relevant comments:
- p2y3YZ-8rm-p2#comment-18819
- p2y3YZ-8rm-p2#comment-18884

After discussing with ToS people we decided to have all TOS related signs to be:

>  By [taking action – dependent on where/how it’s presented], you agree to our [Terms of Service](https://wordpress.com/tos/) and acknowledge you have read our [Privacy Policy](https://automattic.com/privacy/).

## Testing Instructions
To make things easier, you can use the following snippet of code, save it to, say, `generate-blaze-pro-links.js` and then run `node generate-blaze-pro-links.js` to have 2 links: for signup and sign in.
```js
function generateState() {
  const crypto = require('crypto');
  const hmac = crypto.createHmac('sha256', 'secret' );
  const data = hmac.update(new Date().getTime().toString());
  const state = data.digest('hex');
  return state;
}

const redirectUri = 'http://blaze.pro:3005/auth/connected&blog_id=0&wpcom_connect=1&calypso_env=development&scope=global&from-calypso=1';
const getLoginLink = () =>
	`https://public-api.wordpress.com/oauth2/authorize?response_type=code&client_id=92099&state=${generateState()}&redirect_uri=${encodeURIComponent(redirectUri)}`;

const signInLink = `http://calypso.localhost:3000/log-in?client_id=92099&redirect_to=${encodeURIComponent(getLoginLink())}`;

const signUpLink = `http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=92099&oauth2_redirect=${encodeURIComponent(getLoginLink())}`;

console.log('Login URL:');
console.log(signInLink);
console.log('');
console.log('Sign Up URL:');
console.log(signUpLink);
```
- Run Calypso locally (or use a domain from Calypso Live);
- Using those links manage to see the following screens:
  - Sign Up;
  - Sign In;
  - Continue as a User;
- TOS language should satisfy the formula I mentioned above.

The should look like the following:

#### Sign Up
<img src="https://github.com/Automattic/wp-calypso/assets/115007291/a651831d-7584-4e9c-8ecf-b1bb1734cfc0" width="400"/>

#### Sign In
<img src="https://github.com/Automattic/wp-calypso/assets/115007291/8ebb1e6e-59e8-4e11-935e-f09eb014e692" width="400"/>

#### Continue as a User
<img src="https://github.com/Automattic/wp-calypso/assets/115007291/caf292be-b8e7-473d-b465-5d0ab413b2bf" width="400"/>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
