### PR TITLE
Parse transaction error messages so HTML content is properly shown

### DIFF
--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
+import DOMPurify from 'dompurify';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, isValidElement } from 'react';
@@ -145,7 +146,14 @@ export class Notice extends Component {
 					{ renderedIcon }
 				</span>
 				<span className="notice__content">
-					<span className="notice__text">{ text ? text : children }</span>
+					{ typeof text.valueOf() === 'string' ? (
+						<span
+							className="notice__text"
+							dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( text ) } } // eslint-disable-line react/no-danger
+						/>
+					) : (
+						<span className="notice__text">{ text ? text : children }</span>
+					) }
 				</span>
 				{ text ? children : null }
 				{ showDismiss && (

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -146,7 +146,7 @@ export class Notice extends Component {
 					{ renderedIcon }
 				</span>
 				<span className="notice__content">
-					{ typeof text.valueOf() === 'string' ? (
+					{ typeof text?.valueOf() === 'string' ? (
 						<span
 							className="notice__text"
 							dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( text ) } } // eslint-disable-line react/no-danger

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -146,7 +146,7 @@ export class Notice extends Component {
 					{ renderedIcon }
 				</span>
 				<span className="notice__content">
-					{ typeof text?.valueOf() === 'string' ? (
+					{ typeof text.valueOf() === 'string' ? (
 						<span
 							className="notice__text"
 							dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( text ) } } // eslint-disable-line react/no-danger

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -1,6 +1,5 @@
 import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
-import DOMPurify from 'dompurify';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, isValidElement } from 'react';
@@ -146,14 +145,7 @@ export class Notice extends Component {
 					{ renderedIcon }
 				</span>
 				<span className="notice__content">
-					{ typeof text.valueOf() === 'string' ? (
-						<span
-							className="notice__text"
-							dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( text ) } } // eslint-disable-line react/no-danger
-						/>
-					) : (
-						<span className="notice__text">{ text ? text : children }</span>
-					) }
+					<span className="notice__text">{ text ? text : children }</span>
 				</span>
 				{ text ? children : null }
 				{ showDismiss && (

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -6,6 +6,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { isValueTruthy, getContactDetailsType } from '@automattic/wpcom-checkout';
 import { useSelect } from '@wordpress/data';
 import debugFactory from 'debug';
+import DOMPurify from 'dompurify';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useMemo } from 'react';
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
@@ -692,9 +693,13 @@ export default function CheckoutMain( {
 			transactionError: string | null;
 			paymentMethodId: string | null;
 		} ) => {
-			reduxDispatch(
-				errorNotice( transactionError || translate( 'An error occurred during your purchase.' ) )
+			const errorNoticeText = transactionError ? (
+				<div dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( transactionError ) } } /> // eslint-disable-line react/no-danger -- The API response can contain anchor elements that we need to parse so they are rendered properly
+			) : (
+				translate( 'An error occurred during your purchase.' )
 			);
+
+			reduxDispatch( errorNotice( errorNoticeText ) );
 
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_payment_error', {

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -6,6 +6,8 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { isValueTruthy, getContactDetailsType } from '@automattic/wpcom-checkout';
 import { useSelect } from '@wordpress/data';
 import debugFactory from 'debug';
+import DOMPurify from 'dompurify';
+import parse from 'html-react-parser';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useMemo } from 'react';
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
@@ -693,7 +695,10 @@ export default function CheckoutMain( {
 			paymentMethodId: string | null;
 		} ) => {
 			reduxDispatch(
-				errorNotice( transactionError || translate( 'An error occurred during your purchase.' ) )
+				errorNotice(
+					parse( DOMPurify.sanitize( transactionError ) ) ||
+						translate( 'An error occurred during your purchase.' )
+				)
 			);
 
 			reduxDispatch(

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -6,8 +6,6 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { isValueTruthy, getContactDetailsType } from '@automattic/wpcom-checkout';
 import { useSelect } from '@wordpress/data';
 import debugFactory from 'debug';
-import DOMPurify from 'dompurify';
-import parse from 'html-react-parser';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useMemo } from 'react';
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
@@ -694,19 +692,14 @@ export default function CheckoutMain( {
 			transactionError: string | null;
 			paymentMethodId: string | null;
 		} ) => {
-			const errorString = String( transactionError );
-
 			reduxDispatch(
-				errorNotice(
-					parse( DOMPurify.sanitize( errorString ) ) ||
-						translate( 'An error occurred during your purchase.' )
-				)
+				errorNotice( transactionError || translate( 'An error occurred during your purchase.' ) )
 			);
 
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_payment_error', {
 					error_code: null,
-					reason: errorString,
+					reason: String( transactionError ),
 				} )
 			);
 			reduxDispatch(
@@ -714,12 +707,12 @@ export default function CheckoutMain( {
 					error_code: null,
 					payment_method:
 						translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ?? '' ) || '',
-					reason: errorString,
+					reason: String( transactionError ),
 				} )
 			);
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
-					error_message: errorString,
+					error_message: String( transactionError ),
 				} )
 			);
 		},

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -694,9 +694,11 @@ export default function CheckoutMain( {
 			transactionError: string | null;
 			paymentMethodId: string | null;
 		} ) => {
+			const errorString = String( transactionError );
+
 			reduxDispatch(
 				errorNotice(
-					parse( DOMPurify.sanitize( transactionError ) ) ||
+					parse( DOMPurify.sanitize( errorString ) ) ||
 						translate( 'An error occurred during your purchase.' )
 				)
 			);
@@ -704,7 +706,7 @@ export default function CheckoutMain( {
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_payment_error', {
 					error_code: null,
-					reason: String( transactionError ),
+					reason: errorString,
 				} )
 			);
 			reduxDispatch(
@@ -712,12 +714,12 @@ export default function CheckoutMain( {
 					error_code: null,
 					payment_method:
 						translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ?? '' ) || '',
-					reason: String( transactionError ),
+					reason: errorString,
 				} )
 			);
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
-					error_message: String( transactionError ),
+					error_message: errorString,
 				} )
 			);
 		},

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
 		"config": "^3.3.6",
 		"debug": "^4.3.3",
 		"enhanced-resolve": "5.9.3",
