### PR TITLE
Subscriptions: Show successful notice after unsubscribing

### DIFF
--- a/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
+++ b/client/reader/site-subscriptions-manager/site-subscriptions-manager.tsx
@@ -1,15 +1,31 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import ReaderExportButton from 'calypso/blocks/reader-export-button';
 import { READER_EXPORT_TYPE_SUBSCRIPTIONS } from 'calypso/blocks/reader-export-button/constants';
 import ReaderImportButton from 'calypso/blocks/reader-import-button';
 import { AddSitesButton } from 'calypso/landing/subscriptions/components/add-sites-button';
 import { downloadCloud, uploadCloud } from 'calypso/reader/icons';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import ReaderSiteSubscriptions from './reader-site-subscriptions';
 import SubscriptionsManagerWrapper from './subscriptions-manager-wrapper';
 
 const SiteSubscriptionsManager = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		const url = new URL( window.location.href );
+
+		if ( url.searchParams.get( 'status' ) === 'unsubscribed' ) {
+			dispatch(
+				successNotice( translate( 'You have successfully unsubscribed.' ), { duration: 8000 } )
+			);
+			url.searchParams.delete( 'status' );
+			window.history.replaceState( null, '', url.toString() );
+		}
+	}, [ dispatch, translate ] );
 
 	return (
 		<>


### PR DESCRIPTION
This is a follow up PR to D152293-code 

## Proposed Changes

* Shows a successful notice after user unsubscribed. ( visits http://calypso.localhost:3000/read/subscriptions?status=unsubscribed )
* The user end up on the http://calypso.localhost:3000/read/subscriptions url. 
<img width="738" alt="Screenshot 2024-06-14 at 1 39 14 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/aa64455d-9f21-465a-9927-0058529b4e5c">


## Why are these changes being made?


## Testing Instructions

Visit http://calypso.localhost:3000/read/subscriptions?status=unsubscribed 
Notice that you see 

https://github.com/Automattic/wp-calypso/assets/115071/2c2ad409-ae4d-4f6b-b948-308c4375bf6a

Notice that the back button works as expected. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?