### PR TITLE
Simple Classic: Activity Log Upsell Updates

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -289,9 +289,11 @@ class ActivityCardList extends Component {
 		const pageLogs = this.splitLogsByDate( visibleLogs.slice( ( actualPage - 1 ) * pageSize ) );
 		const showLimitUpsell = visibleLogs.length < logs.length && actualPage >= pageCount;
 
+		const wpcomLimitedActivityLog = isWPCOMSite && ! siteHasFullActivityLog;
+
 		return (
 			<>
-				{ showPagination && (
+				{ showPagination && ! wpcomLimitedActivityLog && (
 					<Pagination
 						compact={ isMobile }
 						className="activity-card-list__pagination-top"
@@ -304,12 +306,12 @@ class ActivityCardList extends Component {
 						total={ visibleLogs.length }
 					/>
 				) }
-				{ ! siteHasFullActivityLog && isWPCOMSite && this.renderPlanUpsell( pageLogs ) }
 				{ this.renderLogs( pageLogs ) }
+				{ wpcomLimitedActivityLog && this.renderPlanUpsell( pageLogs ) }
 				{ showLimitUpsell && (
 					<VisibleDaysLimitUpsell cardClassName="activity-card-list__primary-card-with-more" />
 				) }
-				{ showPagination && (
+				{ showPagination && ! wpcomLimitedActivityLog && (
 					<Pagination
 						compact={ isMobile }
 						className="activity-card-list__pagination-bottom"

--- a/client/components/activity-card-list/style.scss
+++ b/client/components/activity-card-list/style.scss
@@ -43,6 +43,7 @@
 
 		p.activity-card__activity-overlay-text {
 			font-size: $font-body;
+			margin-bottom: 0.5rem;
 		}
 	}
 }

--- a/client/components/activity-card/plan-upsell.tsx
+++ b/client/components/activity-card/plan-upsell.tsx
@@ -35,7 +35,7 @@ const PlanUpsellCard: React.FC< Props > = ( { upsellPlanName } ) => {
 
 	return (
 		<div className="activity-card-list__date-group-upsell">
-			<div className="activity-card-list__date-group-date">Past</div>
+			<div className="activity-card-list__date-group-date">{ translate( 'Older' ) }</div>
 			<div className="activity-card-list__date-group-content">
 				<div className="activity-card-list__secondary-card-with-more activity-card">
 					<div className="activity-card__header">
@@ -46,8 +46,10 @@ const PlanUpsellCard: React.FC< Props > = ( { upsellPlanName } ) => {
 					</div>
 					<Card>
 						<ActivityActor actorName="WordPress" actorType="Application" />
-						<div className="activity-card__activity-description">Description</div>
-						<div className="activity-card__activity-title">Title</div>
+						<div className="activity-card__activity-description">
+							Lorem ipsum dolor sit amet consectetur adipiscing elit
+						</div>
+						<div className="activity-card__activity-title">Laboris Nisi</div>
 						<div className="activity-card__activity-overlay">
 							<div className="activity-card__activity-overlay-content">
 								<div className="activity-card__activity-overlay-lock">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7584

## Proposed Changes

This PR adjusts the Activity Log upsell for wpcom sites to closer match the Figma (see issue).

* If a site is WPCOM and does not have the "full activity log" feature.
  * Hide the paging buttons
  * Show the upsell at the bottom of the activity log (because we're insinuating there are older logs that can be seen).
* Change the copy from "Past" to "Older" and translate it.
* Use longer space-filling blurred copy to give the upsell box more room for translated copy.

Before | After
--|--
 <img width="1468" alt="Screenshot 2024-06-12 at 6 44 03 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/02c96787-fdfa-4730-8409-77c837ad4221"> | <img width="1466" alt="Screenshot 2024-06-12 at 6 43 50 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/dccee9d6-8567-4e9d-9d9b-8c9841da22e0">




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improved design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR and head to http://jetpack.cloud.localhost:3000/activity-log/:site
* Select a Free Simple Classic site with some "activity"
* View the upsell
* Ensure pagination works on sites without the upsell


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
