### PR TITLE
Adding the How to migrate step

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -10,3 +10,7 @@ export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
 };
 
 export const SITE_PICKER_FILTER_CONFIG = [ 'wpcom', 'atomic' ];
+export const HOW_TO_MIGRATE_OPTIONS = {
+	DO_IT_FOR_ME: 'difm',
+	DO_IT_MYSELF: 'myself',
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -11,6 +11,8 @@ import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import type { Step } from '../../types';
 
+import './style.scss';
+
 const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 	const translate = useTranslate();
 	const site = useSite();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,10 +1,11 @@
 import { Card } from '@automattic/components';
 import { StepContainer, SubTitle, Title } from '@automattic/onboarding';
-import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
@@ -16,25 +17,29 @@ import './style.scss';
 const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 	const translate = useTranslate();
 	const site = useSite();
-	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
+	const importSiteQueryParam = useQuery().get( 'from' ) || '';
+	usePresalesChat( 'wpcom', true, true );
 
-	const options = [
-		{
-			label: translate( 'Do it for me' ),
-			description: translate(
-				"Share your site with us, and we'll review it and handle the migration if possible."
-			),
-			value: 'difm',
-			selected: true,
-		},
-		{
-			label: translate( "I'll do it myself" ),
-			description: translate(
-				'Install the plugin yourself, find the migration key and migrate the site.'
-			),
-			value: 'myself',
-		},
-	];
+	const options = useMemo(
+		() => [
+			{
+				label: translate( 'Do it for me' ),
+				description: translate(
+					"Share your site with us, and we'll review it and handle the migration if possible."
+				),
+				value: 'difm',
+				selected: true,
+			},
+			{
+				label: translate( "I'll do it myself" ),
+				description: translate(
+					'Install the plugin yourself, find the migration key and migrate the site.'
+				),
+				value: 'myself',
+			},
+		],
+		[ translate ]
+	);
 
 	let importSiteHostName = '';
 
@@ -99,8 +104,6 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 			</div>
 		</>
 	);
-
-	usePresalesChat( 'wpcom', true, true );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
+import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -27,7 +28,7 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 				description: translate(
 					"Share your site with us, and we'll review it and handle the migration if possible."
 				),
