### PR TITLE
Guided Onboarding: Fix survey nav sections

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -85,7 +85,17 @@ export class NavigationLink extends Component {
 			return this.props.backUrl;
 		}
 
-		const { flowName, signupProgress, stepName, userLoggedIn, queryParams } = this.props;
+		const fallbackQueryParams = Object.fromEntries(
+			new URLSearchParams( window.location.search ).entries()
+		);
+
+		const {
+			flowName,
+			signupProgress,
+			stepName,
+			userLoggedIn,
+			queryParams = fallbackQueryParams,
+		} = this.props;
 		const previousStep = this.getPreviousStep( flowName, signupProgress, stepName );
 
 		const stepSectionName = get(

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -85,9 +85,9 @@ export class NavigationLink extends Component {
 			return this.props.backUrl;
 		}
 
-		const fallbackQueryParams = Object.fromEntries(
-			new URLSearchParams( window.location.search ).entries()
-		);
+		const fallbackQueryParams = window.location.search
+			? Object.fromEntries( new URLSearchParams( window.location.search ).entries() )
+			: undefined;
 
 		const {
 			flowName,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1379,7 +1379,8 @@ export class RenderDomainsStep extends Component {
 		} else if ( 'plans-first' === flowName ) {
 			backUrl = getStepUrl( flowName, previousStepName );
 		} else if ( isOnboardingGuidedFlow( flowName ) ) {
-			backUrl = getStepUrl( flowName, previousStepName );
+			// Let the framework decide the back url.
+			backUrl = undefined;
 		} else {
 			backUrl = getStepUrl( flowName, stepName, null, this.getLocale() );
 

--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -17,12 +17,13 @@ interface Props {
 	flowName: string;
 	stepName: string;
 	goToNextStep: () => void;
+	goToStep: ( stepName: string, stepSectionName: number ) => void;
 	submitSignupStep: ( step: any, deps: any ) => void;
 	signupDependencies: {
 		segmentationSurveyAnswers: SurveyData;
 		onboardingSegment: string;
 	};
-	progress: Record< string, any >;
+	stepSectionName: string | undefined;
 }
 
 const QUESTION_CONFIGURATION: QuestionConfiguration = {
@@ -38,8 +39,14 @@ const QUESTION_CONFIGURATION: QuestionConfiguration = {
 };
 
 export default function InitialIntentStep( props: Props ) {
-	const { submitSignupStep, stepName, signupDependencies, flowName, progress } = props;
-	const currentPage = progress[ stepName ]?.stepSectionName ?? 1;
+	const {
+		submitSignupStep,
+		stepName,
+		signupDependencies,
+		flowName,
+		stepSectionName: currentPageString,
+	} = props;
+	const currentPage = currentPageString ? Number( currentPageString ) : 1;
 	const currentAnswers = signupDependencies.segmentationSurveyAnswers || {};
 	const translate = useTranslate();
 	const headerText = translate( 'What brings you to WordPress.com?' );
@@ -136,9 +143,10 @@ export default function InitialIntentStep( props: Props ) {
 					skipNextNavigation={ skipNextNavigation }
 					questionConfiguration={ QUESTION_CONFIGURATION }
 					questionComponentMap={ flowQuestionComponentMap }
-					onGoToPage={ ( stepSectionName: number ) =>
-						submitSignupStep( { flowName, stepName, stepSectionName }, {} )
-					}
+					onGoToPage={ ( stepSectionName: number ) => {
+						submitSignupStep( { flowName, stepName }, {} );
+						props.goToStep( stepName, stepSectionName );
+					} }
 					providedPage={ currentPage }
 				/>
 			}

--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -144,6 +144,7 @@ export default function InitialIntentStep( props: Props ) {
 					questionConfiguration={ QUESTION_CONFIGURATION }
 					questionComponentMap={ flowQuestionComponentMap }
 					onGoToPage={ ( stepSectionName: number ) => {
+						submitSignupStep( { flowName, stepName, stepSectionName }, {} );
 						props.goToStep( stepName, stepSectionName );
 					} }
 					providedPage={ currentPage }

--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -144,7 +144,6 @@ export default function InitialIntentStep( props: Props ) {
 					questionConfiguration={ QUESTION_CONFIGURATION }
 					questionComponentMap={ flowQuestionComponentMap }
 					onGoToPage={ ( stepSectionName: number ) => {
-						submitSignupStep( { flowName, stepName }, {} );
 						props.goToStep( stepName, stepSectionName );
 					} }
 					providedPage={ currentPage }


### PR DESCRIPTION
## Proposed Changes
A better fix than https://github.com/Automattic/wp-calypso/pull/91889 to fix in-survey and after survey navigation.

## Testing Instructions

### Seeing the bug quickly

1. In production, go to http://wordpress.com/start/guided/?flags=onboarding/guided
2. Pick the first choice in both survey questions. 
3. In a parallel new tab, go to http://wordpress.com/start/guided/?flags=onboarding/guided 
4. You'll land on the second question of the survey. 

### Testing the fix

1. Repeat the above using the live link, you should see the first step when you land at /start/guided/?flags=onboarding/guided.
2. Clicking back in Q2, whether using the UI or the browser button should work.
3. Clicking Back in domains step, UI or browser, should send you back to Q2. 