### PR TITLE
Move importer types into clientlib importer

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -10,7 +10,7 @@ import {
 	type ImporterConfigPriority,
 } from 'calypso/lib/importer/importer-config';
 import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
-import type { ImporterPlatform } from '../types';
+import type { ImporterPlatform } from 'calypso/lib/importer/types';
 import './style.scss';
 
 const trackEventName = 'calypso_signup_step_start';

--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -6,11 +6,12 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect, useState } from 'react';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { UrlData, GoToStep, RecordTracksEvent, ImporterPlatform } from '../types';
+import { UrlData, GoToStep, RecordTracksEvent } from '../types';
 import { convertPlatformName, convertToFriendlyWebsiteName } from '../util';
 import ImportPlatformDetails, { coveredPlatforms } from './platform-details';
 import ImportPreview from './preview';
 import type { OnboardSelect } from '@automattic/data-stores';
+import type { ImporterPlatform } from 'calypso/lib/importer/types';
 import './style.scss';
 
 const trackEventName = 'calypso_signup_step_start';

--- a/client/blocks/import/ready/platform-details.tsx
+++ b/client/blocks/import/ready/platform-details.tsx
@@ -5,7 +5,8 @@ import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, close, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { FeatureName, FeatureList, ImporterPlatform, UrlData } from '../types';
+import { FeatureName, FeatureList, UrlData } from '../types';
+import type { ImporterPlatform } from 'calypso/lib/importer/types';
 import type * as React from 'react';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/blocks/import/types.ts
+++ b/client/blocks/import/types.ts
@@ -1,3 +1,5 @@
+import { type ImporterPlatform } from 'calypso/lib/importer/types';
+
 export type GoToStep = (
 	stepName: string,
 	stepSectionName?: string,
@@ -45,27 +47,3 @@ export type FeatureName =
 	| 'plugins';
 
 export type FeatureList = { [ key in FeatureName ]: string };
-
-// List of supported importer platforms (most important)
-export type ImporterMainPlatform =
-	| 'blogger'
-	| 'medium'
-	| 'squarespace'
-	| 'wordpress'
-	| 'wix'
-	| ImporterPlatformOther;
-// List of supported importer platforms (others)
-export type ImporterPlatformOther =
-	| 'blogroll'
-	| 'ghost'
-	| 'livejournal'
-	| 'movabletype'
-	| 'tumblr'
-	| 'xanga'
-	| 'substack';
-export type ImporterPlatformExtra = 'godaddy-central';
-export type ImporterPlatform =
-	| ImporterMainPlatform
-	| ImporterPlatformOther
-	| ImporterPlatformExtra
-	| 'unknown';

--- a/client/blocks/import/util.ts
+++ b/client/blocks/import/util.ts
@@ -1,5 +1,5 @@
 import { capitalize } from 'lodash';
-import { ImporterPlatform } from './types';
+import type { ImporterPlatform } from 'calypso/lib/importer/types';
 
 export const CAPTURE_URL_RGX =
 	/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.][a-z0-9]+)*\.[a-z]{2,63}(:[0-9]{1,5})?(\/.*)?$/i;

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -2,7 +2,6 @@ import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/des
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
@@ -13,6 +12,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import CreateSite from './internals/steps-repository/create-site';
 import DesignSetup from './internals/steps-repository/design-setup';
 import ImportStep from './internals/steps-repository/import';

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -2,7 +2,6 @@ import { IMPORT_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useLayoutEffect } from 'react';
 import localStorageHelper from 'store';
-import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import CreateSite from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/create-site';
 import MigrationError from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/migration-error';
@@ -11,6 +10,7 @@ import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin'
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
+import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { useSite } from '../hooks/use-site';
 import { useLoginUrl } from '../utils/path';
 import Import from './internals/steps-repository/import';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { camelCase } from 'lodash';
-import { ImporterPlatform } from 'calypso/blocks/import/types';
 import {
 	getImporterUrl,
 	getWpComOnboardingUrl,
@@ -9,6 +8,7 @@ import {
 } from 'calypso/blocks/import/util';
 import { WPImportOption } from 'calypso/blocks/importer/wordpress/types';
 import { getImporterEngines } from 'calypso/lib/importer/importer-config';
+import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { BASE_ROUTE } from './config';
 
 export function getFinalImporterUrl(

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -4,9 +4,9 @@ import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/des
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
-import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -2,9 +2,9 @@ import config from '@automattic/calypso-config';
 import { TranslateResult, translate } from 'i18n-calypso';
 import { filter, orderBy, values } from 'lodash';
 import { type ImporterOption } from 'calypso/blocks/import/list';
-import { type ImporterPlatform } from 'calypso/blocks/import/types';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { appStates } from 'calypso/state/imports/constants';
+import type { ImporterPlatform } from 'calypso/lib/importer/types';
 
 export interface ImporterOptionalURL {
 	title: TranslateResult;

--- a/client/lib/importer/types.ts
+++ b/client/lib/importer/types.ts
@@ -1,0 +1,23 @@
+// List of supported importer platforms (most important)
+export type ImporterMainPlatform =
+	| 'blogger'
+	| 'medium'
+	| 'squarespace'
+	| 'wordpress'
+	| 'wix'
+	| ImporterPlatformOther;
+// List of supported importer platforms (others)
+export type ImporterPlatformOther =
+	| 'blogroll'
+	| 'ghost'
+	| 'livejournal'
+	| 'movabletype'
+	| 'tumblr'
+	| 'xanga'
+	| 'substack';
+export type ImporterPlatformExtra = 'godaddy-central';
+export type ImporterPlatform =
+	| ImporterMainPlatform
+	| ImporterPlatformOther
+	| ImporterPlatformExtra
+	| 'unknown';


### PR DESCRIPTION
This is the last piece of moving all of the importer definitions into a single area

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #90635

## Proposed Changes

In #91609, we refactored all of places that define different importers into a single area. As a final step, this moves importer-related types into the same area.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Previously, there were multiple lists of importers in different places. Having a single source of truth will make it easier to keep track of things and make updates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since this is just moving `import` definitions around, visual inspections and verifying all of the CI actions pass should be sufficient.

However, you could follow the testing instructions in #91609 as an optional, additional check.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
