### PR TITLE
Setup goals and intent store values based on site data

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -62,15 +62,24 @@ const siteSetupFlow: Flow = {
 			}
 		}, [] );
 
-		const { setIntent, setGoals } = useDispatch( ONBOARD_STORE );
 		const { site } = useSiteData();
+		const { setIntent, setGoals } = useDispatch( ONBOARD_STORE );
+
+		const goals = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
+			[]
+		);
 
 		useEffect( () => {
+			if ( goals.length ) {
+				return;
+			}
+
 			if ( site?.options?.site_goals?.length ) {
 				setIntent( goalsToIntent( site.options.site_goals ) );
 				setGoals( site.options.site_goals );
 			}
-		}, [ site, setIntent ] );
+		}, [ site, setIntent, setGoals, goals ] );
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -35,6 +35,7 @@ import type {
 } from '@automattic/data-stores';
 
 const SiteIntent = Onboard.SiteIntent;
+const { goalsToIntent } = Onboard.utils;
 
 type ExitFlowOptions = {
 	skipLaunchpad?: boolean;
@@ -60,6 +61,16 @@ const siteSetupFlow: Flow = {
 				navigate( 'goals' );
 			}
 		}, [] );
+
+		const { setIntent, setGoals } = useDispatch( ONBOARD_STORE );
+		const { site } = useSiteData();
+
+		useEffect( () => {
+			if ( site?.options?.site_goals?.length ) {
+				setIntent( goalsToIntent( site.options.site_goals ) );
+				setGoals( site.options.site_goals );
+			}
+		}, [ site, setIntent ] );
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -35,7 +35,6 @@ import type {
 } from '@automattic/data-stores';
 
 const SiteIntent = Onboard.SiteIntent;
-const { goalsToIntent } = Onboard.utils;
 
 type ExitFlowOptions = {
 	skipLaunchpad?: boolean;
@@ -61,16 +60,6 @@ const siteSetupFlow: Flow = {
 				navigate( 'goals' );
 			}
 		}, [] );
-
-		const { setIntent, setGoals } = useDispatch( ONBOARD_STORE );
-		const { site } = useSiteData();
-
-		useEffect( () => {
-			if ( site?.options?.site_goals?.length ) {
-				setIntent( goalsToIntent( site?.options?.site_goals ) );
-				setGoals( site?.options?.site_goals );
-			}
-		}, [ site, setIntent ] );
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -35,6 +35,7 @@ import type {
 } from '@automattic/data-stores';
 
 const SiteIntent = Onboard.SiteIntent;
+const { goalsToIntent } = Onboard.utils;
 
 type ExitFlowOptions = {
 	skipLaunchpad?: boolean;
@@ -60,6 +61,16 @@ const siteSetupFlow: Flow = {
 				navigate( 'goals' );
 			}
 		}, [] );
+
+		const { setIntent, setGoals } = useDispatch( ONBOARD_STORE );
+		const { site } = useSiteData();
+
+		useEffect( () => {
+			if ( site?.options?.site_goals?.length ) {
+				setIntent( goalsToIntent( site?.options?.site_goals ) );
+				setGoals( site?.options?.site_goals );
+			}
+		}, [ site, setIntent ] );
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
@@ -1,5 +1,12 @@
+import { Onboard } from '@automattic/data-stores';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
+import { ONBOARD_STORE } from '../stores';
 import { Flow } from './internals/types';
 import siteSetup from './site-setup-flow';
