### PR TITLE
Plugins: Stick header to the top when scrolling down

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -218,7 +218,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 						</div>
 					</>
 				) }
-				<div ref={ loggedInSearchBoxRef } />
+				{ isLoggedIn && <div ref={ loggedInSearchBoxRef } /> }
 				<div className="plugins-browser__main-container">{ renderList() }</div>
 				{ ! category && ! search && (
 					<div className="plugins-browser__marketplace-footer">

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -38,6 +38,11 @@ import SearchCategories from '../search-categories';
 
 import './style.scss';
 
+const THRESHOLD = 10;
+const SEARCH_CATEGORIES_HEIGHT = 36;
+const LAYOUT_PADDING = 16;
+const MASTERBAR_HEIGHT = 32;
+
 const searchTerms = [ 'woocommerce', 'seo', 'file manager', 'jetpack', 'ecommerce', 'form' ];
 
 const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews, isLoggedIn } ) => {
@@ -69,13 +74,22 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 	} = useScrollAboveElement();
 	const searchRef = useRef( null );
 	const categoriesRef = useRef();
-	const loggedInSearchBoxRef = useRef( null );
-	const isLoggedInSearchBoxSticky = useIsVisible( loggedInSearchBoxRef ) === false;
 	//  another temporary solution until phase 4 is merged
 	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
 
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
+
+	const loggedInSearchBoxRef = useRef( null );
+	const isLoggedInSearchBoxSticky =
+		useIsVisible( loggedInSearchBoxRef, {
+			rootMargin: `${
+				-1 *
+				( THRESHOLD +
+					SEARCH_CATEGORIES_HEIGHT +
+					( selectedSite ? MASTERBAR_HEIGHT : LAYOUT_PADDING ) )
+			}px 0px 0px 0px`,
+		} ) === false;
 
 	const jetpackNonAtomic = useSelector(
 		( state ) =>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -16,6 +16,7 @@ import Categories from 'calypso/my-sites/plugins/categories';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import { MarketplaceFooter } from 'calypso/my-sites/plugins/education-footer';
 import NoPermissionsError from 'calypso/my-sites/plugins/no-permissions-error';
+import useIsVisible from 'calypso/my-sites/plugins/plugins-browser/use-is-visible';
 import SearchBoxHeader from 'calypso/my-sites/plugins/search-box-header';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useIsJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem';
@@ -68,6 +69,9 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 	} = useScrollAboveElement();
 	const searchRef = useRef( null );
 	const categoriesRef = useRef();
+	const stickySearchBoxRef = useRef( null );
+	const isVisible = useIsVisible( stickySearchBoxRef );
+	const isStickyHeader = isVisible === false;
 	//  another temporary solution until phase 4 is merged
 	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
 
@@ -177,11 +181,10 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 					<SearchCategories
 						category={ category }
 						isSearching={ isFetchingPluginsBySearchTerm }
-						isSticky={ isAboveElement }
+						isSticky={ isStickyHeader }
 						searchRef={ searchRef }
 						searchTerm={ search }
 						searchTerms={ searchTerms }
-						stickySearchBoxRef={ searchHeaderRef }
 					/>
 				) : (
 					<>
@@ -216,6 +219,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 						</div>
 					</>
 				) }
+				<div ref={ stickySearchBoxRef } />
 				<div className="plugins-browser__main-container">{ renderList() }</div>
 				{ ! category && ! search && (
 					<div className="plugins-browser__marketplace-footer">

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -69,9 +69,8 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 	} = useScrollAboveElement();
 	const searchRef = useRef( null );
 	const categoriesRef = useRef();
-	const stickySearchBoxRef = useRef( null );
-	const isVisible = useIsVisible( stickySearchBoxRef );
-	const isStickyHeader = isVisible === false;
+	const loggedInSearchBoxRef = useRef( null );
+	const isLoggedInSearchBoxSticky = useIsVisible( loggedInSearchBoxRef ) === false;
 	//  another temporary solution until phase 4 is merged
 	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
 
@@ -181,7 +180,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 					<SearchCategories
 						category={ category }
 						isSearching={ isFetchingPluginsBySearchTerm }
-						isSticky={ isStickyHeader }
+						isSticky={ isLoggedInSearchBoxSticky }
 						searchRef={ searchRef }
 						searchTerm={ search }
 						searchTerms={ searchTerms }
@@ -219,7 +218,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 						</div>
 					</>
 				) }
