### PR TITLE
Bug fix: Calyspo "My Plans" is blank for the legacy Starter plan

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -394,7 +394,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				[ TYPE_BLOGGER ]: () => this.getBloggerFeatures(),
 				[ TYPE_PRO ]: () => this.getProFeatuers(),
 				[ TYPE_100_YEAR ]: () => this.getBusinessFeatures(),
-				[ TYPE_STARTER ]: () => this.getStarterFeatuers(),
+				[ TYPE_STARTER ]: () => this.getWPCOMLegacyStarterFeatures(),
 			},
 			[ GROUP_JETPACK ]: {
 				[ TYPE_BUSINESS ]: () => this.getJetpackBusinessFeatures(),

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -22,6 +22,7 @@ import {
 	TYPE_WOOEXPRESS_MEDIUM,
 	TYPE_WOOEXPRESS_SMALL,
 	TYPE_100_YEAR,
+	TYPE_STARTER,
 } from '@automattic/calypso-products';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -360,6 +361,20 @@ export class ProductPurchaseFeaturesList extends Component {
 		);
 	}
 
+	// Features of the legacy Starter plan in WPCOM that was launched along with the Pro plan in 2022.
+	getWPCOMLegacyStarterFeatures() {
+		const { selectedSite, planHasDomainCredit } = this.props;
+
+		return (
+			<Fragment>
+				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
+				<GoogleAnalyticsStats selectedSite={ selectedSite } />
+				<SiteActivity />
+				<MobileApps onClick={ this.handleMobileAppsClick } />
+			</Fragment>
+		);
+	}
+
 	getFeatures() {
 		const { plan, isPlaceholder } = this.props;
 
@@ -379,6 +394,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				[ TYPE_BLOGGER ]: () => this.getBloggerFeatures(),
 				[ TYPE_PRO ]: () => this.getProFeatuers(),
 				[ TYPE_100_YEAR ]: () => this.getBusinessFeatures(),
+				[ TYPE_STARTER ]: () => this.getStarterFeatuers(),
 			},
 			[ GROUP_JETPACK ]: {
 				[ TYPE_BUSINESS ]: () => this.getJetpackBusinessFeatures(),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* The logged-in "My Plans" page is blank for the legacy Starter (2022) plan. They appear to be inadvertently removed in https://github.com/Automattic/wp-calypso/pull/78965 which was to make changes to the Jetpack Starter plan. This PR restores the WPCOM Starter plan

### BEFORE

<img width="1306" alt="Screenshot 2024-06-07 at 6 58 19 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/fd6dc7cb-1380-4c68-8d70-65d182c7716b">


### AFTER

<img width="1311" alt="Screenshot 2024-06-07 at 7 36 38 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/59cd948c-820f-4fa3-9b98-cd19a2b88530">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Issue reported in p1717764803740669?thread_ts=1717761133.517119-slack-C02BEP610.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sign in to any account with a free plan and purchase the legacy Starter plan (check 34b44-pb on how to purchase this plan).
* Visit `/plans/my-plan/SITE_SLUG` and verify that you see the legacy Starter plan features.

