### PR TITLE
Blaze: Add tooltip to Status column in campaign list

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -1,14 +1,15 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { safeImageUrl } from '@automattic/calypso-url';
-import { Badge } from '@automattic/components';
+import { Badge, Tooltip } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
-import { Fragment, useMemo } from 'react';
+import { Fragment, useMemo, useRef, useState } from 'react';
 import { Campaign } from 'calypso/data/promote-post/types';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
+import { hasTouch } from 'calypso/lib/touch-detect';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
@@ -17,6 +18,7 @@ import {
 	formatNumber,
 	getAdvertisingDashboardPath,
 	getCampaignBudgetData,
+	getCampaignStartDateFormatted,
 	getCampaignStatus,
 	getCampaignStatusBadgeColor,
 } from '../../utils';
@@ -124,6 +126,11 @@ export default function CampaignItem( props: Props ) {
 		page.show( openCampaignURL );
 	};
 
+	const campaignIdString = campaign.campaign_id.toString();
+	const [ activeTooltipId, setActiveTooltipId ] = useState( '' );
+	const tooltipRef = useRef< HTMLDivElement >( null );
+	const isTouch = hasTouch();
+
 	function getMobileStats() {
 		const statElements = [];
 		if ( impressions_total > 0 ) {
@@ -193,7 +200,22 @@ export default function CampaignItem( props: Props ) {
 				</div>
 			</td>
 			<td className="campaign-item__status">
-				<div>{ statusBadge }</div>
+				<div
+					ref={ tooltipRef }
+					onMouseEnter={ () => ! isTouch && setActiveTooltipId( campaignIdString ) }
+					onMouseLeave={ () => ! isTouch && setActiveTooltipId( '' ) }
+				>
+					{ statusBadge }
+				</div>
+				<Tooltip
+					className="import__campaign-schedule-tooptip"
+					position="bottom"
+					hideArrow
+					context={ tooltipRef.current }
+					isVisible={ activeTooltipId === campaignIdString }
+				>
+					<div>{ getCampaignStartDateFormatted( start_date ) }</div>
+				</Tooltip>
 			</td>
 			<td className="campaign-item__ends">
 				<div>

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -200,22 +200,28 @@ export default function CampaignItem( props: Props ) {
 				</div>
 			</td>
 			<td className="campaign-item__status">
-				<div
-					ref={ tooltipRef }
-					onMouseEnter={ () => ! isTouch && setActiveTooltipId( campaignIdString ) }
-					onMouseLeave={ () => ! isTouch && setActiveTooltipId( '' ) }
-				>
-					{ statusBadge }
-				</div>
-				<Tooltip
-					className="import__campaign-schedule-tooptip"
-					position="bottom"
-					hideArrow
-					context={ tooltipRef.current }
-					isVisible={ activeTooltipId === campaignIdString }
-				>
-					<div>{ getCampaignStartDateFormatted( start_date ) }</div>
-				</Tooltip>
+				{ ui_status === campaignStatus.SCHEDULED ? (
+					<>
+						<div
+							ref={ tooltipRef }
+							onMouseEnter={ () => ! isTouch && setActiveTooltipId( campaignIdString ) }
+							onMouseLeave={ () => ! isTouch && setActiveTooltipId( '' ) }
+						>
+							{ statusBadge }
+						</div>
+						<Tooltip
+							className="import__campaign-schedule-tooptip"
+							position="bottom"
+							hideArrow
+							context={ tooltipRef.current }
+							isVisible={ activeTooltipId === campaignIdString }
+						>
+							<div>{ getCampaignStartDateFormatted( start_date ) }</div>
+						</Tooltip>
+					</>
+				) : (
+					<div>{ statusBadge }</div>
+				) }
 			</td>
 			<td className="campaign-item__ends">
 				<div>

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -147,6 +147,16 @@ export const getCampaignDurationFormatted = (
 	return `${ dateStartFormatted } - ${ dateEndFormatted }`;
 };
 
+export const getCampaignStartDateFormatted = ( start_date?: string ) => {
+	if ( ! start_date ) {
+		return '-';
+	}
+
+	// translators: Moment.js date format. LLL: June 7, 2024 9:27 AM
+	const format = _x( 'LLL', 'datetime format' );
+	return moment.utc( start_date ).format( format );
+};
+
 export const getCampaignActiveDays = ( start_date?: string, end_date?: string ) => {
 	if ( ! start_date || ! end_date ) {
 		return 0;


### PR DESCRIPTION
## Proposed Changes

* Adding a tooltip to Status column in Blaze campaign list when the campaign status is `Scheduled`

![image](https://github.com/Automattic/wp-calypso/assets/4564116/01a57ef1-24aa-4fb9-859c-90296cab7eed)


## Why are these changes being made?

* To implement 1458-ghe-Tumblr/a8c-dsp
* Making sure users are aware when exactly their Blaze campaign starts

## Testing Instructions
* Navigate to `/advertising/campaigns/<blog_name>` and hover over the Status column. A tooltip will show when the campaign status is `Scheduled`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
