### PR TITLE
Add section showing "Why host with us" points in site identification step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -88,6 +88,36 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		return <ScanningStep />;
 	}
 
+	// TODO: Remove extra steps and properties for non-English locales once we have translations -- hosting details.
+	const hostingDetailItems = {
+		'unmatched-uptime': {
+			title: translate( 'Unmatched Reliability and Uptime' ),
+			titleString: 'Unmatched Reliability and Uptime', // Temporary string for non-English locales. Remove once we have translations.
+			description: translate(
+				'Our rock-solid infrastructure ensures 99.999% uptime, keeping your site always accessible to your users no matter what!'
+			),
+			descriptionString:
+				'Our rock-solid infrastructure ensures 99.999% uptime, keeping your site always accessible to your users no matter what!', // Temporary string for non-English locales. Remove once we have translations.
+		},
+		'effortless-customization': {
+			title: translate( 'Effortless Customization' ),
+			titleString: 'Effortless Customization',
+			description: translate(
+				'Our intuitive tools and extensive customization options let you design a website that meets all your needs, without any hassle. Whether you’re a beginner or an expert, building your dream site has never been easier.'
+			),
+			descriptionString:
+				'Our intuitive tools and extensive customization options let you design a website that meets all your needs, without any hassle. Whether you’re a beginner or an expert, building your dream site has never been easier.',
+		},
+		'blazing-fast-speed': {
+			title: translate( 'Blazing Fast Page Speed' ),
+			titleString: 'Blazing Fast Page Speed',
+			description: translate(
+				'Deliver lightning-fast load times with our global CDN spanning 28+ locations, providing a seamless experience for your visitors no matter where they are.'
+			),
+			descriptionString:
+				'Deliver lightning-fast load times with our global CDN spanning 28+ locations, providing a seamless experience for your visitors no matter where they are.',
+		},
+	};
 	return (
 		<div>
 			<div className="import__heading import__heading-center">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -145,6 +145,9 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 					{ ...nextLabelProp }
 				/>
 			</div>
+			{ hasTranslationsForAllItems && (
+				<HostingDetails items={ Object.values( hostingDetailItems ) } />
+			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -15,6 +15,32 @@ import type { UrlData } from 'calypso/blocks/import/types';
 
 import './style.scss';
 
+interface HostingDetailsProps {
+	items: { title: string; description: string }[];
+}
+
+const HostingDetails: FC< HostingDetailsProps > = ( { items } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="import__site-identify-hosting-details">
+			<p className="import__site-identify-hosting-details--title">
+				{ translate( 'Why should you host with us?' ) }
+			</p>
+			<div className="import__site-identify-hosting-details--list">
+				{ items.map( ( item, index ) => (
+					<div key={ index } className="import__site-identify-hosting-details--list-item">
+						<p className="import__site-identify-hosting-details--list-item-title">{ item.title }</p>
+						<p className="import__site-identify-hosting-details--list-item-description">
+							{ item.description }
+						</p>
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
 interface Props {
 	hasError?: boolean;
 	onComplete: ( siteInfo: UrlData ) => void;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -118,6 +118,11 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 				'Deliver lightning-fast load times with our global CDN spanning 28+ locations, providing a seamless experience for your visitors no matter where they are.',
 		},
 	};
+
+	const hasTranslationsForAllItems = Object.values( hostingDetailItems ).every(
+		( item ) => hasEnTranslation( item.titleString ) && hasEnTranslation( item.descriptionString )
+	);
+
 	return (
 		<div>
 			<div className="import__heading import__heading-center">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -78,7 +78,7 @@
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	gap: 1.5rem;
+	gap: 1.25rem;
 	margin: 40px auto 0 auto;
 	max-width: 368px;
 	padding: 1.5rem;
@@ -92,7 +92,7 @@
 	&--list {
 		display: flex;
 		flex-direction: column;
-		gap: 1rem;
+		gap: 1.125rem;
 
 		&-item {
 			display: flex;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -72,3 +72,46 @@
 		}
 	}
 }
+
+.import__site-identify-hosting-details {
+	background-color: #f6f7f7;
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+	margin: 40px auto 0 auto;
+	max-width: 368px;
+	padding: 1.5rem;
+
+	&--title {
+		color: var(--studio-gray-100);
+		font-size: 1.25rem;
+		font-weight: 500;
+	}
+
+	&--list {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+
+		&-item {
+			display: flex;
+			flex-direction: column;
+			gap: 0.25rem;
+
+			&-description {
+				color: var(--studio-gray-60);
+				font-size: 0.875rem;
+				font-weight: 400;
+				letter-spacing: -0.16px;
+			}
+
+			&-title {
+				color: var(--studio-gray-70);
+				font-size: 1rem;
+				font-weight: 500;
+				letter-spacing: -0.32px;
+			}
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -154,4 +154,12 @@ describe( 'SiteMigrationIdentify', () => {
 			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { platform: 'unknown' } ) )
 		);
 	} );
+
+	it( 'shows why host with us points', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		expect( screen.getByText( /Why should you host with us/ ) ).toBeVisible();
+		expect( screen.getByText( /Unmatched Reliability and Uptime/ ) ).toBeVisible();
+	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -161,5 +161,10 @@ describe( 'SiteMigrationIdentify', () => {
 
 		expect( screen.getByText( /Why should you host with us/ ) ).toBeVisible();
 		expect( screen.getByText( /Unmatched Reliability and Uptime/ ) ).toBeVisible();
+		expect(
+			screen.getByText(
+				/Our rock-solid infrastructure ensures 99.999% uptime, keeping your site always accessible to your users no matter what!/
+			)
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91561

## Proposed Changes

* Added a section in the site identification step explaining "why host with us" points.
* Currently this section is rendered conditionally behind a locale + translation check. Only visible to users with English locale. For the rest of the users, it will become visible when all translations are available.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the strengths of our hosting more visible

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure your language is English in `https://wordpress.com/me/account`
- In the migration flow (take any migration path, for example `http://calypso.localhost:3000/start`), navigate to the Site Identification step (screenshot attached below in case you're not sure which page)
- Check that "Why host with us" section is visible with all the points, the design also visually matches the design in the issue
- Now go to the `https://wordpress.com/me/account` page and switch the language to some other language.
- Reload the Site Identification step, and make sure "Why host with us" section is not visible

<img width="1971" alt="Screenshot 2024-06-07 at 7 08 37 AM" src="https://github.com/Automattic/wp-calypso/assets/6820724/99dee83e-17b7-432e-b38a-c3307d077304">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
