### PR TITLE
A4A: Update the breakpoint for the Hosting card heading to avoid overlapping text.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -35,7 +35,8 @@
 		@include break-large {
 			height: 95px;
 		}
-		@include break-huge {
+
+		@include break-xhuge {
 			height: 65px;
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue with the Hosting card heading overlapping text to some screen sizes.

| Before | After |
|--------|--------|
| <img width="1158" alt="Screenshot 2024-06-13 at 3 33 28 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/2f154b89-6525-46a9-909f-6e028de4c0a5"> | <img width="1147" alt="Screenshot 2024-06-13 at 3 33 45 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b27f4029-5350-401e-b918-702b7142d01e"> | 

Fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/654

## Proposed Changes

* Adjust the breakpoint for the Hosting card heading element height variants to avoid overlapping text.


## Testing Instructions

* Use the A4A live link and go to `/marketplace/hosting`
* Try to resize your browser and test the responsiveness of the hosting card heading. (e.g. 1523 width)
* Confirm that the issue no longer occurs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
