### PR TITLE
Affiliates: Add new flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -702,6 +702,17 @@ export function generateFlows( {
 			optionalDependenciesInQuery: [ 'toStepper' ],
 			hideProgressIndicator: true,
 		},
+		{
+			name: 'affiliates',
+			steps: [ 'domains', 'plans-affiliates', userSocialStep ],
+			destination: getSignupDestination,
+			description: 'Affiliates flow',
+			lastModified: '2024-06-06',
+			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'coupon' ],
+			optionalDependenciesInQuery: [ 'coupon' ],
+			hideProgressIndicator: true,
+		},
 	];
 
 	// convert the array to an object keyed by `name`

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -703,8 +703,8 @@ export function generateFlows( {
 			hideProgressIndicator: true,
 		},
 		{
-			name: 'affiliates',
-			steps: [ 'domains', 'plans-affiliates', userSocialStep ],
+			name: 'onboarding-affiliate',
+			steps: [ userSocialStep, 'domains', 'plans-affiliate' ],
 			destination: getSignupDestination,
 			description: 'Affiliates flow',
 			lastModified: '2024-06-06',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -36,6 +36,7 @@ const stepNameToModuleName = {
 	'plans-premium': 'plans',
 	'plans-site-selected': 'plans',
 	'plans-site-selected-legacy': 'plans',
+	'plans-affiliates': 'plans',
 	site: 'site',
 	'rewind-migrate': 'rewind-migrate',
 	'rewind-were-backing': 'rewind-were-backing',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -36,7 +36,7 @@ const stepNameToModuleName = {
 	'plans-premium': 'plans',
 	'plans-site-selected': 'plans',
 	'plans-site-selected-legacy': 'plans',
-	'plans-affiliates': 'plans',
+	'plans-affiliate': 'plans',
 	site: 'site',
 	'rewind-migrate': 'rewind-migrate',
 	'rewind-were-backing': 'rewind-were-backing',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -405,6 +405,18 @@ export function generateSteps( {
 			},
 		},
 
+		'plans-affiliates': {
+			stepName: 'plans-affiliates',
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo' ],
+			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],
+			fulfilledStepCallback: isPlanFulfilled,
+			props: {
+				intent: 'plans-affiliates',
+			},
+		},
+
 		'mailbox-plan': {
 			stepName: 'mailbox-plan',
 			apiRequestFunction: addPlanToCart,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -405,15 +405,15 @@ export function generateSteps( {
 			},
 		},
 
-		'plans-affiliates': {
-			stepName: 'plans-affiliates',
+		'plans-affiliate': {
+			stepName: 'plans-affiliate',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
 			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo' ],
 			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isPlanFulfilled,
 			props: {
-				intent: 'plans-affiliates',
+				intent: 'plans-affiliate',
 			},
 		},
 

--- a/client/state/signup/flow/selectors.js
+++ b/client/state/signup/flow/selectors.js
@@ -14,5 +14,5 @@ export function getExcludedSteps( state ) {
 	return get( state, 'signup.flow.excludedSteps', [] );
 }
 
-export const isOnboardingAffiliateFlow = ( state ) =>
+export const getIsOnboardingAffiliateFlow = ( state ) =>
 	'onboarding-affiliate' === getCurrentFlowName( state );

--- a/client/state/signup/flow/selectors.js
+++ b/client/state/signup/flow/selectors.js
@@ -13,3 +13,6 @@ export function getPreviousFlowName( state ) {
 export function getExcludedSteps( state ) {
 	return get( state, 'signup.flow.excludedSteps', [] );
 }
+
+export const isOnboardingAffiliateFlow = ( state ) =>
+	'onboarding-affiliate' === getCurrentFlowName( state );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -256,7 +256,7 @@
 		"guided",
 		"domain-for-gravatar",
 		"plans-first",
-		"affiliates"
+		"onboarding-affiliate"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -255,7 +255,8 @@
 		"site-selected",
 		"guided",
 		"domain-for-gravatar",
-		"plans-first"
+		"plans-first",
+		"affiliates"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"
 }

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -196,6 +196,9 @@ const usePlanTypesWithIntent = ( {
 		case 'plans-videopress':
 			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;
+		case 'plans-affiliates':
+			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			break;
 		default:
 			planTypes = availablePlanTypes;
 	}

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -196,7 +196,7 @@ const usePlanTypesWithIntent = ( {
 		case 'plans-videopress':
 			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;
-		case 'plans-affiliates':
+		case 'plans-affiliate':
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		default:

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -57,7 +57,7 @@ export interface GridPlan {
 export type GridSize = 'small' | 'medium' | 'large';
 
 export type PlansIntent =
-	| 'plans-affiliates'
+	| 'plans-affiliate'
 	| 'plans-blog-onboarding'
 	| 'plans-newsletter'
 	| 'plans-link-in-bio'

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -57,6 +57,7 @@ export interface GridPlan {
 export type GridSize = 'small' | 'medium' | 'large';
 
 export type PlansIntent =
+	| 'plans-affiliates'
 	| 'plans-blog-onboarding'
 	| 'plans-newsletter'
 	| 'plans-link-in-bio'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7149

## Proposed Changes

* Adds the new affiliates flow: `/start/onboarding-affiliate` (name also suggested from discussion pfjeM4-Ps-p2)
* This is a replica of `/start`, excluding the Enterprise plan from the plans step
* A state selector `isOnboardingAffiliateFlow` to be used in follow-ups
* Additional modifications will be done separately in follow-ups

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See PT pfjeM4-Pv-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/onboarding-affiliate`
* Confirm from start to finish the steps reflect what's depicted in the PT's flowchart pfjeM4-Pv-p2 
  * same as `/start` excluding `Enterprise` plan from plans step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?