### PR TITLE
Add error-specific validation message in site identification page

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -12,6 +12,7 @@ import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import getValidationMessage from './url-validation-message-helper';
 import type { OnInputChange, OnInputEnter } from './types';
 import type { FunctionComponent, ReactNode } from 'react';
 
@@ -72,119 +73,13 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		}
 	}
 
-	function isIDN( url: string ) {
-		try {
-			// Regex to extract the hostname from the URL.
-			const urlRegex = /^(?:https?:\/\/)?(?:www\.)?([^/]+)/i;
-			const match = url.match( urlRegex );
-
-			if ( ! match ) {
-				return false;
-			}
-
-			// Extract the hostname.
-			const hostname = match[ 1 ];
-
-			// Check for non-ASCII characters
-			for ( let i = 0; i < hostname.length; i++ ) {
-				if ( hostname.charCodeAt( i ) > 127 ) {
-					return true;
-				}
-			}
-
-			// Check if the hostname starts with the Punycode prefix.
-			if ( hostname.startsWith( 'xn--' ) ) {
-				return true;
-			}
-		} catch ( e ) {
-			return false;
-		}
-	}
-
 	function validateUrl( url: string ) {
 		const isValid = CAPTURE_URL_RGX.test( url );
 		setIsValid( isValid );
-		const tempValidationMessage = isValid ? '' : getValidationMessage( url );
+		const tempValidationMessage = isValid
+			? ''
+			: getValidationMessage( url, translate, hasEnTranslation );
 		setValidationMessage( tempValidationMessage );
-	}
-
-	// TODO: Just return the translated string directly from getValidationMessage once we have translations for all messages.
-	const errorMessages = {
-		'no-tld': {
-			message: translate(
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
-			),
-			messageString:
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com',
-		},
-		email: {
-			message: translate(
-				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).'
-			),
-			messageString:
-				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).',
-		},
-		'invalid-chars': {
-			message: translate(
-				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).'
-			),
-			messageString:
-				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).',
-		},
-		'invalid-protocol': {
-			message: translate(
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).'
-			),
-			messageString:
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).',
-		},
-		'idn-url': {
-			message: translate(
-				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).'
-			),
-			messageString:
-				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).',
-		},
-		default: {
-			message: translate(
-				'Please enter a valid website address (e.g., example.com). You can copy and paste.'
-			),
-			messageString:
-				'Please enter a valid website address (e.g., example.com). You can copy and paste.',
-		},
-	};
-
-	function getValidationMessage( url: string ) {
-		const hasEnTranslationForAllMessages = Object.values( errorMessages ).every( ( message ) =>
-			hasEnTranslation( message.messageString )
-		);
-
-		if ( ! hasEnTranslationForAllMessages ) {
-			return translate( 'Please enter a valid website address. You can copy and paste.' );
-		}
-
-		const missingTLDRegex = /^(?:https?:\/\/)?(?!.*\.[a-z]{2,})([a-zA-Z0-9-_]+)$/;
-		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-		const invalidURLProtocolRegex = /^(?!https?:\/\/)\S+:\/\//;
-		const invalidCharsRegex = /[^a-z0-9\-._~!$&'()*+,;:@/?=%[\]]/i;
-
-		const removedInitialDots = url.replace( 'www.', '' );
-
-		let errorMessage = errorMessages[ 'default' ].message;
-
-		if ( emailRegex.test( url ) ) {
-			errorMessage = errorMessages[ 'email' ].message;
-		} else if ( isIDN( url ) ) {
-			errorMessage = errorMessages[ 'idn-url' ].message;
-		} else if ( invalidCharsRegex.test( url ) ) {
-			errorMessage = errorMessages[ 'invalid-chars' ].message;
-		} else if ( missingTLDRegex.test( removedInitialDots ) ) {
-			errorMessage = errorMessages[ 'no-tld' ].message;
-		} else if ( invalidURLProtocolRegex.test( url ) ) {
-			errorMessage = errorMessages[ 'invalid-protocol' ].message;
-		}
-
-		return errorMessage;
 	}
 
 	function onChange( e: ChangeEvent< HTMLInputElement > ) {

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -193,7 +193,10 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 					<span className={ clsx( { 'is-error': showValidationMsg } ) }>
 						{ showValidationMsg && (
 							<>
-								<Icon icon={ info } size={ 20 } /> { validationMessage }
+								<Icon icon={ info } size={ 20 } />{ ' ' }
+								{ validationMessage
+									? validationMessage
+									: translate( 'Please enter a valid website address. You can copy and paste.' ) }
 							</>
 						) }
 					</span>

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -97,17 +97,17 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		},
 		'invalid-chars': {
 			message: translate(
-				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com)'
+				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).'
 			),
 			messageString:
-				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com)',
+				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).',
 		},
 		'invalid-protocol': {
 			message: translate(
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com)'
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).'
 			),
 			messageString:
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com)',
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).',
 		},
 		default: {
 			message: translate(

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, FormLabel } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { Icon, info } from '@wordpress/icons';
@@ -41,9 +42,11 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	} = props;
 
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const [ urlValue, setUrlValue ] = useState( '' );
 	const [ isValid, setIsValid ] = useState( false );
 	const [ submitted, setSubmitted ] = useState( false );
+	const [ validationMessage, setValidationMessage ] = useState( '' );
 	const lastInvalidValue = useRef< string | undefined >();
 	const showValidationMsg = hasError || ( submitted && ! isValid );
 	const { search } = useLocation();
