### PR TITLE
A4A: Fix missing referral external links.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -53,7 +53,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 
 	const hasCompletedForm = !! email && !! message;
 
-	const learnMoreLink = ''; //FIXME: Add link for A4A;
+	const learnMoreLink = 'https://agencieshelp.automattic.com/knowledge-base/billing-and-payments';
 
 	const productIds = checkoutItems.map( ( item ) => item.product_id ).join( ',' );
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -24,7 +24,7 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 	const { mutate, isPending, status, error } = useSubmitPaymentInfoMutation();
 	const { agencyId, referralId, secret } = getClientReferralQueryArgs();
 
-	const termsLink = '#'; // TODO: Add link to terms and conditions
+	const termsLink = 'https://automattic.com/for-agencies/platform-agreement/';
 
 	const handleTermsClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_terms_click' ) );

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -313,13 +313,6 @@ export default function LayoutBodyContent( {
 								<Button className="a8c-blue-link" borderless href={ A4A_REFERRALS_FAQ }>
 									{ translate( 'How much money will I make?' ) }
 								</Button>
-								<br />
-								{
-									// FIXME: Add link
-									<Button className="a8c-blue-link" borderless href="#">
-										{ translate( 'How does it work?' ) }
-									</Button>
-								}
 							</StepSection>
 						) }
 					</>


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/381

## Proposed Changes

* Remove the 'How does it work?' link on the Dashboard page.

| Before | After |
|--------|--------|
| <img width="325" alt="Screenshot 2024-06-18 at 6 56 04 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/088aecc2-33f8-4a32-9820-e3a3a0ccffe6"> | <img width="338" alt="Screenshot 2024-06-18 at 6 55 38 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/4544e476-3123-436a-b5cb-7b9381224f52"> |

* Redirect Request payment checkouts learn more link to  https://agencieshelp.automattic.com/knowledge-base/billing-and-payments/
<img width="771" alt="Screenshot 2024-06-18 at 7 01 37 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e41ebb8d-7994-4156-b6ff-82b3a0cdb58a">

* Redirect the user to https://automattic.com/for-agencies/platform-agreement/ when clicking the TOS link on the Client's checkout page.
*
<img width="524" alt="Screenshot 2024-06-18 at 8 24 29 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/88a2abf2-5e4d-4da9-90c8-6a1f416ec0a6">



## Testing Instructions

* Use the A4A live link and go to `/referrals/dashboard`
* Confirm that the 'How does it work?' link is no longer visible. **If you already have some referrals, you may need to create a new agency account to access the empty dashboard.**
* Go to `/marketplace/products`
* Create some referrals by toggling 'refer products' and adding items to the cart.
* Checkout the items.
* Confirm that the learn more link redirects to the Billing and payment KB.
* Proceed to checkout with your client account.
* In the client checkout form, confirm that the TOS link works.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
