### PR TITLE
Signup: remove config-related dead code

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -185,9 +185,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding',
-			steps: isEnabled( 'signup/professional-email-step' )
-				? [ userSocialStep, 'new-user-survey', 'domains', 'emails', 'plans' ]
-				: [ userSocialStep, 'new-user-survey', 'domains', 'plans' ],
+			steps: [ userSocialStep, 'new-user-survey', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2023-10-11',
@@ -210,9 +208,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding-2023-pricing-grid',
-			steps: isEnabled( 'signup/professional-email-step' )
-				? [ userSocialStep, 'domains', 'emails', 'plans' ]
-				: [ userSocialStep, 'domains', 'plans' ],
+			steps: [ userSocialStep, 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2023-10-11',
@@ -221,9 +217,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'domain-transfer',
-			steps: isEnabled( 'signup/professional-email-step' )
-				? [ userSocialStep, 'domains', 'emails', 'plans' ]
-				: [ userSocialStep, 'domains', 'plans' ],
+			steps: [ userSocialStep, 'domains', 'plans' ],
 			destination: ( dependencies ) => `/domains/manage/${ dependencies.siteSlug }`,
 			description:
 				'Onboarding flow specifically for domain transfers. Read more in https://wp.me/pdhack-Hk.',
@@ -264,9 +258,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'with-add-ons',
-			steps: isEnabled( 'signup/professional-email-step' )
-				? [ userSocialStep, 'domains', 'emails', 'plans', 'add-ons' ]
-				: [ userSocialStep, 'domains', 'plans', 'add-ons' ],
+			steps: [ userSocialStep, 'domains', 'plans', 'add-ons' ],
 			destination: getSignupDestination,
 			description:
 				'Copy of the onboarding flow that includes an add-ons step; the flow is used for AB testing (ExPlat) add-ons in signup',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The `signup/professional-email-step` flag has been set to false for some time now, so this PR cleans up `flows-pure.js` by removing those checks.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* pau2Xa-605-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* No functional changes, a code review should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?