### PR TITLE
A4A: add signup form validation

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/hooks/use-signup-form-validation.ts
@@ -1,0 +1,71 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { AgencyDetailsPayload } from '../types';
+
+export const CAPTURE_URL_RGX =
+	/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,63}(:[0-9]{1,5})?(\/.*)?$/i;
+
+type ValidationState = {
+	firstName?: string;
+	lastName?: string;
+	agencyName?: string;
+	agencyUrl?: string;
+	line1?: string;
+	city?: string;
+	country?: string;
+};
+
+const useSignupFormValidation = () => {
+	const translate = useTranslate();
+	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
+
+	const updateValidationError = ( newState: ValidationState ) => {
+		return setValidationError( ( prev ) => ( { ...prev, ...newState } ) );
+	};
+
+	const validate = useCallback(
+		( payload: AgencyDetailsPayload ) => {
+			const newValidationError: ValidationState = {};
+			if ( payload.firstName === '' ) {
+				newValidationError.firstName = translate( `First name can't be empty` );
+			}
+			if ( payload.lastName === '' ) {
+				newValidationError.lastName = translate( `Last name can't be empty` );
+			}
+
+			if ( payload.agencyName === '' ) {
+				newValidationError.agencyName = translate( `Agency name can't be empty` );
+			}
+
+			if ( payload.agencyUrl === '' ) {
+				newValidationError.agencyUrl = translate( `Agency URL can't be empty` );
+			} else if ( ! CAPTURE_URL_RGX.test( payload.agencyUrl ) ) {
+				newValidationError.agencyUrl = translate( `Please enter a valid URL` );
+			}
+
+			if ( payload.line1 === '' ) {
+				newValidationError.line1 = translate( `Address can't be empty` );
+			}
+
+			if ( payload.city === '' ) {
+				newValidationError.city = translate( `City can't be empty` );
+			}
+
+			if ( payload.country === '' ) {
+				newValidationError.country = translate( `Please select your country` );
+			}
+
+			if ( Object.keys( newValidationError ).length > 0 ) {
+				setValidationError( newValidationError );
+				return newValidationError;
+			}
+
+			return null;
+		},
+		[ setValidationError, translate ]
+	);
+
+	return { validate, validationError, updateValidationError };
+};
+
+export default useSignupFormValidation;

--- a/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
@@ -38,11 +38,21 @@
 	}
 
 	.agency-details-form__footer-error {
-		margin: 8px 0 0;
+		margin-block-start: 0.25rem;
 		color: var(--color-scary-40);
 		font-style: italic;
-		font-size: 0.9rem; /* stylelint-disable-line scales/font-sizes */
+		font-size: 0.875rem;
 		line-height: 14px;
+
+		&.hidden {
+			display: none;
+		}
+
+		// FIXME: come up with better solution for line1 and line2 separation
+		&.line-separated {
+			margin-block-start: -0.25rem;
+			margin-block-end: 0.5rem;
+		}
 	}
 
 	.company-details-form__tos p {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/637

## Proposed Changes

Adding Form validation on the frontend to avoid confusion

<img width="631" alt="Screenshot 2024-06-06 at 10 00 01 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/d8638816-698b-4cf3-8580-77f11dc7dbd5">

<img width="660" alt="Screenshot 2024-06-06 at 10 00 09 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/bfbc36fd-8f3e-41a8-a53c-430043810d1b">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use live link for this branch
- In new Incognito window open `/signup` and test the form

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
