### PR TITLE
Site Migration: Add live chat to site migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -9,6 +9,7 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import wpcom from 'calypso/lib/wp';
 import type { Step } from '../../types';
 import type { UrlData } from 'calypso/blocks/import/types';
@@ -193,6 +194,8 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 		return shouldHideBasedOnRef || shouldHideBasedOnVariant;
 	};
 
+	usePresalesChat( 'wpcom' );
+
 	return (
 		<>
 			<DocumentHead title={ translate( 'Import your site content' ) } />
@@ -218,7 +221,6 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 					/>
 				}
 				recordTracksEvent={ recordTracksEvent }
-				showPresalesChat
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -218,6 +218,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 					/>
 				}
 				recordTracksEvent={ recordTracksEvent }
+				showPresalesChat
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -12,6 +12,7 @@ import { useState, useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import type { Step } from '../../types';
 import './style.scss';
 
@@ -81,6 +82,8 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 		</div>
 	);
 
+	usePresalesChat( 'wpcom' );
+
 	return (
 		<>
 			<DocumentHead title={ translate( 'What do you want to migrate?' ) } />
@@ -92,7 +95,6 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
 				goBack={ navigation.goBack }
-				showPresalesChat
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -92,6 +92,7 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
 				goBack={ navigation.goBack }
+				showPresalesChat
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -9,6 +9,7 @@ import { usePrepareSiteForMigration } from 'calypso/landing/stepper/hooks/use-pr
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import { MaybeLink } from './maybe-link';
 import { PendingActions } from './pending-actions';
 import { ShowHideInput } from './show-hide-input';
@@ -222,6 +223,8 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 		</div>
 	);
 
+	usePresalesChat( 'wpcom' );
+
 	return (
 		<>
 			<DocumentHead title={ translate( 'Migrate your site' ) } />
@@ -242,7 +245,6 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 				}
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
-				showPresalesChat
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -242,6 +242,7 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 				}
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
+				showPresalesChat
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -35,6 +35,8 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 		? getPlanByPathSlug( selectedPlanPathSlug )
 		: getPlan( PLAN_BUSINESS );
 
+	usePresalesChat( 'wpcom' );
+
 	if ( ! siteItem || ! siteSlug || ! plan ) {
 		return;
 	}
@@ -53,8 +55,6 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 		from: migrateFrom,
 		has_source_site: migrateFrom !== '' && migrateFrom !== null,
 	};
-
-	usePresalesChat( 'wpcom' );
 
 	const stepContent = (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -126,6 +126,7 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 				}
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
+				showPresalesChat
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -15,6 +15,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import { MigrationAssistanceModal } from '../../components/migration-assistance-modal';
 import type { Step } from '../../types';
 
@@ -52,6 +53,8 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 		from: migrateFrom,
 		has_source_site: migrateFrom !== '' && migrateFrom !== null,
 	};
+
+	usePresalesChat( 'wpcom' );
 
 	const stepContent = (
 		<>
@@ -126,7 +129,6 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 				}
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
-				showPresalesChat
 			/>
 		</>
 	);

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -2,7 +2,7 @@ import { WordPressLogo, JetpackLogo, WooCommerceWooLogo } from '@automattic/comp
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
+import { usePresalesChat } from 'calypso/lib/presales-chat'; //eslint-disable-line no-restricted-imports
 import ActionButtons from '../action-buttons';
 import SenseiLogo from '../sensei-logo';
 import StepNavigationLink from '../step-navigation-link';

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -6,7 +6,6 @@ import ActionButtons from '../action-buttons';
 import SenseiLogo from '../sensei-logo';
 import StepNavigationLink from '../step-navigation-link';
 import VideoPressLogo from '../videopress-logo';
-
 import './style.scss';
 
 interface Props {

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -2,7 +2,6 @@ import { WordPressLogo, JetpackLogo, WooCommerceWooLogo } from '@automattic/comp
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
-import { usePresalesChat } from 'calypso/lib/presales-chat'; //eslint-disable-line no-restricted-imports
 import ActionButtons from '../action-buttons';
 import SenseiLogo from '../sensei-logo';
 import StepNavigationLink from '../step-navigation-link';
@@ -48,7 +47,6 @@ interface Props {
 	showFooterWooCommercePowered?: boolean;
 	showSenseiPowered?: boolean;
 	showVideoPressPowered?: boolean;
-	showPresalesChat?: boolean;
 }
 
 const StepContainer: React.FC< Props > = ( {
@@ -88,14 +86,8 @@ const StepContainer: React.FC< Props > = ( {
 	showSenseiPowered,
 	showVideoPressPowered,
 	showFooterWooCommercePowered,
-	showPresalesChat,
 } ) => {
 	const translate = useTranslate();
-
-	function PresalesChat() {
-		usePresalesChat( 'wpcom' );
-		return null;
-	}
 
 	const recordClick = ( direction: 'back' | 'forward', stepSectionName?: string ) => {
 		const tracksProps = {
@@ -219,8 +211,6 @@ const StepContainer: React.FC< Props > = ( {
 			) }
 
 			<div className="step-container__content">{ stepContent }</div>
-
-			{ showPresalesChat && <PresalesChat /> }
 
 			{ ! hideSkip && skipButtonAlign === 'bottom' && (
 				<div className="step-container__buttons">

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -2,10 +2,12 @@ import { WordPressLogo, JetpackLogo, WooCommerceWooLogo } from '@automattic/comp
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import ActionButtons from '../action-buttons';
 import SenseiLogo from '../sensei-logo';
 import StepNavigationLink from '../step-navigation-link';
 import VideoPressLogo from '../videopress-logo';
+
 import './style.scss';
 
 interface Props {
@@ -46,6 +48,7 @@ interface Props {
 	showFooterWooCommercePowered?: boolean;
 	showSenseiPowered?: boolean;
 	showVideoPressPowered?: boolean;
+	showPresalesChat?: boolean;
 }
 
 const StepContainer: React.FC< Props > = ( {
@@ -85,8 +88,14 @@ const StepContainer: React.FC< Props > = ( {
 	showSenseiPowered,
 	showVideoPressPowered,
 	showFooterWooCommercePowered,
+	showPresalesChat,
 } ) => {
 	const translate = useTranslate();
+
+	function PresalesChat() {
+		usePresalesChat( 'wpcom' );
+		return null;
+	}
 
 	const recordClick = ( direction: 'back' | 'forward', stepSectionName?: string ) => {
 		const tracksProps = {
@@ -210,6 +219,8 @@ const StepContainer: React.FC< Props > = ( {
 			) }
 
 			<div className="step-container__content">{ stepContent }</div>
+
+			{ showPresalesChat && <PresalesChat /> }
 
 			{ ! hideSkip && skipButtonAlign === 'bottom' && (
 				<div className="step-container__buttons">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87944

## Proposed Changes

* Adds the pre-sales chat to specific steps in the site migration flow.

<img width="1509" alt="Screenshot 2024-06-10 at 6 37 55 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/1198ddb3-0795-45a2-8779-03d4caa08879">

Once this has shipped we need to let Happiness know so they can configure some things in ZD on their end: p9Jlb4-bYZ-p2#comment-11584 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p9Jlb4-bYZ-p2#comment-11584

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/start`
* Go through the onboarding flow; at the goals step, choose "import"
* You should see the live chat icon in the lower right corner (I think live chat is only enabled during certain times of day, so depending on what time of day it is, you may not see it.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?