### PR TITLE
A4A: Fix the card number unaligned in the Payment method section

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/style.scss
@@ -34,8 +34,9 @@
 	line-height: 1.5;
 
 	@include break-mobile {
-		font-size: rem(35px);
+		font-size: rem(28px);
 		padding-block-start: 65px;
+		text-wrap: nowrap;
 	}
 }
 
@@ -58,7 +59,7 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	margin-block-start: 24px;
+	margin-block-start: 35px;
 }
 
 .stored-credit-card__payment-logo {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

**The issue in production:**

![image](https://github.com/Automattic/wp-calypso/assets/9832440/5050e45c-b6ea-4f1a-bb7f-cd49febac5c2)


**The issue fixed in this branch:**

![image](https://github.com/Automattic/wp-calypso/assets/9832440/667b3c3b-4f15-4db9-89c9-ca8b6f1f7654)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check the styles updated
- Check that in this branch the credit card info remains inside of the card background, on any screen size.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
