### PR TITLE
Update title and make refund text more prominent on the upgrade step in migration

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -179,10 +179,9 @@ $business-plan-color: #7f54b3;
 	}
 
 	.import__upgrade-plan-refund-sub-text {
-		color: #7f54b3;
+		color: $business-plan-color;
 		font-size: 0.75rem;
 		font-weight: 500;
-		line-height: 20px;
 		margin-top: 0.5rem;
 		text-align: center;
 	}

--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -178,6 +178,15 @@ $business-plan-color: #7f54b3;
 		margin-bottom: 2.5rem;
 	}
 
+	.import__upgrade-plan-refund-sub-text {
+		color: #7f54b3;
+		font-size: 0.75rem;
+		font-weight: 500;
+		line-height: 20px;
+		margin-top: 0.5rem;
+		text-align: center;
+	}
+
 	.import__upgrade-plan-features-list {
 		flex-direction: column;
 

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -90,11 +90,15 @@ export const UpgradePlanDetails = ( props: Props ) => {
 						<PlanPrice rawPrice={ rawPrice ?? undefined } currencyCode={ currencyCode } />
 						<span className="plan-time-frame">
 							<small>{ plan?.getBillingTimeFrame() }</small>
-							<small>{ __( 'Refundable within 14 days. No questions asked.' ) }</small>
 						</span>
 					</div>
 
-					<div className="import__upgrade-plan-cta">{ children }</div>
+					<div>
+						<div className="import__upgrade-plan-cta">{ children }</div>
+						<div className="import__upgrade-plan-refund-sub-text">
+							{ __( 'Refundable within 14 days. No questions asked.' ) }
+						</div>
+					</div>
 
 					<div className="import__upgrade-plan-features-list">
 						<UpgradePlanFeatureList

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -106,7 +106,11 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 				formattedHeader={
 					<FormattedHeader
 						id="site-migration-instructions-header"
-						headerText={ translate( 'Take your site to the next level' ) }
+						headerText={
+							hasEnTranslation( 'The plan you need' )
+								? translate( 'The plan you need' )
+								: translate( 'Take your site to the next level' )
+						}
 						subHeaderText={
 							hasEnTranslation(
 								'Migrations are exclusive to the %(planName)s plan. Check out all its benefits, and upgrade to get started.'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -112,17 +112,12 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 								: translate( 'Take your site to the next level' )
 						}
 						subHeaderText={
-							hasEnTranslation(
-								'Migrations are exclusive to the %(planName)s plan. Check out all its benefits, and upgrade to get started.'
-							)
-								? translate(
-										'Migrations are exclusive to the %(planName)s plan. Check out all its benefits, and upgrade to get started.',
-										{
-											args: {
-												planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-											},
-										}
-								  )
+							hasEnTranslation( 'Migrations are exclusive to the %(planName)s plan.' )
+								? translate( 'Migrations are exclusive to the %(planName)s plan.', {
+										args: {
+											planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+										},
+								  } )
 								: translate(
 										'Migrations are exclusive to the Creator plan. Check out all its benefits, and upgrade to get started.'
 								  )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91591

## Proposed Changes

* Changed the title and subheading, and moved the refund text to a more prominent position and styled it as per design.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the need of the creator plan more clear and also make the refunding more clearly visible

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure your language is English in https://wordpress.com/me/account
- In the migration flow (take any migration path, for example http://calypso.localhost:3000/start), navigate to the Upgrade step (Select "Migrate Site" in Migrate/Import page)
- Make sure you see the similar changes as you see in the attached screenshots
- Now change language from your account page
- Make sure you see the old title

<img width="889" alt="CleanShot 2024-06-17 at 14 13 05@2x" src="https://github.com/Automattic/wp-calypso/assets/329356/45aa781c-484b-466d-961f-5da8bde23a54">
<img width="416" alt="CleanShot 2024-06-17 at 14 13 16@2x" src="https://github.com/Automattic/wp-calypso/assets/329356/66a82165-2655-4001-b222-6fc24daf83dc">
<img width="416" alt="CleanShot 2024-06-17 at 14 13 55@2x" src="https://github.com/Automattic/wp-calypso/assets/329356/4a144c4e-f1aa-48a3-9b54-d068f8eb7b97">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
