### PR TITLE
Social Previews: Bump version to 2.0.1

### DIFF
--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## v2.0.1-beta
+## v2.0.1
 
-- Added Mastodon, Instagram and Nextdoor previews
-- Fixed hyperlinks for Facebook
-- Fixed multiple empty lines issue in preview text
-- Fixed video previews for Instagram and Tumblr
-- Fixed empty Twitter preview when no text/description is provided
-- Changed Twitter text and icon to X
+- Added Mastodon, Instagram and Nextdoor previews.
+- Fixed hyperlinks for Facebook.
+- Fixed multiple empty lines issue in preview text.
+- Fixed video previews for Instagram and Tumblr.
+- Fixed empty Twitter preview when no text/description is provided.
+- Changed Twitter text and icon to X.
+- Switch dependency from `classnames` to `clsx`.
 
 ## v2.0.0 (2023-05-24)
 

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.0.1-beta.13",
+	"version": "2.0.1",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This bumps the `@automattic/social-previews` package version to v2.0.1 so we can publish the `classnames` → `clsx` changes.

Internal reference: pdWQjU-Mt-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?