### PR TITLE
Help Center: Fix link to support docs if disconnected from JPOP

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -290,22 +290,17 @@ class Help_Center {
 		$user_id = get_current_user_id();
 		$blog_id = get_current_blog_id();
 
-		// l('$user_id: '.$user_id);
-		// l('$blog_id: '.$blog_id);
-		// l('is_jetpack_site: '.is_jetpack_site( $blog_id ));
-		// l('function exists (is_jetpack_site): '.function_exists( 'is_jetpack_site' ));
-
-		// l('is_jetpack_disconnected: '. is_jetpack_site( $blog_id ) && ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id ));
-		if ( ! function_exists( 'is_jetpack_site' ) ) {
-			return false;
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			return ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
 		}
 
-		if ( ! is_jetpack_site( $blog_id ) ) {
-			return true;
+		if ( true === apply_filters( 'is_jetpack_site', false, $blog_id ) ) {
+			return ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
 		}
 
-		return is_jetpack_site( $blog_id ) && ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
+		return false;
 	}
+
 	/**
 	 * Add icon to WP-ADMIN admin bar.
 	 */
@@ -347,7 +342,8 @@ class Help_Center {
 						'id'     => 'help-center',
 						'title'  => file_get_contents( plugin_dir_path( __FILE__ ) . 'src/help-icon.svg', true ),
 						'parent' => 'top-secondary',
-						'href'   => $this->is_jetpack_disconnected() ? localized_wpcom_url( 'https://wordpress.com/support/' ) : false,
+						// phpcs:ignore WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl
+						'href'   => $this->is_jetpack_disconnected() ? 'https://wordpress.com/support/' : false,
 						'meta'   => array(
 							'html'   => '<div id="help-center-masterbar" />',
 							'class'  => 'menupop',

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -48,7 +48,8 @@ class Help_Center {
 			return;
 		}
 
-		$this->asset_file = include plugin_dir_path( __FILE__ ) . $this->is_jetpack_disconnected() ? 'dist/help-center-disconnected.asset.php' : 'dist/help-center.asset.php';
+		$file             = $this->is_jetpack_disconnected() ? 'dist/help-center-disconnected.asset.php' : 'dist/help-center.asset.php';
+		$this->asset_file = include plugin_dir_path( __FILE__ ) . $file;
 		$this->version    = $this->asset_file['version'];
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script' ), 100 );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -48,7 +48,7 @@ class Help_Center {
 			return;
 		}
 
-		$this->asset_file = include plugin_dir_path( __FILE__ ) . $this->is_jetpack_connected() ? 'dist/help-center.asset.php' : 'dist/help-center-disconnected.asset.php';
+		$this->asset_file = include plugin_dir_path( __FILE__ ) . $this->is_jetpack_disconnected() ? 'dist/help-center-disconnected.asset.php' : 'dist/help-center.asset.php';
 		$this->version    = $this->asset_file['version'];
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script' ), 100 );
@@ -91,7 +91,7 @@ class Help_Center {
 		// The disconnected version is significantly smaller than the connected version.
 		wp_enqueue_script(
 			'help-center-script',
-			plugins_url( $this->is_jetpack_connected() ? 'dist/help-center.min.js' : 'dist/help-center-disconnected.min.js', __FILE__ ),
+			plugins_url( $this->is_jetpack_disconnected() ? 'dist/help-center-disconnected.min.js' : 'dist/help-center.min.js', __FILE__ ),
 			is_array( $script_dependencies ) ? $script_dependencies : array(),
 			$this->version,
 			true
@@ -286,11 +286,26 @@ class Help_Center {
 	/**
 	 * Returns true if the current user is connected through Jetpack
 	 */
-	public function is_jetpack_connected() {
+	public function is_jetpack_disconnected() {
 		$user_id = get_current_user_id();
-		return ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
-	}
+		$blog_id = get_current_blog_id();
 
+		// l('$user_id: '.$user_id);
+		// l('$blog_id: '.$blog_id);
+		// l('is_jetpack_site: '.is_jetpack_site( $blog_id ));
+		// l('function exists (is_jetpack_site): '.function_exists( 'is_jetpack_site' ));
+
+		// l('is_jetpack_disconnected: '. is_jetpack_site( $blog_id ) && ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id ));
+		if ( ! function_exists( 'is_jetpack_site' ) ) {
+			return false;
+		}
+
+		if ( ! is_jetpack_site( $blog_id ) ) {
+			return true;
+		}
+
+		return is_jetpack_site( $blog_id ) && ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
+	}
 	/**
 	 * Add icon to WP-ADMIN admin bar.
 	 */
@@ -332,7 +347,7 @@ class Help_Center {
 						'id'     => 'help-center',
 						'title'  => file_get_contents( plugin_dir_path( __FILE__ ) . 'src/help-icon.svg', true ),
 						'parent' => 'top-secondary',
-						'href'   => $this->is_jetpack_connected() ? false : localized_wpcom_url( 'https://wordpress.com/support/' ),
+						'href'   => $this->is_jetpack_disconnected() ? localized_wpcom_url( 'https://wordpress.com/support/' ) : false,
 						'meta'   => array(
 							'html'   => '<div id="help-center-masterbar" />',
 							'class'  => 'menupop',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/91630

## Proposed Changes

Add more logic to account for Simple sites and remove the localized_wpcom_url function.

## Why are these changes being made?

Previously no checks were made for Simple which caused issues. This makes sure Simple sites are not affected.

## Testing Instructions

See #91630

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
