### PR TITLE
Start With: Add a route to the start with landing page

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -196,21 +196,34 @@ const LayoutLoggedOut = ( {
 			'subscriptions',
 			'theme',
 			'themes',
+			'start-with',
 		].includes( sectionName ) &&
 		! isReaderTagPage &&
 		! isReaderSearchPage &&
 		! isReaderDiscoverPage
 	) {
 		const nonMonochromeSections = [ 'plugins' ];
+		const whiteNavbarSections = [ 'start-with' ];
+
+		const className = clsx( {
+			'is-style-monochrome':
+				isEnabled( 'site-profiler/metrics' ) && ! nonMonochromeSections.includes( sectionName ),
+			'is-style-white':
+				isEnabled( 'start-with/square-payments' ) && whiteNavbarSections.includes( sectionName ),
+		} );
 
 		masterbar = (
 			<UniversalNavbarHeader
 				isLoggedIn={ isLoggedIn }
 				sectionName={ sectionName }
+				className={ className }
 				{ ...( isEnabled( 'site-profiler/metrics' ) &&
 					! nonMonochromeSections.includes( sectionName ) && {
 						logoColor: 'white',
-						className: 'is-style-monochrome',
+					} ) }
+				{ ...( isEnabled( 'start-with/square-payments' ) &&
+					whiteNavbarSections.includes( sectionName ) && {
+						logoColor: 'black',
 					} ) }
 				{ ...( sectionName === 'subscriptions' && { variant: 'minimal' } ) }
 				{ ...( sectionName === 'patterns' && {

--- a/client/sections.js
+++ b/client/sections.js
@@ -247,6 +247,15 @@ const sections = [
 		isomorphic: true,
 	},
 	{
+		name: 'start-with',
+		paths: [ '/start-with' ],
+		module: 'calypso/start-with',
+		enableLoggedOut: true,
+		group: 'start-with',
+		isomorphic: true,
+		trackLoadPerformance: true,
+	},
+	{
 		name: 'jetpack-app',
 		paths: [ '/jetpack-app' ],
 		module: 'calypso/jetpack-app',

--- a/client/start-with/controller.tsx
+++ b/client/start-with/controller.tsx
@@ -1,0 +1,24 @@
+import config from '@automattic/calypso-config';
+import page, { Context } from '@automattic/calypso-router';
+import Main from 'calypso/components/main';
+import { StartWithSquarePayments } from './square-payments';
+
+export function startWithSquarePaymentsContext( context: Context, next: () => void ): void {
+	if ( ! config.isEnabled( 'start-with/square-payments' ) ) {
+		page.redirect( '/' );
+		return;
+	}
+
+	context.primary = (
+		<Main wideLayout>
+			<StartWithSquarePayments />
+		</Main>
+	);
+
+	next();
+}
+
+export function redirectToSquarePayments(): void {
+	page.redirect( '/start-with/square-payments' );
+	return;
+}

--- a/client/start-with/index.node.ts
+++ b/client/start-with/index.node.ts
@@ -1,0 +1,18 @@
+import { getLanguageRouteParam } from '@automattic/i18n-utils';
+import { makeLayout, setLocaleMiddleware } from 'calypso/controller';
+import { serverRouter } from 'calypso/server/isomorphic-routing';
+
+/**
+ * Using the server routing for this section has the sole purpose of defining
+ * a named route parameter for the language, that is used to set `context.lang`
+ * via the `setLocaleMiddleware()`.
+ *
+ * The `context.lang` value is then used in the server renderer to properly
+ * attach the translation files to the page.
+ * @see https://github.com/Automattic/wp-calypso/blob/trunk/client/server/render/index.js#L171.
+ */
+export default ( router: ReturnType< typeof serverRouter > ) => {
+	const lang = getLanguageRouteParam();
+
+	router( [ `/${ lang }/start-with(/*)?` ], setLocaleMiddleware(), makeLayout );
+};

--- a/client/start-with/index.web.ts
+++ b/client/start-with/index.web.ts
@@ -1,0 +1,11 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
+import {
+	redirectToSquarePayments,
+	startWithSquarePaymentsContext,
+} from 'calypso/start-with/controller';
+
+export default function () {
+	page( '/start-with', redirectToSquarePayments );
+	page( '/start-with/square-payments', startWithSquarePaymentsContext, makeLayout, clientRender );
+}

--- a/client/start-with/package.json
+++ b/client/start-with/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.node.ts",
+	"browser": "index.web.ts"
+}

--- a/client/start-with/square-payments/index.tsx
+++ b/client/start-with/square-payments/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const StartWithSquarePayments: React.FC = () => {
+	return <div>Start with SquarePayments</div>;
+};

--- a/config/development.json
+++ b/config/development.json
@@ -191,6 +191,7 @@
 		"redirect-fallback-browsers": false,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
+		"start-with/square-payments": true,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -118,6 +118,7 @@
 		"reader/public-tag-pages": true,
 		"redirect-fallback-browsers": true,
 		"safari-idb-mitigation": true,
+		"start-with/square-payments": false,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/config/production.json
+++ b/config/production.json
@@ -159,6 +159,7 @@
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
+		"start-with/square-payments": false,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -153,6 +153,7 @@
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
+		"start-with/square-payments": true,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -889,3 +889,43 @@ $x-menu-heading-line-height-wide: $x-menu-heading-font-size-wide + 7px; /* 1 */
 }
 
 /* End site profiler section overrides */
+
+/* Start start with section overrides */
+
+.is-style-white {
+	.x-root {
+		.masterbar-menu {
+			.masterbar {
+				border-bottom: none;
+				background: #fff;
+				height: 56px;
+				position: relative;
+				.x-nav {
+					height: 56px;
+				}
+			}
+		}
+	}
+
+	.x-nav-item {
+		color: #000;
+
+		.cta-btn-nav {
+			border-radius: 4px;
+			background: inherit !important;
+			border: 1px solid #000;
+		}
+
+		.x-nav-link__chevron::after,
+		.x-nav-link-chevron::before {
+			content: $lp-chevron-content-down;
+			color: #000;
+		}
+
+		.x-nav-link.x-nav-link.x-nav-link__primary {
+			color: #000 !important;
+		}
+	}
+}
+
+/* End start with section overrides */


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7780

## Proposed Changes

* Create the `start-with/square-payments` flag, enabled only in development and WPCalypso
* Create a route to `/start-with/square-payments`
  * The route pointing to `/start-with` automatically redirects to `/start-with/square-payments`
* Add a new style for white navbar when the user is logged out


## Why are these changes being made?

To create a new landing page with a custom onboarding process for Square Payments

## Testing Instructions

* As a logged out user, go to  `/start-with/square-payments`, and check if what you see matches the image below
* As a logged in user, go to  `/start-with/square-payments`, and check if what you see matches the image below
* Go to `/start-with` and check if you are redirected to  `/start-with/square-payments`

| Logged-out  | Logged-in |
| ------------- | ------------- |
|![CleanShot 2024-06-18 at 15 57 55@2x](https://github.com/Automattic/wp-calypso/assets/5039531/816bbddb-b2ba-425b-8d39-36dd81fd280c)|![CleanShot 2024-06-18 at 15 57 47@2x](https://github.com/Automattic/wp-calypso/assets/5039531/40e284d9-3335-4644-a541-19e4376fb1b4)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?