### PR TITLE
Stats: Fixing margins for the purchase notice

### DIFF
--- a/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/free-plan-purchase-success-notice.tsx
@@ -73,7 +73,7 @@ const FreePlanPurchaseSuccessJetpackStatsNotice = ( {
 									onClick={ ( e ) =>
 										handleUpgradeClick( e, getStatsPurchaseURL( siteId ), isOdysseyStats )
 									}
-									className="notice-banner__action-link"
+									className="notice-banner__action-link notice-banner__action-link--inline"
 									href={ getStatsPurchaseURL( siteId ) }
 									target="_blank"
 									rel="noreferrer"

--- a/packages/components/src/notice-banner/style.scss
+++ b/packages/components/src/notice-banner/style.scss
@@ -56,6 +56,10 @@ $banner-title-height: 22px;
 			box-shadow: none;
 		}
 
+		&.notice-banner__action-link--inline {
+			margin-left: 0;
+		}
+
 		& > span {
 			border-bottom: 1.5px solid var(--jp-black);
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to a regression.

## Proposed Changes

* Fix margins for inline links.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* it's a regression caused by another link styling (Learn more)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* check out the code locally
* force the free success notice to show up
* verify the margins

| Before | After |
| --- | --- |
| <img width="1167" alt="SCR-20240619-lyym" src="https://github.com/Automattic/wp-calypso/assets/112354940/5b2583fa-b330-4331-8234-bc97f3c4b481"> | ![SCR-20240619-mjrq](https://github.com/Automattic/wp-calypso/assets/112354940/c77ae7de-6448-4050-a19f-6560306dbfb7) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?