@@ -72,6 +75,78 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	function validateUrl( url: string ) {
 		const isValid = CAPTURE_URL_RGX.test( url );
 		setIsValid( isValid );
+		const tempValidationMessage = isValid ? '' : getValidationMessage( url );
+		setValidationMessage( tempValidationMessage );
+	}
+
+	// TODO: Just return the translated string directly from getValidationMessage once we have translations for all messages.
+	const errorMessages = {
+		'no-tld': {
+			message: translate(
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
+			),
+			messageString:
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com',
+		},
+		email: {
+			message: translate(
+				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).'
+			),
+			messageString:
+				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).',
+		},
+		'invalid-chars': {
+			message: translate(
+				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com)'
+			),
+			messageString:
+				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com)',
+		},
+		'invalid-protocol': {
+			message: translate(
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com)'
+			),
+			messageString:
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com)',
+		},
+		default: {
+			message: translate(
+				'Please enter a valid website address (e.g., example.com). You can copy and paste.'
+			),
+			messageString:
+				'Please enter a valid website address (e.g., example.com). You can copy and paste.',
+		},
+	};
+
+	function getValidationMessage( url ) {
+		const hasEnTranslationForAllMessages = Object.values( errorMessages ).every( ( message ) =>
+			hasEnTranslation( message.messageString )
+		);
+
+		if ( ! hasEnTranslationForAllMessages ) {
+			return translate( 'Please enter a valid website address. You can copy and paste.' );
+		}
+
+		const missingTLDRegex = /^(?:https?:\/\/)?(?!.*\.[a-z]{2,})([a-zA-Z0-9-_]+)$/;
+		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+		const invalidURLProtocolRegex = /^(?!https?:\/\/)\S+:\/\//;
+		const invalidCharsRegex = /[^a-z0-9\-._~!$&'()*+,;:@/?=%[\]]/i;
+
+		const removedInitialDots = url.replace( 'www.', '' );
+
+		let errorMessage = errorMessages[ 'default' ].message;
+
+		if ( emailRegex.test( url ) ) {
+			errorMessage = errorMessages[ 'email' ].message;
+		} else if ( invalidCharsRegex.test( url ) ) {
+			errorMessage = errorMessages[ 'invalid-chars' ].message;
+		} else if ( missingTLDRegex.test( removedInitialDots ) ) {
+			errorMessage = errorMessages[ 'no-tld' ].message;
+		} else if ( invalidURLProtocolRegex.test( url ) ) {
+			errorMessage = errorMessages[ 'invalid-protocol' ].message;
+		}
+
+		return errorMessage;
 	}
 
 	function onChange( e: ChangeEvent< HTMLInputElement > ) {
@@ -118,8 +193,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 					<span className={ clsx( { 'is-error': showValidationMsg } ) }>
 						{ showValidationMsg && (
 							<>
-								<Icon icon={ info } size={ 20 } />{ ' ' }
-								{ translate( 'Please enter a valid website address. You can copy and paste.' ) }
+								<Icon icon={ info } size={ 20 } /> { validationMessage }
 							</>
 						) }
 					</span>

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -72,7 +72,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		}
 	}
 
-	function isIDN( url ) {
+	function isIDN( url: string ) {
 		try {
 			// Regex to extract the hostname from the URL.
 			const urlRegex = /^(?:https?:\/\/)?(?:www\.)?([^/]+)/i;

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, FormLabel } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { Icon, info } from '@wordpress/icons';
@@ -43,7 +42,6 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	} = props;
 
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
 	const [ urlValue, setUrlValue ] = useState( '' );
 	const [ isValid, setIsValid ] = useState( false );
 	const [ submitted, setSubmitted ] = useState( false );
@@ -76,9 +74,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	function validateUrl( url: string ) {
 		const isValid = CAPTURE_URL_RGX.test( url );
 		setIsValid( isValid );
-		const tempValidationMessage = isValid
-			? ''
-			: getValidationMessage( url, translate, hasEnTranslation );
+		const tempValidationMessage = isValid ? '' : getValidationMessage( url, translate );
 		setValidationMessage( tempValidationMessage );
 	}
 

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -72,6 +72,35 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		}
 	}
 
+	function isIDN( url ) {
+		try {
+			// Regex to extract the hostname from the URL.
+			const urlRegex = /^(?:https?:\/\/)?(?:www\.)?([^/]+)/i;
+			const match = url.match( urlRegex );
+
+			if ( ! match ) {
+				return false;
+			}
+
+			// Extract the hostname.
+			const hostname = match[ 1 ];
+
+			// Check for non-ASCII characters
+			for ( let i = 0; i < hostname.length; i++ ) {
+				if ( hostname.charCodeAt( i ) > 127 ) {
+					return true;
+				}
+			}
+
+			// Check if the hostname starts with the Punycode prefix.
+			if ( hostname.startsWith( 'xn--' ) ) {
+				return true;
+			}
+		} catch ( e ) {
+			return false;
+		}
+	}
+
 	function validateUrl( url: string ) {
 		const isValid = CAPTURE_URL_RGX.test( url );
 		setIsValid( isValid );
@@ -109,6 +138,13 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 			messageString:
 				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).',
 		},
