### PR TITLE
A4A - Partner Directory: Deactivate the form autocomplete for fields

### DIFF
--- a/client/a8c-for-agencies/components/form/index.tsx
+++ b/client/a8c-for-agencies/components/form/index.tsx
@@ -14,8 +14,9 @@ type Props = {
 export default function Form( { className, title, description, children, autocomplete }: Props ) {
 	return (
 		<form className={ clsx( 'a4a-form', className ) } autoComplete={ autocomplete }>
-			( autocomplete === 'off' && (
-			<input autoComplete="off" name="hidden" style={ { display: 'none' } } />)
+			{ autocomplete === 'off' && (
+				<input autoComplete="off" name="hidden" style={ { display: 'none' } } />
+			) }
 			<div className="a4a-form__heading">
 				{ title && <h1 className="a4a-form__heading-title">{ title }</h1> }
 				{ description && <p className="a4a-form__heading-description">{ description }</p> }

--- a/client/a8c-for-agencies/components/form/index.tsx
+++ b/client/a8c-for-agencies/components/form/index.tsx
@@ -7,12 +7,13 @@ type Props = {
 	title?: string;
 	description?: string | ReactNode;
 	children: ReactNode;
+	autocomplete?: 'on' | 'off';
 	className?: string;
 };
 
-export default function Form( { className, title, description, children }: Props ) {
+export default function Form( { className, title, description, children, autocomplete }: Props ) {
 	return (
-		<form className={ clsx( 'a4a-form', className ) }>
+		<form className={ clsx( 'a4a-form', className ) } autoComplete={ autocomplete }>
 			<div className="a4a-form__heading">
 				{ title && <h1 className="a4a-form__heading-title">{ title }</h1> }
 				{ description && <p className="a4a-form__heading-description">{ description }</p> }

--- a/client/a8c-for-agencies/components/form/index.tsx
+++ b/client/a8c-for-agencies/components/form/index.tsx
@@ -14,11 +14,12 @@ type Props = {
 export default function Form( { className, title, description, children, autocomplete }: Props ) {
 	return (
 		<form className={ clsx( 'a4a-form', className ) } autoComplete={ autocomplete }>
+			( autocomplete === 'off' && (
+			<input autoComplete="off" name="hidden" style={ { display: 'none' } } />)
 			<div className="a4a-form__heading">
 				{ title && <h1 className="a4a-form__heading-title">{ title }</h1> }
 				{ description && <p className="a4a-form__heading-description">{ description }</p> }
 			</div>
-
 			{ children }
 		</form>
 	);

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-submit-form.ts
@@ -15,11 +15,11 @@ export default function useSubmitForm( { formData, onSubmitSuccess, onSubmitErro
 			if ( onSubmitSuccess && data?.profile ) {
 				onSubmitSuccess( data );
 			} else {
-				onSubmitError && onSubmitError();
+				onSubmitError?.();
 			}
 		},
 		onError: () => {
-			onSubmitError && onSubmitError();
+			onSubmitError?.();
 		},
 	} );
 

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -75,6 +75,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 		<Form
 			className="partner-directory-agency-details"
 			title={ translate( 'Finish adding details to your public profile' ) }
+			autocomplete="off"
 			description={
 				<>
 					Add details to your agency's public profile for clients to see.{ ' ' }

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
@@ -16,11 +16,11 @@ export default function useSubmitForm( { formData, onSubmitSuccess, onSubmitErro
 				if ( onSubmitSuccess && data?.profile.partner_directory_application?.status ) {
 					onSubmitSuccess( data );
 				} else {
-					onSubmitError && onSubmitError();
+					onSubmitError?.();
 				}
 			},
 			onError: () => {
-				onSubmitError && onSubmitError();
+				onSubmitError?.();
 			},
 		}
 	);

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -117,6 +117,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 		<Form
 			className="partner-directory-agency-expertise"
 			title={ translate( 'Share your expertise' ) }
+			autocomplete="off"
 			description={ translate( "Pick your agency's specialties and choose your directories." ) }
 		>
 			<FormSection title={ translate( 'Product and Service' ) }>


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/693

## Proposed Changes

This PR deactivates the browser autocomplete on the Partner Directory forms (Expertise or Details). 

![image](https://github.com/Automattic/wp-calypso/assets/9832440/a5895a5b-87ae-4d97-94df-9d893ad75eb0)

![image](https://github.com/Automattic/wp-calypso/assets/9832440/2d24e2c9-0002-431d-9182-443f9b26eee9)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Check both forms (Expertise and Agency details) and ensure that on each form input you don't get any autocomplete suggestion from the browser.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
