### PR TITLE
SearchControl: Adapt border style in focus mode

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -176,7 +176,7 @@ $brand-display: "SF Pro Display", sans-serif;
 		margin-bottom: 1.5rem;
 
 		.components-input-control__container {
-			border: solid 1px var(--studio-gray-10);
+			border-radius: 4px;
 			background-color: var(--studio-white);
 		}
 
@@ -186,6 +186,10 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		.components-input-control__suffix svg {
 			fill: var(--studio-gray-30);
+		}
+
+		.components-input-control__backdrop {
+			box-shadow: 0 0 0 1px var(--studio-gray-10);
 		}
 	}
 }

--- a/client/sites-dashboard-v2/dotcom-style.scss
+++ b/client/sites-dashboard-v2/dotcom-style.scss
@@ -248,8 +248,8 @@
 		align-items: center;
 		// Places search above filters
 		z-index: 1;
+		margin-top: 1px;
 		border-radius: 4px;
-		border: 1px solid var(--studio-gray-10);
 		background-color: var(--color-surface, $white);
 
 		.components-input-control__input {
@@ -266,6 +266,10 @@
 		.components-input-control__suffix {
 			color: var(--studio-gray-40);
 			margin-right: 4px;
+		}
+
+		.components-input-control__backdrop {
+			box-shadow: 0 0 0 1px var(--studio-gray-10);
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/7747

## Proposed Changes

* Fixes search control border style in focus mode
* Sets border-radius to 4px

## Testing Instructions

* Go to `/sites` or `/plugins/scheduled-updates`
* Focus on the search control
* Check if there is box-shadow style applied without border property

**Before:**
<img width="930" alt="Screenshot 2024-06-17 at 15 52 47" src="https://github.com/Automattic/wp-calypso/assets/1241413/1ec0335f-09ac-49ce-8c68-e09b606d2b44">
**After:**
<img width="929" alt="Screenshot 2024-06-17 at 15 52 57" src="https://github.com/Automattic/wp-calypso/assets/1241413/a1f5df65-986c-4a28-af6c-0598d549d37d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
