### PR TITLE
Rename Quick actions ➡️ command palette 

### DIFF
--- a/client/hosting-overview/components/quick-actions-card.tsx
+++ b/client/hosting-overview/components/quick-actions-card.tsx
@@ -4,7 +4,7 @@ import { chevronRightSmall, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
-import { HostingCard } from 'calypso/components/hosting-card';
+import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { WriteIcon } from 'calypso/layout/masterbar/write-icon';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
@@ -60,15 +60,28 @@ const QuickActionsCard: FC = () => {
 
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( site?.ID );
 
+	const isMac = window?.navigator.userAgent && window.navigator.userAgent.indexOf( 'Mac' ) > -1;
+	const paletteShortcut = isMac ? '⌘K' : 'Ctrl + K';
+
 	return (
-		<HostingCard
-			className="hosting-overview__quick-actions"
-			title={
-				hasEnTranslation( 'Quick actions' )
-					? translate( 'Quick actions' )
-					: translate( 'WP Admin links' )
-			}
-		>
+		<HostingCard className="hosting-overview__quick-actions">
+			<div className="hosting-card__title-wrapper">
+				<h3 className="hosting-card__title">
+					{ hasEnTranslation( 'Command Palette' )
+						? translate( 'Command Palette' )
+						: translate( 'Quick actions' ) }
+				</h3>
+				<span className="hosting-card__title-shortcut">{ paletteShortcut }</span>
+			</div>
+			<HostingCardDescription>
+				{ translate(
+					// Translators: {{shortcut/}} is "⌘K" or "Ctrl+K" depending on the user's OS.
+					'Navigate your site smoothly. Use the commands below or press %(shortcut)s for more options.',
+					{
+						args: { shortcut: paletteShortcut },
+					}
+				) }
+			</HostingCardDescription>
 			<ul className="hosting-overview__actions-list">
 				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-wordpress-alt hosting-overview__dashicon" /> }

--- a/client/hosting-overview/components/style.scss
+++ b/client/hosting-overview/components/style.scss
@@ -59,6 +59,19 @@ $card-padding: 24px;
 	padding-bottom: 10px;
 }
 
+.hosting-overview__quick-actions .hosting-card__title-wrapper {
+	margin-bottom: 12px;
+}
+.hosting-overview__quick-actions .hosting-card__title {
+	display: inline;
+}
+.hosting-overview__quick-actions .hosting-card__title-shortcut {
+	margin-left: 1em;
+	background-color: var(--studio-gray-0);
+	padding: 0.25em;
+	font-size: 0.75rem;
+}
+
 .hosting-card.support-card {
 	.happiness-engineers-tray {
 		align-items: flex-start;

--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -669,6 +669,13 @@ export function useCommands() {
 			openJetpackStats: {
 				name: 'openJetpackStats',
 				label: __( 'Open Jetpack Stats', __i18n_text_domain__ ),
+				searchLabel: [
+					_x(
+						'see jetpack stats',
+						'Keyword for the Open Jetpack Stats command',
+						__i18n_text_domain__
+					),
+				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
 					commandNavigation(
 						siteUsesWpAdminInterface( params.site )
@@ -1187,6 +1194,7 @@ export function useCommands() {
 					_x( 'activate theme', 'Keyword for the Manage themes command', __i18n_text_domain__ ),
 					_x( 'install theme', 'Keyword for the Manage themes command', __i18n_text_domain__ ),
 					_x( 'delete theme', 'Keyword for the Manage themes command', __i18n_text_domain__ ),
+					_x( 'change theme', 'Keyword for the Manage themes command', __i18n_text_domain__ ),
 					'wp theme*', // WP-CLI command
 				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>
@@ -1240,11 +1248,15 @@ export function useCommands() {
 				label: __( 'Manage plugins', __i18n_text_domain__ ),
 				searchLabel: [
 					_x( 'manage plugins', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
-					_x( 'activate plugin', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
-					_x( 'deactivate plugin', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
-					_x( 'install plugin', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
-					_x( 'delete plugin', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
-					_x( 'update plugin', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
+					_x( 'activate plugins', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
+					_x(
+						'deactivate plugins',
+						'Keyword for the Manage plugins command',
+						__i18n_text_domain__
+					),
+					_x( 'install plugins', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
+					_x( 'delete plugins', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
+					_x( 'update plugins', 'Keyword for the Manage plugins command', __i18n_text_domain__ ),
 					'wp plugin*', // WP-CLI command
 				].join( KEYWORD_SEPARATOR ),
 				callback: ( params ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7687

## Proposed Changes

* Rebrand 'quick actions' to 'Command Palette'
* Add aliases to some commands to the existing quick actions find search results

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To introduce people to the idea of the command palette so that they can explore it.

## Testing Instructions

1. Use calypso live link
2. Go to /overview/:siteSlug
3. Look at the Command Palette panel

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before | After
-------|------
<img width="1195" alt="Screenshot 2024-06-19 at 22 13 49" src="https://github.com/Automattic/wp-calypso/assets/93301/9bf6d698-6bae-49d2-be5c-362ab7d92116"> | <img width="1195" alt="Screenshot 2024-06-19 at 22 13 15" src="https://github.com/Automattic/wp-calypso/assets/93301/80c8acab-1863-4574-8261-c0a234e9e239">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
