### PR TITLE
A4A > Referrals: Implement create site flow for referral

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
@@ -13,10 +13,12 @@ const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
 		const purchases = referral.products.map( ( product ) => ( {
 			...product,
 			status: referral.status,
+			referral_id: referral.id, // referral id is needed for the purchase to be unique
 		} ) );
 		if ( ! acc[ referral.client.id ] ) {
 			acc[ referral.client.id ] = {
-				id: referral.id,
+				// id is a combination of client id and referral id to make it unique
+				id: `${ referral.client.id }${ referral.id }`,
 				client: referral.client,
 				purchases: [ ...purchases ],
 				commissions: referral.commission,

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -8,13 +8,15 @@ interface ReferralPurchaseAPIResponse {
 }
 export interface ReferralPurchase extends ReferralPurchaseAPIResponse {
 	status: string;
+	referral_id: number;
+}
+export interface ReferralClient {
+	id: number;
+	email: string;
 }
 export interface Referral {
-	id: number;
-	client: {
-		id: number;
-		email: string;
-	};
+	id: string;
+	client: ReferralClient;
 	purchases: ReferralPurchase[];
 	commissions: number;
 	statuses: string[];
@@ -22,10 +24,7 @@ export interface Referral {
 
 export interface ReferralAPIResponse {
 	id: number;
-	client: {
-		id: number;
-		email: string;
-	};
+	client: ReferralClient;
 	products: ReferralPurchaseAPIResponse[];
 	commission: number;
 	status: string;

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -117,10 +117,11 @@ export const addSitesContext: Callback = ( context: Context, next ) => {
 
 export const needsSetupContext: Callback = ( context: Context, next ) => {
 	context.secondary = <SitesSidebar path={ context.path } />;
+	const { license_key } = context.query;
 	context.primary = (
 		<>
 			<PageViewTracker title="Sites > Needs Setup" path={ context.path } />
-			<NeedSetup />
+			<NeedSetup licenseKey={ license_key } />
 		</>
 	);
 

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/client-site.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/client-site.tsx
@@ -1,0 +1,35 @@
+import { Tooltip } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
+import type { ReferralAPIResponse } from '../../referrals/types';
+
+export default function ClientSite( { referral }: { referral: ReferralAPIResponse } ) {
+	const translate = useTranslate();
+
+	const tooltipRef = useRef( null );
+	const [ showTooltip, setShowTooltip ] = useState( false );
+
+	return (
+		<>
+			<div
+				onMouseEnter={ () => setShowTooltip( true ) }
+				onMouseLeave={ () => setShowTooltip( false ) }
+				onMouseDown={ () => setShowTooltip( false ) }
+				onTouchStart={ () => setShowTooltip( true ) }
+				role="button"
+				tabIndex={ 0 }
+				ref={ tooltipRef }
+			>
+				{ translate( '{{b}}%(email)s{{/b}} owns this', {
+					args: { email: referral.client.email },
+					components: {
+						b: <strong />,
+					},
+				} ) }
+			</div>
+			<Tooltip showOnMobile context={ tooltipRef.current } isVisible={ showTooltip }>
+				{ referral.client.email }
+			</Tooltip>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/plan-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/plan-field.tsx
@@ -1,10 +1,9 @@
-import { useTranslate } from 'i18n-calypso';
 import wpcomIcon from 'calypso/assets/images/icons/wordpress-logo.svg';
 import CreateSiteButton from './create-site-button';
 
 export type AvailablePlans = {
 	name: string;
-	available: number;
+	subTitle: React.ReactNode;
 	ids: number[];
 };
 
@@ -13,9 +12,7 @@ type Props = AvailablePlans & {
 	onCreateSite: ( id: number ) => void;
 };
 
-export default function PlanField( { name, available, ids, provisioning, onCreateSite }: Props ) {
-	const translate = useTranslate();
-
+export default function PlanField( { name, subTitle, ids, provisioning, onCreateSite }: Props ) {
 	return (
 		<div className="plan-field">
 			<div className="plan-field__icon">
@@ -24,15 +21,7 @@ export default function PlanField( { name, available, ids, provisioning, onCreat
 
 			<div className="plan-field__content">
 				<div className="plan-field__name">{ name }</div>
-				<div className="plan-field__sub">
-					{ translate( '%(count)d site available', '%(count)d sites available', {
-						args: {
-							count: available,
-						},
-						count: available,
-						comment: 'The `count` is the number of available sites.',
-					} ) }
-				</div>
+				<div className="plan-field__sub">{ subTitle }</div>
 			</div>
 
 			<CreateSiteButton

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -1,9 +1,17 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .plan-field {
 	display: flex;
 	flex-direction: row;
 	gap: 12px;
-
 	align-items: center;
+	padding-inline: 8px;
+	flex-wrap: wrap;
+
+	@include break-medium {
+		flex-wrap: unset;
+	}
 }
 
 .plan-field__icon {
@@ -36,11 +44,15 @@
 }
 
 .plan-field__button {
-	padding: 8px 16px;
+	padding: 1px;
 	text-decoration: underline;
 	font-size: rem(13px);
 	font-weight: 400;
 	cursor: pointer;
+
+	@include break-medium {
+		padding: 8px 16px;
+	}
 }
 
 .plan-field__loader {
@@ -70,5 +82,19 @@
 
 	.dataviews-filters__view-actions {
 		display: none;
+	}
+}
+
+.has-product-referral {
+	.plan-field__content {
+		width: 250px;
+
+		.plan-field__sub strong {
+			max-width: 250px;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			overflow: hidden;
+			display: block;
+		}
 	}
 }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -6,12 +6,6 @@
 	flex-direction: row;
 	gap: 12px;
 	align-items: center;
-	padding-inline: 8px;
-	flex-wrap: wrap;
-
-	@include break-medium {
-		flex-wrap: unset;
-	}
 }
 
 .plan-field__icon {
@@ -44,15 +38,11 @@
 }
 
 .plan-field__button {
-	padding: 1px;
+	padding: 8px 16px;
 	text-decoration: underline;
 	font-size: rem(13px);
 	font-weight: 400;
 	cursor: pointer;
-
-	@include break-medium {
-		padding: 8px 16px;
-	}
 }
 
 .plan-field__loader {
@@ -86,6 +76,23 @@
 }
 
 .has-product-referral {
+	.plan-field {
+		padding-inline: 8px;
+		flex-wrap: wrap;
+
+		@include break-medium {
+			flex-wrap: unset;
+		}
+	}
+
+	.plan-field__button {
+		padding: 1px;
+
+		@include break-medium {
+			padding: 8px 16px;
+		}
+	}
+
 	.plan-field__content {
 		width: 250px;
 


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/382

## Proposed Changes

This PR implements create-site flow for referral

## Testing Instructions

1. Checkout to the branch locally and start the server.
2. Go to /sites/need-setup and verify that you can see the sites as expected by comparing it with the production version.
3. Add a hosting & product license by following all the steps here: https://github.com/Automattic/wp-calypso/pull/91713
4. Go to /referrals/dashboard > Click on the detailed view of the client you referred the products to > Click the `Create site` button > Clicking on the Create site should navigate you to the needs-setup page and the selected one is shown like below along with other licenses. 

<img width="597" alt="Screenshot 2024-06-13 at 5 01 26 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/98fc3495-9ade-4692-a25a-de2d6d25f829">

<img width="597" alt="Screenshot 2024-06-13 at 7 36 51 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d04ab3de-d8c5-45eb-be50-f594f0eb513b">

The license users want to assign should be shown on top if multiple client licenses exist.

<img width="857" alt="Screenshot 2024-06-17 at 12 59 20 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/fbdd34b5-8b0f-4a8f-90da-67ebbe32a1c4">

Mobile view:

<img width="322" alt="Screenshot 2024-06-17 at 5 38 22 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/daec86fd-850a-4c97-ac38-a85db83be682">

5. Purchases should show the site name once it is created. 

<img width="1001" alt="Screenshot 2024-06-13 at 7 41 57 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/dc3c059e-2b7b-4c7d-a5c9-a6ff4749a1d3">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
