### PR TITLE
Stepper plans: Support extra wide layout in Stepper's plans

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -32,7 +32,7 @@ const plans: Step = function Plans( { navigation, flow } ) {
 			goBack={ goBack }
 			isHorizontalLayout={ false }
 			isWideLayout={ false }
-			isFullLayout
+			isExtraWideLayout
 			hideFormattedHeader
 			isLargeSkipLayout={ false }
 			hideBack={ ! isAllowedToGoBack }

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -33,6 +33,7 @@ interface Props {
 	headerButton?: ReactElement;
 	customizedActionButtons?: ReactElement;
 	isWideLayout?: boolean;
+	isExtraWideLayout?: boolean;
 	isFullLayout?: boolean;
 	isHorizontalLayout?: boolean;
 	goBack?: () => void;
@@ -70,6 +71,7 @@ const StepContainer: React.FC< Props > = ( {
 	isHorizontalLayout,
 	isFullLayout,
 	isWideLayout,
+	isExtraWideLayout,
 	isExternalBackUrl,
 	isLargeSkipLayout,
 	customizedActionButtons,
@@ -169,6 +171,7 @@ const StepContainer: React.FC< Props > = ( {
 		'is-full-layout': isFullLayout,
 		'is-large-skip-layout': isLargeSkipLayout,
 		'has-navigation': ! shouldHideNavButtons,
+		'is-extra-wide-layout': isExtraWideLayout,
 	} );
 
 	return (


### PR DESCRIPTION
## Proposed Changes

Currently, the plans grid stepper in Stepper doesn't support `isExtraWideLayout`, which is a requirement for the 2023 plans grid. This adds support for that.

## Testing Instructions

1. Go to /setup/newsletter/plans
2. Go to /setup/design-first/plans
3. Go to /setup/domain-upsell/plans
4. All should look good.