### PR TITLE
A4A: Fix the issue with the checkout page when dealing with a long list of items.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -78,7 +78,7 @@
 
 	@include break-large {
 		max-width: 443px;
-		padding: 128px 48px;
+		padding: 128px 48px 48px;
 		background: var(--color-neutral-0);
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -1,20 +1,27 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.checkout .a4a-layout__container,
 .checkout .a4a-layout__body,
 .checkout .a4a-layout__body-wrapper {
-	height: 100%;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 8px;
 }
 
+.a4a-layout__container {
+	height: 100%;
+}
+
 .checkout .a4a-layout__body {
 	padding: 0;
+	flex-grow: 1;
 
 	@include break-large {
 		background: linear-gradient(to right, var(--color-surface) 0%, var(--color-surface) 70%, var(--color-neutral-0) 70%, var(--color-neutral-0) 100%);
 	}
+}
+
+.checkout .a4a-layout__body-wrapper {
+	height: 100%;
 }
 
 .checkout__client-referral-form-footer-error {
@@ -36,7 +43,7 @@
 
 	@include break-large {
 		flex-direction: row;
-		height: 100%;
+		min-height: 100%;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -7,7 +7,7 @@
 	border-radius: 8px;
 }
 
-.a4a-layout__container {
+.checkout .a4a-layout__container {
 	height: 100%;
 }
 
@@ -260,7 +260,6 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	height: calc(100% - 64px);
 	padding-block-end: 0;
 
 	.checkout__aside-actions {


### PR DESCRIPTION
This PR fixes an issue with the checkout page looking broken when there is a long list of items.

| Before | After |
|--------|--------|
| <img width="1727" alt="Screenshot 2024-06-19 at 7 28 43 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7e9e1a7c-31de-47ee-b972-338fa18f62b0"> | <img width="1727" alt="Screenshot 2024-06-19 at 7 28 35 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d0516a30-500f-4258-8923-338c43fd9d92"> | 


Closes https://github.com/Automattic/jetpack-genesis/issues/386

## Proposed Changes

* Fix styling so that the aside container is expanded with its content or parent's height.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/products` page
* Toggle refer products.
* Add 11 items to the cart, then checkout.
* confirm that the checkout page does not look broken.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
