### PR TITLE
Stats: Add Portuguese to the fully supported locales

### DIFF
--- a/apps/odyssey-stats/src/lib/set-locale.ts
+++ b/apps/odyssey-stats/src/lib/set-locale.ts
@@ -8,7 +8,7 @@ const DEFAULT_LANGUAGE = 'en';
 const DEFAULT_MOMENT_LOCALE = 'en';
 // Only Simple Site has the default locale as 'en'. For atomic/jetpack sites the default locale is 'en-us'.
 const SIMPLE_SITE_DEFAULT_LOCALE = 'en';
-const ALWAYS_LOAD_WITH_LOCALE = [ 'zh' ];
+const ALWAYS_LOAD_WITH_LOCALE = [ 'pt', 'zh' ];
 
 const getLanguageCodeFromLocale = ( localeSlug: string ) => {
 	debug( localeSlug );


### PR DESCRIPTION
Based on check-ins with the i18n folks we have more localizations for `pt-br` than `pt` so we want to account for that when setting the locale for Odyssey Stats.

pxLjZ-8A5-p2

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/35

## Proposed Changes

Add `pt` to the `ALWAYS_LOAD_WITH_LOCALE` const so that we properly load `pt-br` inside the Odyssey Stats app. With this change, we get fully localized purchase flows and upgrade nudges for Brazilian Portuguese.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of our effort to improve the localized purchase flows.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow FG instructions to test this branch with Odyssey Stats — PCYsg-Pp7-p2
* Change the language settings for your wp-admin dashboard to Brazilian Portuguese.
* Visit Jetpack → Stats and confirm the upgrade nudges are localized.
* Click through to the purchase flow and confirm the PWYW & commercial flows are localized.

### Upgrade nudge

<img width="922" alt="SCR-20240606-sudu" src="https://github.com/Automattic/wp-calypso/assets/40267301/e99ef562-2ca3-4768-826e-224d601189f0">

### Paywalled module

<img width="918" alt="SCR-20240606-sujc" src="https://github.com/Automattic/wp-calypso/assets/40267301/c73b7bc6-1192-4177-8b87-52036a52e706">

### Commercial flow

<img width="806" alt="SCR-20240606-suqa" src="https://github.com/Automattic/wp-calypso/assets/40267301/44e37800-85aa-4216-b091-7c49dfef6862">

### PWYW flow

<img width="791" alt="SCR-20240606-suwf" src="https://github.com/Automattic/wp-calypso/assets/40267301/226c8a73-67dd-44d1-9059-1304e0acc185">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?