### PR TITLE
A4A: Improve links to contact sales and support

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -36,7 +36,7 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 		<ul className="a4a-sidebar__profile-dropdown-menu" hidden={ ! isExpanded }>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">
 				<Button borderless onClick={ onGetHelp }>
-					{ translate( 'Contact sales' ) }
+					{ translate( 'Contact support' ) }
 				</Button>
 			</li>
 			<li className="a4a-sidebar__profile-dropdown-menu-item">

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -137,7 +137,9 @@ export default function UserContactSupportModalForm( {
 					<Icon size={ 24 } icon={ close } />
 				</Button>
 
-				<h1 className="a4a-contact-support-modal-form__title">{ translate( 'Contact sales' ) }</h1>
+				<h1 className="a4a-contact-support-modal-form__title">
+					{ translate( 'Contact sales & support' ) }
+				</h1>
 
 				<FormFieldset>
 					<FormLabel htmlFor="name">{ translate( 'Your name' ) }</FormLabel>

--- a/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
@@ -50,7 +50,7 @@ export default function OverviewSidebarContactSupport() {
 	return (
 		<>
 			<Button className="overview__contact-support-button" onClick={ toggleContactForm }>
-				{ translate( 'Contact Sales' ) }
+				{ translate( 'Contact sales & support' ) }
 			</Button>
 			<UserContactSupportModalForm
 				show={ showUserSupportForm }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/671

## Proposed Changes

Make the following changes:

* Modal title: Change headline to "Contact sales & support".
* CTA under quick links: Change button text to "Contact sales & support".
* CTA within user menu: Change text to "Contact support".

Of note: Contact sales remains the most prominent link in the sidebar.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To properly highlight how to contact sales and support from the overview page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Automattic for Agencies live branch.
* Visit the Overview page (`/overview`).
* Verify the text of the CTA under quick links is "Contact sales & support".
* Verify the Modal headline is "Contact sales & support".
* Verify the text of the CTA within the user menu is "Contact support".

<table>
<tr>
<th>CTA below Quick links</th>
<th>CTA within the user menu</th>
<th>Modal headline</th>
</tr>
<tr>
<td>
<img width="1283" alt="Google Chrome 2024-06-14 16 34 01" src="https://github.com/Automattic/wp-calypso/assets/3418513/06765aa8-31dd-4d4b-9c65-be07d9700bc5">
</td>
<td>
<img width="1283" alt="Google Chrome 2024-06-14 16 34 05" src="https://github.com/Automattic/wp-calypso/assets/3418513/813b4187-537a-4668-aa15-0f9bafb5d8d7">
</td>
<td>
<img width="1283" alt="Google Chrome 2024-06-14 16 33 58" src="https://github.com/Automattic/wp-calypso/assets/3418513/a9730fba-2b1c-4506-8d64-d291ebc1f7fb">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
