### PR TITLE
A4A: Update the Referral client cancel subscription hook to point to the correct endpoint.

### DIFF
--- a/client/a8c-for-agencies/data/client/use-cancel-client-subscription.ts
+++ b/client/a8c-for-agencies/data/client/use-cancel-client-subscription.ts
@@ -3,16 +3,15 @@ import { Subscription } from 'calypso/a8c-for-agencies/sections/client/types';
 import wpcom from 'calypso/lib/wp';
 
 interface Params {
-	subscriptionId: number;
+	licenseKey: string;
 }
 
-// FIXME: This is not the final endpoint but a temporary one. Will replace this once we figure out the correct endpoint.
-function mutationCancelClientSubscription( { subscriptionId }: Params ): Promise< Subscription > {
+function mutationCancelClientSubscription( { licenseKey }: Params ): Promise< Subscription > {
 	return wpcom.req.post( {
 		method: 'DELETE',
 		apiNamespace: 'wpcom/v2',
-		path: '/agency-client/referrals',
-		body: { license_key: subscriptionId },
+		path: '/agency-client/license',
+		body: { license_key: licenseKey },
 	} );
 }
 

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -35,7 +35,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 
 	const onConfirm = () => {
 		cancelSubscription( {
-			subscriptionId: subscription.id,
+			licenseKey: subscription.license_key,
 		} );
 	};
 


### PR DESCRIPTION
This PR removes the temporary URL for the Cancel client subscription hook. 

Closes https://github.com/Automattic/jetpack-genesis/issues/384

## Proposed Changes

*  Update `mutationCancelClientSubscription` hook to point to the correct endpoint.

## Testing Instructions

Follow the test instructions from https://github.com/Automattic/wp-calypso/pull/91334

* Point `public-api.wordpress.com`  to your sandbox and apply Patch D152379-code 
* On the Client's subscription page, cancel a subscription.
* Confirm that the subscription is cancelled successfully.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?