### PR TITLE
GitHub Deployments: Only show survey after users firs deployment

### DIFF
--- a/client/my-sites/github-deployments/components/deployments-survey/index.tsx
+++ b/client/my-sites/github-deployments/components/deployments-survey/index.tsx
@@ -1,23 +1,37 @@
 import { useLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
 import ReactDOM from 'react-dom';
 import SurveyModal from 'calypso/components/survey-modal';
 
 export const GitHubDeploymentSurvey = () => {
 	const localeSlug = useLocale();
+	const { hasTranslation } = useI18n();
 
 	if ( localeSlug !== 'en' ) {
 		return null;
 	}
 
+	const title = hasTranslation( 'Share your thoughts on GitHub Deployments' )
+		? translate( 'Share your thoughts on GitHub Deployments' )
+		: translate( 'Hey Developer!' );
+
+	const description = hasTranslation(
+		'Got a moment? We’d love to hear about your experience using GitHub Deployments in our quick survey.'
+	)
+		? translate(
+				'Got a moment? We’d love to hear about your experience using GitHub Deployments in our quick survey.'
+		  )
+		: translate(
+				'Got a moment? How do you like using GitHub Deployments so far? Share your thoughts with us in our quick survey.'
+		  );
+
 	return ReactDOM.createPortal(
 		<SurveyModal
 			name="github-deployments"
 			url="https://automattic.survey.fm/github-deployments-survey?initiated-from=calypso"
-			title={ translate( 'Hey Developer!' ) }
-			description={ translate(
-				`Got a moment? How do you like using GitHub Deployments so far? Share your thoughts with us in our quick survey.`
-			) }
+			title={ title }
+			description={ description }
 			dismissText={ translate( 'Remind later' ) }
 			confirmText={ translate( 'Take survey' ) }
 			showOverlay={ false }

--- a/client/my-sites/github-deployments/components/deployments-survey/index.tsx
+++ b/client/my-sites/github-deployments/components/deployments-survey/index.tsx
@@ -1,14 +1,10 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import ReactDOM from 'react-dom';
-import surveyImage from 'calypso/assets/images/illustrations/github-deployments.svg';
 import SurveyModal from 'calypso/components/survey-modal';
 
 export const GitHubDeploymentSurvey = () => {
 	const localeSlug = useLocale();
-
-	// Disable it for now
-	return null;
 
 	if ( localeSlug !== 'en' ) {
 		return null;
@@ -22,7 +18,6 @@ export const GitHubDeploymentSurvey = () => {
 			description={ translate(
 				`Got a moment? How do you like using GitHub Deployments so far? Share your thoughts with us in our quick survey.`
 			) }
-			surveyImage={ surveyImage }
 			dismissText={ translate( 'Remind later' ) }
 			confirmText={ translate( 'Take survey' ) }
 			showOverlay={ false }

--- a/client/my-sites/github-deployments/deployments/index.tsx
+++ b/client/my-sites/github-deployments/deployments/index.tsx
@@ -28,6 +28,7 @@ export function GitHubDeployments() {
 			return (
 				<>
 					<GitHubDeploymentsList deployments={ deployments } />
+					<GitHubDeploymentSurvey />
 				</>
 			);
 		}
@@ -65,7 +66,6 @@ export function GitHubDeployments() {
 			}
 		>
 			{ renderContent() }
-			<GitHubDeploymentSurvey />
 		</PageShell>
 	);
 }

--- a/client/my-sites/github-deployments/deployments/index.tsx
+++ b/client/my-sites/github-deployments/deployments/index.tsx
@@ -28,7 +28,9 @@ export function GitHubDeployments() {
 			return (
 				<>
 					<GitHubDeploymentsList deployments={ deployments } />
-					<GitHubDeploymentSurvey />
+					{ deployments.some( ( deployment ) => deployment.current_deployed_run !== null ) && (
+						<GitHubDeploymentSurvey />
+					) }
 				</>
 			);
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* We only show deployment survey after the users first deployment
* Remove the survey image to make it less intrusive

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the survey more contextual and less intrusive

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/github-deployments/atomic_site`
* Verify the survey does not show if there are no deployments
* Verify the survey only shows after a deployment run has been completed (i.e you have successfully deployed code to your site)

##Before
![image](https://github.com/Automattic/wp-calypso/assets/47489215/5aeb08a7-019e-4287-88d7-4d92c5104ac8)


## After
![image](https://github.com/Automattic/wp-calypso/assets/47489215/934053fb-75f8-421f-b453-b26a5d4c2a16)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
