### PR TITLE
Domains: Add notice when canceling or transferring a free Gravatar domain

### DIFF
--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -300,7 +300,7 @@ const CancelPurchaseRefundInformation = ( {
 		if ( isGravatarDomain ) {
 			text.push(
 				i18n.translate(
-					"This is a free domain for your Gravatar profile. If it expires, you won't be able to get another free domain to use for your Gravatar profile."
+					'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
 				)
 			);
 		}

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -51,32 +51,20 @@ const CancelPurchaseRefundInformation = ( {
 		if ( isDomainRegistration( purchase ) ) {
 			// Domain bought with domain credits, so there's no refund
 			if ( ! hasAmountAvailableToRefund( purchase ) ) {
-				text = [
-					i18n.translate(
-						'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
-							'it will be removed from your site immediately.',
-						{
-							args: { refundPeriodInDays },
-						}
-					),
-				];
+				text = i18n.translate(
+					'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
+						'it will be removed from your site immediately.',
+					{
+						args: { refundPeriodInDays },
+					}
+				);
 			} else {
-				text = [
-					i18n.translate(
-						'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
-							"you'll receive a refund and it will be removed from your site immediately.",
-						{
-							args: { refundPeriodInDays },
-						}
-					),
-				];
-			}
-
-			if ( isGravatarDomain ) {
-				text.push(
-					i18n.translate(
-						"This is a free Gravatar domain. If it is canceled, you won't be able to get another free domain to use with Gravatar."
-					)
+				text = i18n.translate(
+					'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
+						"you'll receive a refund and it will be removed from your site immediately.",
+					{
+						args: { refundPeriodInDays },
+					}
 				);
 			}
 		}

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -300,7 +300,7 @@ const CancelPurchaseRefundInformation = ( {
 		if ( isGravatarDomain ) {
 			text.push(
 				i18n.translate(
-					"This is a free Gravatar domain. If it expires, you won't be able to get another free domain to use with Gravatar."
+					"This is a free domain for your Gravatar profile. If it expires, you won't be able to get another free domain to use for your Gravatar profile."
 				)
 			);
 		}

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -47,7 +47,7 @@ class RemoveDomainDialog extends Component {
 				{ isGravatarDomain && (
 					<p>
 						{ translate(
-							"Also, this is a free domain for your Gravatar profile. If it is deleted, you won't be able to get another free domain to use with your Gravatar profile."
+							'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
 						) }
 					</p>
 				) }

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -47,7 +47,7 @@ class RemoveDomainDialog extends Component {
 				{ isGravatarDomain && (
 					<p>
 						{ translate(
-							"Also, this is a free Gravatar domain. If it is deleted, you won't be able to get another free domain to use with Gravatar."
+							"Also, this is a free domain for your Gravatar profile. If it is deleted, you won't be able to get another free domain to use with your Gravatar profile."
 						) }
 					</p>
 				) }

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -32,7 +32,7 @@ class RemoveDomainDialog extends Component {
 	};
 
 	renderDomainDeletionWarning( productName ) {
-		const { translate, slug, currentRoute, isGravatarDOmain } = this.props;
+		const { translate, slug, currentRoute, isGravatarDomain } = this.props;
 
 		return (
 			<Fragment>
@@ -44,10 +44,10 @@ class RemoveDomainDialog extends Component {
 						}
 					) }
 				</p>
-				{ isGravatarDOmain && (
+				{ isGravatarDomain && (
 					<p>
 						{ translate(
-							"Also, this is a free Gravatar domain. If if is deleted, you won't be able to get another free domain to use with Gravatar."
+							"Also, this is a free Gravatar domain. If it is deleted, you won't be able to get another free domain to use with Gravatar."
 						) }
 					</p>
 				) }
@@ -274,7 +274,7 @@ export default connect( ( state, ownProps ) => {
 	const selectedDomainName = getName( ownProps.purchase );
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 	return {
-		isGravatarDOmain: selectedDomain.isGravatarDomain,
+		isGravatarDomain: selectedDomain.isGravatarDomain,
 		hasTitanWithUs: hasTitanMailWithUs( selectedDomain ),
 		currentRoute: getCurrentRoute( state ),
 		slug: getSelectedSiteSlug( state ),

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -32,7 +32,7 @@ class RemoveDomainDialog extends Component {
 	};
 
 	renderDomainDeletionWarning( productName ) {
-		const { translate, slug, currentRoute } = this.props;
+		const { translate, slug, currentRoute, isGravatarDOmain } = this.props;
 
 		return (
 			<Fragment>
@@ -44,6 +44,13 @@ class RemoveDomainDialog extends Component {
 						}
 					) }
 				</p>
+				{ isGravatarDOmain && (
+					<p>
+						{ translate(
+							"Also, this is a free Gravatar domain. If if is deleted, you won't be able to get another free domain to use with Gravatar."
+						) }
+					</p>
+				) }
 				<p>
 					{ translate(
 						'If you want to use {{strong}}%(domain)s{{/strong}} with another provider you can {{moveAnchor}}move it to another service{{/moveAnchor}} or {{transferAnchor}}transfer it to another provider{{/transferAnchor}}.',
@@ -267,6 +274,7 @@ export default connect( ( state, ownProps ) => {
 	const selectedDomainName = getName( ownProps.purchase );
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 	return {
+		isGravatarDOmain: selectedDomain.isGravatarDomain,
 		hasTitanWithUs: hasTitanMailWithUs( selectedDomain ),
 		currentRoute: getCurrentRoute( state ),
 		slug: getSelectedSiteSlug( state ),

--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -16,6 +16,7 @@ import AdditionalTermsOfServiceInCart from './additional-terms-of-service-in-car
 import BundledDomainNotice, { showBundledDomainNotice } from './bundled-domain-notice';
 import DomainRegistrationAgreement from './domain-registration-agreement';
 import DomainRegistrationDotGay from './domain-registration-dot-gay';
+import { DomainRegistrationFreeGravatarDomain } from './domain-registration-free-gravatar-domain';
 import DomainRegistrationHsts from './domain-registration-hsts';
 import { EbanxTermsOfService } from './ebanx-terms-of-service';
 import { showInternationalFeeNotice, InternationalFeeNotice } from './international-fee-notice';
@@ -97,6 +98,7 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 				{ ! isGiftPurchase && <DomainRegistrationAgreement cart={ cart } /> }
 				{ ! isGiftPurchase && <DomainRegistrationHsts cart={ cart } /> }
 				{ ! isGiftPurchase && <DomainRegistrationDotGay cart={ cart } /> }
+				{ ! isGiftPurchase && <DomainRegistrationFreeGravatarDomain cart={ cart } /> }
 				<EbanxTermsOfService />
 				{ ! isGiftPurchase && <PlanTerms100Year cart={ cart } /> }
 				{ ! isGiftPurchase && <AdditionalTermsOfServiceInCart /> }

--- a/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
+++ b/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
@@ -20,7 +20,7 @@ export function DomainRegistrationFreeGravatarDomain(
 	return (
 		<CheckoutTermsItem>
 			{ translate(
-				"This is a free domain for your Gravatar profile. You're eligible to only one free domain for your Gravatar profile."
+				'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
 			) }
 		</CheckoutTermsItem>
 	);

--- a/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
+++ b/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
@@ -20,7 +20,7 @@ export function DomainRegistrationFreeGravatarDomain(
 	return (
 		<CheckoutTermsItem>
 			{ translate(
-				'This is a free Gravatar domain. You can only get one free domain to use with Gravatar.'
+				"This is a free domain for your Gravatar profile. You're eligible to only one free domain for your Gravatar profile."
 			) }
 		</CheckoutTermsItem>
 	);

--- a/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
+++ b/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
@@ -20,7 +20,7 @@ export function DomainRegistrationFreeGravatarDomain(
 	return (
 		<CheckoutTermsItem>
 			{ translate(
-				'This is a free Gravatar domain. You can only get one free domain to use with Gravatar'
+				'This is a free Gravatar domain. You can only get one free domain to use with Gravatar.'
 			) }
 		</CheckoutTermsItem>
 	);

--- a/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
+++ b/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
@@ -1,0 +1,27 @@
+import { useTranslate } from 'i18n-calypso';
+import { getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+interface DomainRegistrationFreeGravatarDomainProps {
+	cart: ResponseCart;
+}
+
+export function DomainRegistrationFreeGravatarDomain(
+	props: DomainRegistrationFreeGravatarDomainProps
+) {
+	const translate = useTranslate();
+	const domains = getDomainRegistrations( props.cart );
+
+	if ( ! domains.some( ( domain ) => domain.extra?.is_gravatar_domain ) ) {
+		return null;
+	}
+
+	return (
+		<CheckoutTermsItem>
+			{ translate(
+				'This is a free Gravatar domain. You can only get one free domain to use with Gravatar'
+			) }
+		</CheckoutTermsItem>
+	);
+}

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -20,6 +20,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, getTopLevelOfTld, isMappedDomain } from 'calypso/lib/domains';
 import wpcom from 'calypso/lib/wp';
 import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
+import InfoNotice from 'calypso/my-sites/domains/domain-management/components/domain/info-notice';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
@@ -372,6 +373,14 @@ const TransferPage = ( props: TransferPageProps ) => {
 						? __( 'Transfer to another registrar' )
 						: __( 'Advanced Options' ) }
 				</CardHeading>
+				{ domain?.isGravatarDomain && (
+					<InfoNotice
+						redesigned
+						text={ __(
+							"This is a free Gravatar domain. If you transfer it to another registrar, you won't be able to get another free domain to use with Gravatar."
+						) }
+					/>
+				) }
 				{ topLevelOfTld !== 'uk' ? renderCommonTldTransferOptions() : renderUkTransferOptions() }
 			</Card>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -377,7 +377,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 					<InfoNotice
 						redesigned
 						text={ __(
-							"This is a free domain for your Gravatar profile. If you transfer it to another registrar, you won't be able to get another free domain to use with your Gravatar profile."
+							'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you transfer this domain to another registrar, you will have to pay the standard price to register another domain for your Gravatar profile.'
 						) }
 					/>
 				) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -377,7 +377,7 @@ const TransferPage = ( props: TransferPageProps ) => {
 					<InfoNotice
 						redesigned
 						text={ __(
-							"This is a free Gravatar domain. If you transfer it to another registrar, you won't be able to get another free domain to use with Gravatar."
+							"This is a free domain for your Gravatar profile. If you transfer it to another registrar, you won't be able to get another free domain to use with your Gravatar profile."
 						) }
 					/>
 				) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -119,6 +119,11 @@
 		.search-card {
 			padding: 0;
 		}
+
+		/* only used when there's a free Gravatar domain notice */
+		.card-heading + .info-notice {
+			margin: 8px 0;
+		}
 	}
 
 	.transfer-page__transfer-lock-placeholder {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -610,6 +610,7 @@ export interface ResponseCartProductExtra {
 	receipt_for_domain?: number;
 	domain_registration_agreement_url?: string;
 	legal_agreements?: never[] | DomainLegalAgreements;
+	is_gravatar_domain?: boolean;
 
 	/**
 	 * Set to 'renewal' if requesting a renewal.


### PR DESCRIPTION
## Proposed Changes

This PR adds notices and warnings explaining that users won't be able to get another free Gravatar domain in these situations:
- During checkout for a free Gravatar domain (via the `/start/domain-for-gravatar` flow)
- When transferring a free Gravatar domain away and
- When deleting a free Gravatar domain

### Screenshots

| Page | Before | After |
| --- | --- | --- |
| Checkout | ![Markup on 2024-06-14 at 20:35:50](https://github.com/Automattic/wp-calypso/assets/5324818/23086fe7-e92e-45c8-a6a7-8bdfa01d9b5d) | ![Markup on 2024-06-17 at 15:34:15](https://github.com/Automattic/wp-calypso/assets/5324818/985d1468-08bc-453a-945f-23e0b97893a6) |
| Outbound transfer | ![Screenshot 2024-06-13 at 18 24 15](https://github.com/Automattic/wp-calypso/assets/5324818/e588894f-179c-40ad-8668-f32bc5d53b19) | ![Screenshot 2024-06-17 at 15 35 31](https://github.com/Automattic/wp-calypso/assets/5324818/4e43b0b1-2f8e-493f-9877-19d40dd32a60) |
| Disable domain auto-renew | ![Screenshot 2024-06-13 at 16 05 19](https://github.com/Automattic/wp-calypso/assets/5324818/a0970a5c-3994-48d1-a1a8-21c0dba35f7b) | ![Markup on 2024-06-17 at 15:36:01](https://github.com/Automattic/wp-calypso/assets/5324818/e01f765b-ecdd-45b8-8b90-2f9dca0a9f38) |
| Delete domain (after turning auto-renew off) | ![Screenshot 2024-06-13 at 16 12 29](https://github.com/Automattic/wp-calypso/assets/5324818/d5c47668-51bb-49b8-b7b2-0b0fc4e8948e) | ![Markup on 2024-06-17 at 15:36:29](https://github.com/Automattic/wp-calypso/assets/5324818/7c553077-53cc-49b0-9e8e-633576be78d5) |

## Why are these changes being made?

- This is part of the Custom domains on Gravatar project (pcYYhz-24z-p2).

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Checkout
  - Go to the domains for Gravatar flow (`/start/domain-for-gravatar`) and add a domain to the cart
  - Ensure the explanation about only one free Gravatar domain is shown in the checkout page
  - Visit the other flows (`/start`, adding domains to an existing site, etc) and ensure the free Gravatar domain copy isn't shown in the checkout page
- Outbound transfer
  - When you already have a free Gravatar domain, go to its domain transfer page and ensure a warning notice is shown
- Cancel domain
  - When you already have a free Gravatar domain, go to the domain cancelation page and ensure a warning text is shown
  - After you disable auto-renew for that domain, try to cancel it and ensure the deletion confirmation dialog also contains warning text explaining that you won't be able to get another free Gravatar domain

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?