### PR TITLE
A4A: update referral mobile view

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
@@ -71,8 +71,8 @@
 			}
 
 			.section-nav__mobile-header {
-				margin: 16px 24px 0 24px;
-				width: 88%;
+				margin: 16px auto 0 auto;
+				width: 90%;
 				border: 1px solid var(--color-neutral-10) !important;
 				border-radius: 2px;
 				justify-content: space-between;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -1,0 +1,51 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { addQueryArgs, urlToSlug } from 'calypso/lib/url';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import StatusBadge from '../../common/step-section-item/status-badge';
+import { ReferralPurchase } from '../../types';
+
+type Props = {
+	purchase: ReferralPurchase;
+	isFetching: boolean;
+	handleAssignToSite: ( redirectUrl: string ) => void;
+	data?: APIProductFamilyProduct[];
+};
+
+const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props ) => {
+	const translate = useTranslate();
+	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
+	const isWPCOMLicense = product?.family_slug === 'wpcom-hosting';
+	const redirectUrl = isWPCOMLicense
+		? A4A_SITES_LINK_NEEDS_SETUP
+		: purchase.license_key &&
+		  addQueryArgs( { key: purchase.license_key }, '/marketplace/assign-license' );
+
+	const isDisabled = purchase.status !== 'active' || isFetching || ! product || ! redirectUrl;
+
+	return purchase.site_assigned ? (
+		<Button
+			className="referrals-purchases__assign-button"
+			borderless
+			href={ `/sites/overview/${ urlToSlug( purchase.site_assigned ) }` }
+		>
+			{ urlToSlug( purchase.site_assigned ) }
+		</Button>
+	) : (
+		<>
+			<StatusBadge statusProps={ { children: translate( 'Unassigned' ), type: 'warning' } } />
+
+			<Button
+				disabled={ isDisabled }
+				className="referrals-purchases__assign-button"
+				borderless
+				onClick={ () => handleAssignToSite( redirectUrl ) }
+			>
+				{ isWPCOMLicense ? translate( 'Create site' ) : translate( 'Assign to site' ) }
+			</Button>
+		</>
+	);
+};
+
+export default AssignedTo;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/date.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/date.tsx
@@ -1,0 +1,11 @@
+import { ReferralPurchase } from '../../types';
+
+type Props = {
+	purchase: ReferralPurchase;
+};
+
+const DateAssigned = ( { purchase }: Props ) => {
+	return purchase.date_assigned ? new Date( purchase.date_assigned ).toLocaleDateString() : '-';
+};
+
+export default DateAssigned;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/product-details.tsx
@@ -1,0 +1,17 @@
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { ReferralPurchase } from '../../types';
+
+type Props = {
+	purchase: ReferralPurchase;
+	isFetching: boolean;
+	data?: APIProductFamilyProduct[];
+};
+
+const ProductDetails = ( { purchase, data, isFetching }: Props ) => {
+	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
+
+	return isFetching ? <TextPlaceholder /> : product?.name;
+};
+
+export default ProductDetails;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
@@ -1,0 +1,17 @@
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { ReferralPurchase } from '../../types';
+
+type Props = {
+	purchase: ReferralPurchase;
+	isFetching: boolean;
+	data?: APIProductFamilyProduct[];
+};
+
+const TotalAmount = ( { purchase, data, isFetching }: Props ) => {
+	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
+
+	return isFetching ? <TextPlaceholder /> : `$${ product?.amount }`;
+};
+
+export default TotalAmount;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -1,4 +1,4 @@
-import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import ItemPreviewPane, {
@@ -42,7 +42,7 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 		withIcon: false,
 	};
 
