### PR TITLE
Subscriptions: Add "Paid newsletter" section to the Newsletter settings

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/PaidNewsletterSection.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/PaidNewsletterSection.tsx
@@ -1,0 +1,21 @@
+import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+
+export const PaidNewsletterSection = () => {
+	const translate = useTranslate();
+	const siteSlug = useSelectedSiteSelector( getSiteSlug );
+
+	return (
+		<Card className="site-settings__card">
+			<Button href={ `/earn/payments/${ siteSlug }` }>{ translate( 'Set up' ) }</Button>
+			<FormSettingExplanation>
+				{ translate(
+					'Earn money through your Newsletter. Reward your most loyal subscribers with exclusive content or add a paywall to monetize content.'
+				) }
+			</FormSettingExplanation>
+		</Card>
+	);
+};

--- a/client/my-sites/site-settings/settings-newsletter/PaidNewsletterSection.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/PaidNewsletterSection.tsx
@@ -1,6 +1,7 @@
 import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelectedSiteSelector } from 'calypso/state/sites/hooks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
@@ -8,9 +9,15 @@ export const PaidNewsletterSection = () => {
 	const translate = useTranslate();
 	const siteSlug = useSelectedSiteSelector( getSiteSlug );
 
+	const onSetUpButtonClick = () => {
+		recordTracksEvent( 'calypso_newsletter_settings_setup_payment_plans_button_click' );
+	};
+
 	return (
 		<Card className="site-settings__card">
-			<Button href={ `/earn/payments/${ siteSlug }` }>{ translate( 'Set up' ) }</Button>
+			<Button href={ `/earn/payments/${ siteSlug }` } onClick={ onSetUpButtonClick }>
+				{ translate( 'Set up' ) }
+			</Button>
 			<FormSettingExplanation>
 				{ translate(
 					'Earn money through your Newsletter. Reward your most loyal subscribers with exclusive content or add a paywall to monetize content.'

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -16,6 +16,7 @@ import wrapSettingsForm from '../wrap-settings-form';
 import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
+import { PaidNewsletterSection } from './PaidNewsletterSection';
 import { ReplyToSetting } from './ReplyToSetting';
 import { SenderNameSetting } from './SenderNameSetting';
 import { SubscribeModalOnCommentSetting } from './SubscribeModalOnCommentSetting';
@@ -212,6 +213,13 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					</>
 				) }
 			</Card>
+			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
+			<SettingsSectionHeader
+				disabled={ disabled }
+				id="paid-newsletter"
+				title={ translate( 'Paid Newsletter' ) }
+			/>
+			<PaidNewsletterSection />
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 			<SettingsSectionHeader
 				disabled={ disabled }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/36958

Equivalent Jetpack PR https://github.com/Automattic/jetpack/pull/36975

## Proposed Changes

It adds the "Paid Newsletter" section to the Newsletter settings.

<img width="744" alt="Screenshot 2024-06-17 at 14 53 51" src="https://github.com/Automattic/wp-calypso/assets/4068554/243f1738-c109-4c41-b443-f5b02a548d4d">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To be consistent with the Jetpack Newsletter settings.

## Testing Instructions

1. Go to Newsletter settings
2. Make sure the "Paid Newsletter" section is visible and the "Set up" button works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
