### PR TITLE
A4A: Fix minor UI issues in the Need setup page.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -66,12 +66,15 @@ export default function NeedSetup() {
 	);
 
 	return (
-		<Layout className="sites-dashboard sites-dashboard__layout preview-hidden" wide title={ title }>
+		<Layout
+			className="sites-dashboard sites-dashboard__layout is-without-filters preview-hidden"
+			wide
+			title={ title }
+		>
 			<LayoutColumn className="sites-overview" wide>
 				<LayoutTop>
-					<div className="sites-overview__banner">
-						<PurchaseConfirmationMessage />
-					</div>
+					<PurchaseConfirmationMessage />
+
 					<LayoutHeader>
 						<Title>{ translate( 'Sites' ) }</Title>
 						<Actions>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
@@ -34,14 +34,16 @@ export default function PurchaseConfirmationMessage() {
 	}, [ dispatch, wpcomHostingPurchased ] );
 
 	return successNotification ? (
-		<NoticeBanner
-			level="success"
-			title={ translate( 'Congratulations on your WordPress.com purchase!' ) }
-			onClose={ () => setSuccessNotification( false ) }
-		>
-			{ translate(
-				'Set up your sites as you need them, in the “Needs setup” tab within the sites dashboard. Once set up, you can access each site under the “All” tab.'
-			) }
-		</NoticeBanner>
+		<div className="sites-overview__banner">
+			<NoticeBanner
+				level="success"
+				title={ translate( 'Congratulations on your WordPress.com purchase!' ) }
+				onClose={ () => setSuccessNotification( false ) }
+			>
+				{ translate(
+					'Set up your sites as you need them, in the “Needs setup” tab within the sites dashboard. Once set up, you can access each site under the “All” tab.'
+				) }
+			</NoticeBanner>
+		</div>
 	) : null;
 }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -62,3 +62,13 @@
 	margin-block-end: 24px;
 	padding-inline: 64px;
 }
+
+.sites-dashboard.is-without-filters {
+	.dataviews-view-table {
+		margin-block-start: 32px;
+	}
+
+	.dataviews-filters__view-actions {
+		display: none;
+	}
+}


### PR DESCRIPTION
This PR fixes a few issues in the `/sites/need-setup` page.

**Before**
![image](https://github.com/Automattic/wp-calypso/assets/56598660/2df2e955-a25b-4ba0-a426-51577b64066e)

**After**
<img width="1726" alt="Screenshot 2024-06-13 at 8 28 33 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0d4555d9-0366-4f1e-a213-208171b0eb49">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/632

## Proposed Changes

* Fix excessive spacing in the header caused by the banner container occupying space despite not displaying anything.
* Hide the View actions of the data view using CSS style.


## Testing Instructions

* Use the A4A live link and go to `/marketplace/hosting/wpcom`
* Purchase some plans.
* In the Need setup page.
* Confirm that the header no longer has extra spacing.
* Confirm that the view actions are no longer visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
