### PR TITLE
Stepper refactor: add flow variant to track events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -29,12 +29,18 @@ interface Props {
 	stepSlug: string;
 	// If true, the tracking event will not be recorded
 	skipTracking: boolean;
+	flowVariantSlug?: string;
 }
 
 /**
  * Hook to track the step route in the declarative flow.
  */
-export const useStepRouteTracking = ( { flowName, stepSlug, skipTracking }: Props ) => {
+export const useStepRouteTracking = ( {
+	flowName,
+	stepSlug,
+	skipTracking,
+	flowVariantSlug,
+}: Props ) => {
 	const intent = useIntent();
 	const design = useSelectedDesign();
 	const { site, siteSlugOrId } = useSiteData();
@@ -58,6 +64,7 @@ export const useStepRouteTracking = ( { flowName, stepSlug, skipTracking }: Prop
 				intent,
 				is_in_hosting_flow: isAnyHostingFlow( flowName ),
 				...( design && { assembler_source: getAssemblerSource( design ) } ),
+				...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 			} );
 
 			const stepOldSlug = getStepOldSlug( stepSlug );
@@ -67,6 +74,7 @@ export const useStepRouteTracking = ( { flowName, stepSlug, skipTracking }: Prop
 					intent,
 					is_in_hosting_flow: isAnyHostingFlow( flowName ),
 					...( design && { assembler_source: getAssemblerSource( design ) } ),
+					...( flowVariantSlug && { flow_variant: flowVariantSlug } ),
 				} );
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -28,6 +28,7 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep }: StepRouteProps ) =>
 		flowName: flow.name,
 		stepSlug: step.slug,
 		skipTracking: shouldSkipRender,
+		flowVariantSlug: flow.variantSlug,
 	} );
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,5 +1,5 @@
 import { SENSEI_FLOW } from '@automattic/onboarding';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordSignupStart } from 'calypso/lib/analytics/signup';
 import { type Flow } from '../../types';
@@ -21,7 +21,16 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 	// TODO: Check if we can remove the sensei flow reference from here.
 	const firstStepSlug = ( flow.name === SENSEI_FLOW ? steps[ 1 ] : steps[ 0 ] ).slug;
 	const isFirstStep = firstStepSlug === currentStepRoute;
-	const extraProps = flow.useSignupStartEventProps?.();
+	const flowVariant = flow.variantSlug;
+	const signupStartEventProps = flow.useSignupStartEventProps?.();
+
+	const extraProps = useMemo(
+		() => ( {
+			...signupStartEventProps,
+			...( flowVariant && { flow_variant: flowVariant } ),
+		} ),
+		[ signupStartEventProps, flowVariant ]
+	);
 	const flowName = flow.name;
 	const shouldTrack = flow.isSignupFlow && isFirstStep && ! signedUp;
 

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -106,6 +106,22 @@ describe( 'useSignUpTracking', () => {
 			} );
 		} );
 
+		it( 'tracks the calypso_signup_start event includes the flowVariant if the flow has one', () => {
+			render( {
+				flow: {
+					...signUpFlow,
+					variantSlug: 'variant-slug',
+				} satisfies Flow,
+				currentStepRoute: 'step-1',
+			} );
+
+			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
+				flow: 'sign-up-flow',
+				flow_variant: 'variant-slug',
+				ref: '',
+			} );
+		} );
+
 		it( 'does not track events current step is NOT the first step', () => {
 			render( { flow: signUpFlow, currentStepRoute: 'step-2' } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This diff adds flow variant slug to these two track events:
* `calypso_signup_start`
* `calypso_signup_step_start`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I figured it would simplify analysis to have this extra property.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify Unit tests passes
* Open calypso.live link below
* Go to `/setup/hosted-site-migration`
* Verify that the `calypso_signup_start` and `calypso_signup_step_start` have the correct `flow_variant` property


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
