### PR TITLE
Plugins logged out: Center content

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -201,14 +201,17 @@ const LayoutLoggedOut = ( {
 		! isReaderSearchPage &&
 		! isReaderDiscoverPage
 	) {
+		const nonMonochromeSections = [ 'plugins' ];
+
 		masterbar = (
 			<UniversalNavbarHeader
 				isLoggedIn={ isLoggedIn }
 				sectionName={ sectionName }
-				{ ...( isEnabled( 'site-profiler/metrics' ) && {
-					logoColor: 'white',
-					className: 'is-style-monochrome',
-				} ) }
+				{ ...( isEnabled( 'site-profiler/metrics' ) &&
+					! nonMonochromeSections.includes( sectionName ) && {
+						logoColor: 'white',
+						className: 'is-style-monochrome',
+					} ) }
 				{ ...( sectionName === 'subscriptions' && { variant: 'minimal' } ) }
 				{ ...( sectionName === 'patterns' && {
 					startUrl: getPatternLibraryOnboardingUrl( locale, isLoggedIn ),

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -94,10 +94,12 @@ body.command-palette-modal-open {
 		}
 	}
 
-	// The plugins site view needs the header to be full width, so the padding
-	// is added on the header and .plugins-browser__content-wrapper instead
-	.is-section-plugins & {
-		padding: 79px 0 32px calc(var(--sidebar-width-max) + 1px);
+	.is-logged-in & {
+		// The plugins site view needs the header to be full width, so the padding
+		// is added on the header and .plugins-browser__content-wrapper instead
+		.is-section-plugins & {
+			padding: 79px 0 32px calc(var(--sidebar-width-max) + 1px);
+		}
 	}
 
 	// This is needed to ensure the WebPreview component


### PR DESCRIPTION
@lucasmendes-design [noticed](https://github.com/Automattic/dotcom-forge/issues/7537#issuecomment-2155237828) that the content is not properly centered on the plugins page when the user is logged out:

![image](https://github.com/Automattic/wp-calypso/assets/8511199/5edbbe6b-1a2c-46a9-a816-4b5c60aea563)

## Proposed Changes

* Apply the `padding` introduced on https://github.com/Automattic/wp-calypso/pull/91250 only when the user is logged in.

## Testing Instructions

* Open the live preview
* Go to `/plugins`
* Check that the content is centered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
