### PR TITLE
Site Management Panel: Persist the log type after the site switches

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -11,29 +11,20 @@ import { FeaturePreviewInterface, PreviewPaneProps } from './types';
 import './style.scss';
 
 export const createFeaturePreview = (
-	idOrIds: string | string[],
+	id: string,
 	label: string | React.ReactNode,
 	enabled: boolean,
 	selectedFeatureId: string | undefined = '',
 	setSelectedFeatureId: ( id: string ) => void,
 	preview: React.ReactNode
 ): FeaturePreviewInterface => {
-	const ids = typeof idOrIds === 'string' ? [ idOrIds ] : idOrIds;
-	const defaultId = ids[ 0 ];
-	const selected = enabled && ids.includes( selectedFeatureId );
 	return {
-		id: defaultId,
+		id,
 		tab: {
 			label,
 			visible: enabled,
-			selected,
-			onTabClick: () => {
-				if ( ! enabled || selected ) {
-					return;
-				}
-
-				setSelectedFeatureId( defaultId );
-			},
+			selected: enabled && selectedFeatureId === id,
+			onTabClick: () => enabled && setSelectedFeatureId( id ),
 		},
 		enabled,
 		preview: enabled ? preview : null,

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -11,20 +11,29 @@ import { FeaturePreviewInterface, PreviewPaneProps } from './types';
 import './style.scss';
 
 export const createFeaturePreview = (
-	id: string,
+	idOrIds: string | string[],
 	label: string | React.ReactNode,
 	enabled: boolean,
-	selectedFeatureId: string | undefined,
+	selectedFeatureId: string | undefined = '',
 	setSelectedFeatureId: ( id: string ) => void,
 	preview: React.ReactNode
 ): FeaturePreviewInterface => {
+	const ids = typeof idOrIds === 'string' ? [ idOrIds ] : idOrIds;
+	const defaultId = ids[ 0 ];
+	const selected = enabled && ids.includes( selectedFeatureId );
 	return {
-		id,
+		id: defaultId,
 		tab: {
 			label,
 			visible: enabled,
-			selected: enabled && selectedFeatureId === id,
-			onTabClick: () => enabled && setSelectedFeatureId( id ),
+			selected,
+			onTabClick: () => {
+				if ( ! enabled || selected ) {
+					return;
+				}
+
+				setSelectedFeatureId( defaultId );
+			},
 		},
 		enabled,
 		preview: enabled ? preview : null,

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -14,7 +14,7 @@ export const createFeaturePreview = (
 	id: string,
 	label: string | React.ReactNode,
 	enabled: boolean,
-	selectedFeatureId: string | undefined = '',
+	selectedFeatureId: string | undefined,
 	setSelectedFeatureId: ( id: string ) => void,
 	preview: React.ReactNode
 ): FeaturePreviewInterface => {

--- a/client/site-logs/index.tsx
+++ b/client/site-logs/index.tsx
@@ -7,7 +7,10 @@ import {
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
 import { redirectHomeIfIneligible } from 'calypso/my-sites/site-monitoring/controller';
 import { siteDashboard } from 'calypso/sites-dashboard-v2/controller';
-import { DOTCOM_LOGS } from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
+import {
+	DOTCOM_LOGS_PHP,
+	DOTCOM_LOGS_WEB,
+} from 'calypso/sites-dashboard-v2/site-preview-pane/constants';
 import { httpRequestLogs, phpErrorLogs } from './controller';
 
 export default function () {
@@ -25,7 +28,7 @@ export default function () {
 		redirectHomeIfIneligible,
 		navigation,
 		phpErrorLogs,
-		siteDashboard( DOTCOM_LOGS ),
+		siteDashboard( DOTCOM_LOGS_PHP ),
 		makeLayout,
 		clientRender
 	);
@@ -36,7 +39,7 @@ export default function () {
 		redirectHomeIfIneligible,
 		navigation,
 		httpRequestLogs,
-		siteDashboard( DOTCOM_LOGS ),
+		siteDashboard( DOTCOM_LOGS_WEB ),
 		makeLayout,
 		clientRender
 	);

--- a/client/sites-dashboard-v2/site-preview-pane/constants.ts
+++ b/client/sites-dashboard-v2/site-preview-pane/constants.ts
@@ -1,6 +1,7 @@
 export const DOTCOM_OVERVIEW = 'dotcom-hosting';
 export const DOTCOM_MONITORING = 'dotcom-site-monitoring';
-export const DOTCOM_LOGS = 'dotcom-site-logs';
+export const DOTCOM_LOGS_PHP = 'dotcom-site-logs-php';
+export const DOTCOM_LOGS_WEB = 'dotcom-site-logs-web';
 export const DOTCOM_GITHUB_DEPLOYMENTS = 'dotcom-github-deployments';
 export const DOTCOM_HOSTING_CONFIG = 'dotcom-hosting-config';
 export const DOTCOM_HOSTING_FEATURES = 'dotcom-hosting-features';
@@ -9,7 +10,8 @@ export const DOTCOM_STAGING_SITE = 'dotcom-staging-site';
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ DOTCOM_OVERVIEW ]: 'overview/:site',
 	[ DOTCOM_MONITORING ]: 'site-monitoring/:site',
-	[ DOTCOM_LOGS ]: 'site-logs/:site/php',
+	[ DOTCOM_LOGS_PHP ]: 'site-logs/:site/php',
+	[ DOTCOM_LOGS_WEB ]: 'site-logs/:site/web',
 	[ DOTCOM_GITHUB_DEPLOYMENTS ]: 'github-deployments/:site',
 	[ DOTCOM_HOSTING_CONFIG ]: 'hosting-config/:site',
 	[ DOTCOM_HOSTING_FEATURES ]: 'hosting-features/:site',

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -11,7 +11,7 @@ import {
 	DOTCOM_HOSTING_CONFIG,
 	DOTCOM_OVERVIEW,
 	DOTCOM_MONITORING,
-	DOTCOM_LOGS,
+	DOTCOM_LOGS_PHP,
 	DOTCOM_GITHUB_DEPLOYMENTS,
 	DOTCOM_HOSTING_FEATURES,
 	DOTCOM_STAGING_SITE,
@@ -84,7 +84,7 @@ const DotcomPreviewPane = ( {
 				selectedSiteFeaturePreview
 			),
 			createFeaturePreview(
-				DOTCOM_LOGS,
+				DOTCOM_LOGS_PHP,
 				__( 'Logs' ),
 				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -52,13 +52,11 @@ const DotcomPreviewPane = ( {
 		const isActiveAtomicSite = isAtomicSite && ! isPlanExpired;
 		const siteFeatures = [
 			{
-				id: 'overview',
 				label: __( 'Overview' ),
 				enabled: true,
 				featureIds: [ DOTCOM_OVERVIEW ],
 			},
 			{
-				DOTCOM_HOSTING_FEATURES,
 				label: (
 					<span>
 						{ hasEnTranslation( 'Hosting Features' )
@@ -71,31 +69,26 @@ const DotcomPreviewPane = ( {
 				featureIds: [ DOTCOM_HOSTING_FEATURES ],
 			},
 			{
-				id: 'deployments',
 				label: __( 'Deployments' ),
 				enabled: isActiveAtomicSite,
 				featureIds: [ DOTCOM_GITHUB_DEPLOYMENTS ],
 			},
 			{
-				id: 'monitoring',
 				label: __( 'Monitoring' ),
 				enabled: isActiveAtomicSite,
 				featureIds: [ DOTCOM_MONITORING ],
 			},
 			{
-				id: 'logs',
 				label: __( 'Logs' ),
 				enabled: isActiveAtomicSite,
 				featureIds: [ DOTCOM_LOGS_PHP, DOTCOM_LOGS_WEB ],
 			},
 			{
-				id: 'staging-site',
 				label: __( 'Staging Site' ),
 				enabled: isActiveAtomicSite,
 				featureIds: [ DOTCOM_STAGING_SITE ],
 			},
 			{
-				id: 'server-settings',
 				label: hasEnTranslation( 'Server Settings' )
 					? __( 'Server Settings' )
 					: __( 'Server Config' ),
@@ -104,17 +97,18 @@ const DotcomPreviewPane = ( {
 			},
 		];
 
-		return siteFeatures.map( ( { id, label, enabled, featureIds } ) => {
+		return siteFeatures.map( ( { label, enabled, featureIds } ) => {
 			const selected = enabled && featureIds.includes( selectedSiteFeature );
+			const defaultFeatureId = featureIds[ 0 ];
 			return {
-				id,
+				id: defaultFeatureId,
 				tab: {
 					label,
 					visible: enabled,
 					selected,
 					onTabClick: () => {
 						if ( enabled && ! selected ) {
-							setSelectedSiteFeature( featureIds[ 0 ] );
+							setSelectedSiteFeature( defaultFeatureId );
 						}
 					},
 				},

--- a/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites-dashboard-v2/site-preview-pane/dotcom-preview-pane.tsx
@@ -12,6 +12,7 @@ import {
 	DOTCOM_OVERVIEW,
 	DOTCOM_MONITORING,
 	DOTCOM_LOGS_PHP,
+	DOTCOM_LOGS_WEB,
 	DOTCOM_GITHUB_DEPLOYMENTS,
 	DOTCOM_HOSTING_FEATURES,
 	DOTCOM_STAGING_SITE,
@@ -84,7 +85,7 @@ const DotcomPreviewPane = ( {
 				selectedSiteFeaturePreview
 			),
 			createFeaturePreview(
-				DOTCOM_LOGS_PHP,
+				[ DOTCOM_LOGS_PHP, DOTCOM_LOGS_WEB ],
 				__( 'Logs' ),
 				isAtomicSite && ! isPlanExpired,
 				selectedSiteFeature,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7543, https://github.com/Automattic/wp-calypso/pull/91462

## Proposed Changes

* Persist the log type after the site switches

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Pick an atomic site
* Go to Logs
* Switch log type to `Web`
* Pick another atomic site
* Make sure the log type is still `web

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
