### PR TITLE
E2E: Add support for View Revisions menu item in the All Actions dropdown.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -11,7 +11,7 @@ const selectors = {
 
 	// Actions Button
 	allActionsButton: '.editor-all-actions-button',
-	viewRevisionsMenuItem: '[role=menuitem]:has-text("View revisions")',
+	viewRevisionsMenuItem: '.view-revisions-modal-button',
 
 	// Revisions (before 18.5.0)
 	showRevisionButton: '.editor-post-last-revision__panel', // Revision is a link, not a panel.

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -13,7 +13,7 @@ const selectors = {
 	allActionsButton: '.editor-all-actions-button',
 	viewRevisionsMenuItem: '.view-revisions-modal-button',
 
-	// Revisions (before 18.5.0)
+	// Revisions (before 18.4.0)
 	showRevisionButton: '.editor-post-last-revision__panel', // Revision is a link, not a panel.
 
 	// Status & Visibility

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -8,6 +8,12 @@ const panel = '[aria-label="Editor settings"]';
 const selectors = {
 	section: ( name: string ) =>
 		`${ panel } .components-panel__body-title button:has-text("${ name }")`,
+
+	// Actions Button
+	allActionsButton: '.editor-all-actions-button',
+	viewRevisionsMenuItem: '[role=menuitem]:has-text("View revisions")',
+
+	// Revisions (before 18.5.0)
 	showRevisionButton: '.editor-post-last-revision__panel', // Revision is a link, not a panel.
 
 	// Status & Visibility
@@ -335,15 +341,49 @@ export class EditorSettingsSidebarComponent {
 		}
 	}
 
+	/* All Actions Dropdown */
+
+	/**
+	 * Opens the All Actions dropdown
+	 */
+	async openAllActionsDropdown(): Promise< void > {
+		const editorParent = await this.editor.parent();
+		const locator = editorParent.locator( selectors.allActionsButton );
+		await locator.click();
+	}
+
 	/* Revisions */
 
 	/**
-	 * Clicks on the Revisions section in the sidebar to show a revisions modal.
+	 * Clicks on the View Revisions menu itme on the All Actions dropdown
 	 */
-	async showRevisions(): Promise< void > {
+	async showRevisionsViaActionsDropdown(): Promise< void > {
+		// Open the all actions dropdown menu
+		await this.openAllActionsDropdown();
+
+		// Click on the revisions menu item
+		const editorParent = await this.editor.parent();
+		const locator = editorParent.locator( selectors.viewRevisionsMenuItem );
+		await locator.click();
+	}
+
+	/**
+	 * Clicks on the Revision button
+	 */
+	async showRevisionsViaButton(): Promise< void > {
 		const editorParent = await this.editor.parent();
 		const locator = editorParent.locator( selectors.showRevisionButton );
+
 		await locator.click();
+	}
+
+	/**
+	 * Opens the Revisions modal
+	 * via button for Gutenberg < 18.6.0
+	 * via actions dropdown for Gutenberg >= 18.6.0
+	 */
+	async showRevisions(): Promise< void > {
+		await Promise.race( [ this.showRevisionsViaActionsDropdown(), this.showRevisionsViaButton() ] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

Revisions is now moved in the All Actions dropdown. This causes Revisions Modal override to fail which is addressed in https://github.com/Automattic/wp-calypso/pull/91790. This PR updates the E2E tests to open the Revisions Modal via the View Revisions menu item.

## Why are these changes being made?

* Update E2E to support new way of opening the Revisions modal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can run this locally `GUTENBERG_EDGE=true NODE_OPTIONS="--inspect" yarn workspace wp-e2e-tests debug -- specs/editor/editor__revisions.ts`.

<img width="810" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/deaa9482-37eb-4ed7-bf40-5fb7ee5d0efe">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
