### PR TITLE
Admin Interface Style: Use the experiment to determine whether to display the settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -553,14 +553,14 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	renderAdminInterface() {
-		const { site, isSimple } = this.props;
+		const { site, siteSlug, isSimple } = this.props;
 		if ( ! isEnabled( 'layout/dotcom-nav-redesign-v2' ) || isSimple ) {
 			return isEnabled( 'layout/wpcom-admin-interface' ) ? (
-				<SiteAdminInterfaceExperiment siteId={ site.ID } />
+				<SiteAdminInterfaceExperiment siteId={ site.ID } siteSlug={ siteSlug } />
 			) : null;
 		}
 
-		return <SiteAdminInterface siteId={ site.ID } />;
+		return <SiteAdminInterface siteId={ site.ID } siteSlug={ siteSlug } />;
 	}
 
 	render() {

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -63,6 +63,7 @@ import {
 import { DIFMUpsell } from './difm-upsell-banner';
 import Masterbar from './masterbar';
 import SiteAdminInterface from './site-admin-interface';
+import SiteAdminInterfaceExperiment from './site-admin-interface/experiment';
 import SiteIconSetting from './site-icon-setting';
 import LaunchSite from './site-visibility/launch-site';
 import wrapSettingsForm from './wrap-settings-form';
@@ -553,12 +554,10 @@ export class SiteSettingsFormGeneral extends Component {
 
 	renderAdminInterface() {
 		const { site, isSimple } = this.props;
-		if (
-			! isEnabled( 'layout/wpcom-admin-interface' ) &&
-			( ! isEnabled( 'layout/dotcom-nav-redesign-v2' ) ||
-				( isEnabled( 'layout/dotcom-nav-redesign-v2' ) && isSimple ) )
-		) {
-			return null;
+		if ( ! isEnabled( 'layout/dotcom-nav-redesign-v2' ) || isSimple ) {
+			return isEnabled( 'layout/wpcom-admin-interface' ) ? (
+				<SiteAdminInterfaceExperiment siteId={ site.ID } />
+			) : null;
 		}
 
 		return <SiteAdminInterface siteId={ site.ID } />;

--- a/client/my-sites/site-settings/site-admin-interface/experiment.tsx
+++ b/client/my-sites/site-settings/site-admin-interface/experiment.tsx
@@ -1,0 +1,18 @@
+import { useExperiment } from 'calypso/lib/explat';
+import SiteAdminInterface from './';
+
+interface Props {
+	siteId: number;
+}
+
+const SiteAdminInterfaceExperiment = ( { siteId }: Props ) => {
+	const [ isLoading, assignment ] = useExperiment( 'calypso_site_settings_simple_classic' );
+
+	if ( isLoading || assignment?.variationName !== 'treatment' ) {
+		return null;
+	}
+
+	return <SiteAdminInterface siteId={ siteId } />;
+};
+
+export default SiteAdminInterfaceExperiment;

--- a/client/my-sites/site-settings/site-admin-interface/experiment.tsx
+++ b/client/my-sites/site-settings/site-admin-interface/experiment.tsx
@@ -3,16 +3,17 @@ import SiteAdminInterface from './';
 
 interface Props {
 	siteId: number;
+	siteSlug: string;
 }
 
-const SiteAdminInterfaceExperiment = ( { siteId }: Props ) => {
+const SiteAdminInterfaceExperiment = ( { siteId, siteSlug }: Props ) => {
 	const [ isLoading, assignment ] = useExperiment( 'calypso_site_settings_simple_classic' );
 
 	if ( isLoading || assignment?.variationName !== 'treatment' ) {
 		return null;
 	}
 
-	return <SiteAdminInterface siteId={ siteId } />;
+	return <SiteAdminInterface siteId={ siteId } siteSlug={ siteSlug } />;
 };
 
 export default SiteAdminInterfaceExperiment;

--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -35,7 +35,7 @@ const FormRadioStyled = styled( FormRadio )( {
 	},
 } );
 
-const SiteAdminInterface = ( { siteId, siteSlug, isHosting } ) => {
+const SiteAdminInterface = ( { siteId, siteSlug, isHosting = false } ) => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const dispatch = useDispatch();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7057

## Proposed Changes

* Introduce the `SiteAdminInterfaceExperiment` to control the A/B testing for the `Admin Interface Style`
* The experiment is enabled only when the feature flag, `layout/wpcom-admin-interface`, is turned on the production

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /settings/general/<your_simple_site>?flags=-layout/wpcom-admin-interface
* Make sure the Admin Interface Style setting keeps hidden as the experiment is not created yet

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