+		"html-react-parser": "^5.1.10",
 		"i18n-calypso": "workspace:^",
 		"i18n-calypso-cli": "workspace:^",
 		"jsdom": "^20.0.1",

--- a/package.json
+++ b/package.json
@@ -242,6 +242,7 @@
 		"@storybook/react": "^7.6.19",
 		"@tanstack/eslint-plugin-query": "^5.14.6",
 		"@testing-library/jest-dom": "^6.4.5",
+		"@types/dompurify": "^3.0.5",
 		"@types/gtag.js": "^0.0.19",
 		"@types/superagent": "^4.1.24",
 		"@types/wordpress__blocks": "^12.5.14",

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
 		"@storybook/react": "^7.6.19",
 		"@tanstack/eslint-plugin-query": "^5.14.6",
 		"@testing-library/jest-dom": "^6.4.5",
+		"@types/dompurify": "^3.0.5",
 		"@types/gtag.js": "^0.0.19",
 		"@types/superagent": "^4.1.24",
 		"@types/wordpress__blocks": "^12.5.14",

--- a/package.json
+++ b/package.json
@@ -242,7 +242,6 @@
 		"@storybook/react": "^7.6.19",
 		"@tanstack/eslint-plugin-query": "^5.14.6",
 		"@testing-library/jest-dom": "^6.4.5",
-		"@types/dompurify": "^3.0.5",
 		"@types/gtag.js": "^0.0.19",
 		"@types/superagent": "^4.1.24",
 		"@types/wordpress__blocks": "^12.5.14",

--- a/package.json
+++ b/package.json
@@ -204,7 +204,6 @@
 		"config": "^3.3.6",
 		"debug": "^4.3.3",
 		"enhanced-resolve": "5.9.3",
-		"html-react-parser": "^5.1.10",
 		"i18n-calypso": "workspace:^",
 		"i18n-calypso-cli": "workspace:^",
 		"jsdom": "^20.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15236,6 +15236,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"domhandler@npm:5.0.3, domhandler@npm:^5.0, domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "domhandler@npm:5.0.3"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+  checksum: bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
+  languageName: node
+  linkType: hard
+
 "domhandler@npm:^2.3.0":
   version: 2.4.2
   resolution: "domhandler@npm:2.4.2"
@@ -15251,15 +15260,6 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.2.0"
   checksum: fd4e6f1c986402e7a703b671c4f7bdb1dcf278d613ca02a38374eae9d1bba9b3b4d5983519ad902e43c5bd1281456d11f226694e7bb4cfc00dde6f1d5f3aa13e
-  languageName: node
-  linkType: hard
-
-"domhandler@npm:^5.0, domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "domhandler@npm:5.0.3"
-  dependencies:
-    domelementtype: "npm:^2.3.0"
-  checksum: bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
   languageName: node
   linkType: hard
 
