### PR TITLE
A4A > Referrals: show client license info

### DIFF
--- a/client/a8c-for-agencies/data/purchases/lib/format-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/lib/format-licenses.ts
@@ -1,4 +1,5 @@
-import { License } from 'calypso/state/partner-portal/types';
+import type { ReferralAPIResponse } from 'calypso/a8c-for-agencies/sections/referrals/types';
+import type { License } from 'calypso/state/partner-portal/types';
 
 interface APILicense {
 	license_id: number;
@@ -16,6 +17,7 @@ interface APILicense {
 	owner_type: string | null;
 	quantity: number | null;
 	parent_license_id: number | null;
+	referral: ReferralAPIResponse;
 }
 
 export default function formatLicenses( items: APILicense[] ): License[] {
@@ -35,5 +37,6 @@ export default function formatLicenses( items: APILicense[] ): License[] {
 		ownerType: item.owner_type,
 		quantity: item.quantity,
 		parentLicenseId: item.parent_license_id,
+		referral: item.referral,
 	} ) );
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -47,6 +48,8 @@ export default function LicenseDetails( {
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
 
+	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
+
 	return (
 		<Card
 			className={ clsx( 'license-details', {
@@ -92,7 +95,7 @@ export default function LicenseDetails( {
 					</li>
 				) }
 
-				{ referral && (
+				{ isAutomatedReferralsEnabled && referral && (
 					<li className="license-details__list-item-small">
 						<h4 className="license-details__label">{ translate( 'Owned by' ) }</h4>
 						{ referral.client.email }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -24,7 +24,7 @@ interface Props {
 	onCopyLicense?: () => void;
 	licenseType: LicenseType;
 	isChildLicense?: boolean;
-	referral: ReferralAPIResponse;
+	referral?: ReferralAPIResponse | null;
 }
 
 const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -7,6 +7,7 @@ import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
 import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import LicenseDetailsActions from './actions';
+import type { ReferralAPIResponse } from 'calypso/a8c-for-agencies/sections/referrals/types';
 
 import './style.scss';
 
@@ -22,6 +23,7 @@ interface Props {
 	onCopyLicense?: () => void;
 	licenseType: LicenseType;
 	isChildLicense?: boolean;
+	referral: ReferralAPIResponse;
 }
 
 const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
@@ -39,6 +41,7 @@ export default function LicenseDetails( {
 	onCopyLicense = noop,
 	licenseType,
 	isChildLicense,
+	referral,
 }: Props ) {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
@@ -86,6 +89,13 @@ export default function LicenseDetails( {
 					<li className="license-details__list-item-small">
 						<h4 className="license-details__label">{ translate( 'Assigned on' ) }</h4>
 						<FormattedDate date={ attachedAt } format={ DETAILS_DATE_FORMAT_SHORT } />
+					</li>
+				) }
+
+				{ referral && (
+					<li className="license-details__list-item-small">
+						<h4 className="license-details__label">{ translate( 'Owned by' ) }</h4>
+						{ referral.client.email }
 					</li>
 				) }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -93,6 +93,7 @@ export default function LicenseList() {
 								}
 								quantity={ license.quantity }
 								isChildLicense={ !! license.parentLicenseId }
+								referral={ license.referral }
 							/>
 						</LicenseTransition>
 					) ) }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -10,6 +10,7 @@ import {
 	isPressableHostingProduct,
 	isWPCOMHostingProduct,
 } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import ClientSite from 'calypso/a8c-for-agencies/sections/sites/needs-setup-sites/client-site';
 import FormattedDate from 'calypso/components/formatted-date';
 import getLicenseState from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-license-state';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
@@ -29,6 +30,7 @@ import BundleDetails from '../license-details/bundle-details';
 import LicensesOverviewContext from '../licenses-overview/context';
 import LicenseActions from './license-actions';
 import LicenseBundleDropDown from './license-bundle-dropdown';
+import type { ReferralAPIResponse } from 'calypso/a8c-for-agencies/sections/referrals/types';
 
 import './style.scss';
 
@@ -45,6 +47,7 @@ interface Props {
 	parentLicenseId?: number | null;
 	quantity?: number | null;
 	isChildLicense?: boolean;
+	referral: ReferralAPIResponse;
 }
 
 export default function LicensePreview( {
@@ -60,6 +63,7 @@ export default function LicensePreview( {
 	parentLicenseId,
 	quantity,
 	isChildLicense,
+	referral,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -163,7 +167,14 @@ export default function LicensePreview( {
 				} ) }
 			>
 				<div>
-					<span className="license-preview__product">{ productTitle }</span>
+					<span className="license-preview__product">
+						{ productTitle }
+						{ referral && (
+							<div className="license-preview__client-email">
+								<ClientSite referral={ referral } />
+							</div>
+						) }
+					</span>
 				</div>
 
 				<div>
@@ -293,6 +304,7 @@ export default function LicensePreview( {
 						onCopyLicense={ onCopyLicense }
 						licenseType={ licenseType }
 						isChildLicense={ isChildLicense }
+						referral={ referral }
 					/>
 				) ) }
 		</div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Badge, Button, Gridicon } from '@automattic/components';
@@ -67,6 +68,8 @@ export default function LicensePreview( {
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
 
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
@@ -169,7 +172,7 @@ export default function LicensePreview( {
 				<div>
 					<span className="license-preview__product">
 						{ productTitle }
-						{ referral && (
+						{ isAutomatedReferralsEnabled && referral && (
 							<div className="license-preview__client-email">
 								<ClientSite referral={ referral } />
 							</div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -48,7 +48,7 @@ interface Props {
 	parentLicenseId?: number | null;
 	quantity?: number | null;
 	isChildLicense?: boolean;
-	referral: ReferralAPIResponse;
+	referral?: ReferralAPIResponse | null;
 }
 
 export default function LicensePreview( {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -178,3 +178,26 @@ button.button.is-borderless.license-bundle-dropdown__button {
 		fill: var(--color-text-inverted);
 	}
 }
+
+.license-preview__client-email {
+	font-size: 0.75rem;
+	line-height: 1.3;
+	font-weight: 400;
+	color: var(--color-neutral-50);
+	margin-block-start: 4px;
+
+	strong {
+		max-width: 120px;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+		display: block;
+
+		@include break-wide() {
+			max-width: 200px;
+		}
+		@include break-huge() {
+			max-width: 250px;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -6,6 +6,12 @@
 	flex-direction: row;
 	gap: 12px;
 	align-items: center;
+	padding-inline: 8px;
+	flex-wrap: wrap;
+
+	@include break-medium {
+		flex-wrap: unset;
+	}
 }
 
 .plan-field__icon {
@@ -38,11 +44,15 @@
 }
 
 .plan-field__button {
-	padding: 8px 16px;
+	padding: 1px;
 	text-decoration: underline;
 	font-size: rem(13px);
 	font-weight: 400;
 	cursor: pointer;
+
+	@include break-medium {
+		padding: 8px 16px;
+	}
 }
 
 .plan-field__loader {

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -6,12 +6,6 @@
 	flex-direction: row;
 	gap: 12px;
 	align-items: center;
-	padding-inline: 8px;
-	flex-wrap: wrap;
-
-	@include break-medium {
-		flex-wrap: unset;
-	}
 }
 
 .plan-field__icon {
@@ -44,15 +38,11 @@
 }
 
 .plan-field__button {
-	padding: 1px;
+	padding: 8px 16px;
 	text-decoration: underline;
 	font-size: rem(13px);
 	font-weight: 400;
 	cursor: pointer;
-
-	@include break-medium {
-		padding: 8px 16px;
-	}
 }
 
 .plan-field__loader {

--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -19,6 +19,7 @@ import {
 	LicenseCounts,
 	PaginatedItems,
 } from 'calypso/state/partner-portal/types';
+import type { ReferralAPIResponse } from 'calypso/a8c-for-agencies/sections/referrals/types';
 
 // Required for modular state.
 import 'calypso/state/partner-portal/init';
@@ -39,6 +40,7 @@ interface APILicense {
 	owner_type: string | null;
 	quantity: number | null;
 	parent_license_id: number | null;
+	referral: ReferralAPIResponse | null;
 }
 
 interface APIPaginatedItems< T > {
@@ -115,6 +117,7 @@ export function formatLicenses( items: APILicense[] ): License[] {
 		ownerType: item.owner_type,
 		quantity: item.quantity,
 		parentLicenseId: item.parent_license_id,
+		referral: item.referral,
 	} ) );
 }
 

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -5,6 +5,7 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import type { ReferralAPIResponse } from 'calypso/a8c-for-agencies/sections/referrals/types';
 
 /**
  * Utility.
@@ -250,6 +251,7 @@ export interface License {
 	ownerType: string | null;
 	quantity: number | null;
 	parentLicenseId: number | null;
+	referral: ReferralAPIResponse;
 }
 
 export interface LicenseCounts {

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -251,7 +251,7 @@ export interface License {
 	ownerType: string | null;
 	quantity: number | null;
 	parentLicenseId: number | null;
-	referral: ReferralAPIResponse;
+	referral: ReferralAPIResponse | null;
 }
 
 export interface LicenseCounts {


### PR DESCRIPTION
## Proposed Changes

This PR displays the client email on the license for client licenses.

## Testing Instructions

1. Checkout to the branch locally and start the server.
2. Add a hosting & product license by following all the steps here: https://github.com/Automattic/wp-calypso/pull/91713
3. Go to /purchases/licenses and verify that you can see the client email id shown for the clients license as shown below:


<img width="322" alt="Screenshot 2024-06-17 at 6 09 40 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0cd39361-ddfc-44df-8656-707a2e728eab">
<img width="1568" alt="Screenshot 2024-06-17 at 6 09 52 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/abeb8ce0-a130-445a-8f68-db728ea99619">
<img width="544" alt="Screenshot 2024-06-17 at 6 13 41 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4cbe3888-e6f9-43a4-a976-87922b613820">

Mobile view:

<img width="307" alt="Screenshot 2024-06-17 at 4 54 20 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3107b549-ab95-4bfb-bb77-5e9e1ce991cd">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
