### PR TITLE
Guided onboarding: Skip initial step correctly

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1238,7 +1238,13 @@ export function excludeSegmentSurveyStepIfInactive( stepName, _, nextProps ) {
 	const { trailMapExperimentVariant } = nextProps?.initialContext ?? {};
 	// The check has to be null to make we don't remove the step before the experiment loads.
 	if ( trailMapExperimentVariant === null ) {
-		nextProps.submitSignupStep( { stepName, wasSkipped: true } );
+		nextProps.submitSignupStep(
+			{ stepName, wasSkipped: true },
+			{
+				segmentationSurveyAnswers: null,
+				onboardingSegment: null,
+			}
+		);
 		flows.excludeStep( stepName );
 	}
 }


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/91411 introduced a console warning because it doesn't skip the step correctly. This fixes that.

## Testing steps

1. Go through the /start/guided flow.
2. You should not see a console warning or an error as shown here: p1718294475285139/1718283294.913179-slack-C02T4NVL4JJ