### PR TITLE
Add interstitial to launch-big-sky step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -1,26 +1,37 @@
+import { Button } from '@automattic/components';
 import { Onboard } from '@automattic/data-stores';
 import { getAssemblerDesign } from '@automattic/design-picker';
+import { StepContainer } from '@automattic/onboarding';
 import { resolveSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, FormEvent, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useIsBigSkyEligible } from '../../../../hooks/use-is-site-big-sky-eligible';
 import { useSiteData } from '../../../../hooks/use-site-data';
 import type { Step } from '../../types';
 
 const SiteIntent = Onboard.SiteIntent;
 
-const LaunchBigSky: Step = function () {
+const LaunchBigSky: Step = function ( { navigation, flow, stepName } ) {
 	const isBigSkyEligible = useIsBigSkyEligible();
 	if ( ! isBigSkyEligible ) {
 		window.location.assign( '/start' );
 	}
 	const { __ } = useI18n();
+	const { goBack } = navigation;
+	const headerText = __( 'Launch time' );
+
 	const [ isError, setError ] = useState( false );
+	const [ isLaunching, setIsLaunching ] = useState( false );
+
 	const { siteSlug, siteId, site } = useSiteData();
 	const { setDesignOnSite, setStaticHomepageOnSite, setIntentOnSite } = useDispatch( SITE_STORE );
+
 	const hasStaticHomepage = site?.options?.show_on_front === 'page' && site?.options?.page_on_front;
 	const assemblerThemeActive = site?.options?.theme_slug === 'pub/assembler';
 
@@ -67,33 +78,22 @@ const LaunchBigSky: Step = function () {
 			// eslint-disable-next-line no-console
 			console.error( 'An error occurred:', error );
 			setError( true );
+		} finally {
+			setIsLaunching( false );
 		}
 	};
 
 	const onSubmit = async ( event: FormEvent ) => {
+		setIsLaunching( true );
 		event.preventDefault();
 		setIntentOnSite( siteSlug, SiteIntent.AIAssembler );
 		exitFlow( siteId.toString(), siteSlug );
 	};
 
-	useEffect( () => {
-		if ( isError ) {
-			return;
-		}
-		const syntheticEvent = {
-			preventDefault: () => {},
-			target: {
-				elements: {},
-			},
-		} as unknown as FormEvent;
-		onSubmit( syntheticEvent );
-	}, [ isError ] );
-
 	function LaunchingBigSky() {
 		return (
 			<div className="processing-step__container">
 				<div className="processing-step">
-					<h1 className="processing-step__progress-step">{ __( 'Launching Big Sky' ) }</h1>
 					{ ! isError && <LoadingEllipsis /> }
 					{ isError && (
 						<p className="processing-step__error">
@@ -106,11 +106,31 @@ const LaunchBigSky: Step = function () {
 	}
 
 	return (
-		<div className="site-prompt__signup is-woocommerce-install">
-			<div className="site-prompt__is-store-address">
-				<LaunchingBigSky />
-			</div>
-		</div>
+		<>
+			<DocumentHead title={ headerText } />
+			<StepContainer
+				flowName={ flow }
+				stepName={ stepName }
+				isFullLayout
+				formattedHeader={
+					<FormattedHeader
+						headerText={ headerText }
+						subHeaderAlign="center"
+						subHeaderText={ __( 'Big Sky is the AI website builder for WordPress.' ) }
+					/>
+				}
+				stepContent={
+					<>
+						{ isLaunching && <LaunchingBigSky /> }
+						<Button disabled={ isLaunching } busy={ isLaunching } primary onClick={ onSubmit }>
+							{ __( 'Launch Big Sky' ) }
+						</Button>
+					</>
+				}
+				goBack={ goBack }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -556,6 +556,9 @@ const siteSetupFlow: Flow = {
 				case 'importReadyPreview':
 					return navigate( `import?siteSlug=${ siteSlug }` );
 
+				case 'launch-big-sky':
+					return navigate( 'design-choices' );
+
 				case 'options':
 					return navigate( 'goals' );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to an in-progress design change. We'll show an interstitial on `/setup/site-setup/launch-big-sky` step, that will require a manual button press to continue launching. 

## Proposed Changes

*Updates the 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go through the /start/premium flow
- When you land on /design-choices, choose Big Sky (you can also go directly to `/setup/site-setup/design-choices?siteSlug=` if the site matches the criteria for Big Sky)
- Will land on this page: `/setup/site-setup/launch-big-sky?siteSlug=YOURSITEURL`
- Going back should go back to the correct step
- Submitting should load everything as intended and take you to site editor. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
