### PR TITLE
Show the upgrade banner of "Staging Sites" for Pro plan sites

### DIFF
--- a/client/staging-site/components/staging-site/index.tsx
+++ b/client/staging-site/components/staging-site/index.tsx
@@ -1,4 +1,4 @@
-import { FEATURE_SITE_STAGING_SITES, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
+import { FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
 import StagingSiteCard from 'calypso/my-sites/hosting/staging-site-card';
 import StagingSiteProductionCard from 'calypso/my-sites/hosting/staging-site-card/staging-site-production-card';
 import { useSelector } from 'calypso/state';
@@ -10,15 +10,12 @@ import './style.scss';
 
 const StagingSite = () => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) ?? 0;
-	const hasAtomicFeature = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC )
-	);
 	const hasStagingSitesFeature = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, FEATURE_SITE_STAGING_SITES )
 	);
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
-	if ( ! hasAtomicFeature || ! hasStagingSitesFeature ) {
+	if ( ! hasStagingSitesFeature ) {
 		return <StagingSiteUpsellNudge />;
 	}
 

--- a/client/staging-site/components/staging-site/index.tsx
+++ b/client/staging-site/components/staging-site/index.tsx
@@ -18,7 +18,7 @@ const StagingSite = () => {
 	);
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
-	if ( ! hasAtomicFeature && ! hasStagingSitesFeature ) {
+	if ( ! hasAtomicFeature || ! hasStagingSitesFeature ) {
 		return <StagingSiteUpsellNudge />;
 	}
 

--- a/client/staging-site/test/index.js
+++ b/client/staging-site/test/index.js
@@ -12,7 +12,7 @@ jest.mock( 'calypso/my-sites/hosting/staging-site-card/staging-site-production-c
 	</div>
 ) );
 
-import { FEATURE_SITE_STAGING_SITES, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
+import { FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
@@ -102,7 +102,7 @@ describe( 'Staging Site', () => {
 		const testConfig = getTestConfig( {
 			isAtomicSite: true,
 			isWpcomStagingSite: true,
-			siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SITE_STAGING_SITES ],
+			siteFeatures: [ FEATURE_SITE_STAGING_SITES ],
 		} );
 
 		renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );

--- a/client/staging-site/test/index.js
+++ b/client/staging-site/test/index.js
@@ -12,7 +12,7 @@ jest.mock( 'calypso/my-sites/hosting/staging-site-card/staging-site-production-c
 	</div>
 ) );
 
-import { FEATURE_SITE_STAGING_SITES } from '@automattic/calypso-products';
+import { FEATURE_SITE_STAGING_SITES, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
@@ -102,7 +102,7 @@ describe( 'Staging Site', () => {
 		const testConfig = getTestConfig( {
 			isAtomicSite: true,
 			isWpcomStagingSite: true,
-			siteFeatures: [ FEATURE_SITE_STAGING_SITES ],
+			siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SITE_STAGING_SITES ],
 		} );
 
 		renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91616, https://github.com/Automattic/wp-calypso/pull/91276/files#r1620449629

## Proposed Changes

This PR changes to show the upgrade banner of "Staging Sites" for Pro plan sites. 

| before | after |
|--------|--------|
| <img width="1436" alt="Screenshot 2024-06-11 at 11 00 15" src="https://github.com/Automattic/wp-calypso/assets/5287479/e011afb7-5fd2-4685-bd6d-c74816c9eb70"> | <img width="1435" alt="Screenshot 2024-06-11 at 10 59 21" src="https://github.com/Automattic/wp-calypso/assets/5287479/f05652f1-2b4e-48f4-9ec4-796fbea84f18"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/91616
* p1718008791608639-slack-C06DN6QQVAQ

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare a Pro plan site
* Transfer the site to Atomic
* Go to `/staging-site/<site>`
* Click the "Staging Site" tab
* See the banner

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?