### PR TITLE
Login: Fix migrate notice events not triggering

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -899,7 +899,12 @@ export class LoginForm extends Component {
 									name="calypso_login_failed_show_migrate_cta_202406"
 									defaultExperience={ null }
 									loadingExperience={ null }
-									treatmentExperience={ <MigrateNotice /> }
+									treatmentExperience={
+										<MigrateNotice
+											translate={ this.props.translate }
+											recordTracksEvent={ this.props.recordTracksEvent }
+										/>
+									}
 								/>
 							</Fragment>
 						) }

--- a/client/blocks/login/migrate-notice.jsx
+++ b/client/blocks/login/migrate-notice.jsx
@@ -1,20 +1,13 @@
 import { MaterialIcon } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './migrate-notice.scss';
 
-const MigrateNotice = () => {
-	const translate = useTranslate();
-
+const MigrateNotice = ( { translate, recordTracksEvent } ) => {
 	const recordClick = () => {
 		recordTracksEvent( 'calypso_login_failed_migrate_notice_cta_click' );
 	};
 
-	useEffect( () => {
-		recordTracksEvent( 'calypso_login_failed_migrate_notice_show' );
-	}, [] );
+	recordTracksEvent( 'calypso_login_failed_migrate_notice_show' );
 
 	return (
 		<div className="login__form-migrate-notice">

--- a/client/blocks/login/test/migrate-notice.jsx
+++ b/client/blocks/login/test/migrate-notice.jsx
@@ -1,15 +1,18 @@
 /**
  * @jest-environment jsdom
  */
-import { screen, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import MigrateNotice from 'calypso/blocks/login/migrate-notice';
 
 describe( 'MigrateNotice', () => {
-	test( 'displays a migrate notice with a link to wordpress.com/move/', () => {
-		render( <MigrateNotice /> );
+	const defaultProps = {
+		translate: ( string ) => string,
+		recordTracksEvent: jest.fn(),
+	};
 
-		expect(
-			screen.getByRole( 'link', { name: 'Get help moving your site to WordPress.com' } )
-		).toHaveAttribute( 'href', 'https://wordpress.com/move/' );
+	test( 'displays a migrate notice', () => {
+		const { container } = render( <MigrateNotice { ...defaultProps } /> );
+
+		expect( container.getElementsByClassName( 'login__form-migrate-notice' ) ).toHaveLength( 1 );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91188

## Proposed Changes

* This PR fixes the migration notice events not triggering/recording.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The events are essential for the planned experiment: pbxNRc-3KU-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In a new incognito session, go to http://calypso.localhost:3000/log-in
* Manually assign yourself to the "Treatment" group of the 21821-explat-experiment following this guide: PCYsg-SwK-p2 (Manually assign with Abacus assignment bookmarklet)

https://github.com/Automattic/wp-calypso/assets/1612178/a1c9da06-e219-4f44-895f-76f326bfefd0


* After assigning yourself to the "Treatment" group, enter a non-existing email.
* Verify that you see the "User does not exist." error and the migration notice.
* To see the events that are being fired, follow this guide: PCYsg-cae-p2, or check the tracks live view page in MC.
* Make sure the `calypso_login_failed_migrate_notice_cta_click` and `calypso_login_failed_migrate_notice_show` events are tracked.
* If following the above mentioned guide, the console should look like this:
![SRnxON.png](https://github.com/Automattic/wp-calypso/assets/1612178/784f9096-ce09-4a0e-921f-bac36b0fbbb9)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?