### PR TITLE
Agencies: Add temporary migration procedure

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -140,17 +140,20 @@ export default function NeedSetup( { licenseKey }: Props ) {
 		[ createWPCOMSite, refetchPendingSites ]
 	);
 
-	const onMigrateSite = useCallback( ( id: number ) => {
-		createWPCOMSite(
-			{ id },
-			{
-				onSuccess: () => {
-					refetchPendingSites();
-					page( addQueryArgs( A4A_SITES_LINK, { created_site: id, migration: true } ) );
-				},
-			}
-		);
-	} );
+	const onMigrateSite = useCallback(
+		( id: number ) => {
+			createWPCOMSite(
+				{ id },
+				{
+					onSuccess: () => {
+						refetchPendingSites();
+						page( addQueryArgs( A4A_SITES_LINK, { created_site: id, migration: true } ) );
+					},
+				}
+			);
+		},
+		[ createWPCOMSite, refetchPendingSites ]
+	);
 
 	return (
 		<Layout

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -140,6 +140,18 @@ export default function NeedSetup( { licenseKey }: Props ) {
 		[ createWPCOMSite, refetchPendingSites ]
 	);
 
+	const onMigrateSite = useCallback( ( id: number ) => {
+		createWPCOMSite(
+			{ id },
+			{
+				onSuccess: () => {
+					refetchPendingSites();
+					page( addQueryArgs( A4A_SITES_LINK, { created_site: id, migration: true } ) );
+				},
+			}
+		);
+	} );
+
 	return (
 		<Layout
 			className={ clsx(
@@ -169,6 +181,7 @@ export default function NeedSetup( { licenseKey }: Props ) {
 					isLoading={ isFetching }
 					provisioning={ isProvisioning }
 					onCreateSite={ onCreateSite }
+					onMigrateSite={ onMigrateSite }
 				/>
 			</LayoutColumn>
 		</Layout>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/migrate-site-button.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/migrate-site-button.tsx
@@ -1,0 +1,16 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+type Props = {
+	onClick: () => void;
+};
+
+export default function MigrateSiteButton( { onClick }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<Button className="plan-field__button" onClick={ onClick } plain>
+			{ translate( 'Migrate an existing site' ) }
+		</Button>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/plan-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/plan-field.tsx
@@ -1,5 +1,7 @@
+import config from '@automattic/calypso-config';
 import wpcomIcon from 'calypso/assets/images/icons/wordpress-logo.svg';
 import CreateSiteButton from './create-site-button';
+import MigrateSiteButton from './migrate-site-button';
 
 export type AvailablePlans = {
 	name: string;
@@ -10,9 +12,17 @@ export type AvailablePlans = {
 type Props = AvailablePlans & {
 	provisioning?: boolean;
 	onCreateSite: ( id: number ) => void;
+	onMigrateSite: ( id: number ) => void;
 };
 
-export default function PlanField( { name, subTitle, ids, provisioning, onCreateSite }: Props ) {
+export default function PlanField( {
+	name,
+	subTitle,
+	ids,
+	provisioning,
+	onCreateSite,
+	onMigrateSite,
+}: Props ) {
 	return (
 		<div className="plan-field">
 			<div className="plan-field__icon">
@@ -28,6 +38,9 @@ export default function PlanField( { name, subTitle, ids, provisioning, onCreate
 				provisioning={ provisioning }
 				onActivate={ () => onCreateSite( ids[ 0 ] ) }
 			/>
+			{ config.isEnabled( 'a4a/site-migration' ) && (
+				<MigrateSiteButton onClick={ () => onMigrateSite( ids[ 0 ] ) } />
+			) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/table.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/table.tsx
@@ -13,6 +13,7 @@ type Props = {
 	isLoading?: boolean;
 	provisioning?: boolean;
 	onCreateSite: ( id: number ) => void;
+	onMigrateSite: ( id: number ) => void;
 };
 
 export default function NeedSetupTable( {
@@ -20,6 +21,7 @@ export default function NeedSetupTable( {
 	isLoading,
 	provisioning,
 	onCreateSite,
+	onMigrateSite,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -38,7 +40,12 @@ export default function NeedSetupTable( {
 				}
 
 				return (
-					<PlanField { ...item } provisioning={ provisioning } onCreateSite={ onCreateSite } />
+					<PlanField
+						{ ...item }
+						provisioning={ provisioning }
+						onCreateSite={ onCreateSite }
+						onMigrateSite={ onMigrateSite }
+					/>
 				);
 			},
 			enableHiding: false,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -54,6 +54,7 @@ export default function SitesDashboard() {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	const recentlyCreatedSite = getQueryArg( window.location.href, 'created_site' ) ?? null;
+	const migrationIntent = getQueryArg( window.location.href, 'migration' ) ?? null;
 
 	const {
 		dataViewsState,
@@ -223,7 +224,10 @@ export default function SitesDashboard() {
 				<LayoutColumn className="sites-overview" wide>
 					<LayoutTop withNavigation={ navItems.length > 1 }>
 						{ recentlyCreatedSite && (
-							<ProvisioningSiteNotification siteId={ Number( recentlyCreatedSite ) } />
+							<ProvisioningSiteNotification
+								siteId={ Number( recentlyCreatedSite ) }
+								migrationIntent={ !! migrationIntent }
+							/>
 						) }
 
 						<LayoutHeader>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -3,21 +3,28 @@ import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import useIsSiteReady from 'calypso/a8c-for-agencies/data/sites/use-is-site-ready';
+import { addQueryArgs } from 'calypso/lib/url';
 
 type Props = {
 	siteId: number;
+	migrationIntent: boolean;
 };
 
-export default function ProvisioningSiteNotification( { siteId }: Props ) {
+export default function ProvisioningSiteNotification( { siteId, migrationIntent }: Props ) {
 	const { isReady, site } = useIsSiteReady( { siteId } );
 	const [ showBanner, setShowBanner ] = useState( true );
 
 	const translate = useTranslate();
 
-	const wpOverviewUrl = `https://wordpress.com/overview/${ site?.url?.replace(
-		/(^\w+:|^)\/\//,
-		''
-	) }`;
+	const siteSlug = site?.url?.replace( /(^\w+:|^)\/\//, '' );
+	const wpOverviewUrl = `https://wordpress.com/overview/${ siteSlug }`;
+	const wpMigrationUrl = addQueryArgs(
+		{
+			siteId: site?.id,
+			siteSlug,
+		},
+		'https://wordpress.com/setup/hosted-site-migration/site-migration-identify'
+	);
 
 	return (
 		showBanner && (
@@ -33,9 +40,15 @@ export default function ProvisioningSiteNotification( { siteId }: Props ) {
 				actions={
 					isReady
 						? [
-								<Button href={ wpOverviewUrl } target="_blank" rel="noreferrer" primary>
-									{ translate( 'Set up your site' ) }
-								</Button>,
+								migrationIntent ? (
+									<Button href={ wpMigrationUrl } target="_blank" rel="noreferrer" primary>
+										{ translate( 'Migrate to this site' ) }
+									</Button>
+								) : (
+									<Button href={ wpOverviewUrl } target="_blank" rel="noreferrer" primary>
+										{ translate( 'Set up your site' ) }
+									</Button>
+								),
 						  ]
 						: undefined
 				}

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -38,6 +38,7 @@
 		"dev/preferences-helper": true,
 		"oauth": true,
 		"a4a/site-details-pane": true,
+		"a4a/site-migration": true,
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true
 	},

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -34,6 +34,7 @@
 		"cookie-banner": false,
 		"oauth": true,
 		"a4a/site-details-pane": true,
+		"a4a/site-migration": true,
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pfunGA-1Ts-p2

## Proposed Changes

* Add a way to guide the user to migrate an existing site to an A4A WPCOM site 
* When creating a site, user is presented with a new option to migrate a site
* When opting to migrate a site, the same provisioning process will happen to create the target site, but the user will be presented with a call to action to start the migration using the newly created as the preselected target.

![image](https://github.com/Automattic/wp-calypso/assets/5550190/fe5f3af4-e72a-4552-8a8c-f5f785fdac3d)
![image](https://github.com/Automattic/wp-calypso/assets/5550190/aeced0dd-bd5a-4a60-82ca-9a725de7f25d)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is a temporary proposal to help with site migrations to A4A ( pfunGA-1Ts-p2 )

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to agencies.localhost:3000/marketplace/hosting/wpcom
* Purchase any amount of sites
* on the site setup screen you'll see the option to "Migrate a site"
* Clicking to migrate a site, will take you to the sites overview but with the notice banner asking you to complete the migration
* Clicking on the action button will lead to start the regular wordpress.com migration ( as in wordpress.com/move ), but with the target site pre-selected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?