### PR TITLE
Plans Grid: fix CTA for spotlight plan

### DIFF
--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -142,7 +142,8 @@ const PlanFeatures2023GridActions = ( {
 			selectedStorageOptionForPlan && addOn?.featureSlugs?.includes( selectedStorageOptionForPlan )
 	)?.checkoutLink;
 
-	const nonDefaultStorageOptionSelected = defaultStorageOption !== selectedStorageOptionForPlan;
+	const nonDefaultStorageOptionSelected =
+		selectedStorageOptionForPlan && defaultStorageOption !== selectedStorageOptionForPlan;
 
 	let actionButton = (
 		<Plans2023Tooltip


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Currently, the spotlight plan always shows an 'Upgrade' CTA for the Explorer and Starter plans.
<img width="1259" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/d5ef5a81-fc3b-46d9-a72a-0ba7c5676479">

This happened because the following condition resulted in `true` as `selectedStorageOptionForPlan` is `undefined` for these plans. We do not show a storage drop-down for these plans.
https://github.com/Automattic/wp-calypso/blob/550316e3939093283d55fde4e25d4d0f3956ebeb/packages/plans-grid-next/src/components/actions.tsx#L145

This PR fixes the issue by simply checking if the `selectedStorageOptionForPlan` is defined. If it's not, semantically, it means that no storage option is selected, and thus, `nonDefaultStorageOptionSelected` is `false`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Explained above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/<site slug>` for a site on an Explorer/Starter plan.
* Confirm that the CTA is "Manage Plan"
* <img width="1249" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/69b56173-b51d-4c9b-b655-6dc78c66ee98">
* Go to `/plans/<site slug>` for a site on a Creator plan.
* Confirm that the CTA is "Manage Plan"
* Confirm that on choosing a storage option, the CTA is "Upgrade".
* <img width="1219" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/51088c36-2391-4a85-9d1a-889b8fa1eac3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
