### PR TITLE
Reader stream - prevent delayed setting of scroll position when not necessary.

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -96,6 +96,25 @@ export default class InfiniteList extends Component {
 		this._isMounted = true;
 		if ( this._contextLoaded() ) {
 			this._setContainerY( this.state.scrollTop );
+		} else {
+			// This is a workaround to ensure the scroll container is ready by scrolling after the
+			// current callstack is executed. Some streams and device widths for the reader are not
+			// fully ready to have their scroll position set until everything is mounted, causing the
+			// stream to jump back to the top when coming back to view from a post.
+
+			// Use the scrollTop setting from the time the component mounted, as this state could be
+			// changed in the initial update cycle to save scroll position before the saved position
+			// is set.
+			const scrollTop = this.state.scrollTop;
+			// Apply these at the end of the callstack to ensure the scroll container is ready.
+			window.setTimeout( () => {
+				if ( this._contextLoaded() ) {
+					this._setContainerY( scrollTop );
+					this.updateScroll( {
+						triggeredByScroll: false,
+					} );
+				}
+			}, 0 );
 		}
 
 		// only override browser history scroll if navigated via history
@@ -106,24 +125,7 @@ export default class InfiniteList extends Component {
 		this.updateScroll( {
 			triggeredByScroll: false,
 		} );
-		// This is a workaround to ensure the scroll container is ready by scrolling after the
-		// current callstack is executed. Some streams and device widths for the reader are not
-		// fully ready to have their scroll position set until everything is mounted, causing the
-		// stream to jump back to the top when coming back to view from a post.
 
-		// Use the scrollTop setting from the time the component mounted, as this state could be
-		// changed in the initial update cycle to save scroll position before the saved position
-		// is set.
-		const scrollTop = this.state.scrollTop;
-		// Apply these at the end of the callstack to ensure the scroll container is ready.
-		window.setTimeout( () => {
-			if ( this._contextLoaded() ) {
-				this._setContainerY( scrollTop );
-				this.updateScroll( {
-					triggeredByScroll: false,
-				} );
-			}
-		}, 0 );
 		if ( this._contextLoaded() ) {
 			this._scrollContainer.addEventListener( 'scroll', this.onScroll );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #  follow up from https://github.com/Automattic/wp-calypso/pull/91731/files / https://github.com/Automattic/wp-calypso/pull/91859

## Proposed Changes

* Update the delayed setY that happens on mount of the list to only happen if context was not loaded for the first setY to fire.
* I recently added this timeout in a previous PR this week. Since then other changes have allowed the contextLoaded checks here to not give false positives from the reader stream, so lets condition this delayed setY to only trigger if context was not initially loaded - we don't want to set it multiple times and run it unnecessarily. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Code improvement and follow up for stability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the reader streams.
* You should see no observable changes.
* There are rare circumstances without this where you may see both setYs fired and some inconsistent scroll positions as a result, but this is incredibly intermittent and not easy to reproduce.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