@@ -15301,7 +15301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:^3.0.1":
+"domutils@npm:^3.0.1, domutils@npm:^3.1.0":
   version: 3.1.0
   resolution: "domutils@npm:3.1.0"
   dependencies:
@@ -15757,7 +15757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.4.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
@@ -18933,6 +18933,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-dom-parser@npm:5.0.8":
+  version: 5.0.8
+  resolution: "html-dom-parser@npm:5.0.8"
+  dependencies:
+    domhandler: "npm:5.0.3"
+    htmlparser2: "npm:9.1.0"
+  checksum: a0fcd84e0729c7b18c5df03ac0d2de6feae61846e746a7aab11315d6eb3e2352d12897cb8af7667b493a55f3fed066550037d8c37efaa1fe05ebedb28921b7d1
+  languageName: node
+  linkType: hard
+
 "html-encoding-sniffer@npm:^3.0.0":
   version: 3.0.0
   resolution: "html-encoding-sniffer@npm:3.0.0"
@@ -19003,6 +19013,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-react-parser@npm:^5.1.10":
+  version: 5.1.10
+  resolution: "html-react-parser@npm:5.1.10"
+  dependencies:
+    domhandler: "npm:5.0.3"
+    html-dom-parser: "npm:5.0.8"
+    react-property: "npm:2.0.2"
+    style-to-js: "npm:1.1.12"
+  peerDependencies:
+    "@types/react": 17 || 18
+    react: 0.14 || 15 || 16 || 17 || 18
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 8fde26f5f9b53dc03629899bb5af35bde0c8b934c28a917e8bed8bd21a1c404f4ba9f1d349607d1fda6ee93bf8bb48066f22c9c3f22cbad6ceee10fa81c13a74
+  languageName: node
+  linkType: hard
+
 "html-tags@npm:^3.1.0, html-tags@npm:^3.2.0":
   version: 3.3.1
   resolution: "html-tags@npm:3.3.1"
@@ -19047,6 +19075,18 @@ __metadata:
     webpack:
       optional: true
   checksum: 50d1a0f90d512463ea8d798985d91a7ccc9d5e461713dedb240125b2ff0671f58135dd9355f7969af341ff4725e73b2defbc0984cfdce930887a48506d970002
+  languageName: node
+  linkType: hard
+
+"htmlparser2@npm:9.1.0":
+  version: 9.1.0
+  resolution: "htmlparser2@npm:9.1.0"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.1.0"
+    entities: "npm:^4.5.0"
+  checksum: 394f6323efc265bbc791d8c0d96bfe95984e0407565248521ab92e2dc7668e5ceeca7bc6ed18d408b9ee3b25032c5743368a4280d280332d782821d5d467ad8f
   languageName: node
   linkType: hard
 
@@ -26998,6 +27038,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-property@npm:2.0.2":
+  version: 2.0.2
+  resolution: "react-property@npm:2.0.2"
+  checksum: 27a3dfa68d29d45fc3582552715203291d26c6f1b228fdb6775e7ca19b10753141dbe98a0aa3a4da745b39fcd7427dc2d623055e63742062231ee18692a6f0fa
+  languageName: node
+  linkType: hard
+
 "react-redux@npm:^8.1.3":
   version: 8.1.3
   resolution: "react-redux@npm:8.1.3"
@@ -30296,21 +30343,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"style-to-js@npm:1.1.12":
+  version: 1.1.12
+  resolution: "style-to-js@npm:1.1.12"
+  dependencies:
+    style-to-object: "npm:1.0.6"
+  checksum: 4b03ac3cec5d0e4c2578513dfbae9861eb9fb56825bccfd64bddcdf067e66805d6f160b93d2985aad4198893940fa162c4c85c3969e13ba2662a5824231c009c
+  languageName: node
+  linkType: hard
+
+"style-to-object@npm:1.0.6, style-to-object@npm:^1.0.0":
+  version: 1.0.6
+  resolution: "style-to-object@npm:1.0.6"
+  dependencies:
+    inline-style-parser: "npm:0.2.3"
+  checksum: be5e8e3f0e35c0338de4112b9d861db576a52ebbd97f2501f1fb2c900d05c8fc42c5114407fa3a7f8b39301146cd8ca03a661bf52212394125a9629d5b771aba
+  languageName: node
+  linkType: hard
+
 "style-to-object@npm:^0.4.0":
   version: 0.4.1
   resolution: "style-to-object@npm:0.4.1"
   dependencies:
     inline-style-parser: "npm:0.1.1"
   checksum: bde789dab148ec01032d75ea3a7d9294aa8dac369e9ef44f9a8f504df565f806b5a2c7226e3355f09a7e5d127684c65a0b7a7ade08780e0f893299e945d1464e
