### PR TITLE
Update WordPress badge if site is using WordPress

### DIFF
--- a/client/site-profiler/components/results-header/index.tsx
+++ b/client/site-profiler/components/results-header/index.tsx
@@ -16,11 +16,9 @@ type Props = {
 
 function getIcon( isWordPress?: boolean ) {
 	if ( isWordPress ) {
-		return <img src={ wpComSiteIcon } alt={ translate( 'This site is built with WordPress' ) } />;
+		return <img src={ wpComSiteIcon } alt="" />;
 	}
-	return (
-		<img src={ nonWpComSiteIcon } alt={ translate( 'This site is not built with WordPress' ) } />
-	);
+	return <img src={ nonWpComSiteIcon } alt="" />;
 }
 
 function getIsWpComSiteMessage( isWpCom?: boolean, isWordPress?: boolean ) {

--- a/client/site-profiler/components/results-header/index.tsx
+++ b/client/site-profiler/components/results-header/index.tsx
@@ -23,11 +23,11 @@ function getIcon( isWordPress?: boolean ) {
 	);
 }
 
-function getIsWpComSiteMessage( isWpCom?: boolean ) {
-	if ( isWpCom ) {
-		return translate( 'This site is hosted on WordPress.com' );
-	}
-	return translate( 'This site is not hosted on WordPress.com' );
+function getIsWpComSiteMessage( isWpCom?: boolean, isWordPress?: boolean ) {
+	const message = isWordPress
+		? translate( 'This site is built with WordPress' )
+		: translate( 'This site is not built with WordPress' );
+	return message + ( isWpCom ? translate( ', and is hosted on WordPress.com.' ) : '.' );
 }
 
 function getTitleMessage( performanceCategory: PerformanceCategories ) {
@@ -55,7 +55,7 @@ export const ResultsHeader = ( {
 			<div className="results-header--domain-container">
 				<span className="domain-title">{ domain }</span>
 				{ getIcon( isWordPress ) }
-				<span className="domain-message">{ getIsWpComSiteMessage( isWpCom ) }</span>
+				<span className="domain-message">{ getIsWpComSiteMessage( isWpCom, isWordPress ) }</span>
 			</div>
 			<h1>{ getTitleMessage( performanceCategory ) }</h1>
 			<div className="results-header--button-container">

--- a/client/site-profiler/components/results-header/index.tsx
+++ b/client/site-profiler/components/results-header/index.tsx
@@ -10,14 +10,17 @@ type Props = {
 	domain: string;
 	performanceCategory: PerformanceCategories;
 	isWpCom: boolean;
+	isWordPress: boolean;
 	onGetReport: () => void;
 };
 
-function getIcon( isWpCom?: boolean ) {
-	if ( isWpCom ) {
-		return <img src={ wpComSiteIcon } alt={ translate( 'WordPress.com site' ) } />;
+function getIcon( isWordPress?: boolean ) {
+	if ( isWordPress ) {
+		return <img src={ wpComSiteIcon } alt={ translate( 'This site is built with WordPress' ) } />;
 	}
-	return <img src={ nonWpComSiteIcon } alt={ translate( 'Non WordPress.com site' ) } />;
+	return (
+		<img src={ nonWpComSiteIcon } alt={ translate( 'This site is not built with WordPress' ) } />
+	);
 }
 
 function getIsWpComSiteMessage( isWpCom?: boolean ) {
@@ -40,12 +43,18 @@ function getTitleMessage( performanceCategory: PerformanceCategories ) {
 	return translate( 'Room for growth! Let’s optimize your site.' );
 }
 
-export const ResultsHeader = ( { domain, performanceCategory, isWpCom, onGetReport }: Props ) => {
+export const ResultsHeader = ( {
+	domain,
+	performanceCategory,
+	isWpCom,
+	isWordPress,
+	onGetReport,
+}: Props ) => {
 	return (
 		<div className="results-header--container">
 			<div className="results-header--domain-container">
 				<span className="domain-title">{ domain }</span>
-				{ getIcon( isWpCom ) }
+				{ getIcon( isWordPress ) }
 				<span className="domain-message">{ getIsWpComSiteMessage( isWpCom ) }</span>
 			</div>
 			<h1>{ getTitleMessage( performanceCategory ) }</h1>

--- a/client/site-profiler/components/results-header/index.tsx
+++ b/client/site-profiler/components/results-header/index.tsx
@@ -24,10 +24,13 @@ function getIcon( isWordPress?: boolean ) {
 }
 
 function getIsWpComSiteMessage( isWpCom?: boolean, isWordPress?: boolean ) {
-	const message = isWordPress
-		? translate( 'This site is built with WordPress' )
-		: translate( 'This site is not built with WordPress' );
-	return message + ( isWpCom ? translate( ', and is hosted on WordPress.com.' ) : '.' );
+	if ( isWpCom ) {
+		return translate( 'This site is hosted on WordPress.com.' );
+	}
+
+	return isWordPress
+		? translate( 'This site is built with WordPress.' )
+		: translate( 'This site is not built with WordPress.' );
 }
 
 function getTitleMessage( performanceCategory: PerformanceCategories ) {

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -162,6 +162,7 @@ export default function SiteProfilerV2( props: Props ) {
 						<ResultsHeader
 							domain={ domain }
 							performanceCategory={ performanceCategory }
+							isWordPress={ ! noWordPressFound }
 							isWpCom={ isWpCom }
 							onGetReport={ () => setIsGetReportFormOpen( true ) }
 						/>

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -162,7 +162,7 @@ export default function SiteProfilerV2( props: Props ) {
 						<ResultsHeader
 							domain={ domain }
 							performanceCategory={ performanceCategory }
-							isWordPress={ ! noWordPressFound }
+							isWordPress={ urlData?.platform === 'wordpress' }
 							isWpCom={ isWpCom }
 							onGetReport={ () => setIsGetReportFormOpen( true ) }
 						/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6542

## Proposed Changes

* update the badge color if the site is detected to be built with WordPress

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're updating the Site Profiler UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Non-WP site
* Go to Site Profiler and enter a non-WP site URL, eg. `/site-profiler/cloudflare.com`
* Check that the badge is not colored, and the copy says the site is not hosted on WP.com

WP site not on WP.com
* Go to Site Profiler and enter a WP site URL, which is not on WP.com, eg. `/site-profiler/vilagoklangja.hu`
* Check that the badge is colored, and the copy says the site is not hosted on WP.com

WP site on WP.com
* Go to Site Profiler and enter WP.com site URL, eg. `/site-profiler/wordpress.com`
* Check that the badge is colored, and the copy says the site is hosted on WP.com


| Site | Message |
| --- | --- |
| Non-WP site | ![CleanShot 2024-06-07 at 14 56 36@2x](https://github.com/Automattic/wp-calypso/assets/11555574/6cf24ca0-b988-4921-b58c-850d8e23ee64) |
| WP site not on WP.com | ![CleanShot 2024-06-07 at 14 50 22@2x](https://github.com/Automattic/wp-calypso/assets/11555574/fc09c14a-62a5-40fc-a735-e274e2c44382)  |
| WP site on WP.com | ![CleanShot 2024-06-07 at 14 52 45@2x](https://github.com/Automattic/wp-calypso/assets/11555574/6cf97325-43f0-4172-840c-0d2830265f92) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