+
+const { goalsToIntent } = Onboard.utils;
 
 /**
  * A variant of site-setup flow without goals step.
@@ -9,6 +16,19 @@ const siteSetupWithoutGoalsFlow: Flow = {
 	variantSlug: 'site-setup-wg',
 	useSteps() {
 		return siteSetup.useSteps().slice( 2 );
+	},
+	useSideEffect( currentStep, navigate ) {
+		const { setIntent, setGoals } = useDispatch( ONBOARD_STORE );
+		const { site } = useSiteData();
+
+		useEffect( () => {
+			if ( site?.options?.site_goals?.length ) {
+				setIntent( goalsToIntent( site?.options?.site_goals ) );
+				setGoals( site?.options?.site_goals );
+			}
+		}, [ site, setIntent, setGoals ] );
+
+		return siteSetup.useSideEffect?.( currentStep, navigate );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
@@ -1,12 +1,5 @@
-import { Onboard } from '@automattic/data-stores';
-import { useDispatch } from '@wordpress/data';
-import { useEffect } from 'react';
-import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
-import { ONBOARD_STORE } from '../stores';
 import { Flow } from './internals/types';
 import siteSetup from './site-setup-flow';
-
-const { goalsToIntent } = Onboard.utils;
 
 /**
  * A variant of site-setup flow without goals step.
@@ -16,17 +9,6 @@ const siteSetupWithoutGoalsFlow: Flow = {
 	variantSlug: 'site-setup-wg',
 	useSteps() {
 		return siteSetup.useSteps().slice( 2 );
-	},
-	useSideEffect( currentStep, navigate ) {
-		const { setIntent, setGoals } = useDispatch( ONBOARD_STORE );
-		const { site } = useSiteData();
-
-		useEffect( () => {
-			setIntent( goalsToIntent( site?.options?.site_goals ?? [] ) );
-			setGoals( site?.options?.site_goals ?? [] );
-		}, [ site, setIntent, setGoals ] );
-
-		return siteSetup.useSideEffect?.( currentStep, navigate );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
@@ -22,10 +22,8 @@ const siteSetupWithoutGoalsFlow: Flow = {
 		const { site } = useSiteData();
 
 		useEffect( () => {
-			if ( site?.options?.site_goals?.length ) {
-				setIntent( goalsToIntent( site?.options?.site_goals ) );
-				setGoals( site?.options?.site_goals );
-			}
+			setIntent( goalsToIntent( site?.options?.site_goals ?? [] ) );
+			setGoals( site?.options?.site_goals ?? [] );
 		}, [ site, setIntent, setGoals ] );
 
 		return siteSetup.useSideEffect?.( currentStep, navigate );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -1,3 +1,4 @@
+import { SiteGoal } from '../onboard';
 import * as selectors from './selectors';
 import type { ActionCreators } from './actions';
 import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
@@ -270,6 +271,7 @@ export interface SiteDetailsOptions {
 	selected_features?: FeatureId[];
 	show_on_front?: string;
 	site_intent?: string;
+	site_goals?: SiteGoal[];
 	site_segment?: string | null;
 	site_vertical_id?: string | null;
 	software_version?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

The site setup flow depends on the `intent` and `goals` values set in the onboard store.
This PR ensures that these values are set in the site setup flow that doesn't use goals.
The values are set depending on what we have stored in the `site_goals` option for the site.

Related to #

## Proposed Changes

* Adapt `site-setup-wg-flow` to set the values in the store based on the site

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Since we exclude the goals step in our flow, this could lead to unpredictability later in the flow for steps that depend on the derived intent or the site goals values from the onboard store.

## Testing Instructions
- Sync this [PR](https://github.com/Automattic/jetpack/pull/37809) to your sandbox
- Follow the `/start/guided` flow and select `Sell` as goal in the process
- After the site is created there should be a redirect to the site-options step which will display the header `First, let's give your store a name` instead of `First, let's give your site a name`.

| Before  | After |
| ------------- | ------------- |
|  <img width="1813" alt="Screenshot 2024-06-12 at 14 05 42" src="https://github.com/Automattic/wp-calypso/assets/7000684/ae67e3fe-8366-43d7-947c-4b3187aad22e"> | <img width="1386" alt="Screenshot 2024-06-12 at 14 01 24" src="https://github.com/Automattic/wp-calypso/assets/7000684/9be2cf14-aa3b-43cf-9574-ff37b2bf3e68">  |

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
