### PR TITLE
Update CTA for Gravatar domains flow to "Return to Gravatar"

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -67,7 +67,7 @@ export default function ThankYouDomainProduct( {
 	} else if ( isGravatarDomain ) {
 		actions = (
 			<Button variant="primary" href="https://gravatar.com/profile">
-				{ translate( 'Manage domain at Gravatar' ) }
+				{ translate( 'Return to Gravatar' ) }
 			</Button>
 		);
 	} else if ( purchase?.blogId && siteSlug ) {


### PR DESCRIPTION
Related to #91069

## Proposed Changes

This PR updates the CTA label in the thank-you page for the Gravatar domains flow. It was "Manage domain at Gravatar" and now it's "Return to Gravatar".

### Screenshots

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-17 at 15 52 36](https://github.com/Automattic/wp-calypso/assets/5324818/087267a0-0915-400a-b2e5-2981e1c9560d) | ![Screenshot 2024-06-17 at 15 52 18](https://github.com/Automattic/wp-calypso/assets/5324818/87e3875b-92ea-4383-86ee-97673d297a3e) | 

## Why are these changes being made?

The new label should make more sense for users coming to this flow from Gravatar.

This is part of the Custom Domains on Gravatar project (pcYYhz-24z-p2).

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Navigate to the thank you page for the receipt of a Gravatar domain purchase (e.g. `/checkout/thank-you/no-site/93520523`)
- Ensure the CTA is correct
- Open the thank-you page for any other domain-only purchase receipt and ensure the usual WPCOM CTAs are shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?