### PR TITLE
SignupForm: render ToS always before the submit button

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -119,7 +119,6 @@ class SignupForm extends Component {
 		horizontal: PropTypes.bool,
 		shouldDisplayUserExistsError: PropTypes.bool,
 		submitForm: PropTypes.func,
-		isInviteLoggedOutForm: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -1306,7 +1305,6 @@ class SignupForm extends Component {
 						disableSubmitButton={ this.props.disableSubmitButton || emailErrorMessage }
 						queryArgs={ this.props.queryArgs }
 						userEmail={ this.getEmailValue() }
-						isInviteLoggedOutForm={ this.props.isInviteLoggedOutForm }
 						labelText={ this.props.labelText }
 						onInputBlur={ this.handleBlur }
 						onInputChange={ this.handleChangeEvent }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -27,7 +27,6 @@ class PasswordlessSignupForm extends Component {
 		submitButtonLoadingLabel: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 		userEmail: PropTypes.string,
 		labelText: PropTypes.string,
-		isInviteLoggedOutForm: PropTypes.bool,
 		onInputBlur: PropTypes.func,
 		onInputChange: PropTypes.func,
 		onCreateAccountError: PropTypes.func,
@@ -307,18 +306,6 @@ class PasswordlessSignupForm extends Component {
 		return this.props.labelText ?? this.props.translate( 'Enter your email address' );
 	}
 
-	getFormButtonAndToS() {
-		return this.props.isInviteLoggedOutForm ? (
-			<>
-				{ this.formFooter() } { this.props.renderTerms?.() }
-			</>
-		) : (
-			<>
-				{ this.props.renderTerms?.() } { this.formFooter() }
-			</>
-		);
-	}
-
 	render() {
 		const { errorMessages, isSubmitting } = this.state;
 
@@ -344,7 +331,8 @@ class PasswordlessSignupForm extends Component {
 						/>
 						{ this.props.children }
 					</ValidationFieldset>
-					{ this.getFormButtonAndToS() }
+					{ this.props.renderTerms?.() }
+					{ this.formFooter() }
 				</LoggedOutForm>
 			</div>
 		);

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -215,7 +215,6 @@ class InviteAcceptLoggedOut extends Component {
 							}
 						) }
 						submitButtonLabel={ this.props.translate( 'Create an account' ) }
-						isInviteLoggedOutForm
 						labelText={ this.props.translate( 'Your email address' ) }
 					/>
 					{ this.state.userData && this.loginUser() }

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -90,20 +90,23 @@ body.is-section-accept-invite {
 			margin-bottom: 0;
 		}
 	}
-	.signup-form__terms-of-service-link {
-		margin: 0;
-		color: var(--studio-gray-50, #2c3338);
-		font-size: $font-body-small; // 14px
-		line-height: 20px;
-		a {
-			color: var(--studio-gray-80, #2c3338);
-			font-style: normal;
-			text-decoration-line: underline;
+
+	.signup-form__passwordless-form-wrapper {
+		.signup-form__terms-of-service-link {
+			margin: 16px 0;
+			color: var(--studio-gray-50, #2c3338);
+			font-size: $font-body-small; // 14px
+			line-height: 20px;
+			a {
+				color: var(--studio-gray-80, #2c3338);
+				font-style: normal;
+				text-decoration-line: underline;
+			}
 		}
 	}
 
 	.card.logged-out-form__footer {
-		margin: 16px 0 16px 0;
+		margin: 16px 0;
 		padding: 0;
 	}
 	.logged-out-form__link-item {


### PR DESCRIPTION
This PR makes various signup forms a bit more consistent by removing the `isInviteLoggedOutForm` and by always rendering the ToS text before the submit button.

In addition to JS changes, I also had to fix up some CSS margins and CSS selector specificity.

The "accept invite logged out form" before:

<img width="399" alt="Screenshot 2024-06-17 at 17 35 38" src="https://github.com/Automattic/wp-calypso/assets/664258/85da2e95-537d-4bd0-8995-404dab412673">

The same form after this PR:

<img width="439" alt="Screenshot 2024-06-18 at 16 06 23" src="https://github.com/Automattic/wp-calypso/assets/664258/6f543708-134a-4e12-8a17-8d77ef19fefd">

For comparison, this is the regular passwordless WP.com signup:

<img width="433" alt="Screenshot 2024-06-18 at 16 06 36" src="https://github.com/Automattic/wp-calypso/assets/664258/6998de72-fb83-4eee-a05e-84e1885b91d9">

For another comparison, this is the Dropbox signup form, also with ToS above the submit button:

<img width="386" alt="Screenshot 2024-06-14 at 12 42 24" src="https://github.com/Automattic/wp-calypso/assets/664258/6fcb75d2-0202-46e2-b38a-c051b6881b5d">

**How to test:**
1. Invite a user to your site.
2. There is an email with URL like `/accept-invite/:site/:key`. Copy that invite into local Calypso, replacing `wordpress.com` with `calypso.localhost:3000`.
3. Now you can see the affected signup form.

