### PR TITLE
A4A: add links to knowledge base to the Overview page

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -35,3 +35,4 @@ export const A4A_MIGRATIONS_LINK = '/migrations';
 export const A4A_SETTINGS_LINK = '/settings';
 export const A4A_PARTNER_DIRECTORY_LINK = '/partner-directory';
 export const A4A_PARTNER_DIRECTORY_DASHBOARD_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/dashboard`;
+export const EXTERNAL_A4A_KNOWLEDGE_BASE = 'http://automattic.com/for-agencies/help';

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -36,7 +36,7 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 		<ul className="a4a-sidebar__profile-dropdown-menu" hidden={ ! isExpanded }>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">
 				<Button borderless onClick={ onGetHelp }>
-					{ translate( 'Get help' ) }
+					{ translate( 'Contact support' ) }
 				</Button>
 			</li>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Button, Gravatar } from '@automattic/components';
+import { Button, Gridicon, Gravatar } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -10,7 +10,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { A4A_OVERVIEW_LINK } from '../../sidebar-menu/lib/constants';
+import { A4A_OVERVIEW_LINK, EXTERNAL_A4A_KNOWLEDGE_BASE } from '../../sidebar-menu/lib/constants';
 
 import './style.scss';
 
@@ -37,6 +37,16 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 			<li className="a4a-sidebar__profile-dropdown-menu-item">
 				<Button borderless onClick={ onGetHelp }>
 					{ translate( 'Contact support' ) }
+				</Button>
+			</li>
+			<li className="a4a-sidebar__profile-dropdown-menu-item">
+				<Button
+					borderless
+					href={ EXTERNAL_A4A_KNOWLEDGE_BASE }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{ translate( 'View Knowledge Base' ) } <Gridicon icon="external" size={ 18 } />
 				</Button>
 			</li>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -124,6 +124,12 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 			padding-inline: 8px;
 		}
 	}
+
+	a svg.gridicon.gridicons-external {
+		width: 18px;
+		height: 18px;
+		top: 2px;
+	}
 }
 
 a.a4a-sidebar__external-link {

--- a/client/a8c-for-agencies/sections/overview/sidebar/quick-links/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/quick-links/index.tsx
@@ -22,14 +22,6 @@ export default function OverviewSidebarQuickLinks() {
 
 	const navItems: FoldableNavItem[] = [
 		{
-			icon: info,
-			link: EXTERNAL_A4A_KNOWLEDGE_BASE,
-			slug: 'view_knowledge_base',
-			title: translate( 'View Knowledge Base' ),
-			trackEventName: 'calypso_a4a_overview_quick_links_knowledge_base_click',
-			isExternalLink: true,
-		},
-		{
 			icon: category,
 			link: A4A_SITES_LINK,
 			slug: 'manage_sites',
@@ -63,6 +55,14 @@ export default function OverviewSidebarQuickLinks() {
 			slug: 'view_invoices',
 			title: translate( 'View invoices' ),
 			trackEventName: 'calypso_a4a_overview_quick_links_view_invoices_click',
+		},
+		{
+			icon: info,
+			link: EXTERNAL_A4A_KNOWLEDGE_BASE,
+			slug: 'view_knowledge_base',
+			title: translate( 'View Knowledge Base' ),
+			trackEventName: 'calypso_a4a_overview_quick_links_knowledge_base_click',
+			isExternalLink: true,
 		},
 	];
 

--- a/client/a8c-for-agencies/sections/overview/sidebar/quick-links/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/quick-links/index.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@automattic/components';
-import { category, key, receipt, store, tag } from '@wordpress/icons';
+import { category, key, receipt, store, tag, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import FoldableNav from 'calypso/a8c-for-agencies/components/foldable-nav';
 import { FoldableNavItem } from 'calypso/a8c-for-agencies/components/foldable-nav/types';
@@ -20,6 +20,14 @@ export default function OverviewSidebarQuickLinks() {
 	const tracksName = 'calypso_jetpack_manage_overview_quick_links';
 
 	const navItems: FoldableNavItem[] = [
+		{
+			icon: info,
+			link: 'http://automattic.com/for-agencies/help',
+			slug: 'view_knowledge_base',
+			title: translate( 'View Knowledge Base' ),
+			trackEventName: 'calypso_a4a_overview_quick_links_knowledge_base_click',
+			isExternalLink: true,
+		},
 		{
 			icon: category,
 			link: A4A_SITES_LINK,

--- a/client/a8c-for-agencies/sections/overview/sidebar/quick-links/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/quick-links/index.tsx
@@ -9,6 +9,7 @@ import {
 	A4A_PURCHASES_LINK,
 	A4A_BILLING_LINK,
 	A4A_INVOICES_LINK,
+	EXTERNAL_A4A_KNOWLEDGE_BASE,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 
 import './style.scss';
@@ -22,7 +23,7 @@ export default function OverviewSidebarQuickLinks() {
 	const navItems: FoldableNavItem[] = [
 		{
 			icon: info,
-			link: 'http://automattic.com/for-agencies/help',
+			link: EXTERNAL_A4A_KNOWLEDGE_BASE,
 			slug: 'view_knowledge_base',
 			title: translate( 'View Knowledge Base' ),
 			trackEventName: 'calypso_a4a_overview_quick_links_knowledge_base_click',

--- a/client/a8c-for-agencies/sections/overview/sidebar/quick-links/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/quick-links/style.scss
@@ -6,4 +6,10 @@
 		padding-left: 12px;
 		padding-right: 12px;
 	}
+
+	&:hover {
+		svg.sidebar-v2__external-icon {
+			color: var(--color-text-inverted);
+		}
+	}
 }

--- a/client/a8c-for-agencies/sections/overview/sidebar/quick-links/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/quick-links/style.scss
@@ -7,9 +7,11 @@
 		padding-right: 12px;
 	}
 
-	&:hover {
-		svg.sidebar-v2__external-icon {
-			color: var(--color-text-inverted);
+	.sidebar-v2__menu-item {
+		&:hover {
+			svg.sidebar-v2__external-icon {
+				color: var(--color-text-inverted);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/592.

## Proposed Changes

* Add a link to the KB to the Quick Links section.
* Add a link to the KB to the Profile dropdown.
* Rename Get help option to Contact support.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The KB is ready to be included to the dashboard.
* Get help to Contact support to improve consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start Automattic for Agencies from a Live Branch.
* Visit `/overview`.
* Verify that the Quick Links widget has a link to our knowledge base.
* Verify that the Profile dropdown widget has a link to our knowledge base.
* Verify that the Profile dropdown widget no longer has the Get help option. Instead, it has the Contact support option.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="500" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/a4cce916-85b7-467e-91bf-898b7bbc052c">
</td>
<td>
<img width="500" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3418513/03a0a35e-aa34-4d8f-841b-0134b0fba5f9">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
