### PR TITLE
A4A: Add Overview onboarding step for the 'Partner Directory' feature.

### DIFF
--- a/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
+++ b/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
@@ -1,12 +1,14 @@
 import { Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
+import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
 import {
 	A4A_MARKETPLACE_LINK,
+	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_SITES_LINK_ADD_NEW_SITE_TOUR,
 	A4A_SITES_LINK_WALKTHROUGH_TOUR,
 } from '../components/sidebar-menu/lib/constants';
@@ -83,6 +85,31 @@ export default function useOnboardingTours() {
 				title: translate( 'Explore the marketplace' ),
 				useCalypsoPath: true,
 			},
+			...( isSectionNameEnabled( 'a8c-for-agencies-partner-directory' )
+				? [
+						{
+							calypso_path: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
+							completed: checkTourCompletion( preferences, 'boostAgencyVisibility' ),
+							disabled: false,
+							actionDispatch: () => {
+								dispatch(
+									recordTracksEvent(
+										'calypso_a4a_overview_next_steps_boost_agency_visibility_click'
+									)
+								);
+								dispatch(
+									savePreference(
+										A4A_ONBOARDING_TOURS_PREFERENCE_NAME[ 'boostAgencyVisibility' ],
+										true
+									)
+								);
+							},
+							id: 'boost_agency_visibility',
+							title: translate( 'Boost your agency’s visibility across Automattic platforms' ),
+							useCalypsoPath: true,
+						},
+				  ]
+				: [] ),
 		];
 
 		if ( noActiveSite ) {

--- a/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
+++ b/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
@@ -6,6 +6,7 @@ export const A4A_ONBOARDING_TOURS_PREFERENCE_NAME: Record< string, string > = {
 	addSiteStep2: 'a4a-sites-add-new-site-tour-step-2',
 	sitesWalkthrough: 'a4a-sites-tour',
 	exploreMarketplace: 'a4a-marketplace-tour',
+	boostAgencyVisibility: 'a4a-boost-agency-visibility-tour',
 };
 
 export const A4A_ONBOARDING_TOURS_EVENT_NAMES: Record< string, string > = {


### PR DESCRIPTION
Add Overview onboarding steps for the 'Partner directory' feature.

<img width="1271" alt="Screenshot 2024-06-18 at 12 53 50 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/54464ba2-6239-4c8f-a4c2-b4b9ccd60b71">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/566

## Proposed Changes

* Add boarding tour constants related to 'Partner Directory' feature.

## Testing Instructions

* Use the A4A live link and go to `/overview`
* Confirm that you see the new steps for Partner Directory.
* Confirm clicking this will redirect you to the Partner Directory dashboard.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
