### PR TITLE
Reader - fix issues with scroll position.

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -106,6 +106,15 @@ export default class InfiniteList extends Component {
 			triggeredByScroll: false,
 		} );
 		if ( this._contextLoaded() ) {
+			const scrollTop = this.state.scrollTop;
+			window.setTimeout( () => {
+				this._setContainerY( scrollTop );
+				this.updateScroll( {
+					triggeredByScroll: false,
+				} );
+			}, 0 );
+		}
+		if ( this._contextLoaded() ) {
 			this._scrollContainer.addEventListener( 'scroll', this.onScroll );
 		}
 	}

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -108,10 +108,7 @@ export default class InfiniteList extends Component {
 		// This is a workaround to ensure the scroll container is ready by scrolling after the
 		// current callstack is executed. Some streams and device widths for the reader are not
 		// fully ready to have their scroll position set until everything is mounted, causing the
-		// stream to jump back to the top when coming back to view from a post. This is also useful for the
-		// stream component's scrollToSelectedPost functionality: when the selected item is very far
-		// down in the scroll position the method fails to work without the help of this initial
-		// setting.
+		// stream to jump back to the top when coming back to view from a post.
 		if ( this._contextLoaded() ) {
 			// Use the scrollTop setting from the time the component mounted, as this state could be
 			// changed in the initial update cycle to save scroll position before the saved position

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -105,8 +105,19 @@ export default class InfiniteList extends Component {
 		this.updateScroll( {
 			triggeredByScroll: false,
 		} );
+		// This is a workaround to ensure the scroll container is ready by scrolling after the
+		// current callstack is executed. Some streams and device widths for the reader are not
+		// fully ready to have their scroll position set until everything is mounted, causing the
+		// stream to jump back to the top when coming back to view from a post. This is also useful for the
+		// stream component's scrollToSelectedPost functionality: when the selected item is very far
+		// down in the scroll position the method fails to work without the help of this initial
+		// setting.
 		if ( this._contextLoaded() ) {
+			// Use the scrollTop setting from the time the component mounted, as this state could be
+			// changed in the initial update cycle to save scroll position before the saved position
+			// is set.
 			const scrollTop = this.state.scrollTop;
+			// Apply these at the end of the callstack to ensure the scroll container is ready.
 			window.setTimeout( () => {
 				this._setContainerY( scrollTop );
 				this.updateScroll( {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -485,9 +485,9 @@ class ReaderStream extends Component {
 		const itemKey = this.getPostRef( postKey );
 		const showPost = ( args ) => {
 			// Ensure the post selected becomes the selected item. It may already be the selected
-			// item through shortkeys, or not if use a mouse clicking flow. Setting the selected
+			// item through shortkeys, or not if using a mouse clicking flow. Setting the selected
 			// item this way adds consistency to scroll position when coming back from the full post
-			// view, as well as avoids conflict between out systems for preserving scroll position
+			// view, as well as avoids conflict between our systems for preserving scroll position
 			// and scrolling to selected posts when users use a mix of shortkeys and mouse clicks.
 			if ( ! isSelected ) {
 				this.props.selectItem( { streamKey: this.props.streamKey, postKey } );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -109,6 +109,10 @@ class ReaderStream extends Component {
 	 */
 	observer = null;
 
+	// We can use to keep track of whether we need to scroll to the selected post in the update
+	// cycle.
+	wasSelectedByOpeningPost = false;
+
 	handlePostsSelected = () => {
 		this.setState( { selectedTab: 'posts' } );
 	};
@@ -126,7 +130,13 @@ class ReaderStream extends Component {
 		}
 
 		if ( ! keysAreEqual( selectedPostKey, this.props.selectedPostKey ) ) {
-			this.scrollToSelectedPost( true );
+			// Don't scroll to the post if it was clicked for selection. This causes the scroll to
+			// propagate into the full post screen the first time you click select an item in the
+			// reader, meaning the full post screen opens halfway scrolled down the post.
+			if ( ! this.wasSelectedByOpeningPost ) {
+				this.scrollToSelectedPost( true );
+			}
+			this.wasSelectedByOpeningPost = false;
 			this.focusSelectedPost( this.props.selectedPostKey );
 		}
 
@@ -344,6 +354,9 @@ class ReaderStream extends Component {
 			stream: { items },
 		} = this.props;
 
+		// This should already be false but this is a safety.
+		this.wasSelectedByOpeningPost = false;
+
 		// do we have a selected item? if so, just move to the next one
 		if ( this.props.selectedPostKey ) {
 			this.props.selectNextItem( { streamKey, items } );
@@ -395,6 +408,10 @@ class ReaderStream extends Component {
 			selectedPostKey,
 			stream: { items },
 		} = this.props;
+
+		// This should already be false but this is a safety.
+		this.wasSelectedByOpeningPost = false;
+
 		// unlike selectNextItem, we don't want any magic here. Just move back an item if the user
 		// currently has a selected item. Otherwise do nothing.
 		// We avoid the magic here because we expect users to enter the flow using next, not previous.
@@ -491,6 +508,7 @@ class ReaderStream extends Component {
 			// and scrolling to selected posts when users use a mix of shortkeys and mouse clicks.
 			if ( ! isSelected ) {
 				this.props.selectItem( { streamKey: this.props.streamKey, postKey } );
+				this.wasSelectedByOpeningPost = true;
 			}
 			this.props.showSelectedPost( {
 				...args,

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -344,10 +344,6 @@ class ReaderStream extends Component {
 			stream: { items },
 		} = this.props;
 
-		// THIS (below comments) bypasses functionality further below. This prevents a bug, but
-		// loses the ability to behave well with combinations of shortkey selections and manual
-		// scrolling.
-
 		// do we have a selected item? if so, just move to the next one
 		if ( this.props.selectedPostKey ) {
 			this.props.selectNextItem( { streamKey, items } );
@@ -355,13 +351,6 @@ class ReaderStream extends Component {
 		}
 
 		const visibleIndexes = this.getVisibleItemIndexes();
-
-		// THIS (below) doesn't work as expected. First it is being bypassed by the above. When its not, it
-		// causes bugs and selects the previous item if the item you selected is slightly off the
-		// bottom of the page (causing selection loop).
-
-		// We could remove above and check below if the selected item is the last visible index, and call selectNextItem in that case.
-		// Or we could update above instead of romving it entirely to check if the selected item is above the viewport.
 
 		// This is slightly magical...
 		// When a user tries to select the "next" item, we really want to select
@@ -495,7 +484,14 @@ class ReaderStream extends Component {
 
 		const itemKey = this.getPostRef( postKey );
 		const showPost = ( args ) => {
-			this.props.selectItem( { streamKey: this.props.streamKey, postKey } );
+			// Ensure the post selected becomes the selected item. It may already be the selected
+			// item through shortkeys, or not if use a mouse clicking flow. Setting the selected
+			// item this way adds consistency to scroll position when coming back from the full post
+			// view, as well as avoids conflict between out systems for preserving scroll position
+			// and scrolling to selected posts when users use a mix of shortkeys and mouse clicks.
+			if ( ! isSelected ) {
+				this.props.selectItem( { streamKey: this.props.streamKey, postKey } );
+			}
 			this.props.showSelectedPost( {
 				...args,
 				postKey: postKey,

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -483,12 +483,14 @@ class ReaderStream extends Component {
 		const isSelected = !! ( selectedPostKey && keysAreEqual( selectedPostKey, postKey ) );
 
 		const itemKey = this.getPostRef( postKey );
-		const showPost = ( args ) =>
+		const showPost = ( args ) => {
+			this.props.selectItem( { streamKey: this.props.streamKey, postKey } );
 			this.props.showSelectedPost( {
 				...args,
 				postKey: postKey,
 				streamKey,
 			} );
+		};
 
 		return (
 			<Fragment key={ itemKey }>

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -344,6 +344,10 @@ class ReaderStream extends Component {
 			stream: { items },
 		} = this.props;
 
+		// THIS (below comments) bypasses functionality further below. This prevents a bug, but
+		// loses the ability to behave well with combinations of shortkey selections and manual
+		// scrolling.
+
 		// do we have a selected item? if so, just move to the next one
 		if ( this.props.selectedPostKey ) {
 			this.props.selectNextItem( { streamKey, items } );
@@ -351,6 +355,13 @@ class ReaderStream extends Component {
 		}
 
 		const visibleIndexes = this.getVisibleItemIndexes();
+
+		// THIS (below) doesn't work as expected. First it is being bypassed by the above. When its not, it
+		// causes bugs and selects the previous item if the item you selected is slightly off the
+		// bottom of the page (causing selection loop).
+
+		// We could remove above and check below if the selected item is the last visible index, and call selectNextItem in that case.
+		// Or we could update above instead of romving it entirely to check if the selected item is above the viewport.
 
 		// This is slightly magical...
 		// When a user tries to select the "next" item, we really want to select


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* Resolves Automattic/wp-calypso#91314 and Automattic/dotcom-forge#7272
* Resolves some of what is noted in Automattic/loop#181, and plan to follow up to address the rest of that separately.

## Proposed Changes

1. Ensures the infinite stream component's initial scroll call happens after the initial render cycle (used in a 0 delay timeout). 
    * This allows the scroll position to be set properly in many contexts of the reader where it is currently "jumping back to the top of the stream" when going back.
    * This fixes the issue with the selected item not being in view when going back to the stream via keyboard flows when the item is far down in the stream. (part of Automattic/loop#181)
2. Sets a post as the selected post when clicked. 
    * This creates a more consistent behavior with scroll position when going back to a stream from selecting full post view.
    * This removes inconsistency and conflict with returning scroll position when using a combination of keyboard shortkey and mouse click flows.
    * This has the side effect of adding a blue indicator to a post after clicking (the same that is there when selecting via shortkeys). 
3. Adds a class property to the stream component called `wasSelectedByOpeningPost` used to differentiate selecting an item via the shortkeys and clicking.
    * The `componentDidUpdate` lifecycle method checks to see if the selected item changed and triggers a scroll if it did, while clicking to open full post view now selects the item as well. The combination of these 2 things made the scroll triggered by the update cycle bleed into the full post view causing the full post view to open halfway scrolled down the page when clicked open for the first time in a mouse flow session.
    * We use wasSelectedByOpeningPost to check if we need to trigger scroll in the above mentioned update cycle when the selected item changes. This new property defaults to `false`, is set to `true` a post is selected by opening a card, and is set to `false` again after being evaluated every update cycle. We also set it to `false` as a safety in the selectNext/Previous methods used for shortkeys, although this should technically not be necessary.
    * We keep this as a class property and out of state because we do not want changing this value to rerender the component.

BEFORE

Problem 1 (not returning to post selected):
![problem-1-stream-scroll](https://github.com/Automattic/wp-calypso/assets/28742426/f9de4af9-d8ad-4cef-84a3-5913fc04b45a)



Problem 2 (returning to shorkey selected post and not post that was just selected by click):
![problem-2-stream-scroll](https://github.com/Automattic/wp-calypso/assets/28742426/40bd6932-c4b6-4da4-92b7-61b145324b04)


AFTER

Resolved Problem 1 (not returning to post selected):
![solution-1-stream-scroll](https://github.com/Automattic/wp-calypso/assets/28742426/b8482ea1-18b5-4629-b409-a3a95909e2b8)


Resolved Problem 2 (returning to shorkey selected post and not post that was just selected by click):
![solution-2-stream-scroll](https://github.com/Automattic/wp-calypso/assets/28742426/005f0c39-923b-4561-b315-ab2b10fa7d72)


TODO (in follow up PR to give shortkeys some love):
* Fix issues noted in comments of the stream component with the 'magic' behavior of selectNextItem. It seems the magic behavior had a regression and a past bug fix for it bypassed it entirely.
* Ensure when we select a next post ('j' key), that it isn't hanging off the edge of the page and we properly scroll the item into view.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* (for 1) There is a bug in many places of the reader where going back to the stream from full post view will lead the user back to the top of the stream instead of scrolled to where they had left off.
* (for 1) There is a bug in the above places and more where if you are navigating the reader via shortkeys and far enough down in a stream, coming back from the full post view does not scroll to the selected post or any newly initiated selected post.
* (for 2) This makes the position returned to when coming back from the full post view more consistent.
* (for 2) This removes bugs and conflict in scroll position saving/setting related to using combinations of both shortkeys and mouse click flows.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader and test clicking into full post view and back to the stream.
* The stream should be scrolled to the post you had opened after going back, and the post should now have the selected item indicator style.
* Test this in various streams and device widths, verify when going back to the stream it does not "jump back to the top of the page" instead of being around where you left off.
    * Test the lists and A8C streams (these would always end up at the top previously)
    * Test following and discover on tablet viewport where we use tabs in the header. (these would always end up at the top previously, but were ok at full width without the tabs).
    * Test around other streams and widths. 
    * Verify 'j' and 'k' selection shortkeys still work as expected with this.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