-  languageName: node
-  linkType: hard
-
-"style-to-object@npm:^1.0.0":
-  version: 1.0.6
-  resolution: "style-to-object@npm:1.0.6"
-  dependencies:
-    inline-style-parser: "npm:0.2.3"
-  checksum: be5e8e3f0e35c0338de4112b9d861db576a52ebbd97f2501f1fb2c900d05c8fc42c5114407fa3a7f8b39301146cd8ca03a661bf52212394125a9629d5b771aba
   languageName: node
   linkType: hard
 
@@ -33263,6 +33319,7 @@ __metadata:
     glob: "npm:^7.1.6"
     globby: "npm:^10.0.2"
     gzip-size: "npm:^6.0.0"
+    html-react-parser: "npm:^5.1.10"
     husky: "npm:^7.0.4"
     i18n-calypso: "workspace:^"
     i18n-calypso-cli: "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15236,15 +15236,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domhandler@npm:5.0.3, domhandler@npm:^5.0, domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "domhandler@npm:5.0.3"
-  dependencies:
-    domelementtype: "npm:^2.3.0"
-  checksum: bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
-  languageName: node
-  linkType: hard
-
 "domhandler@npm:^2.3.0":
   version: 2.4.2
   resolution: "domhandler@npm:2.4.2"
@@ -15260,6 +15251,15 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.2.0"
   checksum: fd4e6f1c986402e7a703b671c4f7bdb1dcf278d613ca02a38374eae9d1bba9b3b4d5983519ad902e43c5bd1281456d11f226694e7bb4cfc00dde6f1d5f3aa13e
+  languageName: node
+  linkType: hard
+
+"domhandler@npm:^5.0, domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "domhandler@npm:5.0.3"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+  checksum: bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
   languageName: node
   linkType: hard
 
@@ -15301,7 +15301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:^3.0.1, domutils@npm:^3.1.0":
+"domutils@npm:^3.0.1":
   version: 3.1.0
   resolution: "domutils@npm:3.1.0"
   dependencies:
@@ -15757,7 +15757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
@@ -18933,16 +18933,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-dom-parser@npm:5.0.8":
-  version: 5.0.8
-  resolution: "html-dom-parser@npm:5.0.8"
-  dependencies:
-    domhandler: "npm:5.0.3"
-    htmlparser2: "npm:9.1.0"
-  checksum: a0fcd84e0729c7b18c5df03ac0d2de6feae61846e746a7aab11315d6eb3e2352d12897cb8af7667b493a55f3fed066550037d8c37efaa1fe05ebedb28921b7d1
-  languageName: node
-  linkType: hard
-
 "html-encoding-sniffer@npm:^3.0.0":
   version: 3.0.0
   resolution: "html-encoding-sniffer@npm:3.0.0"
@@ -19013,24 +19003,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-react-parser@npm:^5.1.10":
-  version: 5.1.10
-  resolution: "html-react-parser@npm:5.1.10"
-  dependencies:
-    domhandler: "npm:5.0.3"
-    html-dom-parser: "npm:5.0.8"
-    react-property: "npm:2.0.2"
-    style-to-js: "npm:1.1.12"
-  peerDependencies:
-    "@types/react": 17 || 18
-    react: 0.14 || 15 || 16 || 17 || 18
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 8fde26f5f9b53dc03629899bb5af35bde0c8b934c28a917e8bed8bd21a1c404f4ba9f1d349607d1fda6ee93bf8bb48066f22c9c3f22cbad6ceee10fa81c13a74
-  languageName: node
-  linkType: hard
-
 "html-tags@npm:^3.1.0, html-tags@npm:^3.2.0":
   version: 3.3.1
   resolution: "html-tags@npm:3.3.1"
@@ -19075,18 +19047,6 @@ __metadata:
     webpack:
       optional: true
   checksum: 50d1a0f90d512463ea8d798985d91a7ccc9d5e461713dedb240125b2ff0671f58135dd9355f7969af341ff4725e73b2defbc0984cfdce930887a48506d970002
