### PR TITLE
Add banner to profile page explaining syncing

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
+import { Banner } from 'calypso/components/banner';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
@@ -878,6 +879,19 @@ class Account extends Component {
 							components: {
 								learnMoreLink: (
 									<InlineSupportLink supportContext="account-settings" showIcon={ false } />
+								),
+							},
+						}
+					) }
+				/>
+				<Banner
+					disableHref
+					title={ this.props.translate(
+						'These settings are applied to sites using the Default admin interface style. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink supportContext="admin-interface-style" showIcon={ false } />
 								),
 							},
 						}

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -6,6 +6,7 @@ import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import EditGravatar from 'calypso/blocks/edit-gravatar';
+import { Banner } from 'calypso/components/banner';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -60,6 +61,19 @@ class Profile extends Component {
 							components: {
 								learnMoreLink: (
 									<InlineSupportLink supportContext="manage-profile" showIcon={ false } />
+								),
+							},
+						}
+					) }
+				/>
+				<Banner
+					disableHref
+					title={ this.props.translate(
+						'These settings are applied to all of your sites that use the Default admin interface style. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: (
+									<InlineSupportLink supportContext="admin-interface-style" showIcon={ false } />
 								),
 							},
 						}

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -69,7 +69,7 @@ class Profile extends Component {
 				<Banner
 					disableHref
 					title={ this.props.translate(
-						'These settings are applied to all of your sites that use the Default admin interface style. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						'These settings are applied to sites using the Default admin interface style. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
 								learnMoreLink: (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7749

Discussion in Slack here: p1718776336170899-slack-C06DN6QQVAQ

## Proposed Changes

* This PR adds a banner that helps explain that updates made on `/me` and `/me/account` only sync to sites with the Default admin-interface style. Classic admin-interface sites are "untangled" from `/me` and `/me/account` and do not sync.

<img width="1721" alt="me-banner" src="https://github.com/Automattic/wp-calypso/assets/140841/0e419e5d-94ad-4ad1-9602-7ae8799bc31a">

<img width="1064" alt="Screenshot 2024-06-20 at 3 23 12 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/57ec7bee-d8c2-4b41-b0b5-b3716216fd3e">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To inform the user.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live go to `/me` and `/me/account` and view the banner.
* Click the "Learn more" link to see the inline help.
* What's important is that the banner effectively informs the user, not just that it displays technically.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?