### PR TITLE
A4A: Update the WPCOM site creation link to redirect to the Site overview page.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -14,7 +14,10 @@ export default function ProvisioningSiteNotification( { siteId }: Props ) {
 
 	const translate = useTranslate();
 
-	const wpHomeUrl = `https://wordpress.com/home/${ site?.url?.replace( /(^\w+:|^)\/\//, '' ) }`;
+	const wpOverviewUrl = `https://wordpress.com/overview/${ site?.url?.replace(
+		/(^\w+:|^)\/\//,
+		''
+	) }`;
 
 	return (
 		showBanner && (
@@ -30,7 +33,7 @@ export default function ProvisioningSiteNotification( { siteId }: Props ) {
 				actions={
 					isReady
 						? [
-								<Button href={ wpHomeUrl } target="_blank" rel="noreferrer">
+								<Button href={ wpOverviewUrl } target="_blank" rel="noreferrer" primary>
 									{ translate( 'Set up your site' ) }
 								</Button>,
 						  ]
@@ -43,7 +46,7 @@ export default function ProvisioningSiteNotification( { siteId }: Props ) {
 							{
 								args: { siteURL: site?.url ?? '' },
 								components: {
-									a: <a href={ wpHomeUrl } target="_blank" rel="noreferrer" />,
+									a: <a href={ wpOverviewUrl } target="_blank" rel="noreferrer" />,
 								},
 								comment: 'The %(siteURL)s is the URL of the site that has been provisioned.',
 							}


### PR DESCRIPTION
This pull request updates the WPCOM site setup CTA button to redirect the user to the Overview page instead of the Home page.

<img width="2188" alt="Screenshot 2024-06-13 at 9 17 04 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f626a967-14d8-4a63-a2cf-f35388ac1114">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/662


## Proposed Changes

*  Update "Set up your site" CTA from My Home to Overview in a new tab.
* Change the "Set up your site" CTA to a primary call to action so it stands out more.


## Testing Instructions

* Use the A4A live link and go to `/marketplace/hosting/wpcom`.
* Purchase a plan.
* In the Need setup page. Provision 1 site. You will be redirected to the All Sites page.
* On the All Sites page, wait until the notification banner shows the site has been provisioned.
* Confirm that clicking the 'Set up your site' CTA button will redirect you to the WPCOM site's overview page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
