### PR TITLE
Subscribers Page: Show a notice when there are pending import jobs

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -3,10 +3,13 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_UNLIMITED_SUBSCRIBERS } from '@automattic/calypso-products';
 import { SiteDetails } from '@automattic/data-stores';
 import { AddSubscriberForm } from '@automattic/subscriber';
+import { useHasStaleImportJobs } from '@automattic/subscriber/src/hooks/use-has-stale-import-jobs';
+import { useInProgressState } from '@automattic/subscriber/src/hooks/use-in-progress-state';
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { LoadingBar } from 'calypso/components/loading-bar';
+import Notice from 'calypso/components/notice';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { isBusinessTrialSite } from 'calypso/sites-dashboard/utils';
 import './style.scss';
@@ -57,6 +60,9 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 		addSubscribersCallback();
 	};
 
+	const isImportInProgress = useInProgressState();
+	const hasStaleImportJobs = useHasStaleImportJobs();
+
 	if ( ! showAddSubscribersModal ) {
 		return null;
 	}
@@ -92,6 +98,34 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 				</>
 			) }
 
+			{ isImportInProgress && ! hasStaleImportJobs && (
+				<Notice
+					className="add-subscribers-modal__notice"
+					isCompact
+					isReskinned
+					status="is-info"
+					showDismiss={ false }
+				>
+					{ translate(
+						'Your subscribers are being imported. This may take a few minutes. You can close this window and we’ll notify you when the import is complete.'
+					) }
+				</Notice>
+			) }
+
+			{ isImportInProgress && hasStaleImportJobs && (
+				<Notice
+					className="add-subscribers-modal__notice"
+					isCompact
+					isReskinned
+					status="is-warning"
+					showDismiss={ false }
+				>
+					{ translate(
+						'Your recent import is taking longer than expected to complete. If this issue persists, please contact our support team for assistance.'
+					) }
+				</Notice>
+			) }
+
 			{ ! isUploading && (
 				<label className="add-subscribers-modal__label">{ translate( 'Email' ) }</label>
 			) }
@@ -108,6 +142,7 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 				recordTracksEvent={ recordTracksEvent }
 				hidden={ isUploading }
 				isWPCOMSite={ isWPCOMSite }
+				disabled={ isImportInProgress }
 			/>
 		</Modal>
 	);

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -2,12 +2,14 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_UNLIMITED_SUBSCRIBERS } from '@automattic/calypso-products';
 import { SiteDetails } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { useHasStaleImportJobs } from '@automattic/subscriber/src/hooks/use-has-stale-import-jobs';
 import { useInProgressState } from '@automattic/subscriber/src/hooks/use-in-progress-state';
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
@@ -120,9 +122,14 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 					status="is-warning"
 					showDismiss={ false }
 				>
-					{ translate(
-						'Your recent import is taking longer than expected to complete. If this issue persists, please contact our support team for assistance.'
-					) }
+					<span className="add-subscribers-modal__notice-text">
+						{ translate(
+							'Your recent import is taking longer than expected to complete. If this issue persists, please contact our support team for assistance.'
+						) }
+					</span>
+					<InlineSupportLink
+						supportLink={ localizeUrl( 'https://wordpress.com/support/help-support-options' ) }
+					/>
 				</Notice>
 			) }
 

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -73,6 +73,9 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 	const isBusinessTrial = site ? isBusinessTrialSite( site ) : false;
 	const hasSubscriberLimit = ( isFreeSite || isBusinessTrial ) && ! hasUnlimitedSubscribers;
 	const isWPCOMSite = ! site?.jetpack || site?.is_wpcom_atomic;
+	const supportLink = site?.jetpack
+		? localizeUrl( 'https://jetpack.com/contact-support' )
+		: localizeUrl( 'https://wordpress.com/support/help-support-options' );
 
 	return (
 		<Modal
@@ -127,9 +130,7 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 							'Your recent import is taking longer than expected to complete. If this issue persists, please contact our support team for assistance.'
 						) }
 					</span>
-					<InlineSupportLink
-						supportLink={ localizeUrl( 'https://wordpress.com/support/help-support-options' ) }
-					/>
+					<InlineSupportLink supportLink={ supportLink } />
 				</Notice>
 			) }
 

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -98,7 +98,7 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 				</>
 			) }
 
