### PR TITLE
Plans (Storage): Add missing storage group title in mobile

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -122,14 +122,16 @@ const MobileView = ( {
 									{ storageFeatureGroup?.getTitle() }
 								</h2>
 							</PlanFeaturesItem>
-							<PlanFeaturesItem>
-								<StorageFeature
-									planSlug={ gridPlan.planSlug }
-									intervalType={ intervalType }
-									onStorageAddOnClick={ onStorageAddOnClick }
-									showUpgradeableStorage={ showUpgradeableStorage }
-								/>
-							</PlanFeaturesItem>
+							<div className="plan-features-2023-grid__highlighted-feature">
+								<PlanFeaturesItem>
+									<StorageFeature
+										planSlug={ gridPlan.planSlug }
+										intervalType={ intervalType }
+										onStorageAddOnClick={ onStorageAddOnClick }
+										showUpgradeableStorage={ showUpgradeableStorage }
+									/>
+								</PlanFeaturesItem>
+							</div>
 						</>
 					) }
 					<TopButtons

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -83,6 +83,7 @@ const MobileView = ( {
 			) as FeatureGroupSlug[],
 		[ featureGroupMap ]
 	);
+	const storageFeatureGroup = featureGroupMap[ FEATURE_GROUP_STORAGE ];
 
 	return renderedGridPlans
 		.reduce( ( acc, gridPlan ) => {
@@ -114,14 +115,23 @@ const MobileView = ( {
 					) }
 					{ isNotFreePlan && <BillingTimeframes renderedGridPlans={ [ gridPlan ] } /> }
 					<MobileFreeDomain gridPlan={ gridPlan } paidDomainName={ paidDomainName } />
-					<PlanFeaturesItem>
-						<StorageFeature
-							planSlug={ gridPlan.planSlug }
-							intervalType={ intervalType }
-							onStorageAddOnClick={ onStorageAddOnClick }
-							showUpgradeableStorage={ showUpgradeableStorage }
-						/>
-					</PlanFeaturesItem>
+					{ storageFeatureGroup && (
+						<>
+							<PlanFeaturesItem>
+								<h2 className="plans-grid-next-features-grid__feature-group-title">
+									{ storageFeatureGroup?.getTitle() }
+								</h2>
+							</PlanFeaturesItem>
+							<PlanFeaturesItem>
+								<StorageFeature
+									planSlug={ gridPlan.planSlug }
+									intervalType={ intervalType }
+									onStorageAddOnClick={ onStorageAddOnClick }
+									showUpgradeableStorage={ showUpgradeableStorage }
+								/>
+							</PlanFeaturesItem>
+						</>
+					) }
 					<TopButtons
 						renderedGridPlans={ [ gridPlan ] }
 						isInSignup={ isInSignup }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

It looks like, in recent refactors the "Storage" heading/title in mobile was mistakenly removed. 
- This PR brings it back, albeit with the latest styling (bold, not capitalized).
- Also updates some of the spacing between storage feature and CTA below

### Media

#### At some point in the not-so-distant past (taken from `/pricing`):

<img width="400" alt="Screenshot 2024-06-17 at 1 04 57 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/350a47ba-ca30-4f6e-9efe-ed54d1656ee2">

#### Current `trunk`:

<img width="400" alt="Screenshot 2024-06-17 at 1 09 37 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/b07283c8-6f7c-4f81-bb82-05211acb07a2">

#### This PR:

The space between "free domain for one year" and "storage" may not be as exact as between dropdown and CTA, although the paddings/semantics added are the same. This is probably due to letter spacing on "Storage", which we can address in a follow-up.

<img width="400" alt="Screenshot 2024-06-17 at 1 29 04 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/750d33d4-1cb9-4c16-9f7f-6a8ea9bc6438">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix regression. Cleanup code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans`, switch to mobile view, and confirm storage features render with a "Storage" title in each plan's card

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
