### PR TITLE
Catch fringe localStorage errors in Firefox 

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -73,8 +73,12 @@ export const ProviderWrappedLayout = ( {
 
 	useEffect( () => {
 		// TODO: Implement a proper way to reset the experiment assignment
-		localStorage.removeItem( localStorageExperimentAssignmentKey( PLAN_NAME_EXPERIMENT ) );
-		loadExperimentAssignment( PLAN_NAME_EXPERIMENT );
+		try {
+			localStorage.removeItem( localStorageExperimentAssignmentKey( PLAN_NAME_EXPERIMENT ) );
+			loadExperimentAssignment( PLAN_NAME_EXPERIMENT );
+		} catch ( e ) {
+			// Ignore NS_ERROR_FILE_NOT_FOUND Firefox (bug report: https://bugzilla.mozilla.org/show_bug.cgi?id=1536796)
+		}
 	}, [ userLoggedIn ] );
 
 	const layout = userLoggedIn ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90539

## Proposed Changes

* This wraps the localStorage calls in a try-catch so it doesn't affect the rest of the functionality.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is a follow-up to #90539 where a pollyfilled localStorage object is used to clear the current Plan experiment after login. There's an [issue in ](https://bugzilla.mozilla.org/show_bug.cgi?id=1536796)Firefox that can sometimes trigger an NS_ERROR_FILE_NOT_FOUND error. 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Instructions from https://github.com/Automattic/wp-calypso/pull/90483 should still apply

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
