### PR TITLE
Reader: fix spacing and border radius for following intro

### DIFF
--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -45,7 +45,7 @@ class FollowingIntro extends Component {
 			return null;
 		}
 
-		const linkElement = <a onClick={ this.handleManageLinkClick } href="/following/manage" />;
+		const linkElement = <a onClick={ this.handleManageLinkClick } href="/read/subscriptions" />;
 
 		return (
 			<header

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -47,7 +47,6 @@
 	background-size: 450px;
 	border: 1px solid var(--color-neutral-0);
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
-	margin-bottom: 1em;
 	min-height: 140px;
 
 	@media (min-width: 661px) and (max-width: 773px) {
@@ -56,6 +55,10 @@
 
 	@include breakpoint-deprecated( "<660px" ) {
 		background-position: 120px 20px;
+	}
+
+	@include breakpoint-deprecated( ">1400px" ) {
+		margin-bottom: 1em;
 	}
 
 	.following__intro-copy-hidden {

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -42,10 +42,12 @@
 }
 
 .following__intro {
-	border: 1px solid var(--color-neutral-0);
 	background-position: 100% 20px;
 	background-repeat: no-repeat;
 	background-size: 450px;
+	border: 1px solid var(--color-neutral-0);
+	border-radius: 6px; /* stylelint-disable-line scales/radii */
+	margin-bottom: 1em;
 	min-height: 140px;
 
 	@media (min-width: 661px) and (max-width: 773px) {


### PR DESCRIPTION
## Proposed Changes

Fix the spacing and border of the Following Intro component that appears in Reader for a first-time user.

Before:

<img width="1032" alt="Screenshot 2024-06-11 at 15 29 00" src="https://github.com/Automattic/wp-calypso/assets/17325/c064d6a6-707f-44d0-bf3d-b56404357a07">

After:

<img width="1004" alt="Screenshot 2024-06-11 at 17 32 17" src="https://github.com/Automattic/wp-calypso/assets/17325/1f9e89d3-c740-4455-87ae-c0530aa1e1ef">

## Why are these changes being made?

I created a new user account today and noticed that the intro banner sits right up against the first post card (on the largest breakpoint). It also has square edges which do not match the post cards.

## Testing Instructions

* Create a brand new WordPress.com account.
* Navigate to /read.
* Check that the intro banner looks presentable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
