### PR TITLE
Update migration metrics copy

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/cwvtech-report.json
+++ b/client/blocks/importer/wordpress/upgrade-plan/cwvtech-report.json
@@ -1,16 +1,16 @@
 {
 	"WordPress.com": {
-		"date": "Apr 2024",
-		"goodCWM": 0.6986159237,
-		"goodLCP": 0.8552837267,
-		"goodCLS": 0.7935010875,
-		"goodFID": 0.999276568
+		"date": "May 2024",
+		"goodCWM": 0.6855411789,
+		"goodLCP": 0.8544712613,
+		"goodCLS": 0.7805696786,
+		"goodFID": 0.9994334706
 	},
 	"WordPress": {
-		"date": "Apr 2024",
-		"goodCWM": 0.4361328649,
-		"goodLCP": 0.5927887881,
-		"goodCLS": 0.6945178409,
-		"goodFID": 0.999757466
+		"date": "May 2024",
+		"goodCWM": 0.4369906891,
+		"goodLCP": 0.5937459153,
+		"goodCLS": 0.6953353768,
+		"goodFID": 0.9997646454
 	}
 }

--- a/client/blocks/importer/wordpress/upgrade-plan/hooks/use-get-upgrade-plan-hosting-details-list.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/hooks/use-get-upgrade-plan-hosting-details-list.tsx
@@ -15,7 +15,7 @@ export const useUpgradePlanHostingDetailsList = () => {
 		const goodLCPercentage = Math.floor( 100 * cwvtechReportJson[ 'WordPress.com' ].goodLCP );
 
 		newHostingDetails[ 'higher-speed' ].description = translate(
-			'%(goodLCPercentage)d%% of sites on WordPress.com are at least %(lcpPercentageDifference)d%% faster than yours.',
+			'WordPress.com sites are %(lcpPercentageDifference)d%% faster than your current one, with %(goodLCPercentage)d%% more sites loading in under 100ms.',
 			{
 				args: {
 					goodLCPercentage,
@@ -30,7 +30,7 @@ export const useUpgradePlanHostingDetailsList = () => {
 		const goodFIDPercentage = Math.floor( 100 * cwvtechReportJson[ 'WordPress.com' ].goodFID );
 
 		newHostingDetails[ 'faster-response' ].description = translate(
-			'%(goodFIDPercentage)d%% of sites on WordPress.com respond at least %(fidPercentageDifference)d%% faster than yours on the first interaction.',
+			'WordPress.com sites respond %(fidPercentageDifference)d%% faster than yours, with %(goodFIDPercentage)d%% of sites responding within 0.1 seconds of the first interaction.',
 			{
 				args: {
 					goodFIDPercentage,

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
@@ -55,7 +55,7 @@ export const UpgradePlanHostingDetails = () => {
 					</p>
 					<p className="import__upgrade-plan-hosting-details-header-subtext">
 						{ translate(
-							'Google data shows that %(boostPercentage)d%% more WordPress.com sites have good Core Web Vitals as compared to other WordPress hosts.',
+							'%(boostPercentage)d%% more WordPress.com sites have good Core Web Vitals when compared to any other WordPress host [Source: Google data].',
 							{
 								args: { boostPercentage },
 							}

--- a/client/blocks/importer/wordpress/upgrade-plan/use-default-hosting-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/use-default-hosting-details.tsx
@@ -25,9 +25,9 @@ export const useDefaultHostingDetails = (): DefaultHostingDetails => {
 
 	return {
 		'higher-speed': {
-			title: translate( 'Higher speed' ),
+			title: translate( 'Faster loading' ),
 			description: translate(
-				'WordPress.com has %(higherSpeedPercentage)d%% more sites that load quickly compared to other WordPress hosts.',
+				'WordPress.com has %(higherSpeedPercentage)d%% more sites with ultra-fast, sub-100ms loading times versus other WordPress hosts.',
 				{
 					args: { higherSpeedPercentage },
 				}
@@ -35,9 +35,9 @@ export const useDefaultHostingDetails = (): DefaultHostingDetails => {
 			icon: trendingUp,
 		},
 		'faster-response': {
-			title: translate( 'Faster response' ),
+			title: translate( 'Quicker response' ),
 			description: translate(
-				'%(fastResponsePercentage)d%% of sites on WordPress.com respond within 0.1 seconds on the first interaction.',
+				'%(fastResponsePercentage)d%% of sites on WordPress.com respond within 0.1 seconds of the first interaction.',
 				{
 					args: { fastResponsePercentage },
 				}
@@ -45,9 +45,9 @@ export const useDefaultHostingDetails = (): DefaultHostingDetails => {
 			icon: next,
 		},
 		'higher-availability': {
-			title: translate( 'Higher availability' ),
+			title: translate( 'Better availability' ),
 			description: translate(
-				'WordPress.com boasts a %(wpcomPercentageUptime)s%% uptime, compared to %(otherHostsPercentageUptime)s%% uptime for other WordPress hosts.',
+				'WordPress.com sites have %(wpcomPercentageUptime)s%% uptime, compared to the %(otherHostsPercentageUptime)s%% uptime of other WordPress hosts.',
 				{
 					args: {
 						wpcomPercentageUptime,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91732

## Proposed Changes

* It updates the metrics copy during the migration flow.
* It also updates the numbers from https://cwvtech.report/ to the last ones (May 2024).

See the following screenshots. Notice that they are:
- Default: When the site is already optimized.
- Dynamic: When WordPress.com hosting could offer better results to their site.

#### Before (Default / Dynamic):

<img width="348" alt="Screenshot 2024-06-21 at 12 12 00" src="https://github.com/Automattic/wp-calypso/assets/876340/b716464f-45a5-4d40-8b32-ac5135ba9e27">
<img width="348" alt="Screenshot 2024-06-21 at 12 12 11" src="https://github.com/Automattic/wp-calypso/assets/876340/931870e9-71ae-41b2-a857-8990d1a8fb99">

#### After (Default / Dynamic):

<img width="348" alt="Screenshot 2024-06-21 at 12 04 10" src="https://github.com/Automattic/wp-calypso/assets/876340/5f828751-bd3c-4546-afad-972a0fa42794">
<img width="348" alt="Screenshot 2024-06-21 at 12 05 37" src="https://github.com/Automattic/wp-calypso/assets/876340/bf7fd1ce-6af5-4fab-a84f-aaa1c1047fb4">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to improve the copy for the users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the texts look good.
* If you wanna test it running the site, you need to go through the migration flow until the upgrade step (`/setup/site-migration/site-migration-upgrade-plan?from={FROM_SITE}&siteSlug={SITE_SLUG}&siteId={SITE_ID`).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?