### PR TITLE
Refactor list of site importers into a single location

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -5,6 +5,10 @@ import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import {
+	getImportersAsImporterOption,
+	type ImporterConfigPriority,
+} from 'calypso/lib/importer/importer-config';
 import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
 import type { ImporterPlatform } from '../types';
 import './style.scss';
@@ -15,10 +19,11 @@ const trackEventParams = {
 	step: 'list',
 };
 
-interface ImporterOption {
+export interface ImporterOption {
 	value: ImporterPlatform;
 	label: string;
 	icon?: string;
+	priority?: ImporterConfigPriority;
 }
 
 interface Props {
@@ -39,22 +44,14 @@ export default function ListStep( props: Props ) {
 	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
 	const backToFlow = urlQueryParams.get( 'backToFlow' );
 
-	const primaryListOptions: ImporterOption[] = [
-		{ value: 'wordpress', label: 'WordPress', icon: 'wordpress' },
-		{ value: 'blogger', label: 'Blogger', icon: 'blogger-alt' },
-		{ value: 'medium', label: 'Medium', icon: 'medium' },
-		{ value: 'squarespace', label: 'Squarespace', icon: 'squarespace' },
-	];
-
-	const secondaryListOptions: ImporterOption[] = [
-		{ value: 'blogroll', label: 'Blogroll' },
-		{ value: 'ghost', label: 'Ghost' },
-		{ value: 'livejournal', label: 'LiveJournal' },
-		{ value: 'movabletype', label: 'Movable Type & TypePad' },
-		{ value: 'substack', label: 'Substack' },
-		{ value: 'tumblr', label: 'Tumblr' },
-		{ value: 'xanga', label: 'Xanga' },
-	];
+	// We need to remove the wix importer from the primary importers list.
+	const primaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'primary' ).filter(
+		( option ) => option.value !== 'wix'
+	);
+	// We need to remove the icon property for secondary importers to avoid display issues.
+	const secondaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'secondary' ).map(
+		( { icon, ...rest } ) => rest
+	);
 
 	const onImporterSelect = ( platform: ImporterPlatform ): void => {
 		const importerUrl = getFinalImporterUrl(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -8,6 +8,7 @@ import {
 	getWpOrgImporterUrl,
 } from 'calypso/blocks/import/util';
 import { WPImportOption } from 'calypso/blocks/importer/wordpress/types';
+import { getImporterEngines } from 'calypso/lib/importer/importer-config';
 import { BASE_ROUTE } from './config';
 
 export function getFinalImporterUrl(
@@ -18,7 +19,7 @@ export function getFinalImporterUrl(
 ) {
 	let importerUrl;
 	const encodedFromSite = encodeURIComponent( fromSite );
-	const productImporters = [ 'blogger', 'medium', 'substack', 'squarespace', 'wix', 'wordpress' ];
+	const productImporters = getImporterEngines();
 
 	if ( productImporters.includes( platform ) ) {
 		importerUrl = isEnabled( `onboarding/import-from-${ platform }` )

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -14,6 +14,7 @@ export interface ImporterConfig {
 	engine: string;
 	key: string;
 	type: 'file' | 'url';
+	priority: 'primary' | 'secondary';
 	title: string;
 	icon: string;
 	description: TranslateResult;
@@ -50,6 +51,7 @@ function getConfig( {
 		engine: 'wordpress',
 		key: 'importer-type-wordpress',
 		type: 'file',
+		priority: 'primary',
 		title: 'WordPress',
 		icon: 'wordpress',
 		description: (
@@ -89,6 +91,7 @@ function getConfig( {
 		engine: 'blogger',
 		key: 'importer-type-blogger',
 		type: 'file',
+		priority: 'primary',
 		title: 'Blogger',
 		icon: 'blogger-alt',
 		description: (
@@ -131,6 +134,7 @@ function getConfig( {
 		engine: 'medium',
 		key: 'importer-type-medium',
 		type: 'file',
+		priority: 'primary',
 		title: 'Medium',
 		icon: 'medium',
 		description: (
@@ -171,6 +175,7 @@ function getConfig( {
 		engine: 'substack',
 		key: 'importer-type-substack',
 		type: 'file',
+		priority: 'primary',
 		title: 'Substack',
 		icon: 'substack',
 		description: (
@@ -225,6 +230,7 @@ function getConfig( {
 		engine: 'squarespace',
 		key: 'importer-type-squarespace',
 		type: 'file',
+		priority: 'primary',
 		title: 'Squarespace',
 		icon: 'squarespace',
 		description: (
@@ -267,6 +273,7 @@ function getConfig( {
 		engine: 'wix',
 		key: 'importer-type-wix',
 		type: 'url',
+		priority: 'primary',
 		title: 'Wix',
 		icon: 'wix',
 		description: (

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -309,6 +309,17 @@ function getConfig( {
 	return importerConfig;
 }
 
+export function getImporterEngines(): string[] {
+	const importerConfig = getConfig( {} );
+	const engines = [];
+
+	for ( const config in importerConfig ) {
+		engines.push( importerConfig[ config ].engine );
+	}
+
+	return engines;
+}
+
 export function getImporters( args: ImporterConfigArgs = { siteSlug: '', siteTitle: '' } ) {
 	const importerConfig = getConfig( args );
 

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -316,18 +316,6 @@ function getConfig( {
 		weight: 0,
 	};
 
-	importerConfig.ghost = {
-		engine: 'ghost',
-		key: 'importer-type-ghost',
-		type: 'url',
-		priority: 'secondary',
-		title: 'Ghost',
-		icon: 'ghost',
-		description: '',
-		uploadDescription: '',
-		weight: 0,
-	};
-
 	importerConfig.livejournal = {
 		engine: 'livejournal',
 		key: 'importer-type-livejournal',

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -1,6 +1,8 @@
 import config from '@automattic/calypso-config';
 import { TranslateResult, translate } from 'i18n-calypso';
 import { filter, orderBy, values } from 'lodash';
+import { type ImporterOption } from 'calypso/blocks/import/list';
+import { type ImporterPlatform } from 'calypso/blocks/import/types';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { appStates } from 'calypso/state/imports/constants';
 
@@ -10,11 +12,12 @@ export interface ImporterOptionalURL {
 	invalidDescription: TranslateResult;
 }
 
+export type ImporterConfigPriority = 'primary' | 'secondary';
 export interface ImporterConfig {
 	engine: string;
 	key: string;
 	type: 'file' | 'url';
-	priority: 'primary' | 'secondary';
+	priority: ImporterConfigPriority;
 	title: string;
 	icon: string;
 	description: TranslateResult;
@@ -301,6 +304,90 @@ function getConfig( {
 		weight: 0,
 	};
 
+	importerConfig.blogroll = {
+		engine: 'blogroll',
+		key: 'importer-type-blogroll',
+		type: 'url',
+		priority: 'secondary',
+		title: 'Blogroll',
+		icon: 'blogroll',
+		description: '',
+		uploadDescription: '',
+		weight: 0,
+	};
+
+	importerConfig.ghost = {
+		engine: 'ghost',
+		key: 'importer-type-ghost',
+		type: 'url',
+		priority: 'secondary',
+		title: 'Ghost',
+		icon: 'ghost',
+		description: '',
+		uploadDescription: '',
+		weight: 0,
+	};
+
+	importerConfig.livejournal = {
+		engine: 'livejournal',
+		key: 'importer-type-livejournal',
+		type: 'url',
+		priority: 'secondary',
+		title: 'LiveJournal',
+		icon: 'livejournal',
+		description: '',
+		uploadDescription: '',
+		weight: 0,
+	};
+
+	importerConfig.movabletype = {
+		engine: 'movabletype',
+		key: 'importer-type-movabletype',
+		type: 'url',
+		priority: 'secondary',
+		title: 'Movable Type & TypePad',
+		icon: 'movabletype',
+		description: '',
+		uploadDescription: '',
+		weight: 0,
+	};
+
+	importerConfig.substack = {
+		engine: 'substack',
+		key: 'importer-type-substack',
+		type: 'url',
+		priority: 'secondary',
+		title: 'Substack',
+		icon: 'substack',
+		description: '',
+		uploadDescription: '',
+		weight: 0,
+	};
+
+	importerConfig.tumblr = {
+		engine: 'tumblr',
+		key: 'importer-type-tumblr',
+		type: 'url',
+		priority: 'secondary',
+		title: 'Tumblr',
+		icon: 'tumblr',
+		description: '',
+		uploadDescription: '',
+		weight: 0,
+	};
+
+	importerConfig.xanga = {
+		engine: 'xanga',
+		key: 'importer-type-xanga',
+		type: 'url',
+		priority: 'secondary',
+		title: 'Xanga',
+		icon: 'xanga',
+		description: '',
+		uploadDescription: '',
+		weight: 0,
+	};
+
 	const hasUnifiedImporter = config.isEnabled( 'importer/unified' );
 
 	// For Jetpack sites, we don't support migration as destination, so we remove the override here.
@@ -325,6 +412,26 @@ export function getImporterEngines(): string[] {
 	}
 
 	return engines;
+}
+
+export function getImportersAsImporterOption( priority: ImporterConfigPriority ): ImporterOption[] {
+	const importerConfig = getConfig( {} );
+	const importerOptions: ImporterOption[] = [];
+
+	for ( const config in importerConfig ) {
+		if ( importerConfig[ config ].priority !== priority ) {
+			continue;
+		}
+
+		importerOptions.push( {
+			value: importerConfig[ config ].engine as ImporterPlatform,
+			label: importerConfig[ config ].title,
+			icon: importerConfig[ config ].icon,
+			priority: priority,
+		} );
+	}
+
+	return importerOptions;
 }
 
 export function getImporters( args: ImporterConfigArgs = { siteSlug: '', siteTitle: '' } ) {

--- a/client/lib/importer/test/importer-config.tsx
+++ b/client/lib/importer/test/importer-config.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { getImporterEngines } from '../importer-config';
+import { getImporterEngines, getImportersAsImporterOption } from '../importer-config';
 
 describe( 'importer-config', () => {
 	test( 'It retrieves the importer engines', () => {
@@ -10,5 +10,21 @@ describe( 'importer-config', () => {
 
 		expect( Array.isArray( importerEngines ) ).toBeTruthy();
 		expect( importerEngines.every( ( item ) => typeof item === 'string' ) ).toBeTruthy();
+	} );
+
+	test( 'It retrieves the importer primary configs as ImporterOptions', () => {
+		const importerOptions = getImportersAsImporterOption( 'primary' );
+
+		expect( Array.isArray( importerOptions ) ).toBeTruthy();
+		expect( importerOptions.length ).toBeGreaterThan( 0 );
+		expect( importerOptions.every( ( item ) => item?.priority === 'primary' ) ).toBeTruthy();
+	} );
+
+	test( 'It retrieves the importer secondary configs as ImporterOptions', () => {
+		const importerOptions = getImportersAsImporterOption( 'secondary' );
+
+		expect( Array.isArray( importerOptions ) ).toBeTruthy();
+		expect( importerOptions.length ).toBeGreaterThan( 0 );
+		expect( importerOptions.every( ( item ) => item?.priority === 'secondary' ) ).toBeTruthy();
 	} );
 } );

--- a/client/lib/importer/test/importer-config.tsx
+++ b/client/lib/importer/test/importer-config.tsx
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getImporterEngines } from '../importer-config';
+
+describe( 'importer-config', () => {
+	test( 'It retrieves the importer engines', () => {
+		const importerEngines = getImporterEngines();
+
+		expect( Array.isArray( importerEngines ) ).toBeTruthy();
+		expect( importerEngines.every( ( item ) => typeof item === 'string' ) ).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90635

## Proposed Changes

This updates the `getConfig` function in `client/lib/importer/importer-config.tsx` to be the single source of information about available site importers. 

It also updates the `ListStep` and `getFinalImporterUrl` helper so they pull the data they need from the updated `getConfig` function.

This is done with two new functions:

* `getImporterEngines` which returns a list of the importer engine slugs.
* `getImportersAsImporterOption` which returns either the primary or secondary importers in the `ImporterOption` format.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Previously, there were multiple lists of importers in different places. Having a single source of truth will make it easier to keep track of things and make updates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are tests for the two new functions for retrieving importer details:

```
yarn test-client client/lib/importer/test/importer-config.tsx
```

To test the actual UI, you can use either calypso.live or check out this branch and run it locally.

Then there are two ways to get to the importer list.

1. Visit `/sites`, click the `^` next to "Add new site" and click "Import an existing site".
2. Or you can go through `/start` and select the "Import existing content or website" Goal.

You'll eventually arrive at the "Let's find your site" step
![image](https://github.com/Automattic/wp-calypso/assets/917632/ab615c2f-27c5-46fd-851f-04b14e715f5b)

Click "pick your current platform from a list". You should be taken to "Import content from another platform".
![6t3z50ieOx7qalbMSXgKqUYtgKoV3Z72Mk7yp1Dd.jpg](https://github.com/Automattic/wp-calypso/assets/917632/292ff4c5-33cd-4dae-956f-b9b3537474b6)

From here, verify that the options are displaying correctly. 

Then try clicking a few of the importers in the top section and in the "Other platforms" dropdown.

You should be taken to the correct import page for the source slte you selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?