### PR TITLE
Site Profiler: Update the isWordPress check to use basic metrics request data

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -125,6 +125,7 @@ export type PerformanceReport = {
 	performance: number;
 	overall_score: number;
 	is_wpcom: boolean;
+	is_wordpress: boolean;
 } & BasicMetrics;
 
 export interface UrlPerformanceMetricsQueryResponse {

--- a/client/site-profiler/components/site-profiler-v2.tsx
+++ b/client/site-profiler/components/site-profiler-v2.tsx
@@ -125,7 +125,7 @@ export default function SiteProfilerV2( props: Props ) {
 		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
 	};
 
-	const isWpCom = !! performanceMetrics?.is_wpcom;
+	const { is_wpcom: isWpCom = false, is_wordpress: isWordPress = false } = performanceMetrics ?? {};
 
 	return (
 		<div id="site-profiler-v2">
@@ -158,7 +158,7 @@ export default function SiteProfilerV2( props: Props ) {
 						<ResultsHeader
 							domain={ domain }
 							performanceCategory={ performanceCategory }
-							isWordPress={ urlData?.platform === 'wordpress' }
+							isWordPress={ isWordPress }
 							isWpCom={ isWpCom }
 							onGetReport={ () => setIsGetReportFormOpen( true ) }
 						/>


### PR DESCRIPTION

## Proposed Changes

Update the isWordPress check to use basic metrics request data

## Why are these changes being made?

Discussions here: p1718354334303069-slack-C06G283R4LF

## Testing Instructions

* Go to `/site-profiler` and look for a WordPress site. Ex: `atliq.com`
* Click on the `Check site` button
* Verify it says it is a WordPress site

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-06-14 at 11 00 11@2x](https://github.com/Automattic/wp-calypso/assets/5039531/bdb0e3cc-bbd3-452c-b1cc-5c212597c7bf)|![CleanShot 2024-06-14 at 10 59 06@2x](https://github.com/Automattic/wp-calypso/assets/5039531/fb007a28-f8c5-440c-a086-bcccdf4cd4ee)|

