### PR TITLE
Site management panel: Unify CSS around content text

### DIFF
--- a/client/components/hosting-card/index.tsx
+++ b/client/components/hosting-card/index.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 
@@ -50,4 +50,28 @@ export function HostingCardHeading( { id, title, children }: HostingCardHeadingP
 
 export function HostingCardDescription( { children }: HostingCardDescriptionProps ) {
 	return <p className="hosting-card__description">{ children }</p>;
+}
+
+interface HostingCardLinkButtonProps {
+	to: string;
+	children: string | ReactNode;
+	hideOnMobile?: boolean;
+}
+
+export function HostingCardLinkButton( {
+	to,
+	children,
+	hideOnMobile,
+}: HostingCardLinkButtonProps ) {
+	return (
+		<Button
+			className={ clsx( 'hosting-card__link-button', {
+				'hosting-card__link-button--hide-on-mobile': hideOnMobile,
+			} ) }
+			plain
+			href={ to }
+		>
+			{ children }
+		</Button>
+	);
 }

--- a/client/components/hosting-card/style.scss
+++ b/client/components/hosting-card/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/breakpoints";
 
 .hosting-card {
 	width: 100%;
@@ -11,6 +12,15 @@
 
 	&.is-borderless {
 		border: none;
+	}
+
+	.form-label {
+		font-weight: 500;
+	}
+
+	.form-text-input,
+	.form-select {
+		font-size: rem(14px) !important;
 	}
 }
 
@@ -35,5 +45,16 @@ p.hosting-card__description {
 	font-size: rem(14px);
 	font-weight: 400;
 	line-height: 20px;
-	color: var(--studio-gray-100);
+}
+
+a.hosting-card__link-button {
+	font-size: $font-body-extra-small;
+	line-height: 16px;
+	color: var(--color-link);
+}
+
+@media (max-width: $break-xlarge) {
+	.hosting-card__link-button--hide-on-mobile {
+		display: none;
+	}
 }

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -66,7 +66,7 @@
 	}
 
 	.formatted-header__subtitle {
-		color: var(--color-neutral-60);
+		color: var(--studio-gray-50);
 		margin: 0;
 		line-height: 20px;
 		letter-spacing: -0.15px;

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -1,11 +1,13 @@
-import { Button } from '@automattic/components';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable } from '@automattic/domains-table';
 import { useBreakpoint } from '@automattic/viewport-react';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
-import { HostingCard, HostingCardHeading } from 'calypso/components/hosting-card';
+import {
+	HostingCard,
+	HostingCardHeading,
+	HostingCardLinkButton,
+} from 'calypso/components/hosting-card';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
 import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
@@ -28,23 +30,15 @@ const ActiveDomainsCard: FC = () => {
 	return (
 		<HostingCard className="hosting-overview__active-domains">
 			<HostingCardHeading title={ translate( 'Active domains' ) }>
-				<Button
-					className={ clsx(
-						'hosting-overview__link-button',
-						'hosting-overview__mobile-hidden-link-button'
-					) }
-					plain
-					href={ `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }` }
+				<HostingCardLinkButton
+					to={ `/domains/add/${ site?.slug }?redirect_to=${ window.location.pathname }` }
+					hideOnMobile
 				>
 					{ translate( 'Add new domain' ) }
-				</Button>
-				<Button
-					className="hosting-overview__link-button"
-					plain
-					href={ `/domains/manage/${ site?.slug }` }
-				>
+				</HostingCardLinkButton>
+				<HostingCardLinkButton to={ `/domains/manage/${ site?.slug }` }>
 					{ translate( 'Manage domains' ) }
-				</Button>
+				</HostingCardLinkButton>
 			</HostingCardHeading>
 
 			<DomainsTable

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -14,7 +14,7 @@ import { FC } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PlanStorage from 'calypso/blocks/plan-storage';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import { HostingCard } from 'calypso/components/hosting-card';
+import { HostingCard, HostingCardLinkButton } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PlanStorageBar from 'calypso/hosting-overview/components/plan-storage-bar';
 import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
@@ -189,30 +189,19 @@ const PlanCard: FC = () => {
 		}
 		if ( isFreePlan ) {
 			return (
-				<Button
-					className={ clsx(
-						'hosting-overview__link-button',
-						'hosting-overview__mobile-hidden-link-button'
-					) }
-					plain
-					href={ `/add-ons/${ site?.slug }` }
-				>
+				<HostingCardLinkButton to={ `/add-ons/${ site?.slug }` } hideOnMobile>
 					{ translate( 'Manage add-ons' ) }
-				</Button>
+				</HostingCardLinkButton>
 			);
 		}
 		if ( isOwner ) {
 			return (
-				<Button
-					className={ clsx(
-						'hosting-overview__link-button',
-						'hosting-overview__mobile-hidden-link-button'
-					) }
-					plain
-					href={ getManagePurchaseUrlFor( site?.slug, planPurchaseId ?? 0 ) }
+				<HostingCardLinkButton
+					to={ getManagePurchaseUrlFor( site?.slug, planPurchaseId ?? 0 ) }
+					hideOnMobile
 				>
 					{ translate( 'Manage plan' ) }
-				</Button>
+				</HostingCardLinkButton>
 			);
 		}
 	};

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -162,25 +162,6 @@ $card-padding: 24px;
 
 }
 
