### PR TITLE
Stats: Update notices to include PWYW plans

### DIFF
--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -103,9 +103,6 @@ function shouldShowCommercialSiteUpgradeNotice( {
 	isCommercial,
 	isCommercialOwned,
 }: StatsNoticeProps ) {
-	// eslint-disable-next-line prefer-rest-params
-	console.log( 'arguments: ', arguments );
-
 	// Set up test conditions for the notice.
 	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
 	const showUpgradeNoticeOnOdyssey = isOdysseyStats;

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -103,6 +103,9 @@ function originalVisibilityFunc( {
 	isSiteJetpackNotAtomic,
 	isCommercial,
 }: StatsNoticeProps ) {
+	// eslint-disable-next-line prefer-rest-params
+	console.log( 'arguments: ', arguments );
+
 	// Set up test conditions for the notice.
 	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
 	const showUpgradeNoticeOnOdyssey = isOdysseyStats;

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -33,34 +33,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: CommercialSiteUpgradeNotice,
 		noticeId: 'commercial_site_upgrade',
-		isVisibleFunc: ( {
-			isOdysseyStats,
-			isWpcom,
-			isVip,
-			isP2,
-			isOwnedByTeam51,
-			hasPaidStats,
-			isSiteJetpackNotAtomic,
-			isCommercial,
-		}: StatsNoticeProps ) => {
-			const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
-
-			// Show the notice if the site is Jetpack or it is Odyssey Stats.
-			const showUpgradeNoticeOnOdyssey = isOdysseyStats;
-
-			const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
-
-			return !! (
-				( showUpgradeNoticeOnOdyssey ||
-					showUpgradeNoticeForJetpackNotAtomic ||
-					showUpgradeNoticeForWpcomSites ) &&
-				// Show the notice if the site has not purchased the paid stats product.
-				! hasPaidStats &&
-				// Show the notice only if the site is commercial.
-				isCommercial &&
-				! isVip
-			);
-		},
+		isVisibleFunc: originalVisibilityFunc,
 		disabled: false,
 	},
 	{
@@ -119,5 +92,32 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		disabled: false,
 	},
 ];
+
+function originalVisibilityFunc( {
+	isOdysseyStats,
+	isWpcom,
+	isVip,
+	isP2,
+	isOwnedByTeam51,
+	hasPaidStats,
+	isSiteJetpackNotAtomic,
+	isCommercial,
+}: StatsNoticeProps ) {
+	// Set up test conditions for the notice.
+	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
+	const showUpgradeNoticeOnOdyssey = isOdysseyStats;
+	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
+
+	return !! (
+		( showUpgradeNoticeOnOdyssey ||
+			showUpgradeNoticeForJetpackNotAtomic ||
+			showUpgradeNoticeForWpcomSites ) &&
+		// Show the notice if the site has not purchased the paid stats product.
+		! hasPaidStats &&
+		// Show the notice only if the site is commercial.
+		isCommercial &&
+		! isVip
+	);
+}
 
 export default ALL_STATS_NOTICES;

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -33,7 +33,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: CommercialSiteUpgradeNotice,
 		noticeId: 'commercial_site_upgrade',
-		isVisibleFunc: originalVisibilityFunc,
+		isVisibleFunc: shouldShowCommercialSiteUpgradeNotice,
 		disabled: false,
 	},
 	{
@@ -93,7 +93,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	},
 ];
 
-function originalVisibilityFunc( {
+function shouldShowCommercialSiteUpgradeNotice( {
 	isOdysseyStats,
 	isWpcom,
 	isVip,

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -99,9 +99,9 @@ function originalVisibilityFunc( {
 	isVip,
 	isP2,
 	isOwnedByTeam51,
-	hasPaidStats,
 	isSiteJetpackNotAtomic,
 	isCommercial,
+	isCommercialOwned,
 }: StatsNoticeProps ) {
 	// eslint-disable-next-line prefer-rest-params
 	console.log( 'arguments: ', arguments );
@@ -115,10 +115,9 @@ function originalVisibilityFunc( {
 		( showUpgradeNoticeOnOdyssey ||
 			showUpgradeNoticeForJetpackNotAtomic ||
 			showUpgradeNoticeForWpcomSites ) &&
-		// Show the notice if the site has not purchased the paid stats product.
-		! hasPaidStats &&
-		// Show the notice only if the site is commercial.
+		// Show the notice if the site is commercial without a commercial plan.
 		isCommercial &&
+		! isCommercialOwned &&
 		! isVip
 	);
 }

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -33,7 +33,31 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: CommercialSiteUpgradeNotice,
 		noticeId: 'commercial_site_upgrade',
-		isVisibleFunc: shouldShowCommercialSiteUpgradeNotice,
+		isVisibleFunc: ( {
+			isOdysseyStats,
+			isWpcom,
+			isVip,
+			isP2,
+			isOwnedByTeam51,
+			isSiteJetpackNotAtomic,
+			isCommercial,
+			isCommercialOwned,
+		}: StatsNoticeProps ) => {
+			// Set up test conditions for the notice.
+			const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
+			const showUpgradeNoticeOnOdyssey = isOdysseyStats;
+			const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
+
+			return !! (
+				( showUpgradeNoticeOnOdyssey ||
+					showUpgradeNoticeForJetpackNotAtomic ||
+					showUpgradeNoticeForWpcomSites ) &&
+				// Show the notice if the site is commercial without a commercial plan.
+				isCommercial &&
+				! isCommercialOwned &&
+				! isVip
+			);
+		},
 		disabled: false,
 	},
 	{
@@ -92,31 +116,5 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		disabled: false,
 	},
 ];
-
-function shouldShowCommercialSiteUpgradeNotice( {
-	isOdysseyStats,
-	isWpcom,
-	isVip,
-	isP2,
-	isOwnedByTeam51,
-	isSiteJetpackNotAtomic,
-	isCommercial,
-	isCommercialOwned,
-}: StatsNoticeProps ) {
-	// Set up test conditions for the notice.
-	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
-	const showUpgradeNoticeOnOdyssey = isOdysseyStats;
-	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
-
-	return !! (
-		( showUpgradeNoticeOnOdyssey ||
-			showUpgradeNoticeForJetpackNotAtomic ||
-			showUpgradeNoticeForWpcomSites ) &&
-		// Show the notice if the site is commercial without a commercial plan.
-		isCommercial &&
-		! isCommercialOwned &&
-		! isVip
-	);
-}
 
 export default ALL_STATS_NOTICES;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81361.

## Proposed Changes

Show the commercial upgrade notice on any site flagged as `isCommercial` that has a PWYW plan. Previously we didn't show the notice to these sites.

<img width="883" alt="SCR-20240614-rcmz" src="https://github.com/Automattic/wp-calypso/assets/40267301/cb4c7c0c-887f-4a8b-9c28-092bb2d40204">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The PWYW plans are meant for non-commercial sites. It's possible to purchase one if the site has not been classified or if the site's classification changes over time. We want to make sure we surface notices to upgrade to the correct license if we find a mismatch of classification & license type.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a PWYW plan to your test site.
* Force the site to commercial status using the "jetpack-site-is-commercial-override" override on the Blog RC tool.
* Visit the Stats page and confirm the notice is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
