### PR TITLE
Editor: Fix editor loading placeholder styling.

### DIFF
--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -25,12 +25,31 @@
 		border-radius: 8px; /* stylelint-disable-line scales/radii */
 	}
 
+	.edit-post-header {
+		display: flex;
+		margin-top: 18px;
+
+		.placeholder {
+			height: 30px;
+			border-radius: 20px; /* stylelint-disable-line scales/radii */
+		}
+
+		.edit-post-header-toolbar {
+			flex-grow: 1;
+		}
+	}
+
+	.edit-post-header__settings {
+		display: flex;
+	}
+
 	.placeholder-site {
+		width: 120px;
 		margin-left: 18px;
 	}
 
 	.placeholder-button {
-		width: 40px;
+		width: 30px;
 		margin: 0 8px;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fixes the editor loading placeholder styling.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because it looks broken.


## Testing Instructions

* Go to `calypso.localhost:3000/post/yoursitehere.wordpress.com`.

Before:
<img width="1852" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/ddd42b20-5454-4814-b33a-2d519d64c518">

After:
<img width="1489" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/7e640379-e557-41d6-a68e-e13acfa39b1e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