+		'idn-url': {
+			message: translate(
+				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).'
+			),
+			messageString:
+				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).',
+		},
 		default: {
 			message: translate(
 				'Please enter a valid website address (e.g., example.com). You can copy and paste.'
@@ -144,6 +180,8 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 			errorMessage = errorMessages[ 'no-tld' ].message;
 		} else if ( invalidURLProtocolRegex.test( url ) ) {
 			errorMessage = errorMessages[ 'invalid-protocol' ].message;
+		} else if ( isIDN( url ) ) {
+			errorMessage = errorMessages[ 'idn-url' ].message;
 		}
 
 		return errorMessage;

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -174,14 +174,14 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 
 		if ( emailRegex.test( url ) ) {
 			errorMessage = errorMessages[ 'email' ].message;
+		} else if ( isIDN( url ) ) {
+			errorMessage = errorMessages[ 'idn-url' ].message;
 		} else if ( invalidCharsRegex.test( url ) ) {
 			errorMessage = errorMessages[ 'invalid-chars' ].message;
 		} else if ( missingTLDRegex.test( removedInitialDots ) ) {
 			errorMessage = errorMessages[ 'no-tld' ].message;
 		} else if ( invalidURLProtocolRegex.test( url ) ) {
 			errorMessage = errorMessages[ 'invalid-protocol' ].message;
-		} else if ( isIDN( url ) ) {
-			errorMessage = errorMessages[ 'idn-url' ].message;
 		}
 
 		return errorMessage;

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -118,7 +118,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		},
 	};
 
-	function getValidationMessage( url ) {
+	function getValidationMessage( url: string ) {
 		const hasEnTranslationForAllMessages = Object.values( errorMessages ).every( ( message ) =>
 			hasEnTranslation( message.messageString )
 		);

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -151,6 +151,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 
 	function onChange( e: ChangeEvent< HTMLInputElement > ) {
 		const trimmedValue = e.target.value.trim();
+		setSubmitted( false );
 		setUrlValue( trimmedValue );
 		validateUrl( trimmedValue );
 		onInputChange?.( trimmedValue );

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -85,4 +85,23 @@ describe( 'CaptureInput', () => {
 
 		expect( screen.getByRole( 'button', { name: /XYZ/ } ) ).toBeInTheDocument();
 	} );
+
+	it( 'should show no TLD error', async () => {
+		const onInputEnter = jest.fn();
+		const { getByText } = render(
+			<MemoryRouter>
+				<CaptureInput onInputEnter={ onInputEnter } />
+			</MemoryRouter>
+		);
+
+		await userEvent.type( screen.getByLabelText( /Enter the URL of the site/ ), 'myblog' );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect(
+			getByText(
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
+			)
+		).toBeInTheDocument();
+	} );
 } );

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -201,6 +201,26 @@ describe( 'URL Validation', () => {
 		).toBeInTheDocument();
 	} );
 
+	test( 'should show IDN error message for punycode IDNs', async () => {
+		await enterUrlAndContinue( 'https://xn--example.com' );
+
+		expect(
+			screen.getByText(
+				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'should show IDN error message for unicode IDNs', async () => {
+		await enterUrlAndContinue( 'www.例子.测试' );
+
+		expect(
+			screen.getByText(
+				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).'
+			)
+		).toBeInTheDocument();
+	} );
+
 	test( 'should show default error message', async () => {
 		await enterUrlAndContinue( 'example.com-' );
 

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -176,7 +176,7 @@ describe( 'URL Validation', () => {
 
 		expect(
 			screen.getByText(
-				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com)'
+				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).'
 			)
 		).toBeInTheDocument();
 	} );
@@ -186,7 +186,7 @@ describe( 'URL Validation', () => {
 
 		expect(
 			screen.getByText(
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com)'
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).'
 			)
 		).toBeInTheDocument();
 	} );
@@ -196,7 +196,7 @@ describe( 'URL Validation', () => {
 
 		expect(
 			screen.getByText(
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com)'
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).'
 			)
 		).toBeInTheDocument();
 	} );

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -112,22 +112,22 @@ describe( 'URL Validation', () => {
 		{
 			input: 'ftp://example.com',
 			error:
-				"URLs usually start with http:// or https://, but it looks like you might have used something different (like file:// or localhost://). Please try again with something similar to 'https://example.com'",
+				"URLs usually start with http:// or https:// (rather than file:/, ftp://, or similar). Please try again with a URL like 'https://example.com'.",
 		},
 		{
 			input: 'file:///C:/DEVELOPER/index.html',
 			error:
-				"URLs usually start with http:// or https://, but it looks like you might have used something different (like file:// or localhost://). Please try again with something similar to 'https://example.com'",
+				"URLs usually start with http:// or https:// (rather than file:/, ftp://, or similar). Please try again with a URL like 'https://example.com'.",
 		},
 		{
 			input: 'https://xn--example.com',
 			error:
-				'Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like ‘example.com’).',
+				"Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like 'example.com').",
 		},
 		{
 			input: 'www.例子.测试',
 			error:
-				'Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like ‘example.com’).',
+				"Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like 'example.com').",
 		},
 		{
 			input: 'example.com-',

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -124,3 +124,90 @@ describe( 'CaptureInput', () => {
 		).toBeInTheDocument();
 	} );
 } );
