### PR TITLE
A4A > Referrals: Automated Referrals UI enhancements

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -40,13 +40,11 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 			{
 				// Show the "Contact support" button if the user is not a client
 				! isClient && (
-					<>
-						<li className="a4a-sidebar__profile-dropdown-menu-item">
-							<Button borderless onClick={ onGetHelp }>
-								{ translate( 'Contact support' ) }
-							</Button>
-						</li>
-					</>
+					<li className="a4a-sidebar__profile-dropdown-menu-item">
+						<Button borderless onClick={ onGetHelp }>
+							{ translate( 'Contact support' ) }
+						</Button>
+					</li>
 				)
 			}
 			<li className="a4a-sidebar__profile-dropdown-menu-item">

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/overview/sidebar/contact-support';
+import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
 import useOutsideClickCallback from 'calypso/lib/use-outside-click-callback';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
@@ -32,13 +33,22 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 		dispatch( redirectToLogout() );
 	}, [ dispatch ] );
 
+	const isClient = isClientView();
+
 	return (
 		<ul className="a4a-sidebar__profile-dropdown-menu" hidden={ ! isExpanded }>
-			<li className="a4a-sidebar__profile-dropdown-menu-item">
-				<Button borderless onClick={ onGetHelp }>
-					{ translate( 'Contact support' ) }
-				</Button>
-			</li>
+			{
+				// Show the "Contact support" button if the user is not a client
+				! isClient && (
+					<>
+						<li className="a4a-sidebar__profile-dropdown-menu-item">
+							<Button borderless onClick={ onGetHelp }>
+								{ translate( 'Contact support' ) }
+							</Button>
+						</li>
+					</>
+				)
+			}
 			<li className="a4a-sidebar__profile-dropdown-menu-item">
 				<Button
 					borderless

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import UserContactSupportModalForm from 'calypso/a8c-for-agencies/components/user-contact-support-modal-form';
 import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/overview/sidebar/contact-support';
+import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import Sidebar, {
 	SidebarV2Main as SidebarMain,
@@ -15,7 +16,7 @@ import Sidebar, {
 } from 'calypso/layout/sidebar-v2';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { A4A_OVERVIEW_LINK } from '../sidebar-menu/lib/constants';
+import { A4A_OVERVIEW_LINK, A4A_CLIENT_SUBSCRIPTIONS_LINK } from '../sidebar-menu/lib/constants';
 import SidebarHeader from './header';
 import ProfileDropdown from './header/profile-dropdown';
 
@@ -60,6 +61,8 @@ const A4ASidebar = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const isClient = isClientView();
+
 	const [ showUserSupportForm, setShowUserSupportForm ] = useState( false );
 
 	const onShowUserSupportForm = useCallback( () => {
@@ -72,6 +75,11 @@ const A4ASidebar = ( {
 		history.pushState( null, '', window.location.pathname + window.location.search );
 		setShowUserSupportForm( false );
 	}, [] );
+
+	const contactUsUrl = isClient
+		? A4A_CLIENT_SUBSCRIPTIONS_LINK + '#contact-support'
+		: A4A_OVERVIEW_LINK + '#contact-sales';
+	const contactUsText = isClient ? translate( 'Contact support' ) : translate( 'Contact sales' );
 
 	return (
 		<Sidebar className={ clsx( 'a4a-sidebar', className ) }>
@@ -124,10 +132,8 @@ const A4ASidebar = ( {
 					) }
 
 					<SidebarNavigatorMenuItem
-						title={ translate( 'Contact sales', {
-							comment: 'A4A sidebar navigation item',
-						} ) }
-						link={ A4A_OVERVIEW_LINK + '#contact-sales' }
+						title={ contactUsText }
+						link={ contactUsUrl }
 						path=""
 						icon={ <Icon icon={ starEmpty } /> }
 						onClickMenuItem={ onShowUserSupportForm }

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/index.tsx
@@ -3,6 +3,7 @@ import { Modal } from '@wordpress/components';
 import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, FormEventHandler, useCallback, useEffect, useState } from 'react';
+import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -117,6 +118,8 @@ export default function UserContactSupportModalForm( {
 		}
 	}, [ dispatch, show ] );
 
+	const isClient = isClientView();
+
 	if ( ! show ) {
 		return null;
 	}
@@ -138,7 +141,7 @@ export default function UserContactSupportModalForm( {
 				</Button>
 
 				<h1 className="a4a-contact-support-modal-form__title">
-					{ translate( 'Contact sales & support' ) }
+					{ isClient ? translate( 'Contact support' ) : translate( 'Contact sales & support' ) }
 				</h1>
 
 				<FormFieldset>

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -95,7 +95,7 @@ export default function SubscriptionsList() {
 
 	return (
 		<Layout
-			className={ clsx( 'subscriptions-list__layout', {
+			className={ clsx( 'subscriptions-list__layout full-width-layout-with-table', {
 				'is-mobile-view': ! isDesktop,
 			} ) }
 			title={ title }

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/style.scss
@@ -4,7 +4,18 @@
 		padding-block-end: 0;
 	}
 
-	&.is-mobile-view .a4a-layout__top-wrapper {
-		display: none;
+	&.is-mobile-view {
+		.a4a-layout__top-wrapper {
+			display: none;
+		}
+
+		.a4a-layout__body-wrapper {
+			padding-inline: 16px;
+			padding-block-end: 48px;
+
+			@include breakpoint-deprecated( ">660px" ) {
+				padding-inline: 64px;
+			}
+		}
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -48,7 +48,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 		productTitle =
 			product.slug === 'wpcom-hosting-business' ? translate( 'WordPress.com Site' ) : product.name;
 		productDescription = translate(
-			'Plan with %(install)d managed WordPress install, with 50GB of storage each.',
+			'Plan with %(install)d managed WordPress install, with 50GB of storage.',
 			'Plan with %(install)d managed WordPress installs, with 50GB of storage each.',
 			{
 				args: {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -262,6 +262,11 @@
 	justify-content: space-between;
 	padding-block-end: 0;
 
+	@include breakpoint-deprecated( ">960px" ) {
+		width: 400px;
+	}
+
+
 	.checkout__aside-actions {
 		margin-block-start: 16px;
 	}
@@ -270,10 +275,6 @@
 		color: var(--color-neutral-70);
 		font-size: rem(16px);
 		font-weight: 600;
-
-		@include break-large {
-			text-wrap: nowrap;
-		}
 	}
 
 	.checkout__summary-notice {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -90,7 +90,11 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 		<>
 			{ paymentMethodRequired ? (
 				<div className="checkout__summary-client-payment-notice">
-					{ translate( 'Before making a payment, add your payment method.' ) }
+					{ translate( 'Before making a payment, add your payment{{nbsp/}}method.', {
+						components: {
+							nbsp: <>&nbsp;</>,
+						},
+					} ) }
 				</div>
 			) : (
 				<div className="checkout__summary-notice">
@@ -113,7 +117,7 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 					<div>
 						{ translate( `Note: You won't pay for the first 30 days.` ) }
 						<br />
-						{ translate( `After that, we'll charge your card every 30 days` ) }
+						{ translate( `After that, we'll charge your card every 30 days.` ) }
 					</div>
 				</div>
 			) }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -147,7 +147,7 @@ export default function HostingList( { selectedSite }: Props ) {
 					/>
 				) }
 
-				{ isWPCOMOptionEnabled && (
+				{ isWPCOMOptionEnabled && ! hideSection && (
 					<HostingCard
 						plan={ vipPlan }
 						className="hosting-list__vip-card"

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -1,8 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, JetpackLogo } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import SimpleList from '../../common/simple-list';
+import { MarketplaceTypeContext } from '../../context';
 import useWPCOMPlanDescription from './hooks/use-wpcom-plan-description';
 
 import './style.scss';
@@ -21,8 +24,33 @@ export default function WPCOMPlanCard( { plan, quantity, discount, onSelect, isL
 	const originalPrice = Number( plan.amount ) * quantity;
 	const actualPrice = originalPrice - originalPrice * discount;
 
+	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const referralMode = marketplaceType === 'referral';
+
 	const { name, features1, features2, jetpackFeatures1, jetpackFeatures2 } =
 		useWPCOMPlanDescription( plan.slug );
+
+	let buttonText =
+		quantity > 1
+			? translate( 'Add %(quantity)s %(planName)s sites to cart', {
+					args: {
+						quantity,
+						planName: name,
+					},
+					comment:
+						'%(quantity)s is the quantity of plans and %(planName)s is the name of the plan.',
+			  } )
+			: translate( 'Add %(planName)s to cart', {
+					args: {
+						planName: name,
+					},
+					comment: '%(planName)s is the name of the plan.',
+			  } );
+
+	if ( isAutomatedReferrals && referralMode ) {
+		buttonText = translate( 'Add to referral' );
+	}
 
 	return (
 		<div className="wpcom-plan-card">
@@ -65,21 +93,7 @@ export default function WPCOMPlanCard( { plan, quantity, discount, onSelect, isL
 
 				{ ! isLoading && (
 					<Button primary onClick={ () => onSelect( plan, quantity ) }>
-						{ quantity > 1
-							? translate( 'Add %(quantity)s %(planName)s sites to cart', {
-									args: {
-										quantity,
-										planName: name,
-									},
-									comment:
-										'%(quantity)s is the quantity of plans and %(planName)s is the name of the plan.',
-							  } )
-							: translate( 'Add %(planName)s to cart', {
-									args: {
-										planName: name,
-									},
-									comment: '%(planName)s is the name of the plan.',
-							  } ) }
+						{ buttonText }
 					</Button>
 				) }
 

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -88,7 +88,7 @@ export default function CommissionOverview( {
 							header={
 								<div className="commission-overview__heading">
 									<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
-									{ translate( 'Woo Payments revenue share' ) }
+									{ translate( 'WooPayments revenue share' ) }
 								</div>
 							}
 							expanded

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -52,8 +52,10 @@ export default function ReferralsOverview( {
 
 	const isDesktop = useDesktopBreakpoint();
 
+	const selectedItem = dataViewsState.selectedItem;
+
 	const title =
-		isAutomatedReferral && isDesktop
+		isAutomatedReferral && isDesktop && ! selectedItem
 			? translate( 'Your referrals and commissions' )
 			: translate( 'Referrals' );
 
@@ -70,13 +72,11 @@ export default function ReferralsOverview( {
 
 	const isLoading = isFetching || isFetchingReferrals;
 
-	const selectedItem = dataViewsState.selectedItem;
-
 	return (
 		<Layout
 			className={ clsx( 'referrals-layout', {
 				'referrals-layout--automated': isAutomatedReferral,
-				'referrals-layout--full-width': isAutomatedReferral && hasReferrals,
+				'full-width-layout-with-table': isAutomatedReferral && hasReferrals,
 				'referrals-layout--has-selected': selectedItem,
 			} ) }
 			title={ title }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -42,7 +42,7 @@ $data-view-border-color: #f1f1f1;
 	gap: 48px;
 }
 
-.referrals-layout .a4a-layout__body-wrapper {
+.referrals-layout:not(.full-width-layout-with-table) .a4a-layout__body-wrapper {
 	max-width: 900px;
 }
 
@@ -69,14 +69,8 @@ $data-view-border-color: #f1f1f1;
 		margin-block-end: 32px;
 	}
 
-	.a4a-layout__body-wrapper {
+	&:not(.full-width-layout-with-table) .a4a-layout__body-wrapper {
 		max-width: 700px;
-	}
-
-	&.referrals-layout--full-width {
-		.a4a-layout__body-wrapper {
-			max-width: 100%;
-		}
 	}
 
 	.referrals-overview__step-section-woo-payments {

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -23,7 +23,8 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 			? addQueryArgs( { license_key: purchase.license_key }, A4A_SITES_LINK_NEEDS_SETUP )
 			: addQueryArgs( { key: purchase.license_key }, '/marketplace/assign-license' ) );
 
-	const isDisabled = purchase.status !== 'active' || isFetching || ! product || ! redirectUrl;
+	const showAssignButton = purchase.status === 'active' && redirectUrl;
+	const isAwaitingPayment = purchase.status === 'pending';
 
 	return purchase.site_assigned ? (
 		<Button
@@ -35,16 +36,22 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 		</Button>
 	) : (
 		<>
-			<StatusBadge statusProps={ { children: translate( 'Unassigned' ), type: 'warning' } } />
-
-			<Button
-				disabled={ isDisabled }
-				className="referrals-purchases__assign-button"
-				borderless
-				onClick={ () => handleAssignToSite( redirectUrl ) }
-			>
-				{ isWPCOMLicense ? translate( 'Create site' ) : translate( 'Assign to site' ) }
-			</Button>
+			<StatusBadge
+				statusProps={ {
+					children: isAwaitingPayment ? translate( 'Awaiting payment' ) : translate( 'Unassigned' ),
+					type: 'warning',
+				} }
+			/>
+			{ showAssignButton && (
+				<Button
+					disabled={ isFetching }
+					className="referrals-purchases__assign-button"
+					borderless
+					onClick={ () => handleAssignToSite( redirectUrl ) }
+				>
+					{ isWPCOMLicense ? translate( 'Create site' ) : translate( 'Assign to site' ) }
+				</Button>
+			) }
 		</>
 	);
 };

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/date.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/date.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import { ReferralPurchase } from '../../types';
 
 type Props = {
@@ -5,7 +6,11 @@ type Props = {
 };
 
 const DateAssigned = ( { purchase }: Props ) => {
-	return purchase.date_assigned ? new Date( purchase.date_assigned ).toLocaleDateString() : '-';
+	return purchase.date_assigned ? (
+		new Date( purchase.date_assigned ).toLocaleDateString()
+	) : (
+		<Gridicon icon="minus" />
+	);
 };
 
 export default DateAssigned;

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -44,18 +44,16 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							id: 'client',
 							header: translate( 'Client' ).toUpperCase(),
 							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => {
-								return (
-									<Button
-										className="view-details-button client-email-button"
-										data-client-id={ item.client.id }
-										onClick={ () => openSitePreviewPane( item ) }
-										borderless
-									>
-										{ item.client.email }
-									</Button>
-								);
-							},
+							render: ( { item }: { item: Referral } ): ReactNode => (
+								<Button
+									className="view-details-button client-email-button"
+									data-client-id={ item.client.id }
+									onClick={ () => openSitePreviewPane( item ) }
+									borderless
+								>
+									{ item.client.email }
+								</Button>
+							),
 							width: '100%',
 							enableHiding: false,
 							enableSorting: false,
@@ -66,19 +64,17 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 									{
 										id: 'actions',
 										header: null,
-										render: ( { item }: { item: Referral } ) => {
-											return (
-												<div>
-													<Button
-														className="view-details-button"
-														onClick={ () => openSitePreviewPane( item ) }
-														borderless
-													>
-														<Gridicon icon="chevron-right" />
-													</Button>
-												</div>
-											);
-										},
+										render: ( { item }: { item: Referral } ) => (
+											<div>
+												<Button
+													className="view-details-button"
+													onClick={ () => openSitePreviewPane( item ) }
+													borderless
+												>
+													<Gridicon icon="chevron-right" />
+												</Button>
+											</div>
+										),
 										enableHiding: false,
 										enableSorting: false,
 									},
@@ -90,9 +86,16 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							id: 'client',
 							header: translate( 'Client' ).toUpperCase(),
 							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => {
-								return item.client.email;
-							},
+							render: ( { item }: { item: Referral } ): ReactNode => (
+								<Button
+									className="view-details-button"
+									data-client-id={ item.client.id }
+									onClick={ () => openSitePreviewPane( item ) }
+									borderless
+								>
+									{ item.client.email }
+								</Button>
+							),
 							enableHiding: false,
 							enableSorting: false,
 						},
@@ -100,9 +103,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							id: 'purchases',
 							header: translate( 'Purchases' ).toUpperCase(),
 							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => {
-								return item.purchases.length;
-							},
+							render: ( { item }: { item: Referral } ): ReactNode => item.purchases.length,
 							enableHiding: false,
 							enableSorting: false,
 						},
@@ -110,9 +111,8 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							id: 'pending-orders',
 							header: translate( 'Pending Orders' ).toUpperCase(),
 							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => {
-								return item.statuses.filter( ( status ) => status === 'pending' ).length;
-							},
+							render: ( { item }: { item: Referral } ): ReactNode =>
+								item.statuses.filter( ( status ) => status === 'pending' ).length,
 							enableHiding: false,
 							enableSorting: false,
 						},
@@ -129,19 +129,17 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 						{
 							id: 'actions',
 							header: translate( 'Actions' ).toUpperCase(),
-							render: ( { item }: { item: Referral } ) => {
-								return (
-									<div>
-										<Button
-											className="view-details-button action-button"
-											onClick={ () => openSitePreviewPane( item ) }
-											borderless
-										>
-											<Gridicon icon="chevron-right" />
-										</Button>
-									</div>
-								);
-							},
+							render: ( { item }: { item: Referral } ) => (
+								<div>
+									<Button
+										className="view-details-button action-button"
+										onClick={ () => openSitePreviewPane( item ) }
+										borderless
+									>
+										<Gridicon icon="chevron-right" />
+									</Button>
+								</div>
+							),
 							enableHiding: false,
 							enableSorting: false,
 						},
@@ -195,7 +193,7 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 	}, [ dataViewsState ] );
 
 	return (
-		<div className="redesigned-a8c-table">
+		<div className="redesigned-a8c-table full-width">
 			<ItemsDataViews
 				data={ {
 					items: referrals,

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -594,3 +594,28 @@ html {
 		width: 100%;
 	}
 }
+
+.full-width-layout-with-table {
+	.a4a-layout__body-wrapper {
+		max-width: 100%;
+		padding-inline: 0;
+	}
+
+	.redesigned-a8c-table .dataviews-view-table tr {
+		td:first-child,
+		th:first-child {
+			padding-inline-start: 16px;
+
+			@include breakpoint-deprecated( ">660px" ) {
+				padding-inline-start: 64px;
+			}
+		}
+		td:last-child,
+		th:last-child {
+			padding-inline-end: 16px;
+			@include breakpoint-deprecated( ">660px" ) {
+				padding-inline-end: 64px;
+			}
+		}
+	}
+}

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -28,7 +28,5 @@ export function getAgencyRequestError( state: A4AStore ): APIError | null {
 
 export function hasAgency( state: A4AStore ): boolean {
 	const agencies = state.a8cForAgencies.agencies.agencies;
-	const hasAgency = Array.isArray( agencies ) && agencies.length > 0;
-	const isClient = true; // TODO: Remove this line once all the APIs are in place.
-	return hasAgency && ! isClient;
+	return Array.isArray( agencies ) && agencies.length > 0;
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/403
Closes https://github.com/Automattic/jetpack-genesis/issues/387

## Proposed Changes

* UI enhancements to Automated Referrals UI

Includes

- Hide VIP also when referral mode is on
- Change the button to Add to referral for WPCOM hosting
- Remove each from WPCOM hosting when 1 plan is added.
- Remove the long title when the detail section is open
- Change the cursor to a pointer for email
- Change the status of purchases to Awaiting payment when payment is pending.
- Use an icon for a dash for a date on the purchase screen
- Make the referrals list table full-width
- Change “Woo Payments revenue share” to “WooPayments revenue share” (remove space between Woo and Payments)
- Spell out “revenue” on “Receive a rev share of 0.05% per sale.“? Using the full term ensures that all users understand the meaning without ambiguity.

NOTE: Please test the changes without the refer mode on.

## Testing Instructions

- Open A4A live link
- Click on `Make a referral` or `New referral` button
- Click `Hosting` > Verify that you can only see WPCOM as shown below:

<img width="1626" alt="Screenshot 2024-06-19 at 3 29 54 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c404d9e2-757c-4d80-a3e7-1337a7a9435f">

- Click on `Explore WordPress.com` > Verify that the button says `Add to referral` as shown below and add the product to the cart.

<img width="1626" alt="Screenshot 2024-06-19 at 3 30 07 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/24dcd548-cc7c-4bef-affc-70bf940d2ff7">

- Go to Checkout > Verify that the WPCOM plan doesn't show `each` at the end of plan description and shows only `Plan with 1 managed WordPress install, with 50GB of storage`

<img width="961" alt="Screenshot 2024-06-19 at 5 14 26 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c728f9e2-82e2-4a3f-959c-729dc5dd1e9f">


- Go ahead and refer a product.
- In the Referral dashboard, verify that the table is now full width, make sure it looks good on the mobile view too.

<img width="958" alt="Screenshot 2024-06-19 at 3 35 24 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3d1ca39d-05cc-4a25-bc94-e8aa589a6e90">

<img width="375" alt="Screenshot 2024-06-19 at 3 36 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ee39987f-c86c-4d02-9e17-8dd29245fa07">

- Verify that a pointer is shown when hovering over the email id and click on it
- Verify the page title now says `Referral` instead of `Your referrals and commissions`
- Verify the purchases show `Awaiting payment` when the payment is not done from the client.
- Verify that we show an icon for dash instead of `-`

<img width="981" alt="Screenshot 2024-06-19 at 3 38 27 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/32602811-258a-4771-a350-a6e2dc87c718">

- Click on FAQ and verify that WooPayment is a single word now.

<img width="770" alt="Screenshot 2024-06-19 at 3 40 34 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a3612e18-7548-4fb5-aef1-fcd02d9428f8">

- Updated the text from `Receive a rev share of 0.05% per sale.` to `Receive a revenue share of 0.05% per sale.` on the `Install WooPayments` section:

<img width="785" alt="Screenshot 2024-06-19 at 3 43 21 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0088256c-745b-4edb-8cad-556e7a94a20f">

Login as a client by opening the Pay button in the email in an incognito window.

- Visit /client/subscriptions in a new window and delete the existing payment methods if you have any.
- Go back to checkout and refresh the page > Click on Add my payment method > Add a card > Verify that the column width doesn't change after you are redirected and the text in the note `After that, we'll charge your card every 30 days.` has a full stop at the end
- 
<img width="1801" alt="Screenshot 2024-06-19 at 4 34 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/78f3b30c-4357-4cd0-b350-316e5adc9446">

- Click on `Submit my payment information` and once you are redirected to the subscriptions page > Verify that the table is full width as shown below

<img width="1918" alt="Screenshot 2024-06-19 at 4 34 42 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/65ccd3cf-f6af-49bb-b4bb-06ed1072d5a9">

<img width="376" alt="Screenshot 2024-06-19 at 4 35 11 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/eb05f815-158a-4250-97ad-6eb4e9f2fd5f">


- Verify that the sidebar has an item `Contact Support` and open the form as shown below. Verify that this change didn't affect the agency experience by comparing it with production.

<img width="869" alt="Screenshot 2024-06-19 at 4 35 32 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e0d59303-d5dc-4a60-975f-d0afb70c7ebf">
<img width="140" alt="Screenshot 2024-06-19 at 4 36 00 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f1f76f99-c4b8-43fe-bb9a-df9b445daf96">

- Click on the arrow next to the username and verify only 2 options are shown:

@jeffgolenski @madebynoam: we might have to update the link for `View Knowledge Base`

<img width="140" alt="Screenshot 2024-06-19 at 4 36 07 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0de11bdc-94bd-4f74-8235-96c4a6db668a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
