### PR TITLE
Add `resetSignUpStorePostCompletion` flow property

### DIFF
--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -20,6 +20,7 @@ There are also three optional properties:
 - `description` is a brief description of what the flow is for.
 - `lastModified` is a date stamp for when the flow was last updated.
 - `disallowResume` is a boolean that, when true, will send you back to step 1 if you refreshed the page
+- `resetSignUpStorePostCompletion` is a boolean, when true, will wipe-out the signup store **after** flow completion.
 
 Example:
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -638,6 +638,7 @@ export function generateFlows( {
 			lastModified: '2024-05-15',
 			showRecaptcha: true,
 			hideProgressIndicator: true,
+			resetSignUpStorePostCompletion: true,
 		},
 		{
 			name: 'entrepreneur',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -389,6 +389,14 @@ class Signup extends Component {
 			const siteId = dependencies && dependencies.siteId;
 			await flow.postCompleteCallback( { siteId, flowName: this.props.flowName } );
 		}
+
+		if ( flow.resetSignUpStorePostCompletion ) {
+			this.signupFlowController.reset();
+
+			if ( ! this.state.controllerHasReset ) {
+				this.setState( { controllerHasReset: true } );
+			}
+		}
 	};
 
 	handleSignupFlowControllerCompletion = async ( dependencies, destination ) => {


### PR DESCRIPTION
## Proposed Changes

This allows signup flows to reset the signup store upon flow completion. 

## Why are these changes being made?

Because `stepSectionName` is persisted. When you visit the flow again, if your step has multiple sections, it will be stuck on the last section unless the store is cleared. 

I do think there is potentially a more sophisticated fix where the step sections get more surgical persistence, but I couldn't figure that one out after a couple of hours. 

## Testing Instructions

### Seeing the bug quickly

1. In production, go to http://wordpress.com/start/guided/?flags=onboarding/guided
2. Pick the first choice in both survey questions. 
3. In a parallel new tab, go to http://wordpress.com/start/guided/?flags=onboarding/guided 
4. You'll land in the second question of the survey. 

### Testing the fix

1. Go to http://wordpress.com/start/guided/?flags=onboarding/guided
2. Go through the flow (first option, first option, free domain, free plan).
3. Go to http://wordpress.com/start/guided/?flags=onboarding/guided.
4. You should see the first survey question.
