### PR TITLE
Reader: add block converter for meow gallery blocks

### DIFF
--- a/client/lib/post-normalizer/rule-content-convert-gallery-block.js
+++ b/client/lib/post-normalizer/rule-content-convert-gallery-block.js
@@ -1,0 +1,37 @@
+import { forEach } from 'lodash';
+import readerContentWidth from 'calypso/reader/lib/content-width';
+
+export default function convertGalleryBlock( post, dom ) {
+	// Regular expression to find the JSON data
+	const regex = /<!--\s*wp:meow-gallery\/gallery\s*(.*?)\s*-->/;
+	const matches = dom.innerHTML.match( regex );
+	if ( matches && matches.length > 0 ) {
+		// Extract the JSON data
+		const jsonData = matches[ 1 ];
+
+		if ( jsonData ) {
+			// Parse the JSON data
+			const parsedData = JSON.parse( jsonData );
+
+			if ( parsedData && parsedData.images ) {
+				// Extract images from parsed data
+				const extractedImages = parsedData.images;
+				console.log( 'Extracted images:', dom.innerHTML, extractedImages );
+
+				// Loop through each image and create a new image element
+				forEach( extractedImages, ( image ) => {
+					const img = document.createElement( 'img' );
+					img.src = image.url;
+					img.width = image.width;
+					img.height = image.height;
+					img.alt = image.alt;
+					img.title = image.title;
+					//img.className = 'gallery-image';
+					console.log( 'image', img );
+					dom.appendChild( img );
+				} );
+			}
+		}
+	}
+	return post;
+}

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,5 +1,6 @@
 import { flow } from 'lodash';
 import addImageWrapperElement from 'calypso/lib/post-normalizer/rule-add-image-wrapper-element';
+import convertGalleryBlock from 'calypso/lib/post-normalizer/rule-content-convert-gallery-block';
 import convertVideoPressBlocks from 'calypso/lib/post-normalizer/rule-content-convert-videopress-blocks';
 import detectMedia from 'calypso/lib/post-normalizer/rule-content-detect-media';
 import detectPolls from 'calypso/lib/post-normalizer/rule-content-detect-polls';
@@ -115,6 +116,7 @@ const fastPostNormalizationRules = flow( [
 	safeImageProperties( READER_CONTENT_WIDTH ),
 	makeLinksSafe,
 	withContentDom( [
+		convertGalleryBlock,
 		convertVideoPressBlocks,
 		removeStyles,
 		removeElementsBySelector,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6461

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
