### PR TITLE
A4A: Fix some scrollable issues with the Referrals preview pane.

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -88,9 +88,7 @@ export default function ItemPreviewPane( {
 			/>
 			<div ref={ setNavRef }>
 				<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
-					{ navItems && navItems.length > 0 ? (
-						<NavTabs hasHorizontalScroll>{ navItems }</NavTabs>
-					) : null }
+					{ navItems && navItems.length > 0 ? <NavTabs>{ navItems }</NavTabs> : null }
 				</SectionNav>
 			</div>
 			{ addTourDetails && (

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -38,6 +38,7 @@ export default function ItemPreviewPane( {
 	itemData,
 	addTourDetails,
 	itemPreviewPaneHeaderExtraProps,
+	hideNavIfSingleTab,
 }: PreviewPaneProps ) {
 	const [ navRef, setNavRef ] = useState< HTMLElement | null >( null );
 
@@ -78,6 +79,8 @@ export default function ItemPreviewPane( {
 		);
 	} );
 
+	const shouldHideNav = hideNavIfSingleTab && featureTabs.length <= 1;
+
 	return (
 		<div className={ clsx( 'item-preview__pane', className ) }>
 			<ItemPreviewPaneHeader
@@ -87,8 +90,13 @@ export default function ItemPreviewPane( {
 				extraProps={ itemPreviewPaneHeaderExtraProps }
 			/>
 			<div ref={ setNavRef }>
-				<SectionNav className="preview-pane__navigation" selectedText={ selectedFeature.tab.label }>
-					{ navItems && navItems.length > 0 ? <NavTabs>{ navItems }</NavTabs> : null }
+				<SectionNav
+					className={ clsx( 'preview-pane__navigation', { 'is-hidden': shouldHideNav } ) }
+					selectedText={ selectedFeature.tab.label }
+				>
+					{ navItems && navItems.length > 0 ? (
+						<NavTabs hasHorizontalScroll>{ navItems }</NavTabs>
+					) : null }
 				</SectionNav>
 			</div>
 			{ addTourDetails && (

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/style.scss
@@ -9,6 +9,10 @@
 		position: relative;
 		z-index: 1;
 
+		&.is-hidden .section-nav__panel {
+			display: none;
+		}
+
 		.section-nav-tab__link {
 			color: #000;
 		}

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -38,6 +38,7 @@ export interface PreviewPaneProps {
 	hasError?: boolean;
 	addTourDetails?: { id: string; tourId: string };
 	itemPreviewPaneHeaderExtraProps?: ItemPreviewPaneHeaderExtraProps;
+	hideNavIfSingleTab?: boolean;
 }
 
 export interface ItemPreviewPaneHeaderExtraProps {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -214,3 +214,9 @@ $data-view-border-color: #f1f1f1;
 .referrals-layout:not(.referrals-layout--has-selected) .notice-banner {
 	display: flex;
 }
+
+.referrals-layout .item-preview__pane {
+	display: flex;
+	flex-direction: column;
+	height: calc(100vh - 32px);
+}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -68,6 +68,7 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 			itemData={ itemData }
 			closeItemPreviewPane={ closeSitePreviewPane }
 			features={ features }
+			hideNavIfSingleTab
 		/>
 	);
 }


### PR DESCRIPTION
This PR fixes some scrollable issues with the Referrals preview pane.

| Issue | Before | After |
|--------|--------|--------|
| Header shows a horizontal scrollbar | <img width="1056" alt="Screenshot 2024-06-19 at 8 09 14 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/61c5aaec-3dac-4542-84b7-4f32b17fc9b1"> | <img width="1054" alt="Screenshot 2024-06-19 at 8 44 02 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c7e0cabd-cc70-4875-911e-e5bb3618c27f"> |
| Purchases list not scrollable | <img width="1181" alt="Screenshot 2024-06-19 at 8 10 55 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0732935e-28a6-4bd8-b1bb-ea3afe594237"> | <img width="1088" alt="Screenshot 2024-06-19 at 8 11 02 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/bdaff820-4d94-41dc-8bf9-c74d6ab88400"> | 

Closes https://github.com/Automattic/jetpack-genesis/issues/388

## Proposed Changes

* Remove the navigation component for now in Referrals preview pane.
* Apply some referrals layout preview pane specific styling that converts Preview Pane into flex element.

## Testing Instructions

* Use the A4A live link and go to `/referrals/dashboard`.
* Confirm that the issues are no longer existing.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
