### PR TITLE
A4A > Referrals: Automated Referrals UI enhancements & mobile view improvements

### DIFF
--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -5,6 +5,7 @@ import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholde
 import useCancelClientSubscription from 'calypso/a8c-for-agencies/data/client/use-cancel-client-subscription';
 import useFetchClientProducts from 'calypso/a8c-for-agencies/data/client/use-fetch-client-products';
 import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { Subscription } from '../types';
 
@@ -37,6 +38,12 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 		cancelSubscription( {
 			licenseKey: subscription.license_key,
 		} );
+		dispatch( recordTracksEvent( 'calypso_a8c_client_subscription_cancel_confirmed' ) );
+	};
+
+	const handleClose = () => {
+		dispatch( recordTracksEvent( 'calypso_a8c_client_subscription_cancel_cancelled' ) );
+		setIsVisible( false );
 	};
 
 	const productName =
@@ -52,7 +59,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 				className="cancel-subscription-confirmation-dialog"
 				isVisible={ isVisible }
 				buttons={ [
-					<Button onClick={ () => setIsVisible( false ) } disabled={ isPending }>
+					<Button onClick={ handleClose } disabled={ isPending }>
 						{ translate( 'Keep the subscription' ) }
 					</Button>,
 					<Button
@@ -66,7 +73,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 					</Button>,
 				] }
 				shouldCloseOnEsc
-				onClose={ () => setIsVisible( false ) }
+				onClose={ handleClose }
 			>
 				<h1 className="cancel-subscription-confirmation-dialog__title">
 					{ translate( 'Are you sure you want to cancel this subscription?' ) }

--- a/client/a8c-for-agencies/sections/client/controller.tsx
+++ b/client/a8c-for-agencies/sections/client/controller.tsx
@@ -9,11 +9,6 @@ import ClientLanding from './client-landing';
 import ClientCheckout from './primary/checkout';
 import SubscriptionsList from './primary/subscriptions-list';
 
-export const clientContext: Callback = ( context, next ) => {
-	context.secondary = <ClientSidebar path={ context.path } />;
-	next();
-};
-
 export const clientLandingContext: Callback = ( context, next ) => {
 	context.primary = <ClientLanding />;
 	context.secondary = <SidebarPlaceholder />;
@@ -21,7 +16,12 @@ export const clientLandingContext: Callback = ( context, next ) => {
 };
 
 export const clientSubscriptionsContext: Callback = ( context, next ) => {
-	context.primary = <SubscriptionsList />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Client > Subscriptions" path={ context.path } />
+			<SubscriptionsList />
+		</>
+	);
 	context.secondary = <ClientSidebar path={ context.path } />;
 	next();
 };

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -1,0 +1,49 @@
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import StatusBadge from 'calypso/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge';
+import CancelSubscriptionAction from '../../cancel-subscription-confirmation-dialog';
+import { getSubscriptionStatus } from '../../lib/get-subscription-status';
+import { Subscription } from '../../types';
+
+interface Props {
+	isFetching: boolean;
+}
+
+export function SubscriptionPurchase( { isFetching, name }: Props & { name?: string } ) {
+	return isFetching ? <TextPlaceholder /> : name;
+}
+
+export function SubscriptionPrice( { isFetching, amount }: Props & { amount?: string } ) {
+	return isFetching ? <TextPlaceholder /> : `$${ amount }`;
+}
+
+export function SubscriptionStatus( {
+	status,
+	translate,
+}: {
+	status: string;
+	translate: ( key: string ) => string;
+} ) {
+	const { children, type } = getSubscriptionStatus( status, translate );
+	return children ? <StatusBadge statusProps={ { children, type } } /> : '-';
+}
+
+export function SubscriptionAction( {
+	subscription,
+	onCancelSubscription,
+}: {
+	subscription: Subscription;
+	onCancelSubscription: () => void;
+} ) {
+	const status = subscription.status;
+	const isActive = status === 'active';
+	return isActive ? (
+		<span className="action-button">
+			<CancelSubscriptionAction
+				subscription={ subscription }
+				onCancelSubscription={ onCancelSubscription }
+			/>
+		</span>
+	) : (
+		'-'
+	);
+}

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -1,5 +1,7 @@
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, ReactNode, useState } from 'react';
+import { useMemo, ReactNode, useState, useCallback } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
@@ -9,24 +11,34 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useFetchClientProducts from 'calypso/a8c-for-agencies/data/client/use-fetch-client-products';
-import StatusBadge from 'calypso/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge';
-import CancelSubscriptionAction from '../../cancel-subscription-confirmation-dialog';
 import useFetchClientSubscriptions from '../../hooks/use-fetch-client-subscriptions';
