### PR TITLE
Stats: Remove old feature flag for Date picker

### DIFF
--- a/config/client.json
+++ b/config/client.json
@@ -22,7 +22,6 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
-	"stats/date-control",
 	"stats/devices",
 	"stats/paid-wpcom-stats",
 	"stats/plan-usage",

--- a/config/development.json
+++ b/config/development.json
@@ -206,7 +206,6 @@
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": false,
-		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/paid-wpcom-v2": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -131,7 +131,6 @@
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
-		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/paid-wpcom-v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -177,7 +177,6 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/paid-wpcom-v2": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -170,7 +170,6 @@
 		"site-indicator": true,
 		"site-profiler/metrics": false,
 		"ssr/prefetch-timebox": true,
-		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/paid-wpcom-v2": true,

--- a/config/test.json
+++ b/config/test.json
@@ -113,7 +113,6 @@
 		"signup/social-first": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/plan-usage": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -168,7 +168,6 @@
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
-		"stats/date-control": true,
 		"stats/devices": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/paid-wpcom-v2": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88873

## Proposed Changes

* remove old feature flag fro a released feature

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* code cleanup

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch
* smoke test the date picker above the chart for a private and commercial license

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?