-				<div ref={ stickySearchBoxRef } />
+				<div ref={ loggedInSearchBoxRef } />
 				<div className="plugins-browser__main-container">{ renderList() }</div>
 				{ ! category && ! search && (
 					<div className="plugins-browser__marketplace-footer">

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -60,7 +60,7 @@ const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews, isL
 	return null;
 };
 
-const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader } ) => {
+const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 	const {
 		isAboveElement,
 		targetRef: searchHeaderRef,
@@ -163,14 +163,12 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				}
 			/>
 
-			{ ! hideHeader && (
-				<PluginsNavigationHeader
-					navigationHeaderRef={ navigationHeaderRef }
-					categoryName={ categoryName }
-					category={ category }
-					search={ search }
-				/>
-			) }
+			<PluginsNavigationHeader
+				navigationHeaderRef={ navigationHeaderRef }
+				categoryName={ categoryName }
+				category={ category }
+				search={ search }
+			/>
 			<div className="plugins-browser__content-wrapper">
 				{ selectedSite && isJetpack && isPossibleJetpackConnectionProblem && (
 					<JetpackConnectionHealthBanner siteId={ siteId } />

--- a/client/my-sites/plugins/plugins-browser/use-is-visible.tsx
+++ b/client/my-sites/plugins/plugins-browser/use-is-visible.tsx
@@ -6,17 +6,22 @@ export default function useIsVisible(
 ) {
 	const [ isIntersecting, setIntersecting ] = useState< boolean | undefined >( undefined );
 
-	const observer = useMemo(
-		() =>
-			new IntersectionObserver( ( [ entry ] ) => setIntersecting( entry.isIntersecting ), options ),
-		[ options ]
-	);
+	const observer = useMemo( () => {
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+
+		return new IntersectionObserver(
+			( [ entry ] ) => setIntersecting( entry.isIntersecting ),
+			options
+		);
+	}, [ options ] );
 
 	useEffect( () => {
 		if ( ref && ref.current ) {
-			observer.observe( ref.current );
+			observer?.observe( ref.current );
 		}
-		return () => observer.disconnect();
+		return () => observer?.disconnect();
 	}, [ observer, ref ] );
 
 	return isIntersecting;

--- a/client/my-sites/plugins/plugins-browser/use-is-visible.tsx
+++ b/client/my-sites/plugins/plugins-browser/use-is-visible.tsx
@@ -1,0 +1,19 @@
+import { RefObject, useEffect, useMemo, useState } from 'react';
+
+export default function useIsVisible( ref: RefObject< HTMLElement > ) {
+	const [ isIntersecting, setIntersecting ] = useState< boolean | undefined >( undefined );
+
+	const observer = useMemo(
+		() => new IntersectionObserver( ( [ entry ] ) => setIntersecting( entry.isIntersecting ) ),
+		[]
+	);
+
+	useEffect( () => {
+		if ( ref && ref.current ) {
+			observer.observe( ref.current );
+		}
+		return () => observer.disconnect();
+	}, [ observer, ref ] );
+
+	return isIntersecting;
+}

--- a/client/my-sites/plugins/plugins-browser/use-is-visible.tsx
+++ b/client/my-sites/plugins/plugins-browser/use-is-visible.tsx
@@ -1,11 +1,15 @@
 import { RefObject, useEffect, useMemo, useState } from 'react';
 
-export default function useIsVisible( ref: RefObject< HTMLElement > ) {
+export default function useIsVisible(
+	ref: RefObject< HTMLElement >,
+	options?: IntersectionObserverInit
+) {
 	const [ isIntersecting, setIntersecting ] = useState< boolean | undefined >( undefined );
 
 	const observer = useMemo(
-		() => new IntersectionObserver( ( [ entry ] ) => setIntersecting( entry.isIntersecting ) ),
-		[]
+		() =>
+			new IntersectionObserver( ( [ entry ] ) => setIntersecting( entry.isIntersecting ), options ),
+		[ options ]
 	);
 
 	useEffect( () => {

--- a/client/my-sites/plugins/search-categories/index.tsx
+++ b/client/my-sites/plugins/search-categories/index.tsx
@@ -90,21 +90,12 @@ const SearchCategories: FC< {
 	searchRef: MutableRefObject< ImperativeHandle >;
 	searchTerm: string;
 	searchTerms: string[];
-	stickySearchBoxRef: RefObject< HTMLDivElement >;
 	width: number;
-} > = ( {
-	category,
-	isSearching,
-	isSticky,
-	searchRef,
-	searchTerm,
-	searchTerms,
-	stickySearchBoxRef,
-	width,
-} ) => {
+} > = ( { category, isSearching, isSticky, searchRef, searchTerm, searchTerms, width } ) => {
 	const dispatch = useDispatch();
 	const getCategoryUrl = useGetCategoryUrl();
 	const categoriesRef = useRef< HTMLDivElement >( null );
+
 	// We hide these special categories from the category selector
 	const displayCategories = ALLOWED_CATEGORIES.filter(
 		( v ) => [ 'paid', 'popular', 'featured' ].indexOf( v ) < 0
@@ -120,45 +111,42 @@ const SearchCategories: FC< {
 	}, [ searchRef, searchTerm ] );
 
 	return (
-		<>
-			<div className={ clsx( 'search-categories', { 'fixed-top': isSticky } ) }>
-				<SearchBox
-					isSearching={ isSearching }
-					searchBoxRef={ searchRef }
-					searchTerm={ searchTerm }
-					categoriesRef={ categoriesRef }
-					searchTerms={ searchTerms }
-				/>
+		<div className={ clsx( 'search-categories', { 'fixed-top': isSticky } ) }>
+			<SearchBox
+				isSearching={ isSearching }
+				searchBoxRef={ searchRef }
+				searchTerm={ searchTerm }
+				categoriesRef={ categoriesRef }
+				searchTerms={ searchTerms }
+			/>
 
-				{ isDesktop() ? (
-					<>
-						<div className="search-categories__vertical-separator" />
+			{ isDesktop() ? (
+				<>
+					<div className="search-categories__vertical-separator" />
 
-						<ScrollableHorizontalNavigation
-							className="search-categories__categories"
-							onTabClick={ ( tabSlug ) => {
-								dispatch(
-									recordTracksEvent( 'calypso_plugins_category_select', {
-										tag: tabSlug,
-									} )
-								);
+					<ScrollableHorizontalNavigation
+						className="search-categories__categories"
+						onTabClick={ ( tabSlug ) => {
+							dispatch(
+								recordTracksEvent( 'calypso_plugins_category_select', {
+									tag: tabSlug,
+								} )
+							);
 
-								page( getCategoryUrl( tabSlug ) );
-							} }
-							selectedTab={ category ?? categories[ 0 ].slug }
-							tabs={ categories }
-							titleField="menu"
-							width={ width }
-						/>
-					</>
-				) : (
-					<div ref={ categoriesRef }>
-						<Categories selected={ category } noSelection={ searchTerm ? true : false } />
-					</div>
-				) }
-			</div>
-			<div className="search-categories__sticky-ref" ref={ stickySearchBoxRef } />
-		</>
+							page( getCategoryUrl( tabSlug ) );
+						} }
+						selectedTab={ category ?? categories[ 0 ].slug }
+						tabs={ categories }
+						titleField="menu"
+						width={ width }
+					/>
+				</>
+			) : (
+				<div ref={ categoriesRef }>
+					<Categories selected={ category } noSelection={ searchTerm ? true : false } />
+				</div>
+			) }
+		</div>
 	);
 };
 

--- a/client/my-sites/plugins/search-categories/index.tsx
+++ b/client/my-sites/plugins/search-categories/index.tsx
@@ -111,42 +111,45 @@ const SearchCategories: FC< {
 	}, [ searchRef, searchTerm ] );
 
 	return (
-		<div className={ clsx( 'search-categories', { 'fixed-top': isSticky } ) }>
-			<SearchBox
-				isSearching={ isSearching }
-				searchBoxRef={ searchRef }
-				searchTerm={ searchTerm }
-				categoriesRef={ categoriesRef }
-				searchTerms={ searchTerms }
-			/>
+		<>
+			<div className={ clsx( 'search-categories', { 'fixed-top': isSticky } ) }>
+				<SearchBox
+					isSearching={ isSearching }
+					searchBoxRef={ searchRef }
+					searchTerm={ searchTerm }
+					categoriesRef={ categoriesRef }
+					searchTerms={ searchTerms }
+				/>
 
-			{ isDesktop() ? (
-				<>
-					<div className="search-categories__vertical-separator" />
+				{ isDesktop() ? (
+					<>
+						<div className="search-categories__vertical-separator" />
 
-					<ScrollableHorizontalNavigation
-						className="search-categories__categories"
-						onTabClick={ ( tabSlug ) => {
-							dispatch(
-								recordTracksEvent( 'calypso_plugins_category_select', {
-									tag: tabSlug,
-								} )
-							);
+						<ScrollableHorizontalNavigation
+							className="search-categories__categories"
+							onTabClick={ ( tabSlug ) => {
+								dispatch(
+									recordTracksEvent( 'calypso_plugins_category_select', {
+										tag: tabSlug,
+									} )
+								);
 
-							page( getCategoryUrl( tabSlug ) );
-						} }
-						selectedTab={ category ?? categories[ 0 ].slug }
-						tabs={ categories }
-						titleField="menu"
-						width={ width }
-					/>
-				</>
-			) : (
-				<div ref={ categoriesRef }>
-					<Categories selected={ category } noSelection={ searchTerm ? true : false } />
-				</div>
-			) }
-		</div>
+								page( getCategoryUrl( tabSlug ) );
+							} }
+							selectedTab={ category ?? categories[ 0 ].slug }
+							tabs={ categories }
+							titleField="menu"
+							width={ width }
+						/>
+					</>
+				) : (
+					<div ref={ categoriesRef }>
+						<Categories selected={ category } noSelection={ searchTerm ? true : false } />
+					</div>
+				) }
+			</div>
+			{ isSticky && <div className="search-categories__sticky-placeholder" /> }
+		</>
 	);
 };
 

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -1,11 +1,13 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+$search-categories-padding-top: 40px;
+
 .search-categories {
 	display: flex;
 	align-items: center;
 	gap: 12px;
-	padding-top: 40px;
+	padding-top: $search-categories-padding-top;
 
 	@media (max-width: 660px) {
 		padding: 0 16px;
@@ -197,4 +199,10 @@
 			}
 		}
 	}
+}
+
+.search-categories__sticky-placeholder {
+	// This is the height + padding of the .search-categories box when it's not fixed to the top
+	// We add this whitespace so the content doesn't jump when the search box becomes fixed
+	height: calc(#{$search-categories-padding-top} + 16px);
 }

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -178,10 +178,10 @@
 		@media (min-width: 783px) {
 			top: var(--masterbar-height);
 			box-sizing: content-box;
-			padding: 10px calc((100% - var(--sidebar-width-max) - 1040px) / 2);
+			padding: 10px calc((100% - var(--sidebar-width-max) - (1040px - 2 * 2rem)) / 2);
 
 			.layout__secondary ~ .layout__primary & {
-				width: 1040px;
+				width: calc(1040px - 2 * 2rem);
 			}
 		}
 	}

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -158,13 +158,9 @@
 
 	&.fixed-top {
 		@media (min-width: 783px) {
-			margin-top: 0;
 			position: fixed;
 			z-index: 20;
 			top: 16px;
-			left: 0;
-			width: 100%;
-			max-width: 100%;
 			padding: 10px 32px;
 			box-sizing: border-box;
 			border-top-left-radius: 4px;
@@ -174,6 +170,16 @@
 			.layout__secondary ~ .layout__primary & {
 				left: var(--sidebar-width-max);
 				width: calc(100% - var(--sidebar-width-max) - 31px);
+			}
+		}
+	}
+
+	.plugins-browser--site-view &.fixed-top {
+		@media (min-width: 783px) {
+			top: var(--masterbar-height);
+
+			.layout__secondary ~ .layout__primary & {
+				width: calc(100% - var(--sidebar-width-max));
 			}
 		}
 	}

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -155,29 +155,26 @@
 	.categories__menu {
 		padding: 0;
 	}
-}
 
-.search-categories.fixed-top {
-	.search-categories__search {
+	&.fixed-top {
 		@media (min-width: 783px) {
 			margin-top: 0;
 			position: fixed;
 			z-index: 20;
-			top: var(--masterbar-height);
+			top: 16px;
 			left: 0;
 			width: 100%;
 			max-width: 100%;
 			padding: 10px 32px;
 			box-sizing: border-box;
+			border-top-left-radius: 4px;
 			border-bottom: 1px solid var(--studio-gray-5);
 			background-color: var(--studio-white);
 
 			.layout__secondary ~ .layout__primary & {
-				left: calc(var(--sidebar-width-max) + 1px);
-				width: calc(100% - var(--sidebar-width-max) - 1px);
+				left: var(--sidebar-width-max);
+				width: calc(100% - var(--sidebar-width-max) - 31px);
 			}
 		}
-
 	}
-
 }

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -177,9 +177,11 @@
 	.plugins-browser--site-view &.fixed-top {
 		@media (min-width: 783px) {
 			top: var(--masterbar-height);
+			box-sizing: content-box;
+			padding: 10px calc((100% - var(--sidebar-width-max) - 1040px) / 2);
 
 			.layout__secondary ~ .layout__primary & {
-				width: calc(100% - var(--sidebar-width-max));
+				width: 1040px;
 			}
 		}
 	}

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -155,10 +155,6 @@
 	.categories__menu {
 		padding: 0;
 	}
-
-	.search-categories__sticky-ref {
-		padding-bottom: 48px;
-	}
 }
 
 .search-categories.fixed-top {

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .search-categories {
 	display: flex;
 	align-items: center;
@@ -157,7 +160,7 @@
 	}
 
 	&.fixed-top {
-		@media (min-width: 783px) {
+		@include break-medium {
 			position: fixed;
 			z-index: 20;
 			top: 16px;
@@ -175,9 +178,18 @@
 	}
 
 	.plugins-browser--site-view &.fixed-top {
-		@media (min-width: 783px) {
-			top: var(--masterbar-height);
-			box-sizing: content-box;
+		top: var(--masterbar-height);
+		box-sizing: content-box;
+
+		@include break-medium {
+			padding: 10px max(2rem, calc((100% - var(--sidebar-width-max) - (1040px - 2 * 2rem)) / 2));
+
+			.layout__secondary ~ .layout__primary & {
+				width: calc(100vw - var(--sidebar-width-max) - 2 * 2rem);
+			}
+		}
+
+		@include break-wide {
 			padding: 10px calc((100% - var(--sidebar-width-max) - (1040px - 2 * 2rem)) / 2);
 
 			.layout__secondary ~ .layout__primary & {


### PR DESCRIPTION
As discussed on https://github.com/Automattic/dotcom-forge/issues/7491#issuecomment-2155360441, we want the header on the `/plugins` page to be sticky, as it already works on the logged out page.

## Proposed Changes

* Add a `useIsVisible` hook that uses an `IntersectionObserver` to determine whether the header needs to be stuck to the top of the page.

## Testing Instructions

* Apply `Hide whitespace` to make the code diff look better.

* Open the live preview
* Go to `/plugins`, check that scrolling down sticks the search and categories to the top, and that scrolling back undoes that:

![plugins](https://github.com/Automattic/wp-calypso/assets/8511199/a6de18de-3706-447d-8eb7-cefb8b8b6021)

* Go to `/plugins/{siteId}`, check that scrolling down sticks the search and categories to the top, and that scrolling back undoes that:

![site view](https://github.com/Automattic/wp-calypso/assets/8511199/ffe0b484-09da-4279-947d-fab53cb46fd2)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
