### PR TITLE
Command palette: Consistently use _open tracks event

### DIFF
--- a/client/layout/global-sidebar/footer.tsx
+++ b/client/layout/global-sidebar/footer.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { recordCommandPaletteOpen } from '@automattic/command-palette';
+import { recordCommandPaletteOpen } from '@automattic/command-palette/src/tracks';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { LocalizeProps } from 'i18n-calypso';

--- a/client/layout/global-sidebar/footer.tsx
+++ b/client/layout/global-sidebar/footer.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordCommandPaletteOpen } from '@automattic/command-palette';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { LocalizeProps } from 'i18n-calypso';
@@ -9,6 +10,7 @@ import QuickLanguageSwitcher from 'calypso/layout/masterbar/quick-language-switc
 import SidebarFooter from 'calypso/layout/sidebar/footer';
 import { UserData } from 'calypso/lib/user/user';
 import { useSelector } from 'calypso/state';
+import getCurrentRoutePattern from 'calypso/state/selectors/get-current-route-pattern';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { GLOBAL_SIDEBAR_EVENTS } from './events';
 import SidebarMenuItem from './menu-items/menu-item';
@@ -25,6 +27,8 @@ export const GlobalSidebarFooter: FC< {
 
 	const isMac = window?.navigator.userAgent && window.navigator.userAgent.indexOf( 'Mac' ) > -1;
 	const searchShortcut = isMac ? '⌘ + K' : 'Ctrl + K';
+
+	const currentRoute = useSelector( getCurrentRoutePattern ) ?? '';
 
 	return (
 		<SidebarFooter>
@@ -56,7 +60,10 @@ export const GlobalSidebarFooter: FC< {
 								  } )
 								: translate( 'Jump to…' )
 						}
-						onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.SEARCH_CLICK ) }
+						onClick={ () => {
+							recordCommandPaletteOpen( currentRoute, 'sidebar_click' );
+							recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.SEARCH_CLICK );
+						} }
 					/>
 					<SidebarNotifications
 						className="sidebar__item-notifications"

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -13,6 +13,7 @@ import {
 	CommandPaletteContextProvider,
 	useCommandPaletteContext,
 } from './context';
+import { recordCommandPaletteOpen } from './tracks';
 import { COMMAND_SEPARATOR, useCommandFilter } from './use-command-filter';
 import { useCommandPalette } from './use-command-palette';
 import { siteUsesWpAdminInterface } from './utils';
@@ -272,13 +273,6 @@ const toggleModalOpenClassnameOnDocumentHtmlElement = ( isModalOpen: boolean ) =
 	document.body.classList.toggle( COMMAND_PALETTE_MODAL_OPEN_CLASSNAME, isModalOpen );
 };
 
-const recordCommandPaletteOpen = ( currentRoute: string, openType: string ) => {
-	recordTracksEvent( 'calypso_hosting_command_palette_open', {
-		current_route: currentRoute,
-		opened_with: openType,
-	} );
-};
-
 const CommandPalette = ( {
 	currentRoute,
 	currentSiteId,
@@ -475,4 +469,3 @@ export default CommandPalette;
 export type { Command, CommandCallBackParams } from './commands';
 export { useCommands } from './commands';
 export { PromptIcon } from './icons/prompt';
-export { recordCommandPaletteOpen };

--- a/packages/command-palette/src/index.tsx
+++ b/packages/command-palette/src/index.tsx
@@ -272,6 +272,13 @@ const toggleModalOpenClassnameOnDocumentHtmlElement = ( isModalOpen: boolean ) =
 	document.body.classList.toggle( COMMAND_PALETTE_MODAL_OPEN_CLASSNAME, isModalOpen );
 };
 
+const recordCommandPaletteOpen = ( currentRoute: string, openType: string ) => {
+	recordTracksEvent( 'calypso_hosting_command_palette_open', {
+		current_route: currentRoute,
+		opened_with: openType,
+	} );
+};
+
 const CommandPalette = ( {
 	currentRoute,
 	currentSiteId,
@@ -296,9 +303,7 @@ const CommandPalette = ( {
 		toggleModalOpenClassnameOnDocumentHtmlElement( true );
 
 		setIsOpenLocal( true );
-		recordTracksEvent( 'calypso_hosting_command_palette_open', {
-			current_route: currentRoute,
-		} );
+		recordCommandPaletteOpen( currentRoute, 'keyboard' );
 	}, [ currentRoute ] );
 	const close = useCallback< CommandPaletteContext[ 'close' ] >(
 		( commandName = '', isExecuted = false ) => {
@@ -470,3 +475,4 @@ export default CommandPalette;
 export type { Command, CommandCallBackParams } from './commands';
 export { useCommands } from './commands';
 export { PromptIcon } from './icons/prompt';
+export { recordCommandPaletteOpen };

--- a/packages/command-palette/src/tracks.ts
+++ b/packages/command-palette/src/tracks.ts
@@ -1,6 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 
-export const recordCommandPaletteOpen = ( currentRoute: string, openType: 'keyboard' | 'sidebar_click' ) => {
+export const recordCommandPaletteOpen = (
+	currentRoute: string,
+	openType: 'keyboard' | 'sidebar_click'
+) => {
 	recordTracksEvent( 'calypso_hosting_command_palette_open', {
 		current_route: currentRoute,
 		opened_with: openType,

--- a/packages/command-palette/src/tracks.ts
+++ b/packages/command-palette/src/tracks.ts
@@ -1,0 +1,8 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+
+export const recordCommandPaletteOpen = ( currentRoute: string, openType: string ) => {
+	recordTracksEvent( 'calypso_hosting_command_palette_open', {
+		current_route: currentRoute,
+		opened_with: openType,
+	} );
+};

--- a/packages/command-palette/src/tracks.ts
+++ b/packages/command-palette/src/tracks.ts
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 
-export const recordCommandPaletteOpen = ( currentRoute: string, openType: string ) => {
+export const recordCommandPaletteOpen = ( currentRoute: string, openType: 'keyboard' | 'sidebar_click' ) => {
 	recordTracksEvent( 'calypso_hosting_command_palette_open', {
 		current_route: currentRoute,
 		opened_with: openType,


### PR DESCRIPTION
The `calypso_hosting_command_palette_open` event should be used whenever the WordPress.com command palette is opened. This change adds a function to help that happen consistently and uses it from the sites sidebar.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91633

## Proposed Changes

1. Export a `recordCommandPaletteOpen` function to trigger a tracks event
2. Use the function from the sites sidebar

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

So we can have a single event to track how often the command palette is opened, and to be able to break that down with how it was opened - distinguishing between clicks and keyboards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Go to /sites
3. Click on the command palette icon in the footer of the sidebar. 
4. Note that the `calypso_hosting_command_palette_open` tracks event should be fired (check your browser tools for requests to t.gif with a matching `_en`. Note that the current_route should be recorded using the page you're on, and the `opened_with` property should be `sidebar_click`
5. Invoke the command palette with ⌘k, the same event should be fired but the `opened_with` event should be set to `keyboard`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
