### PR TITLE
Stats: Subtitle copy for Subscribers tab

### DIFF
--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -88,7 +88,7 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 				<NavigationHeader
 					className="stats__section-header modernized-header"
 					title={ translate( 'Jetpack Stats' ) }
-					subtitle={ translate( "View your site's performance and learn from trends." ) }
+					subtitle={ translate( 'Track your subscriber growth and engagement.' ) }
 					screenReader={ navItems.subscribers?.label }
 					navigationItems={ [] }
 				></NavigationHeader>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80849

## Proposed Changes

* This PR updates the subtitle copy for the Subscribers tab so that subtitle copy for Insights and Subscribers tab are no longer identical.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* using sidebar, navigate to Stats > Insights.
* confirm subtitle reads: "View your site's performance and learn from trends."
* navigate to Stats > Subscribers.
* confirm subtitle reads: "Track your subscriber growth and engagement."

![image](https://github.com/Automattic/wp-calypso/assets/30754158/76a824dc-2ca5-4483-ba88-03c363dfdb6f)
![image](https://github.com/Automattic/wp-calypso/assets/30754158/99403bcc-5989-4047-b3ac-35a67138beee)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
