### PR TITLE
Site Migration: Add timing information about migration atomic transfer and plugin ins…

### DIFF
--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -1,4 +1,6 @@
 import { FetchStatus } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePluginAutoInstallation } from './use-plugin-auto-installation';
 import { useSiteMigrationKey } from './use-site-migration-key';
 import { useSiteTransfer } from './use-site-transfer';
@@ -26,6 +28,58 @@ const getMigrationKeyStatus = (
 	return status as Status;
 };
 
+interface TransferState {
+	completed: boolean;
+	status: Status;
+}
+
+interface TimeTrackingResult {
+	siteTransferStart: React.MutableRefObject< number >;
+	siteTransferEnd: React.MutableRefObject< number >;
+	pluginInstallationStart: React.MutableRefObject< number >;
+	pluginInstallationEnd: React.MutableRefObject< number >;
+}
+
+const useTransferTimeTracking = (
+	siteTransferState: TransferState,
+	pluginInstallationState: TransferState
+): TimeTrackingResult => {
+	const siteTransferStart = useRef( 0 );
+	const siteTransferEnd = useRef( 0 );
+	const pluginInstallationStart = useRef( 0 );
+	const pluginInstallationEnd = useRef( 0 );
+
+	// Time the Atomic transfer
+	useEffect( () => {
+		if (
+			! siteTransferState.completed &&
+			'pending' === siteTransferState.status &&
+			siteTransferStart.current === 0
+		) {
+			siteTransferStart.current = Date.now();
+		}
+		if ( siteTransferState.completed && siteTransferEnd.current === 0 ) {
+			siteTransferEnd.current = Date.now();
+		}
+	}, [ siteTransferState, siteTransferStart, siteTransferEnd ] );
+
+	// Time the plugin installation
+	useEffect( () => {
+		if (
+			! pluginInstallationState.completed &&
+			'pending' === pluginInstallationState.status &&
+			pluginInstallationStart.current === 0
+		) {
+			pluginInstallationStart.current = Date.now();
+		}
+		if ( pluginInstallationState.completed && pluginInstallationEnd.current === 0 ) {
+			pluginInstallationEnd.current = Date.now();
+		}
+	}, [ pluginInstallationState, pluginInstallationStart, pluginInstallationEnd ] );
+
+	return { siteTransferStart, siteTransferEnd, pluginInstallationStart, pluginInstallationEnd };
+};
+
 /**
  *  Hook to manage the site to prepare a site for migration using Migrate Guru plugin.
  *  This hook manages the site transfer, plugin installation and migration key fetching.
@@ -35,6 +89,7 @@ export const usePrepareSiteForMigration = ( siteId?: number ) => {
 	const pluginInstallationState = usePluginAutoInstallation( PLUGIN, siteId, {
 		enabled: Boolean( siteTransferState.completed ),
 	} );
+	const transferTimingTracked = useRef( false );
 
 	const {
 		data: { migrationKey } = {},
@@ -44,8 +99,27 @@ export const usePrepareSiteForMigration = ( siteId?: number ) => {
 		enabled: Boolean( pluginInstallationState.completed ),
 	} );
 
+	const { siteTransferStart, siteTransferEnd, pluginInstallationStart, pluginInstallationEnd } =
+		useTransferTimeTracking( siteTransferState, pluginInstallationState );
+
 	const completed = siteTransferState.completed && pluginInstallationState.completed;
 	const error = siteTransferState.error || pluginInstallationState.error || migrationKeyError;
+	const hasAllTimingInfo = siteTransferEnd.current !== 0 && pluginInstallationEnd.current !== 0;
+
+	if ( completed && hasAllTimingInfo && ! transferTimingTracked.current ) {
+		const siteTransferElapsed = siteTransferEnd.current - siteTransferStart.current;
+		const pluginInstallationElapsed =
+			pluginInstallationEnd.current - pluginInstallationStart.current;
+
+		recordTracksEvent( 'calypso_onboarding_site_migration_transfer_timing', {
+			error,
+			site_transfer_elapsed: siteTransferElapsed,
+			plugin_installation_elapsed: pluginInstallationElapsed,
+			migration_setup_elapsed: siteTransferElapsed + pluginInstallationElapsed,
+		} );
+
+		transferTimingTracked.current = true;
+	}
 
 	const detailedStatus = {
 		siteTransfer: siteTransferState.status,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #91512

## Proposed Changes

This adds the `calypso_onboarding_site_migration_transfer_timing` Tracks event which logs the time it took for a migrated site to transfer to Atomic, the time it took for the plugins to install, and the combined time of both.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This allows us to track the average time to full provision a migration site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I recommend using the calypso.live url for this.
* With the calypso.live url, go to `/setup/migration-signup`.
* When you reach the "Let's find your site" step, open the browser console and run the following:

```
localStorage.setItem('debug', 'calypso:analytics*'); 
```
* Now you can filter the console log messages for `calypso_onboarding_site_migration_transfer_timing`.
* Continue through the migration flow.
* Once you reach the Migration Instructions step and the site finishes provisioning and installing plugins, you should see the new Tracks event fire.
* You can also view the event in the "Tracks Live View" in MC.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
