### PR TITLE
Update Recent to Home in Reader

### DIFF
--- a/client/reader/components/icons/following-icon.jsx
+++ b/client/reader/components/icons/following-icon.jsx
@@ -8,7 +8,12 @@ export default function ReaderFollowingIcon() {
 			width="20"
 			xmlns="http://www.w3.org/2000/svg"
 		>
-			<path d="m3 10.2794 4.48 4.4706 9.52-9.5" stroke="#a2aab2" strokeWidth="1.5" />
+			<path
+				d="M18 5.57142V17H12.2857V10.1428H7.71428V17H2V5.57142L9.99999 1L18 5.57142Z"
+				stroke="#a2aab2"
+				strokeLinecap="round"
+				strokeWidth="1.5"
+			/>
 		</svg>
 	);
 }

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -126,7 +126,7 @@ export function following( context, next ) {
 		{ pathnameOverride: getCurrentRoute( state ) }
 	);
 
-	setPageTitle( context, i18n.translate( 'Following' ) );
+	setPageTitle( context, i18n.translate( 'Home' ) );
 
 	// warn: don't async load this only. we need it to keep feed-post-store in the reader bundle
 	context.primary = createElement( StreamComponent, {

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -21,7 +21,7 @@ function FollowingStream( { ...props } ) {
 			>
 				<BloganuaryHeader />
 				<NavigationHeader
-					title={ translate( 'Recent' ) }
+					title={ translate( 'Home' ) }
 					subtitle={ translate( "Stay current with the blogs you've subscribed to." ) }
 					className={ classNames( 'following-stream-header', {
 						'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -193,7 +193,7 @@ export class ReaderSidebar extends Component {
 					className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {
 						'sidebar-streams__following': true,
 					} ) }
-					label={ recentLabelTranslationReady ? translate( 'Recent' ) : translate( 'Following' ) }
+					label={ recentLabelTranslationReady ? translate( 'Home' ) : translate( 'Following' ) }
 					onNavigate={ this.handleReaderSidebarFollowedSitesClicked }
 					customIcon={ <ReaderFollowingIcon /> }
 					link="/read"

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -1,6 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { hasTranslation } from '@wordpress/i18n';
 import closest from 'component-closest';
 import i18n, { localize } from 'i18n-calypso';
 import { defer, startsWith } from 'lodash';
@@ -169,8 +168,7 @@ export class ReaderSidebar extends Component {
 	};
 
 	renderSidebarMenu() {
-		const { path, translate, teams, locale } = this.props;
-		const recentLabelTranslationReady = hasTranslation( 'Recent' ) || locale.startsWith( 'en' );
+		const { path, translate, teams } = this.props;
 		return (
 			<SidebarMenu>
 				<QueryReaderLists />
@@ -193,7 +191,7 @@ export class ReaderSidebar extends Component {
 					className={ ReaderSidebarHelper.itemLinkClass( '/read', path, {
 						'sidebar-streams__following': true,
 					} ) }
-					label={ recentLabelTranslationReady ? translate( 'Home' ) : translate( 'Following' ) }
+					label={ translate( 'Home' ) }
 					onNavigate={ this.handleReaderSidebarFollowedSitesClicked }
 					customIcon={ <ReaderFollowingIcon /> }
 					link="/read"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Proposal to update `Recent` to something more meaningful and contextual like `Home`. 
This approach is also an industry standard, with platforms like Twitter, LinkedIn, Substack and even our very own Tumblr using it.

**Before**
<img width="928" alt="Screenshot 2024-06-07 at 15 24 17" src="https://github.com/Automattic/wp-calypso/assets/25607244/acfb7858-8cbb-4f4c-8fc4-fdc1526df1e7">

**After**
<img width="933" alt="Screenshot 2024-06-07 at 15 24 07" src="https://github.com/Automattic/wp-calypso/assets/25607244/ac2a43ab-d3f1-4be5-8b54-19917a08f72a">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this branch
* Check /read

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
