### PR TITLE
Fix the Plan grid downgrade/upgrade buttons

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -21,7 +21,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { localize, useTranslate } from 'i18n-calypso';
 import React, { useLayoutEffect } from 'react';
-import { connect } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router';
 import { useSaveHostingFlowPathStep } from 'calypso/landing/stepper/hooks/use-save-hosting-flow-path-step';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -273,6 +272,4 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	);
 };
 
-export default connect( () => {
-	return {};
-}, {} )( localize( PlansWrapper ) );
+export default localize( PlansWrapper );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -20,7 +20,7 @@ import { useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { localize, useTranslate } from 'i18n-calypso';
-import React, { useEffect, useLayoutEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import { connect } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router';
 import { useSaveHostingFlowPathStep } from 'calypso/landing/stepper/hooks/use-save-hosting-flow-path-step';
@@ -31,8 +31,6 @@ import PlanFAQ from 'calypso/my-sites/plans-features-main/components/plan-faq';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getIntervalType } from 'calypso/signup/steps/plans/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { PlansIntent } from '@automattic/plans-grid-next';
@@ -42,8 +40,6 @@ interface Props {
 	shouldIncludeFAQ?: boolean;
 	flowName: string | null;
 	onSubmit: ( planCartItem: MinimalRequestCartProduct | null ) => void;
-	selectedSiteId: number | null;
-	setSelectedSiteId: ( siteId: number ) => void;
 }
 
 function getPlansIntent( flowName: string | null ): PlansIntent | null {
@@ -76,22 +72,15 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			 ).getHidePlansFeatureComparison(),
 		};
 	}, [] );
-	const { flowName, selectedSiteId, setSelectedSiteId } = props;
+	const { flowName } = props;
 
 	const { setPlanCartItem, setDomain, setDomainCartItem, setProductCartItems } =
 		useDispatch( ONBOARD_STORE );
 
 	const site = useSite();
-	const siteId = site?.ID;
 	const currentPath = window.location.pathname + window.location.search;
 
 	useSaveHostingFlowPathStep( flowName, currentPath );
-
-	useEffect( () => {
-		if ( ! selectedSiteId && siteId ) {
-			setSelectedSiteId( siteId );
-		}
-	}, [ selectedSiteId, siteId, setSelectedSiteId ] );
 
 	const [ planIntervalPath, setPlanIntervalPath ] = useState< string >( '' );
 	const { __ } = useI18n();
@@ -284,13 +273,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	);
 };
 
-export default connect(
-	( state ) => {
-		return {
-			selectedSiteId: getSelectedSiteId( state ),
-		};
-	},
-	{
-		setSelectedSiteId: setSelectedSiteId,
-	}
-)( localize( PlansWrapper ) );
+export default connect( () => {
+	return {};
+}, {} )( localize( PlansWrapper ) );

--- a/client/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase.ts
+++ b/client/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase.ts
@@ -24,6 +24,8 @@ const useCheckPlanAvailabilityForPurchase = ( {
 	planSlugs,
 	siteId,
 }: Props ): PlanAvailabilityForPurchase => {
+	// In some cases, we may not have the selected site ID available, so we fallback to the siteId prop.
+	// For example, when the user is redirected to the domain upsell page from the free signup flow.
 	const selectedSiteId = useSelector( getSelectedSiteId ) || siteId;
 	const currentPlan = Plans.useCurrentPlan( { siteId: selectedSiteId } );
 

--- a/client/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase.ts
+++ b/client/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase.ts
@@ -6,6 +6,7 @@ import type { PlanSlug } from '@automattic/calypso-products';
 
 interface Props {
 	planSlugs: PlanSlug[];
+	siteId?: number | null;
 }
 
 type PlanAvailabilityForPurchase = {
@@ -21,8 +22,9 @@ type PlanAvailabilityForPurchase = {
  */
 const useCheckPlanAvailabilityForPurchase = ( {
 	planSlugs,
+	siteId,
 }: Props ): PlanAvailabilityForPurchase => {
-	const selectedSiteId = useSelector( getSelectedSiteId );
+	const selectedSiteId = useSelector( getSelectedSiteId ) || siteId;
 	const currentPlan = Plans.useCurrentPlan( { siteId: selectedSiteId } );
 
 	return useSelector( ( state ) =>

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -10,7 +10,13 @@ import * as Purchases from '../../purchases';
 import * as WpcomPlansUI from '../../wpcom-plans-ui';
 import type { AddOnMeta } from '../../add-ons/types';
 
-export type UseCheckPlanAvailabilityForPurchase = ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {
+export type UseCheckPlanAvailabilityForPurchase = ( {
+	planSlugs,
+	siteId,
+}: {
+	planSlugs: PlanSlug[];
+	siteId?: number | null;
+} ) => {
 	[ planSlug in PlanSlug ]?: boolean;
 };
 
@@ -63,7 +69,7 @@ const usePricingMetaForGridPlans = ( {
 	useCheckPlanAvailabilityForPurchase,
 	storageAddOns,
 }: Props ): { [ planSlug: string ]: Plans.PricingMetaForGridPlan } | null => {
-	const planAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( { planSlugs } );
+	const planAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( { planSlugs, siteId } );
 	// plans - should have a definition for all plans, being the main source of API data
 	const plans = Plans.usePlans( { coupon } );
 	// sitePlans - unclear if all plans are included

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -259,6 +259,7 @@ const useGridPlans: UseGridPlansType = ( {
 	} );
 	const plansAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( {
 		planSlugs: availablePlanSlugs,
+		siteId,
 	} );
 
 	// only fetch highlights for the plans that are available for the intent


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/83775
* https://github.com/Automattic/wp-calypso/pull/83785

## Proposed Changes

* Following @jeyip's idea, I removed the code that was setting the `selectedSiteID` and passed down the site ID to the `useCheckPlanAvailabilityForPurchase` hook. This way, we can use the site ID as fallback if we don't have the `selectedSiteID` property.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We were getting a bug because the selectedSiteId was being persisted when the user accessed the plan grid having a siteSlug, then when they accessed the plan grid again without a site it would reproduce the state for the previous accessed site. This caused the purchase buttons to be disabled and display the "Please contact support to downgrade your plan" message.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/newsletter/plans?siteSlug=A_PAID_SITE_SLUG`.
* The plans grid won't let you pick a plan because you already have a paid plan.
* Visit `/setup/newsletter/plans` (without the siteSlug).
* The plans grid should no longer be disabled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
