### PR TITLE
Scheduled Updates: Update empty state style to match new Figma version

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -89,10 +89,8 @@ $brand-display: "SF Pro Display", sans-serif;
 		}
 
 		p {
-			color: var(--studio-gray-100);
+			color: var(--studio-gray-80);
 			margin: 1.5rem auto;
-			font-size: rem(18px);
-			line-height: 1.625;
 		}
 	}
 


### PR DESCRIPTION
Related to p1717600891645249-slack-C06DN6QQVAQ

## Proposed Changes

* Updates empty state style to match the new Figma version
  - updates color
  - changes the font size to default value of `14px`, the figma says `13px`, but we are leaving the default one since it's the value in other screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates`
* Make sure you don't have any schedule in your scheduled updates list
* Check if the font size and color value are reduced

| Before | After |
|--------|--------|
| <img width="857" alt="Screenshot 2024-06-10 at 13 34 52" src="https://github.com/Automattic/wp-calypso/assets/1241413/d96c0de0-c605-461f-bff0-5adab51019e2"> | <img width="777" alt="Screenshot 2024-06-10 at 13 46 09" src="https://github.com/Automattic/wp-calypso/assets/1241413/524e65ec-1f58-43e7-92be-da6cbe1924bc"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?