### PR TITLE
E2E: Fix unable to close scheduled post calendar popover and locate settings toggle.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -25,6 +25,8 @@ const selectors = {
 
 	// Schedule
 	scheduleButton: `button.editor-post-schedule__dialog-toggle`,
+	schedulePopoverCloseButton:
+		'[data-wp-component="Popover"][aria-label="Change publish date"] [aria-label="Close"]',
 	scheduleInput: ( name: string ) => `.editor-post-schedule__dialog label:has-text("${ name }")`,
 	scheduleMeridianButton: ( meridian: 'am' | 'pm' ) => `role=button[name="${ meridian }"i]`,
 
@@ -301,8 +303,14 @@ export class EditorSettingsSidebarComponent {
 		}
 
 		const editorParent = await this.editor.parent();
-		const buttonLocator = editorParent.locator( selectors.scheduleButton );
-		await buttonLocator.click();
+
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			const buttonLocator = editorParent.locator( selectors.schedulePopoverCloseButton );
+			await buttonLocator.click();
+		} else {
+			const buttonLocator = editorParent.locator( selectors.scheduleButton );
+			await buttonLocator.click();
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -336,10 +336,13 @@ export class EditorToolbarComponent {
 		const translatedCloseSettingsName = await this.translateFromPage( 'Close Settings' );
 		const translatedCloseJetpackSettingsName = await this.translateFromPage( 'Close plugin' );
 
+		const buttonNames =
+			envVariables.VIEWPORT_NAME === 'mobile'
+				? `Settings`
+				: `${ translatedCloseJetpackSettingsName }|${ translatedCloseSettingsName }`;
+
 		const button = editorParent.getByRole( 'button', {
-			name: new RegExp(
-				`Settings|${ translatedCloseJetpackSettingsName }|${ translatedCloseSettingsName }`
-			),
+			name: new RegExp( buttonNames ),
 		} );
 
 		if ( ! ( await this.targetIsOpen( button ) ) ) {

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -338,7 +338,7 @@ export class EditorToolbarComponent {
 
 		const button = editorParent.getByRole( 'button', {
 			name: new RegExp(
-				`${ translatedCloseJetpackSettingsName }|${ translatedCloseSettingsName }`
+				`Settings|${ translatedCloseJetpackSettingsName }|${ translatedCloseSettingsName }`
 			),
 		} );
 

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -107,7 +107,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 			await editorPage.openSettings();
 		} );
 
-		it( 'Schedule post to fist of the current month of last year', async function () {
+		it( 'Schedule post to first of the current month of last year', async function () {
 			const date = new Date();
 			date.setUTCFullYear( date.getUTCFullYear() - 1 );
 


### PR DESCRIPTION
## Proposed Changes

* Fix unable to close scheduled post calendar popover.
* Fix unable to locate settings toggle.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix E2E tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `VIEWPORT_NAME="mobile" GUTENBERG_EDGE=true node --inspect ../../node_modules/.bin/jest --runInBand specs/editor/editor__schedule.ts`
* Run `GUTENBERG_EDGE=true node --inspect ../../node_modules/.bin/jest --runInBand specs/editor/editor__schedule.ts` to ensure no regression on mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
