### PR TITLE
Scheduled Updates: Fix header and table styles

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-empty.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-empty.tsx
@@ -11,15 +11,22 @@ export const ScheduleListEmpty = ( props: Props ) => {
 	const { onCreateNewSchedule } = props;
 
 	return (
-		<div className="empty-state">
-			<Text as="p">
-				{ translate(
-					"Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind."
-				) }
-			</Text>
-			<Button __next40pxDefaultSize icon={ plus } variant="primary" onClick={ onCreateNewSchedule }>
-				{ translate( 'Add new schedule' ) }
-			</Button>
+		<div className="plugins-update-manager-multisite-table-container">
+			<div className="empty-state">
+				<Text as="p">
+					{ translate(
+						"Take control of your site's maintenance by choosing when your plugins update—whatever day and time is most convenient. Enjoy hassle-free automatic updates, and our built-in rollback feature reverts any flawed updates for added peace of mind."
+					) }
+				</Text>
+				<Button
+					__next40pxDefaultSize
+					icon={ plus }
+					variant="primary"
+					onClick={ onCreateNewSchedule }
+				>
+					{ translate( 'Add new schedule' ) }
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-filter.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-filter.tsx
@@ -8,12 +8,14 @@ export const ScheduleListFilter = () => {
 	const { searchTerm, handleSearch } = useContext( MultisitePluginUpdateManagerContext );
 
 	return (
-		<div className="plugins-update-manager-multisite-filter">
-			<SearchControl
-				value={ searchTerm }
-				placeholder={ translate( 'Search by site' ) }
-				onChange={ handleSearch }
-			/>
+		<div className="plugins-update-manager-multisite-filters">
+			<div className="plugins-update-manager-multisite-filter">
+				<SearchControl
+					value={ searchTerm }
+					placeholder={ translate( 'Search by site' ) }
+					onChange={ handleSearch }
+				/>
+			</div>
 		</div>
 	);
 };

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list-table-row-menu.tsx
@@ -1,6 +1,6 @@
 import { DropdownMenu } from '@wordpress/components';
+import { moreHorizontal } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { ellipsis } from 'calypso/blocks/plugins-scheduled-updates/icons';
 import { SiteSlug } from 'calypso/types';
 import type {
 	MultisiteSchedulesUpdates,
@@ -46,7 +46,7 @@ export const ScheduleListTableRowMenu = ( {
 		<DropdownMenu
 			popoverProps={ { position: 'bottom left' } }
 			controls={ items }
-			icon={ ellipsis }
+			icon={ moreHorizontal }
 			label={ translate( 'More' ) }
 		/>
 	);

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -126,30 +126,31 @@ export const ScheduleList = ( props: Props ) => {
 		<div className="plugins-update-manager plugins-update-manager-multisite">
 			<div className="plugins-update-manager-multisite__header">
 				<div className="plugins-update-manager-multisite__header-main">
-					<h1>{ translate( 'Scheduled Updates' ) }</h1>
-					{ showSubtitle && (
-						<p>
-							{ translate(
-								'Streamline your workflow with scheduled updates, timed to suit your needs.'
-							) }
-						</p>
+					<div className="plugins-update-manager-multisite__header-main-title">
+						<h1>{ translate( 'Scheduled Updates' ) }</h1>
+						{ showSubtitle && (
+							<p>
+								{ translate(
+									'Streamline your workflow with scheduled updates, timed to suit your needs.'
+								) }
+							</p>
+						) }
+					</div>
+					{ showNewScheduleBtn && ! isScheduleEmpty && (
+						<Button
+							__next40pxDefaultSize={ ! compact }
+							isSmall={ compact }
+							variant={ compact ? 'secondary' : 'primary' }
+							onClick={ onCreateNewSchedule }
+							disabled={ false }
+						>
+							{ translate( 'New schedule' ) }
+						</Button>
 					) }
 				</div>
-				{ showNewScheduleBtn && ! isScheduleEmpty && (
-					<Button
-						__next40pxDefaultSize={ ! compact }
-						isSmall={ compact }
-						variant={ compact ? 'secondary' : 'primary' }
-						onClick={ onCreateNewSchedule }
-						disabled={ false }
-					>
-						{ translate( 'New schedule' ) }
-					</Button>
-				) }
 			</div>
 
 			<ScheduleErrors />
-
 			{ isScheduleEmpty && ! compact && (
 				<ScheduleListEmpty onCreateNewSchedule={ onCreateNewSchedule } />
 			) }

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -7,6 +7,28 @@ $brand-display: "SF Pro Display", sans-serif;
 		margin: 1rem;
 	}
 
+	&__header {
+		@media screen and (max-width: $break-large) {
+			padding-top: 24px;
+		}
+	}
+
+	&__header-main {
+		display: flex;
+		margin: 0 auto;
+		justify-content: space-between;
+		box-sizing: border-box;
+		column-gap: 10px;
+		flex: 1;
+		@media screen and (min-width: $break-xhuge) {
+			max-width: 1400px;
+			padding-inline: 64px;
+		}
+		button {
+			padding: 8px 14px;
+		}
+	}
+
 	&.plugins-update-manager-multisite-edit,
 	&.plugins-update-manager-multisite-create {
 		h1 {
@@ -23,6 +45,29 @@ $brand-display: "SF Pro Display", sans-serif;
 		}
 	}
 
+	.plugins-update-manager-multisite-filters,
+	.plugins-update-manager-multisite-table-container {
+		@media screen and (min-width: $break-xhuge) {
+			max-width: 1400px;
+			margin: 0 auto;
+		}
+		@media screen and (min-width: $break-large) {
+			td:last-child,
+			th:last-child {
+				padding-right: 64px;
+				text-align: right;
+			}
+			td.menu button {
+				padding: 0;
+				justify-content: end;
+			}
+		}
+		@media screen and (max-width: $break-small) {
+			.empty-state {
+				padding-inline: 0 !important;
+			}
+		}
+	}
 	.plugins-update-manager-multisite-filter {
 		margin-top: 1.25rem;
 		margin-bottom: 1.25rem;

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -20,10 +20,6 @@ $brand-display: "SF Pro Display", sans-serif;
 		box-sizing: border-box;
 		column-gap: 10px;
 		flex: 1;
-		@media screen and (min-width: $break-xhuge) {
-			max-width: 1400px;
-			padding-inline: 64px;
-		}
 		button {
 			padding: 8px 14px;
 		}
@@ -171,6 +167,17 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		.validation-msg {
 			width: 100%;
+		}
+	}
+}
+
+main.scheduled-updates-list {
+	.plugins-update-manager-multisite {
+		&__header-main {
+			@media screen and (min-width: $break-xhuge) {
+				max-width: 1400px;
+				padding-inline: 64px;
+			}
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -154,7 +154,6 @@ function DnsMenuOptionsButton( {
 		},
 		[ dispatchApplyDnsTemplate, dispatchErrorNotice, dispatchSuccessNotice, domainName ]
 	);
-	ellipsis;
 
 	const restoreDefaultARecords = useCallback( async () => {
 		dispatchUpdateDns( domainName, [], getARecordsToRemove(), true )

--- a/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-menu-options-button.tsx
@@ -154,6 +154,7 @@ function DnsMenuOptionsButton( {
 		},
 		[ dispatchApplyDnsTemplate, dispatchErrorNotice, dispatchSuccessNotice, domainName ]
 	);
+	ellipsis;
 
 	const restoreDefaultARecords = useCallback( async () => {
 		dispatchUpdateDns( domainName, [], getARecordsToRemove(), true )


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7726

## Proposed Changes

Match `Scheduled updates` header (and also some details on the table)  with Sites / Domains / Plugins...

Table details:
- Menu icon is horizontal like in Sites & Domains
- Menu icon in big screens is aligned with the `New schedule` button
- `New schedule` button has the same padding as other pages.

### Screenshots

| Size | Before | After |
| --- | --- | --- |
| 1920x1000 | ![wordpress com_plugins_scheduled-updates](https://github.com/Automattic/wp-calypso/assets/402286/b19d3be5-ed45-4584-bcca-e625a4929122) ![wordpress com_plugins_scheduled-updates (5)](https://github.com/Automattic/wp-calypso/assets/402286/ad52c98f-91d8-4439-b355-4152fe55c9e5) | ![calypso localhost_3000_plugins_scheduled-updates](https://github.com/Automattic/wp-calypso/assets/402286/20e0b36e-3cbf-4b5c-9136-d5687d905c73) ![calypso localhost_3000_plugins_scheduled-updates (5)](https://github.com/Automattic/wp-calypso/assets/402286/05f868fd-9da3-4589-b1ad-10e0bbbd9fc8) |
| 1280x1000 | ![wordpress com_plugins_scheduled-updates (1)](https://github.com/Automattic/wp-calypso/assets/402286/2771e4c7-d25c-4886-b139-4a599afab0f4) ![wordpress com_plugins_scheduled-updates (6)](https://github.com/Automattic/wp-calypso/assets/402286/62c2025c-d506-44e4-8e30-06c9c9a95baf) | ![calypso localhost_3000_plugins_scheduled-updates (1)](https://github.com/Automattic/wp-calypso/assets/402286/95f82e01-e0fd-47ec-85b5-de72c275e8af) ![calypso localhost_3000_plugins_scheduled-updates (6)](https://github.com/Automattic/wp-calypso/assets/402286/7be0659f-0ede-41ed-baea-60bc1fad1784) |
| 800x600 | ![wordpress com_plugins_scheduled-updates (2)](https://github.com/Automattic/wp-calypso/assets/402286/6eef2aec-a073-4ed8-9b68-a1ae08189e57) ![wordpress com_plugins_scheduled-updates (7)](https://github.com/Automattic/wp-calypso/assets/402286/f97dfbdd-fef1-4c2e-93bd-19c93f43f833) | ![calypso localhost_3000_plugins_scheduled-updates (2)](https://github.com/Automattic/wp-calypso/assets/402286/bffc3689-1d9a-4b6b-9608-8fe5e5699128) ![calypso localhost_3000_plugins_scheduled-updates (7)](https://github.com/Automattic/wp-calypso/assets/402286/24bef298-466d-4359-926b-e48e120a4101) |
| 670x600 | ![wordpress com_plugins_scheduled-updates (3)](https://github.com/Automattic/wp-calypso/assets/402286/9bf68745-084b-40c5-a066-e43085d64b73) ![wordpress com_plugins_scheduled-updates (8)](https://github.com/Automattic/wp-calypso/assets/402286/6ef71d9c-0792-494a-946e-c663c60b9044) | ![calypso localhost_3000_plugins_scheduled-updates (3)](https://github.com/Automattic/wp-calypso/assets/402286/ca70d4af-aa50-47ca-8036-532b3e6944e2) ![calypso localhost_3000_plugins_scheduled-updates (8)](https://github.com/Automattic/wp-calypso/assets/402286/15e5773c-c444-413f-a97a-1d196c5339c1) |
| 430x932 | ![wordpress com_plugins_scheduled-updates (4)](https://github.com/Automattic/wp-calypso/assets/402286/080da1f8-ae61-4d53-80f8-985a6d664a63) ![wordpress com_plugins_scheduled-updates (9)](https://github.com/Automattic/wp-calypso/assets/402286/e37a06aa-b338-4078-a207-1d74b2335009) | ![calypso localhost_3000_plugins_scheduled-updates (4)](https://github.com/Automattic/wp-calypso/assets/402286/ff4ab7d6-dd6d-44ed-b883-7307e32d4235) ![calypso localhost_3000_plugins_scheduled-updates (9)](https://github.com/Automattic/wp-calypso/assets/402286/9e603bd1-bac7-4d29-9076-98eb5b83441f) |

## Why are these changes being made?
Header on Scheduled updates looks different than other pages.

## Testing Instructions
* Go to `/plugins/scheduled-updates`
* The header should have the same design as other pages

