### PR TITLE
Revert "Fix Wapuu styles in the Help Center (#91626)"

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -81,17 +81,9 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 
 	const setOdieStorage = useSetOdieStorage( 'chat_id' );
 
-	// Disabled component only applies the class if isDisabled is true, we want it always.
-	const OptionalDisabled = isMinimized
-		? Disabled
-		: ( props: React.HTMLAttributes< HTMLDivElement > ) => <div { ...props } />;
-
 	return (
 		<CardBody ref={ containerRef } className="help-center__container-content">
-			<OptionalDisabled
-				isDisabled={ isMinimized }
-				className="help-center__container-content-wrapper"
-			>
+			<Disabled isDisabled={ isMinimized }>
 				<Routes>
 					<Route
 						path="/"
@@ -130,7 +122,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 						}
 					/>
 				</Routes>
-			</OptionalDisabled>
+			</Disabled>
 		</CardBody>
 	);
 };

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -67,10 +67,6 @@ $head-foot-height: 50px;
 			}
 		}
 
-		.help-center__container-content-wrapper {
-			height: 100%;
-		}
-
 		.help-center__container-content {
 			overflow-y: auto;
 			padding: 16px;
@@ -257,7 +253,9 @@ $head-foot-height: 50px;
 		max-width: 410px;
 
 		.help-center__container-odie-header {
-			border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+			border-width: 1px;
+			border-style: solid;
+			border-color: rgba(0, 0, 0, 0.1);
 			height: 69px;
 			display: flex;
 			align-items: center;
@@ -275,7 +273,7 @@ $head-foot-height: 50px;
 	.help-center__container-content {
 		padding: 0 !important;
 
-		> div > *:not(iframe):not(.help-center__container-content-odie) {
+		> *:not(iframe):not(.help-center__container-content-odie) {
 			padding: 16px;
 			box-sizing: border-box;
 		}

--- a/packages/odie-client/src/components/message/jump-to-recent.tsx
+++ b/packages/odie-client/src/components/message/jump-to-recent.tsx
@@ -3,12 +3,21 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useOdieAssistantContext } from '../../context';
 
+/**
+ * This might be synced with CSS in client/odie/message/style.scss, which is half of the height for the gradient.
+ * Used to calculate the bottom offset for the jump to recent button, so it doesn't overlap with the last message.
+ * Also, making it twice as big, will prevent the gradient to be not visible when the input grows/shrinks in height.
+ */
+const heightOffset = 48;
+
 export const JumpToRecent = ( {
 	scrollToBottom,
 	enableJumpToRecent,
+	bottomOffset,
 }: {
 	scrollToBottom: () => void;
 	enableJumpToRecent: boolean;
+	bottomOffset: number;
 } ) => {
 	const { trackEvent, isMinimized } = useOdieAssistantContext();
 	const translate = useTranslate();
@@ -27,7 +36,7 @@ export const JumpToRecent = ( {
 	} );
 
 	return (
-		<div className={ className }>
+		<div className={ className } style={ { bottom: bottomOffset - heightOffset } }>
 			<button
 				className="odie-jump-to-recent-message-button"
 				disabled={ ! enableJumpToRecent }

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -174,7 +174,6 @@
 }
 
 $feedback-button-size: 28px;
-
 .odie-feedback-component-container {
 	display: flex;
 	justify-content: space-between;
@@ -251,16 +250,17 @@ $feedback-button-size: 28px;
 $custom-border-corner-size: 16px;
 
 .odie-gradient-to-white {
+	position: absolute;
+	left: 0;
+	right: 0;
 	background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 50%);
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	height: 100px;
+	height: 96px;
 	justify-content: center;
 	z-index: 5;
 	pointer-events: none;
-	position: fixed;
-	width: 100%;
 
 	&.is-hidden {
 		opacity: 0;
@@ -324,38 +324,31 @@ $custom-border-corner-size: 16px;
 		-webkit-transform: scale3d(1, 1, 1);
 		transform: scale3d(1, 1, 1);
 	}
-
 	30% {
 		-webkit-transform: scale3d(1.25, 0.75, 1);
 		transform: scale3d(1.25, 0.75, 1);
 	}
-
 	40% {
 		-webkit-transform: scale3d(0.75, 1.25, 1);
 		transform: scale3d(0.75, 1.25, 1);
 	}
-
 	50% {
 		-webkit-transform: scale3d(1.15, 0.85, 1);
 		transform: scale3d(1.15, 0.85, 1);
 	}
-
 	65% {
 		-webkit-transform: scale3d(0.95, 1.05, 1);
 		transform: scale3d(0.95, 1.05, 1);
 	}
-
 	75% {
 		-webkit-transform: scale3d(1.05, 0.95, 1);
 		transform: scale3d(1.05, 0.95, 1);
 	}
-
 	100% {
 		-webkit-transform: scale3d(1, 1, 1);
 		transform: scale3d(1, 1, 1);
 	}
 }
-
 .odie-feedback-message {
 	position: relative;
 	font-weight: 600;
@@ -399,7 +392,6 @@ $custom-border-corner-size: 16px;
 	0% {
 		height: $feedback-button-size;
 	}
-
 	100% {
 		height: 0;
 	}
@@ -409,7 +401,6 @@ $custom-border-corner-size: 16px;
 	0% {
 		opacity: 1;
 	}
-
 	100% {
 		opacity: 0;
 	}
@@ -420,7 +411,6 @@ $custom-border-corner-size: 16px;
 		transform: translateY(1rem);
 		opacity: 0;
 	}
-
 	100% {
 		transform: translateY(0);
 		opacity: 1;

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -80,6 +80,8 @@ export const OdieSendMessageButton = ( {
 		await sendMessageIfNotEmpty();
 	};
 
+	const divContainerHeight = divContainerRef?.current?.clientHeight;
+
 	const userHasAskedToContactHE = chat.messages.some(
 		( message ) => message.context?.flags?.forward_to_human_support === true
 	);
@@ -87,7 +89,11 @@ export const OdieSendMessageButton = ( {
 
 	return (
 		<>
-			<JumpToRecent scrollToBottom={ scrollToRecent } enableJumpToRecent={ enableJumpToRecent } />
+			<JumpToRecent
+				scrollToBottom={ scrollToRecent }
+				enableJumpToRecent={ enableJumpToRecent }
+				bottomOffset={ divContainerHeight ?? 0 }
+			/>
 			<div className="odie-chat-message-input-container" ref={ divContainerRef }>
 				<form onSubmit={ handleSubmit } className="odie-send-message-input-container">
 					<TextareaAutosize

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -22,6 +22,7 @@ export const OdieAssistant: React.FC = () => {
 	const chatboxMessagesRef = useRef< HTMLDivElement | null >( null );
 	const { ref: bottomRef, entry: lastMessageElement, inView } = useInView( { threshold: 0 } );
 	const [ stickToBottom, setStickToBottom ] = useState( true );
+
 	const scrollToBottom = useCallback(
 		( force = false ) => {
 			if ( force || stickToBottom ) {
@@ -29,7 +30,7 @@ export const OdieAssistant: React.FC = () => {
 					if ( lastMessageElement?.target ) {
 						lastMessageElement.target.scrollIntoView( {
 							behavior: 'auto',
-							block: 'end',
+							block: 'start',
 							inline: 'nearest',
 						} );
 					}

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -1,6 +1,7 @@
 .chatbox {
 	width: 100%;
-	height: calc(100% - 138px);
+	height: calc(100% - 69px);
+
 	background-color: #f8f9fa;
 	display: flex;
 	flex-direction: column;
@@ -48,6 +49,9 @@
 .chat-box-message-container {
 	width: 100%;
 	height: 100%;
+	display: flex;
+	flex-direction: column;
+	place-content: flex-end;
 	background-color: #fff;
 }
 
@@ -71,16 +75,13 @@
 
 .odie-chat-message-input-container {
 	z-index: 10;
-	position: fixed;
-	width: 100%;
-	bottom: 0;
 	max-width: 410px;
 	flex-shrink: 0;
-	box-sizing: border-box;
 	border-radius: 4px;
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 	padding: 12px;
-	border-top: 1px solid var(--gray-gray-5, #dcdcde);
+	border: 1px solid var(--gray-gray-5, #dcdcde);
 	background: var(--black-white-white, #fff);
+	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 7px 7px 0 rgba(0, 0, 0, 0.04), 0 15px 9px 0 rgba(0, 0, 0, 0.02), 0 26px 11px 0 rgba(0, 0, 0, 0.01), 0 41px 12px 0 rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
This reverts:

- https://github.com/Automattic/wp-calypso/pull/91626

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The mentioned PR broke Help center. The search term auto-deletes in weird way. See: p1718066439071169-slack-C02FMH4G8

## Testing Instructions

1. Visit /sites
2. Click the help icon at the bottom left
3. Verify that you can search things and it works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?