### PR TITLE
Checkout: remove the Akismet Pro quantity dropdown for renewals

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -377,7 +377,7 @@ function LineItemWrapper( {
 							isOpen={ variantOpenId === product.uuid }
 						/>
 					) }
-					{ isAkPro500Cart && (
+					{ ! isRenewal && isAkPro500Cart && (
 						<AkismetProQuantityDropDown
 							id={ product.uuid }
 							responseCart={ responseCart }


### PR DESCRIPTION
### Issue
Akismet Pro users are unable to manually renew their subscriptions - receiving the following error: `Sorry, this user account does not own the product you are trying to renew.`

### Background
That error message is incorrect in this instance, and is returned from the shopping cart endpoint when a renewal fails validation. This most commonly happens because the user checking out doesn't own the subscription, but there are a number of other conditions for validation too. In this case, the validation is failing because Checkout is passing a `quantity` to the shopping cart, and renewals are expected to use their existing quantities.

On closer inspection, it looks like Checkout is initially correctly loading, passing a null quantity with the renewal, but when the `<AkismetProQuantityDropDown />` component loads, it attempts to validate the null quantity as `1` and then refreshes the cart. This causes the cart validation to fail, with the returned error.

### Changes
Instead of modifying the dropdown to accept a null quantity, @jboland88 suggested that we hide the dropdown entirely for renewals - this PR does that.

See: pNPgK-75P-p2
Discussion: p1718119066712609-slack-C02BEP610

## To test:
- Purchase an Akismet Pro subscription
- Visit Me > Purchases and click on the new subscription
- Click the "Renew Now" button
- Verify that Checkout loads correctly and that the Akismet Pro dropdown is not shown
- Complete Checkout
- Verify that the renewal is successful (the expiration date should be extended)