### PR TITLE
Fix Blaze Advertising URL for Classic sites in Marketing Traffic page

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -9,6 +9,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import CloudflareAnalyticsSettings from 'calypso/my-sites/site-settings/analytics/form-cloudflare-analytics';
 import AnalyticsSettings from 'calypso/my-sites/site-settings/analytics/form-google-analytics';
 import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mode-notice';
@@ -21,7 +22,7 @@ import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form'
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isBlazeEnabled from 'calypso/state/selectors/is-blaze-enabled';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -37,7 +38,6 @@ const SiteSettingsTraffic = ( {
 	isSavingSettings,
 	setFieldValue,
 	siteId,
-	siteSlug,
 	shouldShowAdvertisingOption,
 	translate,
 } ) => {
@@ -47,6 +47,8 @@ const SiteSettingsTraffic = ( {
 			document.getElementById( window.location.hash.substring( 1 ) )?.scrollIntoView();
 		}
 	}, [] );
+
+	const advertisingUrl = useAdvertisingUrl();
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -70,7 +72,7 @@ const SiteSettingsTraffic = ( {
 					) }
 					ctaText={ translate( 'Get started' ) }
 					image={ blazeIllustration }
-					href={ `/advertising/${ siteSlug || '' }` }
+					href={ advertisingUrl }
 				/>
 			) }
 			{ isAdmin && <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> }
@@ -119,7 +121,6 @@ const SiteSettingsTraffic = ( {
 
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const site = getSelectedSite( state );
 	const isAdmin = canCurrentUser( state, siteId, 'manage_options' );
 	const isJetpack = isJetpackSite( state, siteId );
 	const isJetpackAdmin = isJetpack && isAdmin;
@@ -127,7 +128,6 @@ const connectComponent = connect( ( state ) => {
 
 	return {
 		siteId,
-		siteSlug: site?.slug,
 		isAdmin,
 		isJetpack,
 		isJetpackAdmin,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7653

## Proposed Changes

* Sites set to Classic Mode will redirect to the `/wp-admin` Blaze in Marketing > Traffic

![marketing](https://github.com/Automattic/wp-calypso/assets/6586048/ac942ef7-434e-466e-9a27-62aa09c5940a)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In Classic Mode https://wordpress.com/advertising/:site does not exist in the sidebar

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To enable Simple Classic, create a Simple Site, and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
```

* Go to Hosting > Marketing > Traffic
* Click on the Blaze CTA
* Should be directed to Jetpack Blaze
* With a Default site, it should be directed to Calypso Blaze (no Jetpack branding at the top

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
