### PR TITLE
A4A: Add a dismiss button for the Referrals guided tour.

### DIFF
--- a/client/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide.tsx
+++ b/client/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide.tsx
@@ -80,7 +80,7 @@ function useReferralsGuide() {
 	);
 
 	const guideModal = isModalOpen ? (
-		<GuideModal steps={ steps } onClose={ () => setIsModalOpen( false ) } />
+		<GuideModal steps={ steps } onClose={ () => setIsModalOpen( false ) } dismissable />
 	) : null;
 
 	return {

--- a/client/a8c-for-agencies/components/guide-modal/index.tsx
+++ b/client/a8c-for-agencies/components/guide-modal/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { Modal } from '@wordpress/components';
+import { Icon, close } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -15,9 +16,10 @@ type GuideModalStep = {
 export type GuideModalProps = {
 	steps?: GuideModalStep[];
 	onClose: () => void;
+	dismissable?: boolean;
 };
 
-const GuideModal = ( { onClose, steps }: GuideModalProps ) => {
+const GuideModal = ( { onClose, steps, dismissable }: GuideModalProps ) => {
 	const [ step, setStep ] = useState( 0 );
 	const translate = useTranslate();
 
@@ -46,6 +48,17 @@ const GuideModal = ( { onClose, steps }: GuideModalProps ) => {
 	return (
 		<Modal onRequestClose={ onClose } className="guide-modal__wrapper" __experimentalHideHeader>
 			<div className="guide-modal__content">
+				{ dismissable && (
+					<Button
+						className="guide-modal__dismiss-button"
+						onClick={ onClose }
+						plain
+						aria-label={ translate( 'close' ) }
+					>
+						<Icon className="gridicon" icon={ close } />
+					</Button>
+				) }
+
 				<div className="guide-modal__header">{ steps[ step ].preview }</div>
 				<div className="guide-modal__main">
 					<div className="guide-modal__body">

--- a/client/a8c-for-agencies/components/guide-modal/style.scss
+++ b/client/a8c-for-agencies/components/guide-modal/style.scss
@@ -6,6 +6,22 @@
 		margin: 0;
 		padding: 0;
 	}
+	.guide-modal__header::after {
+		content: "";
+		position: absolute;
+		left: 0;
+		top: 0;
+		width: 100%;
+		height: 30%;
+		display: inline-block;
+		background: linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.65) 100%);
+		opacity: 0;
+		transition: opacity 0.3s ease-out;
+	}
+
+	&:hover .guide-modal__header::after {
+		opacity: 1;
+	}
 }
 
 .guide-modal__content {
@@ -21,9 +37,15 @@
 	margin-bottom: 20px;
 	height: 48%;
 
+
 	// FIXME: remove this after proper video aspect ratio added
 	video {
 		margin-block-start: -20px;
+	}
+
+	img,
+	video {
+		z-index: -1;
 	}
 }
 
@@ -37,6 +59,7 @@
 	justify-content: center;
 	border-radius: 4px;
 	box-sizing: border-box;
+	z-index: 10;
 
 	.gridicon {
 		fill: var(--color-text-inverted);

--- a/client/a8c-for-agencies/components/guide-modal/style.scss
+++ b/client/a8c-for-agencies/components/guide-modal/style.scss
@@ -27,6 +27,26 @@
 	}
 }
 
+.guide-modal__dismiss-button {
+	position: absolute;
+	top: 16px;
+	right: 16px;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 4px;
+	box-sizing: border-box;
+
+	.gridicon {
+		fill: var(--color-text-inverted);
+	}
+
+	&:focus-visible {
+		outline: 1px solid var(--color-text-inverted);
+	}
+}
+
 .guide-modal__main {
 	padding: 1rem;
 	display: flex;


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="430" alt="Screenshot 2024-06-19 at 10 01 32 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/cd793b06-e4e9-4030-adf1-e544f4ae32f2"> | <img width="424" alt="Screenshot 2024-06-19 at 10 01 06 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/55818f96-f76c-412c-a85b-a0642a66142e"> |

Closes https://github.com/Automattic/jetpack-genesis/issues/399

## Proposed Changes

* Add a dismiss button on the Guided Tour component. Update Referrals guided tour to use the new dismissible property.

## Testing Instructions

* Use the A4A live link and go to `/marketplace` page.
* Click the refers product tooltip to show the Guided tour. 
   <img width="238" alt="Screenshot 2024-06-19 at 10 01 12 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/41235e7a-f11f-4216-afcb-308bf55062bb">

* Confirm that the dismiss button is now visible.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
