### PR TITLE
Stats: Tweak logic for upgrade notices

### DIFF
--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -29,9 +29,8 @@ function shouldShowCommercialUpgradeNotice( props: StatsNoticeProps ) {
 		isCommercial,
 	} = props;
 
-	// Gate notices for WPCOM sites behind a flag.
-	const showUpgradeNoticeForWpcomSites =
-		config.isEnabled( 'stats/paid-wpcom-stats' ) && isWpcom && ! isP2 && ! isOwnedByTeam51;
+	// Test for WPCOM sites.
+	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
 
 	// Show the notice if the site is Jetpack or it is Odyssey Stats.
 	const showUpgradeNoticeOnOdyssey = isOdysseyStats;

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -41,6 +41,7 @@ function shouldShowCommercialUpgradeNotice( options: StatsNoticeProps ) {
 		if ( isCommercial && ! isCommercialOwned ) {
 			return true;
 		}
+		// Other cases fall through to existing behavour.
 	}
 
 	// Test for WPCOM sites.

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -14,7 +14,7 @@ type StatsNoticeType = {
 	disabled: boolean;
 };
 
-function shouldShowCommercialUpgradeNotice( props: StatsNoticeProps ) {
+function shouldShowCommercialUpgradeNotice( options: StatsNoticeProps ) {
 	// eslint-disable-next-line prefer-rest-params
 	console.log( 'arguments: ', arguments );
 	// Pull props.
@@ -28,7 +28,7 @@ function shouldShowCommercialUpgradeNotice( props: StatsNoticeProps ) {
 		isSiteJetpackNotAtomic,
 		isCommercial,
 		isCommercialOwned,
-	} = props;
+	} = options;
 
 	// Show notice for Jetpack-connected sites that are not Atomic AND
 	// they are classified as commercial but do not have a commercial license.

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -27,15 +27,24 @@ function shouldShowCommercialUpgradeNotice( props: StatsNoticeProps ) {
 		hasPaidStats,
 		isSiteJetpackNotAtomic,
 		isCommercial,
+		isCommercialOwned,
 	} = props;
+
+	// Show notice for Jetpack-connected sites that are not Atomic AND
+	// they are classified as commercial but do not have a commercial license.
+	const showUpgradeNoticeOnOdyssey = isOdysseyStats;
+	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
+	if ( showUpgradeNoticeOnOdyssey || showUpgradeNoticeForJetpackNotAtomic ) {
+		if ( isVip || isOwnedByTeam51 ) {
+			return false;
+		}
+		if ( isCommercial && ! isCommercialOwned ) {
+			return true;
+		}
+	}
 
 	// Test for WPCOM sites.
 	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
-
-	// Show the notice if the site is Jetpack or it is Odyssey Stats.
-	const showUpgradeNoticeOnOdyssey = isOdysseyStats;
-
-	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
 
 	return !! (
 		( showUpgradeNoticeOnOdyssey ||

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -15,8 +15,6 @@ type StatsNoticeType = {
 };
 
 function shouldShowCommercialUpgradeNotice( options: StatsNoticeProps ) {
-	// eslint-disable-next-line prefer-rest-params
-	console.log( 'arguments: ', arguments );
 	// Pull props.
 	const {
 		isOdysseyStats,

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -14,6 +14,42 @@ type StatsNoticeType = {
 	disabled: boolean;
 };
 
+function shouldShowCommercialUpgradeNotice( props: StatsNoticeProps ) {
+	// eslint-disable-next-line prefer-rest-params
+	console.log( 'arguments: ', arguments );
+	// Pull props.
+	const {
+		isOdysseyStats,
+		isWpcom,
+		isVip,
+		isP2,
+		isOwnedByTeam51,
+		hasPaidStats,
+		isSiteJetpackNotAtomic,
+		isCommercial,
+	} = props;
+
+	// Gate notices for WPCOM sites behind a flag.
+	const showUpgradeNoticeForWpcomSites =
+		config.isEnabled( 'stats/paid-wpcom-stats' ) && isWpcom && ! isP2 && ! isOwnedByTeam51;
+
+	// Show the notice if the site is Jetpack or it is Odyssey Stats.
+	const showUpgradeNoticeOnOdyssey = isOdysseyStats;
+
+	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
+
+	return !! (
+		( showUpgradeNoticeOnOdyssey ||
+			showUpgradeNoticeForJetpackNotAtomic ||
+			showUpgradeNoticeForWpcomSites ) &&
+		// Show the notice if the site has not purchased the paid stats product.
+		! hasPaidStats &&
+		// Show the notice only if the site is commercial.
+		isCommercial &&
+		! isVip
+	);
+}
+
 /** Sorted by priority */
 const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
@@ -33,36 +69,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: CommercialSiteUpgradeNotice,
 		noticeId: 'commercial_site_upgrade',
-		isVisibleFunc: ( {
-			isOdysseyStats,
-			isWpcom,
-			isVip,
-			isP2,
-			isOwnedByTeam51,
-			hasPaidStats,
-			isSiteJetpackNotAtomic,
-			isCommercial,
-		}: StatsNoticeProps ) => {
-			// Gate notices for WPCOM sites behind a flag.
-			const showUpgradeNoticeForWpcomSites =
-				config.isEnabled( 'stats/paid-wpcom-stats' ) && isWpcom && ! isP2 && ! isOwnedByTeam51;
-
-			// Show the notice if the site is Jetpack or it is Odyssey Stats.
-			const showUpgradeNoticeOnOdyssey = isOdysseyStats;
-
-			const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
-
-			return !! (
-				( showUpgradeNoticeOnOdyssey ||
-					showUpgradeNoticeForJetpackNotAtomic ||
-					showUpgradeNoticeForWpcomSites ) &&
-				// Show the notice if the site has not purchased the paid stats product.
-				! hasPaidStats &&
-				// Show the notice only if the site is commercial.
-				isCommercial &&
-				! isVip
-			);
-		},
+		isVisibleFunc: shouldShowCommercialUpgradeNotice,
 		disabled: ! config.isEnabled( 'stats/type-detection' ),
 	},
 	{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81361.

## Proposed Changes

Show the commercial upgrade nudge on any site flagged as `isCommercial` that doesn't have a commercial license (excluding Team 51 & VIP). Doesn't touch existing behaviour for WPCom sites.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
