### PR TITLE
Reader tags - Add header to no results tag stream.

### DIFF
--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -121,7 +121,10 @@ class TagStream extends Component {
 					<TagStreamHeader
 						title={ title }
 						imageSearchString={ imageSearchString }
-						showFollow={ false }
+						// This shouldn't be necessary as user should have been able to subscribe to
+						// an error tag. Nevertheless, we should give them a route to unfollow if
+						// that was the case.
+						showFollow={ tag.id && this.isSubscribed() }
 						showSort={ false }
 						showBack={ this.props.showBack }
 					/>
@@ -131,7 +134,7 @@ class TagStream extends Component {
 		}
 
 		// Put the tag stream header at the top of the body, so it can be even with the sidebar in the two column layout.
-		const tagHeader = () => (
+		const tagHeader = ( showSort = true ) => (
 			<TagStreamHeader
 				title={ titleText }
 				description={ this.props.description }
@@ -140,7 +143,7 @@ class TagStream extends Component {
 				following={ this.isSubscribed() }
 				onFollowToggle={ this.toggleFollowing }
 				showBack={ this.props.showBack }
-				showSort
+				showSort={ showSort }
 				sort={ this.props.sort }
 				recordReaderTracksEvent={ this.props.recordReaderTracksEvent }
 			/>
@@ -152,12 +155,19 @@ class TagStream extends Component {
 			sidebarTabTitle: this.props.translate( 'Related' ),
 		};
 
+		const emptyContentWithHeader = () => (
+			<>
+				{ tagHeader( false ) }
+				{ emptyContent() }
+			</>
+		);
+
 		return (
 			<Stream
 				{ ...this.props }
 				className="tag-stream__main"
 				listName={ title }
-				emptyContent={ emptyContent }
+				emptyContent={ emptyContentWithHeader }
 				showFollowInHeader
 				forcePlaceholders={ ! tag } // if tag has not loaded yet, then make everything a placeholder
 				streamHeader={ tagHeader }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -121,9 +121,9 @@ class TagStream extends Component {
 					<TagStreamHeader
 						title={ title }
 						imageSearchString={ imageSearchString }
-						// This shouldn't be necessary as user should have been able to subscribe to
-						// an error tag. Nevertheless, we should give them a route to unfollow if
-						// that was the case.
+						// This shouldn not be necessary as user should not have been able to
+						// subscribe to an error tag. Nevertheless, we should give them a route to
+						// unfollow if that was the case.
 						showFollow={ tag.id && this.isSubscribed() }
 						showSort={ false }
 						showBack={ this.props.showBack }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/86548

## Proposed Changes

* Adds the tag stream header to the no results tag stream. This ensures the tag name and follow toggle is visible even when there are no results for the selected tag.
* Enables the unfollow button on the tag error result if the tag is followed by the user. This should theoretically be unnecessary as a user shouldn't technically be able to follow an error tag, but in case that they were able to before it became an error, this could give a way out.

BEFORE ("good tag" - no results)
<img width="1274" alt="Screenshot 2024-06-11 at 1 45 13 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/ef1dbf8c-47eb-4bcb-bc40-48462daca578">
No header displaying the tag name or follow button when there are no results found.

AFTER ("good tag" - no results)
<img width="1436" alt="Screenshot 2024-06-11 at 1 45 27 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/b492a6cb-f340-413e-a459-05cdad57c2ae">
Now a header displaying the title and follow button.

BEFORE ("error tag")
<img width="1378" alt="Screenshot 2024-06-11 at 1 46 59 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/be751836-30fb-4ad3-8aa7-debbeed89831">
The header with the title was already in place when the tag did not exist and had an error result as seen above. Its odd our no results for good tags did not show this before.

AFTER ("error tag")
should be the same as before. However we have conditioned logic to display in 'unfollow' button in the rare case that somehow the user was able to follow this tag.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users could add tags in the sidebar but if there were no results for the added tag there was no option for the user to unfollow the tag as we were not showing the header in the no results case. Users noted using the mobile app to unfollow tags they added in the web app in this situation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the tags section in the reader
* Visit some good tags streams, verify they look the same as before.
* Visit a tag with no results (ex "rereligion"). Verify there is a follow/unfollow button in the header above no results.
* Visit an invalid tag (ex "rereligions"). Verify there is no follow button if you are not following this. Double check the logic in this PR for displaying the follow button in this case and verify it makes that the 'unfollow' button would appear in the rare case a user was able to follow this tag.
    * I think testing this step as being followed for real would not be worth the time or effort given the simplicity of the code solution, the complexity of reproducing the problem, and the low probability that a user would experience it. If the unfollowed state works, and the followed state looks like it would if it ever happened, this seems good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
