### PR TITLE
A4A > Referral: Fix checkout redirect flow

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -200,18 +200,13 @@ function PaymentMethodForm() {
 		//
 		if ( returnQueryArg || products ) {
 			refetchStoredCards();
+			// If the user is in the client view, we need to redirect to the client view
+			if ( isClientView() && returnQueryArg.startsWith( A4A_CLIENT_CHECKOUT ) ) {
+				page( returnQueryArg );
+			}
+		} else {
+			page( isClientView() ? A4A_CLIENT_PAYMENT_METHODS_LINK : A4A_PAYMENT_METHODS_LINK );
 		}
-
-		// If the user is in the client view, we need to redirect to the client view
-		if ( isClientView() ) {
-			page(
-				returnQueryArg.startsWith( A4A_CLIENT_CHECKOUT )
-					? returnQueryArg
-					: A4A_CLIENT_PAYMENT_METHODS_LINK
-			);
-			return;
-		}
-		page( A4A_PAYMENT_METHODS_LINK );
 	}, [ returnQueryArg, products, refetchStoredCards ] );
 
 	useEffect( () => {


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue of not redirecting the payment methods page to checkout after adding a payment method.


## Testing Instructions

* Open live link
* Go to /purchases/payment-methods and delete all the payment methods
* Now go to the marketplace and add a product to the card > Head to checkout 
* You'll be redirected to the payment method page > Add a card > Verify that you are redirected to the checkout once the payment method is added. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
