### PR TITLE
Stats: disable functionality for commercial upgrade notice dismiss

### DIFF
--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -5,7 +5,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { trackStatsAnalyticsEvent } from '../utils';
@@ -20,22 +19,7 @@ const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) =
 const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
-	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
-	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
-		siteId,
-		'commercial_site_upgrade',
-		'postponed',
-		30 * 24 * 3600
-	);
-
-	const dismissNotice = () => {
-		isOdysseyStats
-			? recordTracksEvent( 'jetpack_odyssey_stats_commercial_site_upgrade_notice_dismissed' )
-			: recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_dismissed' );
-
-		setNoticeDismissed( true );
-		postponeNoticeAsync();
-	};
+	const [ noticeDismissed ] = useState( false );
 
 	const gotoJetpackStatsProduct = () => {
 		isOdysseyStats
@@ -79,7 +63,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 			<NoticeBanner
 				level="info"
 				title={ translate( 'Upgrade to Stats Commercial' ) }
-				onClose={ hideCloseButton ? () => {} : dismissNotice }
+				onClose={ () => {} }
 				hideCloseButton={ hideCloseButton }
 			>
 				{ translate(

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -55,7 +55,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 				level="info"
 				title={ translate( 'Upgrade to Stats Commercial' ) }
 				onClose={ () => {} }
-				hideCloseButton={ false }
+				hideCloseButton
 			>
 				{ translate(
 					'{{p}}Upgrade to get priority support and access to upcoming advanced features. You’ll need to purchase a commercial license based on your site type. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -4,7 +4,7 @@ import NoticeBanner from '@automattic/components/src/notice-banner';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { trackStatsAnalyticsEvent } from '../utils';
@@ -19,7 +19,6 @@ const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) =
 const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
-	const [ noticeDismissed ] = useState( false );
 
 	const gotoJetpackStatsProduct = () => {
 		isOdysseyStats
@@ -37,22 +36,14 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 	};
 
 	useEffect( () => {
-		if ( ! noticeDismissed ) {
-			isOdysseyStats
-				? recordTracksEvent( 'jetpack_odyssey_stats_commercial_site_upgrade_notice_viewed' )
-				: recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_viewed' );
-		}
-	}, [ noticeDismissed, isOdysseyStats ] );
-
-	if ( noticeDismissed ) {
-		return null;
-	}
+		isOdysseyStats
+			? recordTracksEvent( 'jetpack_odyssey_stats_commercial_site_upgrade_notice_viewed' )
+			: recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_viewed' );
+	}, [ isOdysseyStats ] );
 
 	const learnMoreLink = isWPCOMSite
 		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
 		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
-
-	const hideCloseButton = true; // currently hiding close button and dismiss click functionality is disabled for all commerical upgrade notices. To add more specific conditionals later, we can modify here
 
 	return (
 		<div
@@ -64,7 +55,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 				level="info"
 				title={ translate( 'Upgrade to Stats Commercial' ) }
 				onClose={ () => {} }
-				hideCloseButton={ hideCloseButton }
+				hideCloseButton={ false }
 			>
 				{ translate(
 					'{{p}}Upgrade to get priority support and access to upcoming advanced features. You’ll need to purchase a commercial license based on your site type. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -68,6 +68,8 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
 		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
 
+	const hideCloseButton = true; // currently hiding close button and dismiss click functionality is disabled for all commerical upgrade notices. To add more specific conditionals later, we can modify here
+
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
@@ -77,7 +79,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 			<NoticeBanner
 				level="info"
 				title={ translate( 'Upgrade to Stats Commercial' ) }
-				onClose={ dismissNotice }
+				onClose={ hideCloseButton ? () => {} : dismissNotice }
 				hideCloseButton
 			>
 				{ translate(

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -80,7 +80,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 				level="info"
 				title={ translate( 'Upgrade to Stats Commercial' ) }
 				onClose={ hideCloseButton ? () => {} : dismissNotice }
-				hideCloseButton
+				hideCloseButton={ hideCloseButton }
 			>
 				{ translate(
 					'{{p}}Upgrade to get priority support and access to upcoming advanced features. You’ll need to purchase a commercial license based on your site type. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/14

## Proposed Changes

* This PR builds upon the previous PR #91872 to now disable dismiss functionality completely on the notice, rather than only hiding the dismiss icon. 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a testing site which is commercial, check for the commercial upgrade notice. First, confirm that there is no "X" symbol/way to dismiss this notice.
* Secondly, check that dismiss functionality has been disabled and there are now no other ways to dismiss this notice. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
