### PR TITLE
A4A: add email validation for referral checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -1,6 +1,8 @@
 import page from '@automattic/calypso-router';
 import { Button, FormLabel } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
+import clsx from 'clsx';
+import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { A4A_REFERRALS_DASHBOARD } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -22,18 +24,26 @@ interface Props {
 	checkoutItems: ShoppingCartItem[];
 }
 
+type ValidationState = {
+	email?: string;
+};
+
 function RequestClientPayment( { checkoutItems }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const [ email, setEmail ] = useState( '' );
 	const [ message, setMessage ] = useState( '' );
+	const [ validationError, setValidationError ] = useState< ValidationState >( {} );
 
 	const { onClearCart } = useShoppingCart();
 
-	const onEmailChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
+	const onEmailChange = ( event: ChangeEvent< HTMLInputElement > ) => {
 		setEmail( event.currentTarget.value );
-	}, [] );
+		if ( validationError.email ) {
+			setValidationError( { email: undefined } );
+		}
+	};
 
 	const onMessageChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
 		setMessage( event.currentTarget.value );
@@ -51,11 +61,15 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 		if ( ! hasCompletedForm ) {
 			return;
 		}
+		if ( ! emailValidator.validate( email ) ) {
+			setValidationError( { email: translate( 'Please provide correct email' ) } );
+			return;
+		}
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_request_payment_click' )
 		);
 		requestPayment( { client_email: email, client_message: message, product_ids: productIds } );
-	}, [ dispatch, email, hasCompletedForm, message, productIds, requestPayment ] );
+	}, [ dispatch, email, hasCompletedForm, message, productIds, requestPayment, translate ] );
 
 	const onClickLearnMore = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_learn_more_click' ) );
@@ -87,6 +101,14 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 							dispatch( recordTracksEvent( 'calypso_a4a_client_referral_form_email_click' ) )
 						}
 					/>
+					<div
+						className={ clsx( 'checkout__client-referral-form-footer-error', {
+							hidden: ! validationError?.email,
+						} ) }
+						role="alert"
+					>
+						{ validationError.email }
+					</div>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="message">{ translate( 'Custom message' ) }</FormLabel>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -62,7 +62,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 			return;
 		}
 		if ( ! emailValidator.validate( email ) ) {
-			setValidationError( { email: translate( 'Please provide correct email' ) } );
+			setValidationError( { email: translate( 'Please provide correct email address' ) } );
 			return;
 		}
 		dispatch(

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -17,6 +17,18 @@
 	}
 }
 
+.checkout__client-referral-form-footer-error {
+	margin-block-start: 0.25rem;
+	color: var(--color-scary-40);
+	font-style: italic;
+	font-size: 0.875rem;
+	line-height: 14px;
+
+	&.hidden {
+		display: none;
+	}
+}
+
 .checkout__container {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/377

## Proposed Changes

Adding email validation to referral checkout

<img width="379" alt="Screenshot 2024-06-12 at 11 59 56 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/3e3850a3-8230-4010-84a7-cc4d03f77631">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use live link below to test the functionality
- Navigate to `/markeplace` and switch to referral mode
- Add products to the cart and go to checkout
- Check the validation of email (Note it is triggered on the submission)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
