### PR TITLE
Domains: Add notice when canceling or transferring a free Gravatar domain

### DIFF
--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormRadio from 'calypso/components/forms/form-radio';
+import { getSelectedDomain } from 'calypso/lib/domains';
 import {
 	getName,
 	hasAmountAvailableToRefund,
@@ -17,9 +18,11 @@ import {
 	maybeWithinRefundPeriod,
 } from 'calypso/lib/purchases';
 import { getIncludedDomainPurchase } from 'calypso/state/purchases/selectors';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 
 const CancelPurchaseRefundInformation = ( {
 	purchase,
+	isGravatarDomain,
 	isJetpackPurchase,
 	includedDomainPurchase,
 	cancelBundledDomain,
@@ -287,10 +290,20 @@ const CancelPurchaseRefundInformation = ( {
 			);
 		}
 	} else if ( isDomainRegistration( purchase ) ) {
-		text = i18n.translate(
-			'When you cancel your domain, it will remain registered and active until the registration expires, ' +
-				'at which point it will be automatically removed from your site.'
-		);
+		text = [
+			i18n.translate(
+				'When you cancel your domain, it will remain registered and active until the registration expires, ' +
+					'at which point it will be automatically removed from your site.'
+			),
+		];
+
+		if ( isGravatarDomain ) {
+			text.push(
+				i18n.translate(
+					'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
+				)
+			);
+		}
 	} else if (
 		isSubscription( purchase ) &&
 		includedDomainPurchase &&
@@ -382,6 +395,13 @@ CancelPurchaseRefundInformation.propTypes = {
 	onCancelConfirmationStateChange: PropTypes.func,
 };
 
-export default connect( ( state, props ) => ( {
-	includedDomainPurchase: getIncludedDomainPurchase( state, props.purchase ),
-} ) )( CancelPurchaseRefundInformation );
+export default connect( ( state, props ) => {
+	const domains = getDomainsBySiteId( state, props.purchase.siteId );
+	const selectedDomainName = getName( props.purchase );
+	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
+
+	return {
+		includedDomainPurchase: getIncludedDomainPurchase( state, props.purchase ),
+		isGravatarDomain: selectedDomain.isGravatarDomain,
+	};
+} )( CancelPurchaseRefundInformation );

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -32,7 +32,7 @@ class RemoveDomainDialog extends Component {
 	};
 
 	renderDomainDeletionWarning( productName ) {
-		const { translate, slug, currentRoute } = this.props;
+		const { translate, slug, currentRoute, isGravatarDomain } = this.props;
 
 		return (
 			<Fragment>
@@ -44,6 +44,13 @@ class RemoveDomainDialog extends Component {
 						}
 					) }
 				</p>
+				{ isGravatarDomain && (
+					<p>
+						{ translate(
+							'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
+						) }
+					</p>
+				) }
 				<p>
 					{ translate(
 						'If you want to use {{strong}}%(domain)s{{/strong}} with another provider you can {{moveAnchor}}move it to another service{{/moveAnchor}} or {{transferAnchor}}transfer it to another provider{{/transferAnchor}}.',
@@ -267,6 +274,7 @@ export default connect( ( state, ownProps ) => {
 	const selectedDomainName = getName( ownProps.purchase );
 	const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
 	return {
+		isGravatarDomain: selectedDomain.isGravatarDomain,
 		hasTitanWithUs: hasTitanMailWithUs( selectedDomain ),
 		currentRoute: getCurrentRoute( state ),
 		slug: getSelectedSiteSlug( state ),

--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -16,6 +16,7 @@ import AdditionalTermsOfServiceInCart from './additional-terms-of-service-in-car
 import BundledDomainNotice, { showBundledDomainNotice } from './bundled-domain-notice';
 import DomainRegistrationAgreement from './domain-registration-agreement';
 import DomainRegistrationDotGay from './domain-registration-dot-gay';
+import { DomainRegistrationFreeGravatarDomain } from './domain-registration-free-gravatar-domain';
 import DomainRegistrationHsts from './domain-registration-hsts';
 import { EbanxTermsOfService } from './ebanx-terms-of-service';
 import { showInternationalFeeNotice, InternationalFeeNotice } from './international-fee-notice';
@@ -97,6 +98,7 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 				{ ! isGiftPurchase && <DomainRegistrationAgreement cart={ cart } /> }
 				{ ! isGiftPurchase && <DomainRegistrationHsts cart={ cart } /> }
 				{ ! isGiftPurchase && <DomainRegistrationDotGay cart={ cart } /> }
+				{ ! isGiftPurchase && <DomainRegistrationFreeGravatarDomain cart={ cart } /> }
 				<EbanxTermsOfService />
 				{ ! isGiftPurchase && <PlanTerms100Year cart={ cart } /> }
 				{ ! isGiftPurchase && <AdditionalTermsOfServiceInCart /> }

--- a/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
+++ b/client/my-sites/checkout/src/components/domain-registration-free-gravatar-domain.tsx
@@ -1,0 +1,27 @@
+import { useTranslate } from 'i18n-calypso';
+import { getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+interface DomainRegistrationFreeGravatarDomainProps {
+	cart: ResponseCart;
+}
+
+export function DomainRegistrationFreeGravatarDomain(
+	props: DomainRegistrationFreeGravatarDomainProps
+) {
+	const translate = useTranslate();
+	const domains = getDomainRegistrations( props.cart );
+
+	if ( ! domains.some( ( domain ) => domain.extra?.is_gravatar_domain ) ) {
+		return null;
+	}
+
+	return (
+		<CheckoutTermsItem>
+			{ translate(
+				'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you cancel this domain, you will have to pay the standard price to register another domain for your Gravatar profile.'
+			) }
+		</CheckoutTermsItem>
+	);
+}

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/index.tsx
@@ -20,6 +20,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, getTopLevelOfTld, isMappedDomain } from 'calypso/lib/domains';
 import wpcom from 'calypso/lib/wp';
 import AftermarketAutcionNotice from 'calypso/my-sites/domains/domain-management/components/domain/aftermarket-auction-notice';
+import InfoNotice from 'calypso/my-sites/domains/domain-management/components/domain/info-notice';
 import NonOwnerCard from 'calypso/my-sites/domains/domain-management/components/domain/non-owner-card';
 import NonTransferrableDomainNotice from 'calypso/my-sites/domains/domain-management/components/domain/non-transferrable-domain-notice';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
@@ -372,6 +373,14 @@ const TransferPage = ( props: TransferPageProps ) => {
 						? __( 'Transfer to another registrar' )
 						: __( 'Advanced Options' ) }
 				</CardHeading>
+				{ domain?.isGravatarDomain && (
+					<InfoNotice
+						redesigned
+						text={ __(
+							'This domain is provided at no cost for the first year for use with your Gravatar profile. This offer is limited to one free domain per user. If you transfer this domain to another registrar, you will have to pay the standard price to register another domain for your Gravatar profile.'
+						) }
+					/>
+				) }
 				{ topLevelOfTld !== 'uk' ? renderCommonTldTransferOptions() : renderUkTransferOptions() }
 			</Card>
 		);

--- a/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-page/style.scss
@@ -119,6 +119,11 @@
 		.search-card {
 			padding: 0;
 		}
+
+		/* only used when there's a free Gravatar domain notice */
+		.card-heading + .info-notice {
+			margin: 8px 0;
+		}
 	}
 
 	.transfer-page__transfer-lock-placeholder {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -610,6 +610,7 @@ export interface ResponseCartProductExtra {
 	receipt_for_domain?: number;
 	domain_registration_agreement_url?: string;
 	legal_agreements?: never[] | DomainLegalAgreements;
+	is_gravatar_domain?: boolean;
 
 	/**
 	 * Set to 'renewal' if requesting a renewal.


### PR DESCRIPTION
This is a retry of #91782 since pre-release E2E tests were failing when deploying that one.

## Proposed Changes

This PR adds notices and warnings explaining that users won't be able to get another free Gravatar domain in these situations:
- During checkout for a free Gravatar domain (via the `/start/domain-for-gravatar` flow)
- When transferring a free Gravatar domain away and
- When deleting a free Gravatar domain

### Screenshots

| Page | Before | After |
| --- | --- | --- |
| Checkout | ![Markup on 2024-06-14 at 20:35:50](https://github.com/Automattic/wp-calypso/assets/5324818/23086fe7-e92e-45c8-a6a7-8bdfa01d9b5d) | ![Markup on 2024-06-18 at 12:10:30](https://github.com/Automattic/wp-calypso/assets/5324818/61064a86-a8b7-4df6-b29b-4a81fac76793) |
| Outbound transfer | ![Screenshot 2024-06-13 at 18 24 15](https://github.com/Automattic/wp-calypso/assets/5324818/e588894f-179c-40ad-8668-f32bc5d53b19) | ![Screenshot 2024-06-18 at 12 12 11](https://github.com/Automattic/wp-calypso/assets/5324818/dd487621-7179-4fbe-b470-24e09015ef1c) |
| Disable domain auto-renew | ![Screenshot 2024-06-13 at 16 05 19](https://github.com/Automattic/wp-calypso/assets/5324818/a0970a5c-3994-48d1-a1a8-21c0dba35f7b) | ![Markup on 2024-06-18 at 12:13:35](https://github.com/Automattic/wp-calypso/assets/5324818/24a019d3-05e5-4a97-a01b-21273688c2ae) |
| Delete domain (after turning auto-renew off) | ![Screenshot 2024-06-13 at 16 12 29](https://github.com/Automattic/wp-calypso/assets/5324818/d5c47668-51bb-49b8-b7b2-0b0fc4e8948e) | ![Markup on 2024-06-18 at 12:12:42](https://github.com/Automattic/wp-calypso/assets/5324818/8e6b6aae-7627-4061-917a-00c3bbe71026) |

## Why are these changes being made?

- This is part of the Custom domains on Gravatar project (pcYYhz-24z-p2).

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Checkout
  - Go to the domains for Gravatar flow (`/start/domain-for-gravatar`) and add a domain to the cart
  - Ensure the explanation about only one free Gravatar domain is shown in the checkout page
  - Visit the other flows (`/start`, adding domains to an existing site, etc) and ensure the free Gravatar domain copy isn't shown in the checkout page
- Outbound transfer
  - When you already have a free Gravatar domain, go to its domain transfer page and ensure a warning notice is shown
- Cancel domain
  - When you already have a free Gravatar domain, go to the domain cancelation page and ensure a warning text is shown
  - After you disable auto-renew for that domain, try to cancel it and ensure the deletion confirmation dialog also contains warning text explaining that you won't be able to get another free Gravatar domain

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?