### PR TITLE
E2E: Fix FSE save notice test on mobile.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -398,7 +398,7 @@ export class FullSiteEditorPage {
 	 */
 	async openNavSidebar(): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const openButton = editorParent.locator( 'button[aria-label="Open Navigation Sidebar"]' );
+		const openButton = editorParent.locator( 'a[aria-label="Open Navigation"]' );
 
 		await openButton.click();
 	}
@@ -415,7 +415,7 @@ export class FullSiteEditorPage {
 		}
 		const editorParent = await this.editor.parent();
 		const editorCanvas = await this.editor.canvas();
-		const openButton = editorParent.locator( 'button[aria-label="Open Navigation Sidebar"]' );
+		const openButton = editorParent.locator( 'a[aria-label="Open Navigation"]' );
 
 		await Promise.race( [ openButton.waitFor(), editorCanvas.locator( 'body' ).click() ] );
 	}

--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -62,12 +62,24 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC )( 'Site Editor: Limited Global Styl
 	} );
 
 	it( 'Pick a non-default style variation and check that the save notice shows up', async function () {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, the navigation sidebar goes away
+			// and the save notice is displayed on the editor.
+			return;
+		}
+
 		// Style variation names depend on the theme.
 		// If the spec ever begins to permafail, check here.
 		await fullSiteEditorPage.setStyleVariation( 'Aubergine' );
 	} );
 
 	it( 'Reset styles to defaults and check that the save notice does not show up', async function () {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// On mobile, the navigation sidebar goes away
+			// and the save notice is displayed on the editor.
+			return;
+		}
+
 		await fullSiteEditorPage.setStyleVariation( 'Default' );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

On mobile, after pressing "Try It Out", the FSE navigation sidebar goes away and user is dropped on to the editor. The save notice is displayed on the editor. This PR updates the E2E test to skip checking for the save notice on the navigation sidebar.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix E2E tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `VIEWPORT_NAME=mobile PWDEBUG=1 DEBUG=pw:api GUTENBERG_EDGE=true node --inspect ../../node_modules/.bin/jest --runInBand specs/fse/fse__limited-global-styles.ts`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
