### PR TITLE
Jetpack Backup: Add new Tracks events for actions toolbar

### DIFF
--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -63,6 +63,10 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 	const isRestoreDisabled =
 		doesRewindNeedCredentials || isRestoreInProgress || ( ! isAtomic && areCredentialsInvalid );
 
+	const onRestoreClick = () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_actions_restore_click' ) );
+	};
+
 	const onDownloadClick = () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_backup_actions_download_click', {
@@ -94,6 +98,7 @@ const SingleSiteActionsButton: React.FC< SingleSiteOwnProps > = ( {
 					href={ ! isRestoreDisabled && backupRestorePath( siteSlug, rewindId ) }
 					className="toolbar__restore-button"
 					disabled={ isRestoreDisabled }
+					onClick={ onRestoreClick }
 				>
 					{ translate( 'Restore to this point' ) }
 				</Button>

--- a/client/components/activity-card/toolbar/buttons/view-files-button.tsx
+++ b/client/components/activity-card/toolbar/buttons/view-files-button.tsx
@@ -3,6 +3,8 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import Button from 'calypso/components/forms/form-button';
 import { backupContentsPath } from 'calypso/my-sites/backup/paths';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 
 type ViewFilesButtonProps = {
 	siteSlug: string;
@@ -16,14 +18,21 @@ const ViewFilesButton: FunctionComponent< ViewFilesButtonProps > = ( {
 	isPrimary = false,
 } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const backupBrowserLink = backupContentsPath( siteSlug, rewindId );
+
+	const onButtonClick = () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_actions_view_files_click' ) );
+	};
 
 	return (
 		<Button
 			borderless
 			compact
 			isPrimary={ isPrimary }
-			href={ backupContentsPath( siteSlug, rewindId ) }
+			href={ backupBrowserLink }
 			className="toolbar__view-files-button"
+			onClick={ onButtonClick }
 		>
 			<Icon icon={ fileIcon } className="toolbar__view-files-button-icon" size={ 18 } />
 			<span className="toolbar__view-files-button-text">{ translate( 'View files' ) }</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/549

## Proposed Changes
Add the followings Tracks events to the actions toolbar:
* `calypso_jetpack_backup_actions_restore_click` when user clicks on `Restore to this point`
* `calypso_jetpack_backup_actions_view_files_click` when user clicks on `View files`

![CleanShot 2024-06-19 at 09 12 40@2x](https://github.com/Automattic/wp-calypso/assets/1488641/4ac55918-4b73-4cb2-880c-3211717013e1)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We found an issue where the `Actions (+)` toolbar is visible in the copy to staging flow and could potentially make the user leave the flow early because of that. Having these events in the future could help us understand how many users actually clicked those actions.

We were already tracking the `Download files` action.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!TIP]
> You could use this extension to make it easier: p7H4VZ-4cf-p2

* Spin up a Jetpack Cloud live branch
* Open the Network tab in your developer tools
* Navigate to Jetpack Cloud > Backup
* On any available backup, click on `Actions (+)`
* Click on `Restore to this point`
  * Validate the event `calypso_jetpack_backup_actions_restore_click` was triggered.
* Click on `View files`
  * Validate the event `calypso_jetpack_backup_actions_view_files_click` was triggered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?