### PR TITLE
Guided onboarding: Show plan upsell in guided flow

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -35,7 +35,8 @@ export function useModalResolutionCallback( {
 				// TODO: look into decoupling the flowName from here as well.
 				if (
 					paidDomainName &&
-					( flowName === 'onboarding' || intent === 'plans-jetpack-app-site-creation' )
+					( ( flowName && [ 'guided', 'onboarding' ].includes( flowName ) ) ||
+						intent === 'plans-jetpack-app-site-creation' )
 				) {
 					return PAID_PLAN_IS_REQUIRED_DIALOG;
 				}


### PR DESCRIPTION
See: p1717704717481069/1717475153.821149-slack-C02T4NVL4JJ

## Proposed Changes

This makes the guided onboarding upsell a paid plan when a paid domain is picked. 


## Testing Instructions

1. Go to /start/guided.
2. Pick a paid domain.
3. Pick a free plan.
4. A modal should be shown.

![image](https://github.com/Automattic/wp-calypso/assets/17054134/51977d47-64e4-4d24-b587-ace9f0b6bc92)
