### PR TITLE
A4A: Wire Partner directory expertise form to the backend endpoint.

### DIFF
--- a/client/a8c-for-agencies/data/partner-directory/use-submit-partner-directory-application.ts
+++ b/client/a8c-for-agencies/data/partner-directory/use-submit-partner-directory-application.ts
@@ -1,0 +1,52 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+interface Params {
+	agency_id?: number;
+	services: string[];
+	products: string[];
+	directories: {
+		directory: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable';
+		urls: string[];
+		note: string;
+	}[];
+	feedback_url: string;
+}
+
+interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+	data?: any;
+}
+
+interface APIResponse {
+	success: boolean;
+}
+
+function mutationSubmitPartnerDirectoryApplication( params: Params ): Promise< APIResponse > {
+	if ( ! params.agency_id ) {
+		throw new Error( 'Agency ID is required to issue a license' );
+	}
+
+	return wpcom.req.put( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ params.agency_id }/profile/application`,
+		method: 'PUT',
+		body: params,
+	} );
+}
+
+export default function useSubmitPartnerDirectoryApplicationMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, Params, TContext >
+): UseMutationResult< APIResponse, APIError, Params, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< APIResponse, APIError, Params, TContext >( {
+		...options,
+		mutationFn: ( args ) =>
+			mutationSubmitPartnerDirectoryApplication( { ...args, agency_id: agencyId } ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
@@ -2,16 +2,16 @@ import { useCallback, useMemo, useState } from 'react';
 import { AgencyDirectoryApplication, DirectoryApplicationType } from '../../types';
 
 type Props = {
-	initialData?: AgencyDirectoryApplication | null;
+	initialFormData?: AgencyDirectoryApplication | null;
 };
 
 function validateURL( url: string ) {
 	return /^(https?:\/\/)?([a-z0-9-]+\.)*[a-z0-9-]+\.[a-z]+(:[0-9]+)?(\/[a-z0-9-]*)*$/.test( url );
 }
 
-export default function useExpertiseForm( { initialData }: Props ) {
+export default function useExpertiseForm( { initialFormData }: Props ) {
 	const [ formData, setFormData ] = useState< AgencyDirectoryApplication >(
-		initialData ?? {
+		initialFormData ?? {
 			status: 'pending',
 			services: [],
 			products: [],

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { AgencyDirectoryApplication, DirectoryApplicationType } from '../../types';
 
 type Props = {
-	initialData?: AgencyDirectoryApplication;
+	initialData?: AgencyDirectoryApplication | null;
 };
 
 function validateURL( url: string ) {

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
@@ -1,23 +1,33 @@
 import { useCallback } from 'react';
 import useSubmitPartnerDirectoryApplicationMutation from 'calypso/a8c-for-agencies/data/partner-directory/use-submit-partner-directory-application';
+import { Agency } from 'calypso/state/a8c-for-agencies/types';
 import { AgencyDirectoryApplication } from '../../types';
 
 type Props = {
 	formData: AgencyDirectoryApplication;
+	onSubmitSuccess?: ( data: Agency ) => void;
+	onSubmitError?: () => void;
 };
 
-export default function useSubmitForm( { formData }: Props ) {
-	const { mutate: submit, isPending: isSubmitting } =
-		useSubmitPartnerDirectoryApplicationMutation();
+export default function useSubmitForm( { formData, onSubmitSuccess, onSubmitError }: Props ) {
+	const { mutate: submit, isPending: isSubmitting } = useSubmitPartnerDirectoryApplicationMutation(
+		{
+			onSuccess: ( data ) => {
+				if ( onSubmitSuccess && data?.profile.partner_directory_application?.status ) {
+					onSubmitSuccess( data );
+				} else {
+					onSubmitError && onSubmitError();
+				}
+			},
+			onError: () => {
+				onSubmitError && onSubmitError();
+			},
+		}
+	);
 
 	const onSubmit = useCallback( () => {
-		submit( {
-			services: formData.services,
-			products: formData.products,
-			directories: formData.directories,
-			feedback_url: formData.feedbackUrl,
-		} );
-	}, [ formData.directories, formData.feedbackUrl, formData.products, formData.services, submit ] );
+		submit( formData );
+	}, [ formData, submit ] );
 
 	return {
 		onSubmit,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
@@ -1,17 +1,23 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
+import useSubmitPartnerDirectoryApplicationMutation from 'calypso/a8c-for-agencies/data/partner-directory/use-submit-partner-directory-application';
 import { AgencyDirectoryApplication } from '../../types';
 
 type Props = {
 	formData: AgencyDirectoryApplication;
 };
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 export default function useSubmitForm( { formData }: Props ) {
-	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const { mutate: submit, isPending: isSubmitting } =
+		useSubmitPartnerDirectoryApplicationMutation();
 
 	const onSubmit = useCallback( () => {
-		setIsSubmitting( true );
-		// FIXME: Submit the  data to the backend
-	}, [] );
+		submit( {
+			services: formData.services,
+			products: formData.products,
+			directories: formData.directories,
+			feedback_url: formData.feedbackUrl,
+		} );
+	}, [ formData.directories, formData.feedbackUrl, formData.products, formData.services, submit ] );
 
 	return {
 		onSubmit,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -222,7 +222,9 @@ const AgencyExpertise = ( { initialData }: Props ) => {
 
 			<div className="partner-directory-agency-cta__footer">
 				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>
-					{ translate( 'Submit my application' ) }
+					{ agencyApplication
+						? translate( 'Update my expertise' )
+						: translate( 'Submit my application' ) }
 				</Button>
 
 				<Button

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -11,9 +11,7 @@ import {
 	A4A_PARTNER_DIRECTORY_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
-import { useSelector } from 'calypso/state';
 import { setActiveAgency } from 'calypso/state/a8c-for-agencies/agency/actions';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import ProductsSelector from '../components/products-selector';
@@ -64,18 +62,15 @@ const DirectoryClientSamples = ( { label, samples, onChange }: DirectoryClientSa
 };
 
 type Props = {
-	initialData?: AgencyDirectoryApplication | null;
+	initialFormData: AgencyDirectoryApplication | null;
 };
 
-const AgencyExpertise = ( { initialData }: Props ) => {
+const AgencyExpertise = ( { initialFormData }: Props ) => {
 	const translate = useTranslate();
-
-	const agency = useSelector( getActiveAgency );
-	const agencyApplication = agency?.profile?.partner_directory_application;
 
 	const onSubmitSuccess = useCallback(
 		( response: Agency ) => {
-			agency && response && reduxDispatch( setActiveAgency( response ) );
+			response && reduxDispatch( setActiveAgency( response ) );
 
 			reduxDispatch(
 				successNotice( translate( 'Your Partner Directory application was submitted!' ), {
@@ -105,7 +100,7 @@ const AgencyExpertise = ( { initialData }: Props ) => {
 		setDirectorySelected,
 		getDirectoryClientSamples,
 		setDirectorClientSample,
-	} = useExpertiseForm( { initialData } );
+	} = useExpertiseForm( { initialFormData } );
 
 	const { onSubmit, isSubmitting } = useSubmitForm( { formData, onSubmitSuccess, onSubmitError } );
 
@@ -222,7 +217,7 @@ const AgencyExpertise = ( { initialData }: Props ) => {
 
 			<div className="partner-directory-agency-cta__footer">
 				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>
-					{ agencyApplication
+					{ initialFormData
 						? translate( 'Update my expertise' )
 						: translate( 'Submit my application' ) }
 				</Button>

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -54,7 +54,7 @@ const DirectoryClientSamples = ( { label, samples, onChange }: DirectoryClientSa
 };
 
 type Props = {
-	initialData?: AgencyDirectoryApplication;
+	initialData?: AgencyDirectoryApplication | null;
 };
 
 const AgencyExpertise = ( { initialData }: Props ) => {

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -2,7 +2,7 @@ import { BadgeType, Button } from '@automattic/components';
 import { Icon, external, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
 	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
@@ -40,6 +40,11 @@ export default function PartnerDirectoryDashboard() {
 	const onAgencyProfileClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_agency_profile_click' ) );
 	}, [ dispatch ] );
+
+	// We want to scroll to the top of the page when the component is rendered
+	useEffect( () => {
+		document.querySelector( '.partner-directory__body' )?.scrollTo( 0, 0 );
+	}, [] );
 
 	const isSubmitted = true; // FIXME: Replace with actual value
 	const brandStatuses = [

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -3,6 +3,11 @@ import { Icon, external, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
+} from 'calypso/a8c-for-agencies/sections/partner-directory/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import StepSection from '../../referrals/common/step-section';
@@ -123,7 +128,7 @@ export default function PartnerDirectoryDashboard() {
 											<Button
 												className="a8c-blue-link"
 												onClick={ onAgencyProfileClick }
-												href="/partner-directory/agency-details"
+												href={ `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }` }
 												borderless
 											>
 												{ translate( `Your agency's profile` ) }
