### PR TITLE
Subscriptions: Track "Enable subscription pop-up for commenters" toggle switch

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -210,6 +210,12 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 							path,
 						} );
 						break;
+					case 'jetpack_verbum_subscription_modal':
+						trackTracksEvent( 'calypso_settings_verbum_subscription_modal_updated', {
+							value: fields.jetpack_verbum_subscription_modal,
+							path,
+						} );
+						break;
 					case 'jetpack_subscriptions_from_name':
 						trackTracksEvent( 'calypso_setting_jetpack_subscriptions_from_name_updated', {
 							value: fields.jetpack_subscriptions_from_name,


### PR DESCRIPTION
## Proposed Changes

It adds tracking to the "Enable subscription pop-up for commenters" toggle switch.

<img width="749" alt="Screenshot 2024-06-18 at 17 36 06" src="https://github.com/Automattic/wp-calypso/assets/4068554/f4be72ad-6d7b-4465-8550-3696372c6067">

## Why are these changes being made?

We need it to track user behavior.

## Testing Instructions

1. Go to Newsletter Settings
2. Toggle the "Enable subscription pop-up for commenters" and save the settings
3. Make sure the `calypso_settings_verbum_subscription_modal_updated` event is fired

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
