### PR TITLE
Affiliates: Remove pre-sales chat from checkout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -64,6 +64,7 @@ import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import { isAffiliatesFlow } from 'calypso/state/signup/flow/selectors';
 import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useUpdateCachedContactDetails } from '../hooks/use-cached-contact-details';
@@ -345,6 +346,7 @@ export default function CheckoutMainContent( {
 	const wpcomDomain = useSelector( ( state ) =>
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
+	const isFromAffiliatesFlow = useSelector( isAffiliatesFlow );
 
 	// Only show the site preview for WPCOM domains that have a site connected to the site id
 	const shouldShowSitePreview =
@@ -352,7 +354,10 @@ export default function CheckoutMainContent( {
 
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const reduxDispatch = useReduxDispatch();
-	usePresalesChat( getPresalesChatKey( responseCart ), responseCart?.products?.length > 0 );
+	usePresalesChat(
+		getPresalesChatKey( responseCart ),
+		responseCart?.products?.length > 0 && ! isFromAffiliatesFlow
+	);
 
 	const hasCartJetpackProductsOnly = responseCart?.products?.every( ( product ) =>
 		isJetpackPurchasableItem( product.product_slug )

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -354,10 +354,9 @@ export default function CheckoutMainContent( {
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const reduxDispatch = useReduxDispatch();
 
-	usePresalesChat(
-		getPresalesChatKey( responseCart ),
-		! useSelector( isOnboardingAffiliateFlow ) && responseCart?.products?.length > 0
-	);
+	const isPresalesChatEnabled =
+		! useSelector( isOnboardingAffiliateFlow ) && responseCart?.products?.length > 0;
+	usePresalesChat( getPresalesChatKey( responseCart ), isPresalesChatEnabled );
 
 	const hasCartJetpackProductsOnly = responseCart?.products?.every( ( product ) =>
 		isJetpackPurchasableItem( product.product_slug )

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -64,7 +64,7 @@ import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
-import { isOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
+import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useUpdateCachedContactDetails } from '../hooks/use-cached-contact-details';
@@ -355,7 +355,7 @@ export default function CheckoutMainContent( {
 	const reduxDispatch = useReduxDispatch();
 
 	const isPresalesChatEnabled =
-		! useSelector( isOnboardingAffiliateFlow ) && responseCart?.products?.length > 0;
+		! useSelector( getIsOnboardingAffiliateFlow ) && responseCart?.products?.length > 0;
 	usePresalesChat( getPresalesChatKey( responseCart ), isPresalesChatEnabled );
 
 	const hasCartJetpackProductsOnly = responseCart?.products?.every( ( product ) =>

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -64,7 +64,7 @@ import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
-import { isAffiliatesFlow } from 'calypso/state/signup/flow/selectors';
+import { isOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useUpdateCachedContactDetails } from '../hooks/use-cached-contact-details';
@@ -346,7 +346,6 @@ export default function CheckoutMainContent( {
 	const wpcomDomain = useSelector( ( state ) =>
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
-	const isFromAffiliatesFlow = useSelector( isAffiliatesFlow );
 
 	// Only show the site preview for WPCOM domains that have a site connected to the site id
 	const shouldShowSitePreview =
@@ -354,9 +353,10 @@ export default function CheckoutMainContent( {
 
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const reduxDispatch = useReduxDispatch();
+
 	usePresalesChat(
 		getPresalesChatKey( responseCart ),
-		responseCart?.products?.length > 0 && ! isFromAffiliatesFlow
+		! useSelector( isOnboardingAffiliateFlow ) && responseCart?.products?.length > 0
 	);
 
 	const hasCartJetpackProductsOnly = responseCart?.products?.every( ( product ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7149
Based off https://github.com/Automattic/wp-calypso/pull/91631

## Proposed Changes

Removes the happy/chat bot from checkout for the `onboarding-affiliate` flow

### Media

**Before**

<img width="600" alt="Screenshot 2024-06-11 at 1 41 25 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/22fc7901-e58a-4f5f-9c38-46d4b2895657">


**After**

<img width="600" alt="Screenshot 2024-06-11 at 1 41 36 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/7bf576f3-c798-4e66-9e2c-c01f650d2038">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This has been requested by @StacyCarlson01 to be removed as a potential distraction in the user's journey during signup. See pfjeM4-Ps-p2 for related discussions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through `/start/onboarding-affiliate` and reach checkout
* Confirm the happy/chat bot handle is not visible
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?