### PR TITLE
A4A: Switch product feedback to support form; use "Contact sales"

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -36,7 +36,7 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 		<ul className="a4a-sidebar__profile-dropdown-menu" hidden={ ! isExpanded }>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">
 				<Button borderless onClick={ onGetHelp }>
-					{ translate( 'Contact support' ) }
+					{ translate( 'Contact sales' ) }
 				</Button>
 			</li>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -3,6 +3,7 @@ import { Icon, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
+import UserContactSupportModalForm from 'calypso/a8c-for-agencies/components/user-contact-support-modal-form';
 import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/overview/sidebar/contact-support';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import Sidebar, {
@@ -15,13 +16,10 @@ import Sidebar, {
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { A4A_OVERVIEW_LINK } from '../sidebar-menu/lib/constants';
-import UserFeedbackModalForm from '../user-feedback-modal-form';
 import SidebarHeader from './header';
 import ProfileDropdown from './header/profile-dropdown';
 
 import './style.scss';
-
-const USER_FEEDBACK_FORM_URL_HASH = '#product-feedback';
 
 type Props = {
 	className?: string;
@@ -62,20 +60,17 @@ const A4ASidebar = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	// Determine whether to initially show the user feedback form.
-	const shouldShowUserFeedbackForm = window.location.hash === USER_FEEDBACK_FORM_URL_HASH;
+	const [ showUserSupportForm, setShowUserSupportForm ] = useState( false );
 
-	const [ showUserFeedbackForm, setShowUserFeedbackForm ] = useState( shouldShowUserFeedbackForm );
-
-	const onShareProductFeedback = useCallback( () => {
+	const onShowUserSupportForm = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_share_product_feedback_click' ) );
-		setShowUserFeedbackForm( true );
+		setShowUserSupportForm( true );
 	}, [ dispatch ] );
 
-	const onCloseUserFeedbackForm = useCallback( () => {
+	const onCloseUserSupportForm = useCallback( () => {
 		// Remove any hash from the URL.
 		history.pushState( null, '', window.location.pathname + window.location.search );
-		setShowUserFeedbackForm( false );
+		setShowUserSupportForm( false );
 	}, [] );
 
 	return (
@@ -129,20 +124,23 @@ const A4ASidebar = ( {
 					) }
 
 					<SidebarNavigatorMenuItem
-						title={ translate( 'Share product feedback', {
+						title={ translate( 'Contact sales', {
 							comment: 'A4A sidebar navigation item',
 						} ) }
-						link={ USER_FEEDBACK_FORM_URL_HASH }
+						link={ A4A_OVERVIEW_LINK + '#contact-sales' }
 						path=""
 						icon={ <Icon icon={ starEmpty } /> }
-						onClickMenuItem={ onShareProductFeedback }
+						onClickMenuItem={ onShowUserSupportForm }
 					/>
 
 					{ withUserProfileFooter && <ProfileDropdown dropdownPosition="up" /> }
 				</ul>
 			</SidebarFooter>
 
-			<UserFeedbackModalForm show={ showUserFeedbackForm } onClose={ onCloseUserFeedbackForm } />
+			<UserContactSupportModalForm
+				show={ showUserSupportForm }
+				onClose={ onCloseUserSupportForm }
+			/>
 		</Sidebar>
 	);
 };

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -137,9 +137,7 @@ export default function UserContactSupportModalForm( {
 					<Icon size={ 24 } icon={ close } />
 				</Button>
 
-				<h1 className="a4a-contact-support-modal-form__title">
-					{ translate( 'Contact support' ) }
-				</h1>
+				<h1 className="a4a-contact-support-modal-form__title">{ translate( 'Contact sales' ) }</h1>
 
 				<FormFieldset>
 					<FormLabel htmlFor="name">{ translate( 'Your name' ) }</FormLabel>

--- a/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
@@ -50,7 +50,7 @@ export default function OverviewSidebarContactSupport() {
 	return (
 		<>
 			<Button className="overview__contact-support-button" onClick={ toggleContactForm }>
-				{ translate( 'Contact Support' ) }
+				{ translate( 'Contact Sales' ) }
 			</Button>
 			<UserContactSupportModalForm
 				show={ showUserSupportForm }


### PR DESCRIPTION
See p1718101929361909-slack-C06RDCDSGBH

## Proposed Changes

Switches "Share product feedback" to "Contact sales", and updates all support forms to use "Contact sales" language

![CleanShot 2024-06-11 at 04 01 02@2x](https://github.com/Automattic/wp-calypso/assets/36432/ae1249de-75bb-4a0a-91e2-f3ece34073c3)

![CleanShot 2024-06-11 at 04 01 16@2x](https://github.com/Automattic/wp-calypso/assets/36432/80aed63e-ba96-4547-9885-ed6fd147f235)

![CleanShot 2024-06-11 at 04 01 24@2x](https://github.com/Automattic/wp-calypso/assets/36432/559def58-6f79-44db-9ce2-c65174313815)

## Why are these changes being made?

1. "Share product feedback" goes to a black hole. We want to engage in as many sales conversations as possible.
2. Prospective customers are contacting sales, not support.

## Testing Instructions

1. Navigate to the A4A dashboard.
3. Verify the navigation link above the profile is labeled as "Contact sales" and opens the support form.
4. Verify the button on the main overview page is labeled as "Contact sales"