### PR TITLE
Affiliates: Remove help-center support/links from checkout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -46,6 +46,7 @@ import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
+import { isOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
@@ -550,7 +551,8 @@ export default withCurrentRoute(
 			'comments',
 		].includes( sectionName );
 		const sidebarIsHidden = ! secondary || isWcMobileApp() || isDomainAndPlanPackageFlow;
-		const userAllowedToHelpCenter = config.isEnabled( 'calypso/help-center' );
+		const userAllowedToHelpCenter =
+			config.isEnabled( 'calypso/help-center' ) && ! isOnboardingAffiliateFlow( state );
 
 		const calypsoColorScheme = getPreference( state, 'colorScheme' );
 		const siteColorScheme = getAdminColor( state, siteId ) ?? calypsoColorScheme;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -46,7 +46,7 @@ import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
-import { isOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
+import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
@@ -552,7 +552,7 @@ export default withCurrentRoute(
 		].includes( sectionName );
 		const sidebarIsHidden = ! secondary || isWcMobileApp() || isDomainAndPlanPackageFlow;
 		const userAllowedToHelpCenter =
-			config.isEnabled( 'calypso/help-center' ) && ! isOnboardingAffiliateFlow( state );
+			config.isEnabled( 'calypso/help-center' ) && ! getIsOnboardingAffiliateFlow( state );
 
 		const calypsoColorScheme = getPreference( state, 'colorScheme' );
 		const siteColorScheme = getAdminColor( state, siteId ) ?? calypsoColorScheme;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7149
Based off https://github.com/Automattic/wp-calypso/pull/91631

## Proposed Changes

Removes the help center support/links from checkout for the `onboarding-affiliate` flow

### Media

**Before**

<img width="600" alt="Screenshot 2024-06-11 at 11 52 45 AM" src="https://github.com/Automattic/wp-calypso/assets/1705499/2147b9a1-7b27-4507-a6ab-6ee7d320d1a9">

**After**

<img width="600" alt="Screenshot 2024-06-11 at 11 53 13 AM" src="https://github.com/Automattic/wp-calypso/assets/1705499/7721979c-f407-46e1-9ce9-b5e148bd1e30">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This has been requested by @StacyCarlson01 to be removed as a potential distraction in the user's journey during signup. See pfjeM4-Ps-p2 for related discussions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through `/start/onboarding-affiliate` and reach checkout
* Confirm "Need extra help? ..." handle not visible
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?