### PR TITLE
BlockedPurchaseErrorMessage: Link to `/account-assistance-form`

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -97,10 +97,9 @@ function getBlockedPurchaseErrorMessage( {
 			components: {
 				a: (
 					<a
-						href={
-							'https://wordpress.com/error-report/' +
-							( selectedSiteSlug ? '?url=payment@' + selectedSiteSlug : '' )
-						}
+						href={ `https://wordpress.com/account-assistance-form/${
+							selectedSiteSlug ? '?url=payment@' + selectedSiteSlug : ''
+						}` }
 						target="_blank"
 						rel="noopener noreferrer"
 					/>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6948

This PR has a wpcom counterpart: D152076-code

## Proposed Changes

* As requested by the Fraudsquad team, replace the link on the blocked purchases error message so it takes user to the new account assistance form. See paWMBk-1Rg-p2#comment-2651  

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Project thread: paYJgx-4Vv-p2

## Testing Instructions

- Block your user's purchases through the Payments Admin (if you don't have permissions for that, contact me and I'll do it)
- Open the live preview
- Go to /checkout/xlctest.wordpress.com?signup=1
- You'll see a `Purchases are currently disabled.` error message:

![image](https://github.com/Automattic/wp-calypso/assets/8511199/6a54452c-144b-47ee-b49b-38b87865517f)

Check that the `contact us` link goes to https://wordpress.com/account-assistance-form/?url=payment@xlctest.wordpress.com

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?