### PR TITLE
Change plans page compare plans button label

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -21,7 +21,7 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI, AddOns, Plans } from '@automattic/data-stores';
-import { isAnyHostingFlow } from '@automattic/onboarding';
+import { ONBOARDING_GUIDED_FLOW, isAnyHostingFlow } from '@automattic/onboarding';
 import {
 	FeaturesGrid,
 	ComparisonGrid,
@@ -679,6 +679,18 @@ const PlansFeaturesMain = ( {
 		? getWooExpressFeaturesGroupedForFeaturesGrid()
 		: getPlanFeaturesGroupedForFeaturesGrid();
 
+	const getComparisonGridToggleLabel = () => {
+		if ( showPlansComparisonGrid ) {
+			return translate( 'Hide comparison' );
+		}
+		switch ( flowName ) {
+			case ONBOARDING_GUIDED_FLOW:
+				return translate( 'Compare all plans' );
+			default:
+				return translate( 'Compare plans' );
+		}
+	};
+
 	return (
 		<>
 			<div className={ clsx( 'plans-features-main', 'is-pricing-grid-2023-plans-features-main' ) }>
@@ -800,11 +812,7 @@ const PlansFeaturesMain = ( {
 									<>
 										<ComparisonGridToggle
 											onClick={ toggleShowPlansComparisonGrid }
-											label={
-												showPlansComparisonGrid
-													? translate( 'Hide comparison' )
-													: translate( 'Compare plans' )
-											}
+											label={ getComparisonGridToggleLabel() }
 										/>
 										{ showEscapeHatch && (
 											<div className="plans-features-main__escape-hatch">

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -21,6 +21,7 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI, AddOns, Plans } from '@automattic/data-stores';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ONBOARDING_GUIDED_FLOW, isAnyHostingFlow } from '@automattic/onboarding';
 import {
 	FeaturesGrid,
@@ -244,6 +245,7 @@ const PlansFeaturesMain = ( {
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const getPlanTypeDestination = usePlanTypeDestinationCallback();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
@@ -687,7 +689,8 @@ const PlansFeaturesMain = ( {
 			Array.isArray( gridPlansForFeaturesGrid ) &&
 			Array.isArray( gridPlansForComparisonGrid ) &&
 			gridPlansForFeaturesGrid.length < gridPlansForComparisonGrid.length &&
-			flowName === ONBOARDING_GUIDED_FLOW
+			flowName === ONBOARDING_GUIDED_FLOW &&
+			isEnglishLocale
 		) {
 			return translate( 'Compare all plans' );
 		}

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -683,12 +683,15 @@ const PlansFeaturesMain = ( {
 		if ( showPlansComparisonGrid ) {
 			return translate( 'Hide comparison' );
 		}
-		switch ( flowName ) {
-			case ONBOARDING_GUIDED_FLOW:
-				return translate( 'Compare all plans' );
-			default:
-				return translate( 'Compare plans' );
+		if (
+			Array.isArray( gridPlansForFeaturesGrid ) &&
+			Array.isArray( gridPlansForComparisonGrid ) &&
+			gridPlansForFeaturesGrid.length < gridPlansForComparisonGrid.length &&
+			flowName === ONBOARDING_GUIDED_FLOW
+		) {
+			return translate( 'Compare all plans' );
 		}
+		return translate( 'Compare plans' );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Update `Compare plans` button label to `Compare all plans` for the Guided onboarding flow:
(**The button label should not change for other flows**)

<img width="827" alt="CleanShot 2024-06-12 at 11 57 54@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/c4a5de5f-749f-49ab-b88a-d848f5c299b8">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pfGA22-1B-p2#comment-139

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/start/guided` and go through the flow until you reach the plans page.
* Guided onboarding flow plan page: Confirm the `Compare all plans` label appears correctly and the button functions as expected.
* Navigate to `/start/` and go through the flow until you reach the plans page.
* The plan comparison button label should display `Compare plans`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?