### PR TITLE
Site management panel: Update "Hosting Settings" to "Hosting Features"

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -440,10 +440,10 @@ function mergeProps(
 			? WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
 			: FEATURE_INSTALL_PLUGINS;
 		ctaName = 'calypso-plugin-details-eligibility-upgrade-nudge';
-	} else if ( ownProps.currentContext === 'dev-tools' ) {
+	} else if ( ownProps.currentContext === 'hosting-features' ) {
 		context = ownProps.currentContext;
 		feature = FEATURE_SFTP;
-		ctaName = 'calypso-dev-tools-eligibility-upgrade-nudge';
+		ctaName = 'calypso-hosting-features-eligibility-upgrade-nudge';
 	} else if ( includes( ownProps.backUrl, 'plugins' ) ) {
 		context = 'plugins-upload';
 		feature = FEATURE_UPLOAD_PLUGINS;

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,4 +1,5 @@
 import { Card, Badge } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
@@ -13,54 +14,57 @@ interface ExternalProps {
 
 type Props = ExternalProps & LocalizeProps;
 
-export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => (
-	<div>
-		{ getWarningDescription( context, warnings.length, translate ) && (
-			<div className="eligibility-warnings__warning">
-				<div className="eligibility-warnings__message">
-					<span className="eligibility-warnings__message-description">
-						{ getWarningDescription( context, warnings.length, translate ) }
-					</span>
+export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => {
+	const hasEnTranslation = useHasEnTranslation();
+	return (
+		<div>
+			{ getWarningDescription( context, warnings.length, translate, hasEnTranslation ) && (
+				<div className="eligibility-warnings__warning">
+					<div className="eligibility-warnings__message">
+						<span className="eligibility-warnings__message-description">
+							{ getWarningDescription( context, warnings.length, translate, hasEnTranslation ) }
+						</span>
+					</div>
 				</div>
-			</div>
-		) }
+			) }
 
-		{ warnings.map( ( { name, description, supportUrl, domainNames }, index ) => (
-			<div className="eligibility-warnings__warning" key={ index }>
-				<div className="eligibility-warnings__message">
-					{ context !== 'plugin-details' && (
-						<Fragment>
-							<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
-						</Fragment>
-					) }
-					<span className="eligibility-warnings__message-description">
-						<span>{ description } </span>
-						{ domainNames && displayDomainNames( domainNames ) }
-						{ supportUrl && (
-							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
-								{ translate( 'Learn more.' ) }
-							</ExternalLink>
+			{ warnings.map( ( { name, description, supportUrl, domainNames }, index ) => (
+				<div className="eligibility-warnings__warning" key={ index }>
+					<div className="eligibility-warnings__message">
+						{ context !== 'plugin-details' && (
+							<Fragment>
+								<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
+							</Fragment>
 						) }
-					</span>
+						<span className="eligibility-warnings__message-description">
+							<span>{ description } </span>
+							{ domainNames && displayDomainNames( domainNames ) }
+							{ supportUrl && (
+								<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
+									{ translate( 'Learn more.' ) }
+								</ExternalLink>
+							) }
+						</span>
+					</div>
 				</div>
-			</div>
-		) ) }
+			) ) }
 
-		{ showContact && (
-			<div className="eligibility-warnings__warning">
-				<div className="eligibility-warnings__message">
-					<span className="eligibility-warnings__message-description">
-						{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
-							components: {
-								a: <ActionPanelLink href="/help/contact" />,
-							},
-						} ) }
-					</span>
+			{ showContact && (
+				<div className="eligibility-warnings__warning">
+					<div className="eligibility-warnings__message">
+						<span className="eligibility-warnings__message-description">
+							{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
+								components: {
+									a: <ActionPanelLink href="/help/contact" />,
+								},
+							} ) }
+						</span>
+					</div>
 				</div>
-			</div>
-		) }
-	</div>
-);
+			) }
+		</div>
+	);
+};
 
 function displayDomainNames( domainNames: DomainNames ) {
 	return (
@@ -80,7 +84,8 @@ function displayDomainNames( domainNames: DomainNames ) {
 function getWarningDescription(
 	context: string | null,
 	warningCount: number,
-	translate: LocalizeProps[ 'translate' ]
+	translate: LocalizeProps[ 'translate' ],
+	hasTranslation: ( string ) => boolean
 ) {
 	const defaultCopy = translate(
 		'By proceeding the following change will be made to the site:',
@@ -115,15 +120,26 @@ function getWarningDescription(
 				}
 			);
 
-		case 'dev-tools':
-			return translate(
-				'By activating all developer tools the following change will be made to the site:',
-				'By activating all developer tools the following changes will be made to the site:',
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
+		case 'hosting-features':
+			return hasTranslation(
+				'By activating all hosting features the following change will be made to the site:'
+			)
+				? translate(
+						'By activating all hosting features the following change will be made to the site:',
+						'By activating all hosting features the following changes will be made to the site:',
+						{
+							count: warningCount,
+							args: warningCount,
+						}
+				  )
+				: translate(
+						'By activating all developer tools the following change will be made to the site:',
+						'By activating all developer tools the following changes will be made to the site:',
+						{
+							count: warningCount,
+							args: warningCount,
+						}
+				  );
 
 		default:
 			return defaultCopy;

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -85,7 +85,7 @@ function getWarningDescription(
 	context: string | null,
 	warningCount: number,
 	translate: LocalizeProps[ 'translate' ],
-	hasTranslation: ( string ) => boolean
+	hasTranslation: ( arg: string ) => boolean
 ) {
 	const defaultCopy = translate(
 		'By proceeding the following change will be made to the site:',

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -87,7 +87,7 @@ export const redirectWithoutLocaleParamIfLoggedIn = () => {};
 export const redirectIfCurrentUserCannot = ( capability ) => () => {};
 export const redirectIfP2 = () => {};
 export const redirectIfJetpackNonAtomic = () => {};
-export const redirectToDevToolsPromoIfNotAtomic = () => {};
+export const redirectToHostingPromoIfNotAtomic = () => {};
 // eslint-disable-next-line no-unused-vars
 export const render = ( context ) => {};
 export const ProviderWrappedLayout = () => null;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -316,18 +316,18 @@ export function redirectIfJetpackNonAtomic( context, next ) {
 }
 
 /**
- * Middleware to redirect a user to /dev-tools if the site is not Atomic.
+ * Middleware to redirect a user to /hosting-features if the site is not Atomic.
  * @param   {Object}   context Context object
  * @param   {Function} next    Calls next middleware
  * @returns {void}
  */
-export function redirectToDevToolsPromoIfNotAtomic( context, next ) {
+export function redirectToHostingPromoIfNotAtomic( context, next ) {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 	const isAtomicSite = !! site?.is_wpcom_atomic || !! site?.is_wpcom_staging_site;
 
 	if ( config.isEnabled( 'layout/dotcom-nav-redesign-v2' ) && ! isAtomicSite ) {
-		return page.redirect( `/dev-tools/${ site?.slug }` );
+		return page.redirect( `/hosting-features/${ site?.slug }` );
 	}
 
 	next();

--- a/client/dev-tools/controller.tsx
+++ b/client/dev-tools/controller.tsx
@@ -1,7 +1,0 @@
-import { Context as PageJSContext } from '@automattic/calypso-router';
-import DevTools from 'calypso/dev-tools/components/dev-tools';
-
-export function devTools( context: PageJSContext, next: () => void ) {
-	context.primary = <DevTools />;
-	next();
-}

--- a/client/github-deployments/index.tsx
+++ b/client/github-deployments/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectToDevToolsPromoIfNotAtomic,
+	redirectToHostingPromoIfNotAtomic,
 } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
@@ -21,7 +21,7 @@ export default function () {
 	page(
 		'/github-deployments/:site',
 		siteSelection,
-		redirectToDevToolsPromoIfNotAtomic,
+		redirectToHostingPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		deploymentsList,
@@ -33,7 +33,7 @@ export default function () {
 	page(
 		'/github-deployments/:site/create',
 		siteSelection,
-		redirectToDevToolsPromoIfNotAtomic,
+		redirectToHostingPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		deploymentCreation,
@@ -45,7 +45,7 @@ export default function () {
 	page(
 		'/github-deployments/:site/manage/:deploymentId',
 		siteSelection,
-		redirectToDevToolsPromoIfNotAtomic,
+		redirectToHostingPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		deploymentManagement,
@@ -57,7 +57,7 @@ export default function () {
 	page(
 		'/github-deployments/:site/logs/:deploymentId',
 		siteSelection,
-		redirectToDevToolsPromoIfNotAtomic,
+		redirectToHostingPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		deploymentRunLogs,

--- a/client/hosting-features/components/hosting-features-icon.jsx
+++ b/client/hosting-features/components/hosting-features-icon.jsx
@@ -1,6 +1,6 @@
-export default function DevToolsIcon() {
+export default function HostingFeaturesIcon() {
 	return (
-		<span className="dev-tools__icon" key="blogging-prompt__dev-tools-icon">
+		<span className="hosting-features__icon" key="blogging-prompt__hosting-features-icon">
 			<svg
 				fill="none"
 				height="20"

--- a/client/hosting-features/components/hosting-features.tsx
+++ b/client/hosting-features/components/hosting-features.tsx
@@ -22,7 +22,7 @@ type PromoCardProps = {
 };
 
 const PromoCard = ( { title, text, supportContext }: PromoCardProps ) => (
-	<Card className="dev-tools__card">
+	<Card className="hosting-features__card">
 		<CardHeading>{ title }</CardHeading>
 		<p>{ text }</p>
 		{ translate( '{{supportLink}}Learn more{{/supportLink}}', {
@@ -33,7 +33,7 @@ const PromoCard = ( { title, text, supportContext }: PromoCardProps ) => (
 	</Card>
 );
 
-const DevTools = () => {
+const HostingFeatures = () => {
 	const { searchParams } = new URL( document.location.toString() );
 	const showActivationModal = searchParams.get( 'activate' ) !== null;
 	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
@@ -107,11 +107,37 @@ const DevTools = () => {
 		page.replace( redirectUrl.current );
 		return;
 	}
+	const activateTitle = hasEnTranslation( 'Activate all hosting features' )
+		? translate( 'Activate all hosting features' )
+		: translate( 'Activate all developer tools' );
 
-	const upgradeCtaCopy = hasEnTranslation(
-		'Upgrade to the %(planName)s plan or higher to get access to all developer tools'
+	const unlockTitle = hasEnTranslation( 'Unlock all hosting features' )
+		? translate( 'Unlock all hosting features' )
+		: translate( 'Unlock all developer tools' );
+
+	const activateDescription = hasEnTranslation(
+		'Your plan includes all the hosting features listed below. Click "Activate now" to begin.'
+	)
+		? translate(
+				'Your plan includes all the hosting features listed below. Click "Activate now" to begin.'
+		  )
+		: translate(
+				'Your plan includes all the developer tools listed below. Click "Activate now" to begin.'
+		  );
+
+	const unlockDescription = hasEnTranslation(
+		'Upgrade to the %(planName)s plan or higher to get access to all hosting features'
 	)
 		? // translators: %(planName)s is a plan name. E.g. Business plan.
+		  translate(
+				'Upgrade to the %(planName)s plan or higher to get access to all hosting features',
+				{
+					args: {
+						planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+					},
+				}
+		  )
+		: // translators: %(planName)s is a plan name. E.g. Business plan.
 		  translate(
 				'Upgrade to the %(planName)s plan or higher to get access to all developer tools',
 				{
@@ -119,29 +145,18 @@ const DevTools = () => {
 						planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
 					},
 				}
-		  )
-		: translate( 'Upgrade to the Creator plan or higher to get access to all developer tools' );
+		  );
 
 	return (
-		<div className="dev-tools">
-			<div className="dev-tools__hero">
-				<h1>
-					{ showActivationButton
-						? translate( 'Activate all developer tools' )
-						: translate( 'Unlock all developer tools' ) }
-				</h1>
-				<p>
-					{ showActivationButton
-						? translate(
-								'Your plan includes all the developer tools listed below. Click "Activate now" to begin.'
-						  )
-						: upgradeCtaCopy }
-				</p>
+		<div className="hosting-features">
+			<div className="hosting-features__hero">
+				<h1>{ showActivationButton ? activateTitle : unlockTitle }</h1>
+				<p>{ showActivationButton ? activateDescription : unlockDescription }</p>
 				{ showActivationButton ? (
 					<>
 						<Button
 							variant="primary"
-							className="dev-tools__button"
+							className="hosting-features__button"
 							onClick={ () => {
 								if ( showActivationButton ) {
 									return setShowEligibility( true );
@@ -164,19 +179,19 @@ const DevTools = () => {
 								backUrl={ redirectUrl.current }
 								showDataCenterPicker
 								standaloneProceed
-								currentContext="dev-tools"
+								currentContext="hosting-features"
 							/>
 						</Dialog>
 					</>
 				) : (
 					<>
-						<Button variant="primary" className="dev-tools__button" href={ upgradeLink }>
+						<Button variant="primary" className="hosting-features__button" href={ upgradeLink }>
 							{ translate( 'Upgrade now' ) }
 						</Button>
 					</>
 				) }
 			</div>
-			<div className="dev-tools__cards">
+			<div className="hosting-features__cards">
 				{ promoCards.map( ( card ) => (
 					<PromoCard
 						title={ card.title }
@@ -189,4 +204,4 @@ const DevTools = () => {
 	);
 };
 
-export default DevTools;
+export default HostingFeatures;

--- a/client/hosting-features/components/style.scss
+++ b/client/hosting-features/components/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.dev-tools__hero {
+.hosting-features__hero {
 	grid-column: 1 / -1;
 	text-align: center;
 	margin-bottom: 70px;
@@ -19,7 +19,7 @@
 		font-weight: 400;
 		font-size: rem(18px);
 	}
-	.dev-tools__button {
+	.hosting-features__button {
 		margin: 0 5px;
 		padding: 10px 14px;
 		font-size: rem(14px);
@@ -27,7 +27,7 @@
 	}
 }
 
-.dev-tools__cards {
+.hosting-features__cards {
 	display: grid;
 	grid-template-columns: 1fr;
 	grid-column-gap: 16px;
@@ -39,7 +39,7 @@
 	}
 }
 
-.dev-tools__card {
+.hosting-features__card {
 	border-radius: 4px;
 	border: 1px solid var(--studio-gray-5);
 	box-shadow: none;

--- a/client/hosting-features/controller.tsx
+++ b/client/hosting-features/controller.tsx
@@ -1,0 +1,7 @@
+import { Context as PageJSContext } from '@automattic/calypso-router';
+import HostingFeatures from './components/hosting-features';
+
+export function hostingFeatures( context: PageJSContext, next: () => void ) {
+	context.primary = <HostingFeatures />;
+	next();
+}

--- a/client/hosting-features/index.tsx
+++ b/client/hosting-features/index.tsx
@@ -2,9 +2,9 @@ import page, { Context as PageJSContext } from '@automattic/calypso-router';
 import { makeLayout, render as clientRender, redirectIfP2 } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { siteDashboard } from 'calypso/sites-dashboard-v2/controller';
-import { DOTCOM_DEVELOPER_TOOLS } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
+import { DOTCOM_HOSTING_FEATURES } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { devTools } from './controller';
+import { hostingFeatures } from './controller';
 
 const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) => {
 	const state = context.store.getState();
@@ -16,15 +16,15 @@ const redirectForNonSimpleSite = ( context: PageJSContext, next: () => void ) =>
 };
 
 export default function () {
-	page( '/dev-tools', siteSelection, sites, makeLayout, clientRender );
+	page( '/hosting-features', siteSelection, sites, makeLayout, clientRender );
 	page(
-		'/dev-tools/:site',
+		'/hosting-features/:site',
 		siteSelection,
 		navigation,
 		redirectForNonSimpleSite,
 		redirectIfP2,
-		devTools,
-		siteDashboard( DOTCOM_DEVELOPER_TOOLS ),
+		hostingFeatures,
+		siteDashboard( DOTCOM_HOSTING_FEATURES ),
 		makeLayout,
 		clientRender
 	);

--- a/client/hosting-overview/index.tsx
+++ b/client/hosting-overview/index.tsx
@@ -3,7 +3,7 @@ import {
 	makeLayout,
 	render as clientRender,
 	redirectIfCurrentUserCannot,
-	redirectToDevToolsPromoIfNotAtomic,
+	redirectToHostingPromoIfNotAtomic,
 	redirectIfP2,
 	redirectIfJetpackNonAtomic,
 } from 'calypso/controller';
@@ -42,7 +42,7 @@ export default function () {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
-		redirectToDevToolsPromoIfNotAtomic,
+		redirectToHostingPromoIfNotAtomic,
 		handleHostingPanelRedirect,
 		hostingConfiguration,
 		siteDashboard( DOTCOM_HOSTING_CONFIG ),
@@ -57,7 +57,7 @@ export default function () {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		redirectIfCurrentUserCannot( 'manage_options' ),
-		redirectToDevToolsPromoIfNotAtomic,
+		redirectToHostingPromoIfNotAtomic,
 		handleHostingPanelRedirect,
 		hostingActivate,
 		siteDashboard( DOTCOM_HOSTING_CONFIG ),

--- a/client/sections.js
+++ b/client/sections.js
@@ -222,9 +222,9 @@ const sections = [
 		group: 'sites',
 	},
 	{
-		name: 'dev-tools',
-		paths: [ '/dev-tools' ],
-		module: 'calypso/dev-tools',
+		name: 'hosting-features',
+		paths: [ '/hosting-features' ],
+		module: 'calypso/hosting-features',
 		group: 'sites',
 	},
 	{

--- a/client/site-logs/index.tsx
+++ b/client/site-logs/index.tsx
@@ -2,7 +2,7 @@ import page, { type Callback } from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectToDevToolsPromoIfNotAtomic,
+	redirectToHostingPromoIfNotAtomic,
 } from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { redirectHomeIfIneligible } from 'calypso/my-sites/site-monitoring/controller';
@@ -21,7 +21,7 @@ export default function () {
 	page(
 		'/site-logs/:site/php',
 		siteSelection,
-		redirectToDevToolsPromoIfNotAtomic,
+		redirectToHostingPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		phpErrorLogs,
@@ -32,7 +32,7 @@ export default function () {
 	page(
 		'/site-logs/:site/web',
 		siteSelection,
-		redirectToDevToolsPromoIfNotAtomic,
+		redirectToHostingPromoIfNotAtomic,
 		redirectHomeIfIneligible,
 		navigation,
 		httpRequestLogs,

--- a/client/site-monitoring/index.tsx
+++ b/client/site-monitoring/index.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import {
 	makeLayout,
 	render as clientRender,
-	redirectToDevToolsPromoIfNotAtomic,
+	redirectToHostingPromoIfNotAtomic,
 } from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { redirectHomeIfIneligible, siteMetrics } from 'calypso/my-sites/site-monitoring/controller';
@@ -18,7 +18,7 @@ export default function () {
 		page(
 			'/site-monitoring/:site',
 			siteSelection,
-			redirectToDevToolsPromoIfNotAtomic,
+			redirectToHostingPromoIfNotAtomic,
 			redirectHomeIfIneligible,
 			navigation,
 			siteMonitoring,
@@ -30,7 +30,7 @@ export default function () {
 		page(
 			'/site-monitoring/:siteId/:tab(php|web)?',
 			siteSelection,
-			redirectToDevToolsPromoIfNotAtomic,
+			redirectToHostingPromoIfNotAtomic,
 			redirectHomeIfIneligible,
 			navigation,
 			siteMetrics,

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -438,7 +438,7 @@
 
 // Styles for site preview pane.
 .wpcom-site .a4a-layout.sites-dashboard .site-preview-pane {
-	.dev-tools__icon {
+	.hosting-features__icon {
 		display: inline-block;
 		height: 18px;
 		vertical-align: top;

--- a/client/sites-dashboard-v2/site-preview-pane/constants.ts
+++ b/client/sites-dashboard-v2/site-preview-pane/constants.ts
@@ -3,7 +3,7 @@ export const DOTCOM_MONITORING = 'dotcom-site-monitoring';
 export const DOTCOM_LOGS = 'dotcom-site-logs';
 export const DOTCOM_GITHUB_DEPLOYMENTS = 'dotcom-github-deployments';
 export const DOTCOM_HOSTING_CONFIG = 'dotcom-hosting-config';
-export const DOTCOM_DEVELOPER_TOOLS = 'dotcom-developer-tools';
+export const DOTCOM_HOSTING_FEATURES = 'dotcom-hosting-features';
 export const DOTCOM_STAGING_SITE = 'dotcom-staging-site';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
@@ -12,6 +12,6 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_LOGS ]: 'site-logs/:site/php',
 	[ DOTCOM_GITHUB_DEPLOYMENTS ]: 'github-deployments/:site',
 	[ DOTCOM_HOSTING_CONFIG ]: 'hosting-config/:site',
-	[ DOTCOM_DEVELOPER_TOOLS ]: 'dev-tools/:site',
+	[ DOTCOM_HOSTING_FEATURES ]: 'hosting-features/:site',
 	[ DOTCOM_STAGING_SITE ]: 'staging-site/:site',
 };

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -6,14 +6,14 @@ import ItemPreviewPane, {
 	createFeaturePreview,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
-import DevToolsIcon from 'calypso/dev-tools/components/dev-tools-icon';
+import HostingFeaturesIcon from 'calypso/hosting-features/components/hosting-features-icon';
 import {
 	DOTCOM_HOSTING_CONFIG,
 	DOTCOM_OVERVIEW,
 	DOTCOM_MONITORING,
 	DOTCOM_LOGS,
 	DOTCOM_GITHUB_DEPLOYMENTS,
-	DOTCOM_DEVELOPER_TOOLS,
+	DOTCOM_HOSTING_FEATURES,
 	DOTCOM_STAGING_SITE,
 } from './constants';
 import PreviewPaneHeaderButtons from './preview-pane-header-buttons';
@@ -57,10 +57,10 @@ const DotcomPreviewPane = ( {
 				selectedSiteFeaturePreview
 			),
 			createFeaturePreview(
-				DOTCOM_DEVELOPER_TOOLS,
+				DOTCOM_HOSTING_FEATURES,
 				<span>
-					{ hasEnTranslation( 'Hosting Settings' ) ? __( 'Hosting Settings' ) : __( 'Dev Tools' ) }
-					<DevToolsIcon />
+					{ hasEnTranslation( 'Hosting Features' ) ? __( 'Hosting Features' ) : __( 'Dev Tools' ) }
+					<HostingFeaturesIcon />
 				</span>,
 				isSimpleSite || isPlanExpired,
 				selectedSiteFeature,

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -334,7 +334,7 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 	const { __ } = useI18n();
 	const hasFeatureSFTP = useSafeSiteHasFeature( site.ID, FEATURE_SFTP ) && ! site?.plan?.expired;
 	const displayUpsell = ! hasFeatureSFTP;
-	const shouldLinkToDevTools = ! hasFeatureSFTP && isEnabled( 'layout/dotcom-nav-redesign-v2' );
+	const shouldLinkToHostingPromo = ! hasFeatureSFTP && isEnabled( 'layout/dotcom-nav-redesign-v2' );
 	const submenuItems = useSubmenuItems( site );
 	const submenuProps = useSubmenuPopoverProps< HTMLDivElement >( {
 		offset: -8,
@@ -364,18 +364,15 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 						  )
 						: undefined
 				}
-				href={ shouldLinkToDevTools ? `/dev-tools/${ site.slug }` : undefined }
+				href={ shouldLinkToHostingPromo ? `/hosting-features/${ site.slug }` : undefined }
 				onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_site_hosting_click' ) }
 			>
-				{ shouldLinkToDevTools ? (
-					__( 'Dev Tools' )
-				) : (
-					<>
-						{ __( 'Hosting' ) } <MenuItemGridIcon icon="chevron-right" size={ 18 } />
-					</>
-				) }
+				<>
+					{ __( 'Hosting' ) }
+					{ ! shouldLinkToHostingPromo && <MenuItemGridIcon icon="chevron-right" size={ 18 } /> }
+				</>
 			</MenuItemLink>
-			{ ! shouldLinkToDevTools && (
+			{ ! shouldLinkToHostingPromo && (
 				<SubmenuPopover
 					{ ...submenuProps.submenu }
 					inline

--- a/client/staging-site/index.tsx
+++ b/client/staging-site/index.tsx
@@ -3,7 +3,7 @@ import {
 	makeLayout,
 	render as clientRender,
 	redirectIfCurrentUserCannot,
-	redirectToDevToolsPromoIfNotAtomic,
+	redirectToHostingPromoIfNotAtomic,
 } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { handleHostingPanelRedirect } from 'calypso/my-sites/hosting/controller';
@@ -18,7 +18,7 @@ export default function () {
 		'/staging-site/:site',
 		siteSelection,
 		navigation,
-		redirectToDevToolsPromoIfNotAtomic,
+		redirectToHostingPromoIfNotAtomic,
 		redirectIfCurrentUserCannot( 'manage_options' ),
 		handleHostingPanelRedirect,
 		renderStagingSite,

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -16,7 +16,7 @@ const GLOBAL_SITE_DASHBOARD_ROUTES = {
 	'github-deployments': '/github-deployments/',
 	'site-monitoring': '/site-monitoring/',
 	'site-logs': '/site-logs/',
-	'dev-tools': '/dev-tools/',
+	'hosting-features': '/hosting-features/',
 	'staging-site': '/staging-site',
 };
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7641

**DO NOT MERGE**

Requires the `/hosting-features` route to be handled by Calypso: pMz3w-k51-p2

**Tip**

This is slightly easier to review if you hide the whitespaces:

<img width="263" alt="Screenshot 2024-06-06 at 17 37 15" src="https://github.com/Automattic/wp-calypso/assets/1233880/caa50903-618e-4588-af81-840e20855406">

## Proposed Changes

* Updates the "Hosting Settings" promo tab (previously "Dev Tools") to "Hosting Features"
* Updates the `/dev-tools/:site` route to `/hosting-features/:site`
* Updates the "developer tools" instance in that tab to "hosting features"
* Updates the "Dev Tools" site action to "Hosting"

Before | After
--- | ---
<img width="1177" alt="Screenshot 2024-06-06 at 17 27 13" src="https://github.com/Automattic/wp-calypso/assets/1233880/fa62d598-091d-4f08-a4e3-eab1dc925ef8"> | <img width="1183" alt="Screenshot 2024-06-06 at 17 26 27" src="https://github.com/Automattic/wp-calypso/assets/1233880/ce1fcdb2-e155-4a99-9777-57c4f92ed8aa">
<img width="1165" alt="Screenshot 2024-06-06 at 17 27 24" src="https://github.com/Automattic/wp-calypso/assets/1233880/7c83805e-f17f-42a8-8292-84f09dc2e4a1"> | <img width="1183" alt="Screenshot 2024-06-06 at 17 27 04" src="https://github.com/Automattic/wp-calypso/assets/1233880/a2a49007-02a2-4f8b-81e7-aba5ba3f9d43">
<img width="692" alt="Screenshot 2024-06-06 at 17 36 00" src="https://github.com/Automattic/wp-calypso/assets/1233880/e32fd100-42c4-4e90-8beb-b7ace723f934"> | <img width="667" alt="Screenshot 2024-06-06 at 17 35 54" src="https://github.com/Automattic/wp-calypso/assets/1233880/c02fc27d-3b16-4b5c-9d62-8fa6ead44425">
<img width="244" alt="Screenshot 2024-06-06 at 16 39 25" src="https://github.com/Automattic/wp-calypso/assets/1233880/1d877122-ec3e-4cf7-9ca7-42c745435bd4"> | <img width="244" alt="Screenshot 2024-06-06 at 17 26 11" src="https://github.com/Automattic/wp-calypso/assets/1233880/39bb0cd5-4376-4b8e-ad1e-d52981e11b75">




## Why are these changes being made?

To prevent a confusion with "Hosting Settings" since the promo tab does not display settings.

## Testing Instructions

* Use the Calypso live link below
* Go to `/sites`
* Select a Free site
* Make sure the second tab has changed to "Hosting Features"
* Select it
* Make sure the route changes to `/hosting-features/:site`
* Make sure all the "developer tools" instances have changed to "hosting features"
* Go back to `/sites`
* Open the site actions of a Free site
* Make sure the second action has changed to "Hosting"
* Select now a Simple site with a Creator plan
* Go to the "Hosting Features" tab
* Make sure all the "developer tools" instances have changed to "hosting features"
* Click on the "Activate" button
* Make sure all the "developer tools" instances have changed to "hosting features"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?