-import { getSubscriptionStatus } from '../../lib/get-subscription-status';
+import {
+	SubscriptionAction,
+	SubscriptionPrice,
+	SubscriptionPurchase,
+	SubscriptionStatus,
+} from './field-content';
+import SubscriptionsListMobileView from './mobile-view';
 import type { Subscription } from '../../types';
 
 import './style.scss';
 
 export default function SubscriptionsList() {
 	const translate = useTranslate();
+
+	const isDesktop = useDesktopBreakpoint();
+
 	const [ dataViewsState, setDataViewsState ] = useState( initialDataViewsState );
 
 	const { data, isFetching, refetch } = useFetchClientSubscriptions();
 	const { data: products, isFetching: isFetchingProducts } = useFetchClientProducts();
 
 	const title = translate( 'Your subscriptions' );
+
+	const onCancelSubscription = useCallback( () => {
+		refetch();
+	}, [ refetch ] );
 
 	const fields = useMemo(
 		() => [
@@ -36,7 +48,7 @@ export default function SubscriptionsList() {
 				getValue: () => '-',
 				render: ( { item }: { item: Subscription } ): ReactNode => {
 					const product = products?.find( ( product ) => product.product_id === item.product_id );
-					return isFetchingProducts ? <TextPlaceholder /> : product?.name;
+					return <SubscriptionPurchase isFetching={ isFetchingProducts } name={ product?.name } />;
 				},
 				enableHiding: false,
 				enableSorting: false,
@@ -47,7 +59,7 @@ export default function SubscriptionsList() {
 				getValue: () => '-',
 				render: ( { item }: { item: Subscription } ): ReactNode => {
 					const product = products?.find( ( product ) => product.product_id === item.product_id );
-					return isFetchingProducts ? <TextPlaceholder /> : `$${ product?.amount }`;
+					return <SubscriptionPrice isFetching={ isFetchingProducts } amount={ product?.amount } />;
 				},
 				enableHiding: false,
 				enableSorting: false,
@@ -57,8 +69,7 @@ export default function SubscriptionsList() {
 				header: translate( 'Subscription Status' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: Subscription } ): ReactNode => {
-					const { children, type } = getSubscriptionStatus( item.status, translate );
-					return children ? <StatusBadge statusProps={ { children, type } } /> : '-';
+					return <SubscriptionStatus status={ item.status } translate={ translate } />;
 				},
 				enableHiding: false,
 				enableSorting: false,
@@ -68,27 +79,25 @@ export default function SubscriptionsList() {
 				header: translate( 'Actions' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item }: { item: Subscription } ): ReactNode => {
-					const status = item.status;
-					const isActive = status === 'active';
-					return isActive ? (
-						<CancelSubscriptionAction
+					return (
+						<SubscriptionAction
 							subscription={ item }
-							onCancelSubscription={ () => refetch() }
+							onCancelSubscription={ onCancelSubscription }
 						/>
-					) : (
-						'-'
 					);
 				},
 				enableHiding: false,
 				enableSorting: false,
 			},
 		],
-		[ isFetchingProducts, products, refetch, translate ]
+		[ isFetchingProducts, onCancelSubscription, products, translate ]
 	);
 
 	return (
 		<Layout
-			className="subscriptions-list__layout"
+			className={ clsx( 'subscriptions-list__layout', {
+				'is-mobile-view': ! isDesktop,
+			} ) }
 			title={ title }
 			wide
 			sidebarNavigation={ <MobileSidebarNavigation /> }
@@ -101,24 +110,32 @@ export default function SubscriptionsList() {
 			</LayoutTop>
 
 			<LayoutBody>
-				<div className="redesigned-a8c-table">
-					<ItemsDataViews
-						data={ {
-							items: data || [],
-							pagination: {
-								totalItems: 1,
-								totalPages: 1,
-							},
-							itemFieldId: 'id',
-							enableSearch: false,
-							fields: fields,
-							actions: [],
-							setDataViewsState: setDataViewsState,
-							dataViewsState: dataViewsState,
-						} }
-						isLoading={ isFetching }
+				{ isDesktop ? (
+					<div className="redesigned-a8c-table">
+						<ItemsDataViews
+							data={ {
+								items: data || [],
+								pagination: {
+									totalItems: 1,
+									totalPages: 1,
+								},
+								itemFieldId: 'id',
+								enableSearch: false,
+								fields: fields,
+								actions: [],
+								setDataViewsState: setDataViewsState,
+								dataViewsState: dataViewsState,
+							} }
+							isLoading={ isFetching }
+						/>
+					</div>
+				) : (
+					<SubscriptionsListMobileView
+						subscriptions={ data }
+						title={ title }
+						onCancelSubscription={ onCancelSubscription }
 					/>
-				</div>
+				) }
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -134,6 +134,8 @@ export default function SubscriptionsList() {
 						subscriptions={ data }
 						title={ title }
 						onCancelSubscription={ onCancelSubscription }
+						isFetchingProducts={ isFetchingProducts }
+						products={ products }
 					/>
 				) }
 			</LayoutBody>

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
@@ -1,0 +1,88 @@
+import { useTranslate } from 'i18n-calypso';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import {
+	SubscriptionAction,
+	SubscriptionPrice,
+	SubscriptionPurchase,
+	SubscriptionStatus,
+} from '../field-content';
+import type { Subscription } from '../../../types';
+import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+import './style.scss';
+
+type SubscriptionItemProps = {
+	subscription: Subscription;
+	products?: APIProductFamilyProduct[];
+	isFetching: boolean;
+	onCancelSubscription: () => void;
+};
+
+const SubscriptionItem = ( {
+	subscription,
+	products,
+	isFetching,
+	onCancelSubscription,
+}: SubscriptionItemProps ) => {
+	const translate = useTranslate();
+
+	const product = products?.find( ( product ) => product.product_id === subscription.product_id );
+
+	return (
+		<div className="subscriptions-mobile">
+			<div className="subscriptions-mobile__content">
+				<div className="subscriptions-mobile__header">
+					<h3>{ translate( 'PURCHASE' ).toUpperCase() }</h3>
+				</div>
+				<p className="subscriptions-mobile__product-name">
+					<SubscriptionPurchase isFetching={ isFetching } name={ product?.name } />
+				</p>
+			</div>
+			<div className="subscriptions-mobile__content">
+				<h3>{ translate( 'PRICE' ).toUpperCase() }</h3>
+				<p>
+					<SubscriptionPrice isFetching={ isFetching } amount={ product?.amount } />
+				</p>
+			</div>
+			<div className="subscriptions-mobile__content">
+				<h3>{ translate( 'SUBSCRIPTION STATUS' ).toUpperCase() }</h3>
+				<SubscriptionStatus status={ subscription.status } translate={ translate } />
+			</div>
+			<SubscriptionAction
+				subscription={ subscription }
+				onCancelSubscription={ onCancelSubscription }
+			/>
+		</div>
+	);
+};
+
+const SubscriptionsListMobileView = ( {
+	subscriptions,
+	title,
+	onCancelSubscription,
+}: {
+	subscriptions?: Subscription[];
+	title: string;
+	onCancelSubscription: () => void;
+} ) => {
+	const translate = useTranslate();
+	const { data, isFetching } = useProductsQuery();
+
+	return (
+		<div className="subscriptions-mobile__wrapper">
+			<div className="subscriptions-mobile__heading">{ title }</div>
+			{ subscriptions
+				? subscriptions.map( ( subscription ) => (
+						<SubscriptionItem
+							subscription={ subscription }
+							products={ data }
+							isFetching={ isFetching }
+							onCancelSubscription={ onCancelSubscription }
+						/>
+				  ) )
+				: translate( 'No subscriptions found' ) }
+		</div>
+	);
+};
+
+export default SubscriptionsListMobileView;

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import {
 	SubscriptionAction,
 	SubscriptionPrice,
@@ -60,13 +59,16 @@ const SubscriptionsListMobileView = ( {
 	subscriptions,
 	title,
 	onCancelSubscription,
+	isFetchingProducts,
+	products,
 }: {
 	subscriptions?: Subscription[];
 	title: string;
 	onCancelSubscription: () => void;
+	isFetchingProducts: boolean;
+	products?: APIProductFamilyProduct[];
 } ) => {
 	const translate = useTranslate();
-	const { data, isFetching } = useProductsQuery();
 
 	return (
 		<div className="subscriptions-mobile__wrapper">
@@ -75,8 +77,8 @@ const SubscriptionsListMobileView = ( {
 				? subscriptions.map( ( subscription ) => (
 						<SubscriptionItem
 							subscription={ subscription }
-							products={ data }
-							isFetching={ isFetching }
+							products={ products }
+							isFetching={ isFetchingProducts }
 							onCancelSubscription={ onCancelSubscription }
 						/>
 				  ) )

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/style.scss
@@ -1,0 +1,56 @@
+.subscriptions-mobile {
+	border: 1px solid var(--color-neutral-10);
+	border-radius: 4px;
+	margin-block-end: 1rem;
+	padding: 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+
+	.subscriptions-mobile__header {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.subscriptions-mobile__product-name {
+		font-weight: 500;
+		font-size: 0.875rem;
+		color: var(--color-gray-80);
+	}
+
+	h3 {
+		font-weight: 500;
+		font-size: rem(11px);
+		color: var(--color-gray-80);
+	}
+
+	p {
+		font-weight: 400;
+		font-size: rem(13px);
+		color: var(--color-gray-70);
+		margin: 0;
+	}
+
+	.step-section-item__status {
+		margin-block-start: 8px;
+	}
+
+	.action-button {
+		margin-block-start: 8px;
+
+		.button {
+			width: 100%;
+		}
+	}
+}
+
+.subscriptions-mobile__wrapper {
+	overflow-y: auto;
+}
+
+.subscriptions-mobile__heading {
+	padding-block: 8px 32px;
+	font-size: 1.5rem;
+	font-weight: 600;
+	line-height: 1.3;
+}

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
@@ -3,4 +3,8 @@
 		padding-block-start: 24px;
 		padding-block-end: 0;
 	}
+
+	&.is-mobile-view .a4a-layout__top-wrapper {
+		display: none;
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -160,7 +160,7 @@ function Checkout( { isClient }: { isClient?: boolean } ) {
 			wide
 			withBorder={ ! isClient }
 			compact
-			sidebarNavigation={ <MobileSidebarNavigation /> }
+			sidebarNavigation={ ! isClient && <MobileSidebarNavigation /> }
 		>
 			{ isClient ? null : (
 				<LayoutTop>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -53,6 +53,11 @@
 	font-size: 2.25rem;
 	line-height: 1.1;
 	font-weight: 600;
+	margin-block-start: 32px;
+
+	@include breakpoint-deprecated( ">960px" ) {
+		margin-block-start: 0;
+	}
 }
 
 .checkout__main-list {
@@ -259,7 +264,10 @@
 		color: var(--color-neutral-70);
 		font-size: rem(16px);
 		font-weight: 600;
-		text-wrap: nowrap;
+
+		@include break-large {
+			text-wrap: nowrap;
+		}
 	}
 
 	.checkout__summary-notice {
@@ -272,8 +280,12 @@
 	}
 
 	.checkout__aside-footer {
-		margin-top: auto;
-		padding-bottom: 16px;
+		margin-block-start: 32px;
+		padding-block-end: 16px;
+
+		@include breakpoint-deprecated( ">960px" ) {
+			margin-block-start: auto;
+		}
 
 		.checkout__aside-powered-by {
 			div {

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
@@ -2,11 +2,14 @@ import page from '@automattic/calypso-router';
 import { Badge, Button } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useContext } from 'react';
 import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_PAYMENT_METHODS_ADD_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import usePaymentMethod from '../../purchases/payment-methods/hooks/use-payment-method';
+import { MarketplaceTypeContext } from '../context';
+import { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
 import ShoppingCartIcon from './shopping-cart-icon';
 import ShoppingCartMenu from './shopping-cart-menu';
 import type { ShoppingCartItem } from '../types';
@@ -34,8 +37,11 @@ export default function ShoppingCart( {
 }: Props ) {
 	const { paymentMethodRequired } = usePaymentMethod();
 
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const isAutomatedReferrals = marketplaceType === MARKETPLACE_TYPE_REFERRAL;
+
 	const handleOnCheckout = () => {
-		if ( paymentMethodRequired ) {
+		if ( paymentMethodRequired && ! isAutomatedReferrals ) {
 			page( `${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_MARKETPLACE_CHECKOUT_LINK }` );
 			return;
 		}

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -90,7 +90,7 @@ export default function ReferralsBankDetails( {
 							</div>
 							<div className="bank-details__subheading">
 								{ translate(
-									'Enter your bank details to start receiving payments through {{a}}Tipalti{{/a}} ↗, our secure payments platform.',
+									'Enter your bank details to start receiving payments through {{a}}Tipalti{{/a}}↗, our secure payments platform.',
 									{
 										components: {
 											a: (

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -90,7 +90,7 @@ export default function ReferralsBankDetails( {
 							</div>
 							<div className="bank-details__subheading">
 								{ translate(
-									'Enter your bank details to start receiving payments through {{a}}Tipalti ↗{{/a}}, our secure payments platform.',
+									'Enter your bank details to start receiving payments through {{a}}Tipalti{{/a}} ↗, our secure payments platform.',
 									{
 										components: {
 											a: (

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -69,7 +69,11 @@ export default function CommissionOverview( {
 				{ isAutomatedReferral && (
 					<>
 						<div className="commission-overview__section-heading">
-							{ translate( 'Referrals and commissions Frequently Asked Questions (FAQ)' ) }
+							{ translate( 'Referrals and commissions Frequently Asked Questions{{nbsp/}}(FAQ)', {
+								components: {
+									nbsp: <>&nbsp;</>,
+								},
+							} ) }
 						</div>
 						<div className="commission-overview__section-subtitle">
 							{ translate(

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
@@ -22,7 +22,7 @@
 	}
 
 	.a4a-layout__body-wrapper {
-		max-width: 900px;
+		max-width: 700px;
 	}
 
 	.foldable-card.card,

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -160,7 +160,12 @@ export default function LayoutBodyContent( {
 			<div className="referrals-overview__section-subtitle">
 				{ isAutomatedReferral ? (
 					translate(
-						'Make money when your clients buy Automattic products, hosting, or use WooPayments. No promo codes needed.'
+						'Make money when your clients buy Automattic products, hosting, or use WooPayments. No promo codes{{nbsp/}}needed.',
+						{
+							components: {
+								nbsp: <>&nbsp;</>,
+							},
+						}
 					)
 				) : (
 					<>
@@ -210,7 +215,7 @@ export default function LayoutBodyContent( {
 								}
 								description={
 									isAutomatedReferral
-										? translate( 'With {{a}}Tipalti{{/a}} ↗, our secure platform.', {
+										? translate( 'With {{a}}Tipalti{{/a}}↗, our secure platform.', {
 												components: {
 													a: (
 														<a

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -210,7 +210,7 @@ export default function LayoutBodyContent( {
 								}
 								description={
 									isAutomatedReferral
-										? translate( 'With {{a}}Tipalti ↗{{/a}}, our secure platform.', {
+										? translate( 'With {{a}}Tipalti{{/a}} ↗, our secure platform.', {
 												components: {
 													a: (
 														<a
@@ -308,7 +308,7 @@ export default function LayoutBodyContent( {
 						{ isAutomatedReferral && (
 							<StepSection
 								className="referrals-overview__step-section-learn-more"
-								heading={ translate( 'Find out more about the program' ) }
+								heading={ translate( 'Find out more' ) }
 							>
 								<Button className="a8c-blue-link" borderless href={ A4A_REFERRALS_FAQ }>
 									{ translate( 'How much money will I make?' ) }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -70,7 +70,7 @@ $data-view-border-color: #f1f1f1;
 	}
 
 	.a4a-layout__body-wrapper {
-		max-width: 550px;
+		max-width: 700px;
 	}
 
 	&.referrals-layout--full-width {
@@ -152,7 +152,7 @@ $data-view-border-color: #f1f1f1;
 			width: 400px;
 			display: none;
 
-			@include break-large {
+			@include break-wide {
 				display: block;
 			}
 		}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -17,10 +17,11 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 	const translate = useTranslate();
 	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
 	const isWPCOMLicense = product?.family_slug === 'wpcom-hosting';
-	const redirectUrl = isWPCOMLicense
-		? A4A_SITES_LINK_NEEDS_SETUP
-		: purchase.license_key &&
-		  addQueryArgs( { key: purchase.license_key }, '/marketplace/assign-license' );
+	const redirectUrl =
+		purchase.license_key &&
+		( isWPCOMLicense
+			? addQueryArgs( { license_key: purchase.license_key }, A4A_SITES_LINK_NEEDS_SETUP )
+			: addQueryArgs( { key: purchase.license_key }, '/marketplace/assign-license' ) );
 
 	const isDisabled = purchase.status !== 'active' || isFetching || ! product || ! redirectUrl;
 

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -5,8 +5,12 @@ import { useMemo, useCallback, ReactNode, useEffect } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import SubscriptionStatus from './subscription-status';
 import type { Referral } from '../types';
+
+import './style.scss';
 
 interface Props {
 	referrals: Referral[];
@@ -17,6 +21,7 @@ interface Props {
 export default function ReferralList( { referrals, dataViewsState, setDataViewsState }: Props ) {
 	const isDesktop = useDesktopBreakpoint();
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const openSitePreviewPane = useCallback(
 		( referral: Referral ) => {
@@ -25,8 +30,9 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 				selectedItem: referral,
 				type: DATAVIEWS_LIST,
 			} ) );
+			dispatch( recordTracksEvent( 'calypso_a4a_referrals_list_view_details_click' ) );
 		},
-		[ setDataViewsState ]
+		[ dispatch, setDataViewsState ]
 	);
 
 	const fields = useMemo(
@@ -41,7 +47,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							render: ( { item }: { item: Referral } ): ReactNode => {
 								return (
 									<Button
-										className="view-details-button"
+										className="view-details-button client-email-button"
 										data-client-id={ item.client.id }
 										onClick={ () => openSitePreviewPane( item ) }
 										borderless

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -33,6 +33,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 		() =>
 			dataViewsState.selectedItem || ! isDesktop
 				? [
+						// Show the client column as a button on mobile
 						{
 							id: 'client',
 							header: translate( 'Client' ).toUpperCase(),
@@ -53,6 +54,30 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							enableHiding: false,
 							enableSorting: false,
 						},
+						// Only show the actions column only on mobile
+						...( ! dataViewsState.selectedItem
+							? [
+									{
+										id: 'actions',
+										header: null,
+										render: ( { item }: { item: Referral } ) => {
+											return (
+												<div>
+													<Button
+														className="view-details-button"
+														onClick={ () => openSitePreviewPane( item ) }
+														borderless
+													>
+														<Gridicon icon="chevron-right" />
+													</Button>
+												</div>
+											);
+										},
+										enableHiding: false,
+										enableSorting: false,
+									},
+							  ]
+							: [] ),
 				  ]
 				: [
 						{
@@ -102,7 +127,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 								return (
 									<div>
 										<Button
-											className="view-details-button"
+											className="view-details-button action-button"
 											onClick={ () => openSitePreviewPane( item ) }
 											borderless
 										>

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/style.scss
@@ -1,0 +1,15 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.theme-a8c-for-agencies .button.client-email-button {
+	max-width: 215px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	display: block;
+
+	@include break-medium {
+		max-width: unset;
+
+	}
+}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -568,6 +568,11 @@ html {
 				justify-content: flex-end;
 				width: 100%;
 				padding-inline-end: 12px;
+
+				.gridicon {
+					margin-top: 0;
+					top: 0;
+				}
 			}
 			&:first-child {
 				text-align: left;

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -556,16 +556,27 @@ html {
 		color: var(--color-accent-80);
 	}
 
+	.dataviews-filters__view-actions {
+		display: none;
+	}
+
 	.dataviews-view-table tr {
 		td,
 		th {
+			.action-button {
+				display: flex;
+				justify-content: flex-end;
+				width: 100%;
+				padding-inline-end: 12px;
+			}
 			&:first-child {
+				text-align: left;
 				padding-inline-start: 16px;
 			}
-			&:last-child {
-				text-align: right;
-				padding-inline-end: 16px;
-			}
+		}
+		th[data-field-id="actions"] {
+			text-align: right;
+			padding-inline-end: 16px;
 		}
 	}
 

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -48,7 +48,8 @@
 		"a8c-for-agencies-referrals": true,
 		"a8c-for-agencies-settings": true,
 		"a8c-for-agencies-partner-directory": true,
-		"a8c-for-agencies-migrations": true
+		"a8c-for-agencies-migrations": true,
+		"a8c-for-agencies-client": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/385
Closes https://github.com/Automattic/jetpack-genesis/issues/339

## Proposed Changes

This PR 

- Makes some UI enhancements & mobile view improvements to automated referrals.
- Adds some event tracking

## Testing Instructions

- Open A4A live link
- Visit the Referral Dashboard (/referrals/dashboard) > Verify that the UI looks as shown below:

Updated the max-width to 700px
Removed the underline from the icon
Updated the heading from `Find out more about the program` to `Find out more`

<img width="1728" alt="Screenshot 2024-06-18 at 12 50 53 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/81fcec14-d8c6-4729-a75e-d7150fc6d013">

- Go to Payment Settings (/referrals/payment-settings) and verify that the UI looks as shown below:

Removed the underline from the icon

<img width="1728" alt="Screenshot 2024-06-18 at 12 52 24 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8713a0bb-a5d2-4a69-8ea9-f08d3a5363b8">

- Go to FAQ (/referrals/faq) and verify that the UI looks as shown below:

Updated the max-width to 700px

<img width="1728" alt="Screenshot 2024-06-18 at 12 51 03 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6fe3774f-2162-4a4b-b061-1cab27688c61">

- Visit the Referral Dashboard (/referrals/dashboard) > Click the `Make a referral` button > Add WPCOM hosting and any products to the cart > Go to checkout > Enter the client's email address (you will need to create a new account using this email ID later) and a custom message > Click the `Request payment from client` button > You will be redirected to the Referral Dashboard once the request is complete.

-  Verify the UI looks as shown below:

Removed the per-page filter

<img width="1728" alt="Screenshot 2024-06-18 at 1 02 59 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/739f7e25-684d-45fb-86c4-dfd188b8ccf4">

Updated the mobile view

<img width="371" alt="Screenshot 2024-06-18 at 1 01 38 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/941cf5e6-f432-48a8-9a6c-0b3a547ee764">

**Switching to client view**

- Check the email ID that you used for the referral earlier for an email that starts as `Payment requested..` and copy the link address from the `Pay Now` button and open that link in an incognito window:

<img width="479" alt="Screenshot 2024-06-18 at 2 11 13 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/223353f2-9701-4861-b319-814f581e528b">

- Verify that you are redirected to the checkout after logging in > Verify the UI looks good on mobile view > Click the `Add my payment method` button > Notice that you are redirected to the payment method page > Verify the UI looks good on mobile view > Add a new card by entering your payment details > Once you are redirected to the checkout > Verify the UI looks good on mobile view > Click the `Submit my payment information` button > You will be redirected the Subscriptions page once the request is successful. 

<img width="473" alt="Screenshot 2024-06-18 at 12 54 36 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0b417736-e93b-4941-b8b4-2c9caeb9e4e8">

- Verify the mobile view looks as shown below:

<img width="375" alt="Screenshot 2024-06-18 at 2 19 47 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/aa2a4f28-1452-47be-adfa-cf22a52f2858">

- Visit the Payment methods and verify everything looks good.

More testing for designers:

- Go to your agency view
- Go to /purchases/licenses and verify that the client licenses show the email ID as shown here: https://github.com/Automattic/wp-calypso/pull/91840
- Go to /sites/need-setup and verify that the client licenses show the email ID as shown here: https://github.com/Automattic/wp-calypso/pull/91756
- Visit /referrals/dashboard and verify that the paid referral shows `Active` status 
- Click on the client > On the `Purchases` screen > Click the `Assign to site` button > Assign the license to a site 
- Once done, Visit /referrals/dashboard > Click on the same client > On the `Purchases` screen, verify that the assigned site is shown for the purchase, and clicking on the site URL should redirect the user to the site details.
- Visit /referrals/dashboard >Click on the same client > On the `Purchases` screen > Click the `Create site` button > Verify that the license of the client you wanted to create a site for shows up as the first item ([screenshots](https://github.com/Automattic/wp-calypso/pull/91756)) > Click the `Create new site` button > Once the site is created > Visit /referrals/dashboard >Click on the same client > On the `Purchases` screen > Verify that the site name appears. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
