### PR TITLE
Guided Onboard: adjust styling for Flow Card hover

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
@@ -15,22 +15,30 @@
 
 	&:hover,
 	&:focus {
-		background-color: var(--studio-gray-0);
-		box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+		box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #3858e9);
+
+		svg path {
+			fill: var(--wp-admin-theme-color, #3858e9);
+		}
+
+		.flow-question__description,
+		.flow-question__heading {
+			color: var(--wp-admin-theme-color, #3858e9);
+		}
 	}
-}
 
-.flow-question__icon {
-	align-self: flex-start;
-	padding: 2px 1px 0 0;
-}
+	.flow-question__icon {
+		align-self: flex-start;
+		padding: 2px 1px 0 0;
+	}
 
-.flow-question__heading {
-	font-weight: 500;
-	font-size: $font-body-large;
-}
+	.flow-question__heading {
+		font-weight: 500;
+		font-size: $font-body-large;
+	}
 
-.flow-question__description {
-	color: var(--studio-gray-60);
-	padding-right: 10px;
+	.flow-question__description {
+		color: var(--studio-gray-60);
+		padding-right: 10px;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
@@ -1,5 +1,7 @@
 @import "@automattic/typography/styles/variables";
 
+$blueberry-color: #3858e9;
+
 .flow-question {
 	margin: 0 10px 18px;
 	// !important needed here to override component styles
@@ -15,15 +17,15 @@
 
 	&:hover,
 	&:focus {
-		box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #3858e9);
+		box-shadow: 0 0 0 1px $blueberry-color;
 
 		svg path {
-			fill: var(--wp-admin-theme-color, #3858e9);
+			fill: $blueberry-color;
 		}
 
 		.flow-question__description,
 		.flow-question__heading {
-			color: var(--wp-admin-theme-color, #3858e9);
+			color: $blueberry-color;
 		}
 	}
 

--- a/client/signup/steps/initial-intent/styles.scss
+++ b/client/signup/steps/initial-intent/styles.scss
@@ -41,21 +41,6 @@
 				.flow-question {
 					max-width: 430px;
 
-					&:hover {
-						background-color: inherit;
-						box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #3858e9);
-						transition: 200ms ease-in;
-
-						svg {
-							fill: var(--wp-admin-theme-color, #3858e9);
-						}
-
-						.flow-question__heading,
-						.flow-question__description {
-							color: var(--wp-admin-theme-color, #3858e9);
-						}
-					}
-
 					.flow-question__heading {
 						margin-bottom: 4px;
 						line-height: 24px;

--- a/client/signup/steps/initial-intent/styles.scss
+++ b/client/signup/steps/initial-intent/styles.scss
@@ -40,10 +40,27 @@
 
 				.flow-question {
 					max-width: 430px;
+
+					&:hover {
+						background-color: inherit;
+						box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #3858e9);
+						transition: 200ms ease-in;
+
+						svg {
+							fill: var(--wp-admin-theme-color, #3858e9);
+						}
+
+						.flow-question__heading,
+						.flow-question__description {
+							color: var(--wp-admin-theme-color, #3858e9);
+						}
+					}
+
 					.flow-question__heading {
 						margin-bottom: 4px;
 						line-height: 24px;
 					}
+
 					.flow-question__description {
 						line-height: 20px;
 						letter-spacing: -0.15px;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7763

## Proposed Changes

Update hover effect in intent step

## Why are these changes being made?

To make sure that we have matching styles in both questions

## Testing Instructions
Pull branch or use live link. Go to `/start/guided?flags=onboarding/guided`
Hover the stuff and make sure it matches this:

<img width="1456" alt="Segment 1-Offramp" src="https://github.com/Automattic/dotcom-forge/assets/7931304/0949554b-e6b5-480c-ba62-95fe48b1332d">