### PR TITLE
A4A > Referral: Enable Automated Referrals in STG

### DIFF
--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -34,7 +34,8 @@
 		"cookie-banner": false,
 		"oauth": true,
 		"a4a/site-details-pane": true,
-		"a4a-logged-out-signup": true
+		"a4a-logged-out-signup": true,
+		"a4a-automated-referrals": true
 	},
 	"enable_all_sections": false,
 	"sections": {
@@ -50,7 +51,8 @@
 		"a8c-for-agencies-referrals": true,
 		"a8c-for-agencies-settings": false,
 		"a8c-for-agencies-partner-directory": true,
-		"a8c-for-agencies-migrations": true
+		"a8c-for-agencies-migrations": true,
+		"a8c-for-agencies-client": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/336

## Proposed Changes

This PR enabled Automated Referrals: Agency & Client sections/feature flag in STG


## Testing Instructions

- Verify the section & feature flag is enabled only on STG

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
