### PR TITLE
Jetpack Google Analytics: support for the `is_active` setting (part 1)

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -52,6 +52,7 @@ const GoogleAnalyticsJetpackForm = ( {
 	sitePlugins,
 	translate,
 	isAtomic,
+	isJetpackModuleAvailable,
 } ) => {
 	const upsellHref = `/checkout/${ site.slug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_GOOGLE_ANALYTICS ] }`;
 	const analyticsSupportUrl = isAtomic
@@ -80,19 +81,26 @@ const GoogleAnalyticsJetpackForm = ( {
 		handleToggleChange( 'anonymize_ip' );
 	};
 
+	const handleSubmitFormCustom = () => {
+		if ( isJetpackModuleAvailable ) {
+			handleFieldChange( 'is_active', !! jetpackModuleActive );
+		}
+		handleSubmitForm();
+	};
+
 	const renderForm = () => {
 		return (
 			<form
 				aria-label="Google Analytics Site Settings"
 				id="analytics"
-				onSubmit={ handleSubmitForm }
+				onSubmit={ handleSubmitFormCustom }
 			>
 				<QueryJetpackModules siteId={ siteId } />
 
 				<SettingsSectionHeader
 					disabled={ isSubmitButtonDisabled }
 					isSaving={ isSavingSettings }
-					onButtonClick={ handleSubmitForm }
+					onButtonClick={ handleSubmitFormCustom }
 					showButton
 					title={ translate( 'Google' ) }
 				/>

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -83,8 +83,10 @@ const GoogleAnalyticsJetpackForm = ( {
 
 	const handleSubmitFormCustom = () => {
 		if ( isJetpackModuleAvailable ) {
-			handleFieldChange( 'is_active', !! jetpackModuleActive );
+			handleFieldChange( 'is_active', !! jetpackModuleActive, handleSubmitForm );
+			return;
 		}
+
 		handleSubmitForm();
 	};
 

--- a/client/my-sites/site-settings/analytics/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics.jsx
@@ -86,9 +86,13 @@ export const GoogleAnalyticsForm = ( props ) => {
 		setDisplayForm,
 		isAtomic,
 	};
+
 	if ( ( props.siteIsJetpack && ! isAtomic ) || ( isAtomic && isGoogleAnalyticsEligible ) ) {
 		// Google Analytics module is not available (important distinction from not active)
-		if ( ! isJetpackModuleAvailable ) {
+		if (
+			! isJetpackModuleAvailable &&
+			( ! fields.hasOwnProperty( 'wga' ) || ! fields.wga.hasOwnProperty( 'is_active' ) )
+		) {
 			return null;
 		}
 		return <GoogleAnalyticsJetpackForm { ...newProps } />;


### PR DESCRIPTION
https://github.com/Automattic/vulcan/issues/359

## Proposed Changes

Google Analytics is getting extracted from Jetpack into a package.
Calypso relies on it being a Jetpack module, which is being deprecated.
The PR makes Calypso support the new `is_active` setting that will replace the module activation status.

## Why are these changes being made?
pfwV0U-4g-p2

## Testing Instructions
1. Connect Jetpack.
2. Go to "Jetpack -> Settings -> Traffic", find the "Google Analytics" card and purchase a plan.
3. After checkout, go back there and click on "Configure your Google Analytics settings".
4. Replace the `https://wordpress.com` with the Calypso Live URL from this PR.
5. In Calypso, find the "Google" card. Activate it by clicking "Add Google".
6. Open the browser's network monitor, filter by `settings`.
7. Enter a measurement ID (e.g. "G-12345"), click "Save Settings".
8. Check the network log and find a POST request to `https://public-api.wordpress.com/rest/v1.4/sites/[your-blog-id]/settings`.
9. Confirm that both request and response body have `wga.is_active` set to `true`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
