### PR TITLE
Bigsky-TrailMap: Mock experiments 

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -8,6 +8,7 @@ import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { login } from 'calypso/lib/paths';
 import { sectionify } from 'calypso/lib/route';
+import wpcom from 'calypso/lib/wp';
 import flows from 'calypso/signup/config/flows';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { updateDependencies } from 'calypso/state/signup/actions';
@@ -245,7 +246,7 @@ export default {
 				experiment.variationName === 'treatment_scrambled';
 		}
 
-		if ( isOnboardingFlow && userLoggedIn ) {
+		if ( isOnboardingFlow && wpcom.isTokenLoaded() ) {
 			const experimentAssignmentBigSky = await loadExperimentAssignment(
 				'explat_test_calypso_signup_onboarding_bigsky_soft_launch'
 			);

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -245,6 +245,17 @@ export default {
 				experiment.variationName === 'treatment_scrambled';
 		}
 
+		if ( isOnboardingFlow && userLoggedIn ) {
+			const experimentAssignmentBigSky = await loadExperimentAssignment(
+				'explat_test_calypso_signup_onboarding_bigsky_soft_launch'
+			);
+			if ( experimentAssignmentBigSky?.variationName === 'trailmap' ) {
+				await loadExperimentAssignment(
+					'explat_test_calypso_signup_onboarding_trailmap_guided_flow'
+				);
+			}
+		}
+
 		if (
 			config.isEnabled( 'onboarding/new-user-survey' ) ||
 			config.isEnabled( 'onboarding/new-user-survey-scrambled' )


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/91411#pullrequestreview-2108593420

This is to ensure the assignment is not biased when we run stacked experiments on real users
In a mock experiment, users would be randomly given variation assignments, but they would experience the same control. So maintaining the status quo of onboarding.

## Testing 

TBD