### PR TITLE
Site Profiler: update number formatting

### DIFF
--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -1,5 +1,5 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { type I18N, numberFormat } from 'i18n-calypso';
+import { type I18N } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import type { BasicMetricsScored, Metrics, Scores } from 'calypso/data/site-profiler/types';
 
@@ -28,6 +28,8 @@ type CopiesReturnValue = {
 
 export type CopiesReturnValueList = [ Metrics, CopiesProps ][];
 
+const formatValue = ( value: number ) => value.toFixed( 2 );
+
 export function getCopies(
 	basicMetrics: BasicMetricsScored,
 	translate: I18N[ 'translate' ],
@@ -36,12 +38,12 @@ export function getCopies(
 	const migrateUrl = `/setup/hosted-site-migration?ref=site-profiler&from=${ domain }`;
 	const supportUrl = localizeUrl( 'https://wordpress.com/support' );
 
-	const clsValue = numberFormat( basicMetrics?.cls?.value, 2 );
-	const fidValue = numberFormat( basicMetrics?.fid?.value, 2 );
-	const lcpValue = numberFormat( basicMetrics?.lcp?.value, 2 );
-	const fcpValue = numberFormat( basicMetrics?.fcp?.value, 2 );
-	const ttfbValue = numberFormat( basicMetrics?.ttfb?.value, 2 );
-	const inpValue = numberFormat( basicMetrics?.inp?.value, 2 );
+	const clsValue = formatValue( basicMetrics?.cls?.value );
+	const fidValue = formatValue( basicMetrics?.fid?.value );
+	const lcpValue = formatValue( basicMetrics?.lcp?.value );
+	const fcpValue = formatValue( basicMetrics?.fcp?.value );
+	const ttfbValue = formatValue( basicMetrics?.ttfb?.value );
+	const inpValue = formatValue( basicMetrics?.inp?.value );
 
 	const cls: CopiesProps = {
 		title: translate( 'Cumulative Layout Shift (CLS)' ),

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -50,7 +50,7 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Excellent job maintaining low shifts!',
+					'Your site’s CLS is %(value)s, ensuring a stable layout. Excellent job maintaining low shifts!',
 					{ args: { value: clsValue } }
 				),
 				solution: translate(
@@ -61,7 +61,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					'Your site’s CLS is %(value)s, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
 					{
 						args: {
 							value: clsValue,

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -28,7 +28,7 @@ type CopiesReturnValue = {
 
 export type CopiesReturnValueList = [ Metrics, CopiesProps ][];
 
-const formatValue = ( value: number ) => value.toFixed( 2 );
+const formatMsValue = ( value: number ) => Math.floor( value );
 
 export function getCopies(
 	basicMetrics: BasicMetricsScored,
@@ -38,12 +38,12 @@ export function getCopies(
 	const migrateUrl = `/setup/hosted-site-migration?ref=site-profiler&from=${ domain }`;
 	const supportUrl = localizeUrl( 'https://wordpress.com/support' );
 
-	const clsValue = formatValue( basicMetrics?.cls?.value );
-	const fidValue = formatValue( basicMetrics?.fid?.value );
-	const lcpValue = formatValue( basicMetrics?.lcp?.value );
-	const fcpValue = formatValue( basicMetrics?.fcp?.value );
-	const ttfbValue = formatValue( basicMetrics?.ttfb?.value );
-	const inpValue = formatValue( basicMetrics?.inp?.value );
+	const clsValue = basicMetrics?.cls?.value.toFixed( 2 );
+	const fidValue = formatMsValue( basicMetrics?.fid?.value );
+	const lcpValue = formatMsValue( basicMetrics?.lcp?.value );
+	const fcpValue = formatMsValue( basicMetrics?.fcp?.value );
+	const ttfbValue = formatMsValue( basicMetrics?.ttfb?.value );
+	const inpValue = formatMsValue( basicMetrics?.inp?.value );
 
 	const cls: CopiesProps = {
 		title: translate( 'Cumulative Layout Shift (CLS)' ),

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -55,7 +55,7 @@ export const BasicMetric = ( { metric, basicMetrics, name, copies }: BasicMetric
 							? value.toFixed( 2 )
 							: translate( '%(ms)dms', {
 									comment: 'value to be displayed in millisecond',
-									args: { ms: value.toFixed( 2 ) },
+									args: { ms: Math.floor( value ) },
 							  } ) }
 					</div>
 				</div>

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import clsx from 'clsx';
-import { useTranslate, numberFormat } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { ForwardedRef, forwardRef, useMemo } from 'react';
 import { calculateMetricsSectionScrollOffset } from 'calypso/site-profiler/utils/calculate-metrics-section-scroll-offset';
 import { CopiesReturnValueList, MetricsCopies, getCopies } from './copies';
@@ -52,10 +52,10 @@ export const BasicMetric = ( { metric, basicMetrics, name, copies }: BasicMetric
 					</div>
 					<div className="basic-metrics__value">
 						{ metric === 'cls'
-							? numberFormat( value, 2 )
+							? value.toFixed( 2 )
 							: translate( '%(ms)dms', {
 									comment: 'value to be displayed in millisecond',
-									args: { ms: numberFormat( value, 2 ) },
+									args: { ms: value.toFixed( 2 ) },
 							  } ) }
 					</div>
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/91608
Related to https://github.com/Automattic/dotcom-forge/issues/7659

## Proposed Changes

* Update number formatting to not apply regional formatting

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're updating the Site Profiler UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler` and enter any site URL
* Check that on the results page, the ms values make sense to the color of the metric, and the explanation
* Check that the number in the basic metric and the description is formatted the same way


| Before | After |
|--------|--------|
| ![image](https://github.com/Automattic/wp-calypso/assets/11555574/ccf266ea-e3cf-4450-8ad1-da9acb04d373) | ![CleanShot 2024-06-14 at 11 39 47@2x](https://github.com/Automattic/wp-calypso/assets/11555574/5c40f79a-f4ed-4e87-b1e6-0a2db4d64e71) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
