### PR TITLE
E2E: Fix Editor Canvas mobile test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-component.ts
@@ -95,7 +95,9 @@ export class EditorComponent {
 	private async waitForFramedCanvas() {
 		const parentLocator = await this.parent();
 		const canvasLocator = parentLocator
-			.frameLocator( 'iframe[name="editor-canvas"]' )
+			.locator( '.block-editor-iframe__scale-container' )
+			.first()
+			.frameLocator( 'iframe' )
 			.locator( '.editor-styles-wrapper' );
 
 		await canvasLocator.waitFor( { timeout: EDITOR_TIMEOUT } );


### PR DESCRIPTION
## Proposed Changes

The E2E test `specs/fse/fse__temp-smoke-test.ts` was failing because of the iframe editor canvas selector

## Why are these changes being made?
E2E tests were failing

## Testing Instructions
none
