### PR TITLE
Help Center: change disconnected url to help

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -344,7 +344,7 @@ class Help_Center {
 						'title'  => file_get_contents( plugin_dir_path( __FILE__ ) . 'src/help-icon.svg', true ),
 						'parent' => 'top-secondary',
 						// phpcs:ignore WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl
-						'href'   => $this->is_jetpack_disconnected() ? 'https://wordpress.com/support/' : false,
+						'href'   => $this->is_jetpack_disconnected() ? 'https://wordpress.com/help/' : false,
 						'meta'   => array(
 							'html'   => '<div id="help-center-masterbar" />',
 							'class'  => 'menupop',

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -303,6 +303,24 @@ class Help_Center {
 	}
 
 	/**
+	 * Returns the URL for the Help Center redirect.
+	 * Used for the Help Center when disconnected.
+	 */
+	public function get_help_center_url() {
+		$help_url = 'https://wordpress.com/help';
+
+		if ( ! $this->is_jetpack_disconnected() ) {
+			return false;
+		}
+
+		if ( function_exists( 'localized_wpcom_url' ) ) {
+			return localized_wpcom_url( $help_url );
+		}
+
+		return $help_url;
+	}
+
+	/**
 	 * Add icon to WP-ADMIN admin bar.
 	 */
 	public function enqueue_wp_admin_scripts() {
@@ -343,8 +361,7 @@ class Help_Center {
 						'id'     => 'help-center',
 						'title'  => file_get_contents( plugin_dir_path( __FILE__ ) . 'src/help-icon.svg', true ),
 						'parent' => 'top-secondary',
-						// phpcs:ignore WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl
-						'href'   => $this->is_jetpack_disconnected() ? 'https://wordpress.com/help/' : false,
+						'href'   => $this->get_help_center_url(),
 						'meta'   => array(
 							'html'   => '<div id="help-center-masterbar" />',
 							'class'  => 'menupop',

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/help-center-disconnected.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/help-center-disconnected.js
@@ -11,7 +11,7 @@ function HelpCenterContent() {
 		<>
 			<Button
 				className="help-center"
-				onClick={ () => window.open( localizeUrl( 'https://wordpress.com/support/' ), '_blank' ) }
+				onClick={ () => window.open( localizeUrl( 'https://wordpress.com/help/' ), '_blank' ) }
 				icon={ <HelpIcon /> }
 				label="Help"
 				size="compact"

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/help-center-disconnected.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/help-center-disconnected.js
@@ -11,10 +11,11 @@ function HelpCenterContent() {
 		<>
 			<Button
 				className="help-center"
-				onClick={ () => window.open( localizeUrl( 'https://wordpress.com/help/' ), '_blank' ) }
+				href={ localizeUrl( 'https://wordpress.com/help/' ) }
 				icon={ <HelpIcon /> }
 				label="Help"
 				size="compact"
+				target="_blank"
 			/>
 		</>
 	);

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/help-center-disconnected.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/help-center-disconnected.js
@@ -11,7 +11,7 @@ function HelpCenterContent() {
 		<>
 			<Button
 				className="help-center"
-				href={ localizeUrl( 'https://wordpress.com/help/' ) }
+				href={ localizeUrl( 'https://wordpress.com/help' ) }
 				icon={ <HelpIcon /> }
 				label="Help"
 				size="compact"


### PR DESCRIPTION
## Proposed Changes

Change URL for disconnected users to `/help` instead of `/support`

## Why are these changes being made?

`/help` will give the user the ability to talk to us in the event that there is an error.

## Testing Instructions

1. Upload the ETK plugin from the TeamCity artifacts
2. Disconnect your user from Jetpack
3. Click the Help Center icon and you should be taken to /help instead of /support