### PR TITLE
A4A > Referrals > Implement coming soon notice for Automated Referrals

### DIFF
--- a/client/a8c-for-agencies/components/layout/banner.tsx
+++ b/client/a8c-for-agencies/components/layout/banner.tsx
@@ -1,6 +1,9 @@
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import clsx from 'clsx';
 import { ReactNode } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
 
 type Props = {
 	actions?: React.ReactNode[];
@@ -9,14 +12,40 @@ type Props = {
 	level: 'error' | 'warning' | 'info' | 'success';
 	onClose?: () => void;
 	title?: string;
+	preferenceName?: string;
 };
 
-export default function LayoutBanner( { className, children, onClose, title, actions }: Props ) {
+export default function LayoutBanner( {
+	className,
+	children,
+	onClose,
+	title,
+	actions,
+	level = 'success',
+	preferenceName,
+}: Props ) {
+	const dispatch = useDispatch();
+
+	const bannerShown = useSelector( ( state ) =>
+		preferenceName ? getPreference( state, preferenceName ) : false
+	);
+
 	const wrapperClass = clsx( className, 'a4a-layout__banner' );
+
+	const handleClose = () => {
+		if ( preferenceName ) {
+			dispatch( savePreference( preferenceName, true ) );
+		}
+		onClose?.();
+	};
+
+	if ( bannerShown ) {
+		return null;
+	}
 
 	return (
 		<div className={ wrapperClass }>
-			<NoticeBanner level="success" onClose={ onClose } title={ title } actions={ actions }>
+			<NoticeBanner level={ level } onClose={ handleClose } title={ title } actions={ actions }>
 				{ children }
 			</NoticeBanner>
 		</div>

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -82,6 +82,18 @@ html,
 		padding: 0;
 		border-block-end: 1px solid var(--color-neutral-5);
 	}
+
+	.notice-banner {
+		padding: 24px;
+
+		&.is-info {
+			border-left-color: var(--color-primary);
+
+			.notice-banner__icon {
+				fill: var(--color-primary);
+			}
+		}
+	}
 }
 
 .main.a4a-layout.is-compact .a4a-layout__top-wrapper {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/automated-referral-coming-soon-banner.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/automated-referral-coming-soon-banner.tsx
@@ -1,0 +1,18 @@
+import { useTranslate } from 'i18n-calypso';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+
+export default function AutomatedReferralComingSoonBanner() {
+	const translate = useTranslate();
+
+	return (
+		<LayoutBanner
+			title={ translate( 'A better referrals experience is on the way!' ) }
+			level="info"
+			preferenceName="a8c-automated-referral-coming-soon"
+		>
+			{ translate(
+				`Soon, you will have the ability to gather products and hosting for your clients. Send payment requests. Earn commissions. Track your client's details. All from within your Automattic for Agencies Dashboard!`
+			) }
+		</LayoutBanner>
+	);
+}

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/automated-referral-coming-soon-banner.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/automated-referral-coming-soon-banner.tsx
@@ -11,7 +11,7 @@ export default function AutomatedReferralComingSoonBanner() {
 			preferenceName="a8c-automated-referral-coming-soon"
 		>
 			{ translate(
-				`Soon, you will have the ability to gather products and hosting for your clients. Send payment requests. Earn commissions. Track your client's details. All from within your Automattic for Agencies Dashboard!`
+				`Soon, you will have the ability to gather products and hosting for your clients. Send payment requests. Earn commissions. Track your clients' details. All from within your Automattic for Agencies Dashboard!`
 			) }
 		</LayoutBanner>
 	);

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -30,6 +30,7 @@ import useFetchReferrals from '../../hooks/use-fetch-referrals';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
 import ReferralDetails from '../../referral-details';
 import ReferralsFooter from '../footer';
+import AutomatedReferralComingSoonBanner from './automated-referral-coming-soon-banner';
 import LayoutBodyContent from './layout-body-content';
 import NewReferralOrderNotification from './new-referral-order-notification';
 
@@ -91,6 +92,8 @@ export default function ReferralsOverview( {
 							onClose={ () => setReferralEmail( '' ) }
 						/>
 					) }
+
+					{ ! isAutomatedReferral && <AutomatedReferralComingSoonBanner /> }
 
 					<LayoutHeader>
 						<Title>{ title } </Title>


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/666

## Proposed Changes

This PR 

- Implements a coming soon notice for Automated Referrals.
- Updated the padding of the notice 
- Updates the `LayoutBanner` component to support preference name

Note: 

- We have made some adjustments to the padding.
- @jeffgolenski: The other improvements you suggested in another ticket are not addressed in this PR. 

## Testing Instructions

1. Open the A4A live link
2. Append the live link with /referrals?flags=-a4a-automated-referrals
3. Verify that you can see the notice as shown below. Dismissing the notice should make it disappear and never appear again until you clear the preference.

<img width="1724" alt="Screenshot 2024-06-14 at 12 26 14 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/38946de4-9efa-4531-b05b-d88c025746e5">

This is how the other notifications are shown after the padding changes

<img width="1425" alt="Screenshot 2024-06-14 at 12 58 04 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/70a8508e-5e8f-4192-a33c-6e9f7cb86d61">

<img width="1425" alt="Screenshot 2024-06-14 at 12 58 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b09804d4-aded-4083-b460-059e172d4039">

<img width="1363" alt="Screenshot 2024-06-14 at 12 30 23 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8665d8eb-da50-4295-8323-0b6f07c8aaa5">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
