### PR TITLE
Goals: show DIFM for all non-RTL locales

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -1,58 +1,17 @@
 import { Onboard } from '@automattic/data-stores';
-import { useLocale, englishLocales } from '@automattic/i18n-utils';
+import { useLocale, isLocaleRtl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
 import type { Goal } from './types';
 
 const SiteGoal = Onboard.SiteGoal;
 
-const DIFMSupportedLocales = [ ...englishLocales, 'es' ];
-
-// export const CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME =
-// 	'calypso_builtbyexpress_goal_copy_change_202210';
-// export const VARIATION_CONTROL = 'control';
-// export const VARIATION_BUY = 'variation_buy';
-// export const VARIATION_GET = 'variation_get';
-
-const useBBEGoal = () => {
-	const translate = useTranslate();
-	const locale = useLocale();
-	// ************************************************************************
-	// ****  Experiment skeleton left in for future BBE copy change tests  ****
-	// ************************************************************************
-	//
-
-	// const [ , experimentAssignment ] = useExperiment(
-	// 	CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME
-	// );
-	// const variationName = experimentAssignment?.variationName;
-
-	// let builtByExpressGoalDisplayText;
-	// switch ( variationName ) {
-	// 	case VARIATION_BUY:
-	// 		builtByExpressGoalDisplayText = translate( 'Buy a website' );
-	// 		break;
-	// 	case VARIATION_GET:
-	// 		builtByExpressGoalDisplayText = translate( 'Get a website quickly' );
-	// 		break;
-	// 	case VARIATION_CONTROL:
-	// 	default:
-	// 		builtByExpressGoalDisplayText = translate( 'Hire a professional to design my website' );
-	// }
-	//
-	// ************************************************************************
-
-	return locale === 'en'
-		? translate( 'Let us build your site in 4 days' )
-		: translate( 'Get a website built quickly' );
-};
-
 export const useGoals = (): Goal[] => {
 	loadExperimentAssignment( 'calypso_design_picker_image_optimization_202406' ); // Temporary for A/B test.
 
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const locale = useLocale();
-	const builtByExpressGoalDisplayText = useBBEGoal();
 
 	const importDisplayText = () => {
 		return translate( 'Import existing content or website' );
@@ -73,7 +32,9 @@ export const useGoals = (): Goal[] => {
 		},
 		{
 			key: SiteGoal.DIFM,
-			title: builtByExpressGoalDisplayText,
+			title: hasEnTranslation( 'Let us build your site in 4 days' )
+				? translate( 'Let us build your site in 4 days' )
+				: translate( 'Get a website built quickly' ),
 			isPremium: true,
 		},
 		{
@@ -87,10 +48,10 @@ export const useGoals = (): Goal[] => {
 	];
 
 	/**
-	 * Hides the DIFM goal for all locales except English and ES.
+	 * Hides the DIFM goal for RTL locales.
 	 */
 	const hideDIFMGoalForUnsupportedLocales = ( { key }: Goal ) => {
-		if ( key === SiteGoal.DIFM && ! DIFMSupportedLocales.includes( locale ) ) {
+		if ( key === SiteGoal.DIFM && isLocaleRtl( locale ) ) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR relaxes the locale restrictions to show the DIFM goal on the Goals step for all non-RTL locales.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The DIFM team is now able to handle site builds for all non-RTL locales. Therefore, relaxing this restriction would enable more users to benefit from this product.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-RTL locale other than EN and ES.
* Go to `/setup/site-setup/goals?siteSlug=<site slug>`.
* Confirm that you can see the DIFM goal.
* <img width="1501" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/91ecf61b-e489-4557-b257-dd4330eff7ac">
* Switch to an RTL locale and reload the page. Confirm that the DIFM goal is hidden.
* <img width="1498" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/57458b20-1a0d-4781-a1db-db364d798f94">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
