### PR TITLE
A4A: Remove hardcoded plan names

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -45,7 +45,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 		productIcon = wpcomIcon;
 		// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
 		//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
-		productTitle = product.name === 'WordPress.com Creator' ? 'WordPress.com Site' : product.name;
+		productTitle = product.slug === 'wpcom-hosting-business' ? 'WordPress.com Site' : product.name;
 		productDescription = translate(
 			'Plan with %(install)d managed WordPress install, with 50GB of storage each.',
 			'Plan with %(install)d managed WordPress installs, with 50GB of storage each.',

--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -45,7 +45,8 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 		productIcon = wpcomIcon;
 		// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
 		//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
-		productTitle = product.slug === 'wpcom-hosting-business' ? 'WordPress.com Site' : product.name;
+		productTitle =
+			product.slug === 'wpcom-hosting-business' ? translate( 'WordPress.com Site' ) : product.name;
 		productDescription = translate(
 			'Plan with %(install)d managed WordPress install, with 50GB of storage each.',
 			'Plan with %(install)d managed WordPress installs, with 50GB of storage each.',

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -23,7 +23,7 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 	// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
 	//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
 	const productDisplayName =
-		item.name === 'WordPress.com Creator' ? 'WordPress.com Site' : item.name;
+		item.slug === 'wpcom-hosting-business' ? 'WordPress.com Site' : item.name;
 	const itemDisplayName =
 		item.quantity > 1
 			? translate( '%(productName)s x %(quantity)s', {

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -23,7 +23,7 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 	// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
 	//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
 	const productDisplayName =
-		item.slug === 'wpcom-hosting-business' ? 'WordPress.com Site' : item.name;
+		item.slug === 'wpcom-hosting-business' ? translate( 'WordPress.com Site' ) : item.name;
 	const itemDisplayName =
 		item.quantity > 1
 			? translate( '%(productName)s x %(quantity)s', {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -63,7 +63,6 @@ export default function LicenseList() {
 		},
 		[ dispatch ]
 	);
-	// console.log(licenses);
 
 	return (
 		<div className="license-list">

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -63,6 +63,7 @@ export default function LicenseList() {
 		},
 		[ dispatch ]
 	);
+	// console.log(licenses);
 
 	return (
 		<div className="license-list">

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -143,7 +143,9 @@ export default function LicensePreview( {
 
 	// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
 	//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
-	const productTitle = product === 'WordPress.com Creator' ? 'WordPress.com Site' : product;
+	const productTitle = licenseKey.startsWith( 'wpcom-hosting-business' )
+		? 'WordPress.com Site'
+		: product;
 
 	return (
 		<div

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -144,7 +144,7 @@ export default function LicensePreview( {
 	// TODO: We are removing Creator's product name in the frontend because we want to leave it in the backend for the time being,
 	//       We have to refactor this once we have updates. Context: p1714663834375719-slack-C06JY8QL0TU
 	const productTitle = licenseKey.startsWith( 'wpcom-hosting-business' )
-		? 'WordPress.com Site'
+		? translate( 'WordPress.com Site' )
 		: product;
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Related to the issue reported in p1717621117529899-slack-C06EV8FF09J. This PR removes hardcoded reference to "WordPress.com Creator" plan.



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are running a plan name change experiment (check pbxNRc-3Kh-p2) on WP.com, so hardcoding plan names will lead to errors. The A4A pages replace the plan name with a generic "WordPress.com Site", and these searches should use the plan slug instead of plan name.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this branch and start the server by running `yarn start-a8c-for-agencies`.
* Go to `http://agencies.localhost:3000/` and create a new account and log in.
* Go to Marketplace > click on "Explore WordPress.com plans", and then click on "Add WordPress.com to cart". 
* Verify the checkout cart contains "WordPress.com Site".


| BEFORE | AFTER |
|--------|--------|
| <img width="100%" alt="Screenshot 2024-06-07 at 3 01 43 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/f27bf3a6-7f85-42ce-8b3f-84c87d3379e9">   | <img  width="100%" alt="Screenshot 2024-06-07 at 2 57 19 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/b407cb88-d36a-4351-bf91-f60b023b6868"> | 


* Proceed to checkout the plan and on the checkout plan, verify there's no mention of the "Business" or "Creator" plan.

| BEFORE | AFTER |
|--------|--------|
| <img width="1376" alt="Screenshot 2024-06-07 at 3 01 33 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/b09f6f84-46c4-49b1-96d6-c3b30c948e83"> | <img width="1397" alt="Screenshot 2024-06-07 at 2 59 17 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/e324b2a2-f09f-467c-94d5-a96895f4326e"> | 

* Complete purchase and verify on the Purchases > Licenses page that there is no mention of the plan name ("Business" or "Creator").

| Header | Header |
|--------|--------|
| <img width="1354" alt="Screenshot 2024-06-07 at 3 01 52 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/16a885b4-4dd1-487c-a6c0-66acbb980870"> | <img width="1166" alt="Screenshot 2024-06-07 at 2 56 53 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/a14fe215-a720-41ba-a8a4-d7d592369366">
 | 



