### PR TITLE
A4A: Align commission heading content to 'center'.

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
@@ -11,6 +11,7 @@
 		display: flex;
 		flex-direction: row;
 		gap: 8px;
+		align-items: center;
 	}
 
 	.jetpack-logo {


### PR DESCRIPTION
This PR addresses the misalignment of icons on the Referrals FAQ page.

| Before | After |
|--------|--------|
| <img width="726" alt="Screenshot 2024-06-19 at 10 12 31 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8af92f78-102b-4050-aa93-12c1c838c3c0"> | <img width="720" alt="Screenshot 2024-06-19 at 10 12 13 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7ce0816c-d651-40da-9eea-e957753b24db"> | 

Closes https://github.com/Automattic/jetpack-genesis/issues/389

## Proposed Changes

* Set `.commission-overview__heading` item alignment to center.


## Testing Instructions

* Use the A4A live link and go to `/referrals/faq`
* Confirm that the icons in the foldable components is properly aligned.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
