### PR TITLE
Fixes the tooltip message for the CTR field in a Blaze campaign

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -507,7 +507,7 @@ export default function CampaignItemDetails( props: Props ) {
 													<br />
 													<span className="popover-title">
 														{ __(
-															'a metric used to measure the ratio of users who click on your ad to the number of total users view it.'
+															'the ratio of clicks on your ad to the number of impressions delivered.'
 														) }
 													</span>
 												</InfoPopover>


### PR DESCRIPTION
## Proposed Changes

This PR fixes an invalid definition of one of the Blaze campaigns fields. The CTR tooltip refers to the number of users when the calculation of the CTR uses impressions and clicks (a user can click multiple times on an ad).

![Screenshot 2024-06-06 at 2 43 32 PM](https://github.com/Automattic/wp-calypso/assets/1258162/6e6a339d-35c6-425b-a34d-78cfc848aea5)

## Why are these changes being made?

Invalid definition of a field tooltip. Needs correcting.

## Testing Instructions

Code review should be enough. 

For a complete test:
* Open the live preview link and navigate to Tools->Advertising
* Go to the details of one of your campaigns
* Click on the tooltip icon next to the "Click-through rate" label
* Verify that the new text is displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
