### PR TITLE
A4A-Partner Directory: Fix the slug<=>label mapping issue with services and products selectors

### DIFF
--- a/client/a8c-for-agencies/data/partner-directory/use-submit-agency-details.ts
+++ b/client/a8c-for-agencies/data/partner-directory/use-submit-agency-details.ts
@@ -44,6 +44,8 @@ function mutationSubmitAgencyDetails(
 			profile_listing_is_available: agencyDetails.isAvailable,
 			profile_listing_industry: agencyDetails.industry,
 			profile_listing_languages_spoken: languages,
+			profile_listing_services: agencyDetails.services,
+			profile_listing_products: agencyDetails.products,
 			profile_budget_budget_lower_range: agencyDetails.budgetLowerRange,
 		},
 	} );

--- a/client/a8c-for-agencies/sections/partner-directory/components/products-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/products-selector.tsx
@@ -1,6 +1,6 @@
 import { FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { reverseMap, useFormSelectors } from './hooks/use-form-selectors';
 
 type Props = {
@@ -24,14 +24,16 @@ const ProductsSelector = ( { setProducts, selectedProducts }: Props ) => {
 	} );
 
 	// Set the selected products by slug
-	const onProductLabelsSelected = ( selectedProductLabels: ( string | TokenItem )[] ) => {
-		const selectedProductsBySlug = selectedProductLabels.map( ( label ) => {
-			const key = label as string;
-			return availableProductsByLabel[ key ];
-		} );
-
-		setProducts( selectedProductsBySlug );
-	};
+	const onProductLabelsSelected = useCallback(
+		( selectedProductLabels: ( string | TokenItem )[] ) => {
+			const selectedProductsBySlug = selectedProductLabels.map( ( label ) => {
+				const key = label as string;
+				return availableProductsByLabel[ key ];
+			} );
+			setProducts( selectedProductsBySlug );
+		},
+		[ availableProductsByLabel ]
+	);
 
 	return (
 		<FormTokenField

--- a/client/a8c-for-agencies/sections/partner-directory/components/products-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/products-selector.tsx
@@ -1,6 +1,7 @@
 import { FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
-import { useFormSelectors } from './hooks/use-form-selectors';
+import { useMemo } from 'react';
+import { reverseMap, useFormSelectors } from './hooks/use-form-selectors';
 
 type Props = {
 	setProducts: ( tokens: ( string | TokenItem )[] ) => void;
@@ -10,14 +11,26 @@ type Props = {
 const ProductsSelector = ( { setProducts, selectedProducts }: Props ) => {
 	const { availableProducts } = useFormSelectors();
 
-	const setTokens = ( tokens: ( string | TokenItem )[] ) => {
-		const selectedServicesByToken = tokens.filter( ( token ) => {
-			return Object.keys( availableProducts ).find(
-				( key: string ) => availableProducts?.[ key ] === token
-			);
+	// Get the reverse map of available products
+	const availableProductsByLabel = useMemo(
+		() => reverseMap( availableProducts ),
+		[ availableProducts ]
+	);
+
+	// Get the selected products by label
+	const selectedProductsByLabel = selectedProducts.map( ( slug ) => {
+		const key = slug as string;
+		return availableProducts[ key ];
+	} );
+
+	// Set the selected products by slug
+	const onProductLabelsSelected = ( selectedProductLabels: ( string | TokenItem )[] ) => {
+		const selectedProductsBySlug = selectedProductLabels.map( ( label ) => {
+			const key = label as string;
+			return availableProductsByLabel[ key ];
 		} );
 
-		setProducts( selectedServicesByToken );
+		setProducts( selectedProductsBySlug );
 	};
 
 	return (
@@ -27,9 +40,9 @@ const ProductsSelector = ( { setProducts, selectedProducts }: Props ) => {
 			__experimentalShowHowTo={ false }
 			__nextHasNoMarginBottom
 			label=""
-			onChange={ setTokens }
+			onChange={ onProductLabelsSelected }
 			suggestions={ Object.values( availableProducts ) }
-			value={ selectedProducts }
+			value={ selectedProductsByLabel }
 		/>
 	);
 };

--- a/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
@@ -1,6 +1,7 @@
 import { FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
-import { useFormSelectors } from './hooks/use-form-selectors';
+import { useMemo } from 'react';
+import { reverseMap, useFormSelectors } from './hooks/use-form-selectors';
 
 type Props = {
 	setServices: ( services: ( string | TokenItem )[] ) => void;
@@ -10,6 +11,28 @@ type Props = {
 const ServicesSelector = ( { setServices, selectedServices }: Props ) => {
 	const { availableServices } = useFormSelectors();
 
+	// Get the reverse map of available services
+	const availableServicesByLabel = useMemo(
+		() => reverseMap( availableServices ),
+		[ availableServices ]
+	);
+
+	// Get the selected services by label
+	const selectedServicesByLabel = selectedServices.map( ( slug ) => {
+		const key = slug as string;
+		return availableServices[ key ];
+	} );
+
+	// Set the selected services by slug
+	const onServiceLabelsSelected = ( selectedServiceLabels: ( string | TokenItem )[] ) => {
+		const selectedServicesBySlug = selectedServiceLabels.map( ( label ) => {
+			const key = label as string;
+			return availableServicesByLabel[ key ];
+		} );
+
+		setServices( selectedServicesBySlug );
+	};
+
 	return (
 		<FormTokenField
 			__experimentalAutoSelectFirstMatch
@@ -17,9 +40,9 @@ const ServicesSelector = ( { setServices, selectedServices }: Props ) => {
 			__experimentalShowHowTo={ false }
 			__nextHasNoMarginBottom
 			label=""
-			onChange={ setServices }
+			onChange={ onServiceLabelsSelected }
 			suggestions={ Object.values( availableServices ) }
-			value={ selectedServices }
+			value={ selectedServicesByLabel }
 		/>
 	);
 };

--- a/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
@@ -1,6 +1,6 @@
 import { FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { reverseMap, useFormSelectors } from './hooks/use-form-selectors';
 
 type Props = {
@@ -24,14 +24,17 @@ const ServicesSelector = ( { setServices, selectedServices }: Props ) => {
 	} );
 
 	// Set the selected services by slug
-	const onServiceLabelsSelected = ( selectedServiceLabels: ( string | TokenItem )[] ) => {
-		const selectedServicesBySlug = selectedServiceLabels.map( ( label ) => {
-			const key = label as string;
-			return availableServicesByLabel[ key ];
-		} );
+	const onServiceLabelsSelected = useCallback(
+		( selectedServiceLabels: ( string | TokenItem )[] ) => {
+			const selectedServicesBySlug = selectedServiceLabels.map( ( label ) => {
+				const key = label as string;
+				return availableServicesByLabel[ key ];
+			} );
 
-		setServices( selectedServicesBySlug );
-	};
+			setServices( selectedServicesBySlug );
+		},
+		[ availableServicesByLabel, setServices ]
+	);
 
 	return (
 		<FormTokenField


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR fixes the issue with the Services and Products UI selectors. We have to map the slugs and labels. The UI element only supports labels, so we have to perform some mapping to transform the data between the endpoint (as a slug) to the UI (as a label) and vice versa.

Also, this PR fixes an issue with the Agency Details forms, the services and products selection updates were not included in the form submission.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- On the expertise or the agency details, set your services and products. Check the Network to see the products/services as slug values, and in the UI you will see the label value.
   - **Note: ** If previously you had set services, you have to reset/store them by slug. You can use the endpoint directly:

PUT https://public-api.wordpress.com/wpcom/v2/agency/{your_agency_id}/profile
```
"profile_listing_services": ["seo_advertising", "email_social_media_marketing"],
"profile_listing_products": ["woocommerce", "wordpress"],
```

- Check that when you edit the services or products on one form (Expertise), after submitting it, if you go to the other form (Details), you will see the updated products and services.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
