### PR TITLE
E2E: Add support for View Revisions menu item in the All Actions dropdown for Atomic.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -11,7 +11,8 @@ const selectors = {
 
 	// Actions Button
 	allActionsButton: '.editor-all-actions-button',
-	viewRevisionsMenuItem: '.view-revisions-modal-button',
+	viewRevisionsModalMenuItem: '.view-revisions-modal-button',
+	viewRevisionsMenuItem: '[role=menuitem]:has-text("View revisions")',
 
 	// Revisions (before 18.4.0)
 	showRevisionButton: '.editor-post-last-revision__panel', // Revision is a link, not a panel.
@@ -361,9 +362,13 @@ export class EditorSettingsSidebarComponent {
 		// Open the all actions dropdown menu
 		await this.openAllActionsDropdown();
 
+		const menuItem = envVariables.TEST_ON_ATOMIC
+			? selectors.viewRevisionsMenuItem
+			: selectors.viewRevisionsModalMenuItem;
+
 		// Click on the revisions menu item
 		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.viewRevisionsMenuItem );
+		const locator = editorParent.locator( menuItem );
 		await locator.click();
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/pull/91766/

## Proposed Changes

* A follow up to https://github.com/Automattic/wp-calypso/pull/91766 to make the test pass on Atomic.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix E2E tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `PWDEBUG=1 DEBUG=pw:api TEST_ON_ATOMIC=true GUTENBERG_EDGE=true node --inspect-brk ../../node_modules/.bin/jest --runInBand specs/editor/editor__revisions.ts` and the tests should pass.
 
<img width="810" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/13ab3d03-e2d7-4bc8-98be-76dc932a5a59">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
