### PR TITLE
A4A: remove `chat with us` mentions

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -30,13 +30,12 @@ const MigrationOfferBody = () => {
 		<>
 			<p className="a4a-migration-offer__description">{ description }</p>
 			<Button
-				className="a4a-migration-offer__chat-button"
 				onClick={ () => {
 					page( `${ A4A_OVERVIEW_LINK }#contact-support-migration-offer` );
 				} }
 				primary
 			>
-				{ translate( 'Chat with us' ) }
+				{ translate( 'Contact us' ) }
 				<Icon icon={ external } size={ 18 } />
 			</Button>
 			<Button

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -34,8 +34,8 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 		? getProductPricingInfo( userProducts, selectedPlan, 1 )
 		: { discountedCost: 0 };
 
-	const onChatWithUs = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_chat_with_us_click' ) );
+	const onContactUs = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_hosting_pressable_contact_us_click' ) );
 	}, [ dispatch ] );
 
 	const PRESSABLE_CONTACT_LINK = 'https://pressable.com/request-demo';
@@ -126,12 +126,12 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 				{ ! selectedPlan && (
 					<Button
 						className="pressable-overview-plan-selection__details-card-cta-button"
-						onClick={ onChatWithUs }
+						onClick={ onContactUs }
 						href={ PRESSABLE_CONTACT_LINK }
 						target="_blank"
 						primary
 					>
-						{ translate( 'Chat with us' ) } <Icon icon={ external } size={ 16 } />
+						{ translate( 'Contact us' ) } <Icon icon={ external } size={ 16 } />
 					</Button>
 				) }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-5Yj-p2#comment-15622

## Proposed Changes

Remove `Chat with us` mentions from A4A

<img width="593" alt="Screenshot 2024-06-06 at 11 03 53 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/b8f72edb-f12d-4e2e-958d-58e16ca2fc6f">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link check that correct wording appear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?