### PR TITLE
Affiliates: Update sub-header text for User step

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -48,6 +48,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getIsWooPasswordless from 'calypso/state/selectors/get-is-woo-passwordless';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
+import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 
@@ -208,6 +209,7 @@ export class UserStep extends Component {
 			userLoggedIn,
 			wccomFrom,
 			isReskinned,
+			isOnboardingAffiliateFlow,
 		} = this.props;
 
 		let subHeaderText = this.props.subHeaderText;
@@ -332,7 +334,7 @@ export class UserStep extends Component {
 			}
 		}
 
-		if ( 'onboarding-affiliate' === flowName ) {
+		if ( isOnboardingAffiliateFlow ) {
 			subHeaderText = translate(
 				"Thanks for stopping by! You're a few steps away from building your perfect website. Let's do this."
 			);
@@ -784,6 +786,7 @@ const ConnectedUser = connect(
 			isWooPasswordless: getIsWooPasswordless( state ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
+			isOnboardingAffiliateFlow: getIsOnboardingAffiliateFlow( state ),
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -332,6 +332,12 @@ export class UserStep extends Component {
 			}
 		}
 
+		if ( 'onboarding-affiliate' === flowName ) {
+			subHeaderText = translate(
+				"Thanks for stopping by! You're a few steps away from building your perfect website. Let's do this."
+			);
+		}
+
 		if ( this.props.userLoggedIn ) {
 			subHeaderText = '';
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7149
Based off https://github.com/Automattic/wp-calypso/pull/91631

## Proposed Changes

Adds a custom subheader to the signup/user screen for the `onboarding-affiliate` flow

### Media

<img width="600" alt="Screenshot 2024-06-12 at 12 15 46 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/11fc2a7b-fc3c-4951-973b-e7c8550804a0">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This has been requested by @StacyCarlson01 to improve/tailor communication for the respective group. See pfjeM4-Ps-p2 for related discussions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/onboarding-affiliate` logged-out (in incognito window)
* Confirm a subheader renders under "Create your account" as per media above
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?