### PR TITLE
A/B test for image optimizations

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -190,8 +190,6 @@ export class Theme extends Component {
 		) {
 			const { id: themeId, stylesheet } = theme;
 
-			// eslint-disable-next-line no-console
-			console.log( '------------DesignPreviewImage from components/theme/index.jsx' );
 			return (
 				<DesignPreviewImage
 					design={ { slug: themeId, recipe: { stylesheet } } }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -190,6 +190,8 @@ export class Theme extends Component {
 		) {
 			const { id: themeId, stylesheet } = theme;
 
+			// eslint-disable-next-line no-console
+			console.log( '------------DesignPreviewImage from components/theme/index.jsx' );
 			return (
 				<DesignPreviewImage
 					design={ { slug: themeId, recipe: { stylesheet } } }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -42,6 +42,7 @@ import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
 import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useExperiment } from 'calypso/lib/explat';
 import { urlToSlug } from 'calypso/lib/url';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
@@ -98,6 +99,17 @@ const EMPTY_ARRAY: Design[] = [];
 const EMPTY_OBJECT = {};
 
 const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
+	// imageOptimizationExperimentAssignment, exerimentAssignment
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+		'calypso_design_picker_image_optimization_202406'
+	);
+	const variantName = experimentAssignment?.variationName;
+	const oldSlowerImageLoading = ! isLoadingExperiment && variantName === 'treatment';
+	// eslint-disable-next-line no-console
+	console.log(
+		`---isLoading ${ isLoadingExperiment } assignment ${ variantName } slow ${ oldSlowerImageLoading }`
+	);
+
 	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;
 
@@ -907,6 +919,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 			getBadge={ getBadge }
+			oldSlowerImageLoading={ oldSlowerImageLoading }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -105,10 +105,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	);
 	const variantName = experimentAssignment?.variationName;
 	const oldSlowerImageLoading = ! isLoadingExperiment && variantName === 'treatment';
-	// eslint-disable-next-line no-console
-	console.log(
-		`---isLoading ${ isLoadingExperiment } assignment ${ variantName } slow ${ oldSlowerImageLoading }`
-	);
 
 	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -104,9 +104,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		'calypso_design_picker_image_optimization_202406'
 	);
 	const variantName = experimentAssignment?.variationName;
-	// const oldHighResImageLoading = ! isLoadingExperiment && variantName === 'treatment';
-	// Temporary to test undo of Sergio's code path.
-	const oldHighResImageLoading = ! ( ! isLoadingExperiment && variantName === 'treatment' );
+	const oldHighResImageLoading = ! isLoadingExperiment && variantName === 'treatment';
 
 	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -104,7 +104,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		'calypso_design_picker_image_optimization_202406'
 	);
 	const variantName = experimentAssignment?.variationName;
-	const oldSlowerImageLoading = ! isLoadingExperiment && variantName === 'treatment';
+	// const oldHighResImageLoading = ! isLoadingExperiment && variantName === 'treatment';
+	// Temporary to test undo of Sergio's code path.
+	const oldHighResImageLoading = ! ( ! isLoadingExperiment && variantName === 'treatment' );
 
 	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;
@@ -915,7 +917,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 			getBadge={ getBadge }
-			oldSlowerImageLoading={ oldSlowerImageLoading }
+			oldHighResImageLoading={ oldHighResImageLoading }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -1,6 +1,7 @@
 import { Onboard } from '@automattic/data-stores';
 import { useLocale, englishLocales } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import type { Goal } from './types';
 
 const SiteGoal = Onboard.SiteGoal;
@@ -45,6 +46,8 @@ const useBBEGoal = () => {
 };
 
 export const useGoals = (): Goal[] => {
+	loadExperimentAssignment( 'calypso_design_picker_image_optimization_202406' ); // Temporary for A/B test.
+
 	const translate = useTranslate();
 	const locale = useLocale();
 	const builtByExpressGoalDisplayText = useBBEGoal();

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
-import { MShotsImage, MShotsImageTreatment } from '@automattic/onboarding';
+import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
 import photon from 'photon';
@@ -67,29 +67,8 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 		}
 	}
 
