### PR TITLE
Overview tab: Update the See all backups button style in the Site backup card

### DIFF
--- a/client/my-sites/hosting/site-backup-card/index.js
+++ b/client/my-sites/hosting/site-backup-card/index.js
@@ -43,7 +43,21 @@ const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId, sit
 		: null;
 
 	return (
-		<HostingCard className="site-backup-card" title={ translate( 'Site backup' ) }>
+		<HostingCard className="site-backup-card">
+			<div className="hosting-card__heading">
+				<h3 className="hosting-card__title">{ translate( 'Site backup' ) }</h3>
+				<Button
+					className={ clsx( 'site-backup-card__button', 'hosting-overview__link-button' ) }
+					plain
+					href={
+						wpcomAdminInterface === 'wp-admin'
+							? `https://cloud.jetpack.com/backup/${ siteSlug }`
+							: `/backup/${ siteSlug }`
+					}
+				>
+					{ translate( 'See all backups' ) }
+				</Button>
+			</div>
 			{ hasRetrievedLastBackup && lastGoodBackup && ! isLoading && ! disabled && (
 				<>
 					<p className="site-backup-card__date">
@@ -55,17 +69,6 @@ const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId, sit
 							"If you restore your site using this backup, you'll lose any changes made after that date."
 						) }
 					</p>
-					<Button
-						className={ clsx( 'site-backup-card__button', 'hosting-overview__link-button' ) }
-						plain
-						href={
-							wpcomAdminInterface === 'wp-admin'
-								? `https://cloud.jetpack.com/backup/${ siteSlug }`
-								: `/backup/${ siteSlug }`
-						}
-					>
-						{ translate( 'See all backups' ) }
-					</Button>
 				</>
 			) }
 			{ ( ( hasRetrievedLastBackup && ! lastGoodBackup && ! isLoading ) || disabled ) && (

--- a/client/my-sites/hosting/site-backup-card/style.scss
+++ b/client/my-sites/hosting/site-backup-card/style.scss
@@ -27,10 +27,6 @@
 		}
 	}
 
-	&__button.hosting-overview__link-button {
-		font-size: $font-body;
-	}
-
 	&.is-disabled {
 		.site-backup-card__placeholder {
 			animation: none;


### PR DESCRIPTION
## Proposed Changes

This PR updates the See all backups button styles.

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-07 at 2 17 30 PM](https://github.com/Automattic/wp-calypso/assets/797888/4d4db651-5d8d-46e6-bac5-99ba3431b604)| ![Screenshot 2024-06-07 at 2 17 41 PM](https://github.com/Automattic/wp-calypso/assets/797888/2c9ee4ec-73a1-4294-b40c-27f0d2976f9f)|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

UI consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Ensure that the button style is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
