### PR TITLE
Fix Wapuu styles in the Help Center

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -81,9 +81,17 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 
 	const setOdieStorage = useSetOdieStorage( 'chat_id' );
 
+	// Disabled component only applies the class if isDisabled is true, we want it always.
+	const OptionalDisabled = isMinimized
+		? Disabled
+		: ( props: React.HTMLAttributes< HTMLDivElement > ) => <div { ...props } />;
+
 	return (
 		<CardBody ref={ containerRef } className="help-center__container-content">
-			<Disabled isDisabled={ isMinimized }>
+			<OptionalDisabled
+				isDisabled={ isMinimized }
+				className="help-center__container-content-wrapper"
+			>
 				<Routes>
 					<Route
 						path="/"
@@ -122,7 +130,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 						}
 					/>
 				</Routes>
-			</Disabled>
+			</OptionalDisabled>
 		</CardBody>
 	);
 };

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -67,6 +67,10 @@ $head-foot-height: 50px;
 			}
 		}
 
+		.help-center__container-content-wrapper {
+			height: 100%;
+		}
+
 		.help-center__container-content {
 			overflow-y: auto;
 			padding: 16px;
@@ -253,9 +257,7 @@ $head-foot-height: 50px;
 		max-width: 410px;
 
 		.help-center__container-odie-header {
-			border-width: 1px;
-			border-style: solid;
-			border-color: rgba(0, 0, 0, 0.1);
+			border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 			height: 69px;
 			display: flex;
 			align-items: center;
@@ -273,7 +275,7 @@ $head-foot-height: 50px;
 	.help-center__container-content {
 		padding: 0 !important;
 
-		> *:not(iframe):not(.help-center__container-content-odie) {
+		> div > *:not(iframe):not(.help-center__container-content-odie) {
 			padding: 16px;
 			box-sizing: border-box;
 		}

--- a/packages/odie-client/src/components/message/jump-to-recent.tsx
+++ b/packages/odie-client/src/components/message/jump-to-recent.tsx
@@ -3,21 +3,12 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useOdieAssistantContext } from '../../context';
 
-/**
- * This might be synced with CSS in client/odie/message/style.scss, which is half of the height for the gradient.
- * Used to calculate the bottom offset for the jump to recent button, so it doesn't overlap with the last message.
- * Also, making it twice as big, will prevent the gradient to be not visible when the input grows/shrinks in height.
- */
-const heightOffset = 48;
-
 export const JumpToRecent = ( {
 	scrollToBottom,
 	enableJumpToRecent,
-	bottomOffset,
 }: {
 	scrollToBottom: () => void;
 	enableJumpToRecent: boolean;
-	bottomOffset: number;
 } ) => {
 	const { trackEvent, isMinimized } = useOdieAssistantContext();
 	const translate = useTranslate();
@@ -36,7 +27,7 @@ export const JumpToRecent = ( {
 	} );
 
 	return (
-		<div className={ className } style={ { bottom: bottomOffset - heightOffset } }>
+		<div className={ className }>
 			<button
 				className="odie-jump-to-recent-message-button"
 				disabled={ ! enableJumpToRecent }

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -174,6 +174,7 @@
 }
 
 $feedback-button-size: 28px;
+
 .odie-feedback-component-container {
 	display: flex;
 	justify-content: space-between;
@@ -250,17 +251,16 @@ $feedback-button-size: 28px;
 $custom-border-corner-size: 16px;
 
 .odie-gradient-to-white {
-	position: absolute;
-	left: 0;
-	right: 0;
 	background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 50%);
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	height: 96px;
+	height: 100px;
 	justify-content: center;
 	z-index: 5;
 	pointer-events: none;
+	position: fixed;
+	width: 100%;
 
 	&.is-hidden {
 		opacity: 0;
@@ -324,31 +324,38 @@ $custom-border-corner-size: 16px;
 		-webkit-transform: scale3d(1, 1, 1);
 		transform: scale3d(1, 1, 1);
 	}
+
 	30% {
 		-webkit-transform: scale3d(1.25, 0.75, 1);
 		transform: scale3d(1.25, 0.75, 1);
 	}
+
 	40% {
 		-webkit-transform: scale3d(0.75, 1.25, 1);
 		transform: scale3d(0.75, 1.25, 1);
 	}
+
 	50% {
 		-webkit-transform: scale3d(1.15, 0.85, 1);
 		transform: scale3d(1.15, 0.85, 1);
 	}
+
 	65% {
 		-webkit-transform: scale3d(0.95, 1.05, 1);
 		transform: scale3d(0.95, 1.05, 1);
 	}
+
 	75% {
 		-webkit-transform: scale3d(1.05, 0.95, 1);
 		transform: scale3d(1.05, 0.95, 1);
 	}
+
 	100% {
 		-webkit-transform: scale3d(1, 1, 1);
 		transform: scale3d(1, 1, 1);
 	}
 }
+
 .odie-feedback-message {
 	position: relative;
 	font-weight: 600;
@@ -392,6 +399,7 @@ $custom-border-corner-size: 16px;
 	0% {
 		height: $feedback-button-size;
 	}
+
 	100% {
 		height: 0;
 	}
@@ -401,6 +409,7 @@ $custom-border-corner-size: 16px;
 	0% {
 		opacity: 1;
 	}
+
 	100% {
 		opacity: 0;
 	}
@@ -411,6 +420,7 @@ $custom-border-corner-size: 16px;
 		transform: translateY(1rem);
 		opacity: 0;
 	}
+
 	100% {
 		transform: translateY(0);
 		opacity: 1;

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -80,8 +80,6 @@ export const OdieSendMessageButton = ( {
 		await sendMessageIfNotEmpty();
 	};
 
-	const divContainerHeight = divContainerRef?.current?.clientHeight;
-
 	const userHasAskedToContactHE = chat.messages.some(
 		( message ) => message.context?.flags?.forward_to_human_support === true
 	);
@@ -89,11 +87,7 @@ export const OdieSendMessageButton = ( {
 
 	return (
 		<>
-			<JumpToRecent
-				scrollToBottom={ scrollToRecent }
-				enableJumpToRecent={ enableJumpToRecent }
-				bottomOffset={ divContainerHeight ?? 0 }
-			/>
+			<JumpToRecent scrollToBottom={ scrollToRecent } enableJumpToRecent={ enableJumpToRecent } />
 			<div className="odie-chat-message-input-container" ref={ divContainerRef }>
 				<form onSubmit={ handleSubmit } className="odie-send-message-input-container">
 					<TextareaAutosize

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -22,7 +22,6 @@ export const OdieAssistant: React.FC = () => {
 	const chatboxMessagesRef = useRef< HTMLDivElement | null >( null );
 	const { ref: bottomRef, entry: lastMessageElement, inView } = useInView( { threshold: 0 } );
 	const [ stickToBottom, setStickToBottom ] = useState( true );
-
 	const scrollToBottom = useCallback(
 		( force = false ) => {
 			if ( force || stickToBottom ) {
@@ -30,7 +29,7 @@ export const OdieAssistant: React.FC = () => {
 					if ( lastMessageElement?.target ) {
 						lastMessageElement.target.scrollIntoView( {
 							behavior: 'auto',
-							block: 'start',
+							block: 'end',
 							inline: 'nearest',
 						} );
 					}

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -1,7 +1,6 @@
 .chatbox {
 	width: 100%;
-	height: calc(100% - 69px);
-
+	height: calc(100% - 138px);
 	background-color: #f8f9fa;
 	display: flex;
 	flex-direction: column;
@@ -49,9 +48,6 @@
 .chat-box-message-container {
 	width: 100%;
 	height: 100%;
-	display: flex;
-	flex-direction: column;
-	place-content: flex-end;
 	background-color: #fff;
 }
 
@@ -75,13 +71,14 @@
 
 .odie-chat-message-input-container {
 	z-index: 10;
+	position: relative;
 	max-width: 410px;
 	flex-shrink: 0;
+	box-sizing: border-box;
 	border-radius: 4px;
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 	padding: 12px;
-	border: 1px solid var(--gray-gray-5, #dcdcde);
+	border-top: 1px solid var(--gray-gray-5, #dcdcde);
 	background: var(--black-white-white, #fff);
-	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 7px 7px 0 rgba(0, 0, 0, 0.04), 0 15px 9px 0 rgba(0, 0, 0, 0.02), 0 26px 11px 0 rgba(0, 0, 0, 0.01), 0 41px 12px 0 rgba(0, 0, 0, 0);
 }

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -71,7 +71,9 @@
 
 .odie-chat-message-input-container {
 	z-index: 10;
-	position: relative;
+	position: fixed;
+	width: 100%;
+	bottom: 0;
 	max-width: 410px;
 	flex-shrink: 0;
 	box-sizing: border-box;


### PR DESCRIPTION
This improves the styles of Wapuu in the Help Center to make it more usable.

1. Make the top bar sticky even when you scroll.
2. Makes the message field fixed even when you scroll.
3. Removes all the weird blank spaces.
4. Removes a few extra (double) borders.

### Testing
1. Go to My Home.
2. Click "Still need help?".
3. Chat a bit until you have a scrollable thread.
4. See that it has no visual or UX issues. 

| Before | After |
|--------|--------|
| ![image](https://github.com/Automattic/wp-calypso/assets/17054134/c99b14df-a944-4743-bf2d-c6332235ab9b) | ![image](https://github.com/Automattic/wp-calypso/assets/17054134/0327e93a-fc22-41ab-8858-c2fc7af5a72a) |