### PR TITLE
Goals: Update site setup goals DIFM label

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -41,7 +41,7 @@ const useBBEGoal = () => {
 	//
 	// ************************************************************************
 
-	return translate( 'Get a website built quickly' );
+	return translate( 'Let us build your site in 4 days' );
 };
 
 export const useGoals = (): Goal[] => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -15,7 +15,7 @@ const DIFMSupportedLocales = [ ...englishLocales, 'es' ];
 
 const useBBEGoal = () => {
 	const translate = useTranslate();
-
+	const locale = useLocale();
 	// ************************************************************************
 	// ****  Experiment skeleton left in for future BBE copy change tests  ****
 	// ************************************************************************
@@ -41,7 +41,9 @@ const useBBEGoal = () => {
 	//
 	// ************************************************************************
 
-	return translate( 'Let us build your site in 4 days' );
+	return locale === 'en'
+		? translate( 'Let us build your site in 4 days' )
+		: translate( 'Get a website built quickly' );
 };
 
 export const useGoals = (): Goal[] => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91721
Fixes https://github.com/Automattic/wp-calypso/issues/91721

## Proposed Changes

* Update goals DIFM label from `Get a website built quickly` to `Let us build your site in 4 days`

<img width="835" alt="CleanShot 2024-06-12 at 14 33 45@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/b0138f3d-55d3-4c0c-804b-9c524859d040">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Context: p9Jlb4-c9F-p2#comment-11800
Change text to test if its an improvement in the existing onboarding flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Create a new site through `/start/` or use an existing site and navigate to `setup/site-setup/goals?siteSlug={SITE_SLUG}`
* Verify the DIFM option label has changed from `Get a website built quickly` to `Let us build your site in 4 days`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?