### PR TITLE
Remove mentioning WPCOM from Blaze Pro's authentication

### DIFF
--- a/client/blocks/authentication/social/social-tos.jsx
+++ b/client/blocks/authentication/social/social-tos.jsx
@@ -40,10 +40,16 @@ function SocialAuthToS( props ) {
 
 	if ( props.isBlazePro ) {
 		return getToSComponent(
-			props.translate(
-				'By continuing with any of the options above, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and acknowledge you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-				toSLinks
-			)
+			<>
+				{ props.translate(
+					'By continuing with any of the options above, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and acknowledge you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+					toSLinks
+				) }
+				<br />
+				{ props.translate(
+					'Blaze Pro uses WordPress.com accounts under the hood. Tumblr, Blaze Pro, and WordPress.com are properties of Automattic, Inc.'
+				) }
+			</>
 		);
 	}
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -418,6 +418,15 @@ class Login extends Component {
 					) }
 				</p>
 			);
+			if ( this.props.isBlazePro ) {
+				postHeader = (
+					<p className="login__header-subtitle login__lostpassword-subtitle">
+						{ translate(
+							'It happens to the best of us. Enter the email address associated with your Blaze Pro account and we’ll send you a link to reset your password.'
+						) }
+					</p>
+				);
+			}
 		} else if ( privateSite ) {
 			headerText = translate( 'This is a private WordPress.com site' );
 		} else if ( oauth2Client ) {
@@ -574,16 +583,9 @@ class Login extends Component {
 
 			if ( isBlazeProOAuth2Client( oauth2Client ) ) {
 				headerText = <h3>{ translate( 'Log in to your Blaze Pro account' ) }</h3>;
-				const poweredByWpCom = (
-					<>
-						{ translate( 'Log in with your WordPress.com account.' ) }
-						<br />
-					</>
-				);
 
 				postHeader = (
 					<p className="login__header-subtitle">
-						{ poweredByWpCom }
 						{ translate( "Don't have an account? {{signupLink}}Sign up here{{/signupLink}}", {
 							components: { signupLink },
 						} ) }
@@ -848,10 +850,22 @@ class Login extends Component {
 						isWooCoreProfilerFlow={ isWooCoreProfilerFlow }
 						from={ get( currentQuery, 'from' ) }
 					/>
-					{ ! isWooCoreProfilerFlow && (
+					{ ! isWooCoreProfilerFlow && ! isBlazePro && (
 						<div className="login__lost-password-footer">
 							<p className="login__lost-password-no-account">
 								{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
+									components: {
+										signupLink,
+									},
+								} ) }
+							</p>
+						</div>
+					) }
+					{ isBlazePro && (
+						<div className="login__lost-password-footer">
+							<p className="login__lost-password-no-account">
+								<span>{ translate( 'Don’t have an account?' ) }&nbsp;</span>
+								{ translate( '{{signupLink}}Sign up{{/signupLink}}', {
 									components: {
 										signupLink,
 									},

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -921,9 +921,16 @@ class SignupForm extends Component {
 		}
 
 		if ( this.props.isBlazePro ) {
-			tosText = this.props.translate(
-				'By creating an account, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and acknowledge you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-				options
+			tosText = (
+				<>
+					{ this.props.translate(
+						'By creating an account, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and acknowledge you have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+						options
+					) }{ ' ' }
+					{ this.props.translate(
+						'Blaze Pro uses WordPress.com accounts under the hood. Tumblr, Blaze Pro, and WordPress.com are properties of Automattic, Inc.'
+					) }
+				</>
 			);
 		}
 

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -28,6 +28,8 @@ $sfProText: "SF Pro Text", $sans;
 	background: var(--color-white);
 	min-height: 100%;
 
+	$login-form-max-width: 327px;
+
 	.masterbar__blaze-pro-nav {
 		display: flex;
 		flex-direction: row;
@@ -364,7 +366,8 @@ $sfProText: "SF Pro Text", $sans;
 		}
 	}
 
-	.logged-out-form__links {
+	.logged-out-form__links,
+	.login__lost-password-footer {
 		align-items: center;
 		display: flex;
 		flex-direction: row;
@@ -380,13 +383,15 @@ $sfProText: "SF Pro Text", $sans;
 			color: var(--studio-gray-60);
 		}
 
-		a.logged-out-form__link-item {
+		a.logged-out-form__link-item,
+		a {
 			color: var(--color-orange);
 			padding: 0;
 			text-decoration: none;
 		}
 
 		a.logged-out-form__link-item,
+		a,
 		span {
 			font-size: rem(18px);
 			font-weight: 500;
@@ -394,10 +399,16 @@ $sfProText: "SF Pro Text", $sans;
 		}
 	}
 
+	.login__lost-password-footer {
+		max-width: $login-form-max-width;
+		margin: 0 auto;
+	}
+
 	// Log in Styles
 
 	.card.login__form,
 	.signup-form .logged-out-form,
+	.login__lostpassword-form,
 	.two-factor-authentication__verification-code-form-wrapper {
 		box-shadow: none;
 
@@ -435,6 +446,7 @@ $sfProText: "SF Pro Text", $sans;
 	&.layout.is-white-login,
 	.card.login__form,
 	.signup-form .logged-out-form,
+	.login__lostpassword-form,
 	.two-factor-authentication__verification-code-form-wrapper {
 		.login .button.is-primary,
 		.login .button.is-primary:hover,
@@ -455,6 +467,7 @@ $sfProText: "SF Pro Text", $sans;
 	}
 
 	.login__header-subtitle {
+		color: var(--color-neutral-50);
 		font-family: $sfProText !important;
 		font-size: rem(18px);
 		font-weight: 500;
@@ -464,6 +477,10 @@ $sfProText: "SF Pro Text", $sans;
 		a:visited {
 			color: var(--color-orange);
 		}
+	}
+
+	.login__lostpassword-subtitle {
+		width: 360px;
 	}
 
 	&.two-factor-auth-enabled {
@@ -481,8 +498,6 @@ $sfProText: "SF Pro Text", $sans;
 	}
 
 	.login form.is-blaze-pro {
-		$max-width: 327px;
-
 		display: flex;
 		flex-direction: row;
 		margin-top: 48px;
@@ -500,12 +515,12 @@ $sfProText: "SF Pro Text", $sans;
 			flex-direction: column;
 			justify-content: center;
 			width: 100%;
-			max-width: $max-width;
+			max-width: $login-form-max-width;
 			margin: 0;
 
 			~ .auth-form__social.card {
 				width: 100%;
-				max-width: $max-width;
+				max-width: $login-form-max-width;
 				margin: 0;
 			}
 		}
@@ -514,6 +529,15 @@ $sfProText: "SF Pro Text", $sans;
 			@media screen and (min-width: $break-medium) {
 				margin-block: 0;
 			}
+		}
+	}
+
+	.login__lostpassword-form {
+		max-width: $login-form-max-width;
+		margin-bottom: 32px;
+
+		.login__form-userdata {
+			margin-bottom: 20px;
 		}
 	}
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -307,7 +307,7 @@ export class Login extends Component {
 			return null;
 		}
 
-		if ( isReactLostPasswordScreenEnabled() && this.props.isWoo ) {
+		if ( isReactLostPasswordScreenEnabled() && ( this.props.isWoo || this.props.isBlazePro ) ) {
 			return (
 				<a
 					className="login__lost-password-link"

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -276,7 +276,7 @@ export class UserStep extends Component {
 					}
 				);
 			} else if ( isBlazeProOAuth2Client( oauth2Client ) ) {
-				subHeaderText = translate( 'To get started create a new account with WordPress.com.' );
+				subHeaderText = translate( 'Create your new Blaze Pro account.' );
 			} else {
 				subHeaderText = translate(
 					'Not sure what this is all about? {{a}}We can help clear that up for you.{{/a}}',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to A8C-DSP repo, issue 1927.

## Proposed Changes
We want to remove explicit mentioning of WPCOM from authentication flows for Blaze Pro. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

According to the feedback from our first Blaze Pro customers, they were confused with necessity to have WordPress.com account in order to start using Blaze Pro which serves ads on Tumblr.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a file called `generate-links.js`,
- Put the following code there:
```js
function generateState() {
  const crypto = require('crypto');
  const hmac = crypto.createHmac('sha256', 'secret' );
  const data = hmac.update(new Date().getTime().toString());
  const state = data.digest('hex');
  return state;
}

const redirectUri = 'http://blaze.pro:3005/auth/connected&blog_id=0&wpcom_connect=1&calypso_env=development&scope=global&from-calypso=1';
const getLoginLink = () =>
	`https://public-api.wordpress.com/oauth2/authorize?response_type=code&client_id=92099&state=${generateState()}&redirect_uri=${encodeURIComponent(redirectUri)}`;

const signInLink = `http://calypso.localhost:3000/log-in?client_id=92099&redirect_to=${encodeURIComponent(getLoginLink())}`;

const signUpLink = `http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=92099&oauth2_redirect=${encodeURIComponent(getLoginLink())}`;

console.log('Login URL:');
console.log(signInLink);
console.log('');
console.log('Sign Up URL:');
console.log(signUpLink);
```

- Run code using `node generate-links.js`
- Open an incognito tab
- Open the second link (Sign Up URL) from the script's output in your browser
- You should see the update version of the Log In page:

Before
![Screenshot 2024-06-17 at 18 48 58](https://github.com/Automattic/wp-calypso/assets/115007291/6f030d24-f8d6-43f9-b7b4-744f4c2d41a6)

After (again, mentioning of WPCOM was removed, but instead the connection between Blaze Pro, Tumblr, and WPCOM is highlighted)
![Screenshot 2024-06-17 at 18 54 51](https://github.com/Automattic/wp-calypso/assets/115007291/b3f639a0-0f61-4988-99f6-739f84a7d22c)

- Next, click on Log in here

Before
![Screenshot 2024-06-17 at 18 45 10](https://github.com/Automattic/wp-calypso/assets/115007291/80cb5b0d-7482-47c0-9c42-33c6ffa64330)

After (the mention of WPCOM was removed, but instead there's the mention about connection between Blaze Pro, Tumblr, and WPCOM)
![Screenshot 2024-06-17 at 18 42 27](https://github.com/Automattic/wp-calypso/assets/115007291/a2a97374-2153-4ddd-a9b4-e443d5b1e3e6)

- Then, click "Lost your password?" link

Before (it was not styled)
<img width="1096" alt="image" src="https://github.com/Automattic/wp-calypso/assets/115007291/99d928e4-d1de-44c4-9200-a8ae6304f5a2">

After:
<img width="1087" alt="image" src="https://github.com/Automattic/wp-calypso/assets/115007291/52629f14-940a-4bc8-a5ed-4bec51ad74fa">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
