### PR TITLE
Fix currentPage state to be reset on flow start

### DIFF
--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { HOSTED_SITE_MIGRATION_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import SegmentationSurvey from 'calypso/components/segmentation-survey';
 import { SKIP_ANSWER_KEY } from 'calypso/components/segmentation-survey/constants';
@@ -38,8 +38,8 @@ const QUESTION_CONFIGURATION: QuestionConfiguration = {
 };
 
 export default function InitialIntentStep( props: Props ) {
-	const { submitSignupStep, stepName, signupDependencies, flowName, progress } = props;
-	const currentPage = progress[ stepName ]?.stepSectionName ?? 1;
+	const { submitSignupStep, stepName, signupDependencies, flowName } = props;
+	const [ currentPage, setCurrentPage ] = useState< number >( 1 );
 	const currentAnswers = signupDependencies.segmentationSurveyAnswers || {};
 	const translate = useTranslate();
 	const headerText = translate( 'What brings you to WordPress.com?' );
@@ -136,9 +136,10 @@ export default function InitialIntentStep( props: Props ) {
 					skipNextNavigation={ skipNextNavigation }
 					questionConfiguration={ QUESTION_CONFIGURATION }
 					questionComponentMap={ flowQuestionComponentMap }
-					onGoToPage={ ( stepSectionName: number ) =>
-						submitSignupStep( { flowName, stepName, stepSectionName }, {} )
-					}
+					onGoToPage={ ( stepSectionName: number ) => {
+						setCurrentPage( stepSectionName );
+						submitSignupStep( { flowName, stepName, stepSectionName }, {} );
+					} }
 					providedPage={ currentPage }
 				/>
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
After going through the guided flow survey and coming back again to the flow, the user sees the second page instead of the first one. This PR fixes this.

https://github.com/Automattic/wp-calypso/assets/7000684/85dab618-3d63-4c24-923d-b8c00de1ac70


Related to #
p1718677877284119-slack-C02T4NVL4JJ



## Proposed Changes

* Use local state for currentPage instead of dependency

## Why are these changes being made?

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions
- Use build link or build the PR locally
- Visit `start/guided/initial-intent?flags=onboarding/guided`
- Go though the 1st and 2nd link
- Visit the link `start/guided/initial-intent?flags=onboarding/guided` again
- You should see the first page instead of the second one

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?