-	const isMobile = useMobileBreakpoint();
+	const isDesktop = useDesktopBreakpoint();
 
 	const features = useMemo(
 		() => [
@@ -52,14 +52,14 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				true,
 				selectedReferralTab,
 				setSelectedReferralTab,
-				isMobile ? (
+				! isDesktop ? (
 					<ReferralPurchasesMobile purchases={ referral.purchases } />
 				) : (
 					<ReferralPurchases purchases={ referral.purchases } />
 				)
 			),
 		],
-		[ referral, selectedReferralTab, translate, isMobile ]
+		[ referral, selectedReferralTab, translate, isDesktop ]
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -10,12 +10,12 @@ import ReferralPurchases from './purchases';
 import type { Referral } from '../types';
 import type { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
 
+import './style.scss';
+
 interface Props {
 	referral: Referral;
 	closeSitePreviewPane: () => void;
 }
-
-import './style.scss';
 
 const REFERRAL_PURCHASES_ID = 'referral-purchases';
 
@@ -64,6 +64,7 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 
 	return (
 		<ItemPreviewPane
+			className="referral-details-items"
 			itemData={ itemData }
 			closeItemPreviewPane={ closeSitePreviewPane }
 			features={ features }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -1,9 +1,11 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import ItemPreviewPane, {
 	createFeaturePreview,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import SubscriptionStatus from '../referrals-list/subscription-status';
+import ReferralPurchasesMobile from './mobile/purchases-mobile';
 import ReferralPurchases from './purchases';
 import type { Referral } from '../types';
 import type { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
@@ -40,6 +42,8 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 		withIcon: false,
 	};
 
+	const isMobile = useMobileBreakpoint();
+
 	const features = useMemo(
 		() => [
 			createFeaturePreview(
@@ -48,10 +52,14 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				true,
 				selectedReferralTab,
 				setSelectedReferralTab,
-				<ReferralPurchases purchases={ referral.purchases } />
+				isMobile ? (
+					<ReferralPurchasesMobile purchases={ referral.purchases } />
+				) : (
+					<ReferralPurchases purchases={ referral.purchases } />
+				)
 			),
 		],
-		[ referral, selectedReferralTab, translate ]
+		[ referral, selectedReferralTab, translate, isMobile ]
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
@@ -1,17 +1,16 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
-import { Button } from '@automattic/components';
 import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import { addQueryArgs, urlToSlug } from 'calypso/lib/url';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-import StatusBadge from '../../common/step-section-item/status-badge';
 import { ReferralPurchase } from '../../types';
 import './style.scss';
+import AssignedTo from '../components/assigned-to';
+import DateAssigned from '../components/date';
+import ProductDetails from '../components/product-details';
+import TotalAmount from '../components/total-amount';
 
 type PurchaseItemProps = {
 	purchase: ReferralPurchase;
@@ -22,14 +21,6 @@ type PurchaseItemProps = {
 const PurchaseItem = ( { purchase, data, isFetching }: PurchaseItemProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
-	const isWPCOMLicense = product?.family_slug === 'wpcom-hosting';
-	const redirectUrl = isWPCOMLicense
-		? A4A_SITES_LINK_NEEDS_SETUP
-		: purchase.license_key &&
-		  addQueryArgs( { key: purchase.license_key }, '/marketplace/assign-license' );
-
-	const isDisabled = purchase.status !== 'active' || isFetching || ! product || ! redirectUrl;
 
 	const handleAssignToSite = useCallback(
 		( url: string ) => {
@@ -40,55 +31,35 @@ const PurchaseItem = ( { purchase, data, isFetching }: PurchaseItemProps ) => {
 	);
 
 	return (
-		<div className="testmenow">
-			<div className="referral-purchases-mobile">
-				<div className="referral-purchases-mobile__content">
-					<div className="referral-purchases-mobile__header">
-						<h3>{ translate( 'Product Details' ).toUpperCase() }</h3>
-					</div>
-					<p className="referral-purchases-mobile__product-name">
-						{ isFetching ? <TextPlaceholder /> : product?.name }
-					</p>
+		<div className="referral-purchases-mobile">
+			<div className="referral-purchases-mobile__content">
+				<div className="referral-purchases-mobile__header">
+					<h3>{ translate( 'Product Details' ).toUpperCase() }</h3>
 				</div>
-				<div className="referral-purchases-mobile__content">
-					<h3>{ translate( 'Date' ).toUpperCase() }</h3>
-					<p>
-						{ purchase.date_assigned
-							? new Date( purchase.date_assigned ).toLocaleDateString()
-							: '-' }
-					</p>
-				</div>
-				<div className="referral-purchases-mobile__content">
-					<h3>{ translate( 'Assigned to' ).toUpperCase() }</h3>
-					{ purchase.site_assigned ? (
-						<Button
-							className="referrals-purchases__assign-button"
-							borderless
-							href={ `/sites/overview/${ urlToSlug( purchase.site_assigned ) }` }
-						>
-							{ urlToSlug( purchase.site_assigned ) }
-						</Button>
-					) : (
-						<>
-							<StatusBadge
-								statusProps={ { children: translate( 'Unassigned' ), type: 'warning' } }
-							/>
-
-							<Button
-								disabled={ isDisabled }
-								className="referrals-purchases__assign-button"
-								borderless
-								onClick={ () => handleAssignToSite( redirectUrl ) }
-							>
-								{ isWPCOMLicense ? translate( 'Create site' ) : translate( 'Assign to site' ) }
-							</Button>
-						</>
-					) }
-				</div>
-				<div className="referral-purchases-mobile__content">
-					<h3>{ translate( 'Total' ).toUpperCase() }</h3>
-					<p>{ isFetching ? <TextPlaceholder /> : `$${ product?.amount }` }</p>
-				</div>
+				<p className="referral-purchases-mobile__product-name">
+					<ProductDetails purchase={ purchase } isFetching={ isFetching } data={ data } />
+				</p>
+			</div>
+			<div className="referral-purchases-mobile__content">
+				<h3>{ translate( 'Date' ).toUpperCase() }</h3>
+				<p>
+					<DateAssigned purchase={ purchase } />
+				</p>
+			</div>
+			<div className="referral-purchases-mobile__content">
+				<h3>{ translate( 'Assigned to' ).toUpperCase() }</h3>
+				<AssignedTo
+					purchase={ purchase }
+					data={ data }
+					handleAssignToSite={ handleAssignToSite }
+					isFetching={ isFetching }
+				/>
+			</div>
+			<div className="referral-purchases-mobile__content">
+				<h3>{ translate( 'Total' ).toUpperCase() }</h3>
+				<p>
+					<TotalAmount isFetching={ isFetching } data={ data } purchase={ purchase } />
+				</p>
 			</div>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -45,7 +45,6 @@ const PurchaseItem = ( { purchase, data, isFetching }: PurchaseItemProps ) => {
 				<div className="referral-purchases-mobile__content">
 					<div className="referral-purchases-mobile__header">
 						<h3>{ translate( 'Product Details' ).toUpperCase() }</h3>
-						<Gridicon icon="ellipsis" size={ 16 } />
 					</div>
 					<p className="referral-purchases-mobile__product-name">
 						{ isFetching ? <TextPlaceholder /> : product?.name }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
@@ -1,0 +1,53 @@
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { ReferralPurchase } from '../../types';
+
+type PurchaseItemProps = {
+	purchase: ReferralPurchase;
+	data?: APIProductFamilyProduct[];
+	isFetching: boolean;
+};
+
+const PurchaseItem = ( { purchase, data, isFetching }: PurchaseItemProps ) => {
+	const translate = useTranslate();
+	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
+
+	return (
+		<div className="referral-purchases-mobile">
+			<div className="referral-purchases-mobile__header">
+				<h3>{ translate( 'Product Details' ).toUpperCase() }</h3>
+			</div>
+
+			<h2>Woo</h2>
+			<div className="referral-purchases-mobile__content">
+				<h3>{ translate( 'Date' ).toUpperCase() }</h3>
+				<p>May 14, 2023</p>
+			</div>
+			<div className="referral-purchases-mobile__content">
+				<h3>{ translate( 'Assigned to' ).toUpperCase() }</h3>
+				<p>2</p>
+			</div>
+			<div className="referral-purchases-mobile__content">
+				<h3>{ translate( 'Total' ).toUpperCase() }</h3>
+				<p>{ isFetching ? <TextPlaceholder /> : `$${ product?.amount }` }</p>
+			</div>
+		</div>
+	);
+};
+
+const ReferralPurchasesMobile = ( { purchases }: { purchases: ReferralPurchase[] } ) => {
+	const { data, isFetching } = useProductsQuery();
+
+	return (
+		<div className="referral-purchases-mobile__wrapper">
+			{ purchases.map( ( purchase ) => (
+				<PurchaseItem purchase={ purchase } data={ data } isFetching={ isFetching } />
+			) ) }
+		</div>
+	);
+};
+
+export default ReferralPurchasesMobile;

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/purchases-mobile.tsx
@@ -1,9 +1,17 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import page from '@automattic/calypso-router';
+import { Button, Gridicon } from '@automattic/components';
+import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import './style.scss';
+import { useCallback } from 'react';
+import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import { addQueryArgs, urlToSlug } from 'calypso/lib/url';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import StatusBadge from '../../common/step-section-item/status-badge';
 import { ReferralPurchase } from '../../types';
+import './style.scss';
 
 type PurchaseItemProps = {
 	purchase: ReferralPurchase;
@@ -13,26 +21,75 @@ type PurchaseItemProps = {
 
 const PurchaseItem = ( { purchase, data, isFetching }: PurchaseItemProps ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
+	const isWPCOMLicense = product?.family_slug === 'wpcom-hosting';
+	const redirectUrl = isWPCOMLicense
+		? A4A_SITES_LINK_NEEDS_SETUP
+		: purchase.license_key &&
+		  addQueryArgs( { key: purchase.license_key }, '/marketplace/assign-license' );
+
+	const isDisabled = purchase.status !== 'active' || isFetching || ! product || ! redirectUrl;
+
+	const handleAssignToSite = useCallback(
+		( url: string ) => {
+			dispatch( recordTracksEvent( 'calypso_a4a_referrals_assign_purchase_to_site_button_click' ) );
+			page.redirect( url );
+		},
+		[ dispatch ]
+	);
 
 	return (
-		<div className="referral-purchases-mobile">
-			<div className="referral-purchases-mobile__header">
-				<h3>{ translate( 'Product Details' ).toUpperCase() }</h3>
-			</div>
+		<div className="testmenow">
+			<div className="referral-purchases-mobile">
+				<div className="referral-purchases-mobile__content">
+					<div className="referral-purchases-mobile__header">
+						<h3>{ translate( 'Product Details' ).toUpperCase() }</h3>
+						<Gridicon icon="ellipsis" size={ 16 } />
+					</div>
+					<p className="referral-purchases-mobile__product-name">
+						{ isFetching ? <TextPlaceholder /> : product?.name }
+					</p>
+				</div>
+				<div className="referral-purchases-mobile__content">
+					<h3>{ translate( 'Date' ).toUpperCase() }</h3>
+					<p>
+						{ purchase.date_assigned
+							? new Date( purchase.date_assigned ).toLocaleDateString()
+							: '-' }
+					</p>
+				</div>
+				<div className="referral-purchases-mobile__content">
+					<h3>{ translate( 'Assigned to' ).toUpperCase() }</h3>
+					{ purchase.site_assigned ? (
+						<Button
+							className="referrals-purchases__assign-button"
+							borderless
+							href={ `/sites/overview/${ urlToSlug( purchase.site_assigned ) }` }
+						>
+							{ urlToSlug( purchase.site_assigned ) }
+						</Button>
+					) : (
+						<>
+							<StatusBadge
+								statusProps={ { children: translate( 'Unassigned' ), type: 'warning' } }
+							/>
 
-			<h2>Woo</h2>
-			<div className="referral-purchases-mobile__content">
-				<h3>{ translate( 'Date' ).toUpperCase() }</h3>
-				<p>May 14, 2023</p>
-			</div>
-			<div className="referral-purchases-mobile__content">
-				<h3>{ translate( 'Assigned to' ).toUpperCase() }</h3>
-				<p>2</p>
-			</div>
-			<div className="referral-purchases-mobile__content">
-				<h3>{ translate( 'Total' ).toUpperCase() }</h3>
-				<p>{ isFetching ? <TextPlaceholder /> : `$${ product?.amount }` }</p>
+							<Button
+								disabled={ isDisabled }
+								className="referrals-purchases__assign-button"
+								borderless
+								onClick={ () => handleAssignToSite( redirectUrl ) }
+							>
+								{ isWPCOMLicense ? translate( 'Create site' ) : translate( 'Assign to site' ) }
+							</Button>
+						</>
+					) }
+				</div>
+				<div className="referral-purchases-mobile__content">
+					<h3>{ translate( 'Total' ).toUpperCase() }</h3>
+					<p>{ isFetching ? <TextPlaceholder /> : `$${ product?.amount }` }</p>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/style.scss
@@ -1,31 +1,36 @@
 .referral-purchases-mobile {
 	border: 1px solid var(--color-neutral-10);
 	border-radius: 4px;
-	margin: 1rem;
+	margin-block-end: 1rem;
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
-	gap: 0.5rem;
+	gap: 1rem;
 
 	.referral-purchases-mobile__header {
-		display: inline-flex;
+		display: flex;
+		justify-content: space-between;
+
+		.gridicon {
+			transform: rotate(90deg);
+		}
+	}
+
+	.referral-purchases-mobile__product-name {
+		font-weight: 500;
+		font-size: 0.875rem;
+		color: var(--color-gray-80);
 	}
 
 	h3 {
 		font-weight: 500;
-		font-size: 0.75rem;
+		font-size: 11px; // stylelint-disable-line declaration-property-unit-allowed-list
 		color: var(--color-gray-80);
-	}
-
-	h2 {
-		font-weight: 500;
-		font-size: 0.875rem;
-		color: var(--color-black);
 	}
 
 	p {
 		font-weight: 400;
-		font-size: 0.875rem;
+		font-size: 13px; // stylelint-disable-line declaration-property-unit-allowed-list
 		color: var(--color-gray-70);
 		margin: 0;
 	}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/style.scss
@@ -1,0 +1,36 @@
+.referral-purchases-mobile {
+	border: 1px solid var(--color-neutral-10);
+	border-radius: 4px;
+	margin: 1rem;
+	padding: 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+
+	.referral-purchases-mobile__header {
+		display: inline-flex;
+	}
+
+	h3 {
+		font-weight: 500;
+		font-size: 0.75rem;
+		color: var(--color-gray-80);
+	}
+
+	h2 {
+		font-weight: 500;
+		font-size: 0.875rem;
+		color: var(--color-black);
+	}
+
+	p {
+		font-weight: 400;
+		font-size: 0.875rem;
+		color: var(--color-gray-70);
+		margin: 0;
+	}
+}
+
+.referral-purchases-mobile__wrapper {
+	overflow-y: auto;
+}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/style.scss
@@ -10,10 +10,6 @@
 	.referral-purchases-mobile__header {
 		display: flex;
 		justify-content: space-between;
-
-		.gridicon {
-			transform: rotate(90deg);
-		}
 	}
 
 	.referral-purchases-mobile__product-name {
@@ -24,13 +20,13 @@
 
 	h3 {
 		font-weight: 500;
-		font-size: 11px; // stylelint-disable-line declaration-property-unit-allowed-list
+		font-size: rem(11px);
 		color: var(--color-gray-80);
 	}
 
 	p {
 		font-weight: 400;
-		font-size: 13px; // stylelint-disable-line declaration-property-unit-allowed-list
+		font-size: rem(13px);
 		color: var(--color-gray-70);
 		margin: 0;
 	}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
@@ -1,18 +1,15 @@
 import page from '@automattic/calypso-router';
-import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, ReactNode, useCallback } from 'react';
-import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import { addQueryArgs } from 'calypso/lib/url';
-import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ReferralDetailsTable from '../common/referral-details-table';
-import StatusBadge from '../common/step-section-item/status-badge';
+import AssignedTo from './components/assigned-to';
+import DateAssigned from './components/date';
+import ProductDetails from './components/product-details';
+import TotalAmount from './components/total-amount';
 import type { ReferralPurchase } from '../types';
-
 import './style.scss';
 
 export default function ReferralPurchases( { purchases }: { purchases: ReferralPurchase[] } ) {
@@ -36,8 +33,7 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 				header: translate( 'Product Details' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
-					const product = data?.find( ( product ) => product.product_id === item.product_id );
-					return isFetching ? <TextPlaceholder /> : product?.name;
+					return <ProductDetails isFetching={ isFetching } purchase={ item } data={ data } />;
 				},
 				enableHiding: false,
 				enableSorting: false,
@@ -47,7 +43,7 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 				header: translate( 'Date' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
-					return item.date_assigned ? new Date( item.date_assigned ).toLocaleDateString() : '-';
+					return <DateAssigned purchase={ item } />;
 				},
 				enableHiding: false,
 				enableSorting: false,
@@ -57,38 +53,13 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 				header: translate( 'Assigned to' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
-					const product = data?.find( ( product ) => product.product_id === item.product_id );
-					const isWPCOMLicense = product?.family_slug === 'wpcom-hosting';
-					const redirectUrl = isWPCOMLicense
-						? A4A_SITES_LINK_NEEDS_SETUP
-						: item.license_key &&
-						  addQueryArgs( { key: item.license_key }, '/marketplace/assign-license' );
-
-					const isDisabled = item.status !== 'active' || isFetching || ! product || ! redirectUrl;
-
-					return item.site_assigned ? (
-						<Button
-							className="referrals-purchases__assign-button"
-							borderless
-							href={ `/sites/overview/${ urlToSlug( item.site_assigned ) }` }
-						>
-							{ urlToSlug( item.site_assigned ) }
-						</Button>
-					) : (
-						<>
-							<StatusBadge
-								statusProps={ { children: translate( 'Unassigned' ), type: 'warning' } }
-							/>
-
-							<Button
-								disabled={ isDisabled }
-								className="referrals-purchases__assign-button"
-								borderless
-								onClick={ () => handleAssignToSite( redirectUrl ) }
-							>
-								{ isWPCOMLicense ? translate( 'Create site' ) : translate( 'Assign to site' ) }
-							</Button>
-						</>
+					return (
+						<AssignedTo
+							purchase={ item }
+							data={ data }
+							handleAssignToSite={ handleAssignToSite }
+							isFetching={ isFetching }
+						/>
 					);
 				},
 				enableHiding: false,
@@ -99,8 +70,7 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 				header: translate( 'Total' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
-					const product = data?.find( ( product ) => product.product_id === item.product_id );
-					return isFetching ? <TextPlaceholder /> : `$${ product?.amount }`;
+					return <TotalAmount isFetching={ isFetching } purchase={ item } data={ data } />;
 				},
 				enableHiding: false,
 				enableSorting: false,

--- a/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .referral-details__subtitle {
 	margin-block-start: 16px;
 }
@@ -8,4 +10,12 @@
 	top: -1px;
 	left: 8px;
 	text-decoration: underline;
+}
+
+.item-preview__pane.referral-details-items {
+	.item-preview__content {
+		@media (max-width: $break-mobile) {
+			height: 70vh;
+		}
+	}
 }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
@@ -15,7 +15,8 @@
 .item-preview__pane.referral-details-items {
 	.item-preview__content {
 		@media (max-width: $break-mobile) {
-			height: 70vh;
+			height: 75vh;
+			padding: 18px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/371

## Proposed Changes

Improves mobile styles of referrals dashboard view

<img width="431" alt="Screenshot 2024-06-13 at 1 35 04 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/83832016-4b60-4633-9714-1d31eaa52d35">


Note: action button (3 dots) not yet implemented and would be addressed separately

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use live link below
- Make several referrals (in `/marketplace` switch to referral mode, add to cart and checkout).
- Navigate to `/referrals/dashboard`, switch to mobile view in dev console and observe the behavior. Note, by opening every customer tab you should see new view. Customer tab itself hasn't changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
