### PR TITLE
Help Center: clean-up part 2 useZendeskConfig

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/migration-error/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-error/index.tsx
@@ -1,5 +1,9 @@
 import { HelpCenter, MigrationStatusError } from '@automattic/data-stores';
-import { useChatStatus, useChatWidget } from '@automattic/help-center/src/hooks';
+import {
+	useChatStatus,
+	useChatWidget,
+	useCanConnectToZendesk,
+} from '@automattic/help-center/src/hooks';
 import { NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -34,7 +38,8 @@ export const MigrationError = ( props: Props ) => {
 		goToImportContentOnlyPage,
 	} = props;
 	const translate = useTranslate();
-	const { isChatAvailable, isEligibleForChat, canConnectToZendesk } = useChatStatus();
+	const { isChatAvailable, isEligibleForChat } = useChatStatus();
+	const { data: canConnectToZendesk } = useCanConnectToZendesk();
 	const { openChatWidget, isOpeningChatWidget } = useChatWidget(
 		'zendesk_support_chat_key',
 		isEligibleForChat

--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -1,6 +1,10 @@
 import { Button, Gridicon, Spinner } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
-import { useChatStatus, useChatWidget } from '@automattic/help-center/src/hooks';
+import {
+	useChatStatus,
+	useChatWidget,
+	useCanConnectToZendesk,
+} from '@automattic/help-center/src/hooks';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
@@ -65,7 +69,6 @@ const ChatButton: FC< Props > = ( {
 
 	const messagingGroup = getMessagingGroupForIntent( chatIntent );
 	const {
-		canConnectToZendesk,
 		hasActiveChats,
 		isChatAvailable,
 		isEligibleForChat,
@@ -73,6 +76,7 @@ const ChatButton: FC< Props > = ( {
 		isPresalesChatOpen,
 	} = useChatStatus( messagingGroup );
 	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { data: canConnectToZendesk } = useCanConnectToZendesk();
 
 	function shouldShowChatButton(): boolean {
 		if ( isEligibleForChat && hasActiveChats ) {

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -1,7 +1,7 @@
 import {
-	useChatStatus,
 	useMessagingAvailability,
 	useZendeskMessaging,
+	useCanConnectToZendesk,
 } from '@automattic/help-center/src/hooks';
 import { ZENDESK_SOURCE_URL_TICKET_FIELD_ID } from '@automattic/help-center/src/hooks/use-chat-widget';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
@@ -58,7 +58,8 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 	const isWpMobileAppUser = isWpMobileApp();
 	const group = getGroupName( keyType );
 
-	const { canConnectToZendesk } = useChatStatus( group, enabled );
+	const { data: canConnectToZendesk } = useCanConnectToZendesk();
+
 	const isEligibleForPresalesChat =
 		enabled && isEnglishLocale && canConnectToZendesk && ! isWpMobileAppUser;
 

--- a/config/development.json
+++ b/config/development.json
@@ -24,7 +24,7 @@
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
 	"blaze_pro_back_link": "http://blaze.pro:3005/app",
 	"advertising_dashboard_path_prefix": "/advertising",
-	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key": "beefd4ad-db79-4381-9d44-6c4bf92497ed",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
 	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -30,7 +30,12 @@ import { useSiteAnalysis } from '../data/use-site-analysis';
 import { useSubmitForumsMutation } from '../data/use-submit-forums-topic';
 import { useSubmitTicketMutation } from '../data/use-submit-support-ticket';
 import { useUserSites } from '../data/use-user-sites';
-import { useChatStatus, useContactFormTitle, useChatWidget } from '../hooks';
+import {
+	useChatStatus,
+	useContactFormTitle,
+	useChatWidget,
+	useCanConnectToZendesk,
+} from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 import { getSupportVariationFromMode } from '../support-variations';
 import { SearchResult } from '../types';
@@ -123,12 +128,8 @@ export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 	const { resetStore, setUserDeclaredSite, setShowMessagingChat, setSubject, setMessage } =
 		useDispatch( HELP_CENTER_STORE );
 
-	const {
-		canConnectToZendesk,
-		hasActiveChats,
-		isEligibleForChat,
-		isLoading: isLoadingChatStatus,
-	} = useChatStatus();
+	const { data: canConnectToZendesk } = useCanConnectToZendesk();
+	const { hasActiveChats, isEligibleForChat, isLoading: isLoadingChatStatus } = useChatStatus();
 	const { isOpeningChatWidget, openChatWidget } = useChatWidget(
 		'zendesk_support_chat_key',
 		isEligibleForChat || hasActiveChats

--- a/packages/help-center/src/hooks/index.ts
+++ b/packages/help-center/src/hooks/index.ts
@@ -5,7 +5,7 @@ export { useStillNeedHelpURL } from './use-still-need-help-url';
 export { default as useMessagingAuth } from './use-messaging-auth';
 export { default as useMessagingAvailability } from './use-messaging-availability';
 export { default as useTyper } from './use-typer';
-export { default as useZendeskConfig } from './use-zendesk-config';
+export { useCanConnectToZendesk } from './use-can-connect-to-zendesk';
 export { default as useZendeskMessaging } from './use-zendesk-messaging';
 export { default as useChatStatus } from './use-chat-status';
 export { default as useChatWidget } from './use-chat-widget';

--- a/packages/help-center/src/hooks/use-can-connect-to-zendesk.ts
+++ b/packages/help-center/src/hooks/use-can-connect-to-zendesk.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
-function requestZendeskConfig() {
-	return window.fetch( 'https://wpcom.zendesk.com/embeddable/config' );
-}
-
-export default function useZendeskConfig( enabled: boolean ) {
+export function useCanConnectToZendesk( enabled = true ) {
 	return useQuery( {
-		queryKey: [ 'getZendeskConfig' ],
-		queryFn: requestZendeskConfig,
+		queryKey: [ 'canConnectToZendesk' ],
+		queryFn: async () => {
+			const config = await fetch( 'https://wpcom.zendesk.com/embeddable/config' );
+
+			return config.ok;
+		},
 		staleTime: Infinity,
 		retry: false,
 		refetchOnMount: false,

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -6,7 +6,7 @@ import { useSupportAvailability } from '../data/use-support-availability';
 /**
  * Internal Dependencies
  */
-import { useZendeskConfig, useMessagingAvailability } from './';
+import { useMessagingAvailability } from './';
 import type { MessagingGroup } from './use-messaging-availability';
 
 export default function useChatStatus(
@@ -28,10 +28,7 @@ export default function useChatStatus(
 	const { data: chatAvailability, isInitialLoading: isLoadingAvailability } =
 		useMessagingAvailability( group, checkAgentAvailability && isEligibleForChat );
 
-	const { status: zendeskStatus } = useZendeskConfig( isEligibleForChat );
-
 	return {
-		canConnectToZendesk: zendeskStatus !== 'error',
 		hasActiveChats,
 		isChatAvailable: Boolean( chatAvailability?.is_available ),
 		isEligibleForChat,


### PR DESCRIPTION
## Proposed Changes

Refactor `useZendeskConfig` to be called on its own and use apart from `useChatStatus`.

## Why are these changes being made?

Since the recent change to omni-channel support we can break down `useChatStatus` to a more concise hook that only checks the support status. In order to do this we must remove the excess items that are being combined into it.

`useCanConnectToZendesk` is more appropriately named and can be used on its own.

## Testing Instructions

1. Open live link
2. Go to `/home` and make sure Help Center works and you can start a support request.
3. Test from the editor as well.
4. Test from the checkout page to make sure Pre Sales is working properly too.

Part 1 - #91880
Part 3 - #91917 