### PR TITLE
Stats Purchase: Exclude upgrades from site-only flow

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -21,11 +21,12 @@ const getStatsCheckoutURL = (
 	redirectUrl: string,
 	checkoutBackUrl: string,
 	from?: string,
-	adminUrl?: string
+	adminUrl?: string,
+	isUpgrade?: boolean
 ) => {
 	const isFromJetpack = from?.startsWith( 'jetpack' );
 	// Get the checkout URL for the product, or the siteless checkout URL if from Jetpack or no siteSlug is provided
-	const checkoutType = isFromJetpack || ! siteSlug ? 'jetpack' : siteSlug;
+	const checkoutType = ( isFromJetpack && ! isUpgrade ) || ! siteSlug ? 'jetpack' : siteSlug;
 	const checkoutProductUrl = new URL(
 		`/checkout/${ checkoutType }/${ product }`,
 		'https://wordpress.com'
@@ -128,6 +129,7 @@ const gotoCheckoutPage = ( {
 	redirectUri,
 	price,
 	quantity,
+	isUpgrade = false,
 }: {
 	from: string;
 	type: 'pwyw' | 'free' | 'commercial';
@@ -136,6 +138,7 @@ const gotoCheckoutPage = ( {
 	redirectUri?: string;
 	price?: number;
 	quantity?: number;
+	isUpgrade?: boolean;
 } ) => {
 	let eventName = '';
 	let product: string;
@@ -187,7 +190,8 @@ const gotoCheckoutPage = ( {
 				redirectUrl,
 				checkoutBackUrl,
 				from,
-				adminUrl
+				adminUrl,
+				isUpgrade
 			) ),
 		250
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -214,6 +214,7 @@ const StatsCommercialPurchase = ( {
 									redirectUri,
 									price: undefined,
 									quantity: purchaseTierQuantity,
+									isUpgrade: isCommercialOwned,
 								} )
 							}
 						>


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/90778

## Proposed Changes

* When site has already purchased, exclude it from the site-only (siteless with site param) flow to avoid the issue of multiple purchases.

## Testing Instructions

* Point `widgets.wp.com` to your sandbox
* In your sandbox, run `bin/install-plugin.sh odyssey-stats fix/exclude-siteless-for-upgrades`
* Spin up a JN site with access to your sandbox, or start your local Jetpack environment
* Purchase a commercial license for the site first
* Go to `/wp-admin/admin.php?page=my-jetpack`
* Click on "Upgrade" in the Stats section
* <img width="1107" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5714212/489e1eef-74e2-4f5d-87ea-bac0600c61dd">
* Confirm that you are redirected to the checkout page with prorated pricing if the billing cycle matches

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?