### PR TITLE
Stats: Add GDPR cookie consent notice support

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -11,6 +11,7 @@ const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	focus_jetpack_purchase: false,
 	// TODO: Check if the site needs to be upgraded to a higher tier on the back end.
 	tier_upgrade: true,
+	gdpr_cookie_consent: false,
 };
 const DEFAULT_CLIENT_NOTICES_VISIBILITY = {
 	client_paid_plan_purchase_success: true,
@@ -32,6 +33,10 @@ const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< NoticeIdType > > = {
 		'client_free_plan_purchase_success',
 		'do_you_love_jetpack_stats',
 		'commercial_site_upgrade',
+		// Temporarily set the order higher than the TierUpgradeNotice
+		// that would probably not show up by checking inside itself.
+		'gdpr_cookie_consent',
+		// TODO: Check if the current usage is over the tier limit inside the isVisibleFunc.
 		'tier_upgrade',
 	],
 };

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -29,13 +29,12 @@ export type NoticeIdType = keyof Notices;
 const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< NoticeIdType > > = {
 	settings_tool_tips: [ 'traffic_page_settings', 'traffic_page_highlights_module_settings' ],
 	dashboard_notices: [
+		// Set the highest priority to prevent blocking Stats under any circumstances.
+		'gdpr_cookie_consent',
 		'client_paid_plan_purchase_success',
 		'client_free_plan_purchase_success',
 		'do_you_love_jetpack_stats',
 		'commercial_site_upgrade',
-		// Temporarily set the order higher than the TierUpgradeNotice
-		// that would probably not show up by checking inside itself.
-		'gdpr_cookie_consent',
 		// TODO: Check if the current usage is over the tier limit inside the isVisibleFunc.
 		'tier_upgrade',
 	],

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -3,6 +3,7 @@ import { NoticeIdType } from 'calypso/my-sites/stats/hooks/use-notice-visibility
 import CommercialSiteUpgradeNotice from './commercial-site-upgrade-notice';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
+import GDPRCookieConsentNotice from './gdpr-cookie-consent-notice';
 import PaidPlanPurchaseSuccessJetpackStatsNotice from './paid-plan-purchase-success-notice';
 import TierUpgradeNotice from './tier-upgrade-notice';
 import { StatsNoticeProps } from './types';
@@ -120,6 +121,12 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				isCommercialOwned
 			);
 		},
+		disabled: false,
+	},
+	{
+		component: GDPRCookieConsentNotice,
+		noticeId: 'gdpr_cookie_consent',
+		isVisibleFunc: () => true,
 		disabled: false,
 	},
 ];

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -126,7 +126,10 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: GDPRCookieConsentNotice,
 		noticeId: 'gdpr_cookie_consent',
-		isVisibleFunc: () => true,
+		isVisibleFunc: ( { isOdysseyStats } ) => {
+			// Only show the notice for Odyssey Stats since the plugin option is stored locally.
+			return isOdysseyStats;
+		},
 		disabled: false,
 	},
 ];

--- a/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
+++ b/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
@@ -4,10 +4,13 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import { useSelector } from 'calypso/state';
+import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import { StatsNoticeProps } from './types';
 
 const GDPRCookieConsentNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 	const translate = useTranslate();
+	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
 	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
@@ -40,7 +43,11 @@ const GDPRCookieConsentNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps )
 				'To fix, go to {{link}}Complianz settings{{/link}} use the toggle to disable Jetpack integration.',
 				{
 					components: {
-						link: <a href="/wp-admin/admin.php?page=complianz#integrations/integrations-plugins" />,
+						link: (
+							<a
+								href={ `${ adminUrl }admin.php?page=complianz#integrations/integrations-plugins` }
+							/>
+						),
 					},
 				}
 		  )

--- a/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
+++ b/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
@@ -1,0 +1,66 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import NoticeBanner from '@automattic/components/src/notice-banner';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import { StatsNoticeProps } from './types';
+
+const GDPRCookieConsentNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
+	const translate = useTranslate();
+	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
+
+	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
+		siteId,
+		'gdpr_cookie_consent',
+		'postponed',
+		7 * 24 * 3600
+	);
+
+	const dismissNotice = () => {
+		isOdysseyStats
+			? recordTracksEvent( 'jetpack_odyssey_stats_gdpr_cookie_consent_notice_dismissed' )
+			: recordTracksEvent( 'calypso_stats_gdpr_cookie_consent_notice_dismissed' );
+
+		setNoticeDismissed( true );
+		postponeNoticeAsync();
+	};
+
+	if ( noticeDismissed ) {
+		return null;
+	}
+
+	const classNames = clsx(
+		'inner-notice-container has-odyssey-stats-bg-color',
+		! isOdysseyStats && 'inner-notice-container--calypso'
+	);
+
+	const bannerBody = isOdysseyStats
+		? translate(
+				'To fix, go to {{link}}Complianz settings{{/link}} use the toggle to disable Jetpack integration.',
+				{
+					components: {
+						link: <a href="/wp-admin/admin.php?page=complianz#integrations/integrations-plugins" />,
+					},
+				}
+		  )
+		: translate(
+				'To fix, go to Complianz > Integrations > Plugins and use the toggle to disable Jetpack integration.'
+		  );
+
+	return (
+		<div className={ classNames }>
+			<NoticeBanner
+				level="warning"
+				title={ translate(
+					'Complianz - GDBR/CCPA Cookie Consent plugin is not allowing Jetpack Stats to update'
+				) }
+				onClose={ dismissNotice }
+			>
+				<p>{ bannerBody }</p>
+			</NoticeBanner>
+		</div>
+	);
+};
+
+export default GDPRCookieConsentNotice;