+
+// Helper function to enter URL and click CTA.
+const enterUrlAndContinue = async ( url ) => {
+	await userEvent.type( screen.getByLabelText( /Enter the URL of the site/ ), url );
+	await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+};
+
+describe( 'URL Validation', () => {
+	beforeEach( () => {
+		const onInputEnter = jest.fn();
+		render(
+			<MemoryRouter>
+				<CaptureInput onInputEnter={ onInputEnter } />
+			</MemoryRouter>
+		);
+	} );
+
+	test( 'should show error for missing top-level domain', async () => {
+		await enterUrlAndContinue( 'myblog' );
+
+		expect(
+			screen.getByText(
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'should show error for missing top-level domain event when protocol is present', async () => {
+		await enterUrlAndContinue( 'https://myblog' );
+
+		expect(
+			screen.getByText(
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'should show error for email instead of URL', async () => {
+		await enterUrlAndContinue( 'user@example.com' );
+
+		expect(
+			screen.getByText(
+				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'should show error for URL with invalid characters', async () => {
+		await enterUrlAndContinue( 'http://my^blog.com' );
+
+		expect(
+			screen.getByText(
+				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com)'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'should show error for invalid protocol', async () => {
+		await enterUrlAndContinue( 'ftp://example.com' );
+
+		expect(
+			screen.getByText(
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com)'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'should show error for invalid protocol for filepath', async () => {
+		await enterUrlAndContinue( 'file:///C:/DEVELOPER/index.html' );
+
+		expect(
+			screen.getByText(
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com)'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'should show default error message', async () => {
+		await enterUrlAndContinue( 'invalid-url' );
+
+		expect(
+			screen.getByText(
+				'Please enter a valid website address (e.g., example.com). You can copy and paste.'
+			)
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -85,149 +85,65 @@ describe( 'CaptureInput', () => {
 
 		expect( screen.getByRole( 'button', { name: /XYZ/ } ) ).toBeInTheDocument();
 	} );
-
-	it( 'should show no TLD error', async () => {
-		const onInputEnter = jest.fn();
-		const { getByText } = render(
-			<MemoryRouter>
-				<CaptureInput onInputEnter={ onInputEnter } />
-			</MemoryRouter>
-		);
-
-		await userEvent.type( screen.getByLabelText( /Enter the URL of the site/ ), 'myblog' );
-
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
-
-		expect(
-			getByText(
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
-			)
-		).toBeInTheDocument();
-	} );
-
-	it( 'should show no TLD error for URL with protocol', async () => {
-		const onInputEnter = jest.fn();
-		const { getByText } = render(
-			<MemoryRouter>
-				<CaptureInput onInputEnter={ onInputEnter } />
-			</MemoryRouter>
-		);
-
-		await userEvent.type( screen.getByLabelText( /Enter the URL of the site/ ), 'https://myblog' );
-
-		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
-
-		expect(
-			getByText(
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
-			)
-		).toBeInTheDocument();
-	} );
 } );
 
-// Helper function to enter URL and click CTA.
-const enterUrlAndContinue = async ( url ) => {
-	await userEvent.type( screen.getByLabelText( /Enter the URL of the site/ ), url );
-	await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
-};
-
 describe( 'URL Validation', () => {
-	beforeEach( () => {
+	it.each( [
+		{
+			input: 'myblog',
+			error:
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com',
+		},
+		{
+			input: 'https://myblog',
+			error:
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com',
+		},
+		{
+			input: 'user@example.com',
+			error:
+				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).',
+		},
+		{
+			input: 'http://my^blog.com',
+			error:
+				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).',
+		},
+		{
+			input: 'ftp://example.com',
+			error:
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).',
+		},
+		{
+			input: 'file:///C:/DEVELOPER/index.html',
+			error:
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).',
+		},
+		{
+			input: 'https://xn--example.com',
+			error:
+				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).',
+		},
+		{
+			input: 'www.例子.测试',
+			error:
+				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).',
+		},
+		{
+			input: 'example.com-',
+			error: 'Please enter a valid website address (e.g., example.com). You can copy and paste.',
+		},
+	] )( 'shows error message "$error" when input URL is "$input"', async ( { input, error } ) => {
 		const onInputEnter = jest.fn();
 		render(
 			<MemoryRouter>
 				<CaptureInput onInputEnter={ onInputEnter } />
 			</MemoryRouter>
 		);
-	} );
 
-	test( 'should show error for missing top-level domain', async () => {
-		await enterUrlAndContinue( 'myblog' );
+		await userEvent.type( screen.getByLabelText( /Enter the URL of the site/ ), input );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
 
-		expect(
-			screen.getByText(
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
-			)
-		).toBeInTheDocument();
-	} );
-
-	test( 'should show error for missing top-level domain event when protocol is present', async () => {
-		await enterUrlAndContinue( 'https://myblog' );
-
-		expect(
-			screen.getByText(
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
-			)
-		).toBeInTheDocument();
-	} );
-
-	test( 'should show error for email instead of URL', async () => {
-		await enterUrlAndContinue( 'user@example.com' );
-
-		expect(
-			screen.getByText(
-				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).'
-			)
-		).toBeInTheDocument();
-	} );
-
-	test( 'should show error for URL with invalid characters', async () => {
-		await enterUrlAndContinue( 'http://my^blog.com' );
-
-		expect(
-			screen.getByText(
-				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).'
-			)
-		).toBeInTheDocument();
-	} );
-
-	test( 'should show error for invalid protocol', async () => {
-		await enterUrlAndContinue( 'ftp://example.com' );
-
-		expect(
-			screen.getByText(
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).'
-			)
-		).toBeInTheDocument();
-	} );
-
-	test( 'should show error for invalid protocol for filepath', async () => {
-		await enterUrlAndContinue( 'file:///C:/DEVELOPER/index.html' );
-
-		expect(
-			screen.getByText(
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).'
-			)
-		).toBeInTheDocument();
-	} );
-
-	test( 'should show IDN error message for punycode IDNs', async () => {
-		await enterUrlAndContinue( 'https://xn--example.com' );
-
-		expect(
-			screen.getByText(
-				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).'
-			)
-		).toBeInTheDocument();
-	} );
-
-	test( 'should show IDN error message for unicode IDNs', async () => {
-		await enterUrlAndContinue( 'www.例子.测试' );
-
-		expect(
-			screen.getByText(
-				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).'
-			)
-		).toBeInTheDocument();
-	} );
-
-	test( 'should show default error message', async () => {
-		await enterUrlAndContinue( 'example.com-' );
-
-		expect(
-			screen.getByText(
-				'Please enter a valid website address (e.g., example.com). You can copy and paste.'
-			)
-		).toBeInTheDocument();
+		expect( screen.getByText( error ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -92,32 +92,32 @@ describe( 'URL Validation', () => {
 		{
 			input: 'myblog',
 			error:
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com',
+				"Looks like your site address is missing its domain extension. Please try again with something like 'example.com' or 'example.net'.",
 		},
 		{
 			input: 'https://myblog',
 			error:
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com',
+				"Looks like your site address is missing its domain extension. Please try again with something like 'example.com' or 'example.net'.",
 		},
 		{
 			input: 'user@example.com',
 			error:
-				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).',
+				"Looks like you might have added an email address. Please use a URL instead, like 'example.com'.",
 		},
 		{
 			input: 'http://my^blog.com',
 			error:
-				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).',
+				'Looks like your URL has some invalid characters (like ~ or ^). Please delete them and try again.',
 		},
 		{
 			input: 'ftp://example.com',
 			error:
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).',
+				"URLs usually start with http:// or https://, but it looks like you might have used something different (like file:// or localhost://). Please try again with something similar to 'https://example.com'",
 		},
 		{
 			input: 'file:///C:/DEVELOPER/index.html',
 			error:
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).',
+				"URLs usually start with http:// or https://, but it looks like you might have used something different (like file:// or localhost://). Please try again with something similar to 'https://example.com'",
 		},
 		{
 			input: 'https://xn--example.com',
@@ -131,7 +131,8 @@ describe( 'URL Validation', () => {
 		},
 		{
 			input: 'example.com-',
-			error: 'Please enter a valid website address (e.g., example.com). You can copy and paste.',
+			error:
+				"Please add a valid website address (like 'example.com'). Feel free to copy and paste it in if that helps.",
 		},
 	] )( 'shows error message "$error" when input URL is "$input"', async ( { input, error } ) => {
 		const onInputEnter = jest.fn();

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -104,4 +104,23 @@ describe( 'CaptureInput', () => {
 			)
 		).toBeInTheDocument();
 	} );
+
+	it( 'should show no TLD error for URL with protocol', async () => {
+		const onInputEnter = jest.fn();
+		const { getByText } = render(
+			<MemoryRouter>
+				<CaptureInput onInputEnter={ onInputEnter } />
+			</MemoryRouter>
+		);
+
+		await userEvent.type( screen.getByLabelText( /Enter the URL of the site/ ), 'https://myblog' );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect(
+			getByText(
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
+			)
+		).toBeInTheDocument();
+	} );
 } );

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -202,7 +202,7 @@ describe( 'URL Validation', () => {
 	} );
 
 	test( 'should show default error message', async () => {
-		await enterUrlAndContinue( 'invalid-url' );
+		await enterUrlAndContinue( 'example.com-' );
 
 		expect(
 			screen.getByText(

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -122,12 +122,12 @@ describe( 'URL Validation', () => {
 		{
 			input: 'https://xn--example.com',
 			error:
-				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).',
+				'Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like ‘example.com’).',
 		},
 		{
 			input: 'www.例子.测试',
 			error:
-				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).',
+				'Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like ‘example.com’).',
 		},
 		{
 			input: 'example.com-',

--- a/client/blocks/import/capture/url-validation-message-helper.ts
+++ b/client/blocks/import/capture/url-validation-message-helper.ts
@@ -33,10 +33,10 @@ function getErrorMessages(
 		},
 		'idn-url': {
 			message: translate(
-				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).'
+				'Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like ‘example.com’).'
 			),
 			messageString:
-				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).',
+				'Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like ‘example.com’).',
 		},
 		default: {
 			message: translate(

--- a/client/blocks/import/capture/url-validation-message-helper.ts
+++ b/client/blocks/import/capture/url-validation-message-helper.ts
@@ -38,7 +38,7 @@ export default function getValidationMessage( url: string, translate: ( key: str
 	const missingTLDRegex = /^(?:https?:\/\/)?(?!.*\.[a-z]{2,})([a-zA-Z0-9-_]+)$/;
 	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 	const invalidURLProtocolRegex = /^(?!https?:\/\/)\S+:\/\//;
-	const invalidCharsRegex = /[^a-z0-9\-._~!$&'()*+,;:@/?=%[\]]/i;
+	const invalidCharsRegex = /[^a-z0-9\-._!$&'()*+,;:@/?=%[\]]/i;
 
 	const removedInitialDots = url.replace( 'www.', '' );
 

--- a/client/blocks/import/capture/url-validation-message-helper.ts
+++ b/client/blocks/import/capture/url-validation-message-helper.ts
@@ -1,4 +1,6 @@
-function getErrorMessages( translate: ( key: string ) => string ): object {
+function getErrorMessages(
+	translate: ( key: string ) => string
+): Record< string, { message: string; messageString: string } > {
 	// TODO: Just return the translated string directly from getValidationMessage once we have translations for all messages.
 	return {
 		'no-tld': {

--- a/client/blocks/import/capture/url-validation-message-helper.ts
+++ b/client/blocks/import/capture/url-validation-message-helper.ts
@@ -1,53 +1,3 @@
-function getErrorMessages(
-	translate: ( key: string ) => string
-): Record< string, { message: string; messageString: string } > {
-	// TODO: Just return the translated string directly from getValidationMessage once we have translations for all messages.
-	return {
-		'no-tld': {
-			message: translate(
-				"Looks like your site address is missing its domain extension. Please try again with something like 'example.com' or 'example.net'."
-			),
-			messageString:
-				"Looks like your site address is missing its domain extension. Please try again with something like 'example.com' or 'example.net'.",
-		},
-		email: {
-			message: translate(
-				"Looks like you might have added an email address. Please use a URL instead, like 'example.com'."
-			),
-			messageString:
-				"Looks like you might have added an email address. Please use a URL instead, like 'example.com'.",
-		},
-		'invalid-chars': {
-			message: translate(
-				'Looks like your URL has some invalid characters (like ~ or ^). Please delete them and try again.'
-			),
-			messageString:
-				'Looks like your URL has some invalid characters (like ~ or ^). Please delete them and try again.',
-		},
-		'invalid-protocol': {
-			message: translate(
-				"URLs usually start with http:// or https:// (rather than file:/, ftp://, or similar). Please try again with a URL like 'https://example.com'."
-			),
-			messageString:
-				"URLs usually start with http:// or https:// (rather than file:/, ftp://, or similar). Please try again with a URL like 'https://example.com'.",
-		},
-		'idn-url': {
-			message: translate(
-				"Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like 'example.com')."
-			),
-			messageString:
-				"Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like 'example.com').",
-		},
-		default: {
-			message: translate(
-				"Please add a valid website address (like 'example.com'). Feel free to copy and paste it in if that helps."
-			),
-			messageString:
-				"Please add a valid website address (like 'example.com'). Feel free to copy and paste it in if that helps.",
-		},
-	};
-}
-
 function isIDN( url: string ): boolean {
 	try {
 		// Regex to extract the hostname from the URL.
@@ -84,20 +34,7 @@ function isIDN( url: string ): boolean {
  *
  * @return {string} The validation message for the given URL.
  */
-export default function getValidationMessage(
-	url: string,
-	translate: ( key: string ) => string,
-	hasEnTranslation: ( key: string ) => boolean
-) {
-	const errorMessages = getErrorMessages( translate );
-	const hasEnTranslationForAllMessages = Object.values( errorMessages ).every( ( message ) =>
-		hasEnTranslation( message.messageString )
-	);
-
-	if ( ! hasEnTranslationForAllMessages ) {
-		return translate( 'Please enter a valid website address. You can copy and paste.' );
-	}
-
+export default function getValidationMessage( url: string, translate: ( key: string ) => string ) {
 	const missingTLDRegex = /^(?:https?:\/\/)?(?!.*\.[a-z]{2,})([a-zA-Z0-9-_]+)$/;
 	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 	const invalidURLProtocolRegex = /^(?!https?:\/\/)\S+:\/\//;
@@ -105,18 +42,30 @@ export default function getValidationMessage(
 
 	const removedInitialDots = url.replace( 'www.', '' );
 
-	let errorMessage = errorMessages[ 'default' ].message;
+	let errorMessage = translate(
+		"Please add a valid website address (like 'example.com'). Feel free to copy and paste it in if that helps."
+	);
 
 	if ( emailRegex.test( url ) ) {
-		errorMessage = errorMessages[ 'email' ].message;
+		errorMessage = translate(
+			"Looks like you might have added an email address. Please use a URL instead, like 'example.com'."
+		);
 	} else if ( isIDN( url ) ) {
-		errorMessage = errorMessages[ 'idn-url' ].message;
+		errorMessage = translate(
+			"Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like 'example.com')."
+		);
 	} else if ( invalidCharsRegex.test( url ) ) {
-		errorMessage = errorMessages[ 'invalid-chars' ].message;
+		errorMessage = translate(
+			'Looks like your URL has some invalid characters (like ~ or ^). Please delete them and try again.'
+		);
 	} else if ( missingTLDRegex.test( removedInitialDots ) ) {
-		errorMessage = errorMessages[ 'no-tld' ].message;
+		errorMessage = translate(
+			"Looks like your site address is missing its domain extension. Please try again with something like 'example.com' or 'example.net'."
+		);
 	} else if ( invalidURLProtocolRegex.test( url ) ) {
-		errorMessage = errorMessages[ 'invalid-protocol' ].message;
+		errorMessage = translate(
+			"URLs usually start with http:// or https:// (rather than file:/, ftp://, or similar). Please try again with a URL like 'https://example.com'."
+		);
 	}
 
 	return errorMessage;

--- a/client/blocks/import/capture/url-validation-message-helper.ts
+++ b/client/blocks/import/capture/url-validation-message-helper.ts
@@ -5,31 +5,31 @@ function getErrorMessages(
 	return {
 		'no-tld': {
 			message: translate(
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
+				"Looks like your site address is missing its domain extension. Please try again with something like 'example.com' or 'example.net'."
 			),
 			messageString:
-				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com',
+				"Looks like your site address is missing its domain extension. Please try again with something like 'example.com' or 'example.net'.",
 		},
 		email: {
 			message: translate(
-				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).'
+				"Looks like you might have added an email address. Please use a URL instead, like 'example.com'."
 			),
 			messageString:
-				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).',
+				"Looks like you might have added an email address. Please use a URL instead, like 'example.com'.",
 		},
 		'invalid-chars': {
 			message: translate(
-				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).'
+				'Looks like your URL has some invalid characters (like ~ or ^). Please delete them and try again.'
 			),
 			messageString:
-				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).',
+				'Looks like your URL has some invalid characters (like ~ or ^). Please delete them and try again.',
 		},
 		'invalid-protocol': {
 			message: translate(
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).'
+				"URLs usually start with http:// or https://, but it looks like you might have used something different (like file:// or localhost://). Please try again with something similar to 'https://example.com'"
 			),
 			messageString:
-				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).',
+				"URLs usually start with http:// or https://, but it looks like you might have used something different (like file:// or localhost://). Please try again with something similar to 'https://example.com'",
 		},
 		'idn-url': {
 			message: translate(
@@ -40,10 +40,10 @@ function getErrorMessages(
 		},
 		default: {
 			message: translate(
-				'Please enter a valid website address (e.g., example.com). You can copy and paste.'
+				"Please add a valid website address (like 'example.com'). Feel free to copy and paste it in if that helps."
 			),
 			messageString:
-				'Please enter a valid website address (e.g., example.com). You can copy and paste.',
+				"Please add a valid website address (like 'example.com'). Feel free to copy and paste it in if that helps.",
 		},
 	};
 }

--- a/client/blocks/import/capture/url-validation-message-helper.ts
+++ b/client/blocks/import/capture/url-validation-message-helper.ts
@@ -1,0 +1,121 @@
+function getErrorMessages( translate: ( key: string ) => string ): object {
+	// TODO: Just return the translated string directly from getValidationMessage once we have translations for all messages.
+	return {
+		'no-tld': {
+			message: translate(
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com'
+			),
+			messageString:
+				'Your URL is missing a top-level domain (e.g., .com, .net, etc.). Example URL: example.com',
+		},
+		email: {
+			message: translate(
+				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).'
+			),
+			messageString:
+				'It looks like you’ve entered an email address. Please enter a valid URL instead (e.g., example.com).',
+		},
+		'invalid-chars': {
+			message: translate(
+				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).'
+			),
+			messageString:
+				'URL contains invalid characters. Please remove special characters and enter a valid URL (e.g., example.com).',
+		},
+		'invalid-protocol': {
+			message: translate(
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).'
+			),
+			messageString:
+				'URLs with protocols can only start with http:// or https:// (e.g., https://example.com).',
+		},
+		'idn-url': {
+			message: translate(
+				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).'
+			),
+			messageString:
+				'Looks like you’ve entered an internationalized domain name (IDN). Please enter a standard URL instead (e.g., example.com).',
+		},
+		default: {
+			message: translate(
+				'Please enter a valid website address (e.g., example.com). You can copy and paste.'
+			),
+			messageString:
+				'Please enter a valid website address (e.g., example.com). You can copy and paste.',
+		},
+	};
+}
+
+function isIDN( url: string ): boolean {
+	try {
+		// Regex to extract the hostname from the URL.
+		const urlRegex = /^(?:https?:\/\/)?(?:www\.)?([^/]+)/i;
+		const match = url.match( urlRegex );
+
+		if ( ! match ) {
+			return false;
+		}
+
+		// Extract the hostname.
+		const hostname = match[ 1 ];
+
+		// Check for non-ASCII characters
+		for ( let i = 0; i < hostname.length; i++ ) {
+			if ( hostname.charCodeAt( i ) > 127 ) {
+				return true;
+			}
+		}
+
+		// Check if the hostname starts with the Punycode prefix.
+		return hostname.startsWith( 'xn--' );
+	} catch ( e ) {
+		return false;
+	}
+}
+
+/*
+ * Get the validation message for the given URL.
+ *
+ * @param {string} url The URL to validate.
+ * @param {Function} translate The translation function.
+ * @param {Function} hasEnTranslation The function to check if a translation key has an English translation.
+ *
+ * @return {string} The validation message for the given URL.
+ */
+export default function getValidationMessage(
+	url: string,
+	translate: ( key: string ) => string,
+	hasEnTranslation: ( key: string ) => boolean
+) {
+	const errorMessages = getErrorMessages( translate );
+	const hasEnTranslationForAllMessages = Object.values( errorMessages ).every( ( message ) =>
+		hasEnTranslation( message.messageString )
+	);
+
+	if ( ! hasEnTranslationForAllMessages ) {
+		return translate( 'Please enter a valid website address. You can copy and paste.' );
+	}
+
+	const missingTLDRegex = /^(?:https?:\/\/)?(?!.*\.[a-z]{2,})([a-zA-Z0-9-_]+)$/;
+	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+	const invalidURLProtocolRegex = /^(?!https?:\/\/)\S+:\/\//;
+	const invalidCharsRegex = /[^a-z0-9\-._~!$&'()*+,;:@/?=%[\]]/i;
+
+	const removedInitialDots = url.replace( 'www.', '' );
+
+	let errorMessage = errorMessages[ 'default' ].message;
+
+	if ( emailRegex.test( url ) ) {
+		errorMessage = errorMessages[ 'email' ].message;
+	} else if ( isIDN( url ) ) {
+		errorMessage = errorMessages[ 'idn-url' ].message;
+	} else if ( invalidCharsRegex.test( url ) ) {
+		errorMessage = errorMessages[ 'invalid-chars' ].message;
+	} else if ( missingTLDRegex.test( removedInitialDots ) ) {
+		errorMessage = errorMessages[ 'no-tld' ].message;
+	} else if ( invalidURLProtocolRegex.test( url ) ) {
+		errorMessage = errorMessages[ 'invalid-protocol' ].message;
+	}
+
+	return errorMessage;
+}

--- a/client/blocks/import/capture/url-validation-message-helper.ts
+++ b/client/blocks/import/capture/url-validation-message-helper.ts
@@ -26,17 +26,17 @@ function getErrorMessages(
 		},
 		'invalid-protocol': {
 			message: translate(
-				"URLs usually start with http:// or https://, but it looks like you might have used something different (like file:// or localhost://). Please try again with something similar to 'https://example.com'"
+				"URLs usually start with http:// or https:// (rather than file:/, ftp://, or similar). Please try again with a URL like 'https://example.com'."
 			),
 			messageString:
-				"URLs usually start with http:// or https://, but it looks like you might have used something different (like file:// or localhost://). Please try again with something similar to 'https://example.com'",
+				"URLs usually start with http:// or https:// (rather than file:/, ftp://, or similar). Please try again with a URL like 'https://example.com'.",
 		},
 		'idn-url': {
 			message: translate(
-				'Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like ‘example.com’).'
+				"Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like 'example.com')."
 			),
 			messageString:
-				'Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like ‘example.com’).',
+				"Looks like you’ve added an internationalized domain name. Please try a standard URL instead (like 'example.com').",
 		},
 		default: {
 			message: translate(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91479

## Proposed Changes

Added error-specific validation messages for the following scenarios.

1. Input is an Email
2. Input has invalid characters
3. Wrong Protocol (FTP://, file:// etc.)
4. Missing TLD
5. IDN URLs (Either has non ASCII characters in URL or hostname starts with xn--)
6. General error message for fallback

I have replaced "Incomplete URL Error" from the issue with Wrong Protocol because otherwise the error is too ambiguous and broad to detect. But I am a bit unsure about using the word "Protocol" in the error message, looks too technical. I only kept it because we show it only when the user has already used the wrong protocol and it conveys the exact reason. But LMK if you think a different and less technical message should be shown.

Also, detecting missing TLD is super tricky. For example, "test.com" is valid but "test.wpcomstaging" is not even though both of them has the same structure as a string. So it's not too correct when implemented with regex or some other way through code. But it should be helpful because our error log says users mostly write URLs like this "myblog" instead of "myblog.com" in which case, it'll be helpful.

Also, I've included an example of a valid URL with each error message to better convey to the user how a URL looks.

## Why are these changes being made?
To enable the user to better understand what's wrong with the URL they have input.

## Screenshots

![Screenshot 2024-06-18 at 7 58 38 AM](https://github.com/Automattic/wp-calypso/assets/1190420/f5011e43-b26b-47ee-8583-92f4ee430eb3)

![Screenshot 2024-06-18 at 7 59 14 AM](https://github.com/Automattic/wp-calypso/assets/1190420/89ac6da2-365d-4c79-8edc-a630d0645be3)

![Screenshot 2024-06-18 at 7 59 38 AM](https://github.com/Automattic/wp-calypso/assets/1190420/1388b421-64d0-47df-ab25-e338b9a09442)

![Screenshot 2024-06-18 at 8 00 05 AM](https://github.com/Automattic/wp-calypso/assets/1190420/52d4aadf-9d5e-492c-a0fc-dc4f6dfb9fc9)

![Screenshot 2024-06-18 at 8 00 32 AM](https://github.com/Automattic/wp-calypso/assets/1190420/e0612f33-b7a3-45b3-b21c-faf246908fd4)

![Screenshot 2024-06-18 at 8 01 10 AM](https://github.com/Automattic/wp-calypso/assets/1190420/7a0179c7-31a5-4c12-9e19-8d3ed34accfe)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure your language is English in https://wordpress.com/me/account
- In the migration flow (take any migration path, for example http://calypso.localhost:3000/start), navigate to the Site Identification step
- In the URL field, try different wrong URLs (Please check the **Proposed Changes** section above). For example - myblog, https://myblog, https://myblog^, email@myblog.com etc.
- You should see different error messages depending on the URL
- Change the language to some other language in `https://wordpress.com/me/account`
- Go to the site identification page and try different wrong URLs again
- Make sure you see the old error message

https://github.com/Automattic/wp-calypso/assets/6820724/4d46c197-2ac1-4ff6-98e7-d80b5034da9c

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?