### PR TITLE
PAO - Square: Handle partnerBundle query param during the Entrepreneur flow

### DIFF
--- a/client/data/ecommerce/use-add-ecommerce-trial-mutation.ts
+++ b/client/data/ecommerce/use-add-ecommerce-trial-mutation.ts
@@ -7,8 +7,16 @@ interface Variables {
 }
 
 export default function useAddEcommerceTrialMutation(
+	partnerBundle: string | null,
 	options: UseMutationOptions< unknown, unknown, Variables > = {}
 ) {
+	const partnerData = partnerBundle
+		? {
+				woocommerce_onboarding_profile: {
+					partner: partnerBundle,
+				},
+		  }
+		: undefined;
 	const mutation = useMutation( {
 		mutationFn: async ( { siteId }: Variables ) => {
 			await wp.req.post(
@@ -18,6 +26,7 @@ export default function useAddEcommerceTrialMutation(
 				},
 				{
 					is_entrepreneur_signup: 1,
+					wpcom_woocommerce_onboarding: partnerData,
 				}
 			);
 		},

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -39,8 +39,12 @@ const entrepreneurFlow: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 
-		const { setPluginsToVerify } = useDispatch( ONBOARD_STORE );
+		const { setPluginsToVerify, setPartnerBundle } = useDispatch( ONBOARD_STORE );
 		setPluginsToVerify( [ 'woocommerce' ] );
+
+		const params = new URLSearchParams( window.location.search );
+		const partnerBundle = params.get( 'partnerBundle' );
+		setPartnerBundle( partnerBundle );
 
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -67,7 +67,11 @@ function hasSourceSlug( data: unknown ): data is { sourceSlug: string } {
 const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const { mutateAsync: addEcommerceTrial } = useAddEcommerceTrialMutation();
+	const partnerBundle = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPartnerBundle(),
+		[]
+	);
+	const { mutateAsync: addEcommerceTrial } = useAddEcommerceTrialMutation( partnerBundle );
 
 	const urlData = useSelector( getUrlData );
 

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -449,6 +449,10 @@ export const setPaidSubscribers = ( paidSubscribers: boolean ) => ( {
 	paidSubscribers,
 } );
 
+export const setPartnerBundle = ( partnerBundle: string | null ) => ( {
+	type: 'SET_PARTNER_BUNDLE' as const,
+	partnerBundle,
+} );
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -505,4 +509,5 @@ export type OnboardAction = ReturnType<
 	| typeof setPlanCartItem
 	| typeof setIsMigrateFromWp
 	| typeof setPaidSubscribers
+	| typeof setPartnerBundle
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -547,6 +547,16 @@ const paidSubscribers: Reducer< boolean, OnboardAction > = ( state = false, acti
 	return state;
 };
 
+const partnerBundle: Reducer< string | null, OnboardAction > = ( state = null, action ) => {
+	if ( action.type === 'SET_PARTNER_BUNDLE' ) {
+		return action.partnerBundle;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return null;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainCartItem,
@@ -592,6 +602,7 @@ const reducer = combineReducers( {
 	pluginsToVerify,
 	profilerData,
 	paidSubscribers,
+	partnerBundle,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -77,3 +77,4 @@ export const getIsMigrateFromWp = ( state: State ) => state.isMigrateFromWp;
 export const getPluginsToVerify = ( state: State ) => state.pluginsToVerify;
 export const getProfilerData = ( state: State ) => state.profilerData;
 export const getPaidSubscribers = ( state: State ) => state.paidSubscribers;
+export const getPartnerBundle = ( state: State ) => state.partnerBundle;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/7783
Resolves https://github.com/Automattic/dotcom-forge/issues/7784

## Proposed Changes

* Passes the object `woocommerce_onboarding_profile` as a POST param to the `/ecommerce-trial/add/ecommerce-trial-bundle-monthly` endpoint during the `Create Site` step
* Save the query param `partnerBundle` to the `ONBOARD_STORE` in the first step of the flow

### Notes:
- The query param _name_ used is `partnerBundle` instead of `solution` as it seems to reflect better the intention. It can be changed if required.
- The query param _value_ is `square` to match the value expected by the backend. It can be changed once tested if required as a follow-up task.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To pass the required information to the backend when creating the site from a Partner flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the Calypso development link or applying this patch and navigating to your local environment
* Navigate to the following URL `/setup/entrepreneur/start?partnerBundle=square`
* Complete all the steps to create the site, including the creation of the Store
* Once the Store is created, navigate back to the Home page 
![CleanShot 2024-06-18 at 17 00 40@2x](https://github.com/Automattic/wp-calypso/assets/3519124/56ab6d36-ff05-47a8-a491-8cb1540ddae9)
* Ensure in the `wp-admin` home screen you can see `Get paid with Square` instead of `Get paid with WooPayments` 
![CleanShot 2024-06-18 at 17 01 22@2x](https://github.com/Automattic/wp-calypso/assets/3519124/2320237b-8904-4e70-a47c-35c6cdab56a3)
* Open the `_cli` of your newly created site navigating to `<your site URL>/_cli`
* Run `plugin list` 
* Check `woocommerce-square` is installed and `woocommerce-payments` is not installed
![CleanShot 2024-06-18 at 17 05 57@2x](https://github.com/Automattic/wp-calypso/assets/3519124/8f56fa98-772d-4300-ac31-140a1164f72a)

- Repeat all the above steps with a logged-out user For that is probably better to use the Calypso Live link in [the section below](https://github.com/Automattic/wp-calypso/pull/91899#issuecomment-2176311931). I have not been able to test that so maybe this can be tested in production using the proper `wordress.com` domain.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