-  languageName: node
-  linkType: hard
-
-"htmlparser2@npm:9.1.0":
-  version: 9.1.0
-  resolution: "htmlparser2@npm:9.1.0"
-  dependencies:
-    domelementtype: "npm:^2.3.0"
-    domhandler: "npm:^5.0.3"
-    domutils: "npm:^3.1.0"
-    entities: "npm:^4.5.0"
-  checksum: 394f6323efc265bbc791d8c0d96bfe95984e0407565248521ab92e2dc7668e5ceeca7bc6ed18d408b9ee3b25032c5743368a4280d280332d782821d5d467ad8f
   languageName: node
   linkType: hard
 
@@ -27038,13 +26998,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-property@npm:2.0.2":
-  version: 2.0.2
-  resolution: "react-property@npm:2.0.2"
-  checksum: 27a3dfa68d29d45fc3582552715203291d26c6f1b228fdb6775e7ca19b10753141dbe98a0aa3a4da745b39fcd7427dc2d623055e63742062231ee18692a6f0fa
-  languageName: node
-  linkType: hard
-
 "react-redux@npm:^8.1.3":
   version: 8.1.3
   resolution: "react-redux@npm:8.1.3"
@@ -30343,30 +30296,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"style-to-js@npm:1.1.12":
-  version: 1.1.12
-  resolution: "style-to-js@npm:1.1.12"
-  dependencies:
-    style-to-object: "npm:1.0.6"
-  checksum: 4b03ac3cec5d0e4c2578513dfbae9861eb9fb56825bccfd64bddcdf067e66805d6f160b93d2985aad4198893940fa162c4c85c3969e13ba2662a5824231c009c
-  languageName: node
-  linkType: hard
-
-"style-to-object@npm:1.0.6, style-to-object@npm:^1.0.0":
-  version: 1.0.6
-  resolution: "style-to-object@npm:1.0.6"
-  dependencies:
-    inline-style-parser: "npm:0.2.3"
-  checksum: be5e8e3f0e35c0338de4112b9d861db576a52ebbd97f2501f1fb2c900d05c8fc42c5114407fa3a7f8b39301146cd8ca03a661bf52212394125a9629d5b771aba
-  languageName: node
-  linkType: hard
-
 "style-to-object@npm:^0.4.0":
   version: 0.4.1
   resolution: "style-to-object@npm:0.4.1"
   dependencies:
     inline-style-parser: "npm:0.1.1"
   checksum: bde789dab148ec01032d75ea3a7d9294aa8dac369e9ef44f9a8f504df565f806b5a2c7226e3355f09a7e5d127684c65a0b7a7ade08780e0f893299e945d1464e
+  languageName: node
+  linkType: hard
+
+"style-to-object@npm:^1.0.0":
+  version: 1.0.6
+  resolution: "style-to-object@npm:1.0.6"
+  dependencies:
+    inline-style-parser: "npm:0.2.3"
+  checksum: be5e8e3f0e35c0338de4112b9d861db576a52ebbd97f2501f1fb2c900d05c8fc42c5114407fa3a7f8b39301146cd8ca03a661bf52212394125a9629d5b771aba
   languageName: node
   linkType: hard
 
@@ -33319,7 +33263,6 @@ __metadata:
     glob: "npm:^7.1.6"
     globby: "npm:^10.0.2"
     gzip-size: "npm:^6.0.0"
-    html-react-parser: "npm:^5.1.10"
     husky: "npm:^7.0.4"
     i18n-calypso: "workspace:^"
     i18n-calypso-cli: "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7643,6 +7643,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/dompurify@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@types/dompurify@npm:3.0.5"
+  dependencies:
+    "@types/trusted-types": "npm:*"
+  checksum: a34dcc4498ca250815ccf9aecbe82df96ba5db247d0440cf266a876757d47c52519c240db3475e794d7deb0d6b1af23328e02879be368ad0e26b20c0f0865dba
+  languageName: node
+  linkType: hard
+
 "@types/ejs@npm:^3.1.1":
   version: 3.1.2
   resolution: "@types/ejs@npm:3.1.2"
@@ -8427,6 +8436,13 @@ __metadata:
   version: 1.0.0
   resolution: "@types/treeify@npm:1.0.0"
   checksum: 8a279d0f1897e47cc02b4b5a570141ab70de6bc5d95cafe976aaee78740c13c2e80dae69f7ae9ca1c735c653b65a4ec59a7eed6970683cd04fc0ddf4b98794ff
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:*":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
   languageName: node
   linkType: hard
 
@@ -33192,6 +33208,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.4.5"
     "@types/cookie": "npm:^0.4.1"
     "@types/debug": "npm:^4.1.7"
