### PR TITLE
Sites: Hide All sites from filters

### DIFF
--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -35,7 +35,6 @@ type Props = {
 };
 
 export const siteStatusGroups = [
-	{ value: 1, label: __( 'All sites' ), slug: 'all' },
 	{ value: 2, label: __( 'Public' ), slug: 'public' },
 	{ value: 3, label: __( 'Private' ), slug: 'private' },
 	{ value: 4, label: __( 'Coming soon' ), slug: 'coming-soon' },


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7103

## Proposed Changes

Remove `All Sites` from Sites filters.

| Before | After |
| --- | --- | 
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/5c343fb7-1783-4bfc-aa6d-32aff578e754) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/41e0441f-ae13-4036-a53a-312956418d46) |

## Why are these changes being made?

More details here: https://github.com/Automattic/dotcom-forge/issues/7103#issuecomment-2105727811

## Testing Instructions

* Go to `/sites`
* Click on filters.
* `All sites` should not show.

