### PR TITLE
Revert "Fix the redirect back to the new migration flow (#91457)"

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -4,7 +4,6 @@ import { Title, SubTitle } from '@automattic/onboarding';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect } from 'react';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import {
 	getImportersAsImporterOption,
 	type ImporterConfigPriority,
@@ -29,20 +28,13 @@ export interface ImporterOption {
 interface Props {
 	siteSlug: string | null;
 	submit?: ( dependencies: Record< string, unknown > ) => void;
-	getFinalImporterUrl: (
-		siteSlug: string,
-		fromSite: string,
-		platform: ImporterPlatform,
-		backToFlow?: string
-	) => string;
+	getFinalImporterUrl: ( siteSlug: string, fromSite: string, platform: ImporterPlatform ) => string;
 	onNavBack?: () => void;
 }
 
 export default function ListStep( props: Props ) {
 	const { __ } = useI18n();
-	const urlQueryParams = useQuery();
 	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
-	const backToFlow = urlQueryParams.get( 'backToFlow' );
 
 	// We need to remove the wix importer from the primary importers list.
 	const primaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'primary' ).filter(
@@ -54,12 +46,7 @@ export default function ListStep( props: Props ) {
 	);
 
 	const onImporterSelect = ( platform: ImporterPlatform ): void => {
-		const importerUrl = getFinalImporterUrl(
-			siteSlug ?? '',
-			'',
-			platform,
-			backToFlow ?? undefined
-		);
+		const importerUrl = getFinalImporterUrl( siteSlug ?? '', '', platform );
 		submit?.( { platform, url: importerUrl } );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -14,8 +14,7 @@ import { BASE_ROUTE } from './config';
 export function getFinalImporterUrl(
 	targetSlug: string,
 	fromSite: string,
-	platform: ImporterPlatform,
-	backToFlow?: string
+	platform: ImporterPlatform
 ) {
 	let importerUrl;
 	const encodedFromSite = encodeURIComponent( fromSite );
@@ -37,12 +36,6 @@ export function getFinalImporterUrl(
 		}
 	} else {
 		importerUrl = getWpOrgImporterUrl( targetSlug, platform );
-	}
-
-	if ( backToFlow ) {
-		importerUrl = addQueryArgs( importerUrl, {
-			backToFlow,
-		} );
 	}
 
 	return importerUrl;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -542,9 +542,6 @@ const siteSetupFlow: Flow = {
 				case 'importerBlogger':
 				case 'importerMedium':
 				case 'importerSquarespace':
-					if ( backToFlow ) {
-						return navigate( `importList?siteSlug=${ siteSlug }&backToFlow=${ backToFlow }` );
-					}
 					return navigate( `importList?siteSlug=${ siteSlug }` );
 
 				case 'importerWordpress':


### PR DESCRIPTION
This reverts commit 7a3ffc504329d6e5b924acc5ef9f4cb00043ce03.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

THIS IS NOT MEANT TO BE MERGED. Just testing wether a bug was caused by the reverted commit.
*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
