### PR TITLE
A4A: fix referrals purchases count

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
@@ -17,7 +17,7 @@ const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
 				id: referral.id,
 				client_id: referral.client_id,
 				client_email: referral.client_email,
-				purchases: referral.products,
+				purchases: [ ...referral.products ],
 				commissions: referral.commission,
 				statuses: [ referral.status ],
 			} );

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
@@ -9,25 +9,25 @@ export const getReferralsQueryKey = ( agencyId?: number ) => {
 };
 
 const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
-	const clients: Referral[] = [];
-	referrals.forEach( ( referral ) => {
-		const clientIndex = clients.findIndex( ( client ) => client.client_id === referral.client_id );
-		if ( clientIndex === -1 ) {
-			clients.push( {
+	const clients = referrals.reduce< { [ key: string ]: Referral } >( ( acc, referral ) => {
+		if ( ! acc[ referral.client_id ] ) {
+			acc[ referral.client_id ] = {
 				id: referral.id,
 				client_id: referral.client_id,
 				client_email: referral.client_email,
 				purchases: [ ...referral.products ],
 				commissions: referral.commission,
 				statuses: [ referral.status ],
-			} );
+			};
 		} else {
-			clients[ clientIndex ].purchases.push( ...referral.products );
-			clients[ clientIndex ].commissions += referral.commission;
-			clients[ clientIndex ].statuses.push( referral.status );
+			acc[ referral.client_id ].purchases.push( ...referral.products );
+			acc[ referral.client_id ].commissions += referral.commission;
+			acc[ referral.client_id ].statuses.push( referral.status );
 		}
-	} );
-	return clients;
+		return acc;
+	}, {} );
+
+	return Object.values( clients );
 };
 
 export default function useFetchReferrals( isEnabled: boolean ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/375

## Proposed Changes

Fix issue with wrong Purchases number in referrals overview. We were overwritting original. Also, refactored a function a bit. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Using live link below make several referrals
- Navigate to `/referrals/dashboard` and check the number of referrals
- Leave the page and enter again, check that behavior is correct.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
