### PR TITLE
Stepper: Remove error on e-commerce flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,5 +1,5 @@
 import { SENSEI_FLOW } from '@automattic/onboarding';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordSignupStart } from 'calypso/lib/analytics/signup';
 import { type Flow } from '../../types';
@@ -21,7 +21,7 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 	// TODO: Check if we can remove the sensei flow reference from here.
 	const firstStepSlug = ( flow.name === SENSEI_FLOW ? steps[ 1 ] : steps[ 0 ] ).slug;
 	const isFirstStep = firstStepSlug === currentStepRoute;
-	const extraProps = useMemo( () => flow.useSignupStartEventProps?.() || {}, [ flow ] );
+	const extraProps = flow.useSignupStartEventProps?.();
 	const flowName = flow.name;
 	const shouldTrack = flow.isSignupFlow && isFirstStep && ! signedUp;
 
@@ -30,6 +30,6 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 			return;
 		}
 
-		recordSignupStart( flowName, ref, extraProps );
+		recordSignupStart( flowName, ref, extraProps || {} );
 	}, [ extraProps, flowName, ref, shouldTrack ] );
 };


### PR DESCRIPTION
## Proposed Changes
* Fix error rendering the e-commerce flow.
The error was caused because there is 

## Testing Instructions
* Access: /setup/ecommerce/storeProfiler
* Check if there is no console error on dev tools.
* Check if the page is rendered.

![error](https://github.com/Automattic/wp-calypso/assets/38718/17c16614-baff-486e-9733-b0dfa047c5be)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
