### PR TITLE
A4A: Update Partner Directory forms styles

### DIFF
--- a/client/a8c-for-agencies/components/form/field/index.tsx
+++ b/client/a8c-for-agencies/components/form/field/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 
 import './style.scss';
@@ -6,14 +7,23 @@ type Props = {
 	label: string;
 	sub?: string;
 	description?: string;
+	isOptional?: boolean;
 	children: ReactNode;
 };
 
-export default function FormField( { label, sub, children, description }: Props ) {
+export default function FormField( { label, sub, children, description, isOptional }: Props ) {
+	const translate = useTranslate();
+
 	return (
 		<div className="a4a-form__section-field">
 			<div className="a4a-form__section-field-heading">
-				<h3 className="a4a-form__section-field-label">{ label }</h3>
+				<h3 className="a4a-form__section-field-label">
+					{ label }
+
+					{ isOptional && (
+						<span className="a4a-form__section-field-optional">({ translate( 'optional' ) })</span>
+					) }
+				</h3>
 				{ sub && <p className="a4a-form__section-field-sub">{ sub }</p> }
 			</div>
 

--- a/client/a8c-for-agencies/components/form/field/style.scss
+++ b/client/a8c-for-agencies/components/form/field/style.scss
@@ -16,7 +16,12 @@
 }
 
 .a4a-form__section-field-sub,
-.a4a-form__section-field-description {
+.a4a-form__section-field-description,
+.a4a-form__section-field-optional {
 	font-weight: 400;
 	color: var(--color-neutral-50);
+}
+
+.a4a-form__section-field-optional {
+	margin-inline-start: 4px;
 }

--- a/client/a8c-for-agencies/components/form/style.scss
+++ b/client/a8c-for-agencies/components/form/style.scss
@@ -6,6 +6,10 @@
 	max-width: 700px;
 	margin: 0 auto;
 
+	@include breakpoint-deprecated("<660px") {
+		margin-block-end: rem(76px);
+	}
+
 	h1,
 	h2,
 	h3,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -200,7 +200,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			</FormSection>
 			<div className="partner-directory-agency-cta__footer">
 				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>
-					{ translate( 'Publish public profile' ) }
+					{ translate( 'Save public profile' ) }
 				</Button>
 			</div>
 		</Form>

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -191,11 +191,12 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 					'Optionally set your minimum budget. Clients can filter these details to find the right agency.'
 				) }
 			>
-				<div>{ translate( 'Minimum project budget' ) }</div>
-				<BudgetSelector
-					budgetLowerRange={ formData.budgetLowerRange }
-					setBudget={ ( budget: string ) => setFormFields( { budgetLowerRange: budget } ) }
-				/>
+				<FormField label={ translate( 'Minimum project budget' ) }>
+					<BudgetSelector
+						budgetLowerRange={ formData.budgetLowerRange }
+						setBudget={ ( budget: string ) => setFormFields( { budgetLowerRange: budget } ) }
+					/>
+				</FormField>
 			</FormSection>
 			<div className="partner-directory-agency-cta__footer">
 				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -200,6 +200,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 					description={ translate(
 						'Great support is key to our success. Share a link to your customer feedback from Google, Clutch, Facebook, etc., or testimonials featured on your website. If you don’t have online reviews, provide a link to client references or case studies.'
 					) }
+					isOptional
 				>
 					<TextControl
 						type="text"

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -217,17 +217,17 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 			</FormSection>
 
 			<div className="partner-directory-agency-cta__footer">
-				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>
-					{ initialFormData
-						? translate( 'Update my expertise' )
-						: translate( 'Submit my application' ) }
-				</Button>
-
 				<Button
 					href={ `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_DASHBOARD_SLUG }` }
 					disabled={ isSubmitting }
 				>
 					{ translate( 'Cancel' ) }
+				</Button>
+
+				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>
+					{ initialFormData
+						? translate( 'Update my expertise' )
+						: translate( 'Submit my application' ) }
 				</Button>
 			</div>
 		</Form>

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
@@ -4,6 +4,10 @@
 	grid-template-columns: 1fr 1fr;
 	row-gap: 16px;
 	column-gap: 32px;
+
+	@include breakpoint-deprecated("<960px") {
+		grid-template-columns: 1fr;
+	}
 }
 
 .partner-directory-agency-expertise__client-site,

--- a/client/a8c-for-agencies/sections/partner-directory/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/style.scss
@@ -1,12 +1,21 @@
 .partner-directory-agency-cta__footer {
 	display: flex;
 	flex-direction: row;
+	justify-content: flex-end;
 	gap: 8px;
 	margin-block-start: -16px;
+
+	@include breakpoint-deprecated("<660px") {
+		flex-direction: column;
+	}
 }
 
-.partner-directory-agency-cta__footer button {
-	margin-left: auto;
+.partner-directory-agency-cta__footer a {
+
+	@include breakpoint-deprecated("<660px") {
+		width: 100%;
+		order: 2;
+	}
 }
 
 .partner-directory__body {


### PR DESCRIPTION
## Proposed Changes

* [Fix label for minimum project budget field](https://github.com/Automattic/wp-calypso/commit/4305537e42f346ad7dc77e8b531a4b65feb6a773)

Before | After
--|--
<img width="730" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/2e3ad938-6d00-476d-b924-f369a95babb4"> | <img width="731" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/2688a8e4-7b3e-4dff-9452-3958f8a9f778">

* [Update CTA copy in Agency Details form in preparation for the upcoming flow changes](https://github.com/Automattic/wp-calypso/commit/a55270e0d5f4dc3737ac0bc2a04c8995c15a7679)

Before | After
--|--
<img width="735" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/64b9bbbe-4e54-42c8-bd53-fa5516f710a9"> | <img width="740" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/9a9f8535-48c4-460d-9219-4d08b8401068">

* [Add new `isOptional` prop to form field component](https://github.com/Automattic/wp-calypso/commit/7248361b96f4f7c0d0b1faa10e7eb87385de4a30)
* [Highlight Share customer feedback as optional](https://github.com/Automattic/wp-calypso/commit/0ec12ba1820f0fd5c2d40f33b9d791f946025e55)

Before | After
--|--
<img width="733" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/c8bbe9a4-1f96-4ec0-9205-dfb89f9216a9"> | <img width="728" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/10176e44-e5bc-45d5-bc10-ae93588dbcd6">

* [Fix form button visibility in smaller screens](https://github.com/Automattic/wp-calypso/commit/75fe3b5b6df4ad4a4a4f3cf349aafc5d20e8c7f4)
* [Reorder primary and secondary CTAs, add mobile styles](https://github.com/Automattic/wp-calypso/commit/381595f8eb770307651522860c8117a691897099)

Before | After
--|--
<img width="734" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/210516f9-6a0f-42a7-a636-ccfa0adb6092">| <img width="727" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/33e11b16-fab2-430f-8c63-5cf5154fb78c">
<img width="388" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/15a0cfac-a60c-4720-aaf5-c6b047d790ba"> | <img width="389" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/fb29fd4b-6f2c-4428-808c-23e5543c860e">


* [Fix the client sites examples grid in smaller screens](https://github.com/Automattic/wp-calypso/commit/a7b15c6379c1f7952e3a7fdc40a6f89f6272f59d)

Before | After
--|--
<img width="360" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/8b01f6bb-f89b-4220-a210-e61839a27a4f"> | <img width="360" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/090ee039-98ef-4769-a570-569edbd71e6e">


## Testing Instructions

* Fire up this PR.
* Go to the Partner Directory section in A4A.
* Make sure all the forms are working as expected and look good.
