### PR TITLE
Site Management panel - Line-height of last published table header

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -24,7 +24,7 @@ const BlazePressStrings = () => {
 	translate( 'Get started' );
 	translate( 'Learn more' );
 	translate( "Don't show me this step again." );
-	translate( 'Uploading images...' );
+	translate( 'Uploading images…' );
 	translate( 'Checking payment information…' );
 	translate( 'Fetching pages…' );
 	translate( 'Fetching products…' );
@@ -64,7 +64,7 @@ const BlazePressStrings = () => {
 	translate( 'Ad creative' );
 	translate( "Use post's media" );
 	translate( 'Site title' );
-	translate( 'Loading page title...' );
+	translate( 'Loading page title…' );
 	translate( 'Page title' );
 	translate( 'Snippet' );
 	translate(

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -160,11 +160,18 @@
 		}
 
 		&:nth-child(4) {
-			span {
+			.site-sort {
 				display: inline-block;
+				font-size: $font-body-small;
 				max-width: calc(100% - 14px);
-				white-space: normal;
 				overflow-wrap: anywhere;
+				white-space: normal;
+
+				span {
+					display: inline-block;
+					max-width: calc(100% - 14px);
+					vertical-align: middle;
+				}
 			}
 
 			svg.site-sort__icon {

--- a/client/sites-dashboard-v2/style.scss
+++ b/client/sites-dashboard-v2/style.scss
@@ -397,7 +397,7 @@
 	thead .dataviews-view-table__row th span {
 		font-size: rem(11px);
 		font-weight: 500;
-		line-height: 20px;
+		line-height: 14px;
 		color: var(--color-accent-80);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7684

## Proposed Changes

Update Sites list header line-height from 20px to 14px.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/0ea54583-11fa-44f8-b2c4-68eb84a4cd65) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/ed044659-be8f-41ed-b64d-4f0102d68585) |

## Why are these changes being made?
The line-height of "Last Published" looks a little excessive on the site management panel.

## Testing Instructions

* Go to `/sites`
* Check the line-height on `LAST PUBLISHED`
