### PR TITLE
Update q1 styling to latest design

### DIFF
--- a/client/signup/steps/initial-intent/styles.scss
+++ b/client/signup/steps/initial-intent/styles.scss
@@ -48,7 +48,7 @@
 					.flow-question__heading {
 						margin-bottom: 4px;
 						line-height: 24px;
-						letter-spacing: -0.7px;
+						letter-spacing: -0.6px;
 					}
 
 					.flow-question__description {

--- a/client/signup/steps/initial-intent/styles.scss
+++ b/client/signup/steps/initial-intent/styles.scss
@@ -43,17 +43,27 @@
 				flex-direction: column;
 
 				.flow-question {
-					max-width: 430px;
+					max-width: 452px;
 
 					.flow-question__heading {
 						margin-bottom: 4px;
 						line-height: 24px;
+						letter-spacing: -0.7px;
 					}
 
 					.flow-question__description {
 						line-height: 20px;
 						letter-spacing: -0.15px;
 						margin-bottom: 0;
+					}
+
+					.components-card__body {
+						padding: 24px;
+
+						.components-flex {
+							gap: 1rem;
+						}
+
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1718646563153269-slack-C02T4NVL4JJ

## Proposed Changes

* Update Guided Onboarding Segmentation Q1 styling

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Match the latest design for Segmentation Q1

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/start/guided/initial-intent?flags=onboarding/guided`
* Verify `Creating a site for myself, a business, or a friend` for Q1 option 1 is displayed on one line like the design: https://www.figma.com/design/3u71fUJraClkRQiLrAORPf/Trail-Map-Project?node-id=4464-13366&m=dev

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
