### PR TITLE
Domain Management: Fix misaligned buttons on the smaller screen

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
@@ -93,7 +93,7 @@ const ConnectedDomainDetails = ( {
 	return (
 		<div className="details-card">
 			<div className="details-card__section">{ getDescriptionText() }</div>
-			<div className="details-card__section">
+			<div className="details-card__section details-card__section-actions">
 				{ renderPlanDetailsButton() }
 				{ renderMappingInstructionsButton() }
 			</div>

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -154,7 +154,7 @@ const RegisteredDomainDetails = ( {
 		<div className="details-card">
 			<div className="details-card__section dates">{ renderDates() }</div>
 			<div className="details-card__section">{ renderAutoRenewToggle() }</div>
-			<div className="details-card__section">
+			<div className="details-card__section details-card__section-actions">
 				{ renderRenewButton() }
 				{ renderPaymentDetailsButton() }
 			</div>

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -19,6 +19,12 @@
 			}
 		}
 
+		&.details-card__section-actions {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 16px;
+		}
+
 		.details-card__date {
 			display: block;
 			margin-top: 16px;
@@ -45,9 +51,6 @@
 
 		& .button:not(.is-primary):not(:disabled) {
 			color: var(--studio-gray-80);
-		}
-		& .button:not(:first-child) {
-			margin-left: 16px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7633

## Proposed Changes

* Fix misaligned buttons on the smaller screen

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/72eed855-0430-47b7-9315-1de7dcffab32) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/39e95b11-b210-4e1c-846e-6a615b868967) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to manage your domain
* Resize your window to the smaller screen
* Make sure the buttons are not misaligned

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
