### PR TITLE
Stats: Support memberships API for Odyssey in simple

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-memberships.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-memberships.ts
@@ -7,11 +7,16 @@ import { MEMBERSHIPS_PRODUCTS_RECEIVE } from 'calypso/state/action-types';
 import { membershipProductFromApi } from 'calypso/state/data-layer/wpcom/sites/memberships';
 import 'calypso/state/memberships/init';
 import { SiteId } from 'calypso/types';
+import { getApiPath } from '../lib/get-api';
 
-function queryMemberships() {
+function queryMemberships( siteId: SiteId ) {
 	return wpcom.req
 		.get(
-			{ path: '/memberships/products', apiNamespace: 'wpcom/v2', isLocalApiCall: true },
+			{
+				path: getApiPath( '/memberships/products', { siteId } ),
+				apiNamespace: 'wpcom/v2',
+				isLocalApiCall: true,
+			},
 			{ type: 'all', is_editable: true }
 		)
 		.catch( () => ( { products: [] } ) );
@@ -21,7 +26,7 @@ function useQueryMemberships( siteId: SiteId ) {
 	return useQuery( {
 		...getDefaultQueryParams< { products: Array< object > } >(),
 		queryKey: [ 'odyssey-stats', 'memberships', 'products', siteId ],
-		queryFn: () => queryMemberships(),
+		queryFn: () => queryMemberships( siteId ),
 		select: ( data ) => data?.products.map( membershipProductFromApi ),
 	} );
 }

--- a/apps/odyssey-stats/src/lib/get-api.ts
+++ b/apps/odyssey-stats/src/lib/get-api.ts
@@ -23,6 +23,8 @@ export const getApiPath = ( jetpackPath: string, params: Record< string, string 
 			return `/sites/${ params.siteId }/purchases`;
 		case '/site':
 			return `/sites/${ params.siteId }`;
+		case '/memberships/products':
+			return `/sites/${ params.siteId }/memberships/products`;
 		default:
 			return jetpackPath;
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/91585

## Proposed Changes

* Fix the API path for Odyssey in Simple sites

## Testing Instructions

* Install the branch on your sandbox `bin/install-plugin.sh odyssey-stats fix/api-path-for-simple-sites`
* Sandbox `widgets.wp.com`
* Open a simple site and turn on WP-Admin (https://wordpress.com/settings/general/slug.wordpress.com)

<img width="753" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/8e2b1766-4b57-4886-8469-42ed8e3b7db4">

* Open `https://slug.wordpress.com/wp-admin/admin.php?page=stats#!/stats/subscribers/slug.wordpress.com`
* Inspect network
* Ensure `memberships/products` is successful

<img width="491" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/5cb70df5-c973-476d-9ade-1222365157f5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?