### PR TITLE
Sensei: Set signup flow on the sensei flow

### DIFF
--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -26,7 +26,7 @@ const sensei: Flow = {
 	get title() {
 		return translate( 'Course Creator' );
 	},
-	isSignupFlow: false,
+	isSignupFlow: true,
 	useSteps() {
 		return [
 			{ slug: 'intro', component: Intro },


### PR DESCRIPTION
## Proposed Changes
* Set sensei flow as a Signup Flow


## Why are these changes being made?
Since sensei is a flow that creates a site and the user can start the flow without being logged in, we can consider it as a signup flow.

Setting this flag enables the flow to trigger the `calypso_signup_start`.


## Testing Instructions
* Start the `/setup/sensei` flow
* Go to the second step
* Check if the event `calypso_signup_start` is initiated. 


NOTE: There is a specific logic that only triggers the calypso_signup_start only on the second step, this logic will be reviewed in future PRs. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
