### PR TITLE
Stats: Fixing chart width after period changes

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -122,6 +122,11 @@ export default function SubscribersChartSection( {
 	}, [ status, isError ] );
 
 	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
+
+	// Products with an undefined value rather than an empty array means the API call has not been completed yet.
+	const isPaidSubscriptionProductsLoading = ! products;
+	const isChartLoading = isLoading || isPaidSubscriptionProductsLoading;
+
 	const hasAddedPaidSubscriptionProduct = products && products.length > 0;
 	const chartData = transformData( data?.data || [], hasAddedPaidSubscriptionProduct );
 
@@ -166,14 +171,14 @@ export default function SubscribersChartSection( {
 					</div>
 				</div>
 			</div>
-			{ isLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
-			{ ! isLoading && chartData.length === 0 && (
+			{ isChartLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
+			{ ! isChartLoading && chartData.length === 0 && (
 				<p className="subscribers-section__no-data">
 					{ translate( 'No data available for the specified period.' ) }
 				</p>
 			) }
 			{ errorMessage && <div>Error: { errorMessage }</div> }
-			{ ! isLoading && chartData.length !== 0 && (
+			{ ! isChartLoading && chartData.length !== 0 && (
 				<UplotChart
 					data={ chartData }
 					legendContainer={ legendRef }

--- a/client/my-sites/stats/stats-subscribers-chart-section/style.scss
+++ b/client/my-sites/stats/stats-subscribers-chart-section/style.scss
@@ -47,6 +47,11 @@
 		display: flex;
 		justify-content: right;
 	}
+
+	.u-value {
+		vertical-align: middle;
+		display: inline-block;
+	}
 }
 
 .subscribers-section-duration-control-with-legend > .stats__period-header {

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -117,7 +117,6 @@ export default function SubscribersHighlightSection( { siteId }: { siteId: numbe
 	// Intentionally not using getProductsForSiteId here because we want to show the loading state.
 	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
 
-	// Odyssey Stats doesn't support the membership API endpoint yet.
 	// Products with an undefined value rather than an empty array means the API call has not been completed yet.
 	const isPaidSubscriptionProductsLoading = ! products;
 	const hasAddedPaidSubscriptionProduct = products && products.length > 0;

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -1,5 +1,5 @@
 import { getLocaleSlug, numberFormat, useTranslate } from 'i18n-calypso';
-import { useMemo, useState, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import uPlot from 'uplot';
 import UplotReact from 'uplot-react';
 import useResize from './hooks/use-resize';
@@ -49,145 +49,144 @@ export default function UplotChart( {
 
 	const scaleGradient = useScaleGradient( fillColorFrom );
 
-	const [ options ] = useState< uPlot.Options >(
-		useMemo( () => {
-			const seriesTemplate = {
-				width: 2,
-				paths: ( u: uPlot, seriesIdx: number, idx0: number, idx1: number ) => {
-					return spline?.()( u, seriesIdx, idx0, idx1 ) || null;
+	const options = useMemo( () => {
+		const seriesTemplate = {
+			width: 2,
+			paths: ( u: uPlot, seriesIdx: number, idx0: number, idx1: number ) => {
+				return spline?.()( u, seriesIdx, idx0, idx1 ) || null;
+			},
+			points: {
+				show: false,
+			},
+			value: ( self: uPlot, rawValue: number ) => {
+				if ( ! rawValue ) {
+					return '-';
+				}
+
+				return numberFormat( rawValue, 0 );
+			},
+		};
+
+		// Total subscribers series.
+		const mainSeries = {
+			...seriesTemplate,
+			fill: solidFill
+				? fillColorFrom
+				: getGradientFill( fillColorFrom, fillColorTo, scaleGradient ),
+			label: translate( 'Subscribers' ),
+			stroke: mainColor,
+		};
+
+		// Paid subscribers series.
+		const subSeries = {
+			...seriesTemplate,
+			fill: getGradientFill( 'rgba(230, 139, 40, 0.4)', 'rgba(230, 139, 40, 0)', scaleGradient ),
+			label: translate( 'Paid Subscribers' ),
+			stroke: '#e68b28',
+		};
+
+		const seriesSet = data.length === 3 ? [ mainSeries, subSeries ] : [ mainSeries ];
+
+		const defaultOptions: uPlot.Options = {
+			class: 'calypso-uplot-chart',
+			...DEFAULT_DIMENSIONS,
+			// Set incoming dates as UTC.
+			tzDate: ( ts ) => uPlot.tzDate( new Date( ts * 1e3 ), 'Etc/UTC' ),
+			fmtDate: ( chartDateStringTemplate: string ) => {
+				// first it cycles through all possible templates in case they are substitues
+				// the date for a specific point
+				return ( date ) => getDateFormat( chartDateStringTemplate, date, getLocaleSlug() || 'en' );
+			},
+			axes: [
+				{
+					// x-axis
+					grid: {
+						show: false,
+					},
+					ticks: {
+						stroke: '#646970',
+						width: 1,
+						size: 3,
+					},
 				},
+				{
+					// y-axis
+					side: 1,
+					gap: 8,
+					space: 40,
+					size: 50,
+					grid: {
+						stroke: 'rgba(220, 220, 222, 0.5)', // #DCDCDE with 0.5 opacity
+						width: 1,
+					},
+					ticks: {
+						show: false,
+					},
+					filter: yAxisFilter,
+				},
+			],
+			cursor: {
+				x: false,
+				y: false,
 				points: {
-					show: false,
-				},
-				value: ( self: uPlot, rawValue: number ) => {
-					if ( ! rawValue ) {
-						return '-';
-					}
-
-					return numberFormat( rawValue, 0 );
-				},
-			};
-
-			const mainSeries = {
-				...seriesTemplate,
-				fill: solidFill
-					? fillColorFrom
-					: getGradientFill( fillColorFrom, fillColorTo, scaleGradient ),
-				label: translate( 'Subscribers' ),
-				stroke: mainColor,
-			};
-
-			const subSeries = {
-				...seriesTemplate,
-				fill: getGradientFill( 'rgba(230, 139, 40, 0.4)', 'rgba(230, 139, 40, 0)', scaleGradient ),
-				label: translate( 'Paid Subscribers' ),
-				stroke: '#e68b28',
-			};
-
-			const seriesSet = data.length === 3 ? [ mainSeries, subSeries ] : [ mainSeries ];
-
-			const defaultOptions: uPlot.Options = {
-				class: 'calypso-uplot-chart',
-				...DEFAULT_DIMENSIONS,
-				// Set incoming dates as UTC.
-				tzDate: ( ts ) => uPlot.tzDate( new Date( ts * 1e3 ), 'Etc/UTC' ),
-				fmtDate: ( chartDateStringTemplate: string ) => {
-					// first it cycles through all possible templates in case they are substitues
-
-					// the date for a specific point
-					return ( date ) =>
-						getDateFormat( chartDateStringTemplate, date, getLocaleSlug() || 'en' );
-				},
-				axes: [
-					{
-						// x-axis
-						grid: {
-							show: false,
-						},
-						ticks: {
-							stroke: '#646970',
-							width: 1,
-							size: 3,
-						},
+					size: ( u, seriesIdx ) => ( u.series[ seriesIdx ].points?.size || 1 ) * 2,
+					width: ( u, seriesIdx, size ) => size / 4,
+					stroke: ( u, seriesIdx ) => {
+						const stroke = u.series[ seriesIdx ]?.points?.stroke;
+						return typeof stroke === 'function'
+							? ( stroke( u, seriesIdx ) as CanvasRenderingContext2D[ 'strokeStyle' ] )
+							: ( stroke as CanvasRenderingContext2D[ 'strokeStyle' ] );
 					},
-					{
-						// y-axis
-						side: 1,
-						gap: 8,
-						space: 40,
-						size: 50,
-						grid: {
-							stroke: 'rgba(220, 220, 222, 0.5)', // #DCDCDE with 0.5 opacity
-							width: 1,
-						},
-						ticks: {
-							show: false,
-						},
-						filter: yAxisFilter,
-					},
-				],
-				cursor: {
-					x: false,
-					y: false,
-					points: {
-						size: ( u, seriesIdx ) => ( u.series[ seriesIdx ].points?.size || 1 ) * 2,
-						width: ( u, seriesIdx, size ) => size / 4,
-						stroke: ( u, seriesIdx ) => {
-							const stroke = u.series[ seriesIdx ]?.points?.stroke;
-							return typeof stroke === 'function'
-								? ( stroke( u, seriesIdx ) as CanvasRenderingContext2D[ 'strokeStyle' ] )
-								: ( stroke as CanvasRenderingContext2D[ 'strokeStyle' ] );
-						},
-						fill: () => '#fff',
-					},
+					fill: () => '#fff',
 				},
-				series: [
-					{
-						label: translate( 'Date' ),
-						value: ( self: uPlot, rawValue: number ) => {
-							// outputs legend content - value available when mouse is hovering the chart
-							if ( ! rawValue ) {
-								return '-';
-							}
-
-							return getPeriodDateFormat(
-								period,
-								new Date( rawValue * 1000 ),
-								getLocaleSlug() || 'en'
-							);
-						},
-					},
-					...seriesSet,
-				],
-				legend: {
-					isolate: true,
-					mount: ( self: uPlot, el: HTMLElement ) => {
-						// If legendContainer is defined, move the legend into it.
-						if ( legendContainer?.current ) {
-							legendContainer?.current.append( el );
+			},
+			series: [
+				{
+					label: translate( 'Date' ),
+					value: ( self: uPlot, rawValue: number ) => {
+						// outputs legend content - value available when mouse is hovering the chart
+						if ( ! rawValue ) {
+							return '-';
 						}
+
+						return getPeriodDateFormat(
+							period,
+							new Date( rawValue * 1000 ),
+							getLocaleSlug() || 'en'
+						);
 					},
 				},
-			};
+				...seriesSet,
+			],
+			legend: {
+				isolate: true,
+				mount: ( self: uPlot, el: HTMLElement ) => {
+					// If legendContainer is defined, move the legend into it.
+					if ( legendContainer?.current ) {
+						legendContainer?.current.append( el );
+					}
+				},
+			},
+		};
 
-			return {
-				...defaultOptions,
-				...( typeof propOptions === 'object' ? propOptions : {} ),
-			};
-		}, [
-			mainColor,
-			fillColorFrom,
-			fillColorTo,
-			legendContainer,
-			propOptions,
-			scaleGradient,
-			solidFill,
-			spline,
-			translate,
-			period,
-			data.length,
-		] )
-	);
+		return {
+			...defaultOptions,
+			...( typeof propOptions === 'object' ? propOptions : {} ),
+		};
+	}, [
+		mainColor,
+		fillColorFrom,
+		fillColorTo,
+		legendContainer,
+		propOptions,
+		scaleGradient,
+		solidFill,
+		spline,
+		translate,
+		period,
+		data,
+		yAxisFilter,
+	] );
 
 	useResize( uplot, uplotContainer );
 

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -92,9 +92,9 @@ export default function UplotChart( {
 			...DEFAULT_DIMENSIONS,
 			// Set incoming dates as UTC.
 			tzDate: ( ts ) => uPlot.tzDate( new Date( ts * 1e3 ), 'Etc/UTC' ),
+			// First, it cycles through all possible templates in case they are substitutes.
 			fmtDate: ( chartDateStringTemplate: string ) => {
-				// first it cycles through all possible templates in case they are substitues
-				// the date for a specific point
+				// The date for a specific point in the chart.
 				return ( date ) => getDateFormat( chartDateStringTemplate, date, getLocaleSlug() || 'en' );
 			},
 			axes: [


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91688

## Proposed Changes

* move data set options from useEffect to useMemo to update only when the number of data sets changes
* updating value position to align it with its label

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* it seems that rerendering was causing incorrect chart width calculation when interacting with periods (e.g. switching from `days` to `weeks`)
* the issue was not occurring with a single dataset
* the change is also unifying how data set options are generated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch
* test with a blog that only has one data set (no paid subscribers) - verify on a screen 1440px or smaller, test with different periods
* test with a blog that has paid subscribers
* test switching between blogs and pages

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?