### PR TITLE
A4A > Referrals: Implement assign site flow for agency referrals

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
@@ -10,19 +10,22 @@ export const getReferralsQueryKey = ( agencyId?: number ) => {
 
 const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
 	const clients = referrals.reduce< { [ key: string ]: Referral } >( ( acc, referral ) => {
-		if ( ! acc[ referral.client_id ] ) {
-			acc[ referral.client_id ] = {
+		const purchases = referral.products.map( ( product ) => ( {
+			...product,
+			status: referral.status,
+		} ) );
+		if ( ! acc[ referral.client.id ] ) {
+			acc[ referral.client.id ] = {
 				id: referral.id,
-				client_id: referral.client_id,
-				client_email: referral.client_email,
-				purchases: [ ...referral.products ],
+				client: referral.client,
+				purchases: [ ...purchases ],
 				commissions: referral.commission,
 				statuses: [ referral.status ],
 			};
 		} else {
-			acc[ referral.client_id ].purchases.push( ...referral.products );
-			acc[ referral.client_id ].commissions += referral.commission;
-			acc[ referral.client_id ].statuses.push( referral.status );
+			acc[ referral.client.id ].purchases.push( ...purchases );
+			acc[ referral.client.id ].commissions += referral.commission;
+			acc[ referral.client.id ].statuses.push( referral.status );
 		}
 		return acc;
 	}, {} );

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -23,7 +23,7 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 	const [ selectedReferralTab, setSelectedReferralTab ] = useState( REFERRAL_PURCHASES_ID );
 
 	const itemData: ItemData = {
-		title: referral.client_email,
+		title: referral.client.email,
 		subtitle: (
 			<div className="referral-details__subtitle">
 				{ translate( 'Payment status {{badge}}%(status)s{{/badge}}', {

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -41,11 +41,11 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 								return (
 									<Button
 										className="view-details-button"
-										data-client-id={ item.client_id }
+										data-client-id={ item.client.id }
 										onClick={ () => openSitePreviewPane( item ) }
 										borderless
 									>
-										{ item.client_email }
+										{ item.client.email }
 									</Button>
 								);
 							},
@@ -60,7 +60,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							header: translate( 'Client' ).toUpperCase(),
 							getValue: () => '-',
 							render: ( { item }: { item: Referral } ): ReactNode => {
-								return item.client_email;
+								return item.client.email;
 							},
 							enableHiding: false,
 							enableSorting: false,
@@ -168,7 +168,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 			<ItemsDataViews
 				data={ {
 					items: referrals,
-					getItemId: ( item: Referral ) => `${ item.client_id }`,
+					getItemId: ( item: Referral ) => `${ item.client.id }`,
 					onSelectionChange: ( data ) => {
 						openSitePreviewPane( data[ 0 ] );
 					},

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -1,12 +1,20 @@
-export interface ReferralPurchase {
+interface ReferralPurchaseAPIResponse {
 	license_id: number;
 	quantity: number;
 	product_id: number;
+	date_assigned: string;
+	site_assigned: string;
+	license_key: string;
+}
+export interface ReferralPurchase extends ReferralPurchaseAPIResponse {
+	status: string;
 }
 export interface Referral {
 	id: number;
-	client_id: number;
-	client_email: string;
+	client: {
+		id: number;
+		email: string;
+	};
 	purchases: ReferralPurchase[];
 	commissions: number;
 	statuses: string[];
@@ -14,13 +22,11 @@ export interface Referral {
 
 export interface ReferralAPIResponse {
 	id: number;
-	client_id: number;
-	client_email: string;
-	products: {
-		license_id: number;
-		quantity: number;
-		product_id: number;
-	}[];
+	client: {
+		id: number;
+		email: string;
+	};
+	products: ReferralPurchaseAPIResponse[];
 	commission: number;
 	status: string;
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/350

## Proposed Changes

This PR implements the assign-site flow for agency referrals.

NOTE: 

- [Design](https://www.figma.com/design/fuufP6VNfZXYmvLsTRWRlG/Referrals?node-id=6711-71510&m=dev)
- The backed changes for assign site flow is WIP, so that will be done later.


## Testing Instructions

1. Checkout to the branch locally and start the server.
2. arc patch D151769
3. Create a new WPCOM account, but don't sign up for A4A.
4. Get the ID(WPCOM ID) from this API that gets called when you log in: 
https://public-api.wordpress.com/rest/v1.1/me and note it down.
5. Login to your agency account > Go to Marketplace > Toggle Refer products > Select one product & WPCOM hosting > Go to Checkout > Enter the email ID of the newly created account > Open the network tab > Click the `Request payment from client` button > Get the ID of the API response that gets called when the button is clicked.
6. Repeat the previous step again to the same client
7. Follow the instructions here to make it active, please do it only for one referral: 34bbb-pb
8. Go to /referrals/dashboard > Click on the detailed view of the client you referred the products to > Verify the UI looks like below. The `Assign to site` or `Create site` button should be disabled if the payment status is pending. Clicking on Assign site should navigate you to the Assign License page and clicking on the Create site should navigate you to the needs-setup page. Please note assigning the license or creating a site is WIP. 

<img width="1016" alt="Screenshot 2024-06-11 at 7 20 19 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/89567c35-ffc5-40c2-ac46-49e7685fca29">

9. Go to https://github.com/Automattic/wp-calypso/blob/f59750443dacca9bd099287d35c475ba323815f6/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts#L14-L15 and add the line `site_assigned: '<any-existing-site-full-url>'` and refresh the page. 
10. Go to /referrals/dashboard > Click on the detailed view of the client you referred the products to > Verify that the Assigned to column shows the site name and clicking on that navigate you the site details. 

<img width="972" alt="Screenshot 2024-06-11 at 7 27 21 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ff911240-094f-45d8-ab6e-948003fe7aa5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
