### PR TITLE
A4A: Make Sticky card and Partner Directory onboarding card responsive.

### DIFF
--- a/client/a8c-for-agencies/components/sticky-card/style.scss
+++ b/client/a8c-for-agencies/components/sticky-card/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .sticky-card {
 	--margin-spacing: 40px;
 	--spring-easing: linear(0, 0.008, 0.031 1.9%, 0.127 4%, 0.669 12%, 0.879 15.8%, 0.957, 1.017, 1.062, 1.091 23.7%, 1.101, 1.106, 1.107 27.8%, 1.103 29.4%, 1.088 32.2%, 1.038 39%, 1.016 42.6%, 1 46.5%, 0.991 50.8%, 0.989 56.7%, 1.001 76.7%, 1);
@@ -16,42 +19,65 @@
 	}
 
 
-	display: block;
+	display: flex;
+	flex-direction: column;
 	position: absolute;
-	border-radius: 4px;
-	min-width: 420px;
+	width: 100%;
+	height: 100%;
 	background-color: var(--color-surface);
-
-	box-shadow: 0 4px 15.7px 0 #0000001a;
 	z-index: 999999999;
-	animation: var(--spring-duration) var(--spring-easing) 1s unveil forwards;
-	opacity: 0;
+	top: 0;
+	left: 0;
+	right: auto;
+	bottom: auto;
 
-	&.is-positioned-top-left {
-		top: var(--margin-spacing);
-		left: var(--margin-spacing);
-	}
+	@include break-small {
+		min-width: 420px;
+		height: auto;
+		width: auto;
+		box-shadow: 0 4px 15.7px 0 #0000001a;
+		border-radius: 4px;
+		animation: var(--spring-duration) var(--spring-easing) 1s unveil forwards;
+		opacity: 0;
 
+		&.is-positioned-top-left {
+			top: var(--margin-spacing);
+			left: var(--margin-spacing);
+			right: auto;
+			bottom: auto;
+		}
 
-	&.is-positioned-top-right {
-		top: var(--margin-spacing);
-		right: var(--margin-spacing);
-	}
+		&.is-positioned-top-right {
+			top: var(--margin-spacing);
+			right: var(--margin-spacing);
+			left: auto;
+			bottom: auto;
+		}
 
-	&.is-positioned-bottom-left {
-		bottom: var(--margin-spacing);
-		left: var(--margin-spacing);
-	}
+		&.is-positioned-bottom-left {
+			bottom: var(--margin-spacing);
+			left: var(--margin-spacing);
+			top: auto;
+			right: auto;
+		}
 
-	&.is-positioned-bottom-right {
-		bottom: var(--margin-spacing);
-		right: var(--margin-spacing);
+		&.is-positioned-bottom-right {
+			bottom: var(--margin-spacing);
+			right: var(--margin-spacing);
+			top: auto;
+			left: auto;
+		}
 	}
 }
 
 .sticky-card__heading,
 .sticky-card__body {
 	padding: 16px;
+}
+
+
+.sticky-card__body {
+	flex-grow: 1;
 }
 
 .sticky-card__heading {

--- a/client/a8c-for-agencies/sections/overview/partner-directory-onboarding-card/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/partner-directory-onboarding-card/index.tsx
@@ -39,18 +39,20 @@ export default function PartnerDirectoryOnboardingCard() {
 			dismissable
 			onClose={ onDismiss }
 		>
-			<img className="partner-director-onboarding-card__banner" src={ banner } alt="" />
+			<div className="partner-director-onboarding-card__top">
+				<img className="partner-director-onboarding-card__banner" src={ banner } alt="" />
 
-			<div className="partner-directory-onboarding-card__content">
-				<h1 className="partner-directory-onboarding-card__content-title">
-					{ translate( 'Boost your agency’s visibility across Automattic platforms' ) }
-				</h1>
+				<div className="partner-directory-onboarding-card__content">
+					<h1 className="partner-directory-onboarding-card__content-title">
+						{ translate( 'Boost your agency’s visibility across Automattic platforms' ) }
+					</h1>
 
-				<p className="partner-directory-onboarding-card__content-description">
-					{ translate(
-						'Complete your agency profile on our platform to be featured in our partner directories.'
-					) }
-				</p>
+					<p className="partner-directory-onboarding-card__content-description">
+						{ translate(
+							'Complete your agency profile on our platform to be featured in our partner directories.'
+						) }
+					</p>
+				</div>
 			</div>
 
 			<div className="partner-directory-onboarding-card__footer">

--- a/client/a8c-for-agencies/sections/overview/partner-directory-onboarding-card/style.scss
+++ b/client/a8c-for-agencies/sections/overview/partner-directory-onboarding-card/style.scss
@@ -1,11 +1,25 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .partner-directory-onboarding-card {
 	.sticky-card__body {
 		padding: 0;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
 
 		> * {
-			max-width: 420px;
 			width: 100%;
 			box-sizing: border-box;
+		}
+
+		@include break-small {
+			display: block;
+
+			> * {
+				max-width: 420px;
+				height: auto;
+			}
 		}
 	}
 }
@@ -37,11 +51,15 @@
 
 .partner-directory-onboarding-card__footer {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	gap: 16px;
-	align-items: center;
-	justify-content: flex-end;
 	padding: 8px 16px 16px;
+
+	@include break-small {
+		flex-direction: row;
+		align-items: center;
+		justify-content: flex-end;
+	}
 }
 
 .partner-directoy-onboarding-card__dismiss-button {


### PR DESCRIPTION
This PR makes the Partner directory onboarding card mobile responsive.

<img width="399" alt="Screenshot 2024-06-20 at 2 27 56 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d351dd74-b8b1-49df-98d6-c93afdbbf4d6">


Follow-ups https://github.com/Automattic/wp-calypso/pull/91895

## Proposed Changes

* Update styling so Sticky card and Partner directory onboarding card are mobile responsive.

## Testing Instructions

* Reset the `a4a-partner-directory-onboarding-card` preference using the Calypso dev tool.
* Use the A4A live link and go to the `/overview` page.
* Set your browser's width to mobile view.
* Confirm that the Onboarding card is responsive.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
