### PR TITLE
Signup: Add Mock WP.com script

### DIFF
--- a/bin/mock-wordpressdotcom.sh
+++ b/bin/mock-wordpressdotcom.sh
@@ -25,10 +25,10 @@ if [ $# -eq 0 ]; then
     echo "✨ Happy hacking!"
 elif [ $1 == '--unmock' ]; then
     echo "Unmocking WordPress.com locally"
-    git checkout -- client/server/boot/index.js
-    git checkout -- config/development.json
-    git checkout -- package.json
-    git checkout -- yarn.lock
+    git checkout trunk -- client/server/boot/index.js
+    git checkout trunk -- config/development.json
+    git checkout trunk -- package.json
+    git checkout trunk -- yarn.lock
     
     echo "Done!"
     echo "Make sure to remove ${GREEN}127.0.0.1 wordpress.com${NC} to your hosts file."

--- a/bin/mock-wordpressdotcom.sh
+++ b/bin/mock-wordpressdotcom.sh
@@ -1,0 +1,36 @@
+if [ $# -eq 0 ]; then
+    echo "Mocking WordPress.com locally"
+    GREEN='\033[1;32m'
+    NC='\033[0m' # No Color
+
+    echo "Pulling files from ${GREEN}PR#91208${NC}"
+
+    # This checks out loose files from a branch.
+    git checkout add/mock-wp.com -- client/server/boot/index.js
+    git checkout add/mock-wp.com -- config/development.json
+    git checkout add/mock-wp.com -- package.json
+    git checkout add/mock-wp.com -- yarn.lock
+
+    echo "Installing dependencies..."
+
+    yarn > /dev/null
+
+    echo "Done!"
+
+    echo "Make sure to:"
+    echo "  1. Add ${GREEN}127.0.0.1 wordpress.com${NC} to your hosts file."
+    echo "  2. Restart Calypso with ${GREEN}yarn start${NC}."
+    echo "  3. Type ${GREEN}thisisunsafe${NC} in Chrome when you visit wordpress.com."
+    echo "  4. Unmock when done by calling this script with ${GREEN}--unmock${NC}"
+    echo "✨ Happy hacking!"
+elif [ $1 == '--unmock' ]; then
+    echo "Unmocking WordPress.com locally"
+    git checkout -- client/server/boot/index.js
+    git checkout -- config/development.json
+    git checkout -- package.json
+    git checkout -- yarn.lock
+    
+    echo "Done!"
+    echo "Make sure to remove ${GREEN}127.0.0.1 wordpress.com${NC} to your hosts file."
+fi
+


### PR DESCRIPTION
## Proposed Changes

This adds a simple script to mock WordPress.com locally.

## Why are these changes being made?
To make testing signup stuff easier (they require wordpress.com domain).

## Testing Instructions

1. run `chmod +x bin/mock-wordpressdotcom`
2. run `bin/mock-wordpressdotcom`
3. run `yarn start`.
4. add `127.0.0.1 wordpress.com` to your hosts file.
5. visit wordpress.com.
6. Type `thisisunsafe`.
7. It should work!