### PR TITLE
A4A: Show referral order confirmation message.

### DIFF
--- a/client/a8c-for-agencies/components/layout/banner.tsx
+++ b/client/a8c-for-agencies/components/layout/banner.tsx
@@ -1,0 +1,24 @@
+import NoticeBanner from '@automattic/components/src/notice-banner';
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+
+type Props = {
+	actions?: React.ReactNode[];
+	className?: string;
+	children: ReactNode;
+	level: 'error' | 'warning' | 'info' | 'success';
+	onClose?: () => void;
+	title?: string;
+};
+
+export default function LayoutBanner( { className, children, onClose, title, actions }: Props ) {
+	const wrapperClass = clsx( className, 'a4a-layout__banner' );
+
+	return (
+		<div className={ wrapperClass }>
+			<NoticeBanner level="success" onClose={ onClose } title={ title } actions={ actions }>
+				{ children }
+			</NoticeBanner>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -57,6 +57,7 @@ html,
 	padding-block-end: 32px;
 }
 
+.a4a-layout__banner,
 .a4a-layout__top-wrapper,
 .a4a-layout__body {
 	margin-inline: 0;

--- a/client/a8c-for-agencies/constants/index.ts
+++ b/client/a8c-for-agencies/constants/index.ts
@@ -2,3 +2,5 @@ export const A4A_DOWNLOAD_LINK_ON_GITHUB =
 	'https://github.com/Automattic/automattic-for-agencies-client/releases/download/v0.1.0/automattic-for-agencies-client.zip';
 export const JETPACK_CONNECT_A4A_LINK =
 	'https://wordpress.com/jetpack/connect?source=a8c-for-agencies';
+
+export const REFERRAL_EMAIL_QUERY_PARAM_KEY = 'referral_email';

--- a/client/a8c-for-agencies/hooks/use-url-query-param.ts
+++ b/client/a8c-for-agencies/hooks/use-url-query-param.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import { useURLQueryParams } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+
+export default function useUrlQueryParam( key: string ) {
+	const { setParams, resetParams, getParamValue } = useURLQueryParams();
+
+	const setValue = useCallback(
+		( value: string ) => {
+			if ( value ) {
+				setParams( [
+					{
+						key: key,
+						value,
+					},
+				] );
+			} else {
+				resetParams( [ key ] );
+			}
+		},
+		[ key, resetParams, setParams ]
+	);
+
+	return {
+		value: getParamValue( key ),
+		setValue,
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -1,8 +1,10 @@
 import page from '@automattic/calypso-router';
 import { Button, FormLabel } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { A4A_REFERRALS_DASHBOARD } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { REFERRAL_EMAIL_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
@@ -60,14 +62,16 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 	}, [ dispatch ] );
 
 	useEffect( () => {
-		if ( isSuccess ) {
+		if ( isSuccess && !! email ) {
+			sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, MARKETPLACE_TYPE_REGULAR );
+			page.redirect(
+				addQueryArgs( A4A_REFERRALS_DASHBOARD, { [ REFERRAL_EMAIL_QUERY_PARAM_KEY ]: email } )
+			);
 			setEmail( '' );
 			setMessage( '' );
 			onClearCart();
-			sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, MARKETPLACE_TYPE_REGULAR );
-			page.redirect( A4A_REFERRALS_DASHBOARD );
 		}
-	}, [ isSuccess, onClearCart ] );
+	}, [ email, isSuccess, onClearCart ] );
 
 	return (
 		<>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -29,6 +29,7 @@ import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
 import ReferralDetails from '../../referral-details';
 import ReferralsFooter from '../footer';
 import LayoutBodyContent from './layout-body-content';
+import NewRefferalOrderNotification from './new-referral-order-notification';
 
 import './style.scss';
 
@@ -64,6 +65,8 @@ export default function ReferralsOverview( {
 
 	const selectedItem = dataViewsState.selectedItem;
 
+	const referralEmail = 'jkguidaven@gmail.com';
+
 	return (
 		<Layout
 			className={ clsx( 'referrals-layout', {
@@ -78,6 +81,8 @@ export default function ReferralsOverview( {
 		>
 			<LayoutColumn wide className="referrals-layout__column">
 				<LayoutTop>
+					{ !! referralEmail && <NewRefferalOrderNotification email={ referralEmail } /> }
+
 					<LayoutHeader>
 						<Title>{ title } </Title>
 						{ isAutomatedReferral && (

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -31,7 +31,7 @@ import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
 import ReferralDetails from '../../referral-details';
 import ReferralsFooter from '../footer';
 import LayoutBodyContent from './layout-body-content';
-import NewRefferalOrderNotification from './new-referral-order-notification';
+import NewReferralOrderNotification from './new-referral-order-notification';
 
 import './style.scss';
 
@@ -86,7 +86,7 @@ export default function ReferralsOverview( {
 			<LayoutColumn wide className="referrals-layout__column">
 				<LayoutTop>
 					{ !! referralEmail && (
-						<NewRefferalOrderNotification
+						<NewReferralOrderNotification
 							email={ referralEmail }
 							onClose={ () => setReferralEmail( '' ) }
 						/>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -18,6 +18,8 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { REFERRAL_EMAIL_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
+import useUrlQueryParam from 'calypso/a8c-for-agencies/hooks/use-url-query-param';
 import {
 	MARKETPLACE_TYPE_SESSION_STORAGE_KEY,
 	MARKETPLACE_TYPE_REFERRAL,
@@ -43,6 +45,10 @@ export default function ReferralsOverview( {
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( initialDataViewsState );
 
+	const { value: referralEmail, setValue: setReferralEmail } = useUrlQueryParam(
+		REFERRAL_EMAIL_QUERY_PARAM_KEY
+	);
+
 	const isDesktop = useDesktopBreakpoint();
 
 	const title =
@@ -65,8 +71,6 @@ export default function ReferralsOverview( {
 
 	const selectedItem = dataViewsState.selectedItem;
 
-	const referralEmail = 'jkguidaven@gmail.com';
-
 	return (
 		<Layout
 			className={ clsx( 'referrals-layout', {
@@ -81,7 +85,12 @@ export default function ReferralsOverview( {
 		>
 			<LayoutColumn wide className="referrals-layout__column">
 				<LayoutTop>
-					{ !! referralEmail && <NewRefferalOrderNotification email={ referralEmail } /> }
+					{ !! referralEmail && (
+						<NewRefferalOrderNotification
+							email={ referralEmail }
+							onClose={ () => setReferralEmail( '' ) }
+						/>
+					) }
 
 					<LayoutHeader>
 						<Title>{ title } </Title>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
@@ -1,0 +1,30 @@
+import NoticeBanner from '@automattic/components/src/notice-banner';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+
+type Props = {
+	email: string;
+	onClose?: () => void;
+};
+
+export default function NewRefferalOrderNotification( { email, onClose }: Props ) {
+	const [ showBanner, setShowBanner ] = useState( true );
+
+	const translate = useTranslate();
+
+	const onCloseClick = () => {
+		setShowBanner( false );
+		onClose?.();
+	};
+
+	return (
+		showBanner && (
+			<NoticeBanner level="success" onClose={ onCloseClick }>
+				{ translate( 'Your referral order was emailed to %(referralEmail)s for payment.', {
+					args: { referralEmail: email },
+					comment: 'The %(referralEmail)s is the email where referral order was sent.',
+				} ) }
+			</NoticeBanner>
+		)
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
@@ -1,6 +1,6 @@
-import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 
 type Props = {
 	email: string;
@@ -19,12 +19,12 @@ export default function NewRefferalOrderNotification( { email, onClose }: Props 
 
 	return (
 		showBanner && (
-			<NoticeBanner level="success" onClose={ onCloseClick }>
+			<LayoutBanner level="success" onClose={ onCloseClick }>
 				{ translate( 'Your referral order was emailed to %(referralEmail)s for payment.', {
 					args: { referralEmail: email },
 					comment: 'The %(referralEmail)s is the email where referral order was sent.',
 				} ) }
-			</NoticeBanner>
+			</LayoutBanner>
 		)
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
@@ -7,7 +7,7 @@ type Props = {
 	onClose?: () => void;
 };
 
-export default function NewRefferalOrderNotification( { email, onClose }: Props ) {
+export default function NewReferralOrderNotification( { email, onClose }: Props ) {
 	const [ showBanner, setShowBanner ] = useState( true );
 
 	const translate = useTranslate();

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -204,3 +204,13 @@ $data-view-border-color: #f1f1f1;
 	height: auto;
 	overflow-y: scroll;
 }
+
+
+.referrals-layout .notice-banner {
+	display: none;
+	margin-block-end: 24px;
+}
+
+.referrals-layout:not(.referrals-layout--has-selected) .notice-banner {
+	display: flex;
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/343

## Proposed Changes

* Add Official A4A banner layout component. This is necessary to ensure consistent spacing. **We will need to update any existing notifications to use the official banner layout on a separate PR.**
* Add a new hook to simplify URL query param usage that ties with UI state. This is a recurring pattern, and we need to simplify this implementation for later usage.
* Implement the `NewReferralOrderNotification` component using the A4A banner layout, which will be rendered when the referral email URL query parameter is present.
* Update the Checkout flow for the Referral purchases to redirect user with Referral email in the URL parameter.


## Testing Instructions

* Use the A4A live link and go to `/marketplace/products`
* Enable 'Referral` mode.
* Add a few items to the cart, then proceed to checkout.
   <img width="1586" alt="Screenshot 2024-06-11 at 8 12 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7b298f48-9066-4b2b-b8de-96a229b17ac8">

* On the checkout page, input a referral email and request payment.
   <img width="1591" alt="Screenshot 2024-06-11 at 8 14 04 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/605329ba-6db4-457d-b25d-b8d1425d607b">

* Confirm that you are redirected to the Referrals dashboard with the Order confirmation.
   <img width="1725" alt="Screenshot 2024-06-11 at 8 14 17 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/eb7d45d1-d086-4a9d-9b17-6008ebbae851">


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
