### PR TITLE
Fallback to raw category name for /plugins/browse/:category

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -96,7 +96,8 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	const locale = useLocale();
 
 	const categories = useCategories();
-	const categoryName = categories[ category ]?.menu || category;
+	const fallbackCategoryName = category.charAt( 0 ).toUpperCase() + category.slice( 1 );
+	const categoryName = categories[ category ]?.menu || fallbackCategoryName;
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -96,7 +96,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	const locale = useLocale();
 
 	const categories = useCategories();
-	const categoryName = categories[ category ]?.menu || __( 'Plugins' );
+	const categoryName = categories[ category ]?.menu || category;
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -96,7 +96,9 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	const locale = useLocale();
 
 	const categories = useCategories();
-	const fallbackCategoryName = category.charAt( 0 ).toUpperCase() + category.slice( 1 );
+	const fallbackCategoryName = category
+		? category.charAt( 0 ).toUpperCase() + category.slice( 1 )
+		: __( 'Plugins' );
 	const categoryName = categories[ category ]?.menu || fallbackCategoryName;
 
 	// this is a temporary hack until we merge Phase 4 of the refactor


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7675

## Proposed Changes

* Uses the raw category retrieved from the URL for categories that have not yet been defined in https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plugins/categories/use-categories.tsx

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When searching WP.com plugins in Google, Google's search points to categories that are not yet in our categories file
![google](https://github.com/Automattic/wp-calypso/assets/6586048/901c84c5-4980-40e2-9c31-00b277a9c64f)

This results in seeing Plugins Plugins for the <title> (logged in and logged out) and also the Header section (when logged in)

![header](https://github.com/Automattic/wp-calypso/assets/6586048/00a7cc88-426b-46e7-a027-4c550fccbfd7)
![title](https://github.com/Automattic/wp-calypso/assets/6586048/3a0aa4be-090f-4627-a7cc-09308864ee7d)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test for login and logged out scenarios
* Go to `/plugins/browse/:any undefined category` e.g., `/plugins/browse/datepicker` and see if it looks like this:
![date](https://github.com/Automattic/wp-calypso/assets/6586048/b7eda3cb-8842-4a30-9658-1bad4e6f9739)
![date](https://github.com/Automattic/wp-calypso/assets/6586048/fa67d146-1114-461b-99d3-fb435621303b)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
