### PR TITLE
Site Profiler: Show the values on basic metrics as seconds when too big

### DIFF
--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -37,11 +37,11 @@ export function getCopies(
 	const supportUrl = localizeUrl( 'https://wordpress.com/support' );
 
 	const clsValue = basicMetrics?.cls?.value.toFixed( 2 );
-	const fidValue = formatMsValue( basicMetrics?.fid?.value, translate );
-	const lcpValue = formatMsValue( basicMetrics?.lcp?.value, translate );
-	const fcpValue = formatMsValue( basicMetrics?.fcp?.value, translate );
-	const ttfbValue = formatMsValue( basicMetrics?.ttfb?.value, translate );
-	const inpValue = formatMsValue( basicMetrics?.inp?.value, translate );
+	const fidValue = formatMsValue( basicMetrics?.fid?.value );
+	const lcpValue = formatMsValue( basicMetrics?.lcp?.value );
+	const fcpValue = formatMsValue( basicMetrics?.fcp?.value );
+	const ttfbValue = formatMsValue( basicMetrics?.ttfb?.value );
+	const inpValue = formatMsValue( basicMetrics?.inp?.value );
 
 	const cls: CopiesProps = {
 		title: translate( 'Cumulative Layout Shift (CLS)' ),

--- a/client/site-profiler/components/basic-metrics/copies.tsx
+++ b/client/site-profiler/components/basic-metrics/copies.tsx
@@ -1,6 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { type I18N } from 'i18n-calypso';
 import { ReactNode } from 'react';
+import { formatMsValue } from 'calypso/site-profiler/utils/format-ms-value';
 import type { BasicMetricsScored, Metrics, Scores } from 'calypso/data/site-profiler/types';
 
 type SubsetScores = Exclude< Scores, 'needs-improvement' >;
@@ -27,9 +28,6 @@ type CopiesReturnValue = {
 };
 
 export type CopiesReturnValueList = [ Metrics, CopiesProps ][];
-
-const formatMsValue = ( value: number ) => Math.floor( value );
-
 export function getCopies(
 	basicMetrics: BasicMetricsScored,
 	translate: I18N[ 'translate' ],
@@ -39,29 +37,29 @@ export function getCopies(
 	const supportUrl = localizeUrl( 'https://wordpress.com/support' );
 
 	const clsValue = basicMetrics?.cls?.value.toFixed( 2 );
-	const fidValue = formatMsValue( basicMetrics?.fid?.value );
-	const lcpValue = formatMsValue( basicMetrics?.lcp?.value );
-	const fcpValue = formatMsValue( basicMetrics?.fcp?.value );
-	const ttfbValue = formatMsValue( basicMetrics?.ttfb?.value );
-	const inpValue = formatMsValue( basicMetrics?.inp?.value );
+	const fidValue = formatMsValue( basicMetrics?.fid?.value, translate );
+	const lcpValue = formatMsValue( basicMetrics?.lcp?.value, translate );
+	const fcpValue = formatMsValue( basicMetrics?.fcp?.value, translate );
+	const ttfbValue = formatMsValue( basicMetrics?.ttfb?.value, translate );
+	const inpValue = formatMsValue( basicMetrics?.inp?.value, translate );
 
 	const cls: CopiesProps = {
 		title: translate( 'Cumulative Layout Shift (CLS)' ),
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)s, ensuring a stable layout. Excellent job maintaining low shifts!',
+					"Your site's CLS is %(value)s, ensuring a stable layout. Excellent job maintaining low shifts!",
 					{ args: { value: clsValue } }
 				),
 				solution: translate(
-					'Migrate to WordPress.com to maintain this stability and further enhance your site’s layout performance.'
+					"Migrate to WordPress.com to maintain this stability and further enhance your site's layout performance."
 				),
 				cta: translate( 'Enhance stability' ),
 				url: migrateUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)s, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					"Your site's CLS is %(value)s, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.",
 					{
 						args: {
 							value: clsValue,
@@ -78,18 +76,18 @@ export function getCopies(
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.',
+					"Your site's CLS is %(value)f, ensuring a stable layout. Great job maintaining low shifts.",
 					{ args: { value: clsValue } }
 				),
 				solution: translate(
-					'Keep up the good work! Continue using best practices to maintain your site’s stability.'
+					"Keep up the good work! Continue using best practices to maintain your site's stability."
 				),
 				cta: translate( 'Explore Advanced Tips' ),
 				url: supportUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.',
+					"Your site's CLS is %(value)f, higher than average, causing noticeable shifts. Aim for 0.1 for smoother layout.",
 					{ args: { value: clsValue } }
 				),
 				solution: translate(
@@ -106,7 +104,7 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s FID is %(value)fms, offering quick response times. Excellent job maintaining fast interactions!',
+					"Your site's FID is %(value)s, offering quick response times. Excellent job maintaining fast interactions!",
 					{ args: { value: fidValue } }
 				),
 				solution: translate(
@@ -117,7 +115,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s FID is %(value)fms, slower than most. Aim for less than 100ms for better responsiveness.',
+					"Your site's FID is %(value)s, slower than most. Aim for less than 100ms for better responsiveness.",
 					{
 						args: {
 							value: fidValue,
@@ -134,7 +132,7 @@ export function getCopies(
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s FID is %(value)fms, offering quick response times. Excellent job on maintaining swift interactions!',
+					"Your site's FID is %(value)s, offering quick response times. Excellent job on maintaining swift interactions!",
 					{ args: { value: fidValue } }
 				),
 				solution: translate(
@@ -145,11 +143,11 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s FID is %(value)fms, slower than most. Aim for less than 100ms for better responsiveness.',
+					"Your site's FID is %(value)s, slower than most. Aim for less than 100ms for better responsiveness.",
 					{ args: { value: fidValue } }
 				),
 				solution: translate(
-					'Connect with a Happiness Engineer to optimize FID and improve your site’s responsiveness'
+					"Connect with a Happiness Engineer to optimize FID and improve your site's responsiveness"
 				),
 				cta: translate( 'Enhance responsiveness' ),
 				url: supportUrl,
@@ -162,7 +160,7 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s FCP is %(value)fms, providing a fast initial load. Great job on maintaining quick content display!',
+					"Your site's FCP is %(value)s, providing a fast initial load. Great job on maintaining quick content display!",
 					{ args: { value: fcpValue } }
 				),
 				solution: translate(
@@ -173,7 +171,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s FCP is %(value)fms, slower than average. Aim for under 2s to improve user experience.',
+					"Your site's FCP is %(value)s, slower than average. Aim for under 2s to improve user experience.",
 					{
 						args: {
 							value: fcpValue,
@@ -190,7 +188,7 @@ export function getCopies(
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s FCP is %(value)fms, providing a fast initial load. Excellent job maintaining quick content delivery!',
+					"Your site's FCP is %(value)s, providing a fast initial load. Excellent job maintaining quick content delivery!",
 					{ args: { value: fcpValue } }
 				),
 				solution: translate(
@@ -201,7 +199,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s FCP is %(value)fms, slower than average. Aim for under 2s to improve user experience.',
+					"Your site's FCP is %(value)s, slower than average. Aim for under 2s to improve user experience.",
 					{ args: { value: fcpValue } }
 				),
 				solution: translate(
@@ -218,18 +216,18 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s LCP is %(value)fms, loading main content quickly. Well done on maintaining fast load times!',
+					"Your site's LCP is %(value)s, loading main content quickly. Well done on maintaining fast load times!",
 					{ args: { value: lcpValue } }
 				),
 				solution: translate(
-					'Migrate to WordPress.com to achieve even faster LCP and enhance your site’s overall performance.'
+					"Migrate to WordPress.com to achieve even faster LCP and enhance your site's overall performance."
 				),
 				cta: translate( 'Optimize main load' ),
 				url: migrateUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s LCP is %(value)fms, slower than typical sites. Aim for under 2.5s for better performance.',
+					"Your site's LCP is %(value)s, slower than typical sites. Aim for under 2.5s for better performance.",
 					{
 						args: {
 							value: lcpValue,
@@ -246,7 +244,7 @@ export function getCopies(
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s LCP is %(value)fms, loading main content quickly. Excellent job maintaining fast content display!',
+					"Your site's LCP is %(value)s, loading main content quickly. Excellent job maintaining fast content display!",
 					{ args: { value: lcpValue } }
 				),
 				solution: translate(
@@ -257,7 +255,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s LCP is %(value)fms, slower than typical sites. Aim for under 2.5s for better performance.',
+					"Your site's LCP is %(value)s, slower than typical sites. Aim for under 2.5s for better performance.",
 					{ args: { value: lcpValue } }
 				),
 				solution: translate(
@@ -274,7 +272,7 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s TTFB is %(value)fms, offering fast server response. Excellent job on maintaining quick response!',
+					"Your site's TTFB is %(value)s, offering fast server response. Excellent job on maintaining quick response!",
 					{ args: { value: ttfbValue } }
 				),
 				solution: translate(
@@ -285,7 +283,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s TTFB is %(value)fms, longer than most sites. Aim for less than 600ms for better performance.',
+					"Your site's TTFB is %(value)s, longer than most sites. Aim for less than 600ms for better performance.",
 					{
 						args: {
 							value: ttfbValue,
@@ -302,7 +300,7 @@ export function getCopies(
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s TTFB is %(value)fms, offering fast server response. Excellent job on maintaining quick server performance!',
+					"Your site's TTFB is %(value)s, offering fast server response. Excellent job on maintaining quick server performance!",
 					{ args: { value: ttfbValue } }
 				),
 				solution: translate(
@@ -313,7 +311,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s TTFB is %(value)fms, longer than most sites. Aim for less than 600ms for better performance.',
+					"Your site's TTFB is %(value)s, longer than most sites. Aim for less than 600ms for better performance.",
 					{ args: { value: ttfbValue } }
 				),
 				solution: translate(
@@ -330,18 +328,18 @@ export function getCopies(
 		nonWpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s INP is %(value)fms, providing smooth interactions. Great job on maintaining quick responses!',
+					"Your site's INP is %(value)s, providing smooth interactions. Great job on maintaining quick responses!",
 					{ args: { value: inpValue } }
 				),
 				solution: translate(
-					'Migrate to WordPress.com to sustain and further enhance your site’s interaction speed.'
+					"Migrate to WordPress.com to sustain and further enhance your site's interaction speed."
 				),
 				cta: translate( 'Improve INP speed' ),
 				url: migrateUrl,
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s INP is %(value)fms, higher than average. Aim for less than 100ms for smoother interactions.',
+					"Your site's INP is %(value)s, higher than average. Aim for less than 100ms for smoother interactions.",
 					{
 						args: {
 							value: inpValue,
@@ -358,7 +356,7 @@ export function getCopies(
 		wpcom: {
 			good: {
 				diagnostic: translate(
-					'Your site’s INP is %(value)fms, providing smooth interactions. Excellent performance, keep it up!',
+					"Your site's INP is %(value)s, providing smooth interactions. Excellent performance, keep it up!",
 					{ args: { value: inpValue } }
 				),
 				solution: translate(
@@ -369,7 +367,7 @@ export function getCopies(
 			},
 			poor: {
 				diagnostic: translate(
-					'Your site’s INP is %(value)fms, higher than average. Aim for less than 100ms for smoother interactions.',
+					"Your site's INP is %(value)s, higher than average. Aim for less than 100ms for smoother interactions.",
 					{ args: { value: inpValue } }
 				),
 				solution: translate(

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -38,7 +38,6 @@ type BasicMetricProps = {
 };
 
 export const BasicMetric = ( { metric, basicMetrics, name, copies }: BasicMetricProps ) => {
-	const translate = useTranslate();
 	const { value, score } = basicMetrics[ metric ];
 	const showMetric = value !== undefined && value !== null;
 	const isPositiveScore = score === 'good';
@@ -52,7 +51,7 @@ export const BasicMetric = ( { metric, basicMetrics, name, copies }: BasicMetric
 						{ name }
 					</div>
 					<div className="basic-metrics__value">
-						{ metric === 'cls' ? value.toFixed( 2 ) : formatMsValue( value, translate ) }
+						{ metric === 'cls' ? value.toFixed( 2 ) : formatMsValue( value ) }
 					</div>
 				</div>
 				<h3>{ isPositiveScore ? copies.good.diagnostic : copies.poor.diagnostic }</h3>

--- a/client/site-profiler/components/basic-metrics/index.tsx
+++ b/client/site-profiler/components/basic-metrics/index.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ForwardedRef, forwardRef, useMemo } from 'react';
 import { calculateMetricsSectionScrollOffset } from 'calypso/site-profiler/utils/calculate-metrics-section-scroll-offset';
+import { formatMsValue } from 'calypso/site-profiler/utils/format-ms-value';
 import { CopiesReturnValueList, MetricsCopies, getCopies } from './copies';
 import type { BasicMetricsScored, Metrics, Scores } from 'calypso/data/site-profiler/types';
 import './styles.scss';
@@ -51,12 +52,7 @@ export const BasicMetric = ( { metric, basicMetrics, name, copies }: BasicMetric
 						{ name }
 					</div>
 					<div className="basic-metrics__value">
-						{ metric === 'cls'
-							? value.toFixed( 2 )
-							: translate( '%(ms)dms', {
-									comment: 'value to be displayed in millisecond',
-									args: { ms: Math.floor( value ) },
-							  } ) }
+						{ metric === 'cls' ? value.toFixed( 2 ) : formatMsValue( value, translate ) }
 					</div>
 				</div>
 				<h3>{ isPositiveScore ? copies.good.diagnostic : copies.poor.diagnostic }</h3>

--- a/client/site-profiler/components/styles-v2.scss
+++ b/client/site-profiler/components/styles-v2.scss
@@ -45,11 +45,11 @@
 		font-size: 1.75rem;
 		line-height: normal;
 		margin-bottom: 1rem;
-		height: 165px;
+		height: 200px;
 	}
 
 	h4 {
-		height: 60px;
+		height: 80px;
 		margin-bottom: 1rem;
 	}
 

--- a/client/site-profiler/components/styles-v2.scss
+++ b/client/site-profiler/components/styles-v2.scss
@@ -43,11 +43,13 @@
 	h3 {
 		font-family: $font-sf-pro-text;
 		font-size: 1.75rem;
-		line-height: 1.15;
+		line-height: normal;
 		margin-bottom: 1rem;
+		height: 165px;
 	}
 
 	h4 {
+		height: 60px;
 		margin-bottom: 1rem;
 	}
 

--- a/client/site-profiler/utils/format-ms-value.ts
+++ b/client/site-profiler/utils/format-ms-value.ts
@@ -1,0 +1,18 @@
+import { I18N } from 'i18n-calypso';
+
+export const formatMsValue = (
+	msValue: number,
+	translate: I18N[ 'translate' ]
+): React.ReactElement | string | number => {
+	if ( msValue < 1000 ) {
+		return translate( '%(value)sms', {
+			comment: 'value to be displayed in milliseconds',
+			args: { value: Math.floor( msValue ) },
+		} );
+	}
+
+	return translate( '%(value)ss', {
+		comment: 'value to be displayed in seconds',
+		args: { value: ( msValue / 1000 ).toFixed( 2 ) },
+	} );
+};

--- a/client/site-profiler/utils/format-ms-value.ts
+++ b/client/site-profiler/utils/format-ms-value.ts
@@ -1,9 +1,6 @@
-import { I18N } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
-export const formatMsValue = (
-	msValue: number,
-	translate: I18N[ 'translate' ]
-): React.ReactElement | string | number => {
+export const formatMsValue = ( msValue: number ): React.ReactElement | string | number => {
 	if ( msValue < 1000 ) {
 		return translate( '%(value)sms', {
 			comment: 'value to be displayed in milliseconds',


### PR DESCRIPTION

## Proposed Changes
* Display values bigger than `1000ms` in seconds
* Replace `’` per `'` the correct single quote character
* Set a fixed height for text containers to keep the sections aligned


## Why are these changes being made?

Discussions here: p1718354334303069-slack-C06G283R4LF

## Testing Instructions

* Go to `/site-profiler` and look for a site. Ex: `atliq.com`
* Click on the `Check site` button
* Verify all the style changes matches the ones below

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-06-14 at 10 48 41@2x](https://github.com/Automattic/wp-calypso/assets/5039531/30a825c6-8f30-4fad-88de-64847fd27ef1)|![CleanShot 2024-06-14 at 10 46 46@2x](https://github.com/Automattic/wp-calypso/assets/5039531/4cc93ea4-fe02-4529-8ac8-10f851283c4c)|
