### PR TITLE
A4A: remove AppPromo from magic flow

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -137,11 +137,16 @@ class MagicLogin extends Component {
 	renderLinks() {
 		const { isJetpackLogin, locale, showCheckYourEmail, translate, isWoo, query } = this.props;
 
+		const isA4A = query?.redirect_to?.includes( 'agencies.automattic.com' ) ?? false;
+
 		if ( isWoo ) {
 			return null;
 		}
 
 		if ( showCheckYourEmail ) {
+			if ( isA4A ) {
+				return null;
+			}
 			return (
 				<AppPromo
 					title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }
@@ -179,14 +184,16 @@ class MagicLogin extends Component {
 						{ linkBack }
 					</a>
 				</div>
-				<AppPromo
-					title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }
-					campaign="calypso-login-link"
-					className="magic-link-app-promo"
-					iconSize={ 32 }
-					hasQRCode
-					hasGetAppButton={ false }
-				/>
+				{ ! isA4A && (
+					<AppPromo
+						title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }
+						campaign="calypso-login-link"
+						className="magic-link-app-promo"
+						iconSize={ 32 }
+						hasQRCode
+						hasGetAppButton={ false }
+					/>
+				) }
 			</>
 		);
 	}

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -137,7 +137,7 @@ class MagicLogin extends Component {
 	renderLinks() {
 		const { isJetpackLogin, locale, showCheckYourEmail, translate, isWoo, query } = this.props;
 
-		const isA4A = query?.redirect_to?.includes( 'agencies.automattic.com' ) ?? false;
+		const isA4A = query?.redirect_to?.includes( 'agencies.automattic.com/client' ) ?? false;
 
 		if ( isWoo ) {
 			return null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-genesis/issues/404

## Proposed Changes

We need to find a way to hide AppPromo only for A4A magic links flow. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
