### PR TITLE
Help Center: Update live chat text to contact us

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -528,7 +528,7 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 		}
 
 		if ( mode === 'CHAT' && showingHelpOrGPTResults ) {
-			return __( 'Still chat with us', __i18n_text_domain__ );
+			return __( 'Still contact us', __i18n_text_domain__ );
 		}
 
 		if ( mode === 'EMAIL' && showingHelpOrGPTResults ) {

--- a/packages/help-center/src/hooks/use-contact-form-title.tsx
+++ b/packages/help-center/src/hooks/use-contact-form-title.tsx
@@ -15,7 +15,7 @@ export const useContactFormTitle = (
 		CHAT: {
 			formTitle: __( 'Contact WordPress.com Support', __i18n_text_domain__ ),
 			trayText: __( 'Our WordPress experts will be with you right away', __i18n_text_domain__ ),
-			buttonLabel: __( 'Chat with us', __i18n_text_domain__ ),
+			buttonLabel: __( 'Contact us', __i18n_text_domain__ ),
 			buttonSubmittingLabel: __( 'Connecting to chat', __i18n_text_domain__ ),
 		},
 		EMAIL: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #pau2Xa-5Yj-p2#comment-15617

## Proposed Changes

* Update 'Live chat' references to 'Contact us'

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to ensure users are not seeing any text references to live chat since it has been decommissioned. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify text changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?