### PR TITLE
Newsletter Settings: Apply site settings styles

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -292,7 +292,7 @@ const NewsletterSettings = () => {
 	const translate = useTranslate();
 
 	return (
-		<Main>
+		<Main className="site-settings">
 			<DocumentHead title={ translate( 'Newsletter Settings' ) } />
 			<NavigationHeader navigationItems={ [] } title={ translate( 'Newsletter Settings' ) } />
 			<SubscriptionsModuleBanner />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1718630741223199-slack-C052XEUUBL4

## Proposed Changes

It applies default settings site styles for the Newsletter Settings page.

| Before | After |
|--------|--------|
| <img width="737" alt="Screenshot 2024-06-17 at 15 23 03" src="https://github.com/Automattic/wp-calypso/assets/4068554/aeb4753a-ae38-477f-a424-c23147df9452"> | <img width="737" alt="Screenshot 2024-06-17 at 15 23 08" src="https://github.com/Automattic/wp-calypso/assets/4068554/9a7beb2b-5543-49e2-9fa5-8e4064c7482a"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To be consistent with other settings pages.

## Testing Instructions

Go to the Newsletter Settings page and make sure it looks consistent with other settings pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?