### PR TITLE
Domains: Skip availability check for Gravatar domains flow

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1058,6 +1058,12 @@ class RegisterDomainStep extends Component {
 			return;
 		}
 
+		if ( this.props.flowName === 'domain-for-gravatar' ) {
+			// Skips availability check for the Gravatar flow - so TLDs that are
+			// available but not eligible for Gravatar won't be displayed
+			return;
+		}
+
 		return new Promise( ( resolve ) => {
 			checkDomainAvailability(
 				{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
Removes the availability check for FQDNs on the Gravatar flow.

By doing so, we restrict the results for the TLDs that are eligible for the campaign.
If the user types an FQDN that is available and within the campaign TLDs, we display it — otherwise, if it's available but not within the campaign TLDs, we don't. 

## Testing Instructions

- Try to search for a FQDN on the Gravatar domains flow;
- Ensure the domain won't be displayed if the TLD isn't in the campaign;
- Ensure the domain will be displayed (as a featured suggestion) if the TLD is in the campaign;
- Open your browser devtools and ensure you don't see a request to the `/is-available` endpoint 😬;
- Also analyze the code statically.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
