### PR TITLE
LoggedOutForm: modernize class components

### DIFF
--- a/client/components/logged-out-form/back-link.jsx
+++ b/client/components/logged-out-form/back-link.jsx
@@ -1,14 +1,14 @@
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
 
 import './link-item.scss';
 
-function LoggedOutFormBackLink( props ) {
-	const { locale, oauth2Client, translate, recordClick } = props;
+export default function LoggedOutFormBackLink( { locale, oauth2Client, recordClick, classes } ) {
+	const translate = useTranslate();
 
 	let url = localizeUrl( 'https://wordpress.com', locale );
 	let message = translate( 'Back to WordPress.com' );
@@ -35,7 +35,7 @@ function LoggedOutFormBackLink( props ) {
 			className={ clsx( {
 				'logged-out-form__link-item': true,
 				'logged-out-form__back-link': true,
-				...props.classes,
+				...classes,
 			} ) }
 		>
 			<Gridicon icon="arrow-left" size={ 18 } />
@@ -43,12 +43,10 @@ function LoggedOutFormBackLink( props ) {
 		</a>
 	);
 }
+
 LoggedOutFormBackLink.propTypes = {
 	classes: PropTypes.object,
 	locale: PropTypes.string,
-	translate: PropTypes.func.isRequired,
 	recordClick: PropTypes.func.isRequired,
 	oauth2Client: PropTypes.object,
 };
-
-export default localize( LoggedOutFormBackLink );

--- a/client/components/logged-out-form/footer.jsx
+++ b/client/components/logged-out-form/footer.jsx
@@ -1,28 +1,19 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 
 import './footer.scss';
 
-class LoggedOutFormFooter extends Component {
-	static propTypes = {
-		children: PropTypes.node.isRequired,
-		className: PropTypes.string,
-		isBlended: PropTypes.bool,
-	};
-
-	render() {
-		return (
-			<Card
-				className={ clsx( 'logged-out-form__footer', this.props.className, {
-					'is-blended': this.props.isBlended,
-				} ) }
-			>
-				{ this.props.children }
-			</Card>
-		);
-	}
+export default function LoggedOutFormFooter( { className, isBlended, children } ) {
+	return (
+		<Card className={ clsx( 'logged-out-form__footer', className, { 'is-blended': isBlended } ) }>
+			{ children }
+		</Card>
+	);
 }
 
-export default LoggedOutFormFooter;
+LoggedOutFormFooter.propTypes = {
+	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
+	isBlended: PropTypes.bool,
+};

--- a/client/components/logged-out-form/index.jsx
+++ b/client/components/logged-out-form/index.jsx
@@ -1,22 +1,18 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
-import { omit } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 
 import './style.scss';
 
-export default class LoggedOutForm extends Component {
-	static propTypes = {
-		children: PropTypes.node.isRequired,
-		className: PropTypes.string,
-	};
-
-	render() {
-		return (
-			<Card className={ clsx( 'logged-out-form', this.props.className ) }>
-				<form { ...omit( this.props, 'className' ) }>{ this.props.children }</form>
-			</Card>
-		);
-	}
+export default function LoggedOutForm( { className, ...props } ) {
+	return (
+		<Card className={ clsx( 'logged-out-form', className ) }>
+			<form { ...props } />
+		</Card>
+	);
 }
+
+LoggedOutForm.propTypes = {
+	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
+};

--- a/client/components/logged-out-form/link-item.jsx
+++ b/client/components/logged-out-form/link-item.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 import './link-item.scss';
 
-export default function LoggedOutFormLinkItem( props ) {
-	return (
-		<a { ...props } className={ clsx( 'logged-out-form__link-item', props.className ) }>
-			{ props.children }
-		</a>
-	);
+export default function LoggedOutFormLinkItem( { className, ...props } ) {
+	return <a className={ clsx( 'logged-out-form__link-item', className ) } { ...props } />;
 }
-LoggedOutFormLinkItem.propTypes = { className: PropTypes.string };
+
+LoggedOutFormLinkItem.propTypes = {
+	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
+};

--- a/client/components/logged-out-form/links.jsx
+++ b/client/components/logged-out-form/links.jsx
@@ -1,24 +1,13 @@
 import clsx from 'clsx';
-import { omit } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 
 import './links.scss';
 
-export default class LoggedOutFormLinks extends Component {
-	static propTypes = {
-		children: PropTypes.node.isRequired,
-		className: PropTypes.string,
-	};
-
-	render() {
-		return (
-			<div
-				{ ...omit( this.props, 'classNames' ) }
-				className={ clsx( 'logged-out-form__links', this.props.className ) }
-			>
-				{ this.props.children }
-			</div>
-		);
-	}
+export default function LoggedOutFormLinks( { className, ...props } ) {
+	return <div className={ clsx( 'logged-out-form__links', className ) } { ...props } />;
 }
+
+LoggedOutFormLinks.propTypes = {
+	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
+};


### PR DESCRIPTION
This PR modernizes the `LoggedOutForm` components: rewrite class components to functions, remove some Lodash usages in favor of destructuring.

A nice next step would be converting to TypeScript and removing proptypes, but I didn't do that in this PR.
