### PR TITLE
Hosting: Display upsell if the backups is not available

### DIFF
--- a/client/hosting-overview/components/hosting-overview.tsx
+++ b/client/hosting-overview/components/hosting-overview.tsx
@@ -1,4 +1,3 @@
-import { WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -9,8 +8,6 @@ import SiteBackupCard from 'calypso/my-sites/hosting/site-backup-card';
 import SupportCard from 'calypso/my-sites/hosting/support-card';
 import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -18,11 +15,6 @@ import './style.scss';
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
 	const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
-	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, site?.ID || -1 ) );
-	const hasAtomicFeature = useSelector( ( state ) =>
-		siteHasFeature( state, site?.ID || -1, WPCOM_FEATURES_ATOMIC )
-	);
-
 	const subtitle = isJetpackNotAtomic
 		? translate( 'Get a quick glance at your plans and upgrades.' )
 		: translate( 'Get a quick glance at your plans, storage, and domains.' );
@@ -36,7 +28,7 @@ const HostingOverview: FC = () => {
 			/>
 			<PlanCard />
 			<QuickActionsCard />
-			<SiteBackupCard disabled={ ! hasAtomicFeature || ! isSiteAtomic } />
+			<SiteBackupCard />
 			<SupportCard />
 			<ActiveDomainsCard />
 		</div>

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -174,7 +174,7 @@ const SidebarCards = ( { isBasicHostingDisabled } ) => {
 	const sidebarCards = [
 		{
 			feature: 'site-backup',
-			content: <SiteBackupCard disabled={ isBasicHostingDisabled } />,
+			content: <SiteBackupCard />,
 			type: 'basic',
 		},
 		{

--- a/client/my-sites/hosting/site-backup-card/index.js
+++ b/client/my-sites/hosting/site-backup-card/index.js
@@ -63,7 +63,7 @@ const SiteBackupCard = ( { lastGoodBackup, requestBackups, siteId, siteSlug } ) 
 					</p>
 					<p>
 						{ translate(
-							'Unlock more granular control over your site, with the ability to restore it to any previous state, and export it at any time'
+							'Unlock more granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
 						) }
 					</p>
 					<Button

--- a/client/my-sites/hosting/site-backup-card/index.js
+++ b/client/my-sites/hosting/site-backup-card/index.js
@@ -1,4 +1,5 @@
-import { getPlan, WPCOM_FEATURES_BACKUPS, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_BACKUPS, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -62,36 +63,22 @@ const SiteBackupCard = ( { lastGoodBackup, requestBackups, siteId, siteSlug } ) 
 					</p>
 					<p>
 						{ translate(
-							// Translators: %(planName)s is the plan - Business or Creator
-							"Don't risk losing your hard work. With the %(planName)s plan, you can easily restore your site using our easy-to-use backup feature.",
-							{
-								args: {
-									planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-								},
-							}
+							'Unlock more granular control over your site, with the ability to restore it to any previous state, and export it at any time'
 						) }
 					</p>
-					<p>
-						{ translate(
-							'{{link}}Upgrade today{{/link}} to keep your site safe and your content fresh!',
-							{
-								components: {
-									link: (
-										<a
-											href={ addQueryArgs( `/checkout/${ siteSlug }/${ PLAN_BUSINESS }`, {
-												redirect_to: window.location.href.replace( window.location.origin, '' ),
-											} ) }
-											onClick={ () =>
-												dispatch(
-													recordTracksEvent( 'calypso_hosting_overview_backups_upgrade_plan_click' )
-												)
-											}
-										/>
-									),
-								},
-							}
-						) }
-					</p>
+					<Button
+						primary
+						compact
+						href={ addQueryArgs( `/plans/${ siteSlug }`, {
+							feature: WPCOM_FEATURES_BACKUPS,
+							plan: PLAN_BUSINESS,
+						} ) }
+						onClick={ () =>
+							dispatch( recordTracksEvent( 'calypso_hosting_overview_backups_upgrade_plan_click' ) )
+						}
+					>
+						{ translate( 'Upgrade your plan' ) }
+					</Button>
 				</>
 			);
 		}

--- a/client/my-sites/hosting/site-backup-card/index.js
+++ b/client/my-sites/hosting/site-backup-card/index.js
@@ -1,3 +1,5 @@
+import { getPlan, WPCOM_FEATURES_BACKUPS, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
@@ -7,16 +9,19 @@ import {
 	HostingCardLinkButton,
 } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import getLastGoodRewindBackup from 'calypso/state/selectors/get-last-good-rewind-backup';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId, siteSlug } ) => {
+const SiteBackupCard = ( { lastGoodBackup, requestBackups, siteId, siteSlug } ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 
@@ -26,13 +31,17 @@ const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId, sit
 		getSiteOption( state, siteId, 'wpcom_admin_interface' )
 	);
 
+	const hasBackup = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS )
+	);
+
 	useEffect( () => {
-		const shouldRequestLastBackup = ! disabled && ! hasRetrievedLastBackup && ! isLoading;
+		const shouldRequestLastBackup = hasBackup && ! hasRetrievedLastBackup && ! isLoading;
 		if ( shouldRequestLastBackup ) {
 			requestBackups( siteId );
 			setIsLoading( true );
 		}
-	}, [ disabled, hasRetrievedLastBackup, isLoading, lastGoodBackup, requestBackups, siteId ] );
+	}, [ hasBackup, hasRetrievedLastBackup, isLoading, lastGoodBackup, requestBackups, siteId ] );
 
 	useEffect( () => {
 		if ( hasRetrievedLastBackup ) {
@@ -44,20 +53,61 @@ const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId, sit
 		? moment.utc( lastGoodBackup.last_updated, 'YYYY-MM-DD hh:mma' ).local().format( 'LLL' )
 		: null;
 
-	return (
-		<HostingCard className="site-backup-card">
-			<HostingCardHeading title={ translate( 'Site backup' ) }>
-				<HostingCardLinkButton
-					to={
-						wpcomAdminInterface === 'wp-admin'
-							? `https://cloud.jetpack.com/backup/${ siteSlug }`
-							: `/backup/${ siteSlug }`
-					}
-				>
-					{ translate( 'See all backups' ) }
-				</HostingCardLinkButton>
-			</HostingCardHeading>
-			{ hasRetrievedLastBackup && lastGoodBackup && ! isLoading && ! disabled && (
+	const renderContent = () => {
+		if ( ! hasBackup ) {
+			return (
+				<>
+					<p>
+						<strong>{ translate( "Your plan doesn't support backups!" ) }</strong>
+					</p>
+					<p>
+						{ translate(
+							// Translators: %(planName)s is the plan - Business or Creator
+							"Don't risk losing your hard work. With the %(planName)s plan, you can easily restore your site using our easy-to-use backup feature.",
+							{
+								args: {
+									planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+								},
+							}
+						) }
+					</p>
+					<p>
+						{ translate(
+							'{{link}}Upgrade today{{/link}} to keep your site safe and your content fresh!',
+							{
+								components: {
+									link: (
+										<a
+											href={ addQueryArgs( `/checkout/${ siteSlug }/${ PLAN_BUSINESS }`, {
+												redirect_to: window.location.href.replace( window.location.origin, '' ),
+											} ) }
+											onClick={ () =>
+												dispatch(
+													recordTracksEvent( 'calypso_hosting_overview_backups_upgrade_plan_click' )
+												)
+											}
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+				</>
+			);
+		}
+
+		if ( isLoading ) {
+			return (
+				<>
+					<div className="site-backup-card__placeholder"></div>
+					<div className="site-backup-card__placeholder"></div>
+					<div className="site-backup-card__placeholder is-large"></div>
+				</>
+			);
+		}
+
+		if ( lastGoodBackup ) {
+			return (
 				<>
 					<p className="site-backup-card__date">
 						{ translate( 'Last backup was on:' ) }
@@ -69,17 +119,28 @@ const SiteBackupCard = ( { disabled, lastGoodBackup, requestBackups, siteId, sit
 						) }
 					</p>
 				</>
-			) }
-			{ ( ( hasRetrievedLastBackup && ! lastGoodBackup && ! isLoading ) || disabled ) && (
-				<div>{ translate( 'There are no recent backups for your site.' ) }</div>
-			) }
-			{ isLoading && ! hasRetrievedLastBackup && (
-				<>
-					<div className="site-backup-card__placeholder"></div>
-					<div className="site-backup-card__placeholder"></div>
-					<div className="site-backup-card__placeholder is-large"></div>
-				</>
-			) }
+			);
+		}
+
+		return <div>{ translate( 'There are no recent backups for your site.' ) }</div>;
+	};
+
+	return (
+		<HostingCard className="site-backup-card">
+			<HostingCardHeading title={ translate( 'Site backup' ) }>
+				{ hasBackup && (
+					<HostingCardLinkButton
+						to={
+							wpcomAdminInterface === 'wp-admin'
+								? `https://cloud.jetpack.com/backup/${ siteSlug }`
+								: `/backup/${ siteSlug }`
+						}
+					>
+						{ translate( 'See all backups' ) }
+					</HostingCardLinkButton>
+				) }
+			</HostingCardHeading>
+			{ renderContent() }
 		</HostingCard>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7655

## Proposed Changes

* Display the upsell on the backups card if the feature is not available

![image](https://github.com/Automattic/wp-calypso/assets/13596067/6e1cef21-1b89-4cac-b0da-5784c837384d)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Pick a free site
* Make sure the backups card displays the upsell message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
