### PR TITLE
Reader - update shortkeys and selected post scrolling.

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -95,7 +95,7 @@ $z-layers: (
 		"ul.module-content-list-item-actions.collapsed": 3,
 		".jetpack-connect__password-form .gridicon": 3,
 		".jetpack-connect__creds-form-footer .jetpack-connect__creds-form-spinner": 3,
-		".stream__init-overlay": 10,
+		".stream__init-overlay-enabled": 10,
 		".site-selector": 10,
 		".layout__secondary .site-selector": 10,
 		".range__label": 10,

--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -95,6 +95,7 @@ $z-layers: (
 		"ul.module-content-list-item-actions.collapsed": 3,
 		".jetpack-connect__password-form .gridicon": 3,
 		".jetpack-connect__creds-form-footer .jetpack-connect__creds-form-spinner": 3,
+		".stream__init-overlay": 10,
 		".site-selector": 10,
 		".layout__secondary .site-selector": 10,
 		".range__label": 10,

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -174,7 +174,8 @@ class ReaderStream extends Component {
 		const selectedNode = ReactDom.findDOMNode( this ).querySelector( '.card.is-selected' );
 		if ( selectedNode ) {
 			selectedNode.focus();
-			const scrollContainerPosition = this.state.listContext.scrollTop;
+			const scrollContainer = this.state.listContext || window;
+			const scrollContainerPosition = scrollContainer.scrollTop;
 			const boundingClientRect = selectedNode.getBoundingClientRect();
 			const scrollY = parseInt(
 				scrollContainerPosition + boundingClientRect.top + HEADER_OFFSET,
@@ -185,10 +186,10 @@ class ReaderStream extends Component {
 					x: 0,
 					y: scrollY,
 					duration: 200,
-					container: this.state.listContext,
+					container: scrollContainer,
 				} );
 			} else {
-				window.scrollTo( 0, scrollY );
+				scrollContainer.scrollTo( 0, scrollY );
 			}
 		}
 	}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -53,7 +53,6 @@ import './style.scss';
 // 64 is padding, 8 is margin
 export const WIDE_DISPLAY_CUTOFF = 950 + 64 * 2 + 8 * 2;
 const GUESSED_POST_HEIGHT = 600;
-const HEADER_OFFSET_TOP = 46;
 const noop = () => {};
 const pagesByKey = new Map();
 const inputTags = [ 'INPUT', 'SELECT', 'TEXTAREA' ];
@@ -170,7 +169,8 @@ class ReaderStream extends Component {
 	};
 
 	scrollToSelectedPost( animate ) {
-		const HEADER_OFFSET = -32; // a fixed position header means we can't just scroll the element into view.
+		const headerOffset = -1 * this.props.fixedHeaderHeight || 0; // a fixed position header means we can't just scroll the element into view.
+		const totalOffset = headerOffset - 35; // 35px of constant offset to ensure the post isnt cramped against the top container or header border.
 		const selectedNode = ReactDom.findDOMNode( this ).querySelector( '.card.is-selected' );
 		if ( selectedNode ) {
 			selectedNode.focus();
@@ -178,7 +178,7 @@ class ReaderStream extends Component {
 			const scrollContainerPosition = scrollContainer.scrollTop;
 			const boundingClientRect = selectedNode.getBoundingClientRect();
 			const scrollY = parseInt(
-				scrollContainerPosition + boundingClientRect.top + HEADER_OFFSET,
+				scrollContainerPosition + boundingClientRect.top + totalOffset,
 				10
 			);
 			if ( animate ) {
@@ -345,7 +345,7 @@ class ReaderStream extends Component {
 	getVisibleItemIndexes() {
 		return (
 			this.listRef.current &&
-			this.listRef.current.getVisibleItemIndexes( { offsetTop: HEADER_OFFSET_TOP } )
+			this.listRef.current.getVisibleItemIndexes( { offsetTop: this.props.fixedHeaderHeight || 0 } )
 		);
 	}
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -173,17 +173,19 @@ class ReaderStream extends Component {
 		const HEADER_OFFSET = -32; // a fixed position header means we can't just scroll the element into view.
 		const selectedNode = ReactDom.findDOMNode( this ).querySelector( '.card.is-selected' );
 		if ( selectedNode ) {
-			const documentElement = document.documentElement;
 			selectedNode.focus();
-			const windowTop =
-				( window.pageYOffset || documentElement.scrollTop ) - ( documentElement.clientTop || 0 );
+			const scrollContainerPosition = this.state.listContext.scrollTop;
 			const boundingClientRect = selectedNode.getBoundingClientRect();
-			const scrollY = parseInt( windowTop + boundingClientRect.top + HEADER_OFFSET, 10 );
+			const scrollY = parseInt(
+				scrollContainerPosition + boundingClientRect.top + HEADER_OFFSET,
+				10
+			);
 			if ( animate ) {
 				scrollTo( {
 					x: 0,
 					y: scrollY,
 					duration: 200,
+					container: this.state.listContext,
 				} );
 			} else {
 				window.scrollTo( 0, scrollY );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -212,13 +212,13 @@ class ReaderStream extends Component {
 			// Show an overlay while we are handling initial scroll and focus to prevent flashing
 			// content.
 			if ( this.overlayRef.current ) {
-				this.overlayRef.current.classList.add( 'stream__init-overlay' );
+				this.overlayRef.current.classList.add( 'stream__init-overlay-enabled' );
 			}
 			this.mountTimeout = setTimeout( () => {
 				this.scrollToSelectedPost( false );
 				this.focusSelectedPost( this.props.selectedPostKey );
 				if ( this.overlayRef.current ) {
-					this.overlayRef.current.classList.remove( 'stream__init-overlay' );
+					this.overlayRef.current.classList.remove( 'stream__init-overlay-enabled' );
 				}
 			}, 100 );
 		}
@@ -696,8 +696,7 @@ class ReaderStream extends Component {
 		const TopLevel = this.props.isMain ? ReaderMain : 'div';
 		return (
 			<TopLevel className={ baseClassnames }>
-				{ /* This div is the .stream__init-overlay component, it only gets this class when it should be displayed */ }
-				<div ref={ this.overlayRef } />
+				<div ref={ this.overlayRef } className="stream__init-overlay" />
 				{ shouldPoll && <Interval onTick={ this.poll } period={ EVERY_MINUTE } /> }
 
 				<UpdateNotice streamKey={ streamKey } onClick={ this.showUpdates } />

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -208,6 +208,7 @@ class ReaderStream extends Component {
 
 		if ( this.props.selectedPostKey ) {
 			setTimeout( () => {
+				this.scrollToSelectedPost( false );
 				this.focusSelectedPost( this.props.selectedPostKey );
 			}, 100 );
 		}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1009,7 +1009,7 @@
 	.stream__init-overlay {
 		display: none;
 
-		&.stream__init-ovarlay-enabled {
+		&.stream__init-overlay-enabled {
 			background: var(--studio-white);
 			position: absolute;
 			display: block;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1006,14 +1006,19 @@
 .is-reader-page .main {
 	position: relative;
 
-	.stream__init-ovarlay {
-		background: var(--studio-white);
-		position: absolute;
-		left: 0;
-		right: 0;
-		top: 0;
-		bottom: 0;
-		z-index: z-index("root", ".stream__init-overlay");
+	.stream__init-overlay {
+		display: none;
+
+		&.stream__init-ovarlay-enabled {
+			background: var(--studio-white);
+			position: absolute;
+			display: block;
+			left: 0;
+			right: 0;
+			top: 0;
+			bottom: 0;
+			z-index: z-index("root", ".stream__init-overlay-enabled");
+		}
 	}
 }
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -1000,3 +1000,20 @@
 		min-width: 200px;
 	}
 }
+
+// Styles to allow a temporary ovarlay positioned over the stream feed while loading and initial
+// scrolling.
+.is-reader-page .main {
+	position: relative;
+
+	.stream__init-ovarlay {
+		background: var(--studio-white);
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: 0;
+		z-index: z-index("root", ".stream__init-overlay");
+	}
+}
+


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/loop#181 

## Proposed Changes

* Updates the `scrollToSelectedPost` method in various ways.
    *  Uses the listContext element instead of window for determining scroll positions and triggering scroll. This scroll functionality was not working since we were not passing the scrollContainer and it was falling back to the window which is not the scroll container. Similarly the calculations to figure out what scroll position to set were messed up by evaluating the scroll positions of the window and document instead of the actual scroll container.
    * Uses the prop for an accurate `headerOffset` value instead of using a hardcoded magic number.
* Ensures `scrollToSelectedPost` is called on `componentDidMount` if a post is selected, so that the selected post is in view.
* Adds an overlay element to the stream component that is only visible when the focus and scroll functionality triggered by timeout in `componentDidMount` is in progress. This prevents a 'flashing' of content when going back to a stream (content from the initial scroll position before the appropriate scroll position is set).


BEFORE

![scroll-before](https://github.com/Automattic/wp-calypso/assets/28742426/3db45aaf-70cc-4c5a-8b7f-737b55426eee)

Notice both the positioning of selected items not scrolling all the way into view, AND the flicker of the donkey (first post image) when coming back from the first selected full-post page.

AFTER

![scroll-after](https://github.com/Automattic/wp-calypso/assets/28742426/a76c46b1-6405-4b9c-a41c-4ec552b90386)

Both scrolling and content flicker are removed.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Probelm 1 described in https://github.com/Automattic/loop/issues/181 - currently when navigating the reader with shorkeys the position of the selected post is unreliable and sometimes hangs off the edge of the page.
* And the overlay is added to prevent the flickering that happens underneath the functionality when called on initialization.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the reader.
* Navigate a stream with 'j' and 'k' shorkeys.
* Verify the newly selected post is always visible.
* enter full post view and return back to the stream, verify selected post is visible in the stream and that there is no flickering of other images before it is there.
* test this on various streams and device widths.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
