### PR TITLE
A4A - Partner Directory: Add agency profile application form

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { AgencyDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
 
 export default function useDetailsForm() {
@@ -18,7 +18,7 @@ export default function useDetailsForm() {
 		products: [],
 	} );
 
-	const isValidFormData = useCallback(
+	const isValidFormData = useMemo(
 		(): boolean =>
 			formData.name.length > 0 &&
 			formData.email.length > 0 &&

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from 'react';
+import { AgencyDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
+
+export default function useDetailsForm() {
+	const [ formData, setFormData ] = useState< AgencyDetails >( {
+		name: '',
+		email: '',
+		website: '',
+		bioDescription: '',
+		logoUrl: '',
+		landingPageUrl: '',
+		country: '',
+		isAvailable: true,
+		industry: '',
+		languagesSpoken: [],
+		budgetLowerRange: 0,
+		services: [],
+		products: [],
+	} );
+
+	const isValidFormData = useCallback(
+		(): boolean =>
+			formData.name.length > 0 &&
+			formData.email.length > 0 &&
+			formData.website.length > 0 &&
+			formData.bioDescription.length > 0 &&
+			formData.logoUrl.length > 0 &&
+			formData.landingPageUrl.length > 0 &&
+			formData.country.length > 0 &&
+			formData.industry.length > 0 &&
+			formData.services.length > 0 &&
+			formData.products.length > 0 &&
+			formData.languagesSpoken.length > 0,
+		[ formData ]
+	);
+
+	return {
+		formData,
+		setFormData,
+		isValidFormData,
+	};
+}

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-submit-form.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from 'react';
+import { AgencyDetails } from '../../types';
+
+type Props = {
+	formData: AgencyDetails;
+};
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function useSubmitForm( { formData }: Props ) {
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+
+	const onSubmit = useCallback( () => {
+		setIsSubmitting( true );
+		// FIXME: Submit the  data to the backend
+	}, [] );
+
+	return {
+		onSubmit,
+		isSubmitting,
+	};
+}

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -1,9 +1,152 @@
-const AgencyDetails = () => {
+import { Button } from '@automattic/components';
+import { CheckboxControl, TextareaControl, TextControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import Form from 'calypso/a8c-for-agencies/components/form';
+import FormField from 'calypso/a8c-for-agencies/components/form/field';
+import FormSection from 'calypso/a8c-for-agencies/components/form/section';
+import { AgencyDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
+import IndustrySelector from '../components/industry-selector';
+import LanguageSelector from '../components/laguages-selector';
+import ProductsSelector from '../components/products-selector';
+import ServicesSelector from '../components/services-selector';
+import useDetailsForm from './hooks/use-details-form';
+import useSubmitForm from './hooks/use-submit-form';
+
+const AgencyDetailsForm = () => {
+	const translate = useTranslate();
+
+	const { formData, setFormData, isValidFormData } = useDetailsForm();
+
+	const { onSubmit, isSubmitting } = useSubmitForm( { formData } );
+
+	const setFormFields = ( fields: Record< string, any > ) => {
+		setFormData( ( state: AgencyDetails ) => {
+			return {
+				...state,
+				...fields,
+			};
+		} );
+	};
+
 	return (
-		<div>
-			<h2>Agency Details</h2>
-		</div>
+		<Form
+			title={ translate( 'Finish adding details to your public profile' ) }
+			description={
+				"Add details to your agency's public profile for clients to see. Want to update your expertise instead?"
+			}
+		>
+			<FormSection title={ translate( 'Agency information' ) }>
+				<FormField label={ translate( 'Company name' ) }>
+					<TextControl
+						value={ formData.name }
+						onChange={ ( value ) => setFormFields( { name: value } ) }
+					/>
+				</FormField>
+				<FormField
+					label={ translate( 'Company email' ) }
+					description={ translate( 'Client inquiries and leads will go to this email.' ) }
+				>
+					<TextControl
+						value={ formData.email }
+						onChange={ ( value ) => setFormFields( { email: value } ) }
+					/>
+				</FormField>
+				<FormField label={ translate( 'Company website' ) }>
+					<TextControl
+						value={ formData.website }
+						onChange={ ( value ) => setFormFields( { website: value } ) }
+					/>
+				</FormField>
+				<FormField
+					label={ translate( "Clients' landing page" ) }
+					description={ translate(
+						"Optional: Include your custom landing page for leads from Automattic platforms. We'll direct clients to this page."
+					) }
+				>
+					<TextControl
+						value={ formData.landingPageUrl }
+						onChange={ ( value ) => setFormFields( { landingPageUrl: value } ) }
+					/>
+				</FormField>
+				<FormField label={ translate( 'Company bio' ) }>
+					<TextareaControl
+						value={ formData.bioDescription }
+						onChange={ ( value ) => setFormFields( { bioDescription: value } ) }
+					/>
+				</FormField>
+				<FormField label={ translate( 'Company location' ) }>
+					<TextControl
+						value={ formData.country }
+						onChange={ ( value ) => setFormFields( { country: value } ) }
+					/>
+				</FormField>
+				<FormField
+					label={ translate( 'Company logo' ) }
+					description={ translate( 'Upload your agency logo sized at 800px by 320px.' ) }
+				>
+					<TextControl
+						value={ formData.logoUrl }
+						onChange={ ( value ) => setFormFields( { logoUrl: value } ) }
+					/>
+				</FormField>
+			</FormSection>
+
+			<FormSection
+				title={ translate( 'Listing details' ) }
+				description={ translate( 'Clients can filter these details to find the right agency.' ) }
+			>
+				<FormField label={ translate( 'Availability' ) }>
+					<CheckboxControl
+						checked={ formData.isAvailable }
+						onChange={ ( isChecked ) => setFormFields( { isAvailable: isChecked } ) }
+						label={ translate( "I'm accepting new clients" ) }
+					/>
+				</FormField>
+				<FormField label={ translate( 'Industry' ) }>
+					<IndustrySelector
+						industry={ formData.industry }
+						setIndustry={ ( industry ) => setFormFields( { industry: industry } ) }
+					/>
+				</FormField>
+				<FormField label={ translate( 'Services you offer' ) }>
+					<ServicesSelector
+						selectedServices={ formData.services }
+						setServices={ ( services ) => setFormFields( { services } ) }
+					/>
+				</FormField>
+				<FormField label={ translate( 'Products you work with' ) }>
+					<ProductsSelector
+						selectedProducts={ formData.products }
+						setProducts={ ( products ) => setFormFields( { products } ) }
+					/>
+				</FormField>
+				<FormField label={ translate( 'Languages spoken' ) }>
+					<LanguageSelector
+						selectedLanguages={ formData.languagesSpoken }
+						setLanguages={ ( languagesSpoken ) => setFormFields( { languagesSpoken } ) }
+					/>
+				</FormField>
+			</FormSection>
+
+			<FormSection title={ translate( 'Budget details' ) }>
+				<div>{ translate( 'Budget details' ) }</div>
+				<TextControl
+					value={ formData.budgetLowerRange }
+					onChange={ ( value ) => setFormFields( { budgetLowerRange: value } ) }
+				/>
+				<div>
+					{ translate(
+						'Optionally set your minimum budget. Clients can filter these details to find the right agency.'
+					) }
+				</div>
+			</FormSection>
+			<div className="agency-details-form__footer">
+				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData() || isSubmitting }>
+					{ translate( 'Publish public profile' ) }
+				</Button>
+			</div>
+		</Form>
 	);
 };
 
-export default AgencyDetails;
+export default AgencyDetailsForm;

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -141,7 +141,7 @@ const AgencyDetailsForm = () => {
 				</div>
 			</FormSection>
 			<div className="agency-details-form__footer">
-				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData() || isSubmitting }>
+				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>
 					{ translate( 'Publish public profile' ) }
 				</Button>
 			</div>

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { AgencyDirectoryApplication, DirectoryApplicationType } from '../../types';
 
 type Props = {
@@ -88,7 +88,7 @@ export default function useExpertiseForm( { initialData }: Props ) {
 		} ) );
 	}, [] );
 
-	const isValidFormData = useCallback(
+	const isValidFormData = useMemo(
 		(): boolean =>
 			formData.services.length > 0 &&
 			formData.products.length > 0 &&

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -185,7 +185,7 @@ const AgencyExpertise = ( { initialData }: Props ) => {
 			</FormSection>
 
 			<div className="partner-directory-agency-expertise__footer">
-				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData() || isSubmitting }>
+				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>
 					{ translate( 'Submit my application' ) }
 				</Button>
 

--- a/client/a8c-for-agencies/sections/partner-directory/components/industry-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/industry-selector.tsx
@@ -2,11 +2,11 @@ import { SelectControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 
 type Props = {
-	setIndustry: () => void;
+	setIndustry: ( industry: string ) => void;
 	industry: string;
 };
 
-const IndustrySelector = ( { setIndustry }: Props ) => {
+const IndustrySelector = ( { setIndustry, industry }: Props ) => {
 	const translate = useTranslate();
 
 	const industries = [
@@ -62,7 +62,13 @@ const IndustrySelector = ( { setIndustry }: Props ) => {
 		},
 	];
 
-	return <SelectControl options={ industries } onChange={ setIndustry }></SelectControl>;
+	return (
+		<SelectControl
+			value={ industry }
+			options={ industries }
+			onChange={ setIndustry }
+		></SelectControl>
+	);
 };
 
 export default IndustrySelector;

--- a/client/a8c-for-agencies/sections/partner-directory/components/industry-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/industry-selector.tsx
@@ -11,52 +11,42 @@ const IndustrySelector = ( { setIndustry, industry }: Props ) => {
 
 	const industries = [
 		{
-			disabled: true,
 			label: translate( 'Agricultural services' ),
 			value: 'agricultural_services',
 		},
 		{
-			disabled: true,
 			label: translate( 'Contracted services' ),
 			value: 'contracted_services',
 		},
 		{
-			disabled: true,
 			label: translate( 'Transportation services' ),
 			value: 'transportation_services',
 		},
 		{
-			disabled: true,
 			label: translate( 'Utility services' ),
 			value: 'utility_services',
 		},
 		{
-			disabled: true,
 			label: translate( 'Retail outlet services' ),
 			value: 'retail_outlet_services',
 		},
 		{
-			disabled: true,
 			label: translate( 'Clothing shops' ),
 			value: 'clothing_shops',
 		},
 		{
-			disabled: true,
 			label: translate( 'Miscellaneous shops' ),
 			value: 'miscellaneous_shops',
 		},
 		{
-			disabled: true,
 			label: translate( 'Business services' ),
 			value: 'business_services',
 		},
 		{
-			disabled: true,
 			label: translate( 'Professional services and membership organisations' ),
 			value: 'professional_services_and_membership_organisations',
 		},
 		{
-			disabled: true,
 			label: translate( 'Government services' ),
 			value: 'government_services',
 		},

--- a/client/a8c-for-agencies/sections/partner-directory/components/laguages-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/laguages-selector.tsx
@@ -7,6 +7,7 @@ type Props = {
 };
 
 const LanguagesSelector = ( { setLanguages, selectedLanguages }: Props ) => {
+	// todo: add the language ISO codes as object index
 	const availableLanguages = [
 		'Afrikaans',
 		'Albanian',

--- a/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
@@ -3,7 +3,7 @@ import { TokenItem } from '@wordpress/components/build-types/form-token-field/ty
 import { useTranslate } from 'i18n-calypso';
 
 type Props = {
-	setServices: ( tokens: ( string | TokenItem )[] ) => void;
+	setServices: ( services: ( string | TokenItem )[] ) => void;
 	selectedServices: ( string | TokenItem )[];
 };
 
@@ -25,6 +25,7 @@ const ServicesSelector = ( { setServices, selectedServices }: Props ) => {
 		government_services: translate( 'Government services' ),
 	};
 
+	// It converts the values selected into their keys
 	const setTokens = ( tokens: ( string | TokenItem )[] ) => {
 		const selectedServicesByToken = tokens.filter( ( token ) => {
 			return Object.keys( availableServices ).find(

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -11,7 +11,7 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
-import AgencyDetails from './agency-details';
+import AgencyDetailsForm from './agency-details';
 import AgencyExpertise from './agency-expertise';
 import {
 	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
@@ -50,7 +50,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 		};
 
 		sections[ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ] = {
-			content: <AgencyDetails />,
+			content: <AgencyDetailsForm />,
 			breadcrumbItems: [
 				...sections[ PARTNER_DIRECTORY_DASHBOARD_SLUG ].breadcrumbItems,
 				{

--- a/client/a8c-for-agencies/sections/partner-directory/types.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/types.ts
@@ -22,14 +22,14 @@ export interface AgencyDetails {
 	name: string;
 	email: string;
 	website: string;
-	bio_description: string;
-	logo_url: string;
-	landing_page_url: string;
+	bioDescription: string;
+	logoUrl: string;
+	landingPageUrl: string;
 	country: string;
-	is_available: boolean;
+	isAvailable: boolean;
 	industry: string;
 	services: string[];
 	products: string[];
-	languages_spoken: string[];
-	budget_lower_range: number;
+	languagesSpoken: string[];
+	budgetLowerRange: number;
 }


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/487

## Proposed Changes

This PR implements the Agency Profile page:

**Agency Information**

<img width="620" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/5626ca90-8ba3-4658-8ee0-75f659431ab3">

**Listing details**

<img width="606" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/b4e0ae44-a0b9-429a-a190-566d0b03b2f2">

**Budget details**

<img width="614" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/61ffde9e-4e90-459a-8105-1aa923df0e3c">

**Notes about known issues that will be addressed in another PR**

- The company logo, for now, will be a link. In the next PR, we will address the possibility of uploading it to the Agency profile (WPCOM site) instead of asking for a link. If the logo exist, it will display.
- The Minimum project budget list will be addressed in the next PR.
- The Budget details `Optionally set your minimum budget. Clients can filter these details to find the right agency.` should be under the title.
- The Availability checkbox should be a switcher
- The button `Publish public profile` should be at the right.
- The dropdown selector should be larger:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/60784c09-73d7-4707-b8e7-f8924fbacfb4)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions
- Check the code
- Test the form. Fill out all the fields, and the `Publish public profile` button will be active. If you don't fill out all the fields, the button will be disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