-a.hosting-overview__link-button {
-	color: var(--color-link);
-	font-family: "SF Pro Text", $sans;
-	font-size: $font-body-extra-small;
-	line-height: 16px;
-}
-
-@media (max-width: $break-xlarge) {
-	.hosting-overview__mobile-hidden-link-button {
-		display: none;
-	}
-}
-
-.hosting-overview__card-header {
-	display: flex;
-	gap: var(--grid-unit-15, 12px);
-	margin-bottom: 16px;
-}
-
 .hosting-overview__plan-info {
 	color: var(--studio-gray-80);
 	font-family: "SF Pro Text", $sans;
@@ -257,7 +238,7 @@ a.hosting-overview__link-button {
 	margin: 0;
 }
 
-.hosting-overview__action-button {
+a.hosting-overview__action-button {
 	display: flex;
 	justify-content: space-between;
 	color: var(--studio-gray-100);

--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -28,8 +28,6 @@ const Hr = styled.hr( {
 } );
 
 const EdgeCacheNotice = styled.p( {
-	fontSize: '14px',
-	fontStyle: 'italic',
 	color: '#646970',
 	marginTop: '18px',
 } );

--- a/client/my-sites/hosting/site-backup-card/index.js
+++ b/client/my-sites/hosting/site-backup-card/index.js
@@ -1,9 +1,11 @@
-import { Button } from '@automattic/components';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import { HostingCard } from 'calypso/components/hosting-card';
+import {
+	HostingCard,
+	HostingCardHeading,
+	HostingCardLinkButton,
+} from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useSelector } from 'calypso/state';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
@@ -44,27 +46,24 @@ const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId, sit
 
 	return (
 		<HostingCard className="site-backup-card">
-			<div className="hosting-card__heading">
-				<h3 className="hosting-card__title">{ translate( 'Site backup' ) }</h3>
-				<Button
-					className={ clsx( 'site-backup-card__button', 'hosting-overview__link-button' ) }
-					plain
-					href={
+			<HostingCardHeading title={ translate( 'Site backup' ) }>
+				<HostingCardLinkButton
+					to={
 						wpcomAdminInterface === 'wp-admin'
 							? `https://cloud.jetpack.com/backup/${ siteSlug }`
 							: `/backup/${ siteSlug }`
 					}
 				>
 					{ translate( 'See all backups' ) }
-				</Button>
-			</div>
+				</HostingCardLinkButton>
+			</HostingCardHeading>
 			{ hasRetrievedLastBackup && lastGoodBackup && ! isLoading && ! disabled && (
 				<>
 					<p className="site-backup-card__date">
 						{ translate( 'Last backup was on:' ) }
 						<strong>{ lastGoodBackupTime }</strong>
 					</p>
-					<p className="site-backup-card__warning">
+					<p>
 						{ translate(
 							"If you restore your site using this backup, you'll lose any changes made after that date."
 						) }

--- a/client/my-sites/hosting/site-backup-card/style.scss
+++ b/client/my-sites/hosting/site-backup-card/style.scss
@@ -7,12 +7,6 @@
 		}
 	}
 
-	&__warning {
-		color: var(--color-text-subtle);
-		font-size: $font-body-small;
-		margin-bottom: 16px;
-	}
-
 	&__placeholder {
 		@include placeholder();
 		height: 24px;

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -158,7 +158,6 @@ $areas: sftp, site-backup, support, phpmyadmin, staging-site, restore-plan-softw
 	}
 
 	.components-panel__body-title .components-button {
-		font-size: 1rem;
 		font-weight: 600;
 	}
 

--- a/client/my-sites/site-monitoring/components/site-logs-table/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-table/style.scss
@@ -5,7 +5,6 @@ $border-color:#eeeeee; /* stylelint-disable-line color-hex-length */
 	white-space: normal;
 	border-collapse: collapse;
 	background-color: var(--studio-white);
-	color: var(--studio-gray-100);
 	margin: 0 0 1.5rem;
 	font-family: "SF Pro Text", $sans;
 	table-layout: fixed;
@@ -43,7 +42,7 @@ $border-color:#eeeeee; /* stylelint-disable-line color-hex-length */
 
 .site-logs-table th {
 	font-family: "SF Pro Text", $sans;
-	color: var(--color-neutral-60);
+	color: var(--studio-gray-50);
 	font-weight: 400;
 
 	&:first-child {
@@ -200,7 +199,6 @@ td.timestamp {
 
 td.message {
 	font-size: 0.875rem;
-	color: var(--studio-gray-100);
 }
 
 @media (max-width: 600px) {

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -142,10 +142,6 @@ div.is-section-site-monitoring:not(.is-global-sidebar-visible) {
 }
 
 .site-monitoring__chart {
-	padding: 24px;
-	border: 1px solid var(--studio-gray-5);
-	border-radius: 5px; /* stylelint-disable-line scales/radii */
-	background-color: var(--studio-white);
 	position: relative;
 
 	.components-spinner {

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -506,6 +506,8 @@
 	}
 	.item-preview__content {
 		padding: 32px 48px 48px;
+		font-size: rem(14px);
+		color: var(--studio-gray-100);
 
 		.navigation-header {
 			padding: 0;
@@ -539,7 +541,7 @@
 		font-weight: 400;
 		font-size: rem(13px);
 		line-height: 20px;
-		color: #757575;
+		color: var(--studio-gray-50);
 		text-transform: capitalize;
 	}
 }


### PR DESCRIPTION
Related to: p1718017001266039-slack-C06DN6QQVAQ

## Proposed Changes

This PR unifies the CSS around texts in the site management panel tabs, so that they use consistent styles. Mostly based on @lucasmendes-design's Figma file. The principle is to use very small set of different sizes/colors.

The main issue that I see is that many content text is bigger than the card subheading, which makes the IA look confusing.

### Tab heading

<img width="687" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/334ce8bf-d4fa-4d0e-8d4e-3d2dd11d8cf9">

||Before|After|
|-|-|-|
|Subheading|`var(--color-neutral-60)`|`var(--studio-gray-50)`|

### Card heading

<img width="488" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/5372f65b-f43c-41f5-9479-b00c8ad7fda7">

No changes as they are already correct.

### Card content

I'm using the following principle:

1. Use 14px by default
2. Use `var(--studio-gray-100)` by default, and `var(--studio-gray-50)` for "subtle" texts

Some screenshots:

|Before|After|
|-|-|
|<img width="563" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/5315f43a-558b-4b12-8097-59a9fb445a95">|<img width="563" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/62d8390a-ec3b-479c-b780-7dcee4fae48d">|
|<img width="911" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/70d4a869-2a00-4af7-8013-7dbbdd95c6d6">|<img width="911" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/44e52579-24aa-4cce-bf6f-5f1f103b1ae1">|
|<img width="565" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/750c09f5-8d18-42c7-842e-a2b6f1362cc3">|<img width="564" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/c8e00a31-ce18-4ca6-95a9-d0cc0d46134b">|


### Implementation Details

I added the above default CSS inside `sites-dashboard-v2's CSS file and remove redundant styles from the features.

## Note

I deliberately left out Deployments and Staging Sites tab because there are active PRs modifying their layout. I can come back to them later.

## Why are these changes being made?

Currently, the texts do not have consistent styles, as they were picked up from various pages before Untangling.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open /sites
2. Click an Atomic sites
3. Click around the tabs and "feel" that the texts are now more consistent and easier to read, especially in the Overview and Server Settings tabs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?