### PR TITLE
Update react-router and react-router-dom

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -189,7 +189,7 @@
 		"react-markdown": "^8.0.7",
 		"react-modal": "^3.16.1",
 		"react-redux": "^8.1.3",
-		"react-router-dom": "^6.10.0",
+		"react-router-dom": "^6.23.1",
 		"react-transition-group": "^4.3.0",
 		"redux": "^4.2.1",
 		"redux-dynamic-middlewares": "^2.2.0",
@@ -239,7 +239,7 @@
 		"html-loader": "^0.5.5",
 		"ignore-loader": "^0.1.2",
 		"pkg-dir": "^5.0.0",
-		"react-router": "^6.10.0",
+		"react-router": "^6.23.1",
 		"react-test-renderer": "^18.2.0",
 		"redux-mock-store": "^1.5.4",
 		"stream-browserify": "^3.0.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,7 +45,7 @@
 		"lodash": "^4.17.21",
 		"prop-types": "^15.7.2",
 		"react-modal": "^3.16.1",
-		"react-router-dom": "^6.10.0",
+		"react-router-dom": "^6.23.1",
 		"react-slider": "^2.0.5",
 		"utility-types": "^3.10.0",
 		"uuid": "^9.0.1"

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -36,7 +36,7 @@
 		"@wordpress/icons": "^10.0.0",
 		"@wordpress/react-i18n": "^4.0.0",
 		"clsx": "^2.1.1",
-		"react-router-dom": "^6.10.0",
+		"react-router-dom": "^6.23.1",
 		"tslib": "^2.5.0",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,7 +652,7 @@ __metadata:
     prop-types: "npm:^15.7.2"
     qrcode.react: "npm:^3.1.0"
     react-modal: "npm:^3.16.1"
-    react-router-dom: "npm:^6.10.0"
+    react-router-dom: "npm:^6.23.1"
     react-slider: "npm:^2.0.5"
     resize-observer-polyfill: "npm:^1.5.1"
     typescript: "npm:^5.3.3"
@@ -1507,7 +1507,7 @@ __metadata:
     css-loader: "npm:^3.6.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
-    react-router-dom: "npm:^6.10.0"
+    react-router-dom: "npm:^6.23.1"
     redux: "npm:^4.2.1"
     sass-loader: "npm:^10.1.1"
     style-loader: "npm:^1.3.0"
@@ -6137,7 +6137,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.5.0, @remix-run/router@npm:^1.5.0":
+"@remix-run/router@npm:1.16.1":
+  version: 1.16.1
+  resolution: "@remix-run/router@npm:1.16.1"
+  checksum: 5f1b0aef4924830eeab9c86dcaa5af8157066e5de65b449e7fdf406532b2384828a46a447c31b0735fd713a06938dd88bfd4e566d9989be70c770457dda16c92
+  languageName: node
+  linkType: hard
+
+"@remix-run/router@npm:^1.5.0":
   version: 1.5.0
   resolution: "@remix-run/router@npm:1.5.0"
   checksum: 63c3695df0470943213f8144183501bbb6a8176671f2ed4547ffa1852f79fd71054b4b4a715795e9e250198991d9e6e121b3fcab9c27df37871dcdfbc8de83a1
@@ -12478,8 +12485,8 @@ __metadata:
     react-markdown: "npm:^8.0.7"
     react-modal: "npm:^3.16.1"
     react-redux: "npm:^8.1.3"
-    react-router: "npm:^6.10.0"
-    react-router-dom: "npm:^6.10.0"
+    react-router: "npm:^6.23.1"
+    react-router-dom: "npm:^6.23.1"
     react-test-renderer: "npm:^18.2.0"
     react-transition-group: "npm:^4.3.0"
     redux: "npm:^4.2.1"
@@ -27124,16 +27131,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.10.0":
-  version: 6.10.0
-  resolution: "react-router-dom@npm:6.10.0"
+"react-router-dom@npm:^6.23.1":
+  version: 6.23.1
+  resolution: "react-router-dom@npm:6.23.1"
   dependencies:
-    "@remix-run/router": "npm:1.5.0"
-    react-router: "npm:6.10.0"
+    "@remix-run/router": "npm:1.16.1"
+    react-router: "npm:6.23.1"
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: c62e4b4aac2067e64af632e113b8db0626b846ec88fb668e84492ceb04179a0789120844263e35dead1e13f70f6554c1a463c7c33d8feed579bf5a2a02f916f4
+  checksum: 01b954d7d0ff4c53bb2edbc816458f3fad1ce9ee49a4dfdc5c866065c23026c9cce429b46b754cbaebb83b22cfe5f605bbf441acf515e3c377cbdf021b0bec4c
   languageName: node
   linkType: hard
 
@@ -27156,14 +27163,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:6.10.0, react-router@npm:^6.10.0":
-  version: 6.10.0
-  resolution: "react-router@npm:6.10.0"
+"react-router@npm:6.23.1, react-router@npm:^6.23.1":
+  version: 6.23.1
+  resolution: "react-router@npm:6.23.1"
   dependencies:
-    "@remix-run/router": "npm:1.5.0"
+    "@remix-run/router": "npm:1.16.1"
   peerDependencies:
     react: ">=16.8"
-  checksum: 83b8d6a7d1572403b9227045148b34253d3e705dd196d5beff9be2e3c044ba1136100a6e45c219c109de7c764d548302242ab029b0df4c5536b8aaddb3b1aa57
+  checksum: 091949805745136350ab049b2a96281bf38742c9d3651019fb48ea79c5eafbfb0379f1d3e636602dd56b0ef278389e8fd25be983dc2c0ffd1103d06dfa8019f3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6137,17 +6137,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.16.1":
+"@remix-run/router@npm:1.16.1, @remix-run/router@npm:^1.5.0":
   version: 1.16.1
   resolution: "@remix-run/router@npm:1.16.1"
   checksum: 5f1b0aef4924830eeab9c86dcaa5af8157066e5de65b449e7fdf406532b2384828a46a447c31b0735fd713a06938dd88bfd4e566d9989be70c770457dda16c92
-  languageName: node
-  linkType: hard
-
-"@remix-run/router@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@remix-run/router@npm:1.5.0"
-  checksum: 63c3695df0470943213f8144183501bbb6a8176671f2ed4547ffa1852f79fd71054b4b4a715795e9e250198991d9e6e121b3fcab9c27df37871dcdfbc8de83a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* Update react-router-dom and react-router


## Why are these changes being made?
The updated version fixes important features like the [useMatch](https://github.com/remix-run/react-router/pull/10768) that is essential for some stepper improvements https://github.com/Automattic/wp-calypso/pull/91935

## Testing Instructions

* Access one of the apps using the <Routes> feature. (E.g /setup/migration-signup) and check if the page is rendered


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
