### PR TITLE
Guided onboarding: Remove go back button in options step post checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
@@ -10,6 +10,15 @@ const siteSetupWithoutGoalsFlow: Flow = {
 	useSteps() {
 		return siteSetup.useSteps().slice( 2 );
 	},
+	useStepNavigation( currentStep, navigate ) {
+		const navigation = siteSetup.useStepNavigation( currentStep, navigate );
+		const isFirstStep = this.useSteps()[ 0 ].slug === currentStep;
+		// Delete `goBack` function on the first step fo the flow.
+		if ( isFirstStep ) {
+			delete navigation.goBack;
+		}
+		return navigation;
+	},
 };
 
 export default siteSetupWithoutGoalsFlow;

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -106,7 +106,8 @@ const StepContainer: React.FC< Props > = ( {
 	};
 
 	function BackButton() {
-		if ( shouldHideNavButtons ) {
+		// Hide back button if goBack is falsy, it won't do anything in that case.
+		if ( shouldHideNavButtons || ! goBack ) {
 			return null;
 		}
 		return (


### PR DESCRIPTION
Fixes: 7739-gh-Automattic/dotcom-forge

## Proposed Changes

This updates `StepContainer` to hide the back button when its handler is undefined. We do the same thing for `goNext`. 

## Why are these changes being made?

Because the back button doesn't work in that step.

## Testing Instructions

1. Go to /start/guided.
2. Pick "Creating a site for myself, a business, or a friend".
3. Pick "Publish a blog"
4. Pick free plan.
5. You should land in /site-setup/options. 
6. The back button should be hidden.