+    "@types/dompurify": "npm:^3.0.5"
     "@types/fast-json-stable-stringify": "npm:^2.0.0"
     "@types/gtag.js": "npm:^0.0.19"
     "@types/jest": "npm:^29.5.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7643,15 +7643,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/dompurify@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "@types/dompurify@npm:3.0.5"
-  dependencies:
-    "@types/trusted-types": "npm:*"
-  checksum: a34dcc4498ca250815ccf9aecbe82df96ba5db247d0440cf266a876757d47c52519c240db3475e794d7deb0d6b1af23328e02879be368ad0e26b20c0f0865dba
-  languageName: node
-  linkType: hard
-
 "@types/ejs@npm:^3.1.1":
   version: 3.1.2
   resolution: "@types/ejs@npm:3.1.2"
@@ -8436,13 +8427,6 @@ __metadata:
   version: 1.0.0
   resolution: "@types/treeify@npm:1.0.0"
   checksum: 8a279d0f1897e47cc02b4b5a570141ab70de6bc5d95cafe976aaee78740c13c2e80dae69f7ae9ca1c735c653b65a4ec59a7eed6970683cd04fc0ddf4b98794ff
-  languageName: node
-  linkType: hard
-
-"@types/trusted-types@npm:*":
-  version: 2.0.7
-  resolution: "@types/trusted-types@npm:2.0.7"
-  checksum: 4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
   languageName: node
   linkType: hard
 
@@ -33264,7 +33248,6 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.4.5"
     "@types/cookie": "npm:^0.4.1"
     "@types/debug": "npm:^4.1.7"
-    "@types/dompurify": "npm:^3.0.5"
     "@types/fast-json-stable-stringify": "npm:^2.0.0"
     "@types/gtag.js": "npm:^0.0.19"
     "@types/jest": "npm:^29.5.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7643,6 +7643,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/dompurify@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@types/dompurify@npm:3.0.5"
+  dependencies:
+    "@types/trusted-types": "npm:*"
+  checksum: a34dcc4498ca250815ccf9aecbe82df96ba5db247d0440cf266a876757d47c52519c240db3475e794d7deb0d6b1af23328e02879be368ad0e26b20c0f0865dba
+  languageName: node
+  linkType: hard
+
 "@types/ejs@npm:^3.1.1":
   version: 3.1.2
   resolution: "@types/ejs@npm:3.1.2"
@@ -8427,6 +8436,13 @@ __metadata:
   version: 1.0.0
   resolution: "@types/treeify@npm:1.0.0"
   checksum: 8a279d0f1897e47cc02b4b5a570141ab70de6bc5d95cafe976aaee78740c13c2e80dae69f7ae9ca1c735c653b65a4ec59a7eed6970683cd04fc0ddf4b98794ff
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:*":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
   languageName: node
   linkType: hard
 
@@ -33248,6 +33264,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.4.5"
     "@types/cookie": "npm:^0.4.1"
     "@types/debug": "npm:^4.1.7"
+    "@types/dompurify": "npm:^3.0.5"
     "@types/fast-json-stable-stringify": "npm:^2.0.0"
     "@types/gtag.js": "npm:^0.0.19"
     "@types/jest": "npm:^29.5.12"


### PR DESCRIPTION
While working on https://github.com/Automattic/wp-calypso/pull/91678, I noticed that when our API returns transaction error messages containing HTML it is not parsed properly, so the user ends up seeing things like `Please <a href="https://wordpress.com/error-report/?url=purchases@xlctest.wordpress.com">contact us</a> to re-enable purchases.`:

![Screenshot from 2024-06-12 15-36-52](https://github.com/Automattic/wp-calypso/assets/8511199/5ebd575d-ccb1-4dc3-b803-269793609790)

## Proposed Changes

* Use the `html-react-parser` [library](https://www.npmjs.com/package/html-react-parser) to parse the response in order to get a React element instead of a string containing HTML.

## Testing Instructions

* Block your user's purchases through the Payments Admin (if you don't have permissions for that, contact me and I'll do it)
* Open the live preview
* Go to `/checkout/xlctest.wordpress.com?signup=1`
* You'll see a first `Purchases are currently disabled.` error triggered by Calypso
* Pick `PayPal` as your payment method
* Click on the `PayPal` checkout button
* You should see a second error message that's properly parsed

![image](https://github.com/Automattic/wp-calypso/assets/8511199/9e53b9a8-28a7-4d82-b8f8-b15aa1bd38ad)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
