### PR TITLE
Social : Remove from from multi-plans

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -1,7 +1,6 @@
 import {
 	isJetpackAISlug,
 	isJetpackPlanSlug,
-	isJetpackSocialSlug,
 	isJetpackStatsPaidProductSlug,
 } from '@automattic/calypso-products';
 import clsx from 'clsx';
@@ -102,13 +101,9 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 					);
 
 					const isMultiPlanSelectProduct =
-						isJetpackSocialSlug( item.productSlug ) ||
 						isJetpackAISlug( item.productSlug ) ||
 						isJetpackStatsPaidProductSlug( item.productSlug );
 
-					// Go to the checkout page for all products when they click on the 'GET' CTA,
-					// except for Jetpack Social when it isn't owned or included in an active plan,
-					// in which case we open a modal.
 					let ctaHref = getCheckoutURL( item );
 					if ( isMultiPlanSelectProduct && ! isIncludedInPlanOrSuperseded ) {
 						ctaHref = `#${ item.productSlug }`;

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -1,6 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	isJetpackAISlug,
 	isJetpackPlanSlug,
+	isJetpackSocialSlug,
 	isJetpackStatsPaidProductSlug,
 } from '@automattic/calypso-products';
 import clsx from 'clsx';
@@ -101,6 +103,8 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 					);
 
 					const isMultiPlanSelectProduct =
+						( isJetpackSocialSlug( item.productSlug ) &&
+							! isEnabled( 'jetpack/social-plans-v1' ) ) ||
 						isJetpackAISlug( item.productSlug ) ||
 						isJetpackStatsPaidProductSlug( item.productSlug );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-reach/issues/388

With the new V1 Social plan Social will stop being a multiplan

## Proposed Changes

* Removed Social from categorized as a multiplan

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Have the basic or advanced plan on your site.

* Go to `pricing/<site>`
* Click on `Manage Subscription` near Social, it should open the pricing modal
* Go to `pricing/<site>?flags=jetpack/social-plans-v1`
* Click on it again, now it should direct you to `https://wordpress.com/purchases/subscriptions/<site>`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
