### PR TITLE
Update reblog to repost and add a tooltip

### DIFF
--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -71,10 +71,6 @@
 			}
 		}
 	}
-
-	&.is-inline * {
-		font-size: $font-body;
-	}
 }
 
 .comments__info-bar {

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -130,9 +130,7 @@ class ReaderShare extends Component {
 							{ ReaderShareIcon( {
 								iconSize: this.props.iconSize,
 							} ) }
-							{ this.props.showLabel && (
-								<span className="reader-share__label">{ translate( 'Share' ) }</span>
-							) }
+							<span className="reader-share__label">{ translate( 'Share' ) }</span>
 						</>
 					) : (
 						<>
@@ -142,11 +140,9 @@ class ReaderShare extends Component {
 								title={ reblogTitle }
 								style={ { height: this.props.iconSize, width: this.props.iconSize } }
 							/>
-							{ this.props.showLabel && (
-								<span className="reader-share__label" title={ reblogTitle }>
-									{ translate( 'Reblog' ) }
-								</span>
-							) }
+							<span className="reader-share__label" title={ reblogTitle }>
+								{ translate( 'Repost' ) }
+							</span>
 						</>
 					) }
 				</Button>

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -97,6 +97,7 @@ class ReaderShare extends Component {
 			'reader-share__button': true,
 			'ignore-click': true,
 			'is-active': this.state.showingMenu,
+			tooltip: this.props.isReblogSelection,
 		} );
 
 		const popoverProps = {
@@ -106,8 +107,6 @@ class ReaderShare extends Component {
 			position: this.props.position,
 			className: 'popover reader-share__popover',
 		};
-
-		const reblogTitle = this.props.comment && translate( 'Turn this comment into its own post' );
 
 		// The event.preventDefault() on the wrapping div is needed to prevent the
 		// full post opening when a share method is selected in the popover
@@ -123,7 +122,8 @@ class ReaderShare extends Component {
 					onMouseEnter={ preloadEditor }
 					onTouchStart={ preloadEditor }
 					ref={ this.shareButton }
-					title={ this.props.isReblogSelection ? translate( 'Reblog' ) : translate( 'Share' ) }
+					data-tooltip={ this.props.isReblogSelection && translate( 'Repost with your thoughts' ) }
+					title={ ! this.props.isReblogSelection && translate( 'Share' ) }
 				>
 					{ ! this.props.isReblogSelection ? (
 						<>
@@ -137,12 +137,9 @@ class ReaderShare extends Component {
 							<Gridicon
 								icon="reblog"
 								size={ this.props.iconSize }
-								title={ reblogTitle }
 								style={ { height: this.props.iconSize, width: this.props.iconSize } }
 							/>
-							<span className="reader-share__label" title={ reblogTitle }>
-								{ translate( 'Repost' ) }
-							</span>
+							<span className="reader-share__label">{ translate( 'Repost' ) }</span>
 						</>
 					) }
 				</Button>

--- a/client/blocks/reader-share/reblog.jsx
+++ b/client/blocks/reader-share/reblog.jsx
@@ -46,7 +46,7 @@ const ReaderReblogSelection = ( props ) => {
 	return (
 		<ReaderPopoverMenu
 			{ ...props.popoverProps }
-			popoverTitle={ translate( 'Reblog on' ) }
+			popoverTitle={ translate( 'Repost on' ) }
 			onClose={ props.closeMenu }
 		>
 			<SiteSelector

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -39,6 +39,33 @@
 				fill: var(--color-primary);
 			}
 		}
+
+		&.tooltip {
+			position: relative;
+			overflow: visible;
+		}
+
+		&.tooltip::after {
+			height: 20px;
+			line-height: 20px;
+			background: var(--color-sidebar-tooltip-background);
+			border-radius: 4px;
+			color: var(--color-sidebar-tooltip-text);
+			content: attr(data-tooltip);
+			display: none;
+			font-size: $font-body-extra-small;
+			padding: 3px 6px;
+			position: absolute;
+			white-space: nowrap;
+			top: -29px;
+			left: 50%;
+			transform: translateX(-50%);
+			z-index: 8;
+		}
+
+		&.tooltip:hover::after {
+			display: block;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Addresses https://github.com/Automattic/wp-calypso/issues/91811

We're going to experiment with renaming reblog to repost and adding a tooltip that says, "Repost with your thoughts" to see if these changes make it less stressful to click.

## Before

**POST**

![CleanShot 2024-06-17 at 16 54 05@2x](https://github.com/Automattic/wp-calypso/assets/5634774/b4129430-ba9c-4509-b9c3-79c750113ec9)

**COMMENT**

![CleanShot 2024-06-17 at 16 54 24@2x](https://github.com/Automattic/wp-calypso/assets/5634774/9daa7f5d-31b0-4466-a651-15ae2b31ae86)



## After

**POST**

![CleanShot 2024-06-17 at 18 16 00@2x](https://github.com/Automattic/wp-calypso/assets/5634774/86afc4e0-0540-4de1-ba1d-a03a68ad0006)

**COMMENT**

![CleanShot 2024-06-17 at 18 15 35@2x](https://github.com/Automattic/wp-calypso/assets/5634774/f63da91e-39f5-4c7d-9668-4422fd711a0e)

## Testing Instructions

- Apply this PR
- Head to the reader
- Mouse over repost link in regular feed and in comments
