### PR TITLE
Domains: Improve domain expiration message for sidebar notices

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -4,7 +4,7 @@ import {
 	SETTING_PRIMARY_DOMAIN,
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	GDPR_POLICIES,
-	DOMAIN_EXPIRATION,
+	DOMAIN_EXPIRATION_AUCTION,
 } from '@automattic/urls';
 import i18n, { getLocaleSlug } from 'i18n-calypso';
 import moment from 'moment';
@@ -224,7 +224,7 @@ export function resolveDomainStatus(
 								strong: <strong />,
 								a: (
 									<a
-										href={ localizeUrl( DOMAIN_EXPIRATION ) }
+										href={ localizeUrl( DOMAIN_EXPIRATION_AUCTION ) }
 										rel="noopener noreferrer"
 										target="_blank"
 									/>

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -7,7 +7,7 @@ import {
 	MAP_SUBDOMAIN,
 	SETTING_PRIMARY_DOMAIN,
 	MAP_DOMAIN_CHANGE_NAME_SERVERS,
-	DOMAIN_EXPIRATION,
+	DOMAIN_EXPIRATION_AUCTION,
 } from '@automattic/urls';
 import _debug from 'debug';
 import { localize } from 'i18n-calypso';
@@ -107,7 +107,7 @@ export class DomainWarnings extends PureComponent {
 	expiredDomainLink( onClick ) {
 		const { translate } = this.props;
 		return (
-			<NoticeAction href={ DOMAIN_EXPIRATION } onClick={ onClick }>
+			<NoticeAction href={ DOMAIN_EXPIRATION_AUCTION } onClick={ onClick }>
 				{ translate( 'Learn more', {
 					context: 'Call to action link for support page of expired domains in auction.',
 				} ) }

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -7,6 +7,7 @@ import {
 	MAP_SUBDOMAIN,
 	SETTING_PRIMARY_DOMAIN,
 	MAP_DOMAIN_CHANGE_NAME_SERVERS,
+	DOMAIN_EXPIRATION,
 } from '@automattic/urls';
 import _debug from 'debug';
 import { localize } from 'i18n-calypso';
@@ -318,9 +319,38 @@ export class DomainWarnings extends PureComponent {
 					comment: '%(timeSince)s is something like "a year ago"',
 				}
 			);
+			if ( expiredDomains[ 0 ].aftermarketAuction ) {
+				text = translate(
+					'The domain {{strong}}%(domainName)s{{/strong}} expired %(timeSince)s. ' +
+						"It's no longer available to manage or renew. " +
+						'We may be able to restore it after {{strong}}%(aftermarketAuctionEnd)s{{/strong}}. {{a}}Learn more{{/a}}',
+					{
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									href={ localizeUrl( DOMAIN_EXPIRATION ) }
+									rel="noopener noreferrer"
+									target="_blank"
+								/>
+							),
+						},
+						args: {
+							timeSince: moment( expiredDomains[ 0 ].expiry ).fromNow(),
+							domainName: expiredDomains[ 0 ].name,
+							owner: expiredDomains[ 0 ].owner,
+							aftermarketAuctionEnd: moment
+								.utc( expiredDomains[ 0 ].aftermarketAuctionEnd )
+								.format( 'LL' ),
+						},
+						context: 'Expired domain notice',
+						comment: '%(timeSince)s is something like "a year ago"',
+					}
+				);
+			}
 		} else {
 			text = translate(
-				'Some domains on this site expired recently. They can be renewed by their owners.',
+				'Some domains on this site expired recently. They can be renewed by their owners depending on the expiration date.',
 				{
 					context: 'Expired domain notice',
 				}

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -289,7 +289,7 @@ export class DomainWarnings extends PureComponent {
 			} );
 			if ( expiredDomains[ 0 ].aftermarketAuction ) {
 				text = translate(
-					'{{strong}}%(domainName)s{{/strong}} expired %(timeSince)s. ' +
+					'The domain {{strong}}%(domainName)s{{/strong}} expired %(timeSince)s. ' +
 						"It's no longer available to manage or renew. " +
 						'We may be able to restore it after {{strong}}%(aftermarketAuctionEnd)s{{/strong}}.',
 					{
@@ -323,7 +323,7 @@ export class DomainWarnings extends PureComponent {
 				key={ expiredDomainsCanManageWarning }
 				text={ text }
 			>
-				{ expiredDomainsNotAuctionLocked.length
+				{ expiredDomainsNotAuctionLocked.length > 0
 					? this.renewLink( expiredDomainsNotAuctionLocked, this.onExpiredDomainsNoticeClick )
 					: this.expiredDomainLink( this.onExpiredDomainsNoticeClick ) }
 				{ this.trackImpression( expiredDomainsCanManageWarning, expiredDomains.length ) }

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -289,19 +289,12 @@ export class DomainWarnings extends PureComponent {
 			} );
 			if ( expiredDomains[ 0 ].aftermarketAuction ) {
 				text = translate(
-					'{{strong}}%(domainName)s{{/strong}} expired %(timeSince)s.' +
+					'{{strong}}%(domainName)s{{/strong}} expired %(timeSince)s. ' +
 						"It's no longer available to manage or renew. " +
-						'We may be able to restore it after {{strong}}%(aftermarketAuctionEnd)s{{/strong}}. {{a}}Learn more{{/a}}',
+						'We may be able to restore it after {{strong}}%(aftermarketAuctionEnd)s{{/strong}}.',
 					{
 						components: {
 							strong: <strong />,
-							a: (
-								<a
-									href={ localizeUrl( DOMAIN_EXPIRATION ) }
-									rel="noopener noreferrer"
-									target="_blank"
-								/>
-							),
 						},
 						args: {
 							timeSince: moment( expiredDomains[ 0 ].expiry ).fromNow(),
@@ -350,6 +343,7 @@ export class DomainWarnings extends PureComponent {
 
 		const { translate, moment } = this.props;
 		let text;
+		let cta;
 		if ( expiredDomains.length === 1 ) {
 			text = translate(
 				'The domain {{strong}}%(domainName)s{{/strong}} expired %(timeSince)s. ' +
@@ -369,17 +363,10 @@ export class DomainWarnings extends PureComponent {
 				text = translate(
 					'The domain {{strong}}%(domainName)s{{/strong}} expired %(timeSince)s. ' +
 						"It's no longer available to manage or renew. " +
-						'We may be able to restore it after {{strong}}%(aftermarketAuctionEnd)s{{/strong}}. {{a}}Learn more{{/a}}',
+						'We may be able to restore it after {{strong}}%(aftermarketAuctionEnd)s{{/strong}}.',
 					{
 						components: {
 							strong: <strong />,
-							a: (
-								<a
-									href={ localizeUrl( DOMAIN_EXPIRATION ) }
-									rel="noopener noreferrer"
-									target="_blank"
-								/>
-							),
 						},
 						args: {
 							timeSince: moment( expiredDomains[ 0 ].expiry ).fromNow(),
@@ -393,6 +380,7 @@ export class DomainWarnings extends PureComponent {
 						comment: '%(timeSince)s is something like "a year ago"',
 					}
 				);
+				cta = this.expiredDomainLink( this.onExpiredDomainsNoticeClick );
 			}
 		} else {
 			text = translate( 'Some domains on this site expired recently.', {
@@ -407,6 +395,7 @@ export class DomainWarnings extends PureComponent {
 				key={ expiredDomainsCannotManageWarning }
 				text={ text }
 			>
+				{ cta }
 				{ this.trackImpression( expiredDomainsCannotManageWarning, expiredDomains.length ) }
 			</Notice>
 		);

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -3,7 +3,7 @@ import {
 	SETTING_PRIMARY_DOMAIN,
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	GDPR_POLICIES,
-	DOMAIN_EXPIRATION,
+	DOMAIN_EXPIRATION_AUCTION,
 } from '@automattic/urls';
 import moment from 'moment';
 import {
@@ -189,7 +189,7 @@ export function resolveDomainStatus(
 								strong: <strong />,
 								a: (
 									<a
-										href={ localizeUrl( DOMAIN_EXPIRATION ) }
+										href={ localizeUrl( DOMAIN_EXPIRATION_AUCTION ) }
 										rel="noopener noreferrer"
 										target="_blank"
 									/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
## Proposed Changes

Since we enabled auctions for our domains, we haven't updated the messages displayed in the sidebar; this would confuse our users as the messages, sometimes, would indicate the domain could be renewed. This PR updates this by changing the message depending on the domains' auction stage.

If a domain has expired and it's still not locked, then we show the same message as before.
If the domain is locked for auction, then we show the new message.

If there are two or more domains and at least one renewable domain (still not locked), we allow the user to renew those - nothing changes, except we only add the renewable domains to the shopping cart.

If two or more domains have been locked for auction, we don't allow the user to take any action — the CTA is replaced by a "Learn more" link that points to our [support page on expiry auctions](https://wordpress.com/support/domains/domain-expiration/#expiry-auction).

See here for more details: p2MSmN-dkr-p2.

## Screenshots

### Manageable domains

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/18705930/b543eee4-7b0e-40fd-a21a-c74704f5d996) | ![image](https://github.com/Automattic/wp-calypso/assets/18705930/4e1cbbdc-08aa-4c4a-9ac8-cabbd206dd50) | 

### Unmanageable domains

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/18705930/1797bac4-e823-4a3a-a63a-523351e09ee2) | ![image](https://github.com/Automattic/wp-calypso/assets/18705930/70eb88c9-fcf7-49ba-9259-826d06a703ea) | 

### Multiple manageable domains
| Case | Preview |
| --- | --- |
| At least one renewable (not locked) domain | ![image](https://github.com/Automattic/wp-calypso/assets/18705930/9de6ad72-2f80-45c5-963c-d9db32c4703b) |
| Only locked domains | ![image](https://github.com/Automattic/wp-calypso/assets/18705930/113b6aca-9998-4461-bad4-9ad22253c3ca) |

### Multiple unmanageable domains
Just removed the last bit for this one, as it can be misleading depending on the auction stage.
| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/18705930/f2921076-d142-49b8-95c6-16b8cba0d0f9) | ![image](https://github.com/Automattic/wp-calypso/assets/18705930/db16bda7-0eeb-4b79-b9ee-d4e79916f06a) |

## Testing Instructions
- Hack your registered domain to be marked as `aftermarketAuction` and `currentUserCanManage`;
- Ensure the messages are displayed according to the screenshots.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?