### PR TITLE
A4A: use test-connection endpoint for more reliable data on sites das…

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -23,6 +23,9 @@ import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/s
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+// import { useSelector } from 'calypso/state';
+// import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
+import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
 import { AllowedTypes, Site, SiteData } from '../../types';
 import type { MouseEvent, KeyboardEvent } from 'react';
 
@@ -42,22 +45,28 @@ export const JetpackSitesDataViews = ( {
 	const sitesPerPage = dataViewsState.perPage > 0 ? dataViewsState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 
-	const sites = useFormattedSites( data?.sites ?? [] ).reduce< SiteData[] >( ( acc, item ) => {
-		item.ref = item.site.value.blog_id;
-		acc.push( item );
-		// If this site has an error, we duplicate this row - while changing the duplicate's type to 'error' - to display an error message below it.
-		if ( item.site.error ) {
-			acc.push( {
-				...item,
-				site: {
-					...item.site,
-					type: 'error',
-				},
-				ref: `error-${ item.ref }`,
-			} );
-		}
-		return acc;
-	}, [] );
+	const possibleSites = data?.sites ?? [];
+	const connectionStatus = useFetchTestConnections( true, possibleSites );
+
+	const sites = useFormattedSites( possibleSites, connectionStatus ).reduce< SiteData[] >(
+		( acc, item ) => {
+			item.ref = item.site.value.blog_id;
+			acc.push( item );
+			// If this site has an error, we duplicate this row - while changing the duplicate's type to 'error' - to display an error message below it.
+			if ( item.site.error ) {
+				acc.push( {
+					...item,
+					site: {
+						...item.site,
+						type: 'error',
+					},
+					ref: `error-${ item.ref }`,
+				} );
+			}
+			return acc;
+		},
+		[]
+	);
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -23,8 +23,6 @@ import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/s
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-// import { useSelector } from 'calypso/state';
-// import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
 import { AllowedTypes, Site, SiteData } from '../../types';
 import type { MouseEvent, KeyboardEvent } from 'react';

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -19,11 +19,11 @@ import {
 } from 'calypso/a8c-for-agencies/sections/sites/sites-dataviews/interfaces';
 import SiteDataField from 'calypso/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
-import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
+import useFormattedSites from '../../hooks/use-formatted-sites';
 import { AllowedTypes, Site, SiteData } from '../../types';
 import type { MouseEvent, KeyboardEvent } from 'react';
 

--- a/client/a8c-for-agencies/sections/sites/hooks/use-fetch-test-connection.ts
+++ b/client/a8c-for-agencies/sections/sites/hooks/use-fetch-test-connection.ts
@@ -1,0 +1,62 @@
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { Site } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import wpcom from 'calypso/lib/wp';
+
+// We don't want to trigger another API request to the /test-connection endpoint for a given site
+// one minute after the first successful one.
+const STALE_TIME = 1000 * 60;
+
+const getQueryKey = ( ID: Site[ 'blog_id' ] ) => [ 'jetpack-fetch-test-connection', ID ];
+
+const queryOptions = {
+	staleTime: STALE_TIME,
+};
+
+const createQueryFn =
+	( siteId: Site[ 'blog_id' ], isConnectionHealthy: Site[ 'is_connection_healthy' ] ) => () =>
+		wpcom.req.get(
+			{
+				path: `/jetpack-blogs/${ siteId }/test-connection`,
+				apiNamespace: 'rest/v1.1',
+			},
+			{
+				// We call the current health state "stale", as it might be different than the actual state.
+				is_stale_connection_healthy: Boolean( isConnectionHealthy ),
+			}
+		);
+
+export const useFetchTestConnections = ( isPartnerOAuthTokenLoaded: boolean, sites: Site[] ) => {
+	const results = useQueries( {
+		queries: sites.map( ( site ) => ( {
+			queryKey: getQueryKey( site.blog_id ),
+			queryFn: createQueryFn( site.blog_id, site.is_connection_healthy ),
+			enabled: isPartnerOAuthTokenLoaded && Array.isArray( sites ) && sites.length > 0,
+			...queryOptions,
+		} ) ),
+	} );
+
+	return results.map( ( result, index ) => ( {
+		ID: sites[ index ].blog_id,
+		connected: result.data?.connected ?? true,
+	} ) );
+};
+
+export const useFetchTestConnection = (
+	isPartnerOAuthTokenLoaded: boolean,
+	isConnectionHealthy: boolean,
+	siteId: number
+) => {
+	return useQuery( {
+		queryKey: getQueryKey( siteId ),
+		queryFn: createQueryFn( siteId, isConnectionHealthy ),
+		...queryOptions,
+		select( data ) {
+			return {
+				ID: siteId,
+				connected: data?.connected ?? true,
+			};
+		},
+	} );
+};
+
+export default useFetchTestConnection;

--- a/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
+++ b/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
@@ -7,16 +7,16 @@ import {
 	PREINSTALLED_PREMIUM_PLUGINS,
 } from 'calypso/my-sites/plugins/constants';
 import {
-	BackupNode,
+	StatsNode,
 	BoostNode,
-	ErrorNode,
+	BackupNode,
+	ScanNode,
 	MonitorNode,
 	PluginNode,
-	ScanNode,
-	Site,
+	ErrorNode,
 	SiteData,
-	StatsNode,
-} from '../../types';
+	Site,
+} from '../types';
 
 const INITIAL_UNIX_EPOCH = '1970-01-01 00:00:00';
 
@@ -185,10 +185,10 @@ const useFormatPluginData = () => {
 	);
 };
 
