### PR TITLE
A4A: Change client purchases CTA button label to 'Submit purchase'.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -127,7 +127,7 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 				>
 					{ paymentMethodRequired
 						? translate( 'Add my payment method' )
-						: translate( 'Submit my payment information' ) }
+						: translate( 'Submit purchase' ) }
 				</Button>
 			</div>
 			<div className="checkout__aside-footer">


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="449" alt="Screenshot 2024-06-19 at 11 21 49 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/bc9d342c-dc1e-4cb1-b355-46b6ebe55fb7"> | <img width="373" alt="Screenshot 2024-06-19 at 11 21 59 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0a8d70b7-f0ea-4892-ac54-d77b150ec3e1"> | 


Closes https://github.com/Automattic/jetpack-genesis/issues/395

## Proposed Changes

* Change the **'Submit my payment information'** CTA label to **'Submit purchase'**.


## Testing Instructions


* Create a new referral for your dummy client account.
* Confirm that in the client's checkout page, the CTA for purchase button is correct.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
