### PR TITLE
Editor: Fix unable to open revisions modal.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -136,6 +136,9 @@ function overrideRevisions( calypsoPort ) {
 				menuItem.replaceWith( replacementMenuItem );
 				replacementMenuItem.addEventListener( 'click', openRevisions );
 
+				// Add a class to uniquely identify the cloned menu item
+				replacementMenuItem.className += ' view-revisions-modal-button';
+
 				// Replicate hovering effect
 				replacementMenuItem.addEventListener( 'mouseover', () => {
 					replacementMenuItem.setAttribute( 'data-active-item', '' );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -113,13 +113,32 @@ function handlePostTrash( calypsoPort ) {
 }
 
 function overrideRevisions( calypsoPort ) {
+	// For Gutenberg <= 18.4.1
 	addEditorListener( '[href*="revision.php"]', ( e ) => {
 		e.preventDefault();
+		openRevisions();
+	} );
+
+	// For Gutenberg >= 18.5
+	// Temporary solution to identify View Revisions menu item
+	// until the Gutenberg PR is deployed.
+	addEditorListener( 'div[id^=portal] [role=menuitem]', ( e ) => {
+		const menuItemLabel = e.target.innerText || '';
+		const viewRevisionsLabel =
+			/View revisions|Revisionen anzeigen|Visualizza revisioni|リビジョンを表示|수정본 보기|Bekijk revisies|Vezi reviziile|Visa versioner/gi;
+
+		if ( menuItemLabel.match( viewRevisionsLabel ) ) {
+			e.preventDefault();
+			openRevisions();
+		}
+	} );
+
+	function openRevisions() {
 		calypsoPort.postMessage( { action: 'openRevisions' } );
 
 		calypsoPort.addEventListener( 'message', onLoadRevision, false );
 		calypsoPort.start();
-	} );
+	}
 
 	function onLoadRevision( message ) {
 		const action = get( message, 'data.action', '' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Revisions modal is broken since it was moved into the All Actions dropdown menu (See: https://github.com/WordPress/gutenberg/pull/61867). It attempts to go to `revision.php` but in an iframe, it causes cross-site redirection error.

This PR proposes a temporary solution to restore the revision modal by anticipating the clicking of the All Actions dropdown menu and replacing it with an alternative menu item.

A proper fix needs to be introduced on the Gutenberg end, allowing third party to override the View Revisions behaviour.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Revisions modal is broken.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox your test site and widgets.wp.com.
* Run `cd apps/wpcom-block-editor` and `yarn dev --sync`.
* Open up a post with revisions in the editor.
* Click on All Actions dropdown and click View Revisions.
* The View Revisions modal should now open.


https://github.com/Automattic/wp-calypso/assets/1287077/bf4c29b0-4e05-4c40-bcee-de657f328231





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
