### PR TITLE
Remove free hosting trial slug from useFreeTrialPlanSlugs()

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs.ts
+++ b/client/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs.ts
@@ -11,6 +11,8 @@ export const useFreeTrialPlanSlugs: UseFreeTrialPlanSlugs = ( {
 
 		if ( intent === 'plans-new-hosted-site' && eligibleForFreeHostingTrial ) {
 			freeTrialSlugs[ TYPE_BUSINESS ] = PLAN_HOSTING_TRIAL_MONTHLY;
+			// Disable free hosting trials - see pMz3w-k4H-p2#comment-119368
+			delete freeTrialSlugs[ TYPE_BUSINESS ];
 		}
 
 		return freeTrialSlugs;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR removes the free Creator trial from the `useFreeTrialPlanSlugs()` hook so we can prevent users from starting free trials.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're disabling the trials for the time being. More context in pMz3w-k4H-p2#comment-119368

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Navigate to `/setup/new-hosted-site` and work through the flow until you get to the plans page
* On the plans page, verify that the Creator plan only has a single "Get Creator" CTA

### Screenshots

| Before | After |
| ------ | ------ |
| <img width="816" alt="Screenshot 2024-06-07 at 09 40 35" src="https://github.com/Automattic/wp-calypso/assets/3376401/0e99067a-7361-463f-8977-4444a6003d90"> | <img width="816" alt="Screenshot 2024-06-07 at 09 40 47" src="https://github.com/Automattic/wp-calypso/assets/3376401/0a45508e-a9e1-4885-9da8-0a04730b6a86"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?