-			{ isImportInProgress && ! hasStaleImportJobs && (
+			{ ! isUploading && isImportInProgress && ! hasStaleImportJobs && (
 				<Notice
 					className="add-subscribers-modal__notice"
 					isCompact
@@ -112,7 +112,7 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 				</Notice>
 			) }
 
-			{ isImportInProgress && hasStaleImportJobs && (
+			{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
 				<Notice
 					className="add-subscribers-modal__notice"
 					isCompact

--- a/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
@@ -63,6 +63,10 @@
 		line-height: rem(20px);
 	}
 
+	.add-subscribers-modal__notice {
+		margin-bottom: 24px !important;
+	}
+
 	.add-subscriber__form-submit-btn {
 		float: right;
 		min-width: auto;

--- a/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
@@ -65,6 +65,10 @@
 
 	.add-subscribers-modal__notice {
 		margin-bottom: 24px !important;
+
+		.add-subscribers-modal__notice-text {
+			margin-right: 6px;
+		}
 	}
 
 	.add-subscriber__form-submit-btn {

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -48,6 +48,7 @@ interface Props {
 	showSkipLink?: boolean;
 	hidden?: boolean;
 	isWPCOMSite?: boolean;
+	disabled?: boolean;
 }
 
 export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
@@ -78,6 +79,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		showSkipLink,
 		hidden = false,
 		isWPCOMSite = false,
+		disabled,
 	} = props;
 
 	const {
@@ -115,7 +117,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		createElement( FormFileUpload, {
 			name: 'import',
 			onChange: onFileInputChange,
-			disabled: inProgress,
+			disabled: inProgress || disabled,
 		} )
 	);
 
@@ -494,7 +496,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 								) }
 								<TextControl
 									className={ showError ? 'is-error' : '' }
-									disabled={ inProgress }
+									disabled={ inProgress || disabled }
 									placeholder={ placeholder }
 									value={ emails[ i ] || '' }
 									help={ isValidEmails[ i ] ? <Icon icon={ check } /> : undefined }
@@ -526,8 +528,8 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					<NextButton
 						type="submit"
 						className="add-subscriber__form-submit-btn"
-						isBusy={ inProgress }
-						disabled={ ! submitBtnReady }
+						isBusy={ inProgress && ! disabled }
+						disabled={ ! submitBtnReady || disabled }
 					>
 						{ submitBtnName }
 					</NextButton>

--- a/packages/subscriber/src/hooks/use-active-job-recognition.ts
+++ b/packages/subscriber/src/hooks/use-active-job-recognition.ts
@@ -5,10 +5,11 @@ import { useEffect } from 'react';
 type ImportJob = Subscriber.ImportJob;
 type ImportJobStatus = Subscriber.ImportJobStatus;
 
+const INTERVAL_ACTIVE = 5000;
+const INTERVAL_INACTIVE = 10000;
+const ACTIVE_STATE: ImportJobStatus[] = [ 'pending', 'importing' ];
+
 export function useActiveJobRecognition( siteId: number ) {
-	const INTERVAL_ACTIVE = 1000;
-	const INTERVAL_INACTIVE = 5000;
-	const ACTIVE_STATE: ImportJobStatus[] = [ 'pending', 'importing' ];
 	const { getSubscribersImports, importCsvSubscribersUpdate } = useDispatch( Subscriber.store );
 
 	const imports =
@@ -18,7 +19,7 @@ export function useActiveJobRecognition( siteId: number ) {
 
 	useEffect( () => {
 		importCsvSubscribersUpdate( activeJob );
-	}, [ activeJob?.status ] );
+	}, [ activeJob, importCsvSubscribersUpdate ] );
 
 	useEffect( () => {
 		const interval = setInterval(
@@ -31,7 +32,7 @@ export function useActiveJobRecognition( siteId: number ) {
 		return () => {
 			clearInterval( interval );
 		};
-	}, [ activeJob?.status ] );
+	}, [ activeJob, getSubscribersImports, siteId ] );
 
 	return activeJob;
 }

--- a/packages/subscriber/src/hooks/use-has-stale-import-jobs.ts
+++ b/packages/subscriber/src/hooks/use-has-stale-import-jobs.ts
@@ -1,0 +1,26 @@
+import { Subscriber } from '@automattic/data-stores';
+import { useSelect } from '@wordpress/data';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export function useHasStaleImportJobs() {
+	const imports =
+		useSelect( ( select ) => select( Subscriber.store ).getImportJobsSelector(), [] ) || [];
+	const pendingImports = imports.filter(
+		( importJob ) => importJob.status === 'pending' || importJob.status === 'importing'
+	);
+
+	if ( ! pendingImports ) {
+		return false;
+	}
+
+	const now = new Date();
+	const staleJob = pendingImports
+		.filter( ( importJob ) => !! importJob.scheduled_at )
+		.find( ( importJob ) => {
+			const jobDate = new Date( importJob.scheduled_at || 0 );
+			return now.getTime() - jobDate.getTime() > DAY_IN_MS;
+		} );
+
+	return !! staleJob;
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/85666

## Proposed Changes

* Display an info notice when there are pending imports for less than 24 hours
* Display a warning notice when there are pending imports for more than 24 hours
* Increase refresh timeout for checking pending jobs
* Add disabled prop to the `AddSubscriberForm` component

<img width="577" alt="Screenshot 2024-06-17 at 14 26 42" src="https://github.com/Automattic/wp-calypso/assets/3113712/e76b5ecf-9999-4444-a3bb-1124aaa0c989">

<img width="566" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/d7ca5529-f4cc-488c-aa7f-2f6f58f064f1">

## Why are these changes being made?

* There is an edge case that makes users stuck on the import modal without any feedback. This PR updates the UI to properly inform the user when something goes wrong with the importing jobs.

## Testing Instructions

* Use a test site to force an import job to fail before finishing (see p1718657753807679/1718653229.079269-slack-C02TCEHP3HA)
* Apply this PR to your local
* Go to `http://calypso.localhost:3000/subscribers/<site-slug>`
* Click on "Add Subscribers"
* If the job is stuck for less than 24 hours, you should see an info notice
* If the job is stuck for more than 24 hours, you should see a warning notice
* Open the network tab, you should see that the refresh timeout increased to 5 seconds

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?