### PR TITLE
Add A4A plan description to plan card

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -256,6 +256,17 @@ const PlanCard: FC = () => {
 						</PlanStorage>
 					</>
 				) }
+				{ isAgencyPurchase && (
+					<div className="hosting-overview__plan-agency-purchase">
+						{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
+							components: {
+								a: (
+									<a href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }></a>
+								),
+							},
+						} ) }
+					</div>
+				) }
 			</HostingCard>
 		</>
 	);

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -22,6 +22,7 @@ import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { isStagingSite } from 'calypso/sites-dashboard/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -171,6 +172,7 @@ const PlanCard: FC = () => {
 	);
 	const planPurchase = useSelector( getSelectedPurchase );
 	const isAgencyPurchase = planPurchase && isPartnerPurchase( planPurchase );
+	const isAgency = useSelector( isAgencyUser );
 	// Show that this is an Agency Managed plan for agency purchases.
 	const planName = isAgencyPurchase
 		? purchaseType( planPurchase )
@@ -261,10 +263,12 @@ const PlanCard: FC = () => {
 						<p>
 							{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
 								components: {
-									a: (
+									a: isAgency ? (
 										<a
 											href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
 										></a>
+									) : (
+										<strong></strong>
 									),
 								},
 							} ) }

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -258,13 +258,17 @@ const PlanCard: FC = () => {
 				) }
 				{ isAgencyPurchase && (
 					<div className="hosting-overview__plan-agency-purchase">
-						{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
-							components: {
-								a: (
-									<a href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }></a>
-								),
-							},
-						} ) }
+						<p>
+							{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
+								components: {
+									a: (
+										<a
+											href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
+										></a>
+									),
+								},
+							} ) }
+						</p>
 					</div>
 				) }
 			</HostingCard>

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -22,7 +22,7 @@ import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { isStagingSite } from 'calypso/sites-dashboard/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
+import { isA4AUser } from 'calypso/state/partner-portal/partner/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -172,7 +172,7 @@ const PlanCard: FC = () => {
 	);
 	const planPurchase = useSelector( getSelectedPurchase );
 	const isAgencyPurchase = planPurchase && isPartnerPurchase( planPurchase );
-	const isAgency = useSelector( isAgencyUser );
+	const isA4A = useSelector( isA4AUser );
 	// Show that this is an Agency Managed plan for agency purchases.
 	const planName = isAgencyPurchase
 		? purchaseType( planPurchase )
@@ -263,7 +263,7 @@ const PlanCard: FC = () => {
 						<p>
 							{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
 								components: {
-									a: isAgency ? (
+									a: isA4A ? (
 										<a
 											href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
 										></a>

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -398,3 +398,9 @@ a.hosting-overview__link-button {
 .domains-table-row__actions-group {
 	font-family: "SF Pro Text", $sans;
 }
+
+.hosting-overview__plan-agency-purchase {
+	p {
+		font-size: 0.875rem;
+	}
+}

--- a/client/state/partner-portal/partner/selectors.ts
+++ b/client/state/partner-portal/partner/selectors.ts
@@ -61,7 +61,8 @@ export function isAgencyUser( state: PartnerPortalStore | IAppState ): boolean {
 	const currentUser = getCurrentUser( state );
 	return (
 		( currentUser?.jetpack_partner_types?.includes( 'agency' ) ||
-			currentUser?.jetpack_partner_types?.includes( 'agency_beta' ) ) ??
+			currentUser?.jetpack_partner_types?.includes( 'agency_beta' ) ||
+			currentUser?.jetpack_partner_types?.includes( 'a4a_agency' ) ) ??
 		false
 	);
 }

--- a/client/state/partner-portal/partner/selectors.ts
+++ b/client/state/partner-portal/partner/selectors.ts
@@ -61,10 +61,14 @@ export function isAgencyUser( state: PartnerPortalStore | IAppState ): boolean {
 	const currentUser = getCurrentUser( state );
 	return (
 		( currentUser?.jetpack_partner_types?.includes( 'agency' ) ||
-			currentUser?.jetpack_partner_types?.includes( 'agency_beta' ) ||
-			currentUser?.jetpack_partner_types?.includes( 'a4a_agency' ) ) ??
+			currentUser?.jetpack_partner_types?.includes( 'agency_beta' ) ) ??
 		false
 	);
+}
+
+export function isA4AUser( state: PartnerPortalStore | IAppState ): boolean {
+	const currentUser = getCurrentUser( state );
+	return currentUser?.jetpack_partner_types?.includes( 'a4a_agency' ) ?? false;
 }
 
 export function showAgencyDashboard( state: PartnerPortalStore ): boolean {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7642

## Proposed Changes

* Adds plan description for A4A in plan card with link to site overview

## Before
<img width="951" alt="Screenshot 2024-06-06 at 21 45 08" src="https://github.com/Automattic/wp-calypso/assets/5560595/f84cd16f-756b-4e8f-86a7-eaa4e4c762d8">

## After
<img width="964" alt="Screenshot 2024-06-06 at 21 55 29" src="https://github.com/Automattic/wp-calypso/assets/5560595/fddb6ace-e959-4280-bbaf-a6b647b6ab8b">

If user viewing plan is not user with access to A4A dashboard, the link will be replaced by `<strong>` tag

<img width="704" alt="Screenshot 2024-06-11 at 22 43 08" src="https://github.com/Automattic/wp-calypso/assets/5560595/a9587409-6468-40bf-af61-655440344b41">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidying up UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to your list of sites and click on an A4A site and confirm plan description looks ok and link works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
