### PR TITLE
Remove Translator Invite link

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -15,7 +15,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import Main from 'calypso/components/main';
-import TranslatorInvite from 'calypso/components/translator-invite';
 import {
 	getSignupUrl,
 	isReactLostPasswordScreenEnabled,
@@ -433,7 +432,6 @@ export class Login extends Component {
 			twoFactorAuthType,
 			locale,
 			isLoginView,
-			path,
 			signupUrl,
 			isWooCoreProfilerFlow,
 			isWooPasswordless,
@@ -450,7 +448,6 @@ export class Login extends Component {
 			return (
 				<>
 					<LoginFooter lostPasswordLink={ this.getLostPasswordLink() } shouldRenderTos />
-					<TranslatorInvite path={ path } />
 				</>
 			);
 		}
@@ -459,7 +456,6 @@ export class Login extends Component {
 			return (
 				<>
 					<LoginFooter lostPasswordLink={ this.getLostPasswordLink() } />
-					{ isLoginView && <TranslatorInvite path={ path } /> }
 				</>
 			);
 		}
@@ -491,12 +487,11 @@ export class Login extends Component {
 						getLostPasswordLink={ this.getLostPasswordLink.bind( this ) }
 						renderSignUpLink={ this.renderSignUpLink.bind( this ) }
 					/>
-					{ isLoginView && <TranslatorInvite path={ path } /> }
 				</>
 			);
 		}
 
-		return isLoginView ? <TranslatorInvite path={ path } /> : null;
+		return null;
 	}
 
 	renderContent( isSocialFirst ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#700

## Proposed Changes

* Removes the link to invite users to add translations on GlotPress.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See ticket

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/log-in/uk` and verify that the translator nudge has been removed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
