### PR TITLE
Reader streams - Fix return scroll position inconsistencies

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -94,6 +94,7 @@ export default class InfiniteList extends Component {
 	componentDidMount() {
 		this._isMounted = true;
 		if ( this._contextLoaded() ) {
+			console.log( 'InfiniteList mounted - setY' );
 			this._setContainerY( this.state.scrollTop );
 		}
 
@@ -109,19 +110,21 @@ export default class InfiniteList extends Component {
 		// current callstack is executed. Some streams and device widths for the reader are not
 		// fully ready to have their scroll position set until everything is mounted, causing the
 		// stream to jump back to the top when coming back to view from a post.
-		if ( this._contextLoaded() ) {
-			// Use the scrollTop setting from the time the component mounted, as this state could be
-			// changed in the initial update cycle to save scroll position before the saved position
-			// is set.
-			const scrollTop = this.state.scrollTop;
-			// Apply these at the end of the callstack to ensure the scroll container is ready.
-			window.setTimeout( () => {
+
+		// Use the scrollTop setting from the time the component mounted, as this state could be
+		// changed in the initial update cycle to save scroll position before the saved position
+		// is set.
+		const scrollTop = this.state.scrollTop;
+		// Apply these at the end of the callstack to ensure the scroll container is ready.
+		window.setTimeout( () => {
+			if ( this._contextLoaded() ) {
+				console.log( 'InfiniteList mounted timeout - setY' );
 				this._setContainerY( scrollTop );
 				this.updateScroll( {
 					triggeredByScroll: false,
 				} );
-			}, 0 );
-		}
+			}
+		}, 0 );
 		if ( this._contextLoaded() ) {
 			this._scrollContainer.addEventListener( 'scroll', this.onScroll );
 		}
@@ -165,7 +168,7 @@ export default class InfiniteList extends Component {
 
 			// only override browser history scroll if navigated via history
 			if ( detectHistoryNavigation.loadedViaHistory() ) {
-				this._overrideHistoryScroll();
+				// this._overrideHistoryScroll();
 			}
 		}
 
@@ -445,6 +448,7 @@ export default class InfiniteList extends Component {
 	}
 
 	_setContainerY( position ) {
+		console.log( 'SET Y' );
 		if ( this.props.context && this.props.context !== window ) {
 			this.props.context.scrollTop = position;
 			return;
@@ -470,6 +474,7 @@ export default class InfiniteList extends Component {
 			return;
 		}
 		debug( 'history setting scroll position:', event );
+		console.log( 'RESET SCROLL - setY' );
 		this._setContainerY( position );
 		this._scrollContainer.removeEventListener( 'scroll', this._resetScroll );
 		debug( 'override scroll position from HTML5 history popstate:', position );
@@ -480,6 +485,6 @@ export default class InfiniteList extends Component {
 	 * @returns {boolean} whether context is available
 	 */
 	_contextLoaded() {
-		return this.props.context || this.props.context === false || ! ( 'context' in this.props );
+		return this.props.context || ! ( 'context' in this.props );
 	}
 }

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -460,6 +460,7 @@ export default class InfiniteList extends Component {
 	 * HTML5 history.
 	 */
 	_overrideHistoryScroll() {
+		// If we have a selected item, assume scroll is handled elsewhere.
 		if ( ! this._contextLoaded() || this.props.selectedItem ) {
 			return;
 		}

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -30,6 +30,7 @@ export default class InfiniteList extends Component {
 		renderLoadingPlaceholders: PropTypes.func.isRequired,
 		renderTrailingItems: PropTypes.func,
 		context: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		selectedItem: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -94,7 +95,6 @@ export default class InfiniteList extends Component {
 	componentDidMount() {
 		this._isMounted = true;
 		if ( this._contextLoaded() ) {
-			console.log( 'InfiniteList mounted - setY' );
 			this._setContainerY( this.state.scrollTop );
 		}
 
@@ -118,7 +118,6 @@ export default class InfiniteList extends Component {
 		// Apply these at the end of the callstack to ensure the scroll container is ready.
 		window.setTimeout( () => {
 			if ( this._contextLoaded() ) {
-				console.log( 'InfiniteList mounted timeout - setY' );
 				this._setContainerY( scrollTop );
 				this.updateScroll( {
 					triggeredByScroll: false,
@@ -168,7 +167,7 @@ export default class InfiniteList extends Component {
 
 			// only override browser history scroll if navigated via history
 			if ( detectHistoryNavigation.loadedViaHistory() ) {
-				// this._overrideHistoryScroll();
+				this._overrideHistoryScroll();
 			}
 		}
 
@@ -448,7 +447,6 @@ export default class InfiniteList extends Component {
 	}
 
 	_setContainerY( position ) {
-		console.log( 'SET Y' );
 		if ( this.props.context && this.props.context !== window ) {
 			this.props.context.scrollTop = position;
 			return;
@@ -462,7 +460,7 @@ export default class InfiniteList extends Component {
 	 * HTML5 history.
 	 */
 	_overrideHistoryScroll() {
-		if ( ! this._contextLoaded() ) {
+		if ( ! this._contextLoaded() || this.props.selectedItem ) {
 			return;
 		}
 		this._scrollContainer.addEventListener( 'scroll', this._resetScroll );
@@ -474,7 +472,6 @@ export default class InfiniteList extends Component {
 			return;
 		}
 		debug( 'history setting scroll position:', event );
-		console.log( 'RESET SCROLL - setY' );
 		this._setContainerY( position );
 		this._scrollContainer.removeEventListener( 'scroll', this._resetScroll );
 		debug( 'override scroll position from HTML5 history popstate:', position );

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -483,6 +483,6 @@ export default class InfiniteList extends Component {
 	 * @returns {boolean} whether context is available
 	 */
 	_contextLoaded() {
-		return this.props.context || ! ( 'context' in this.props );
+		return this.props.context || this.props.context === false || ! ( 'context' in this.props );
 	}
 }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -183,7 +183,6 @@ class ReaderStream extends Component {
 				scrollContainerPosition + boundingClientRect.top + totalOffset,
 				10
 			);
-			this.checkReccomendedPostsHeight();
 			if ( animate ) {
 				scrollTo( {
 					x: 0,

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -135,6 +135,7 @@ class ReaderStream extends Component {
 			// propagate into the full post screen the first time you click select an item in the
 			// reader, meaning the full post screen opens halfway scrolled down the post.
 			if ( ! this.wasSelectedByOpeningPost ) {
+				console.log( 'ComponentDidUpdate: scrollToSelectedPost' );
 				this.scrollToSelectedPost( true );
 			}
 			this.wasSelectedByOpeningPost = false;
@@ -166,9 +167,17 @@ class ReaderStream extends Component {
 
 	_popstate = () => {
 		if ( this.props.selectedPostKey && window.history.scrollRestoration !== 'manual' ) {
+			console.log( '_popstate: scrollToSelectedPost' );
 			this.scrollToSelectedPost( false );
 		}
 	};
+
+	checkReccomendedPostsHeight() {
+		const recPostBlocks = document.querySelectorAll( '.reader-stream__recommended-posts' );
+		recPostBlocks.forEach( ( recPostBlock, index ) => {
+			console.log( `recPostBlock${ index }: `, recPostBlock.clientHeight );
+		} );
+	}
 
 	scrollToSelectedPost( animate ) {
 		const headerOffset = -1 * this.props.fixedHeaderHeight || 0; // a fixed position header means we can't just scroll the element into view.
@@ -183,6 +192,7 @@ class ReaderStream extends Component {
 				scrollContainerPosition + boundingClientRect.top + totalOffset,
 				10
 			);
+			this.checkReccomendedPostsHeight();
 			if ( animate ) {
 				scrollTo( {
 					x: 0,
@@ -193,6 +203,28 @@ class ReaderStream extends Component {
 			} else {
 				scrollContainer.scrollTo( 0, scrollY );
 			}
+			console.log( 'I SCROLLED TO THE POST!' );
+			console.log( 'I scrolled to: ', scrollY );
+			const scrollContainerPosition2 = scrollContainer.scrollTop;
+			const boundingClientRect2 = selectedNode.getBoundingClientRect();
+			const scrollY2 = parseInt(
+				scrollContainerPosition2 + boundingClientRect2.top + totalOffset,
+				10
+			);
+			console.log( 'Now I calculate I should go to: ', scrollY2 );
+			console.log( 'i am at: ', scrollContainerPosition2 );
+			this.checkReccomendedPostsHeight();
+			window.setTimeout( () => {
+				const scrollContainerPosition3 = scrollContainer.scrollTop;
+				const boundingClientRect3 = selectedNode.getBoundingClientRect();
+				const scrollY3 = parseInt(
+					scrollContainerPosition3 + boundingClientRect3.top + totalOffset,
+					10
+				);
+				console.log( '200ms later - Now I calculate I should go to: ', scrollY3 );
+				console.log( 'i am at: ', scrollContainerPosition3 );
+				this.checkReccomendedPostsHeight();
+			}, 200 );
 		}
 	}
 
@@ -215,6 +247,7 @@ class ReaderStream extends Component {
 				this.overlayRef.current.classList.add( 'stream__init-overlay-enabled' );
 			}
 			this.mountTimeout = setTimeout( () => {
+				console.log( 'Component did mount: scrollToSelectedPost' );
 				this.scrollToSelectedPost( false );
 				this.focusSelectedPost( this.props.selectedPostKey );
 				if ( this.overlayRef.current ) {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -633,7 +633,7 @@ class ReaderStream extends Component {
 					renderItem={ this.renderPost }
 					renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
 					className="stream__list"
-					context={ this.state.listContext ?? false }
+					context={ this.state.listContext }
 					selectedItem={ selectedPostKey }
 				/>
 			);

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -135,7 +135,6 @@ class ReaderStream extends Component {
 			// propagate into the full post screen the first time you click select an item in the
 			// reader, meaning the full post screen opens halfway scrolled down the post.
 			if ( ! this.wasSelectedByOpeningPost ) {
-				console.log( 'ComponentDidUpdate: scrollToSelectedPost' );
 				this.scrollToSelectedPost( true );
 			}
 			this.wasSelectedByOpeningPost = false;
@@ -167,17 +166,9 @@ class ReaderStream extends Component {
 
 	_popstate = () => {
 		if ( this.props.selectedPostKey && window.history.scrollRestoration !== 'manual' ) {
-			console.log( '_popstate: scrollToSelectedPost' );
 			this.scrollToSelectedPost( false );
 		}
 	};
-
-	checkReccomendedPostsHeight() {
-		const recPostBlocks = document.querySelectorAll( '.reader-stream__recommended-posts' );
-		recPostBlocks.forEach( ( recPostBlock, index ) => {
-			console.log( `recPostBlock${ index }: `, recPostBlock.clientHeight );
-		} );
-	}
 
 	scrollToSelectedPost( animate ) {
 		const headerOffset = -1 * this.props.fixedHeaderHeight || 0; // a fixed position header means we can't just scroll the element into view.
@@ -203,28 +194,6 @@ class ReaderStream extends Component {
 			} else {
 				scrollContainer.scrollTo( 0, scrollY );
 			}
-			console.log( 'I SCROLLED TO THE POST!' );
-			console.log( 'I scrolled to: ', scrollY );
-			const scrollContainerPosition2 = scrollContainer.scrollTop;
-			const boundingClientRect2 = selectedNode.getBoundingClientRect();
-			const scrollY2 = parseInt(
-				scrollContainerPosition2 + boundingClientRect2.top + totalOffset,
-				10
-			);
-			console.log( 'Now I calculate I should go to: ', scrollY2 );
-			console.log( 'i am at: ', scrollContainerPosition2 );
-			this.checkReccomendedPostsHeight();
-			window.setTimeout( () => {
-				const scrollContainerPosition3 = scrollContainer.scrollTop;
-				const boundingClientRect3 = selectedNode.getBoundingClientRect();
-				const scrollY3 = parseInt(
-					scrollContainerPosition3 + boundingClientRect3.top + totalOffset,
-					10
-				);
-				console.log( '200ms later - Now I calculate I should go to: ', scrollY3 );
-				console.log( 'i am at: ', scrollContainerPosition3 );
-				this.checkReccomendedPostsHeight();
-			}, 200 );
 		}
 	}
 
@@ -247,7 +216,6 @@ class ReaderStream extends Component {
 				this.overlayRef.current.classList.add( 'stream__init-overlay-enabled' );
 			}
 			this.mountTimeout = setTimeout( () => {
-				console.log( 'Component did mount: scrollToSelectedPost' );
 				this.scrollToSelectedPost( false );
 				this.focusSelectedPost( this.props.selectedPostKey );
 				if ( this.overlayRef.current ) {
@@ -624,7 +592,8 @@ class ReaderStream extends Component {
 	};
 
 	render() {
-		const { translate, forcePlaceholders, lastPage, streamHeader, streamKey } = this.props;
+		const { translate, forcePlaceholders, lastPage, streamHeader, streamKey, selectedPostKey } =
+			this.props;
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
 		let { items, isRequesting } = this.props;
 		let body;
@@ -666,6 +635,7 @@ class ReaderStream extends Component {
 					renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
 					className="stream__list"
 					context={ this.state.listContext ?? false }
+					selectedItem={ selectedPostKey }
 				/>
 			);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # follow up to https://github.com/Automattic/wp-calypso/pull/91812  and Automattic/loop#181

## Proposed Changes

Fixes an issue in the reader where going back to the stream will not have the correct scroll position or show the selected post.
* Prevents the override scroll functionality that is added to the 'scroll' listener in the InfiniteStream component from being added when there is a selectedItem. 
    * Since we are calling `scrollToSelectedItem` in the stream, this triggers the scroll listener with the override functionality which then sets the scroll position after it has already scrolled to the selected post. Sometimes this is within a couple hundred pixels and in view, other times it causes the selected item to be out of view entirely.
    * This functionality will still behave as it did previously if there is no selected item.
* Removes the `false` fallback for the context prop passed from the stream to the InfiniteList component.
    *  The stream's listContainer is nullish until it is set on the scroll container. The InfiniteList takes the specific `false` value for the listContainer (context prop) as a signal to say context is loaded (there is no special context to load). Thus the stream passing `false` as a fallback to the listContainer causes the infiniteStream to think the context is loaded before it is initialized and set, triggering unwanted functionality.

BEFORE
![safari-read-before](https://github.com/Automattic/wp-calypso/assets/28742426/ea5d180b-eb76-41aa-8a91-f80ce4e6f11e)

TO REPRO:
* I find this happens most consistently on SAFARI, although I have seen it on other browsers now and then.
* Scroll wayyyy down into the stream feed.
* Select a post to view, return to the stream.
* Notice the selected post may not show up at the top of the content area, or be within view at all.
    * This is intermittent, but try a few times and you should find the funky behavior. 

AFTER
![safari-read-after](https://github.com/Automattic/wp-calypso/assets/28742426/b5a580a8-c02c-45e6-8f6d-1775c417d74d)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We recently added `scrollToSelectedPost` to be called in initialization of the stream component. If there is a selected item, the infiniteList's override scroll functionality conflicts with this. So we prevent that by disabling override functionality when an item is selected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I found the bug happens most consistently on SAFARI, although I have seen it on other browsers now and then.
* Scroll wayyyy down into the stream feed.
* Select a post to view, return to the stream.
* Verify the post is within view and at the top of the content area.
* Try this a few times, and with various streams and browsers. Verify there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
