### PR TITLE
Fix Help Center back to top button

### DIFF
--- a/packages/help-center/src/components/back-to-top-button.tsx
+++ b/packages/help-center/src/components/back-to-top-button.tsx
@@ -1,6 +1,6 @@
 import { useScrollToTop } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { useCallback, useRef } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { Icon, arrowUp } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
@@ -9,7 +9,14 @@ import './back-to-top-button.scss';
 
 export const BackToTopButton: FC = () => {
 	const elementRef = useRef< HTMLElement | null >( null );
+	const scrollParentRef = useRef< HTMLElement | null >( null );
 	const { __ } = useI18n();
+
+	useEffect( () => {
+		if ( elementRef.current ) {
+			scrollParentRef.current = elementRef.current?.closest( '.help-center__container-content' );
+		}
+	}, [ elementRef ] );
 
 	const isBelowThreshold = useCallback( ( containerNode: HTMLElement ) => {
 		const SCROLL_THRESHOLD = 400;
@@ -18,16 +25,14 @@ export const BackToTopButton: FC = () => {
 	}, [] );
 
 	const { isButtonVisible, scrollToTop } = useScrollToTop( {
-		scrollTargetRef: elementRef,
+		scrollTargetRef: scrollParentRef,
 		isBelowThreshold,
 		smoothScrolling: false,
 	} );
 
 	return (
 		<Button
-			ref={ ( element: HTMLButtonElement ) => {
-				elementRef.current = element?.parentElement ?? null;
-			} }
+			ref={ elementRef }
 			className={ clsx( 'back-to-top-button__help-center', {
 				'is-visible': isButtonVisible,
 			} ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR fixes the help center back to top button.
The scroll container that was used for threshold detection was an invalid one.
Also the button and container refs must be different ones to avoid issues.


| Before  | After |
| ------------- | ------------- |
| <img width="417" alt="Screenshot 2024-06-11 at 14 18 38" src="https://github.com/Automattic/wp-calypso/assets/7000684/31770be7-4311-475e-8dcd-397eebb4e617">  |  <img width="421" alt="Screenshot 2024-06-11 at 14 18 15" src="https://github.com/Automattic/wp-calypso/assets/7000684/d84ce205-9bba-4ec6-b984-0c6573107cbb"> |

Related to #
https://github.com/Automattic/wp-calypso/issues/91670

## Proposed Changes

* Add `scrollParentRef` for back to top button


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This fixes a regression

## Testing Instructions
- Use the PR link and sync
- Open an article in the help center
- Scroll the article
- Back to top button should appear. And by clicking it the article should scroll to the top.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
