### PR TITLE
Plugins: Add sidebar subheading

### DIFF
--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -83,7 +83,7 @@ const GlobalSidebar = ( {
 		return <Spinner className="sidebar__menu-loading" />;
 	}
 
-	const { requireBackLink, siteTitle, backLinkHref, ...sidebarProps } = props;
+	const { requireBackLink, siteTitle, backLinkHref, subHeading, ...sidebarProps } = props;
 	const sidebarBackLinkHref = getBackLinkFromURL() || backLinkHref || previousLink || '/sites';
 
 	return (
@@ -99,6 +99,7 @@ const GlobalSidebar = ( {
 							<span className="sidebar__site-title">{ siteTitle || translate( 'Back' ) }</span>
 						</div>
 					) }
+					{ subHeading && <div className="sidebar__sub-heading">{ subHeading }</div> }
 					{ children }
 				</Sidebar>
 			</div>

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -20,6 +20,10 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 			siteTitle={ ! isCollapsed && translate( 'Plugins' ) }
 			requireBackLink
 			backLinkHref="/sites"
+			subHeading={
+				! isCollapsed &&
+				translate( "Access plugins that enhance your site's functionality and features." )
+			}
 		>
 			<SidebarMenu>
 				<SidebarItem

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -22,7 +22,9 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 			backLinkHref="/sites"
 			subHeading={
 				! isCollapsed &&
-				translate( "Access plugins that enhance your site's functionality and features." )
+				translate(
+					"Enhance your site's features with plugins, or schedule updates to fit your needs."
+				)
 			}
 		>
 			<SidebarMenu>

--- a/client/my-sites/plugins/sidebar/style.scss
+++ b/client/my-sites/plugins/sidebar/style.scss
@@ -1,6 +1,23 @@
 .global-sidebar .sidebar--plugins {
 	.sidebar__back-link {
-		margin-bottom: 1rem;
+		margin-bottom: 0;
+		a {
+			padding-inline: 0;
+		}
+		.sidebar__site-title {
+			font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-weight: 500;
+		}
+	}
+
+	.sidebar__sub-heading {
+		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		padding-left: 20px;
+		margin-top: 4px;
+		margin-bottom: 13px;
+		display: flex;
+		align-items: center;
+		gap: 4px;
 	}
 }
 

--- a/client/my-sites/plugins/sidebar/style.scss
+++ b/client/my-sites/plugins/sidebar/style.scss
@@ -12,7 +12,7 @@
 
 	.sidebar__sub-heading {
 		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		padding-left: 20px;
+		padding-inline: 20px;
 		margin-top: 4px;
 		margin-bottom: 13px;
 		display: flex;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7619

## Proposed Changes

Add sidebar subheading on Multisite's plugins page.

We have two copy options suggested [here](https://github.com/Automattic/wp-calypso/pull/91965#issuecomment-2188865548) and asked for copy review

| Before | After (option 1) | After (option 2) |
| --- | --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/36b78d8e-4e19-4466-a302-0f2e708e3815) |![image](https://github.com/Automattic/wp-calypso/assets/402286/fa48bb83-2baa-48f4-bde4-02d7b686dcd0) ![image](https://github.com/Automattic/wp-calypso/assets/402286/c5189760-d464-4ba9-aaa8-a5c3e23a44d0) |![image](https://github.com/Automattic/wp-calypso/assets/402286/8535b586-ca20-49e1-9fec-5f179c3d56c7) ![image](https://github.com/Automattic/wp-calypso/assets/402286/518aee5b-c2dc-4763-a731-250e75ec1b09) |

## Why are these changes being made?
Discussion here: p9Jlb4-cb9-p2

## Testing Instructions
* Go to `/plugins` or `/plugins/scheduled-updates`
* You should see a sidebar subheading.
* Check the copy.
* Check the `< Plugins` styles.
* Check in different screen sizes.
