### PR TITLE
Update Sign Up page for logged in users

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -7,7 +7,9 @@ import Gravatar from 'calypso/components/gravatar';
 import wpcom from 'calypso/lib/wp';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
+import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWooPasswordless from 'calypso/state/selectors/get-is-woo-passwordless';
+import SocialToS from '../authentication/social/social-tos';
 
 import './continue-as-user.scss';
 
@@ -44,7 +46,7 @@ function ContinueAsUser( {
 	isSignUpFlow,
 	isWooOAuth2Client,
 	isWooPasswordless,
-	isBlazeProOAuth2Client,
+	isBlazePro,
 } ) {
 	const translate = useTranslate();
 	const { url: validatedRedirectUrlFromQuery, loading: validatingQueryURL } =
@@ -157,7 +159,7 @@ function ContinueAsUser( {
 		);
 	}
 
-	if ( isBlazeProOAuth2Client ) {
+	if ( isBlazePro ) {
 		return (
 			<div className="continue-as-user">
 				<div className="continue-as-user__user-info">
@@ -183,6 +185,7 @@ function ContinueAsUser( {
 						context: 'Continue as an existing WordPress.com user',
 					} ) } ${ userName }` }
 				</Button>
+				<SocialToS />
 			</div>
 		);
 	}
@@ -208,4 +211,5 @@ export default connect( ( state ) => ( {
 	currentUser: getCurrentUser( state ),
 	redirectUrlFromQuery: get( getCurrentQueryArguments( state ), 'redirect_to', null ),
 	isWooPasswordless: getIsWooPasswordless( state ),
+	isBlazePro: getIsBlazePro( state ),
 } ) )( ContinueAsUser );

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -931,6 +931,7 @@ class Login extends Component {
 						<ContinueAsUser
 							onChangeAccount={ this.handleContinueAsAnotherUser }
 							isWooOAuth2Client={ isWoo }
+							isBlazePro={ isBlazePro }
 						/>
 						<LoginForm
 							disableAutoFocus={ disableAutoFocus }
@@ -956,7 +957,7 @@ class Login extends Component {
 					<div className="login__body login__body--continue-as-user">
 						<ContinueAsUser
 							onChangeAccount={ this.handleContinueAsAnotherUser }
-							isBlazeProOAuth2Client={ isBlazePro }
+							isBlazePro={ isBlazePro }
 						/>
 						<LoginForm
 							disableAutoFocus={ disableAutoFocus }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -44,6 +44,7 @@ import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tour
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
@@ -315,6 +316,9 @@ class Layout extends Component {
 				<AsyncLoad require="calypso/layout/masterbar/woo-core-profiler" placeholder={ null } />
 			);
 		}
+		if ( this.props.isBlazePro ) {
+			return <AsyncLoad require="calypso/layout/masterbar/blaze-pro" placeholder={ null } />;
+		}
 
 		const MasterbarComponent = config.isEnabled( 'jetpack-cloud' )
 			? JetpackCloudMasterbar
@@ -355,6 +359,7 @@ class Layout extends Component {
 			'is-global-sidebar-visible': this.props.isGlobalSidebarVisible,
 			'is-global-sidebar-collapsed': this.props.isGlobalSidebarCollapsed,
 			'is-unified-site-sidebar-visible': this.props.isUnifiedSiteSidebarVisible,
+			'is-blaze-pro': this.props.isBlazePro,
 		} );
 
 		const optionalBodyProps = () => {
@@ -496,6 +501,7 @@ export default withCurrentRoute(
 		const isWooCoreProfilerFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
 			isWooCommerceCoreProfilerFlow( state );
+		const isBlazePro = getIsBlazePro( state );
 		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
 			state,
 			siteId,
@@ -522,7 +528,9 @@ export default withCurrentRoute(
 		const noMasterbarForSection =
 			// hide the masterBar until the section is loaded. To flicker the masterBar in, is better than to flicker it out.
 			! sectionName ||
-			( ! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName ) );
+			( ! isWooCoreProfilerFlow &&
+				! isBlazePro &&
+				[ 'signup', 'jetpack-connect' ].includes( sectionName ) );
 		const isFromAutomatticForAgenciesPlugin =
 			'automattic-for-agencies-client' === currentQuery?.from;
 		const masterbarIsHidden =
@@ -569,6 +577,7 @@ export default withCurrentRoute(
 			isWooCoreProfilerFlow,
 			isFromAutomatticForAgenciesPlugin,
 			isEligibleForJITM,
+			isBlazePro,
 			oauth2Client,
 			wccomFrom,
 			isLoggedIn: isUserLoggedIn( state ),

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -14,14 +14,43 @@
 
 $inter: Inter, $sans;
 $sfProText: "SF Pro Text", $sans;
+$colorBlack: #1f1f1f;
 
 * {
 	font-family: $inter;
 }
 
-.blaze-pro {
+body.is-section-signup {
+	--font-inter:
+		"Inter",
+		-apple-system,
+		system-ui,
+		blinkmacsystemfont,
+		"Segoe UI",
+		"Roboto",
+		"Oxygen-Sans",
+		"Ubuntu",
+		"Cantarell",
+		"Helvetica Neue",
+		sans-serif;
+
+	&:has(.is-blaze-pro) {
+		background: #fff;
+
+		.layout:not(.dops):not(.is-wccom-oauth-flow) .formatted-header .formatted-header__title {
+			color: $colorBlack;
+			font-family: var(--font-inter);
+			font-size: 2rem;
+			font-weight: 700;
+			line-height: 40px;
+		}
+	}
+}
+
+.blaze-pro,
+.is-blaze-pro { // is-blaze-pro is used by Sign Up flow (for logged in users)
 	--color-white: #fff;
-	--color-black: #1f1f1f;
+	--color-black: $colorBlack;
 	--color-gray: #50575e;
 	--color-orange: #ff6433;
 
@@ -218,16 +247,20 @@ $sfProText: "SF Pro Text", $sans;
 
 		.continue-as-user__username {
 			color: var(--color-black);
+			font-family: $inter;
 			font-size: 1rem;
+			font-weight: 600;
 			line-height: 20px;
 		}
 
 		.continue-as-user__email {
-			font-size: 0.875rem;
-			line-height: 20px;
 			color: var(--studio-gray-60);
-			text-align: center;
+			font-family: $inter;
+			font-size: 0.875rem;
+			font-weight: 500;
+			line-height: 20px;
 			margin: 0;
+			text-align: center;
 		}
 
 		.continue-as-user__not-you {
@@ -243,12 +276,13 @@ $sfProText: "SF Pro Text", $sans;
 		}
 
 		.continue-as-user__change-user-link {
-			text-decoration: none;
 			color: var(--color-orange);
+			font-family: $inter;
 			font-size: 0.875rem;
 			font-style: normal;
 			font-weight: 500;
 			line-height: 20px;
+			text-decoration: none;
 
 			&:hover {
 				color: var(--color-orange);
@@ -256,10 +290,15 @@ $sfProText: "SF Pro Text", $sans;
 		}
 
 		.continue-as-user__continue-button {
-			margin-top: 24px;
 			background: var(--color-orange);
 			border-color: var(--color-orange);
 			border-radius: 4px;
+			font-family: $inter;
+			font-size: rem(13px);
+			font-weight: 600;
+			line-height: 14px;
+			margin-top: 24px;
+			padding: 12px 16px;
 			width: 326px;
 		}
 	}
@@ -558,5 +597,28 @@ $sfProText: "SF Pro Text", $sans;
 			font-weight: 500;
 			line-height: 24px;
 		}
+	}
+}
+
+// Hacks for Continue-as-a-user for Sign Up (but user is already logged in)
+.is-blaze-pro {
+	.step-wrapper__content {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+	}
+
+	&.layout:not(.dops) .step-wrapper .step-wrapper__header {
+		margin-top: 0;
+	}
+
+	// Do not show ToS twice for Sign In...
+	&.layout.is-section-login .continue-as-user .auth-form__social-buttons-tos {
+		display: none;
+	}
+
+	// ... though ToS should be shown for Sign Up (for logged in users)
+	&.layout.is-section-signup.is-logged-in .continue-as-user .auth-form__social-buttons-tos {
+		margin-top: 24px;
 	}
 }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -46,6 +46,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWooPasswordless from 'calypso/state/selectors/get-is-woo-passwordless';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies/selectors';
@@ -494,9 +495,13 @@ export class UserStep extends Component {
 			wccomFrom,
 			isSocialFirst,
 			userLoggedIn,
+			isBlazePro,
 		} = this.props;
 
 		if ( userLoggedIn ) {
+			if ( isBlazePro ) {
+				return translate( 'Log in to your Blaze Pro account' );
+			}
 			return translate( 'Is this you?' );
 		}
 
@@ -776,6 +781,7 @@ const ConnectedUser = connect(
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),
 			isWooPasswordless: getIsWooPasswordless( state ),
+			isBlazePro: getIsBlazePro( state ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 		};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to A8C-DSP repo's issue 1880.

Previously similar changes were applied in #91095.

Related design in [Figma](https://www.figma.com/design/0YQJMNMOVVOMqzCWufls0l/BlazePro-(Self-Served-for-Advertisers)?node-id=7096-11442&t=uxjxP1rdqOTtXXcz-0).

## Proposed Changes
- Customize Sign Up flow's step for users that are already logged in

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We can open a Sign Up link while being logged in. Even though logically, it should be the same screen as Sign In for logged in users but it is not. Since that I have to customize this edge case as well.

## Testing Instructions
- Make sure you are logged in WPCOM,
- As it was mentioned in #91095, we need a Sign Up link,
- Create a file called `generate-links.js` with following content:
```js
function generateState() {
  const crypto = require('crypto');
  const hmac = crypto.createHmac('sha256', 'secret' );
  const data = hmac.update(new Date().getTime().toString());
  const state = data.digest('hex');
  return state;
}

const redirectUri = 'http://blaze.pro:3005/auth/connected&blog_id=0&wpcom_connect=1&calypso_env=development&scope=global&from-calypso=1';
const getLoginLink = () =>
	`https://public-api.wordpress.com/oauth2/authorize?response_type=code&client_id=92099&state=${generateState()}&redirect_uri=${encodeURIComponent(redirectUri)}`;

const signInLink = `http://calypso.localhost:3000/log-in?client_id=92099&redirect_to=${encodeURIComponent(getLoginLink())}`;

const signUpLink = `http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=92099&oauth2_redirect=${encodeURIComponent(getLoginLink())}`;

console.log('Login URL:');
console.log(signInLink);
console.log('');
console.log('Sign Up URL:');
console.log(signUpLink);
```

- Run the script using something like `node generate-links.js`
- Copy Sign Up link and open it in your browser,
- It should look similar to what I have:

<img width="594" alt="image" src="https://github.com/Automattic/wp-calypso/assets/115007291/2e59bc2e-49c6-44c2-8e84-5dbe852d47c4">

- Optionally, you can open Sign Up and Sign In links from what the script generated and make sure the rest of customizations work fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