@@ -154,12 +159,16 @@ export default function PartnerDirectoryDashboard() {
 					<div>
 						<Button
 							onClick={ onEditExpertiseClick }
-							href="/partner-directory/agency-expertise"
+							href={ `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }` }
 							compact
 						>
 							{ translate( 'Edit expertise' ) }
 						</Button>
-						<Button onClick={ onEditProfileClick } href="/partner-directory/agency-details" compact>
+						<Button
+							onClick={ onEditProfileClick }
+							href={ `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }` }
+							compact
+						>
 							{ translate( 'Edit profile' ) }
 						</Button>
 					</div>
@@ -216,7 +225,7 @@ export default function PartnerDirectoryDashboard() {
 					}
 					buttonProps={ {
 						children: isSubmitted ? translate( 'Edit expertise' ) : translate( 'Apply now' ),
-						href: '/partner-directory/agency-expertise',
+						href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`,
 						onClick: onApplyNowClick,
 						primary: ! isSubmitted,
 						compact: true,
@@ -231,7 +240,7 @@ export default function PartnerDirectoryDashboard() {
 					) }
 					buttonProps={ {
 						children: translate( 'Finish profile' ),
-						href: '/partner-directory/agency-details',
+						href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
 						onClick: onFinishProfileClick,
 						primary: isSubmitted,
 						disabled: ! isSubmitted || ! showFinishProfileButton,

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -11,9 +11,9 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
-import AgencyDetailsForm from './agency-details';
 import { useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import AgencyDetailsForm from './agency-details';
 import AgencyExpertise from './agency-expertise';
 import {
 	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
@@ -21,7 +21,7 @@ import {
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
 } from './constants';
 import Dashboard from './dashboard';
-import parseFormData from './utils/parse-form-data';
+import mapApplicationFormData from './utils/map-application-form-data';
 
 import './style.scss';
 
@@ -41,7 +41,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 
 	const agency = useSelector( getActiveAgency );
 
-	const application = useMemo( () => parseFormData( agency ), [ agency ] );
+	const application = useMemo( () => mapApplicationFormData( agency ), [ agency ] );
 
 	// Define the sub-menu sections
 	const sections: { [ slug: string ]: Section } = useMemo( () => {

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -12,6 +12,8 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
 import AgencyDetailsForm from './agency-details';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import AgencyExpertise from './agency-expertise';
 import {
 	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
@@ -19,6 +21,7 @@ import {
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
 } from './constants';
 import Dashboard from './dashboard';
+import parseFormData from './utils/parse-form-data';
 
 import './style.scss';
 
@@ -35,6 +38,10 @@ interface Section {
 export default function PartnerDirectory( { selectedSection }: Props ) {
 	const translate = useTranslate();
 	const title = translate( 'Partner Directory' );
+
+	const agency = useSelector( getActiveAgency );
+
+	const application = useMemo( () => parseFormData( agency ), [ agency ] );
 
 	// Define the sub-menu sections
 	const sections: { [ slug: string ]: Section } = useMemo( () => {
@@ -63,7 +70,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 		};
 
 		sections[ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG ] = {
-			content: <AgencyExpertise />,
+			content: <AgencyExpertise initialData={ application } />,
 			breadcrumbItems: [
 				...sections[ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ].breadcrumbItems,
 				{

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -81,7 +81,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 		};
 
 		return sections;
-	}, [ translate ] );
+	}, [ translate, application ] );
 
 	// Set the selected section
 	const section: Section = sections[ selectedSection ];

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -21,7 +21,7 @@ import {
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
 } from './constants';
 import Dashboard from './dashboard';
-import mapApplicationFormData from './utils/map-application-form-data';
+import { mapApplicationFormData } from './utils/map-application-form-data';
 
 import './style.scss';
 
@@ -40,8 +40,6 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 	const title = translate( 'Partner Directory' );
 
 	const agency = useSelector( getActiveAgency );
-
-	const application = useMemo( () => mapApplicationFormData( agency ), [ agency ] );
 
 	// Define the sub-menu sections
 	const sections: { [ slug: string ]: Section } = useMemo( () => {
@@ -70,7 +68,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 		};
 
 		sections[ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG ] = {
-			content: <AgencyExpertise initialData={ application } />,
+			content: <AgencyExpertise initialFormData={ mapApplicationFormData( agency ) } />,
 			breadcrumbItems: [
 				...sections[ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ].breadcrumbItems,
 				{
@@ -81,7 +79,7 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 		};
 
 		return sections;
-	}, [ translate, application ] );
+	}, [ translate, agency ] );
 
 	// Set the selected section
 	const section: Section = sections[ selectedSection ];

--- a/client/a8c-for-agencies/sections/partner-directory/types.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/types.ts
@@ -3,19 +3,19 @@ export type AgencyDirectoryApplicationStatus = 'pending' | 'in-progress' | 'comp
 export type DirectoryApplicationType = 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable';
 
 export interface AgencyDirectoryApplication {
-	status: AgencyDirectoryApplicationStatus;
 	products: string[];
 	services: string[];
 	directories: DirectoryApplication[];
 	feedbackUrl: string;
+	status?: AgencyDirectoryApplicationStatus;
 }
 
 export interface DirectoryApplication {
 	directory: DirectoryApplicationType;
-	published: boolean;
-	status: 'pending' | 'approved' | 'rejected' | 'closed';
 	urls: string[];
-	note: string;
+	note?: string;
+	isPublished?: boolean;
+	status?: 'pending' | 'approved' | 'rejected' | 'closed';
 }
 
 export interface AgencyDetails {

--- a/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
@@ -1,9 +1,7 @@
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
 import { AgencyDirectoryApplication } from '../types';
 
-export default function mapApplicationFormData(
-	agency: Agency | null
-): AgencyDirectoryApplication | null {
+export function mapApplicationFormData( agency: Agency | null ): AgencyDirectoryApplication | null {
 	if ( ! agency?.profile?.partner_directory_application ) {
 		return null;
 	}

--- a/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
@@ -1,7 +1,9 @@
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
 import { AgencyDirectoryApplication } from '../types';
 
-export default function parseFormData( agency: Agency | null ): AgencyDirectoryApplication | null {
+export default function mapApplicationFormData(
+	agency: Agency | null
+): AgencyDirectoryApplication | null {
 	if ( ! agency?.profile?.partner_directory_application ) {
 		return null;
 	}

--- a/client/a8c-for-agencies/sections/partner-directory/utils/parse-form-data.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/parse-form-data.ts
@@ -1,0 +1,24 @@
+import { Agency } from 'calypso/state/a8c-for-agencies/types';
+import { AgencyDirectoryApplication } from '../types';
+
+export default function parseFormData( agency: Agency | null ): AgencyDirectoryApplication | null {
+	if ( ! agency?.profile?.partner_directory_application ) {
+		return null;
+	}
+
+	return {
+		status: agency.profile.partner_directory_application.status,
+		products: agency.profile.listing_details.products ?? [],
+		services: agency.profile.listing_details.services ?? [],
+		directories: agency.profile.partner_directory_application.directories.map(
+			( { status, directory, published, urls, note } ) => ( {
+				status: status,
+				directory: directory,
+				published: published,
+				urls: urls,
+				note: note,
+			} )
+		),
+		feedbackUrl: agency.profile.partner_directory_application.feedback_url,
+	};
+}

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -24,6 +24,36 @@ export interface Agency {
 			pressable_id: number;
 		};
 	};
+	profile: {
+		company_details: {
+			name: string;
+			email: string;
+			website: string;
+			bio_description: string;
+			logo_url: string;
+			landing_page_url: string;
+			country: string;
+		};
+		listing_details: {
+			is_available: boolean;
+			industry: string;
+			services: string[];
+			products: string[];
+			languages_spoken: string[];
+		};
+		partner_directory_application: null | {
+			status: 'pending' | 'in-progress' | 'completed';
+			directories: {
+				status: 'pending' | 'approved' | 'rejected' | 'closed';
+				directory: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable';
+				published: boolean;
+				urls: string[];
+				note: string;
+				is_published?: boolean;
+			}[];
+			feedback_url: string;
+		};
+	};
 }
 
 export interface AgencyStore {

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -43,6 +43,9 @@ export interface Agency {
 		};
 		budget_details: {
 			budget_lower_range: string;
+			budget_upper_range: string;
+			has_hourly_rate: boolean;
+			hourly_rate_value: string;
 		};
 		partner_directory_application: null | {
 			status: 'pending' | 'in-progress' | 'completed';

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -41,6 +41,9 @@ export interface Agency {
 			products: string[];
 			languages_spoken: string[];
 		};
+		budget_details: {
+			budget_lower_range: string;
+		};
 		partner_directory_application: null | {
 			status: 'pending' | 'in-progress' | 'completed';
 			directories: {

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -48,7 +48,7 @@ export interface Agency {
 			hourly_rate_value: string;
 		};
 		partner_directory_application: null | {
-			status: 'pending' | 'in-progress' | 'completed';
+			status?: 'pending' | 'in-progress' | 'completed';
 			directories: {
 				status: 'pending' | 'approved' | 'rejected' | 'closed';
 				directory: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable';


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/550

## Proposed Changes

This PR wires the Expertise form to submit the form data to the endpoint.

![image](https://github.com/Automattic/wp-calypso/assets/9832440/92eeb8a9-b07b-457f-8cb6-1fa59a31bea5)

![image](https://github.com/Automattic/wp-calypso/assets/9832440/86f4c9f3-5fb9-4f1d-96a8-f2e5ca38450f)

Also, this PR fixes some issues. It updates the Agency data when the endpoint responds with the Agency object.

## Testing Instructions

- Use the A4A live and go to `/partner-directory/agency-expertise`
- Submit the expertise form.
   - If it's the first time you submit an application for your agency you will see this button `Submit my application` if not, you will see: `Update my expertise`
- Confirm it is successful. You will see this message `Your Partner Directory application was submitted!` and you will redirected to the Partner Directory Dashboard.
- You can go again to the Expertise form and check that the data you filled out is there. If you refresh the page, you will see the data, it's retrieved from the GET agency endpoint.
- You can provoke an error, just change the endpoint `/profile/application` in this file `client/a8c-for-agencies/data/partner-directory/use-submit-partner-directory-application.ts` to `/profile/application2` and try to submit the form again, and you will see this error message `Something went wrong submitting your application!`. You won't be redirected to the Dashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
