### PR TITLE
Guided Onboarding: Add back button for site migration step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -196,16 +196,6 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 		return ( shouldHideBasedOnRef || shouldHideBasedOnVariant ) && ! shouldNotHideBasedOnRef;
 	};
 
-	const handleGoBack = () => {
-		const ref = urlQueryParams.get( 'ref' ) || '';
-
-		if ( ref === GUIDED_ONBOARDING_FLOW_REFERRER ) {
-			window.location.href = '/start/guided/initial-intent';
-		} else {
-			navigation?.goBack && navigation.goBack();
-		}
-	};
-
 	usePresalesChat( 'wpcom', true, true );
 
 	return (
@@ -218,7 +208,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 				hideBack={ shouldHideBackButton() }
 				hideSkip
 				hideFormattedHeader
-				goBack={ handleGoBack }
+				goBack={ navigation?.goBack }
 				goNext={ navigation?.submit }
 				isFullLayout
 				stepContent={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -11,6 +11,7 @@ import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
 import wpcom from 'calypso/lib/wp';
+import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
 import type { Step } from '../../types';
 import type { UrlData } from 'calypso/blocks/import/types';
 
@@ -190,8 +191,19 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 		const ref = urlQueryParams.get( 'ref' ) || '';
 		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'calypso-importer' ].includes( ref );
 		const shouldHideBasedOnVariant = [ HOSTED_SITE_MIGRATION_FLOW ].includes( variantSlug || '' );
+		const shouldNotHideBasedOnRef = [ GUIDED_ONBOARDING_FLOW_REFERRER ].includes( ref );
 
-		return shouldHideBasedOnRef || shouldHideBasedOnVariant;
+		return ( shouldHideBasedOnRef || shouldHideBasedOnVariant ) && ! shouldNotHideBasedOnRef;
+	};
+
+	const handleGoBack = () => {
+		const ref = urlQueryParams.get( 'ref' ) || '';
+
+		if ( ref === GUIDED_ONBOARDING_FLOW_REFERRER ) {
+			window.location.href = '/start/guided/initial-intent';
+		} else {
+			navigation?.goBack && navigation.goBack();
+		}
 	};
 
 	usePresalesChat( 'wpcom', true, true );
@@ -206,7 +218,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 				hideBack={ shouldHideBackButton() }
 				hideSkip
 				hideFormattedHeader
-				goBack={ navigation.goBack }
+				goBack={ handleGoBack }
 				goNext={ navigation?.submit }
 				isFullLayout
 				stepContent={

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -10,6 +10,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { addQueryArgs } from 'calypso/lib/url';
+import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
 import { useIsSiteAdmin } from '../hooks/use-is-site-admin';
 import { useSiteData } from '../hooks/use-site-data';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
@@ -329,6 +330,9 @@ const siteMigration: Flow = {
 					return navigate( STEPS.SITE_MIGRATION_IDENTIFY.slug );
 				}
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
+					if ( urlQueryParams.get( 'ref' ) === GUIDED_ONBOARDING_FLOW_REFERRER ) {
+						window.location.assign( '/start/guided/initial-intent' );
+					}
 					return exitFlow( `/setup/site-setup/goals?${ urlQueryParams }` );
 				}
 

--- a/client/signup/steps/initial-intent/constants.ts
+++ b/client/signup/steps/initial-intent/constants.ts
@@ -1,1 +1,2 @@
 export const GUIDED_FLOW_SEGMENTATION_SURVEY_KEY = 'guided-onboarding-flow';
+export const GUIDED_ONBOARDING_FLOW_REFERRER = 'guided-onboarding';

--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -9,7 +9,7 @@ import { flowQuestionComponentMap } from 'calypso/components/survey-container/co
 import { QuestionConfiguration } from 'calypso/components/survey-container/types';
 import { getSegmentedIntent } from 'calypso/my-sites/plans/utils/get-segmented-intent';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { GUIDED_FLOW_SEGMENTATION_SURVEY_KEY } from './constants';
+import { GUIDED_FLOW_SEGMENTATION_SURVEY_KEY, GUIDED_ONBOARDING_FLOW_REFERRER } from './constants';
 import { SurveyData } from './types';
 import './styles.scss';
 
@@ -65,7 +65,6 @@ export default function InitialIntentStep( props: Props ) {
 	}, [] );
 
 	const getRedirectForAnswers = ( _answerKeys: string[] ): string => {
-		const referrer = 'guided-onboarding';
 		let redirect = '';
 
 		if ( _answerKeys.includes( 'import' ) ) {
@@ -79,7 +78,7 @@ export default function InitialIntentStep( props: Props ) {
 		}
 
 		if ( redirect ) {
-			return `${ redirect }?ref=${ referrer }`;
+			return `${ redirect }?ref=${ GUIDED_ONBOARDING_FLOW_REFERRER }`;
 		}
 
 		return redirect;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7797

## Proposed Changes

* Adds back button to site migration step

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Allow users to navigate back to the segmentation survey questions with the UI back button.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `start/guided/initial-intent?flags=onboarding/guided` and click the `Migrating or importing an existing site` option.
* Verify the back button appears on the site migration step. It should navigate back to the Guided onboarding initial intent step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
