### PR TITLE
Allow to set feature flags with dotenv

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -17,6 +17,7 @@ const ReactRefreshWebpackPlugin = require( '@pmmmwh/react-refresh-webpack-plugin
 const SentryCliPlugin = require( '@sentry/webpack-plugin' );
 const autoprefixerPlugin = require( 'autoprefixer' );
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
+const Dotenv = require( 'dotenv-webpack' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
 const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' );
 const pkgDir = require( 'pkg-dir' );
@@ -294,6 +295,7 @@ const webpackConfig = {
 	},
 	node: false,
 	plugins: [
+		new Dotenv(),
 		new webpack.DefinePlugin( {
 			'typeof window': JSON.stringify( 'object' ),
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),

--- a/config/README.md
+++ b/config/README.md
@@ -29,7 +29,7 @@ You can search for feature flags by partial string or regular expression with th
 
 Run `yarn feature-search [search]` from the root calypso directory to see example searches.
 
-You can also activate feature flags only in your development environment. To do this, create a `.env` file in the root folder of the cloned repository. Add the variable `ACTIVE_FEATURE_FLAGS`, and specify the feature flags you want to activate, separated by commas. For more details, see https://github.com/motdotla/dotenv.
+You can also activate feature flags only in your development environment. To do this, create a `.env` file in the root folder of the cloned repository. Add the variable `ACTIVE_FEATURE_FLAGS`, and specify the feature flags you want to activate, as a string separated by commas. For more details of how to create the `.env` file, see https://github.com/mrsteele/dotenv-webpack#create-a-env-file.
 
 ### Progression of Environments
 

--- a/config/README.md
+++ b/config/README.md
@@ -29,6 +29,8 @@ You can search for feature flags by partial string or regular expression with th
 
 Run `yarn feature-search [search]` from the root calypso directory to see example searches.
 
+You can also activate feature flags only in your development environment. To do this, create a `.env` file in the root folder of the cloned repository. Add the variable `ACTIVE_FEATURE_FLAGS`, and specify the feature flags you want to activate, separated by commas. For more details, see https://github.com/motdotla/dotenv.
+
 ### Progression of Environments
 
 When working with feature flags, there is a progression of environments that should be considered.

--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
 		"chroma-js": "^2.1.2",
 		"css-loader": "^6.11.0",
 		"doctrine": "^3.0.0",
+		"dotenv-webpack": "^8.1.0",
 		"eslint": "^8.57.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-nibble": "^8.1.0",

--- a/packages/create-calypso-config/src/index.ts
+++ b/packages/create-calypso-config/src/index.ts
@@ -68,8 +68,21 @@ const config =
  */
 const isEnabled =
 	( data: ConfigData ) =>
-	( feature: string ): boolean =>
-		( data.features && !! data.features[ feature ] ) || false;
+	( feature: string ): boolean => {
+		// Feature flags activated from environment variables.
+		if (
+			process.env.ACTIVE_FEATURE_FLAGS &&
+			typeof process.env.ACTIVE_FEATURE_FLAGS === 'string'
+		) {
+			const env_active_feature_flags = process.env.ACTIVE_FEATURE_FLAGS?.split( ',' );
+
+			if ( env_active_feature_flags.includes( feature ) ) {
+				return true;
+			}
+		}
+
+		return ( data.features && !! data.features[ feature ] ) || false;
+	};
 
 /**
  * Gets a list of all enabled features.

--- a/yarn.lock
+++ b/yarn.lock
@@ -15356,6 +15356,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv-defaults@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "dotenv-defaults@npm:2.0.2"
+  dependencies:
+    dotenv: "npm:^8.2.0"
+  checksum: 14b7b8f6c21a30404106384398728746e63405bfeabe47ef7aadd0e81de49986d5896a612e5b1acddf655af6472a24947b7b113aa3ef3270a2877afa9c5bd287
+  languageName: node
+  linkType: hard
+
 "dotenv-expand@npm:^10.0.0":
   version: 10.0.0
   resolution: "dotenv-expand@npm:10.0.0"
@@ -15370,10 +15379,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv-webpack@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "dotenv-webpack@npm:8.1.0"
+  dependencies:
+    dotenv-defaults: "npm:^2.0.2"
+  peerDependencies:
+    webpack: ^4 || ^5
+  checksum: 7a64587fc96eba8e4ffccf56d6af09606611a32bc5cf04a37057b8c2881bcd11bf43c3395404581be734ae7fd2788471ceac76cb3d0ba1283e675223f98e5816
+  languageName: node
+  linkType: hard
+
 "dotenv@npm:^16.0.0":
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
   checksum: 109457ac5f9e930ca8066ea33887b6f839ab24d647a7a8b49ddcd1f32662e2c35591c5e5b9819063e430148a664d0927f0cbe60cf9575d89bc524f47ff7e78f0
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^8.2.0":
+  version: 8.6.0
+  resolution: "dotenv@npm:8.6.0"
+  checksum: 6750431dea8efbd54b9f2d9681b04e1ccc7989486461dcf058bb708d9e3d63b04115fcdf8840e38ad1e24a4a2e1e7c1560626c5e3ac7bc09371b127c49e2d45f
   languageName: node
   linkType: hard
 
@@ -33260,6 +33287,7 @@ __metadata:
     css-loader: "npm:^6.11.0"
     debug: "npm:^4.3.3"
     doctrine: "npm:^3.0.0"
+    dotenv-webpack: "npm:^8.1.0"
     enhanced-resolve: "npm:5.9.3"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

I'm proposing here to add a way to activate feature flags per dev environment. It would be done with `.env` through the variable `ACTIVE_FEATURE_FLAGS`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We faced an issue (See #91892) where multiple devs were working on related features. Some needed to activate a feature flag to write the new feature, while others needed the previous behavior to work for integration purposes.

With the new approach, we can keep the feature flag disabled in all config files, and activate it locally. So we don't need to worry about git-ignoring the config files locally, or changing them every time and maybe committing it accidentally.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* First, test that the feature flags are working properly.
  * Check that an activated feature flag is still activated.
  * Check that a deactivated feature flag continues deactivated.
* Create an `.env` file in the root of the cloned repository.
  * Add the following content: `ACTIVE_FEATURE_FLAGS="feature-flag-1,feature-flag-2"` (Use 2 existing and not activated feature flags, or add the check somewhere to test it - `config.isEnabled`).
* Check that the features are now activated in your environment.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
