### PR TITLE
Add Stepper framework login handling to ecommerce flow

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -7,8 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from 'react';
-import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
+import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	setSignupCompleteSlug,
@@ -19,8 +18,8 @@ import { useSite } from '../hooks/use-site';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
 import getQuantityFromStorageType from '../utils/get-quantity-from-storage-slug';
-import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { STEPS } from './internals/steps';
 import { AssertConditionState } from './internals/types';
 import type { Flow, ProvidedDependencies, AssertConditionResult } from './internals/types';
 import type {
@@ -57,37 +56,31 @@ const ecommerceFlow: Flow = {
 		return { recur };
 	},
 	useSteps() {
-		return [
+		const steps = [
 			{
 				slug: 'storeProfiler',
 				asyncComponent: () => import( './internals/steps-repository/store-profiler' ),
 			},
-			{ slug: 'domains', asyncComponent: () => import( './internals/steps-repository/domains' ) },
+			STEPS.DOMAINS,
 			{
 				slug: 'designCarousel',
 				asyncComponent: () => import( './internals/steps-repository/design-carousel' ),
 			},
 			{
+				// Note: the slug for STEPS.SITE_CREATION_STEP is 'create-site'
 				slug: 'createSite',
 				asyncComponent: () => import( './internals/steps-repository/create-site' ),
 			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
-			{
-				slug: 'waitForPluginInstall',
-				asyncComponent: () => import( './internals/steps-repository/wait-for-plugin-install' ),
-			},
-			{
-				slug: 'waitForAtomic',
-				asyncComponent: () => import( './internals/steps-repository/wait-for-atomic' ),
-			},
+			STEPS.PROCESSING,
+			STEPS.WAIT_FOR_PLUGIN_INSTALL,
+			STEPS.WAIT_FOR_ATOMIC,
 			{
 				slug: 'checkPlan',
 				asyncComponent: () => import( './internals/steps-repository/check-plan' ),
 			},
 		];
+
+		return stepsWithRequiredLogin( steps );
 	},
 
 	useAssertConditions(): AssertConditionResult {
@@ -97,67 +90,10 @@ const ecommerceFlow: Flow = {
 		);
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
-		const flags = new URLSearchParams( window.location.search ).get( 'flags' );
-		const flowName = this.name;
-
-		const locale = useFlowLocale();
-
-		const { recurType, couponCode, storageAddonSlug } = useSelect(
-			( select ) => ( {
-				recurType: ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
-				couponCode: ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
-				storageAddonSlug: ( select( ONBOARD_STORE ) as OnboardSelect ).getStorageAddonSlug(),
-			} ),
-			[]
-		);
-
-		const getStartUrl = () => {
-			let hasFlowParams = false;
-			const flowParams = new URLSearchParams();
-
-			if ( recurType !== ecommerceFlowRecurTypes.YEARLY ) {
-				flowParams.set( 'recur', recurType );
-				hasFlowParams = true;
-			}
-			if ( locale && locale !== 'en' ) {
-				flowParams.set( 'locale', locale );
-				hasFlowParams = true;
-			}
-
-			if ( couponCode || storageAddonSlug ) {
-				hasFlowParams = true;
-				flowParams.set( 'storage', storageAddonSlug );
-				flowParams.set( 'coupon', couponCode );
-			}
-
-			const redirectTarget =
-				`/setup/ecommerce/storeProfiler` +
-				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
-			const logInUrl = getLoginUrl( {
-				variationName: flowName,
-				redirectTo: redirectTarget,
-				locale,
-			} );
-
-			return logInUrl + ( flags ? `&flags=${ flags }` : '' );
-		};
-
-		// Despite sending a CHECKING state, this function gets called again with the
-		// /setup/blog/blogger-intent route which has no locale in the path so we need to
-		// redirect off of the first render.
-		// This effects both /setup/blog/<locale> starting points and /setup/blog/blogger-intent/<locale> urls.
-		// The double call also hapens on urls without locale.
-		useEffect( () => {
-			if ( ! userIsLoggedIn ) {
-				const logInUrl = getStartUrl();
-				window.location.assign( logInUrl );
-			}
-		}, [] );
-
 		if ( ! userIsLoggedIn ) {
 			result = {
 				state: AssertConditionState.FAILURE,
-				message: 'store-setup requires a logged in user',
+				message: 'ecommerce requires a logged in user',
 			};
 		}
 

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -110,13 +110,20 @@ const ecommerceFlow: Flow = {
 			resetStorageAddonSlug,
 		} = useDispatch( ONBOARD_STORE );
 		setPluginsToVerify( [ 'woocommerce' ] );
-		const { selectedDesign, recurType, couponCode, storageAddonSlug } = useSelect(
-			( select ) => ( {
-				selectedDesign: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
-				recurType: ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
-				couponCode: ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
-				storageAddonSlug: ( select( ONBOARD_STORE ) as OnboardSelect ).getStorageAddonSlug(),
-			} ),
+		const selectedDesign = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
+			[]
+		);
+		const recurType = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
+			[]
+		);
+		const couponCode = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
+			[]
+		);
+		const storageAddonSlug = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStorageAddonSlug(),
 			[]
 		);
 		const selectedPlan = getPlanFromRecurType( recurType );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
 * https://github.com/Automattic/wp-calypso/pull/91241
 * https://github.com/Automattic/dotcom-forge/issues/7643

## Proposed Changes

* This PR updates the `/setup/ecommerce` flow to leverage the new flag for steps that require a login that were added in https://github.com/Automattic/wp-calypso/pull/91241, and removes all login-related logic from the flow definition

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to centralise login handling in the Stepper framework, rather than having divergent implementations across flows, so we're rolling out these changes flow by flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live in a window where you are _not_ logged in
* Navigate to any of the following URLs with and without URL parameters:
  - `/setup/ecommerce`
  - `/setup/ecommerce/storeProfiler`
  - `/setup/ecommerce/designCarousel`
  - `/setup/ecommerce/processing`
  - `/setup/ecommerce/checkPlan`
* In all cases, verify that you're redirected to `/start/account/user-social` and any URL parameters are included in the `redirect_to` URL parameter.
* Also verify that no `calypso_signup_step_start` event was logged for the `ecommerce` flow before the redirect
* Repeat the tests above with a locale _in the path_, e.g. `/setup/ecommerce/de`
* Verify that everything works and you are correctly redirected to a localised version of login page
  - _I am seeing a pre-existing race condition occurring for this in some cases - I think I have tracked it down, but will try to address it in a follow-up PR_
* Now repeat the tests while logged in, and verify that you're not redirected, and that the `calypso_signup_step_start` event is fired for each step in the flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?