### PR TITLE
Update style to prevent last line getting hidden in mobile

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/breakpoints";
 
 .import__capture-container {
 	max-width: 368px;
@@ -79,9 +80,14 @@
 	display: flex;
 	flex-direction: column;
 	gap: 1.25rem;
-	margin: 40px auto;
+	margin: 40px auto 0 auto;
 	max-width: 368px;
 	padding: 1.5rem;
+
+	@media (max-width: $break-small) {
+		margin: 40px auto 60px auto;
+	}
+
 
 	&--title {
 		color: var(--studio-gray-100);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -79,7 +79,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 1.25rem;
-	margin: 40px auto 0 auto;
+	margin: 40px auto;
 	max-width: 368px;
 	padding: 1.5rem;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/91584

## Proposed Changes

* In mobile display, the last line of text was getting hidden. We've added margin in the bottom to fix it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- To make all part of the text visible

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure your language is English in https://wordpress.com/me/account
- In the migration flow (take any migration path, for example http://calypso.localhost:3000/start), navigate to the Site Identification step
- Check that "Why host with us" section is visible with all the points, the design also visually matches the design in the issue
- Now change display to mobile view
- Scroll down to the bottom.
- Make sure you can see the full text.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
