### PR TITLE
Guided Onboarding: Update segment goals options desktop alignment

### DIFF
--- a/client/signup/steps/initial-intent/styles.scss
+++ b/client/signup/steps/initial-intent/styles.scss
@@ -25,6 +25,10 @@
 				justify-content: center;
 				gap: 16px;
 
+				@media (min-width: $break-large) {
+					justify-content: start;
+				}
+
 				.question-options__option-control {
 					padding: 24px;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1718643292954749-slack-C02T4NVL4JJ

## Proposed Changes

* Update the alignment for the segment goal options to ensure the `Let us build your site in 4 days` option isn't center aligned on desktop viewport

Before:

<img width="857" alt="CleanShot 2024-06-17 at 14 17 47@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/ce2dc6ad-1045-4de2-8208-50b720c87481">


After:

<img width="860" alt="CleanShot 2024-06-17 at 14 17 21@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/04fd4092-1345-4e2f-afbc-0d6dfd070751">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Updating to the latest design to ensure consistency across the segment question 2 options.
 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link.
* Navigate to `/start/guided/initial-intent?flags=onboarding/guided`
* Select the first option for segment Question 1, then verify the design on segment Question 2: https://www.figma.com/design/3u71fUJraClkRQiLrAORPf/Trail-Map-Project?node-id=4464-13374&m=dev
* Verify the options are centered align on smaller viewport.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
