### PR TITLE
Untangling: localize link in A4A banner

### DIFF
--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	SitesSortKey,
 	useSitesListFiltering,
@@ -281,7 +282,7 @@ const SitesDashboardV2 = ( {
 								dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
 								event="learn-more"
 								horizontal
-								href="https://wordpress.com/for-agencies"
+								href={ localizeUrl( 'https://wordpress.com/for-agencies' ) }
 								title={ translate( 'Managing multiple sites? Meet our agency hosting' ) }
 								tracksClickName="calypso_sites_dashboard_a4a_banner_click"
 							/>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7680

## Proposed Changes
With this PR we are fixing localization of a link, specifically "Leatn more" link in A4A banner.


## Testing Instructions
1) Open `http://calypso.localhost:3000/sites`
2) Make sure that you have EN locale for your user
3) Assert that "Learn more" link points to "https://wordpress.com/for-agencies/" <br /> <img width="1097" alt="Screenshot 2024-06-11 at 16 06 18" src="https://github.com/Automattic/wp-calypso/assets/5598437/a722dc90-f8bb-418b-9697-a345cd76d39c">
4) Set Spanish locale
5) Assert that "Learn more" link points to "https://wordpress.com/es/for-agencies/" (if you click it redirects to the localized slug "https://wordpress.com/es/para-agencias/").