### PR TITLE
Hosting Features: update cards to match actual features

### DIFF
--- a/client/hosting-features/components/hosting-features.tsx
+++ b/client/hosting-features/components/hosting-features.tsx
@@ -1,12 +1,12 @@
 import { FEATURE_SFTP, getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Card, Dialog } from '@automattic/components';
+import { Dialog } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
-import CardHeading from 'calypso/components/card-heading';
+import { HostingCard } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -23,15 +23,14 @@ type PromoCardProps = {
 };
 
 const PromoCard = ( { title, text, supportContext }: PromoCardProps ) => (
-	<Card className="hosting-features__card">
-		<CardHeading>{ title }</CardHeading>
+	<HostingCard className="hosting-features__card" title={ title }>
 		<p>{ text }</p>
 		{ translate( '{{supportLink}}Learn more{{/supportLink}}', {
 			components: {
 				supportLink: <InlineSupportLink supportContext={ supportContext } showIcon={ false } />,
 			},
 		} ) }
-	</Card>
+	</HostingCard>
 );
 
 const HostingFeatures = () => {
@@ -70,16 +69,16 @@ const HostingFeatures = () => {
 			supportContext: 'site-monitoring-metrics',
 		},
 		{
-			title: translate( 'PHP Logs' ),
-			text: translate( 'View and download PHP error logs to diagnose and resolve issues quickly.' ),
+			title: translate( 'Logs' ),
+			text: translate(
+				'View and download PHP error and web server logs to diagnose and resolve issues quickly.'
+			),
 			supportContext: 'site-monitoring-logs',
 		},
 		{
-			title: translate( 'Server Logs' ),
-			text: translate(
-				'Gain full visibility into server activity, helping you manage traffic and spot security issues early.'
-			),
-			supportContext: 'site-monitoring-logs',
+			title: translate( 'Staging Site' ),
+			text: translate( 'Preview and troubleshoot changes before updating your production site.' ),
+			supportContext: 'hosting-staging-site',
 		},
 		{
 			title: hasEnTranslation( 'Server Settings' )

--- a/client/hosting-features/components/style.scss
+++ b/client/hosting-features/components/style.scss
@@ -40,20 +40,6 @@
 }
 
 .hosting-features__card {
-	border-radius: 4px;
-	border: 1px solid var(--studio-gray-5);
-	box-shadow: none;
-	margin: 0;
-	padding: 24px;
-	display: flex;
-	flex-direction: column;
-
-	> .card-heading {
-		font-size: rem(16px);
-		font-weight: 500;
-		margin-bottom: 6px;
-	}
-
 	> p {
 		font-size: rem(14px);
 		margin-bottom: 20px;


### PR DESCRIPTION
## Proposed Changes

This PR updates the Hosting Features upsell cards to match with the actual features, by:

- combining the PHP Logs and Server Logs into Logs
- adding Staging Site

|Before|After|
|-|-|
|<img width="1405" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/a3ff195a-8273-4185-b4d6-e00130274115">|<img width="1396" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/b619c1f9-169b-45f0-a4b3-ed273b17a138">|

### Implementation Details

This PR also updates the cards to use the `<HostingCard />` component, so that the style matches with the rest of the cards in Site Management Panel.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The cards now match with the actual features on an Atomic site.

## Testing Instructions

1. Go to /sites
2. Click a Simple site
3. Click Hosting Features tab
4. Verify the cards as screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