--- a/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
+++ b/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
@@ -17,7 +17,8 @@ const GDPRCookieConsentNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps )
 		siteId,
 		'gdpr_cookie_consent',
 		'postponed',
-		7 * 24 * 3600
+		// Postpone for 2 months to avoid bothering users too often.
+		60 * 24 * 3600
 	);
 
 	const dismissNotice = () => {

--- a/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
+++ b/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
@@ -41,7 +41,7 @@ const GDPRCookieConsentNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps )
 
 	const bannerBody = isOdysseyStats
 		? translate(
-				'To fix, go to {{link}}Complianz settings{{/link}} use the toggle to disable Jetpack integration.',
+				'Your site visitors must now consent to be tracked in Jetpack Stats, which might result in a decrease in reported statistics as some visitors may not give consent. To adjust this, go to {{link}}Complianz settings{{/link}} to manage the Jetpack integration.',
 				{
 					components: {
 						link: (
@@ -59,10 +59,8 @@ const GDPRCookieConsentNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps )
 	return (
 		<div className={ classNames }>
 			<NoticeBanner
-				level="warning"
-				title={ translate(
-					'Complianz - GDBR/CCPA Cookie Consent plugin is not allowing Jetpack Stats to update'
-				) }
+				level="info"
+				title={ translate( 'Complianz - GDBR/CCPA Cookie Consent plugin impact on site stats' ) }
 				onClose={ dismissNotice }
 			>
 				<p>{ bannerBody }</p>

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -32,6 +32,7 @@ const ensureOnlyOneNoticeVisible = (
 	noticeOptions: StatsNoticeProps
 ) => {
 	const calculatedNoticesVisibility = { ...serverNoticesVisibility };
+
 	ALL_STATS_NOTICES.forEach(
 		( notice ) =>
 			( calculatedNoticesVisibility[ notice.noticeId ] =
@@ -39,6 +40,7 @@ const ensureOnlyOneNoticeVisible = (
 				serverNoticesVisibility[ notice.noticeId ] &&
 				notice.isVisibleFunc( noticeOptions ) )
 	);
+
 	return processConflictNotices( calculatedNoticesVisibility );
 };
 

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -10,6 +10,12 @@
 		display: inline-block;
 	}
 
+	a,
+	a:visited {
+		color: var(--studio-gray-80);
+		text-decoration: underline;
+	}
+
 	&.inner-notice-container--calypso {
 		p,
 		button,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/1517

## Proposed Changes

* Add the `GDPRCookieConsentNotice` with the notice id `gdpr_cookie_consent`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  If the user has the [Complianz GDPR plugin](https://wordpress.com/plugins/complianz-gdpr) installed, it will interfere with Jetpack Stats unless they configure something specific.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install the `Complianz | GDPR/CCPA Cookie Consent` [plugin](https://wordpress.com/plugins/complianz-gdpr) on a Jetpack or Atomic site and complete the settings to launch the cookie consent banner.
* Apply the Diff D151956-code.

> We plan only to **_show_** the notice for Odyssey Stats since the plugin option is stored locally in Jetpack. Furthermore, users need to enter the plugin settings in WPAdmin to toggle the integration, which would also make it more reasonable to show on Odyssey Stats.

#### ~Calypso Stats~
* ~Sandbox `public-api.wordpress.com`.~
* ~Spin this change up with the Calypso Live branch.~
* ~Navigate to Stats > Traffic page.~
* ~Ensure the GDPR cookie consent notice shows.~

#### Odyssey Stats
* Spin this change up on the local Jetpack site: `STATS_PACKAGE_PATH=/path-to-jetpack/projects/packages/stats-admin yarn dev`.
* Apply the Jetpack change to package `stats-admin`: https://github.com/Automattic/jetpack/pull/37870.
* Sandbox Jetpack API endpoints: `define( 'JETPACK__SANDBOX_DOMAIN', 'xxx' );`.
* Navigate to Stats > Traffic page.
* Ensure the GDPR cookie consent notice shows with the plugin page link.
* Ensure the plugin page link works correctly.

<img width="1290" alt="截圖 2024-06-20 上午10 36 31" src="https://github.com/Automattic/wp-calypso/assets/6869813/0e983979-69ea-4c96-aa27-53bc0c186697">

* Disable the plugin integration with Jetpack.

<img width="1247" alt="截圖 2024-06-14 下午3 00 43" src="https://github.com/Automattic/wp-calypso/assets/6869813/e3cdfd3b-0c7a-4d0c-bf20-c9f6187fdde1">

* Ensure the GDPR cookie consent notice does not appear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?