### PR TITLE
A4A: Make the referral list to have rows clickable.

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -113,6 +113,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 			<ItemsDataViews
 				data={ {
 					items: referrals,
+					getItemId: ( item: Referral ) => `${ item.client_id }`,
 					pagination: {
 						totalItems: 1,
 						totalPages: 1,

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -44,6 +44,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 									</Button>
 								);
 							},
+							width: '100%',
 							enableHiding: false,
 							enableSorting: false,
 						},
@@ -114,6 +115,9 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 				data={ {
 					items: referrals,
 					getItemId: ( item: Referral ) => `${ item.client_id }`,
+					onSelectionChange: ( data ) => {
+						openSitePreviewPane( data[ 0 ] );
+					},
 					pagination: {
 						totalItems: 1,
 						totalPages: 1,

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -551,4 +551,13 @@ html {
 	.dataviews-view-table tr th:first-child {
 		padding-inline-start: 16px;
 	}
+
+	.dataviews-view-list li {
+		cursor: pointer;
+	}
+
+	.dataviews-view-list li .components-h-stack {
+		display: block;
+		width: 100%;
+	}
 }


### PR DESCRIPTION
To enhance the user experience of the referrals page, we need to ensure that the rows are clickable. This PR implements this improvement.


https://github.com/Automattic/wp-calypso/assets/56598660/6ebca1b4-713d-4e41-9d2a-916ec5909c54



Closes https://github.com/Automattic/jetpack-genesis/issues/373

## Proposed Changes

* Fixed issue with `getItemId` not being set, causing all rows to be set as selectable when clicking 1 item.
* Add some styling to make the entire row look clickable.
* Add some hacks to trigger View details when clicking any area within a row. I couldn't find an elegant way to do this, but I found the WPCOM implementation does this hack, and I followed the implementation. https://github.com/Automattic/wp-calypso/blob/trunk/client/sites-dashboard-v2/sites-dataviews/index.tsx#L78

## Testing Instructions

* Use the A4A live link below and go to `/referrals?flags=a4a-automated-referrals`
* Confirm that the table rows is working as expected.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
