### PR TITLE
[Blaze] Rename Woo blaze DNA flow name to blaze-ads

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -214,7 +214,7 @@ export class AuthFormHeader extends Component {
 						return translate(
 							'Approve your connection. Your account will enable you to start using the features and benefits offered by WooPayments'
 						);
-					} else if ( wooDnaConfig.getFlowName() === 'woodna:woo-blaze' ) {
+					} else if ( wooDnaConfig.getFlowName() === 'woodna:blaze-ads' ) {
 						const pluginName = wooDnaConfig.getServiceName();
 						/* translators: pluginName is the name of the Woo extension that initiated the connection flow */
 						return translate(

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -399,7 +399,7 @@ export class JetpackSignup extends Component {
 					subHeader = translate(
 						'Enter your email address to get started. Your account will enable you to start using the features and benefits offered by WooPayments'
 					);
-				} else if ( wooDna.getFlowName() === 'woodna:woo-blaze' ) {
+				} else if ( wooDna.getFlowName() === 'woodna:blaze-ads' ) {
 					/* translators: pluginName is the name of the Woo extension that initiated the connection flow */
 					subHeader = translate(
 						'Enter your email address to get started. Your account will enable you to start using the features and benefits offered by %(pluginName)s',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to blaze-ads PR#1

## Proposed Changes

* Rename Woo Blaze plugin flow name from `woodna:woo-blaze` to `woodna:blaze-ads` in anticipation of releasing to the dot org repo.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is a corresponding change with respect to Woo Blaze plugin slug change from `woo-blaze` to `blaze-ads` in anticipation of releasing to the dot org repo.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a WooCommerce site, and make sure the Jetpack plugin is deactivated or not installed
* Point `widgets.wp.com` to your WP Sandbox.
* Run `yarn start` to start calypso 
* In the blaze-ads plugin repo, set `define( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT', 'development' );` in `blaze-ads.php`
* Generate the release plugin build from the blaze-ads plugin repo and install it in your test blog OR run locally as described in repo readme.
* In WP Admin, Go to `Marketing` -> `Blaze for WooCommerce`
* Click `Connect now` button and you should see the customized sub header in the Woo DNA based Jetpack connect flow.

**Before**

Logged in
<img width="1521" alt="before" src="https://github.com/Automattic/wp-calypso/assets/9039613/03a805c5-16fa-4ab5-8b9a-ed93095c21d1">

New user

<img width="957" alt="new" src="https://github.com/Automattic/wp-calypso/assets/9039613/d77bc40b-d20b-4ce0-a05c-08e609bc5e1c">

**After**

Logged in

<img width="1397" alt="after" src="https://github.com/Automattic/wp-calypso/assets/9039613/d5233b85-3375-4e84-808b-2274323ac65a">

New user

<img width="1108" alt="new after" src="https://github.com/Automattic/wp-calypso/assets/9039613/c8cf8df7-fbc6-49d8-a16f-fd7b6e4f327c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
