### PR TITLE
Advertising A4A: Remove translation checks for now translated strings

### DIFF
--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -1,11 +1,10 @@
-import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useHandleClickLink } from './use-handle-click-link';
 
 export const useFeaturesList = () => {
 	const translate = useTranslate();
 	const handleClickLink = useHandleClickLink();
-	const hasEnTranslation = useHasEnTranslation();
 
 	return [
 		{
@@ -38,28 +37,15 @@ export const useFeaturesList = () => {
 		},
 		{
 			id: 'multi-site-management',
-			title: hasEnTranslation( 'Multiple site management' )
-				? translate( 'Multiple site management', {
-						comment: 'Feature title',
-				  } )
-				: translate( 'Multi-site management', {
-						comment: 'Feature title',
-				  } ),
-			description: hasEnTranslation(
-				'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.'
-			)
-				? translate(
-						'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.',
-						{
-							comment: 'Feature description',
-						}
-				  )
-				: translate(
-						'Seamlessly manage and host multiple sites. Receive 50% revenue sharing and volume discounts when you migrate sites to our platform and refer products to clients.',
-						{
-							comment: 'Feature description',
-						}
-				  ),
+			title: translate( 'Multiple site management', {
+				comment: 'Feature title',
+			} ),
+			description: translate(
+				'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.',
+				{
+					comment: 'Feature description',
+				}
+			),
 			linkLearnMore: localizeUrl( 'https://wordpress.com/for-agencies/' ),
 		},
 		{

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -1,5 +1,4 @@
 import { Gridicon } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import {
 	SitesSortKey,
 	useSitesListFiltering,
@@ -241,7 +240,6 @@ const SitesDashboardV2 = ( {
 	const isNarrowView = false;
 
 	const showA8CForAgenciesBanner = paginatedSites.length >= 5;
-	const hasEnTranslation = useHasEnTranslation();
 
 	return (
 		<Layout
@@ -277,25 +275,13 @@ const SitesDashboardV2 = ( {
 									},
 								} ) }
 								className="sites-a8c-for-agencies-banner"
-								description={
-									hasEnTranslation(
-										'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.'
-									)
-										? translate(
-												'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.'
-										  )
-										: translate(
-												'As you’re managing multiple sites, Automattic for Agencies offers you efficient multisite management, volume discounts on hosting products, and up to 50% revenue share for migrating sites and referring products.'
-										  )
-								}
+								description={ translate(
+									'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.'
+								) }
 								dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
 								horizontal
 								href="https://wordpress.com/for-agencies"
-								title={
-									hasEnTranslation( 'Managing multiple sites? Meet our agency hosting' )
-										? translate( 'Managing multiple sites? Meet our agency hosting' )
-										: translate( 'Streamlined multisite agency hosting' )
-								}
+								title={ translate( 'Managing multiple sites? Meet our agency hosting' ) }
 							/>
 						</div>
 					) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/91527

## Proposed Changes

* Because all translations have been completed, this PR removes logic that short circuits for A4A touchpoints if a translation isn't available.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Translations have been completed. We no longer need this extra logic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Sites Dashboard**
* Check out branch
* Navigate to `/sites` as a user with 5 or more sites
* Verify that the banner is rendered
* Verify that the banner can be dismissed permanently
* Switch to a language besides english like ES and verify that the content is translated properly

<img width="1685" alt="Screenshot 2024-06-05 at 10 51 09 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/398f3a62-514b-421d-8b22-92a378c7c1c1">

**/me/developer dashboard**
* Visit `/me/developer`
* Verify that the new multi-site management card is shown
* Verify that the "Learn more" hyperlink leads to the A4A website
* Switch to a language besides english like ES and verify that the banner is translated properly

<img width="1128" alt="Screenshot 2024-06-05 at 10 50 58 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/51618035-fe52-4e63-8737-21356ea429ea">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
