### PR TITLE
A4A > Referrals: Implement payment methods UI for client

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -41,3 +41,4 @@ export const EXTERNAL_A4A_KNOWLEDGE_BASE = 'http://automattic.com/for-agencies/h
 export const A4A_CLIENT_LANDING_LINK = '/client/landing';
 export const A4A_CLIENT_SUBSCRIPTIONS_LINK = '/client/subscriptions';
 export const A4A_CLIENT_PAYMENT_METHODS_LINK = '/client/payment-methods';
+export const A4A_CLIENT_PAYMENT_METHODS_ADD_LINK = `${ A4A_CLIENT_PAYMENT_METHODS_LINK }/add`;

--- a/client/a8c-for-agencies/sections/client/controller.tsx
+++ b/client/a8c-for-agencies/sections/client/controller.tsx
@@ -1,6 +1,9 @@
 import { type Callback } from '@automattic/calypso-router';
 import SidebarPlaceholder from 'calypso/a8c-for-agencies/components/sidebar-placeholder';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import ClientSidebar from '../../components/sidebar-menu/client';
+import PaymentMethodAdd from '../purchases/payment-methods/payment-method-add';
+import PaymentMethodOverview from '../purchases/payment-methods/payment-method-overview';
 import ClientLanding from './client-landing';
 
 export const clientContext: Callback = ( context, next ) => {
@@ -21,7 +24,23 @@ export const clientSubscriptionsContext: Callback = ( context, next ) => {
 };
 
 export const clientPaymentMethodsContext: Callback = ( context, next ) => {
-	context.primary = <div>Payment Methods</div>;
+	context.primary = (
+		<>
+			<PageViewTracker title="Client > Payment Methods" path={ context.path } />
+			<PaymentMethodOverview />
+		</>
+	);
+	context.secondary = <ClientSidebar path={ context.path } />;
+	next();
+};
+
+export const clientPaymentMethodsAddContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker title="Client > Payment Methods > Add" path={ context.path } />
+			<PaymentMethodAdd />
+		</>
+	);
 	context.secondary = <ClientSidebar path={ context.path } />;
 	next();
 };