-				value: 'difm',
+				value: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
 				selected: true,
 			},
 			{
@@ -35,7 +36,7 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 				description: translate(
 					'Install the plugin yourself, find the migration key and migrate the site.'
 				),
-				value: 'myself',
+				value: HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF,
 			},
 		],
 		[ translate ]

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,5 +1,4 @@
-import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
-import { Badge, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { StepContainer, SubTitle, Title } from '@automattic/onboarding';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -19,17 +18,19 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 
 	const options = [
 		{
-			label: translate( 'Migrate site' ),
+			label: translate( 'Do it for me' ),
 			description: translate(
-				"All your site's content, themes, plugins, users and customizations."
+				"Share your site with us, and we'll review it and handle the migration if possible."
 			),
-			value: 'migrate',
+			value: 'difm',
 			selected: true,
 		},
 		{
-			label: translate( 'Import content only' ),
-			description: translate( 'Import just posts, pages, comments and media.' ),
-			value: 'import',
+			label: translate( "I'll do it myself" ),
+			description: translate(
+				'Install the plugin yourself, find the migration key and migrate the site.'
+			),
+			value: 'myself',
 		},
 	];
 
@@ -58,12 +59,9 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 		? true
 		: false;
 
-	const handleClick = ( destination: string ) => {
-		if ( destination === 'migrate' && ! canInstallPlugins ) {
-			return navigation.submit?.( { destination: 'upgrade' } );
-		}
-
-		return navigation.submit?.( { destination } );
+	const handleClick = ( how: string ) => {
+		const destination = canInstallPlugins ? 'migrate' : 'upgrade';
+		return navigation.submit?.( { how, destination } );
 	};
 
 	const stepContent = (
@@ -81,7 +79,7 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 				</SubTitle>
 			) }
 
-			<div className="import-or-migrate__list">
+			<div className="how-to-migrate__list">
 				{ options.map( ( option, i ) => (
 					<Card
 						tagName="button"
@@ -89,22 +87,11 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 						key={ i }
 						onClick={ () => handleClick( option.value ) }
 					>
-						<div className="import-or-migrate__header">
-							<h2 className="import-or-migrate__name">{ option.label }</h2>
-
-							{ option.value === 'migrate' && (
-								<Badge type="info-blue">
-									{
-										// translators: %(planName)s is a plan name (e.g. Commerce plan).
-										translate( 'Requires %(planName)s plan', {
-											args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-										} )
-									}
-								</Badge>
-							) }
+						<div className="how-to-migrate__header">
+							<h2 className="how-to-migrate__name">{ option.label }</h2>
 						</div>
 
-						<p className="import-or-migrate__description">{ option.description }</p>
+						<p className="how-to-migrate__description">{ option.description }</p>
 					</Card>
 				) ) }
 			</div>
@@ -115,10 +102,10 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 
 	return (
 		<>
-			<DocumentHead title={ translate( 'What do you want to do?' ) } />
+			<DocumentHead title={ translate( 'How do you want to migrate?' ) } />
 			<StepContainer
-				stepName="site-migration-import-or-migrate"
-				className="import-or-migrate"
+				stepName="site-migration-how-to-migrate"
+				className="how-to-migrate"
 				shouldHideNavButtons={ false }
 				hideSkip
 				stepContent={ stepContent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,0 +1,132 @@
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import { Badge, Card } from '@automattic/components';
+import { StepContainer, SubTitle, Title } from '@automattic/onboarding';
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
+import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
+import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
+import type { Step } from '../../types';
+
+const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
+	const translate = useTranslate();
+	const site = useSite();
+	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
+
+	const options = [
+		{
+			label: translate( 'Migrate site' ),
+			description: translate(
+				"All your site's content, themes, plugins, users and customizations."
+			),
+			value: 'migrate',
+			selected: true,
+		},
+		{
+			label: translate( 'Import content only' ),
+			description: translate( 'Import just posts, pages, comments and media.' ),
+			value: 'import',
+		},
+	];
+
+	let importSiteHostName = '';
+
+	try {
+		importSiteHostName = new URL( importSiteQueryParam )?.hostname;
+	} catch ( e ) {}
+
+	const { data: urlData } = useAnalyzeUrlQuery( importSiteQueryParam, true );
+	const { data: hostingProviderData } = useHostingProviderQuery( importSiteHostName, true );
+	const hostingProviderName = useHostingProviderName(
+		hostingProviderData?.hosting_provider,
+		urlData
+	);
+
+	const hostingProviderSlug = hostingProviderData?.hosting_provider?.slug;
+	const shouldDisplayHostIdentificationMessage =
+		hostingProviderSlug &&
+		hostingProviderSlug !== 'unknown' &&
+		hostingProviderSlug !== 'automattic';
+
+	const canInstallPlugins = site?.plan?.features?.active.find(
+		( feature ) => feature === 'install-plugins'
+	)
+		? true
+		: false;
+
+	const handleClick = ( destination: string ) => {
+		if ( destination === 'migrate' && ! canInstallPlugins ) {
+			return navigation.submit?.( { destination: 'upgrade' } );
+		}
+
+		return navigation.submit?.( { destination } );
+	};
+
+	const stepContent = (
+		<>
+			<Title>{ translate( 'How do you want to migrate?' ) }</Title>
+
+			{ shouldDisplayHostIdentificationMessage && (
+				<SubTitle>
+					{
+						// translators: %(hostingProviderName)s is the name of a hosting provider (e.g. WP Engine).
+						translate( 'Your WordPress site is hosted with %(hostingProviderName)s.', {
+							args: { hostingProviderName },
+						} )
+					}
+				</SubTitle>
+			) }
+
+			<div className="import-or-migrate__list">
+				{ options.map( ( option, i ) => (
+					<Card
+						tagName="button"
+						displayAsLink
+						key={ i }
+						onClick={ () => handleClick( option.value ) }
+					>
+						<div className="import-or-migrate__header">
+							<h2 className="import-or-migrate__name">{ option.label }</h2>
+
+							{ option.value === 'migrate' && (
+								<Badge type="info-blue">
+									{
+										// translators: %(planName)s is a plan name (e.g. Commerce plan).
+										translate( 'Requires %(planName)s plan', {
+											args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+										} )
+									}
+								</Badge>
+							) }
+						</div>
+
+						<p className="import-or-migrate__description">{ option.description }</p>
+					</Card>
+				) ) }
+			</div>
+		</>
+	);
+
+	usePresalesChat( 'wpcom', true, true );
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'What do you want to do?' ) } />
+			<StepContainer
+				stepName="site-migration-import-or-migrate"
+				className="import-or-migrate"
+				shouldHideNavButtons={ false }
+				hideSkip
+				stepContent={ stepContent }
+				recordTracksEvent={ recordTracksEvent }
+				goBack={ navigation.goBack }
+			/>
+		</>
+	);
+};
+
+export default SiteMigrationHowToMigrate;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
@@ -1,0 +1,57 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.how-to-migrate {
+	max-width: 602px;
+	padding: 0 12px;
+
+	.onboarding-title {
+		font-size: 2.75rem;
+		text-align: center;
+	}
+
+	.onboarding-subtitle {
+		color: var(--studio-gray-50, #646970);
+		font-size: 1rem;
+		letter-spacing: -0.32px;
+		line-height: 1.5;
+		text-align: center;
+	}
+
+	.how-to-migrate__list {
+		margin-top: 50px;
+		padding-bottom: 108px;
+
+		@include break-mobile {
+			margin-top: 80px;
+			padding-bottom: revert;
+		}
+
+		.card {
+			svg {
+				fill: #1e1e1e;
+			}
+		}
+	}
+
+	.how-to-migrate__header {
+		align-items: center;
+		margin-bottom: 8px;
+
+		@include break-mobile {
+			display: flex;
+			margin-bottom: 0;
+		}
+	}
+
+	.how-to-migrate__name {
+		color: var(--studio-gray-100);
+		font-size: 1.25rem;
+		font-weight: 500;
+		margin-right: 8px;
+	}
+
+	.how-to-migrate__description {
+		color: var(--studio-gray-60);
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -246,6 +246,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-migration-import-or-migrate' ),
 	},
 
+	SITE_MIGRATION_HOW_TO_MIGRATE: {
+		slug: 'site-migration-how-to-migrate',
+		asyncComponent: () => import( './steps-repository/site-migration-how-to-migrate' ),
+	},
+
 	SITE_MIGRATION_UPGRADE_PLAN: {
 		slug: 'site-migration-upgrade-plan',
 		asyncComponent: () => import( './steps-repository/site-migration-upgrade-plan' ),

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -39,6 +39,7 @@ const siteMigration: Flow = {
 		const baseSteps = [
 			STEPS.SITE_MIGRATION_IDENTIFY,
 			STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
+			STEPS.SITE_MIGRATION_HOW_TO_MIGRATE,
 			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
 			STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN,
 			MIGRATION_INSTRUCTIONS_STEP,
@@ -261,19 +262,23 @@ const siteMigration: Flow = {
 						);
 					}
 
-					// Take the user to the upgrade plan step.
-					if ( providedDependencies?.destination === 'upgrade' ) {
-						return navigate( STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug, {
-							siteId,
-							siteSlug,
-						} );
-					}
-
-					// Continue with the migration flow.
-					return navigate( MIGRATION_INSTRUCTIONS_STEP.slug, {
+					return navigate( STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug, {
 						siteId,
 						siteSlug,
 					} );
+					// Take the user to the upgrade plan step.
+					// if ( providedDependencies?.destination === 'upgrade' ) {
+					// 	return navigate( STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug, {
+					// 		siteId,
+					// 		siteSlug,
+					// 	} );
+					// }
+
+					// // Continue with the migration flow.
+					// return navigate( MIGRATION_INSTRUCTIONS_STEP.slug, {
+					// 	siteId,
+					// 	siteSlug,
+					// } );
 				}
 
 				case STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug: {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -263,7 +263,23 @@ const siteMigration: Flow = {
 						);
 					}
 
-					return navigate( STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug, {
+					if ( config.isEnabled( 'migration-flow/enable-migration-assistant' ) ) {
+						return navigate( STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug, {
+							siteId,
+							siteSlug,
+						} );
+					}
+
+					// Take the user to the upgrade plan step.
+					if ( providedDependencies?.destination === 'upgrade' ) {
+						return navigate( STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug, {
+							siteId,
+							siteSlug,
+						} );
+					}
+
+					// Continue with the migration flow.
+					return navigate( MIGRATION_INSTRUCTIONS_STEP.slug, {
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -388,6 +388,12 @@ const siteMigration: Flow = {
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
 					if ( urlQueryParams.has( 'showModal' ) || ! isFromSiteWordPress ) {
 						urlQueryParams.delete( 'showModal' );
+						if ( config.isEnabled( 'migration-flow/enable-migration-assistant' ) ) {
+							return navigate(
+								`${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?${ urlQueryParams }`
+							);
+						}
+
 						return navigate(
 							`${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?${ urlQueryParams }`
 						);

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -11,6 +11,7 @@ import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { addQueryArgs } from 'calypso/lib/url';
 import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
+import { HOW_TO_MIGRATE_OPTIONS } from '../constants';
 import { useIsSiteAdmin } from '../hooks/use-is-site-admin';
 import { useSiteData } from '../hooks/use-site-data';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
@@ -286,7 +287,7 @@ const siteMigration: Flow = {
 					}
 
 					// Do it for me option.
-					if ( providedDependencies?.how === 'difm' ) {
+					if ( providedDependencies?.how === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
 						return navigate( STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug, {
 							siteId,
 							siteSlug,
@@ -317,7 +318,7 @@ const siteMigration: Flow = {
 
 						if (
 							providedDependencies?.userAcceptedDeal ||
-							urlQueryParams.get( 'how' ) === 'difm'
+							urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME
 						) {
 							redirectAfterCheckout = STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug;
 						}

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -358,6 +358,9 @@ const siteMigration: Flow = {
 				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {
 					return navigate( STEPS.SITE_MIGRATION_IDENTIFY.slug );
 				}
+				case STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug: {
+					return navigate( STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug );
+				}
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
 					if ( urlQueryParams.get( 'ref' ) === GUIDED_ONBOARDING_FLOW_REFERRER ) {
 						window.location.assign( '/start/guided/initial-intent' );

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -266,19 +266,38 @@ const siteMigration: Flow = {
 						siteId,
 						siteSlug,
 					} );
-					// Take the user to the upgrade plan step.
-					// if ( providedDependencies?.destination === 'upgrade' ) {
-					// 	return navigate( STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug, {
-					// 		siteId,
-					// 		siteSlug,
-					// 	} );
-					// }
+				}
 
-					// // Continue with the migration flow.
-					// return navigate( MIGRATION_INSTRUCTIONS_STEP.slug, {
-					// 	siteId,
-					// 	siteSlug,
-					// } );
+				case STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug: {
+					// Take the user to the upgrade plan step.
+					if ( providedDependencies?.destination === 'upgrade' ) {
+						return navigate(
+							addQueryArgs(
+								{
+									siteId,
+									siteSlug,
+									from: fromQueryParam,
+									destination: providedDependencies?.destination,
+									how: providedDependencies?.how as string,
+								},
+								STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
+							)
+						);
+					}
+
+					// Do it for me option.
+					if ( providedDependencies?.how === 'difm' ) {
+						return navigate( STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug, {
+							siteId,
+							siteSlug,
+						} );
+					}
+
+					// Continue with the migration flow.
+					return navigate( MIGRATION_INSTRUCTIONS_STEP.slug, {
+						siteId,
+						siteSlug,
+					} );
 				}
 
 				case STEPS.SITE_MIGRATION_ASSIGN_TRIAL_PLAN.slug: {
@@ -294,9 +313,14 @@ const siteMigration: Flow = {
 
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
 					if ( providedDependencies?.goToCheckout ) {
-						const redirectAfterCheckout = providedDependencies?.userAcceptedDeal
-							? STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
-							: MIGRATION_INSTRUCTIONS_STEP.slug;
+						let redirectAfterCheckout = MIGRATION_INSTRUCTIONS_STEP.slug;
+
+						if (
+							providedDependencies?.userAcceptedDeal ||
+							urlQueryParams.get( 'how' ) === 'difm'
+						) {
+							redirectAfterCheckout = STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug;
+						}
 
 						const destination = addQueryArgs(
 							{

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -7,6 +7,7 @@ import { waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
+import { HOW_TO_MIGRATE_OPTIONS } from '../../constants';
 import { goToCheckout } from '../../utils/checkout';
 import hostedSiteMigrationFlow from '../hosted-site-migration-flow';
 import { STEPS } from '../internals/steps';
@@ -185,7 +186,7 @@ describe( 'Hosted site Migration Flow', () => {
 				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
 				dependencies: {
 					destination: 'migrate',
-					how: 'difm',
+					how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
 				},
 			} );
 

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -144,7 +144,7 @@ describe( 'Hosted site Migration Flow', () => {
 				state: null,
 			} );
 		} );
-		it( 'migrate redirects from the import-from page to new instructions if flag enabled', () => {
+		it( 'migrate redirects from the import-from page to how-to-migrate page', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
@@ -152,7 +152,7 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`,
+				path: `/${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }`,
 				state: {
 					siteSlug: 'example.wordpress.com',
 				},
@@ -184,7 +184,7 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'upgrade redirects from the import-from page to site-migration-upgrade-plan page', () => {
+		it( 'upgrade redirects from the import-from page to site-migration-how-to-migrate', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
@@ -195,7 +195,7 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: '/site-migration-upgrade-plan',
+				path: '/site-migration-how-to-migrate',
 				state: { siteSlug: 'example.wordpress.com' },
 			} );
 		} );

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -159,6 +159,60 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 		} );
 
+		it( 'migrate redirects from the how-to-migrate (myself) page page to instructions page', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
+				dependencies: {
+					destination: 'migrate',
+					how: 'myself',
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`,
+				state: {
+					siteSlug: 'example.wordpress.com',
+				},
+			} );
+		} );
+
+		it( 'migrate redirects from the how-to-migrate (do it for me) page to assisted migration page', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
+				dependencies: {
+					destination: 'migrate',
+					how: 'difm',
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }`,
+				state: {
+					siteSlug: 'example.wordpress.com',
+				},
+			} );
+		} );
+
+		it( 'migrate redirects from the how-to-migrate (upgrade needed) page to site-migration-upgrade-plan step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
+				dependencies: {
+					destination: 'upgrade',
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&destination=upgrade`,
+				state: null,
+			} );
+		} );
+
 		it( 'redirects the user to the checkout page with the correct destination params', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( hostedSiteMigrationFlow );
 

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -278,7 +278,7 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?siteSlug=example.wordpress.com`,
+				path: `/${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?siteSlug=example.wordpress.com`,
 				state: null,
 			} );
 		} );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -187,7 +187,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'migrate redirects from the import-from page to new instructions if flag enabled', () => {
+		it( 'migrate redirects from the import-from page to how-to-migrate page', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
@@ -195,7 +195,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`,
+				path: `/${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }`,
 				state: {
 					siteSlug: 'example.wordpress.com',
 				},
@@ -227,7 +227,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'upgrade redirects from the import-from page to site-migration-upgrade-plan page', () => {
+		it( 'upgrade redirects from the import-from page to site-migration-how-to-migrate page', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
@@ -238,7 +238,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: '/site-migration-upgrade-plan',
+				path: '/site-migration-how-to-migrate',
 				state: { siteSlug: 'example.wordpress.com' },
 			} );
 		} );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -202,6 +202,60 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
+		it( 'migrate redirects from the how-to-migrate (myself) page page to instructions page', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
+				dependencies: {
+					destination: 'migrate',
+					how: 'myself',
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`,
+				state: {
+					siteSlug: 'example.wordpress.com',
+				},
+			} );
+		} );
+
+		it( 'migrate redirects from the how-to-migrate (do it for me) page to assisted migration page', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
+				dependencies: {
+					destination: 'migrate',
+					how: 'difm',
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }`,
+				state: {
+					siteSlug: 'example.wordpress.com',
+				},
+			} );
+		} );
+
+		it( 'migrate redirects from the how-to-migrate (upgrade needed) page to site-migration-upgrade-plan step', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
+				dependencies: {
+					destination: 'upgrade',
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&destination=upgrade`,
+				state: null,
+			} );
+		} );
+
 		it( 'redirects the user to the checkout page with the correct destination params', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -9,6 +9,7 @@ import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-tri
 import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { addQueryArgs } from '../../../../lib/url';
+import { HOW_TO_MIGRATE_OPTIONS } from '../../constants';
 import { goToCheckout } from '../../utils/checkout';
 import { STEPS } from '../internals/steps';
 import siteMigrationFlow from '../site-migration-flow';
@@ -228,7 +229,7 @@ describe( 'Site Migration Flow', () => {
 				currentStep: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug,
 				dependencies: {
 					destination: 'migrate',
-					how: 'difm',
+					how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME,
 				},
 			} );
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -357,7 +357,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?siteSlug=example.wordpress.com`,
+				path: `/${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?siteSlug=example.wordpress.com`,
 				state: null,
 			} );
 		} );

--- a/config/development.json
+++ b/config/development.json
@@ -144,6 +144,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration-flow/new-migration-instructions-step": false,
+		"migration-flow/enable-migration-assistant": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"oauth": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,6 +90,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration-flow/new-migration-instructions-step": false,
+		"migration-flow/enable-migration-assistant": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -117,6 +117,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration-flow/new-migration-instructions-step": false,
+		"migration-flow/enable-migration-assistant": false,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -113,6 +113,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration-flow/new-migration-instructions-step": false,
+		"migration-flow/enable-migration-assistant": true,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/test.json
+++ b/config/test.json
@@ -83,6 +83,7 @@
 		"me/account-close": true,
 		"me/vat-details": true,
 		"migration-flow/new-migration-instructions-step": false,
+		"migration-flow/enable-migration-assistant": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"p2-enabled": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -110,6 +110,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"migration-flow/new-migration-instructions-step": false,
+		"migration-flow/enable-migration-assistant": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7723

More context: p9Jlb4-c3O-p2#comment-11797

## Proposed Changes

We want to offer users the option of an assisted migration, in which our HEs would do the migration while keeping the users in touch.

To achieve this, we are adding a new step that allows the users to select whether they want us to do the migration for them or continue doing it themselves.

![image](https://github.com/Automattic/wp-calypso/assets/3801502/031766a2-7f08-4f95-8ada-5bd5116d963a)

When the users pick the "Do it for me" option(and upgrade in case the user doesn't have the Creator plan), they will be redirected to the conclusion step that was introduced in https://github.com/Automattic/wp-calypso/pull/89896.

![image](https://github.com/Automattic/wp-calypso/assets/3801502/a6810725-bbb9-4b97-a2b1-184771d4686d)

I added the feature flags to allow us to test it before we sent this to production. By default, I enabled all environments except production. The tests are also now dependent of this change.

## Testing Instructions

* Using this branch (or Calypso live), go through the migration flow (`/start`)
* On the "Migrate or Import" step, select "Migrate". You should be redirected to the "How to migrate" step.
* Click on "Do it for me" and upgrade your site.
* You should be redirected to the "Assisted Migration" step.
* Create a new site and go through the flow again until you reach the "How to migrate" step.
* Now select "I'll do it myself" and make sure you can continue to the migration by yourself.