### PR TITLE
Site Profiler: Fix the Insight Header text on mobile

### DIFF
--- a/client/site-profiler/components/metrics-insight/index.tsx
+++ b/client/site-profiler/components/metrics-insight/index.tsx
@@ -33,10 +33,13 @@ const Header = styled.div`
 	font-size: 16px;
 	filter: ${ ( props: Header ) => ( props.locked ? 'blur(3px)' : 'none' ) };
 	user-select: ${ ( props: Header ) => ( props.locked ? 'none' : 'auto' ) };
-	display: flex;
 
 	span {
 		display: inline-block;
+
+		&.is-mobile {
+			display: block;
+		}
 	}
 `;
 

--- a/client/site-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/site-profiler/components/metrics-insight/insight-header.tsx
@@ -1,3 +1,4 @@
+import { isMobile } from '@automattic/viewport';
 import Markdown from 'react-markdown';
 import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
 
@@ -21,7 +22,8 @@ export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 			>
 				{ title }
 			</Markdown>
-			{ value && (
+			{ value && isMobile() && <span className="value is-mobile"> { value }</span> }
+			{ value && ! isMobile() && (
 				<span>
 					&nbsp;&minus;&nbsp;<span className="value"> { value }</span>
 				</span>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7569

## Proposed Changes

Fix the issue of displaying the Insight Header info on mobile view

## Why are these changes being made?

To fix https://github.com/Automattic/dotcom-forge/issues/7569

## Testing Instructions

* Load the page `/site-profiler/:site` on a mobile view
* And check the item is displayed as the image below
* Load the page `/site-profiler/:site` on desktop view and check it still works as in trunk

| Desktop  | Mobile |
| ------------- | ------------- |
|![CleanShot 2024-06-06 at 16 22 24@2x](https://github.com/Automattic/wp-calypso/assets/5039531/78bbcb65-0bf8-448a-b01b-4e17bd921cfd)|![CleanShot 2024-06-06 at 16 22 00@2x](https://github.com/Automattic/wp-calypso/assets/5039531/7f454774-8942-4618-a806-bd9de05cfa37)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?