--- a/client/a8c-for-agencies/sections/client/index.tsx
+++ b/client/a8c-for-agencies/sections/client/index.tsx
@@ -3,6 +3,7 @@ import {
 	A4A_CLIENT_LANDING_LINK,
 	A4A_CLIENT_SUBSCRIPTIONS_LINK,
 	A4A_CLIENT_PAYMENT_METHODS_LINK,
+	A4A_CLIENT_PAYMENT_METHODS_ADD_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireClientAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
@@ -21,6 +22,13 @@ export default function () {
 		A4A_CLIENT_PAYMENT_METHODS_LINK,
 		requireClientAccessContext,
 		controller.clientPaymentMethodsContext,
+		makeLayout,
+		clientRender
+	);
+	page(
+		A4A_CLIENT_PAYMENT_METHODS_ADD_LINK,
+		requireClientAccessContext,
+		controller.clientPaymentMethodsAddContext,
 		makeLayout,
 		clientRender
 	);

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-delete-card.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-delete-card.ts
@@ -10,6 +10,7 @@ import wpcom from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { isClientView } from '../lib/is-client-view';
 import { getFetchStoredCardsKey } from './use-stored-cards';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 
@@ -28,6 +29,7 @@ function useDeleteCardMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIResponse, Error, DeleteCardProps, TContext >
 ): UseMutationResult< APIResponse, Error, DeleteCardProps, TContext > {
 	const agencyId = useSelector( getActiveAgencyId );
+	const isClient = isClientView();
 
 	return useMutation< APIResponse, Error, DeleteCardProps, TContext >( {
 		...options,
@@ -35,9 +37,11 @@ function useDeleteCardMutation< TContext = unknown >(
 			wpcom.req.post( {
 				method: 'DELETE',
 				apiNamespace: 'wpcom/v2',
-				path: `/jetpack-licensing/stripe/payment-method`,
+				path: isClient
+					? '/agency-client/stripe/payment-method'
+					: '/jetpack-licensing/stripe/payment-method',
 				body: {
-					...( agencyId && { agency_id: agencyId } ),
+					...( ! isClient && agencyId && { agency_id: agencyId } ),
 					payment_method_id: paymentMethodId,
 					primary_payment_method_id: primaryPaymentMethodId,
 				},

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-set-as-primary-card.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-set-as-primary-card.ts
@@ -10,6 +10,7 @@ import wpcom from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { isClientView } from '../lib/is-client-view';
 import { getFetchStoredCardsKey } from './use-stored-cards';
 import type { SetAsPrimaryCardProps } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 
@@ -23,15 +24,18 @@ function useSetAsPrimaryCardMutation< TContext = unknown >(
 	options?: UseMutationOptions< APIResponse, Error, SetAsPrimaryCardProps, TContext >
 ): UseMutationResult< APIResponse, Error, SetAsPrimaryCardProps, TContext > {
 	const agencyId = useSelector( getActiveAgencyId );
+	const isClient = isClientView();
 
 	return useMutation< APIResponse, Error, SetAsPrimaryCardProps, TContext >( {
 		...options,
 		mutationFn: ( { paymentMethodId, useAsPrimaryPaymentMethod } ) =>
 			wpcom.req.post( {
 				apiNamespace: 'wpcom/v2',
-				path: `/jetpack-licensing/stripe/payment-method`,
+				path: isClient
+					? '/agency-client/stripe/payment-method'
+					: '/jetpack-licensing/stripe/payment-method',
 				body: {
-					...( agencyId && { agency_id: agencyId } ),
+					...( ! isClient && agencyId && { agency_id: agencyId } ),
 					payment_method_id: paymentMethodId,
 					use_as_primary_payment_method: useAsPrimaryPaymentMethod,
 				},

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-stored-cards.ts
@@ -3,19 +3,18 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import formatStoredCards from '../../lib/format-stored-cards';
+import { isClientView } from '../lib/is-client-view';
 
 interface Paging {
 	startingAfter: string;
 	endingBefore: string;
 }
 
-export const getFetchStoredCardsKey = ( agencyId?: number, paging?: Paging ) => [
-	'a4a-stored-cards',
-	paging,
-	agencyId,
-];
+export const getFetchStoredCardsKey = ( agencyId?: number, paging?: Paging ) =>
+	isClientView() ? [ 'a4a-stored-client-cards', paging ] : [ 'a4a-stored-cards', paging, agencyId ];
 
 export default function useStoredCards( paging?: Paging, useStaleData = false ) {
+	const isClientUI = isClientView();
 	const agencyId = useSelector( getActiveAgencyId );
 
 	const queryClient = useQueryClient();
@@ -30,22 +29,26 @@ export default function useStoredCards( paging?: Paging, useStaleData = false ) 
 
 	return useQuery( {
 		staleTime,
+		// isClientUI is used to send or not send the agency_id parameter to the API.
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey: getFetchStoredCardsKey( agencyId, paging ),
 		queryFn: () =>
 			wpcom.req.get(
 				{
 					apiNamespace: 'wpcom/v2',
-					path: '/jetpack-licensing/stripe/payment-methods',
+					path: isClientUI
+						? '/agency-client/stripe/payment-methods'
+						: '/jetpack-licensing/stripe/payment-methods',
 				},
 				{
-					...( agencyId && { agency_id: agencyId } ),
+					...( ! isClientUI && agencyId && { agency_id: agencyId } ),
 					...( paging && {
 						starting_after: paging.startingAfter,
 						ending_before: paging.endingBefore,
 					} ),
 				}
 			),
-		enabled: !! agencyId,
+		enabled: isClientUI ? true : !! agencyId,
 		select: formatStoredCards,
 		refetchOnWindowFocus: false,
 		initialData: {

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view.ts
@@ -1,0 +1,3 @@
+export const isClientView = (): boolean => {
+	return window.location.pathname.startsWith( '/client/' );
+};

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/index.tsx
@@ -10,9 +10,13 @@ import LayoutHeader, {
 import LayoutStepper from 'calypso/a8c-for-agencies/components/layout/stepper';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { A4A_PAYMENT_METHODS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_PAYMENT_METHODS_LINK,
+	A4A_CLIENT_PAYMENT_METHODS_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PaymentMethodStripeInfo from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-stripe-info';
 import { usePaymentMethodStepper } from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/hooks/use-payment-method-stepper';
+import { isClientView } from '../lib/is-client-view';
 import PaymentMethodForm from './payment-method-form';
 
 import './style.scss';
@@ -28,6 +32,12 @@ export default function PaymentMethodAdd( { withAssignLicense }: Props ) {
 
 	const stepper = usePaymentMethodStepper( { withAssignLicense } );
 
+	const isClientUI = isClientView();
+
+	const paymentMethodsLink = isClientUI
+		? A4A_CLIENT_PAYMENT_METHODS_LINK
+		: A4A_PAYMENT_METHODS_LINK;
+
 	return (
 		<Layout
 			className="payment-method-add"
@@ -42,7 +52,7 @@ export default function PaymentMethodAdd( { withAssignLicense }: Props ) {
 					{ ! stepper && (
 						<Breadcrumb
 							items={ [
-								{ label: translate( 'Payment Methods' ), href: A4A_PAYMENT_METHODS_LINK },
+								{ label: translate( 'Payment Methods' ), href: paymentMethodsLink },
 								{ label: translate( 'Add new card' ) },
 							] }
 						/>

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -26,6 +26,7 @@ import {
 	A4A_MARKETPLACE_LINK,
 	A4A_PAYMENT_METHODS_ADD_LINK,
 	A4A_PAYMENT_METHODS_LINK,
+	A4A_CLIENT_PAYMENT_METHODS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useIssueAndAssignLicenses from 'calypso/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses';
 import { parseQueryStringProducts } from 'calypso/jetpack-cloud/sections/partner-portal/lib/querystring-products';
@@ -43,6 +44,7 @@ import usePaymentMethod from '../../hooks/use-payment-method';
 import { useReturnUrl } from '../../hooks/use-return-url';
 import useStoredCards from '../../hooks/use-stored-cards';
 import { getStripeConfiguration } from '../../lib/get-stripe-configuration';
+import { isClientView } from '../../lib/is-client-view';
 import CreditCardLoading from '../credit-card-fields/credit-card-loading';
 
 import './style.scss';
@@ -198,7 +200,7 @@ function PaymentMethodForm() {
 		if ( returnQueryArg || products ) {
 			refetchStoredCards();
 		} else {
-			page( A4A_PAYMENT_METHODS_LINK );
+			page( isClientView() ? A4A_CLIENT_PAYMENT_METHODS_LINK : A4A_PAYMENT_METHODS_LINK );
 		}
 	}, [ returnQueryArg, products, refetchStoredCards ] );
 
@@ -237,6 +239,9 @@ function PaymentMethodForm() {
 	}, [ setupIntentError, reduxDispatch ] );
 
 	const getPreviousPageLink = () => {
+		if ( isClientView() ) {
+			return A4A_CLIENT_PAYMENT_METHODS_LINK;
+		}
 		if ( products ) {
 			if ( source === 'sitesdashboard' ) {
 				const productsSlugs = products

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/empty-state.tsx
@@ -2,24 +2,40 @@ import { Button } from '@automattic/components';
 import { Icon, lock, currencyDollar, postDate } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { A4A_PAYMENT_METHODS_ADD_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_CLIENT_PAYMENT_METHODS_ADD_LINK,
+	A4A_PAYMENT_METHODS_ADD_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import CreditCardImg from 'calypso/assets/images/jetpack/credit-cards.png';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isClientView } from '../lib/is-client-view';
 
 export default function EmptyState() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const isClientUI = isClientView();
+
 	const navigateToCreateMethod = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_license_list_empty_issue_license_click' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent(
+				isClientUI
+					? 'calypso_a4a_client_license_list_empty_issue_license_click'
+					: 'calypso_a4a_license_list_empty_issue_license_click'
+			)
+		);
+	}, [ dispatch, isClientUI ] );
+
+	const addCardURL = isClientUI
+		? A4A_CLIENT_PAYMENT_METHODS_ADD_LINK
+		: A4A_PAYMENT_METHODS_ADD_LINK;
 
 	return (
 		<div className="payment-method-overview-empty-state">
 			<div className="payment-method-overview-empty-state__top-content">
 				<img src={ CreditCardImg } alt={ translate( 'Credit Cards' ) } />
-				<Button primary href={ A4A_PAYMENT_METHODS_ADD_LINK } onClick={ navigateToCreateMethod }>
+				<Button primary href={ addCardURL } onClick={ navigateToCreateMethod }>
 					{ translate( 'Add a card' ) }
 				</Button>
 			</div>

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
@@ -11,7 +11,10 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { A4A_PAYMENT_METHODS_ADD_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_PAYMENT_METHODS_ADD_LINK,
+	A4A_CLIENT_PAYMENT_METHODS_ADD_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import Pagination from 'calypso/components/pagination';
 import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 import { useDispatch } from 'calypso/state';
@@ -19,6 +22,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { PaymentMethodOverviewContext } from '../context';
 import useStoredCards from '../hooks/use-stored-cards';
 import useStoredCardsPagination from '../hooks/use-stored-cards-pagination';
+import { isClientView } from '../lib/is-client-view';
 import EmptyState from './empty-state';
 import LoadingState from './loading-state';
 import StoredCreditCard from './stored-credit-card';
@@ -42,7 +46,7 @@ export default function PaymentMethodOverview() {
 			hasMoreStoredCards,
 		},
 		isFetching,
-	} = useStoredCards( paging );
+	} = useStoredCards( paging, undefined );
 
 	const { page, showPagination, onPageClick } = useStoredCardsPagination( {
 		storedCards: allStoredCards,
@@ -51,9 +55,17 @@ export default function PaymentMethodOverview() {
 		setPaging,
 	} );
 
+	const isClientUI = isClientView();
+
 	const onAddNewCardClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_payments_add_new_card_button_click' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent(
+				isClientUI
+					? 'calypso_a4a_client_payments_add_new_card_button_click'
+					: 'calypso_a4a_payments_add_new_card_button_click'
+			)
+		);
+	}, [ dispatch, isClientUI ] );
 
 	const content = useMemo( () => {
 		if ( isFetching ) {
@@ -104,6 +116,10 @@ export default function PaymentMethodOverview() {
 		showPagination,
 	] );
 
+	const addCardURL = isClientUI
+		? A4A_CLIENT_PAYMENT_METHODS_ADD_LINK
+		: A4A_PAYMENT_METHODS_ADD_LINK;
+
 	return (
 		<Layout className="payment-method-overview" title={ translate( 'Payment Methods' ) } wide>
 			<LayoutTop>
@@ -116,7 +132,7 @@ export default function PaymentMethodOverview() {
 						<MobileSidebarNavigation />
 
 						{ hasStoredCards && (
-							<Button href={ A4A_PAYMENT_METHODS_ADD_LINK } onClick={ onAddNewCardClick } primary>
+							<Button href={ addCardURL } onClick={ onAddNewCardClick } primary>
 								{ translate( 'Add new card' ) }
 							</Button>
 						) }

--- a/client/sections.js
+++ b/client/sections.js
@@ -834,7 +834,12 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-client',
-		paths: [ '/client/landing', '/client/subscriptions', '/client/payment-methods' ],
+		paths: [
+			'/client/landing',
+			'/client/subscriptions',
+			'/client/payment-methods',
+			'/client/payment-methods/add',
+		],
 		module: 'calypso/a8c-for-agencies/sections/client',
 		group: 'a8c-for-agencies',
 	},


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/369

## Proposed Changes

This PR implements payment methods UI for the client

NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)
- The card UI issue will be fixed in another PR.

<img width="1728" alt="Screenshot 2024-06-11 at 6 17 12 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b178c828-7917-4464-9ac4-a5464e874ddd">

## Testing Instructions

1. Checkout to the branch locally and start the server.
2. Create a new WPCOM account, but don't sign up for A4A.
3. Go to /client/payment-methods using the new WPCOM account
8. Verify that you see the UI for payment methods & matches with the UI in production (/purchases/payment-methods)
9. Please verify all the operations work as expected, including list, delete, set as primary, and add card.
10. Verify the breadcrumbs & `Go back` button on the add card page works as expected. Also, make sure you are redirected to /client/payment-methods after a card is added.
11. Login as an agency locally > Go to /purchases/payment-methods and verify all the operations work as expected, including list, delete, set as primary, and add card.
12. Verify the breadcrumbs & `Go back` button on the add card page works as expected.




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
