### PR TITLE
A4A: Add required field markers on Partner directory forms.

### DIFF
--- a/client/a8c-for-agencies/components/form/field/index.tsx
+++ b/client/a8c-for-agencies/components/form/field/index.tsx
@@ -7,7 +7,7 @@ type Props = {
 	label: string;
 	sub?: string;
 	description?: string;
-	isOptional?: boolean;
+	showOptionalLabel?: boolean;
 	children: ReactNode;
 	isRequired?: boolean;
 };
@@ -17,7 +17,7 @@ export default function FormField( {
 	sub,
 	children,
 	description,
-	isOptional,
+	showOptionalLabel,
 	isRequired,
 }: Props ) {
 	const translate = useTranslate();
@@ -27,7 +27,7 @@ export default function FormField( {
 			<div className="a4a-form__section-field-heading">
 				<h3 className="a4a-form__section-field-label">
 					{ label } { isRequired && <span className="a4a-form__section-field-required">*</span> }
-					{ isOptional && (
+					{ showOptionalLabel && (
 						<span className="a4a-form__section-field-optional">({ translate( 'optional' ) })</span>
 					) }
 				</h3>

--- a/client/a8c-for-agencies/components/form/field/index.tsx
+++ b/client/a8c-for-agencies/components/form/field/index.tsx
@@ -27,7 +27,7 @@ export default function FormField( {
 			<div className="a4a-form__section-field-heading">
 				<h3 className="a4a-form__section-field-label">
 					{ label } { isRequired && <span className="a4a-form__section-field-required">*</span> }
-					{ showOptionalLabel && (
+					{ ! isRequired && showOptionalLabel && (
 						<span className="a4a-form__section-field-optional">({ translate( 'optional' ) })</span>
 					) }
 				</h3>

--- a/client/a8c-for-agencies/components/form/field/index.tsx
+++ b/client/a8c-for-agencies/components/form/field/index.tsx
@@ -9,17 +9,24 @@ type Props = {
 	description?: string;
 	isOptional?: boolean;
 	children: ReactNode;
+	isRequired?: boolean;
 };
 
-export default function FormField( { label, sub, children, description, isOptional }: Props ) {
+export default function FormField( {
+	label,
+	sub,
+	children,
+	description,
+	isOptional,
+	isRequired,
+}: Props ) {
 	const translate = useTranslate();
 
 	return (
 		<div className="a4a-form__section-field">
 			<div className="a4a-form__section-field-heading">
 				<h3 className="a4a-form__section-field-label">
-					{ label }
-
+					{ label } { isRequired && <span className="a4a-form__section-field-required">*</span> }
 					{ isOptional && (
 						<span className="a4a-form__section-field-optional">({ translate( 'optional' ) })</span>
 					) }

--- a/client/a8c-for-agencies/components/form/field/style.scss
+++ b/client/a8c-for-agencies/components/form/field/style.scss
@@ -27,5 +27,5 @@
 }
 
 .a4a-form__section-field-required {
-	color: var(--color-error);
+	color: var(--color-neutral-50);
 }

--- a/client/a8c-for-agencies/components/form/field/style.scss
+++ b/client/a8c-for-agencies/components/form/field/style.scss
@@ -25,3 +25,7 @@
 .a4a-form__section-field-optional {
 	margin-inline-start: 4px;
 }
+
+.a4a-form__section-field-required {
+	color: var(--color-error);
+}

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
@@ -31,7 +31,6 @@ export default function useDetailsForm( { initialFormData }: Props ) {
 			formData.website.length > 0 &&
 			formData.bioDescription.length > 0 &&
 			formData.logoUrl.length > 0 &&
-			formData.landingPageUrl.length > 0 &&
 			formData.country?.length > 0 &&
 			formData.industry.length > 0 &&
 			formData.services.length > 0 &&

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -204,6 +204,11 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 					/>
 				</FormField>
 			</FormSection>
+
+			<div className="partner-directory-agency-cta__required-information">
+				{ translate( '* indicates a required information' ) }
+			</div>
+
 			<div className="partner-directory-agency-cta__footer">
 				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>
 					{ translate( 'Save public profile' ) }

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -206,7 +206,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			</FormSection>
 
 			<div className="partner-directory-agency-cta__required-information">
-				{ translate( '* indicates a required information' ) }
+				{ translate( '* indicates required information' ) }
 			</div>
 
 			<div className="partner-directory-agency-cta__footer">

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -86,7 +86,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			}
 		>
 			<FormSection title={ translate( 'Agency information' ) }>
-				<FormField label={ translate( 'Company name' ) }>
+				<FormField label={ translate( 'Company name' ) } isRequired>
 					<TextControl
 						value={ formData.name }
 						onChange={ ( value ) => setFormFields( { name: value } ) }
@@ -95,13 +95,14 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 				<FormField
 					label={ translate( 'Company email' ) }
 					description={ translate( 'Client inquiries and leads will go to this email.' ) }
+					isRequired
 				>
 					<TextControl
 						value={ formData.email }
 						onChange={ ( value ) => setFormFields( { email: value } ) }
 					/>
 				</FormField>
-				<FormField label={ translate( 'Company website' ) }>
+				<FormField label={ translate( 'Company website' ) } isRequired>
 					<TextControl
 						value={ formData.website }
 						onChange={ ( value ) => setFormFields( { website: value } ) }
@@ -112,19 +113,20 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 					description={ translate(
 						"Optional: Include your custom landing page for leads from Automattic platforms. We'll direct clients to this page."
 					) }
+					isOptional
 				>
 					<TextControl
 						value={ formData.landingPageUrl }
 						onChange={ ( value ) => setFormFields( { landingPageUrl: value } ) }
 					/>
 				</FormField>
-				<FormField label={ translate( 'Company bio' ) }>
+				<FormField label={ translate( 'Company bio' ) } isRequired>
 					<TextareaControl
 						value={ formData.bioDescription }
 						onChange={ ( value ) => setFormFields( { bioDescription: value } ) }
 					/>
 				</FormField>
-				<FormField label={ translate( 'Company location' ) }>
+				<FormField label={ translate( 'Company location' ) } isRequired>
 					<SearchableDropdown
 						value={ formData.country }
 						onChange={ ( value ) => {
@@ -139,6 +141,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 					description={ translate(
 						'Upload your agency logo sized at 800px by 320px. Format allowed: JPG, PNG'
 					) }
+					isRequired
 				>
 					<TextControl
 						value={ formData.logoUrl }
@@ -162,25 +165,25 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 						}
 					/>
 				</FormField>
-				<FormField label={ translate( 'Industry' ) }>
+				<FormField label={ translate( 'Industry' ) } isRequired>
 					<IndustrySelector
 						industry={ formData.industry }
 						setIndustry={ ( industry ) => setFormFields( { industry: industry } ) }
 					/>
 				</FormField>
-				<FormField label={ translate( 'Services you offer' ) }>
+				<FormField label={ translate( 'Services you offer' ) } isRequired>
 					<ServicesSelector
 						selectedServices={ formData.services }
 						setServices={ ( services ) => setFormFields( { services } ) }
 					/>
 				</FormField>
-				<FormField label={ translate( 'Products you work with' ) }>
+				<FormField label={ translate( 'Products you work with' ) } isRequired>
 					<ProductsSelector
 						selectedProducts={ formData.products }
 						setProducts={ ( products ) => setFormFields( { products } ) }
 					/>
 				</FormField>
-				<FormField label={ translate( 'Languages spoken' ) }>
+				<FormField label={ translate( 'Languages spoken' ) } isRequired>
 					<LanguageSelector
 						selectedLanguages={ formData.languagesSpoken }
 						setLanguages={ ( languagesSpoken ) => setFormFields( { languagesSpoken } ) }
@@ -194,7 +197,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 					'Optionally set your minimum budget. Clients can filter these details to find the right agency.'
 				) }
 			>
-				<FormField label={ translate( 'Minimum project budget' ) }>
+				<FormField label={ translate( 'Minimum project budget' ) } isRequired>
 					<BudgetSelector
 						budgetLowerRange={ formData.budgetLowerRange }
 						setBudget={ ( budget: string ) => setFormFields( { budgetLowerRange: budget } ) }

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -113,7 +113,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 					description={ translate(
 						"Optional: Include your custom landing page for leads from Automattic platforms. We'll direct clients to this page."
 					) }
-					isOptional
+					showOptionalLabel
 				>
 					<TextControl
 						value={ formData.landingPageUrl }

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
@@ -98,6 +98,7 @@ export default function useExpertiseForm( { initialFormData }: Props ) {
 			formData.services.length > 0 &&
 			formData.products.length > 0 &&
 			formData.directories.length > 0 &&
+			formData.feedbackUrl.length > 0 &&
 			// Ensure that each directory request has 5 valid URLs
 			formData.directories.every( ( { urls } ) => {
 				return urls.every( ( url ) => url && validateURL( url ) ) && areURLsUnique( urls );

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -117,6 +117,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 					description={ translate(
 						'We allow each agency to offer up to five services to help you focus on what you do best.'
 					) }
+					isRequired
 				>
 					<ServicesSelector
 						selectedServices={ services }
@@ -129,7 +130,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 					/>
 				</FormField>
 
-				<FormField label={ translate( 'What products do you work with?' ) }>
+				<FormField label={ translate( 'What products do you work with?' ) } isRequired>
 					<ProductsSelector
 						selectedProducts={ products }
 						setProducts={ ( value ) =>
@@ -146,6 +147,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 				<FormField
 					label={ translate( 'Automattic Partner Directories' ) }
 					sub={ translate( 'Select the Automattic directories you would like to appear on.' ) }
+					isRequired
 				>
 					<div className="partner-directory-agency-expertise__directory-options">
 						{ directoryOptions.map( ( directory ) => (
@@ -166,6 +168,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 						sub={ translate(
 							"For each directory you selected, provide URLs of 5 client sites you've worked on. This helps us gauge your expertise."
 						) }
+						isRequired
 					>
 						<div className="partner-directory-agency-expertise__directory-client-sites">
 							{ directories.map( ( { directory } ) => (

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -195,7 +195,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 					description={ translate(
 						'Share a link to your customer feedback from Google, Clutch, Facebook, etc., or testimonials featured on your website. If you don’t have online reviews, provide a link to client references or case studies.'
 					) }
-					isOptional
+					isRequired
 				>
 					<TextControl
 						type="text"

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -211,6 +211,10 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 				</FormField>
 			</FormSection>
 
+			<div className="partner-directory-agency-cta__required-information">
+				{ translate( '* indicates a required information' ) }
+			</div>
+
 			<div className="partner-directory-agency-cta__footer">
 				<Button
 					href={ `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_DASHBOARD_SLUG }` }

--- a/client/a8c-for-agencies/sections/partner-directory/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/style.scss
@@ -27,3 +27,9 @@
 		font-size: rem(14px);
 	}
 }
+
+.partner-directory-agency-cta__required-information {
+	font-size: rem(14px);
+	color: var(--color-neutral-50);
+	margin-block-start: -32px;
+}


### PR DESCRIPTION
This pull request adds required field indicators to the Partner directory forms.

| Before | After |
|--------|--------|
| <img width="677" alt="Screenshot 2024-06-19 at 12 15 01 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f584b222-b652-480d-90bf-163e959975ab"> | <img width="670" alt="Screenshot 2024-06-19 at 12 42 01 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e8141ac4-2ff5-41cf-92c6-85ff24df5c16"> | 


Additionally, add information about the required indicator at the bottom of the form.
<img width="763" alt="Screenshot 2024-06-19 at 12 54 36 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9a6ab9d4-efbb-40c6-a2df-07896cb0c30b">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/688
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/689

## Proposed Changes

* Add the `isRequired` prop in the FormField component. Update the expertise and details form to use the new prop to mark the required fields.
* Make the Client's landing page an optional field. address https://github.com/Automattic/automattic-for-agencies-dev/issues/688
* Add information about required indicator at the bottom of the form.


## Testing Instructions
* Use the A4A live link and go to `/partner-directory/dashboard`
* Confirm that when filling out the expertise form, all required fields have the marker.
* Confirm that when filling out the details form, all required fields have the marker.
* Confirm that the Client's landing page is not required.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
