### PR TITLE
Trailmap: Handle already logged in users as well

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -246,7 +246,7 @@ export default {
 				experiment.variationName === 'treatment_scrambled';
 		}
 
-		if ( isOnboardingFlow && wpcom.isTokenLoaded() ) {
+		if ( isOnboardingFlow && ( wpcom.isTokenLoaded() || userLoggedIn ) ) {
 			const experimentAssignmentBigSky = await loadExperimentAssignment(
 				'explat_test_calypso_signup_onboarding_bigsky_soft_launch'
 			);


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/91674

When the user had just signed up, `userLoggedIn` is annoyingly false. But `wpcom.isTokenLoaded` is actually true. But more annoying, when the user is already logged in (not had just signed up), the `wpcom.isTokenLoaded` is false and `userLoggedIn` is true.

This PR covers both cases to handle just-signed-up or already logged in users. 

### Testing

1. Put a debugger [here](https://github.com/Automattic/wp-calypso/blob/fix/already-logged-in-users/client/signup/controller.js#L250).
2. Visit the /start flow while logged out and sign up.
3. The debugger should fire right after you log in.
4. Refresh the page, the debugger should still fire (because `userLoggedIn` is true now). 
5. Re-visit /start incognito, the debugger should not fire. 