### PR TITLE
Newsletter Settings: Add the subtitle

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -294,7 +294,13 @@ const NewsletterSettings = () => {
 	return (
 		<Main>
 			<DocumentHead title={ translate( 'Newsletter Settings' ) } />
-			<NavigationHeader navigationItems={ [] } title={ translate( 'Newsletter Settings' ) } />
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Newsletter Settings' ) }
+				subtitle={ translate(
+					'Transform your blog posts into newsletters to easily reach your subscribers.'
+				) }
+			/>
 			<SubscriptionsModuleBanner />
 			<NewsletterSettingsForm />
 		</Main>


### PR DESCRIPTION
## Proposed Changes

It adds the subtitle to the Newsletter Settings page.

<img width="749" alt="Screenshot 2024-06-17 at 16 31 45" src="https://github.com/Automattic/wp-calypso/assets/4068554/a81a806e-7bc8-40e3-ab98-239550f50796">

## Testing Instructions

Go to the Newsletter Settings page making sure the subtitle is there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
