### PR TITLE
A4A: fix referral wording

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -291,13 +291,17 @@ export default function LayoutBodyContent( {
 										: translate( 'Install WooPayments on your clients’ online stores' )
 								}
 								description={
-									isAutomatedReferral
-										? translate(
-												'Receive a revenue share of 5 basis points on the total payments volume.'
-										  )
-										: translate(
-												'Receive a revenue share of 5 basis points (0.05%) on new WooPayments total payments volume (TPV) on clients’ sites.'
-										  )
+									isAutomatedReferral ? (
+										<>
+											{ translate( 'Receive a revenue share of 5 basis points on the' ) }
+											<br />
+											{ translate( 'total payments volume.' ) }
+										</>
+									) : (
+										translate(
+											'Receive a revenue share of 5 basis points (0.05%) on new WooPayments total payments volume (TPV) on clients’ sites.'
+										)
+									)
 								}
 								buttonProps={ {
 									children: isAutomatedReferral

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -292,7 +292,9 @@ export default function LayoutBodyContent( {
 								}
 								description={
 									isAutomatedReferral
-										? translate( 'Receive a rev share of 0.05% per sale.' )
+										? translate(
+												'Receive a revenue share of 5 basis points on the total payments volume.'
+										  )
 										: translate(
 												'Receive a revenue share of 5 basis points (0.05%) on new WooPayments total payments volume (TPV) on clients’ sites.'
 										  )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1718830020506339/1718741158.723619-slack-C06JY8QL0TU

## Proposed Changes

Update wording as per request

<img width="753" alt="Screenshot 2024-06-19 at 2 08 44 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/edf21c1a-8fab-4108-af05-e0e08452978f">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using account with no referrals yet navigate to `/referrals/dashboard` and check wording

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?