### PR TITLE
SignupForm: remove legacy code for handling back button

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Button, FormInputValidation, FormLabel } from '@automattic/components';
+import { FormInputValidation, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
@@ -1028,16 +1028,6 @@ class SignupForm extends Component {
 	};
 
 	formFooter() {
-		if ( this.userCreationComplete() ) {
-			return (
-				<LoggedOutFormFooter>
-					<Button primary onClick={ () => this.props.goToNextStep() }>
-						{ this.props.translate( 'Continue' ) }
-					</Button>
-				</LoggedOutFormFooter>
-			);
-		}
-
 		const params = new URLSearchParams( window.location.search );
 		const variationName = params.get( 'variationName' );
 
@@ -1117,10 +1107,6 @@ class SignupForm extends Component {
 		);
 	}
 
-	userCreationComplete() {
-		return this.props.step && 'completed' === this.props.step.status;
-	}
-
 	handleOnChangeAccount = () => {
 		recordTracksEvent( 'calypso_signup_click_on_change_account' );
 		this.props.redirectToLogout( window.location.href );
@@ -1183,7 +1169,7 @@ class SignupForm extends Component {
 
 						{ this.renderWooCommerce() }
 
-						{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
+						{ this.props.isSocialSignupEnabled && (
 							<SocialSignupForm
 								handleResponse={ this.handleWooCommerceSocialConnect }
 								socialService={ this.props.socialService }
@@ -1230,7 +1216,6 @@ class SignupForm extends Component {
 		if ( this.props.isSocialFirst ) {
 			return (
 				<SignupFormSocialFirst
-					step={ this.props.step }
 					stepName={ this.props.stepName }
 					flowName={ this.props.flowName }
 					goToNextStep={ this.props.goToNextStep }
@@ -1251,8 +1236,7 @@ class SignupForm extends Component {
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
 		const showSeparator =
-			( ! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete() ) ||
-			this.props.isWoo;
+			( ! config.isEnabled( 'desktop' ) && this.isHorizontal() ) || this.props.isWoo;
 
 		if (
 			( this.props.isPasswordless &&
@@ -1287,7 +1271,6 @@ class SignupForm extends Component {
 				>
 					{ this.getNotice() }
 					<PasswordlessSignupForm
-						step={ this.props.step }
 						stepName={ this.props.stepName }
 						flowName={ this.props.flowName }
 						goToNextStep={ this.props.goToNextStep }
@@ -1324,8 +1307,7 @@ class SignupForm extends Component {
 					{ ! isGravatar && (
 						<>
 							{ showSeparator && <FormDivider /> }
-
-							{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
+							{ this.props.isSocialSignupEnabled && (
 								<SocialSignupForm
 									handleResponse={ this.props.handleSocialResponse }
 									socialService={ this.props.socialService }
@@ -1362,7 +1344,7 @@ class SignupForm extends Component {
 
 				{ showSeparator && <FormDivider /> }
 
-				{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
+				{ this.props.isSocialSignupEnabled && (
 					<SocialSignupForm
 						handleResponse={ this.props.handleSocialResponse }
 						socialService={ this.props.socialService }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -269,21 +269,8 @@ class PasswordlessSignupForm extends Component {
 		);
 	}
 
-	userCreationComplete() {
-		return this.props.step && 'completed' === this.props.step.status;
-	}
-
 	formFooter() {
 		const { isSubmitting } = this.state;
-		if ( this.userCreationComplete() ) {
-			return (
-				<LoggedOutFormFooter>
-					<Button primary onClick={ () => this.props.goToNextStep() }>
-						{ this.props.translate( 'Continue' ) }
-					</Button>
-				</LoggedOutFormFooter>
-			);
-		}
 		const submitButtonText = isSubmitting
 			? this.props.submitButtonLoadingLabel || this.props.translate( 'Creating Your Account…' )
 			: this.props.submitButtonLabel || this.props.translate( 'Create your account' );

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -15,7 +15,6 @@ import './style.scss';
 
 interface SignupFormSocialFirst {
 	goToNextStep: () => void;
-	step: object;
 	stepName: string;
 	flowName: string;
 	redirectToAfterLoginUrl: string;
@@ -60,7 +59,6 @@ const options = {
 
 const SignupFormSocialFirst = ( {
 	goToNextStep,
-	step,
 	stepName,
 	flowName,
 	redirectToAfterLoginUrl,
@@ -159,7 +157,6 @@ const SignupFormSocialFirst = ( {
 			return (
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
-						step={ step }
 						stepName={ stepName }
 						flowName={ flowName }
 						goToNextStep={ goToNextStep }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/user/index.tsx
@@ -41,7 +41,6 @@ const StepContent: Step = ( { flow, stepName, navigation } ) => {
 		<>
 			<FormattedHeader align="center" headerText={ translate( 'Create your account' ) } brandFont />
 			<SignupFormSocialFirst
-				step={ {} }
 				stepName={ stepName }
 				flowName={ flow }
 				goToNextStep={ () => {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -10,7 +10,6 @@ import {
 import { isOnboardingGuidedFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
 import { get, includes, reject } from 'lodash';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
-import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs } from 'calypso/lib/url';
 import { generateFlows } from 'calypso/signup/config/flows-pure';
@@ -386,14 +385,10 @@ const Flows = {
 		}
 
 		if ( isUserLoggedIn ) {
-			const urlParams = new URLSearchParams( window.location.search );
-			const param = urlParams.get( 'user_completed' );
 			const isUserStepOnly = flow.steps.length === 1 && stepConfig[ flow.steps[ 0 ] ].providesToken;
 
-			// Remove the user step unless the user has just completed the step
-			// and then clicked the back button.
-			// If the user step is the only step in the whole flow, e.g. /start/account, don't remove it as well.
-			if ( ! param && ! detectHistoryNavigation.loadedViaHistory() && ! isUserStepOnly ) {
+			// Remove the user step unless it is the only step in the whole flow, e.g., `/start/account`
+			if ( ! isUserStepOnly ) {
 				flow = removeUserStepFromFlow( flow );
 			}
 		}


### PR DESCRIPTION
The `user` step in signup has one problem that it needs to solve: if the `user` step is completed and the user account is created, you proceed to the next step, like `domains`. Now what happens when you click the back button? You go back to `user`. Without any treatment, this step would should the signup form again, confusing the user to fill and submit it again, creating a duplicate account. We want to prevent that. And over the years, we iterated through three solutions.

The first solution was in #27832 by @mattwiebe. It solved it by using an `userCreationComplete` helper to detect that the `user` step is `completed` and show a notice and a slightly altered form. The user is warned that the user is already created.

The second iteration was #58221 by @enejb and it showed a `ContinueAsUser` UI instead of the signup form when a back-button navigation was detected and the user was logged in. It implemented history navigation detection and `?user_completed=true` query param to show the right thing. After this PR, the user should never see the first version with a notice again after clicking the back button.

And the final iteration, which obsoleted the previous two, was #65908 by @zaguiini and @danielbachhuber. It added a `componentDidMount/Update` effect that simply redirects to the next step (`goToNextStep`) if the `user` step is `completed`. If you navigate from, e.g., `/start/domain` back to `/start/user`, you are immediately redirected back to `/start/domains` (the next step). There's no longer a need for `/start/user` to render anything special.

The only case where `/start/user` still shows `ContinueAsUser` is when it's the only step in the flow, like in `account`. But there's no next step to go back from. After the `user` step completes, the signup flow ends, its state is reset and it navigates to the flow "destination".

My PR removes all the code that is legacy and no longer needed. The `userCreationComplete` checks, the `detectHistoryNavigation` usages. One of the consequences is that many of the `user` components no longer need the `step` prop. Which is a good thing because it's a data structure specific to the classic signup framework, and all these components are also used in other contexts: Jetpack Connect, Invite Accept, Stepper.

In a sense this is also a followup to #91883.

**How to test:**
First thing to note is that most user creations today are passwordless, and passwordless signup doesn't have the back button problem. Because the flow is interrupted after signup, and you continue it only after opening a link in email, in another browser tab.

So, first thing I did was to disable passwordless signup by disabling the `signup/social-first` feature flag in dev mode.

Then I went through the `onboarding` flow:

https://github.com/Automattic/wp-calypso/assets/664258/1c0b7219-7d4a-435a-af2c-a9ae75341f23

Things that you should notice:
- after the user creation is complete and before displaying the Domains step, there is a brief moment when just a white screen (with a little WP logo) is rendered. That's the `step.status === 'completed'` state where the `User` step renders nothing.
- after you click back in the Domains step, you can see in the console (I put some logpoints in the Calypso router) that the app navigates back to `/start/user` but then redirects immediately back to `/start/domains`.

Another flow you should test is `/start/account`, because it's the special case where a flow has just a single `user` step.
