### PR TITLE
Add a custom message for the posts_not_ready error code

### DIFF
--- a/client/my-sites/promote-post-i2/components/posts-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-list/index.tsx
@@ -7,6 +7,7 @@ import Notice from 'calypso/components/notice';
 import { BlazablePost } from 'calypso/data/promote-post/types';
 import { useInfiniteScroll } from 'calypso/data/promote-post/use-infinite-scroll';
 import { DSPMessage } from 'calypso/my-sites/promote-post-i2/main';
+import { APIError } from 'calypso/state/partner-portal/types';
 import './style.scss';
 import PostsTable from '../posts-table';
 import SearchBar, { SearchOptions } from '../search-bar';
@@ -24,6 +25,7 @@ type Props = {
 };
 
 const ERROR_NO_LOCAL_USER = 'no_local_user';
+const ERROR_POSTS_NOT_READY = 'posts_not_ready';
 
 const fetchErrorListMessage = translate(
 	'There was a problem obtaining the posts list. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
@@ -32,6 +34,13 @@ const fetchErrorListMessage = translate(
 			contactSupportLink: <a href={ CALYPSO_CONTACT } />,
 		},
 		comment: 'Validation error when filling out domain checkout contact details form',
+	}
+);
+
+const postsNotReadyErrorMessage = translate(
+	'Blaze is syncing your content as part of first-time setup – this can take up to 15 minutes or a few hours.',
+	{
+		comment: 'Validation error when fetching the posts and they are not ready/sync',
 	}
 );
 
@@ -54,6 +63,7 @@ export default function PostsList( props: Props ) {
 	const translate = useTranslate();
 
 	const hasLocalUser = ( isError as DSPMessage )?.errorCode !== ERROR_NO_LOCAL_USER;
+	const hasPostsNotReadyError = ( isError as APIError )?.code === ERROR_POSTS_NOT_READY;
 
 	const { containerRef } = useInfiniteScroll( {
 		offset: '200px',
@@ -66,6 +76,19 @@ export default function PostsList( props: Props ) {
 	const onChangeFilter = ( postType: string ) => {
 		setPostType( postType );
 	};
+
+	if ( isError && hasPostsNotReadyError ) {
+		return (
+			<Notice
+				className="promote-post-notice promote-post-i2__aux-wrapper"
+				status="is-info"
+				icon="mention"
+				showDismiss={ false }
+			>
+				{ postsNotReadyErrorMessage }
+			</Notice>
+		);
+	}
 
 	if ( isError && hasLocalUser ) {
 		return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add a custom message when the posts are not ready to be promoted.

![image](https://github.com/Automattic/wp-calypso/assets/692065/054c6876-5032-4c2d-8f69-f084279495d3)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DSP needs the posts to be synced to blaze it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Overwride the response of `https://public-api.wordpress.com/wpcom/v2/sites/<your_blog_id>/blaze/posts?page=1&posts_per_page=1&_envelope=1` to return the following the JSON:

````JSON
{
    "code": "posts_not_ready",
    "message": "Posts not ready yet. Please try again later.",
    "data": null
}
````
* Go to http://calypso.localhost:3000/advertising/posts/<your_blog_domain>
* See if the message appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
