### PR TITLE
Stepper: Add a flag to skip the `calypso_signup_start` on sign up flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,0 +1,35 @@
+import { SENSEI_FLOW } from '@automattic/onboarding';
+import { useEffect, useMemo } from 'react';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { recordSignupStart } from 'calypso/lib/analytics/signup';
+import { type Flow } from '../../types';
+
+/**
+ * Hook to track the start of a signup flow.
+ */
+interface Props {
+	flow: Flow;
+	currentStepRoute: string;
+}
+
+export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
+	const steps = flow.useSteps();
+	const queryParams = useQuery();
+	const ref = queryParams.get( 'ref' ) || '';
+	const signedUp = queryParams.has( 'signed_up' );
+
+	// TODO: Check if we can remove the sensei flow reference from here.
+	const firstStepSlug = ( flow.name === SENSEI_FLOW ? steps[ 1 ] : steps[ 0 ] ).slug;
+	const isFirstStep = firstStepSlug === currentStepRoute;
+	const extraProps = useMemo( () => flow.useSignupStartEventProps?.() || {}, [ flow ] );
+	const flowName = flow.name;
+	const shouldTrack = flow.isSignupFlow && isFirstStep && ! signedUp;
+
+	useEffect( () => {
+		if ( ! shouldTrack ) {
+			return;
+		}
+
+		recordSignupStart( flowName, ref, extraProps );
+	}, [ extraProps, flowName, ref, shouldTrack ] );
+};

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { SENSEI_FLOW } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
+import { useSignUpStartTracking } from '../';
+import type { Flow, StepperStep } from '../../../types';
+
+const steps = [ { slug: 'step-1' }, { slug: 'step-2' } ] as StepperStep[];
+
+const regularFlow: Flow = {
+	name: 'regular-flow',
+	useSteps: () => steps,
+	useStepNavigation: () => ( {
+		submit: () => {},
+	} ),
+	isSignupFlow: false,
+};
+
+const signUpFlow: Flow = {
+	...regularFlow,
+	name: 'sign-up-flow',
+	isSignupFlow: true,
+};
+
+const senseiFlow: Flow = {
+	...regularFlow,
+	name: SENSEI_FLOW,
+	// The original sensei flow is missing the isSignupFlow flag as true, it will be addressed by wp-calypso/pull/91593
+	isSignupFlow: true,
+};
+
+jest.mock( '@automattic/calypso-analytics' );
+
+const render = ( { flow, currentStepRoute, queryParams = {} } ) => {
+	return renderHookWithProvider(
+		() =>
+			useSignUpStartTracking( {
+				flow,
+				currentStepRoute,
+			} ),
+		{
+			wrapper: ( { children } ) => (
+				<MemoryRouter initialEntries={ [ addQueryArgs( `/setup/${ flow.name }`, queryParams ) ] }>
+					{ children }
+				</MemoryRouter>
+			),
+		}
+	);
+};
+
+describe( 'useSignUpTracking', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'does not track event when the flow is not a isSignupFlow', () => {
+		render( { flow: regularFlow, currentStepRoute: 'step-1' } );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'sign-up-flow', () => {
+		it( 'tracks the event current step is first step', () => {
+			render( {
+				flow: signUpFlow,
+				currentStepRoute: 'step-1',
+				queryParams: { ref: 'another-flow-or-cta' },
+			} );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
+				flow: 'sign-up-flow',
+				ref: 'another-flow-or-cta',
+			} );
+		} );
+
+		it( 'skips the tracking when the signed up flag is set', () => {
+			render( {
+				flow: signUpFlow,
+				currentStepRoute: 'step-1',
+				queryParams: { signed_up: 1 },
+			} );
+
+			expect( recordTracksEvent ).not.toHaveBeenCalled();
+		} );
+
+		it( 'tracks the event with extra props from useSighupStartEventProps', () => {
+			render( {
+				flow: {
+					...signUpFlow,
+					useSignupStartEventProps: () => ( { extra: 'props' } ),
+				} satisfies Flow,
+				currentStepRoute: 'step-1',
+				queryParams: { ref: 'another-flow-or-cta' },
+			} );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
+				flow: 'sign-up-flow',
+				ref: 'another-flow-or-cta',
+				extra: 'props',
+			} );
+		} );
+
+		it( 'does not track events current step is NOT the first step', () => {
+			render( { flow: signUpFlow, currentStepRoute: 'step-2' } );
+
+			expect( recordTracksEvent ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not track events current step is the first step AND the user is returning from the sign in flow', () => {
+			render( { flow: signUpFlow, currentStepRoute: 'step-1', queryParams: { signed_up: true } } );
+
+			expect( recordTracksEvent ).not.toHaveBeenCalled();
+		} );
+
+		// Check if sensei is a sign-up flow;
+		it( "tracks when the user is on the sensei's flow second step", () => {
+			render( { flow: senseiFlow, currentStepRoute: 'step-2' } );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
+				flow: SENSEI_FLOW,
+				ref: '',
+			} );
+		} );
+
+		it( 'does not trigger the event on rerender', () => {
+			const { rerender } = render( {
+				flow: { ...signUpFlow, useSignupStartEventProps: () => ( { extra: 'props' } ) },
+				currentStepRoute: 'step-1',
+				queryParams: { ref: 'another-flow-or-cta' },
+			} );
+
+			rerender();
+
+			expect( recordTracksEvent ).toHaveBeenNthCalledWith( 1, 'calypso_signup_start', {
+				flow: 'sign-up-flow',
+				ref: 'another-flow-or-cta',
+				extra: 'props',
+			} );
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,28 +1,27 @@
 import {
-	SENSEI_FLOW,
 	isNewsletterOrLinkInBioFlow,
 	isSenseiFlow,
 	isWooExpressFlow,
 } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useEffect, useCallback, useMemo, Suspense, lazy } from 'react';
+import React, { useEffect, useMemo, Suspense, lazy } from 'react';
 import Modal from 'react-modal';
 import { Navigate, Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
-import { recordSignupStart } from 'calypso/lib/analytics/signup';
 import AsyncCheckoutModal from 'calypso/my-sites/checkout/modal/async';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
-import { useQuery } from '../../hooks/use-query';
 import { useSaveQueryParams } from '../../hooks/use-save-query-params';
 import { useSiteData } from '../../hooks/use-site-data';
 import useSyncRoute from '../../hooks/use-sync-route';
 import { ONBOARD_STORE } from '../../stores';
 import { StepRoute, StepperLoader } from './components';
+import { useSignUpStartTracking } from './hooks/use-sign-up-start-tracking';
 import { AssertConditionState, type Flow, type StepperStep, type StepProps } from './types';
 import type { OnboardSelect, StepperInternalSelect } from '@automattic/data-stores';
+
 import './global.scss';
 
 /**
@@ -40,6 +39,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	Modal.setAppElement( '#wpcom' );
 	const flowSteps = flow.useSteps();
 	const stepPaths = flowSteps.map( ( step ) => step.slug );
+
 	const stepComponents: Record< string, React.FC< StepProps > > = useMemo(
 		() =>
 			flowSteps.reduce(
@@ -64,7 +64,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	);
 
 	useSaveQueryParams();
-	const ref = useQuery().get( 'ref' ) || '';
 
 	const { site, siteSlugOrId } = useSiteData();
 
@@ -90,18 +89,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		// some steps, and they'll simply be loaded later.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ flow, siteSlugOrId, selectedSite ] );
-
-	const isFlowStart = useCallback( () => {
-		if ( ! flow || ! stepPaths.length ) {
-			return false;
-		}
-
-		if ( flow.name === SENSEI_FLOW ) {
-			return currentStepRoute === stepPaths[ 1 ];
-		}
-
-		return currentStepRoute === stepPaths[ 0 ];
-	}, [ flow, currentStepRoute, ...stepPaths ] );
 
 	const _navigate = async ( path: string, extraData = {} ) => {
 		// If any extra data is passed to the navigate() function, store it to the stepper-internal store.
@@ -139,16 +126,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		window.scrollTo( 0, 0 );
 	}, [ location ] );
 
-	// Get any flow-specific event props to include in the
-	// `calypso_signup_start` Tracks event triggerd in the effect below.
-	const signupStartEventProps = flow.useSignupStartEventProps?.() ?? {};
-
-	useEffect( () => {
-		if ( flow.isSignupFlow && isFlowStart() ) {
-			recordSignupStart( flow.name, ref, signupStartEventProps );
-		}
-	}, [ flow, ref, isFlowStart ] );
-
 	const assertCondition = flow.useAssertConditions?.( _navigate ) ?? {
 		state: AssertConditionState.SUCCESS,
 	};
@@ -183,6 +160,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 			return __( 'Course Creator' );
 		}
 	};
+
+	useSignUpStartTracking( { flow, currentStepRoute: currentStepRoute } );
 
 	return (
 		<Suspense fallback={ <StepperLoader /> }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Solves part of  #91280

## Proposed Changes
* Move all `calypso_signup_start` to a separate hook with automated tests.
* Add a `signed_up` flag to skip the `calypso_signup_start` event when the user backs from the `/account/user` page.

## Why are these changes being made?
We observed duplicated instance of `calypso_signup_start`. It is caused by the follow sequence of user interactions:
* A non-logged user starts a signup flow (e.g. `/setup/migration-signup`)
* The flow will trigger the `calypso_signup_start` 
* The user is  redirected to /account/users with a redirect_to query param
* After the login/signing the user is redirected back to the original flow
* The original flow calls the `calypso_signup_start` again

The overall idea is to add a flag to the redirect_to param to indicate the user is backing from a sign-in flow. 

> [!NOTE]
>  I am going to add the flag on the redirect_to on my next PR.


## Testing Instructions
* Open any flow with the flag `isSignupFlow` (E.g `/setup/migration-signup`)
* Check if the event `calypso_signup_start` was triggered
* Add the flag `signed_up=1` to the current URL (E.g. `/setup/migration-signup/site-migration-identify?siteSlug=YOUR_SITE&signed_up=1`
* Reload the page and check if no `calypso_signup_start` is triggered. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
