### PR TITLE
Site Profiler: Use Basic Metrics from advanced endpoint

### DIFF
--- a/client/data/site-profiler/metrics-dictionaries.ts
+++ b/client/data/site-profiler/metrics-dictionaries.ts
@@ -1,4 +1,12 @@
-import { Metrics, PerformanceCategories, PerformanceReport, Scores } from './types';
+import {
+	BasicMetrics,
+	BasicMetricsList,
+	BasicMetricsScored,
+	Metrics,
+	PerformanceCategories,
+	PerformanceReport,
+	Scores,
+} from './types';
 
 export const BASIC_METRICS_SCORES: Record< Metrics, [ number, number ] > = {
 	cls: [ 0.1, 0.25 ], // https://web.dev/articles/cls
@@ -62,4 +70,29 @@ export function getPerformanceCategory( metrics?: PerformanceReport ): Performan
 		return 'wpcom-low-performer';
 	}
 	return 'non-wpcom-low-performer';
+}
+
+export function getBasicMetricsScored( metrics: BasicMetrics ) {
+	return ( Object.entries( metrics ) as BasicMetricsList ).reduce( ( acc, [ key, value ] ) => {
+		acc[ key ] = { value: value, score: getScore( key as Metrics, value ) };
+		return acc;
+	}, {} as BasicMetricsScored );
+}
+
+export function getBasicMetricsFromPerfReport(
+	metrics?: PerformanceReport
+): BasicMetricsScored | undefined {
+	if ( ! metrics ) {
+		return undefined;
+	}
+
+	const basicMetrics = {
+		cls: metrics.cls,
+		fid: metrics.fid,
+		lcp: metrics.lcp,
+		fcp: metrics.fcp,
+		ttfb: metrics.ttfb,
+		inp: metrics.inp,
+	};
+	return getBasicMetricsScored( basicMetrics );
 }

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -117,7 +117,7 @@ export interface UrlSecurityMetricsQueryResponse {
 	};
 }
 
-export interface PerformanceReport {
+export type PerformanceReport = {
 	audits: {
 		health: PerformanceMetricsDataQueryResponse;
 		performance: PerformanceMetricsDataQueryResponse;
@@ -125,7 +125,7 @@ export interface PerformanceReport {
 	performance: number;
 	overall_score: number;
 	is_wpcom: boolean;
-}
+} & BasicMetrics;
 
 export interface UrlPerformanceMetricsQueryResponse {
 	webtestpage_org: {

--- a/client/data/site-profiler/use-url-basic-metrics-query.ts
+++ b/client/data/site-profiler/use-url-basic-metrics-query.ts
@@ -1,25 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
-import {
-	BasicMetricsList,
-	BasicMetricsScored,
-	Metrics,
-	UrlBasicMetricsQueryResponse,
-} from 'calypso/data/site-profiler/types';
+import { BasicMetricsScored, UrlBasicMetricsQueryResponse } from 'calypso/data/site-profiler/types';
 import wp from 'calypso/lib/wp';
-import { getScore } from './metrics-dictionaries';
+import { getBasicMetricsScored } from './metrics-dictionaries';
 
 function mapScores( response: UrlBasicMetricsQueryResponse ) {
 	const { basic } = response;
 
 	let basicMetricsScored = {} as BasicMetricsScored;
 	if ( basic.success ) {
-		basicMetricsScored = ( Object.entries( basic.data ) as BasicMetricsList ).reduce(
-			( acc, [ key, value ] ) => {
-				acc[ key ] = { value: value, score: getScore( key as Metrics, value ) };
-				return acc;
-			},
-			{} as BasicMetricsScored
-		);
+		basicMetricsScored = getBasicMetricsScored( basic.data );
 	}
 
 	return { ...response, success: basic.success, basic: basicMetricsScored };

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -1,10 +1,12 @@
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
-import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { getPerformanceCategory } from 'calypso/data/site-profiler/metrics-dictionaries';
+import {
+	getBasicMetricsFromPerfReport,
+	getPerformanceCategory,
+} from 'calypso/data/site-profiler/metrics-dictionaries';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
@@ -33,8 +35,6 @@ import { PerformanceSection } from './performance-section';
 import { ResultsHeader } from './results-header';
 import { SecuritySection } from './security-section';
 import './styles-v2.scss';
-
-const debug = debugFactory( 'apps:site-profiler' );
 
 interface Props {
 	routerDomain?: string;
@@ -89,25 +89,16 @@ export default function SiteProfilerV2( props: Props ) {
 
 	const url = useMemo( () => getValidUrl( routerDomain ), [ routerDomain ] );
 
-	const {
-		data: basicMetrics,
-		isFetching: isFetchingBasicMetrics,
-		error: errorBasicMetrics,
-	} = useUrlBasicMetricsQuery( url, hash, true );
-	const showBasicMetrics =
-		basicMetrics && basicMetrics.success && ! isFetchingBasicMetrics && ! errorBasicMetrics;
-
-	// TODO: Remove this debug statement once we have a better error handling mechanism
-	if ( errorBasicMetrics ) {
-		debug(
-			`Error fetching basic metrics for domain ${ domain }: ${ errorBasicMetrics.message }`,
-			errorBasicMetrics
-		);
-	}
+	const { data: basicMetrics } = useUrlBasicMetricsQuery( url, hash, true );
 
 	const showGetReportForm = !! url && isGetReportFormOpen;
 
 	const { data: performanceMetrics } = useUrlPerformanceMetricsQuery( routerDomain, hash );
+
+	const basicMetricsFromPerfReport = useMemo(
+		() => getBasicMetricsFromPerfReport( performanceMetrics ),
+		[ performanceMetrics ]
+	);
 
 	const { final_url: finalUrl, token } = basicMetrics || {};
 	const finalUrlDomain = useMemo( () => getDomainFromUrl( finalUrl ), [ finalUrl ] );
@@ -169,9 +160,9 @@ export default function SiteProfilerV2( props: Props ) {
 						/>
 					</LayoutBlock>
 					<LayoutBlock width="medium">
-						{ showBasicMetrics && (
+						{ basicMetricsFromPerfReport && (
 							<BasicMetrics
-								basicMetrics={ basicMetrics.basic }
+								basicMetrics={ basicMetricsFromPerfReport }
 								domain={ domain }
 								isWpCom={ isWpCom }
 							/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/7579

## Proposed Changes

* Populate the basic metrics from the `advanced` endpoint
* Delete the usage of basic metrics from `basic` endpoint as it is not used anymore for that

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The basic metrics were not always returned from the `basic` endpoint
* There is a loading screen that waits until the metrics are returned to display the results

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Navigate to site profiler and add a site to test
* When the results are displayed, check the Basic Metrics cards are correctly displayed
* Refresh the screen
* Check the Basic Metrics cards are still correctly displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
~~- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
~~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~