-const formatErrorData = ( site: Site ): ErrorNode => ( {
-	status: site.is_connection_healthy ? 'success' : 'failed',
+const formatErrorData = ( isConnected: boolean ): ErrorNode => ( {
+	status: isConnected ? 'success' : 'failed',
 	type: 'error',
-	value: site.is_connection_healthy ? 'error' : '',
+	value: isConnected ? 'error' : '',
 } );
 
 const useFormatSite = () => {
@@ -198,11 +198,11 @@ const useFormatSite = () => {
 	const formatScanData = useFormatScanData();
 
 	return useCallback(
-		( site: Site ): SiteData => {
+		( site: Site, isConnected: boolean ): SiteData => {
 			return {
 				site: {
 					value: site,
-					error: ! site.is_connection_healthy,
+					error: ! isConnected,
 					status: 'active',
 					type: 'site',
 				},
@@ -212,7 +212,7 @@ const useFormatSite = () => {
 				scan: formatScanData( site ),
 				monitor: formatMonitorData( site ),
 				plugin: formatPluginData( site ),
-				error: formatErrorData( site ),
+				error: formatErrorData( isConnected ),
 				isFavorite: site.is_favorite,
 				isSelected: site.isSelected,
 				onSelect: site.onSelect,
@@ -222,13 +222,29 @@ const useFormatSite = () => {
 	);
 };
 
+type SiteConnectionStatus = {
+	ID: number;
+	connected: boolean;
+};
+
 /**
  * Returns formatted sites
  */
-const useFormattedSites = ( sites: Site[] ): SiteData[] => {
+const useFormattedSites = (
+	sites: Site[],
+	connectionStatus: SiteConnectionStatus[]
+): SiteData[] => {
 	const formatSite = useFormatSite();
 
-	return useMemo( () => sites.map( ( site ) => formatSite( site ) ), [ formatSite, sites ] );
+	return useMemo(
+		() =>
+			sites.map( ( site ) => {
+				const isConnected =
+					connectionStatus.find( ( status ) => status.ID === site.blog_id )?.connected || false;
+				return formatSite( site, isConnected );
+			} ),
+		[ formatSite, sites, connectionStatus ]
+	);
 };
 
 export default useFormattedSites;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -185,10 +185,10 @@ const useFormatPluginData = () => {
 	);
 };
 
-const formatErrorData = ( site: Site ): ErrorNode => ( {
-	status: site.is_connection_healthy ? 'success' : 'failed',
+const formatErrorData = ( isConnected: boolean ): ErrorNode => ( {
+	status: isConnected ? 'success' : 'failed',
 	type: 'error',
-	value: site.is_connection_healthy ? 'error' : '',
+	value: isConnected ? 'error' : '',
 } );
 
 const useFormatSite = () => {
@@ -198,7 +198,7 @@ const useFormatSite = () => {
 	const formatScanData = useFormatScanData();
 
 	return useCallback(
-		( site: Site ): SiteData => {
+		( site: Site, isConnected: boolean ): SiteData => {
 			return {
 				site: {
 					value: site,
@@ -212,7 +212,7 @@ const useFormatSite = () => {
 				scan: formatScanData( site ),
 				monitor: formatMonitorData( site ),
 				plugin: formatPluginData( site ),
-				error: formatErrorData( site ),
+				error: formatErrorData( isConnected ),
 				isFavorite: site.is_favorite,
 				isSelected: site.isSelected,
 				onSelect: site.onSelect,
@@ -222,13 +222,29 @@ const useFormatSite = () => {
 	);
 };
 
+type SiteConnectionStatus = {
+	ID: number;
+	connected: boolean;
+};
+
 /**
  * Returns formatted sites
  */
-const useFormattedSites = ( sites: Site[] ): SiteData[] => {
+const useFormattedSites = (
+	sites: Site[],
+	connectionStatus: SiteConnectionStatus[]
+): SiteData[] => {
 	const formatSite = useFormatSite();
 
-	return useMemo( () => sites.map( ( site ) => formatSite( site ) ), [ formatSite, sites ] );
+	return useMemo(
+		() =>
+			sites.map( ( site ) => {
+				const isConnected =
+					connectionStatus.find( ( status ) => status.ID === site.blog_id )?.connected || false;
+				return formatSite( site, isConnected );
+			} ),
+		[ formatSite, sites, connectionStatus ]
+	);
 };
 
 export default useFormattedSites;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -202,7 +202,7 @@ const useFormatSite = () => {
 			return {
 				site: {
 					value: site,
-					error: ! site.is_connection_healthy,
+					error: ! isConnected,
 					status: 'active',
 					type: 'site',
 				},


### PR DESCRIPTION
…hboard

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/641

## Proposed Changes

This aims to improve reliability of sites dashboard by querying actual status of every site on the page. 

It's not the prettiest code, but the matter is pretty urgent and it's hard to integrate it differently into data views.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Note: I'm haven't worked much with these flow so would appreciate additional testing
- Using live link navigate to `/sites` and observe that previous state shows correctly
- Create new JN site and connect with A4A plugin.
- Check it in the dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