-	if ( oldHighResImageLoading ) {
-		return (
-			<MShotsImage
-				url={ getDesignPreviewUrl( design, {
-					use_screenshot_overrides: true,
-					style_variation: styleVariation,
-					...( locale && { language: locale } ),
-				} ) }
-				aria-labelledby={ makeOptionId( design ) }
-				alt=""
-				options={ getMShotOptions( {
-					scrollable: false,
-					highRes: ! isMobile,
-					isMobile,
-					oldHighResImageLoading,
-				} ) }
-				scrollable={ false }
-			/>
-		);
-	}
-	// else, prettier doesn't want return in else.
 	return (
-		<MShotsImageTreatment
+		<MShotsImage
 			url={ getDesignPreviewUrl( design, {
 				use_screenshot_overrides: true,
 				style_variation: styleVariation,

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
-import { MShotsImage } from '@automattic/onboarding';
+import { MShotsImage, MShotsImageTreatment } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
 import photon from 'photon';
@@ -67,8 +67,29 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 		}
 	}
 
+	if ( oldHighResImageLoading ) {
+		return (
+			<MShotsImage
+				url={ getDesignPreviewUrl( design, {
+					use_screenshot_overrides: true,
+					style_variation: styleVariation,
+					...( locale && { language: locale } ),
+				} ) }
+				aria-labelledby={ makeOptionId( design ) }
+				alt=""
+				options={ getMShotOptions( {
+					scrollable: false,
+					highRes: ! isMobile,
+					isMobile,
+					oldHighResImageLoading,
+				} ) }
+				scrollable={ false }
+			/>
+		);
+	}
+	// else, prettier doesn't want return in else.
 	return (
-		<MShotsImage
+		<MShotsImageTreatment
 			url={ getDesignPreviewUrl( design, {
 				use_screenshot_overrides: true,
 				style_variation: styleVariation,

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -31,14 +31,14 @@ interface DesignPreviewImageProps {
 	imageOptimizationExperiment?: boolean;
 	locale?: string;
 	styleVariation?: StyleVariation;
-	oldSlowerImageLoading?: boolean; // Temporary for A/B test.
+	oldHighResImageLoading?: boolean; // Temporary for A/B test.
 }
 
 const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 	design,
 	locale,
 	styleVariation,
-	oldSlowerImageLoading,
+	oldHighResImageLoading,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
 
@@ -49,7 +49,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 		const themeImgSrc = photon( design.screenshot, { fit } ) || design.screenshot;
 		const themeImgSrcDoubleDpi = photon( design.screenshot, { fit, zoom: 2 } ) || design.screenshot;
 
-		if ( oldSlowerImageLoading ) {
+		if ( oldHighResImageLoading ) {
 			<img
 				src={ themeImgSrc }
 				srcSet={ `${ themeImgSrcDoubleDpi } 2x` }
@@ -80,7 +80,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 				scrollable: false,
 				highRes: ! isMobile,
 				isMobile,
-				oldSlowerImageLoading,
+				oldHighResImageLoading,
 			} ) }
 			scrollable={ false }
 		/>
@@ -175,7 +175,7 @@ interface DesignCardProps {
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
-	oldSlowerImageLoading?: boolean; // Temporary for A/B test.
+	oldHighResImageLoading?: boolean; // Temporary for A/B test.
 }
 
 const DesignCard: React.FC< DesignCardProps > = ( {
@@ -187,7 +187,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	onChangeVariation,
 	onPreview,
 	getBadge,
-	oldSlowerImageLoading,
+	oldHighResImageLoading,
 } ) => {
 	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState< StyleVariation >();
 
@@ -213,7 +213,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 					design={ design }
 					locale={ locale }
 					styleVariation={ selectedStyleVariation }
-					oldSlowerImageLoading={ oldSlowerImageLoading }
+					oldHighResImageLoading={ oldHighResImageLoading }
 				/>
 			}
 			badge={ getBadge( design.slug, isLocked ) }
@@ -240,7 +240,7 @@ interface DesignPickerProps {
 	isPremiumThemeAvailable?: boolean;
 	shouldLimitGlobalStyles?: boolean;
 	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
-	oldSlowerImageLoading?: boolean; // Temporary for A/B test
+	oldHighResImageLoading?: boolean; // Temporary for A/B test
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -254,7 +254,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	isPremiumThemeAvailable,
 	shouldLimitGlobalStyles,
 	getBadge,
-	oldSlowerImageLoading,
+	oldHighResImageLoading,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useMemo( () => {
@@ -307,7 +307,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 							onChangeVariation={ onChangeVariation }
 							onPreview={ onPreview }
 							getBadge={ getBadge }
-							oldSlowerImageLoading={ oldSlowerImageLoading }
+							oldHighResImageLoading={ oldHighResImageLoading }
 						/>
 					);
 				} ) }
@@ -330,7 +330,7 @@ export interface UnifiedDesignPickerProps {
 	isPremiumThemeAvailable?: boolean;
 	shouldLimitGlobalStyles?: boolean;
 	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
-	oldSlowerImageLoading?: boolean; // Temporary for A/B test
+	oldHighResImageLoading?: boolean; // Temporary for A/B test
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -346,7 +346,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	isPremiumThemeAvailable,
 	shouldLimitGlobalStyles,
 	getBadge,
-	oldSlowerImageLoading,
+	oldHighResImageLoading,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
@@ -379,7 +379,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }
 					shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 					getBadge={ getBadge }
-					oldSlowerImageLoading={ oldSlowerImageLoading }
+					oldHighResImageLoading={ oldHighResImageLoading }
 				/>
 				{ bottomAnchorContent }
 			</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -40,9 +40,6 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 	styleVariation,
 	oldSlowerImageLoading,
 } ) => {
-	// eslint-disable-next-line no-console
-	console.log( `--DesignPreviewImage slow ${ oldSlowerImageLoading }` );
-
 	const isMobile = useViewportMatch( 'small', '<' );
 
 	if ( design.is_externally_managed && design.screenshot ) {
@@ -362,10 +359,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	} );
 	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 	const bottomAnchorContent = <div className="design-picker__bottom_anchor" ref={ ref }></div>;
-
-	// TODO: remove, temp logging
-	// eslint-disable-next-line no-console
-	console.log( `---packages/unified-design-picker, slow: ${ oldSlowerImageLoading }.` );
 
 	return (
 		<div

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -23,9 +23,6 @@ export const getMShotOptions = ( {
 	// end up serving WEBPs instead of JPEGs, spend fewer bits on parts of images that are not displayed, and possibly display fewer images.
 	//
 	// See #88786 for more info.
-
-	// eslint-disable-next-line no-console
-	console.log( `--getMShotOptions slow ${ oldSlowerImageLoading }` );
 	let w = 500;
 	let screen_height = 1100;
 	if ( oldSlowerImageLoading ) {

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -6,6 +6,7 @@ type MShotInputOptions = {
 	scrollable?: boolean;
 	highRes?: boolean;
 	isMobile?: boolean;
+	oldSlowerImageLoading?: boolean; // Temporary for A/B test.
 };
 
 // Used for both prefetching and loading design screenshots
@@ -13,6 +14,7 @@ export const getMShotOptions = ( {
 	scrollable,
 	highRes,
 	isMobile,
+	oldSlowerImageLoading,
 }: MShotInputOptions = {} ): MShotsOptions => {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
 
@@ -21,11 +23,21 @@ export const getMShotOptions = ( {
 	// end up serving WEBPs instead of JPEGs, spend fewer bits on parts of images that are not displayed, and possibly display fewer images.
 	//
 	// See #88786 for more info.
+
+	// eslint-disable-next-line no-console
+	console.log( `--getMShotOptions slow ${ oldSlowerImageLoading }` );
+	let w = 500;
+	let screen_height = 1100;
+	if ( oldSlowerImageLoading ) {
+		w = highRes ? 1199 : 600;
+		screen_height = 3600;
+	}
 	return {
 		vpw: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
 		vph: scrollable ? 1600 : 1040,
-		w: highRes ? 500 : 500, // Stubbed out. See #88786 for more info.
-		screen_height: 1100,
+		w: w,
+		screen_height: screen_height,
+		oldSlowerImageLoading: oldSlowerImageLoading,
 	};
 };
 

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -6,7 +6,7 @@ type MShotInputOptions = {
 	scrollable?: boolean;
 	highRes?: boolean;
 	isMobile?: boolean;
-	oldSlowerImageLoading?: boolean; // Temporary for A/B test.
+	oldHighResImageLoading?: boolean; // Temporary for A/B test.
 };
 
 // Used for both prefetching and loading design screenshots
@@ -14,7 +14,7 @@ export const getMShotOptions = ( {
 	scrollable,
 	highRes,
 	isMobile,
-	oldSlowerImageLoading,
+	oldHighResImageLoading,
 }: MShotInputOptions = {} ): MShotsOptions => {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
 
@@ -25,7 +25,7 @@ export const getMShotOptions = ( {
 	// See #88786 for more info.
 	let w = 500;
 	let screen_height = 1100;
-	if ( oldSlowerImageLoading ) {
+	if ( oldHighResImageLoading ) {
 		w = highRes ? 1199 : 600;
 		screen_height = 3600;
 	}
@@ -34,7 +34,7 @@ export const getMShotOptions = ( {
 		vph: scrollable ? 1600 : 1040,
 		w: w,
 		screen_height: screen_height,
-		oldSlowerImageLoading: oldSlowerImageLoading,
+		oldHighResImageLoading: oldHighResImageLoading,
 	};
 };
 

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -54,9 +54,6 @@ const useMshotsImg = (
 	options: MShotsOptions,
 	imgRef: React.MutableRefObject< HTMLImageElement | null >
 ): string | null => {
-	// eslint-disable-next-line no-console
-	console.log( `--useMshotsImg options ${ options?.oldSlowerImageLoading } ` );
-
 	const [ loadedImg, setLoadedImg ] = useState< string | null >( null );
 	const [ count, setCount ] = useState( 0 );
 	const previousSrc = useRef( src );
@@ -154,9 +151,6 @@ const MShotsImage = ( {
 	options,
 	scrollable = false,
 }: MShotsImageProps ) => {
-	// eslint-disable-next-line no-console
-	console.log( `--MShotsImage slow ${ options?.oldSlowerImageLoading }` );
-
 	const imgRef = useRef< HTMLImageElement | null >( null );
 	const currentlyLoadedUrl = useMshotsImg( url, options, imgRef );
 	const src: string = imgRef.current?.src || '';

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -20,7 +20,7 @@ export type MShotsOptions = {
 	h?: number;
 	screen_height?: number;
 	format?: 'png' | 'jpeg';
-	oldSlowerImageLoading?: boolean;
+	oldHighResImageLoading?: boolean;
 };
 
 const debug = debugFactory( 'design-picker:mshots-image' );
@@ -176,7 +176,7 @@ const MShotsImage = ( {
 		visible ? 'mshots-image-visible' : 'mshots-image__loader'
 	);
 
-	if ( options?.oldSlowerImageLoading ) {
+	if ( options?.oldHighResImageLoading ) {
 		return scrollable ? (
 			<div className={ className } style={ style } aria-labelledby={ labelledby }>
 				<img ref={ imgRef } className="mshots-dummy-image" aria-hidden="true" alt="" />

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -20,6 +20,7 @@ export type MShotsOptions = {
 	h?: number;
 	screen_height?: number;
 	format?: 'png' | 'jpeg';
+	oldSlowerImageLoading?: boolean;
 };
 
 const debug = debugFactory( 'design-picker:mshots-image' );
@@ -53,6 +54,9 @@ const useMshotsImg = (
 	options: MShotsOptions,
 	imgRef: React.MutableRefObject< HTMLImageElement | null >
 ): string | null => {
+	// eslint-disable-next-line no-console
+	console.log( `--useMshotsImg options ${ options?.oldSlowerImageLoading } ` );
+
 	const [ loadedImg, setLoadedImg ] = useState< string | null >( null );
 	const [ count, setCount ] = useState( 0 );
 	const previousSrc = useRef( src );
@@ -150,6 +154,9 @@ const MShotsImage = ( {
 	options,
 	scrollable = false,
 }: MShotsImageProps ) => {
+	// eslint-disable-next-line no-console
+	console.log( `--MShotsImage slow ${ options?.oldSlowerImageLoading }` );
+
 	const imgRef = useRef< HTMLImageElement | null >( null );
 	const currentlyLoadedUrl = useMshotsImg( url, options, imgRef );
 	const src: string = imgRef.current?.src || '';
@@ -175,6 +182,20 @@ const MShotsImage = ( {
 		visible ? 'mshots-image-visible' : 'mshots-image__loader'
 	);
 
+	if ( options?.oldSlowerImageLoading ) {
+		return scrollable ? (
+			<div className={ className } style={ style } aria-labelledby={ labelledby }>
+				<img ref={ imgRef } className="mshots-dummy-image" aria-hidden="true" alt="" />
+			</div>
+		) : (
+			<img
+				ref={ imgRef }
+				{ ...{ className, style, src, alt } }
+				aria-labelledby={ labelledby }
+				alt={ alt }
+			/>
+		);
+	} // else, prettier doesn't like having an else after a return
 	return scrollable ? (
 		<div className={ className } style={ style } aria-labelledby={ labelledby }>
 			<img ref={ imgRef } loading="lazy" className="mshots-dummy-image" aria-hidden="true" alt="" />

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -138,6 +138,94 @@ const useMshotsImg = (
 	return loadedImg;
 };
 
+// Temporary for A/B test.
+const useMshotsImgTreatment = (
+	src: string,
+	options: MShotsOptions
+): HTMLImageElement | undefined => {
+	const [ loadedImg, setLoadedImg ] = useState< HTMLImageElement >();
+	const [ count, setCount ] = useState( 0 );
+	const previousSrc = useRef( src );
+
+	const imgRef = useRef< HTMLImageElement >();
+	const timeoutIdRef = useRef< number >();
+
+	const previousImg = useRef< HTMLImageElement >();
+	const previousOptions = useRef< MShotsOptions >();
+	// Oddly, we need to assign to current here after ref creation in order to
+	// pass the equivalence check and avoid a spurious reset
+	previousOptions.current = options;
+
+	// Note: Mshots doesn't care about the "count" param, but it is important
+	// to browser caching. Getting this wrong looks like the url resolving
+	// before the image is ready.
+	useEffect( () => {
+		// If there's been a "props" change we need to reset everything:
+		if (
+			options !== previousOptions.current ||
+			( src !== previousSrc.current && imgRef.current )
+		) {
+			// Make sure an old image can't trigger a spurious state update
+			debug( 'resetting mShotsUrl request' );
+			if ( src !== previousSrc.current ) {
+				debug( 'src changed\nfrom', previousSrc.current, '\nto', src );
+			}
+			if ( options !== previousOptions.current ) {
+				debug( 'options changed\nfrom', previousOptions.current, '\nto', options );
+			}
+			if ( previousImg.current && previousImg.current.onload ) {
+				previousImg.current.onload = null;
+				if ( timeoutIdRef.current ) {
+					clearTimeout( timeoutIdRef.current );
+					timeoutIdRef.current = undefined;
+				}
+			}
+
+			setLoadedImg( undefined );
+			setCount( 0 );
+			previousImg.current = imgRef.current;
+
+			previousOptions.current = options;
+			previousSrc.current = src;
+		}
+
+		const srcUrl = mshotsUrl( src, options, count );
+		const newImage = new Image();
+		newImage.onload = () => {
+			// Detect default image (Don't request a 400x300 image).
+			//
+			// If this turns out to be a problem, it might help to know that the
+			// http request status for the default is a 307. Unfortunately we
+			// don't get the request through an img element so we'd need to
+			// take a completely different approach using ajax.
+			if ( newImage.naturalWidth !== 400 || newImage.naturalHeight !== 300 ) {
+				// Note we're using the naked object here, not the ref, because
+				// this is the callback on the image itself. We'd never want
+				// the image to finish loading and set some other image.
+				setLoadedImg( newImage );
+			} else if ( count < MAXTRIES ) {
+				// Only refresh 10 times
+				// Triggers a target.src change with increasing timeouts
+				timeoutIdRef.current = window.setTimeout(
+					() => setCount( ( count ) => count + 1 ),
+					count * 500
+				);
+			}
+		};
+		newImage.src = srcUrl;
+		imgRef.current = newImage;
+
+		return () => {
+			if ( imgRef.current && imgRef.current.onload ) {
+				imgRef.current.onload = null;
+			}
+			clearTimeout( timeoutIdRef.current );
+		};
+	}, [ src, count, options ] );
+
+	return loadedImg;
+};
+
 // For hover-scroll, we use a div with a background image (rather than an img element)
 // in order to use transitions between `top` and `bottom` on the
 // `background-position` property.
@@ -205,4 +293,50 @@ const MShotsImage = ( {
 	);
 };
 
-export default MShotsImage;
+// Temporary for A/B test.
+const MShotsImageTreatment = ( {
+	url,
+	'aria-labelledby': labelledby,
+	alt,
+	options,
+	scrollable = false,
+}: MShotsImageProps ) => {
+	const maybeImage = useMshotsImgTreatment( url, options );
+	const src: string = maybeImage?.src || '';
+	const visible = !! src;
+	const backgroundImage = maybeImage?.src && `url( ${ maybeImage?.src } )`;
+
+	const animationScrollSpeedInPixelsPerSecond = 400;
+	const animationDuration =
+		( maybeImage?.naturalHeight || 600 ) / animationScrollSpeedInPixelsPerSecond;
+
+	const scrollableStyles = {
+		backgroundImage,
+		transition: `background-position ${ animationDuration }s`,
+	};
+
+	const style = {
+		...( scrollable ? scrollableStyles : {} ),
+	};
+
+	const className = clsx(
+		'mshots-image__container',
+		scrollable && 'hover-scroll',
+		visible ? 'mshots-image-visible' : 'mshots-image__loader'
+	);
+
+	// The "! visible" here is only to dodge a particularly specific css
+	// rule effecting the placeholder while loading static images:
+	// '.design-picker .design-picker__image-frame img { ..., height: auto }'
+	return scrollable || ! visible ? (
+		<div className={ className } style={ style } aria-labelledby={ labelledby } />
+	) : (
+		<img { ...{ className, style, src, alt } } aria-labelledby={ labelledby } alt={ alt } />
+	);
+};
+
+// export default MShotsImage;
+// Temporary for A/B test.
+export default () => {
+	return { MShotsImage, MShotsImageTreatment };
+};

--- a/packages/onboarding/src/mshots-image/index.tsx
+++ b/packages/onboarding/src/mshots-image/index.tsx
@@ -226,13 +226,7 @@ const useMshotsImgTreatment = (
 	return loadedImg;
 };
 
-// For hover-scroll, we use a div with a background image (rather than an img element)
-// in order to use transitions between `top` and `bottom` on the
-// `background-position` property.
-// The "normal" top & bottom properties are problematic individually because we
-// don't know how big the images will be, and using both gets the
-// right positions but with no transition (as they're different properties).
-const MShotsImage = ( {
+const MShotsImageControl = ( {
 	url,
 	'aria-labelledby': labelledby,
 	alt,
@@ -335,8 +329,40 @@ const MShotsImageTreatment = ( {
 	);
 };
 
-// export default MShotsImage;
-// Temporary for A/B test.
-export default () => {
-	return { MShotsImage, MShotsImageTreatment };
+// For hover-scroll, we use a div with a background image (rather than an img element)
+// in order to use transitions between `top` and `bottom` on the
+// `background-position` property.
+// The "normal" top & bottom properties are problematic individually because we
+// don't know how big the images will be, and using both gets the
+// right positions but with no transition (as they're different properties).
+const MShotsImage = ( {
+	url,
+	'aria-labelledby': labelledby,
+	alt,
+	options,
+	scrollable = false,
+}: MShotsImageProps ) => {
+	// Return MShotsImageControl or MShotsImageTreatment depending on options.oldHighResImageLoading
+	if ( options?.oldHighResImageLoading ) {
+		return (
+			<MShotsImageTreatment
+				url={ url }
+				aria-labelledby={ labelledby }
+				alt={ alt }
+				options={ options }
+				scrollable={ scrollable }
+			/>
+		);
+	}
+	return (
+		<MShotsImageControl
+			url={ url }
+			aria-labelledby={ labelledby }
+			alt={ alt }
+			options={ options }
+			scrollable={ scrollable }
+		/>
+	);
 };
+
+export default MShotsImage;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88786, #88925, #90741

## Proposed Changes

* A/B test impact of the above image optimization changes
* This doesn't fully back out #90741 in the experimental condition, but it does test the lazy loading part of that, which should account for almost all of the performance impact of that change
    * @sgomes, from a correctness standpoint, do see a reason just removing the lazy attribute shouldn't work?

## Why are these changes being made?

Looking retrospectively, we saw almost no impact from the changes above.

@sgomes's testing of #90741 alone found that when testing with Chrome dev tools "Fast 3G", LCP improved from 49s to 5.4s. If we add in the other two PRs, which reduce the page weight from ~50MB to ~5MB, it seems a bit surprising that we appeared to see a small impact (perhaps a 1% improvement in conversions at best, and possibly much less) given that our RUM stats show that almost 20% of users at the design picker were on a 3G or slower connection. One caveat about that stat is that Chrome appears to report 3G or slower if either latency or bandwidth are worse than some threshold. If users have high bandwidth and high latency, they could see a much smaller performance improvement than we saw in tests.

The hope is that this A/B test gives us some more info about the impact of these changes.

## Testing Instructions

We should look at the experimental and control conditions to see that we're actually displaying the correct images in the correct order in both conditions. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
