### PR TITLE
Site Settings: Add Jetpack Firewall Toggle to Security Settings Screen

### DIFF
--- a/client/my-sites/site-settings/allow-list.jsx
+++ b/client/my-sites/site-settings/allow-list.jsx
@@ -10,7 +10,7 @@ import FormTextarea from 'calypso/components/forms/form-textarea';
 
 class AllowList extends Component {
 	static propTypes = {
-		fields: PropTypes.object,
+		fields: PropTypes.object.isRequired,
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
 		onChangeField: PropTypes.func.isRequired,

--- a/client/my-sites/site-settings/allow-list.jsx
+++ b/client/my-sites/site-settings/allow-list.jsx
@@ -5,6 +5,7 @@ import { includes, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 
@@ -21,6 +22,16 @@ class AllowList extends Component {
 		fields: {},
 		isRequestingSettings: true,
 		isSavingSettings: false,
+	};
+
+	togglingAllowListSupported = () => {
+		return this.props.settings.jetpack_waf_ip_allow_list_enabled !== undefined;
+	};
+
+	showAllowList = () => {
+		return (
+			! this.togglingAllowListSupported() || this.props.fields.jetpack_waf_ip_allow_list_enabled
+		);
 	};
 
 	handleAddToAllowedList = () => {
@@ -81,19 +92,29 @@ class AllowList extends Component {
 			<div className="site-settings__allow-list-settings">
 				<Card>
 					<FormFieldset>
-						<ToggleControl
-							disabled={ this.disableForm() }
-							onChange={ this.props.handleAutosavingToggle( 'jetpack_waf_ip_allow_list_enabled' ) }
-							checked={ !! this.props.fields.jetpack_waf_ip_allow_list_enabled }
-							label={ translate( 'Always allow specific IP addresses' ) }
-						/>
-						<FormSettingExplanation isIndented>
+						{ this.togglingAllowListSupported() ? (
+							<ToggleControl
+								disabled={ this.disableForm() }
+								onChange={ this.props.handleAutosavingToggle(
+									'jetpack_waf_ip_allow_list_enabled'
+								) }
+								checked={ !! this.props.fields.jetpack_waf_ip_allow_list_enabled }
+								label={ translate( 'Always allow specific IP addresses' ) }
+							/>
+						) : (
+							<FormLegend>{ translate( 'Always allow specific IP addresses' ) }</FormLegend>
+						) }{ ' ' }
+						<FormSettingExplanation isIndented={ !! this.togglingAllowListSupported() }>
 							{ translate(
 								"IP addresses added to this list will never be blocked by Jetpack's security features."
 							) }
 						</FormSettingExplanation>
-						{ !! this.props.fields.jetpack_waf_ip_allow_list_enabled && (
-							<div className="protect__module-settings site-settings__child-settings">
+						{ this.showAllowList() && (
+							<div
+								className={ `protect__module-settings ${
+									this.togglingAllowListSupported() ? 'site-settings__child-settings' : ''
+								}` }
+							>
 								<FormTextarea
 									id="jetpack_waf_ip_allow_list"
 									value={ this.getProtectAllowedIps() }

--- a/client/my-sites/site-settings/allow-list.jsx
+++ b/client/my-sites/site-settings/allow-list.jsx
@@ -1,0 +1,144 @@
+import { Button, Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import { includes, some } from 'lodash';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+
+class AllowList extends Component {
+	static propTypes = {
+		fields: PropTypes.object,
+		isRequestingSettings: PropTypes.bool,
+		isSavingSettings: PropTypes.bool,
+		onChangeField: PropTypes.func.isRequired,
+		setFieldValue: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		fields: {},
+		isRequestingSettings: true,
+		isSavingSettings: false,
+	};
+
+	handleAddToAllowedList = () => {
+		const { setFieldValue } = this.props;
+		let allowedIps = this.getProtectAllowedIps().trimEnd();
+
+		if ( allowedIps.length ) {
+			allowedIps += '\n';
+		}
+
+		setFieldValue( 'jetpack_waf_ip_allow_list', allowedIps + this.getIpAddress() );
+	};
+
+	getIpAddress() {
+		if ( window.app && window.app.clientIp ) {
+			return window.app.clientIp;
+		}
+
+		return null;
+	}
+
+	getProtectAllowedIps() {
+		const { jetpack_waf_ip_allow_list } = this.props.fields;
+		return jetpack_waf_ip_allow_list || '';
+	}
+
+	isIpAddressAllowed() {
+		const ipAddress = this.getIpAddress();
+		if ( ! ipAddress ) {
+			return false;
+		}
+
+		const allowedIps = this.getProtectAllowedIps().split( '\n' );
+
+		return (
+			includes( allowedIps, ipAddress ) ||
+			some( allowedIps, ( entry ) => {
+				if ( entry.indexOf( '-' ) < 0 ) {
+					return false;
+				}
+
+				const range = entry.split( '-' ).map( ( ip ) => ip.trim() );
+				return includes( range, ipAddress );
+			} )
+		);
+	}
+
+	disableForm() {
+		return this.props.isRequestingSettings || this.props.isSavingSettings;
+	}
+
+	render() {
+		const { translate } = this.props;
+		const ipAddress = this.getIpAddress();
+		const isIpAllowed = this.isIpAddressAllowed();
+
+		return (
+			<div className="site-settings__allow-list-settings">
+				<Card>
+					<FormFieldset>
+						<ToggleControl
+							disabled={ this.disableForm() }
+							onChange={ this.props.handleAutosavingToggle( 'jetpack_waf_ip_allow_list_enabled' ) }
+							checked={ !! this.props.fields.jetpack_waf_ip_allow_list_enabled }
+							label={ translate( 'Always allow specific IP addresses' ) }
+						/>
+						<FormSettingExplanation isIndented>
+							{ translate(
+								"IP addresses added to this list will never be blocked by Jetpack's security features."
+							) }
+						</FormSettingExplanation>
+						{ !! this.props.fields.jetpack_waf_ip_allow_list_enabled && (
+							<div className="protect__module-settings site-settings__child-settings">
+								<FormTextarea
+									id="jetpack_waf_ip_allow_list"
+									value={ this.getProtectAllowedIps() }
+									onChange={ this.props.onChangeField( 'jetpack_waf_ip_allow_list' ) }
+									disabled={ this.disableForm() }
+									placeholder={ translate( 'Example: 12.12.12.1-12.12.12.100' ) }
+								/>
+								<FormSettingExplanation>
+									{ translate(
+										'IPv4 and IPv6 are acceptable. ' +
+											'To specify a range, enter the low value and high value separated by a dash. ' +
+											'Example: 12.12.12.1-12.12.12.100'
+									) }
+								</FormSettingExplanation>
+								<p>
+									{ translate( 'Your current IP address: {{strong}}%(IP)s{{/strong}}{{br/}}', {
+										args: {
+											IP: ipAddress || translate( 'Unknown IP address' ),
+										},
+										components: {
+											strong: <strong />,
+											br: <br />,
+										},
+									} ) }
+
+									{ ipAddress && (
+										<Button
+											className="site-settings__add-to-explicitly-allowed-list"
+											onClick={ this.handleAddToAllowedList }
+											disabled={ this.disableForm() || isIpAllowed }
+											compact
+										>
+											{ isIpAllowed
+												? translate( 'Already in list of allowed IPs' )
+												: translate( 'Add to list of allowed IPs' ) }
+										</Button>
+									) }
+								</p>
+							</div>
+						) }
+					</FormFieldset>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( AllowList );

--- a/client/my-sites/site-settings/firewall.jsx
+++ b/client/my-sites/site-settings/firewall.jsx
@@ -45,12 +45,16 @@ class Firewall extends Component {
 	};
 
 	disableForm() {
-		return this.props.isRequestingSettings || this.props.isSavingSettings;
+		return (
+			this.props.moduleDetailsLoading ||
+			this.props.isRequestingSettings ||
+			this.props.isSavingSettings
+		);
 	}
 
 	wafModuleSupported = () => {
 		return (
-			! this.props.firewallModuleUnavailable &&
+			this.props.firewallModuleAvailable &&
 			! this.props.isAtomic &&
 			! this.props.isVip &&
 			! this.props.isSimple
@@ -239,9 +243,8 @@ export default connect(
 	( state ) => {
 		const selectedSiteSlug = getSelectedSiteSlug( state );
 		const selectedSiteId = getSelectedSiteId( state );
-		const moduleDetails = getJetpackModule( state, selectedSiteId, 'waf' );
 		const moduleDetailsLoading = isFetchingJetpackModules( state, selectedSiteId );
-		const moduleDetailsNotLoaded = moduleDetails === null;
+		const firewallModuleDetails = getJetpackModule( state, selectedSiteId, 'waf' );
 		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
 		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
 			state,
@@ -254,9 +257,9 @@ export default connect(
 			selectedSiteId,
 			selectedSiteSlug,
 			firewallModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'waf' ),
-			firewallModuleUnavailable:
-				( moduleDetailsNotLoaded && ! moduleDetailsLoading ) ||
-				( siteInDevMode && moduleUnavailableInDevMode ),
+			firewallModuleAvailable:
+				firewallModuleDetails !== null && ( ! siteInDevMode || ! moduleUnavailableInDevMode ),
+			moduleDetailsLoading,
 			hasRequiredFeature,
 		};
 	},

--- a/client/my-sites/site-settings/firewall.jsx
+++ b/client/my-sites/site-settings/firewall.jsx
@@ -29,6 +29,7 @@ class Firewall extends Component {
 		isAtomic: PropTypes.bool.isRequired,
 		isRequestingSettings: PropTypes.bool.isRequired,
 		isSavingSettings: PropTypes.bool.isRequired,
+		isSimple: PropTypes.bool.isRequired,
 		isVip: PropTypes.bool.isRequired,
 		onChangeField: PropTypes.func.isRequired,
 		setFieldValue: PropTypes.func.isRequired,
@@ -47,7 +48,7 @@ class Firewall extends Component {
 	}
 
 	wafModuleSupported = () => {
-		return ! this.props.isAtomic && ! this.props.isVip;
+		return ! this.props.isAtomic && ! this.props.isVip && ! this.props.isSimple;
 	};
 
 	disableWafForm = () => {

--- a/client/my-sites/site-settings/firewall.jsx
+++ b/client/my-sites/site-settings/firewall.jsx
@@ -97,18 +97,19 @@ class Firewall extends Component {
 
 	render() {
 		const {
-			selectedSiteId,
-			selectedSiteSlug,
-			translate,
-			hasRequiredFeature,
+			dirtyFields,
 			disableProtect,
 			fields,
-			isSavingSettings,
-			isRequestingSettings,
-			onChangeField,
-			setFieldValue,
-			dirtyFields,
 			handleAutosavingToggle,
+			hasRequiredFeature,
+			isRequestingSettings,
+			isSavingSettings,
+			onChangeField,
+			selectedSiteId,
+			selectedSiteSlug,
+			setFieldValue,
+			settings,
+			translate,
 		} = this.props;
 
 		return (
@@ -185,34 +186,37 @@ class Firewall extends Component {
 				/>
 
 				{ /* IP Block List */ }
-				{ this.wafModuleSupported() && (
-					<Card>
-						<FormFieldset>
-							<ToggleControl
-								disabled={ this.disableWafForm() }
-								onChange={ this.handleBlockListToggle }
-								checked={ !! fields.jetpack_waf_ip_block_list_enabled }
-								label={ translate( 'Block specific IP addresses' ) }
-							/>
-							<FormSettingExplanation isIndented>
-								{ translate(
-									'IP addresses added to this list will be blocked from accessing your site.'
+				{ this.wafModuleSupported() &&
+					this.props.settings.jetpack_waf_ip_block_list_enabled !== undefined && (
+						<Card>
+							<FormFieldset>
+								<ToggleControl
+									disabled={ this.disableWafForm() }
+									onChange={ this.handleBlockListToggle }
+									checked={ !! fields.jetpack_waf_ip_block_list_enabled }
+									label={ translate( 'Block specific IP addresses' ) }
+								/>
+								<FormSettingExplanation isIndented>
+									{ translate(
+										'IP addresses added to this list will be blocked from accessing your site.'
+									) }
+								</FormSettingExplanation>
+								{ fields.jetpack_waf_ip_block_list_enabled && (
+									<div className="site-settings__child-settings">
+										<FormTextarea
+											id="jetpack_waf_ip_block_list"
+											value={ fields.jetpack_waf_ip_block_list }
+											onChange={ onChangeField( 'jetpack_waf_ip_block_list' ) }
+											disabled={
+												this.disableWafForm() || ! fields.jetpack_waf_ip_block_list_enabled
+											}
+											placeholder={ translate( 'Example: 12.12.12.1-12.12.12.100' ) }
+										/>
+									</div>
 								) }
-							</FormSettingExplanation>
-							{ fields.jetpack_waf_ip_block_list_enabled && (
-								<div className="site-settings__child-settings">
-									<FormTextarea
-										id="jetpack_waf_ip_block_list"
-										value={ fields.jetpack_waf_ip_block_list }
-										onChange={ onChangeField( 'jetpack_waf_ip_block_list' ) }
-										disabled={ this.disableWafForm() || ! fields.jetpack_waf_ip_block_list_enabled }
-										placeholder={ translate( 'Example: 12.12.12.1-12.12.12.100' ) }
-									/>
-								</div>
-							) }
-						</FormFieldset>
-					</Card>
-				) }
+							</FormFieldset>
+						</Card>
+					) }
 
 				{ /* IP Allow List */ }
 				<AllowList
@@ -222,6 +226,7 @@ class Firewall extends Component {
 					isSavingSettings={ isSavingSettings }
 					onChangeField={ onChangeField }
 					setFieldValue={ setFieldValue }
+					settings={ settings }
 				/>
 			</div>
 		);

--- a/client/my-sites/site-settings/firewall.jsx
+++ b/client/my-sites/site-settings/firewall.jsx
@@ -12,6 +12,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
+import getJetpackModule from 'calypso/state/selectors/get-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
@@ -125,7 +126,7 @@ class Firewall extends Component {
 					<Card>
 						<FormFieldset>
 							<ToggleControl
-								disabled={ this.disableForm() || this.disableWafForm() }
+								disabled={ this.disableWafForm() }
 								onChange={ this.handleAutomaticRulesToggle }
 								checked={ hasRequiredFeature ? !! fields.jetpack_waf_automatic_rules : false }
 								label={ translate( 'Enable automatic firewall protection' ) }
@@ -186,7 +187,7 @@ class Firewall extends Component {
 					<Card>
 						<FormFieldset>
 							<ToggleControl
-								disabled={ this.disableForm() || this.disableWafForm() }
+								disabled={ this.disableWafForm() }
 								onChange={ this.handleBlockListToggle }
 								checked={ !! fields.jetpack_waf_ip_block_list_enabled }
 								label={ translate( 'Block specific IP addresses' ) }
@@ -202,7 +203,7 @@ class Firewall extends Component {
 										id="jetpack_waf_ip_block_list"
 										value={ fields.jetpack_waf_ip_block_list }
 										onChange={ onChangeField( 'jetpack_waf_ip_block_list' ) }
-										disabled={ this.disableForm() || ! fields.jetpack_waf_ip_block_list_enabled }
+										disabled={ this.disableWafForm() || ! fields.jetpack_waf_ip_block_list_enabled }
 										placeholder={ translate( 'Example: 12.12.12.1-12.12.12.100' ) }
 									/>
 								</div>
@@ -229,6 +230,8 @@ export default connect(
 	( state ) => {
 		const selectedSiteSlug = getSelectedSiteSlug( state );
 		const selectedSiteId = getSelectedSiteId( state );
+		const moduleDetails = getJetpackModule( state, selectedSiteId, 'waf' );
+		const moduleDetailsNotLoaded = moduleDetails === null;
 		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
 		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
 			state,
@@ -241,7 +244,8 @@ export default connect(
 			selectedSiteId,
 			selectedSiteSlug,
 			firewallModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'waf' ),
-			firewallModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+			firewallModuleUnavailable:
+				moduleDetailsNotLoaded || ( siteInDevMode && moduleUnavailableInDevMode ),
 			hasRequiredFeature,
 		};
 	},

--- a/client/my-sites/site-settings/firewall.jsx
+++ b/client/my-sites/site-settings/firewall.jsx
@@ -13,6 +13,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import getJetpackModule from 'calypso/state/selectors/get-jetpack-module';
+import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
@@ -48,13 +49,16 @@ class Firewall extends Component {
 	}
 
 	wafModuleSupported = () => {
-		return ! this.props.isAtomic && ! this.props.isVip && ! this.props.isSimple;
+		return (
+			! this.props.firewallModuleUnavailable &&
+			! this.props.isAtomic &&
+			! this.props.isVip &&
+			! this.props.isSimple
+		);
 	};
 
 	disableWafForm = () => {
-		return (
-			this.disableForm() || ! this.wafModuleSupported() || this.props.firewallModuleUnavailable
-		);
+		return this.disableForm() || ! this.wafModuleSupported();
 	};
 
 	ensureWafModuleActive = () => {
@@ -236,6 +240,7 @@ export default connect(
 		const selectedSiteSlug = getSelectedSiteSlug( state );
 		const selectedSiteId = getSelectedSiteId( state );
 		const moduleDetails = getJetpackModule( state, selectedSiteId, 'waf' );
+		const moduleDetailsLoading = isFetchingJetpackModules( state, selectedSiteId );
 		const moduleDetailsNotLoaded = moduleDetails === null;
 		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
 		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
@@ -250,7 +255,8 @@ export default connect(
 			selectedSiteSlug,
 			firewallModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'waf' ),
 			firewallModuleUnavailable:
-				moduleDetailsNotLoaded || ( siteInDevMode && moduleUnavailableInDevMode ),
+				( moduleDetailsNotLoaded && ! moduleDetailsLoading ) ||
+				( siteInDevMode && moduleUnavailableInDevMode ),
 			hasRequiredFeature,
 		};
 	},

--- a/client/my-sites/site-settings/firewall.jsx
+++ b/client/my-sites/site-settings/firewall.jsx
@@ -1,0 +1,251 @@
+import { PRODUCT_JETPACK_SCAN, WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { UpsellNudge } from 'calypso/blocks/upsell-nudge';
+import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import { activateModule } from 'calypso/state/jetpack/modules/actions';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
+import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import AllowList from './allow-list';
+import Protect from './protect';
+import SettingsSectionHeader from './settings-section-header';
+
+class Firewall extends Component {
+	static propTypes = {
+		fields: PropTypes.object.isRequired,
+		handleSubmitForm: PropTypes.func.isRequired,
+		isAtomic: PropTypes.bool.isRequired,
+		isRequestingSettings: PropTypes.bool.isRequired,
+		isSavingSettings: PropTypes.bool.isRequired,
+		isVip: PropTypes.bool.isRequired,
+		onChangeField: PropTypes.func.isRequired,
+		setFieldValue: PropTypes.func.isRequired,
+		settings: PropTypes.object.isRequired,
+	};
+
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {},
+		settings: {},
+	};
+
+	disableForm() {
+		return this.props.isRequestingSettings || this.props.isSavingSettings;
+	}
+
+	wafModuleSupported = () => {
+		return ! this.props.isAtomic && ! this.props.isVip;
+	};
+
+	disableWafForm = () => {
+		return (
+			this.disableForm() || ! this.wafModuleSupported() || this.props.firewallModuleUnavailable
+		);
+	};
+
+	ensureWafModuleActive = () => {
+		if ( this.wafModuleSupported() && ! this.props.firewallModuleActive ) {
+			this.props.activateModule( this.props.selectedSiteId, 'waf', true );
+		}
+	};
+
+	hasAutomaticRulesInstalled = () => {
+		return !! this.props.settings.jetpack_waf_automatic_rules_last_updated_timestamp;
+	};
+
+	canUpdateAutomaticRules = () => {
+		return this.props.hasRequiredFeature || this.hasAutomaticRulesInstalled();
+	};
+
+	automaticRulesLastUpdated = () => {
+		const timestamp = this.props.settings.jetpack_waf_automatic_rules_last_updated_timestamp;
+		if ( timestamp ) {
+			return moment( timestamp * 1000 ).format( 'MMMM D, YYYY h:mm A' );
+		}
+		return '';
+	};
+
+	handleAutomaticRulesToggle = ( event ) => {
+		this.ensureWafModuleActive();
+		this.props.handleAutosavingToggle( 'jetpack_waf_automatic_rules' )( event );
+	};
+
+	handleBlockListToggle = ( event ) => {
+		this.ensureWafModuleActive();
+		this.props.handleAutosavingToggle( 'jetpack_waf_ip_block_list_enabled' )( event );
+	};
+
+	handleSubmitForm = ( event ) => {
+		this.ensureWafModuleActive();
+		return this.props.handleSubmitForm( event );
+	};
+
+	render() {
+		const {
+			selectedSiteId,
+			selectedSiteSlug,
+			translate,
+			hasRequiredFeature,
+			disableProtect,
+			fields,
+			isSavingSettings,
+			isRequestingSettings,
+			onChangeField,
+			setFieldValue,
+			dirtyFields,
+			handleAutosavingToggle,
+		} = this.props;
+
+		return (
+			<div className="site-settings__security-settings site-settings__firewall-settings">
+				<QueryJetpackConnection siteId={ selectedSiteId } />
+
+				<SettingsSectionHeader
+					title={ translate( 'Web Application Firewall (WAF)' ) }
+					isSaving={ this.disableForm() }
+					showButton
+					onButtonClick={ this.handleSubmitForm }
+					disabled={ this.disableForm() || dirtyFields.length === 0 }
+				/>
+
+				{ /* Automatic Rules */ }
+				{ this.wafModuleSupported() && this.canUpdateAutomaticRules() && (
+					<Card>
+						<FormFieldset>
+							<ToggleControl
+								disabled={ this.disableForm() || this.disableWafForm() }
+								onChange={ this.handleAutomaticRulesToggle }
+								checked={ hasRequiredFeature ? !! fields.jetpack_waf_automatic_rules : false }
+								label={ translate( 'Enable automatic firewall protection' ) }
+							/>
+							{ this.automaticRulesLastUpdated() && (
+								<FormSettingExplanation isIndented>
+									{ translate( 'Automatic security rules installed. Last updated on %(date)s.', {
+										args: {
+											date: this.automaticRulesLastUpdated(),
+										},
+									} ) }
+								</FormSettingExplanation>
+							) }
+							<FormSettingExplanation isIndented>
+								{ translate(
+									'Block untrusted traffic sources by scanning every request made to your site. Jetpack’s advanced security rules are automatically kept up-to-date to protect your site from the latest threats.'
+								) }
+							</FormSettingExplanation>
+						</FormFieldset>
+					</Card>
+				) }
+
+				{ /* Upgrade Prompt */ }
+				{ ! hasRequiredFeature && this.wafModuleSupported() && (
+					<UpsellNudge
+						className="site-settings__security-settings-firewall-nudge"
+						title={
+							this.hasAutomaticRulesInstalled()
+								? translate( 'Your site is not receiving the latest updates to automatic rules' )
+								: translate( 'Set up automatic rules with one click' )
+						}
+						description={
+							this.hasAutomaticRulesInstalled()
+								? translate( 'Upgrade to keep your site secure with up-to-date firewall rules' )
+								: translate( 'Upgrade to enable automatic firewall protection.' )
+						}
+						event="calypso_scan_settings_upgrade_nudge"
+						feature={ WPCOM_FEATURES_SCAN }
+						showIcon
+						href={ `/checkout/${ selectedSiteSlug }/${ PRODUCT_JETPACK_SCAN }?redirect_to=/settings/security/${ selectedSiteSlug }` }
+						forceDisplay
+						isJetpack
+					/>
+				) }
+
+				{ /* Brute Force Login Protection */ }
+				<Protect
+					disableProtect={ disableProtect }
+					fields={ fields }
+					isRequestingSettings={ isRequestingSettings }
+					isSavingSettings={ isSavingSettings }
+					onChangeField={ onChangeField }
+					setFieldValue={ setFieldValue }
+				/>
+
+				{ /* IP Block List */ }
+				{ this.wafModuleSupported() && (
+					<Card>
+						<FormFieldset>
+							<ToggleControl
+								disabled={ this.disableForm() || this.disableWafForm() }
+								onChange={ this.handleBlockListToggle }
+								checked={ !! fields.jetpack_waf_ip_block_list_enabled }
+								label={ translate( 'Block specific IP addresses' ) }
+							/>
+							<FormSettingExplanation isIndented>
+								{ translate(
+									'IP addresses added to this list will be blocked from accessing your site.'
+								) }
+							</FormSettingExplanation>
+							{ fields.jetpack_waf_ip_block_list_enabled && (
+								<div className="site-settings__child-settings">
+									<FormTextarea
+										id="jetpack_waf_ip_block_list"
+										value={ fields.jetpack_waf_ip_block_list }
+										onChange={ onChangeField( 'jetpack_waf_ip_block_list' ) }
+										disabled={ this.disableForm() || ! fields.jetpack_waf_ip_block_list_enabled }
+										placeholder={ translate( 'Example: 12.12.12.1-12.12.12.100' ) }
+									/>
+								</div>
+							) }
+						</FormFieldset>
+					</Card>
+				) }
+
+				{ /* IP Allow List */ }
+				<AllowList
+					fields={ fields }
+					handleAutosavingToggle={ handleAutosavingToggle }
+					isRequestingSettings={ isRequestingSettings }
+					isSavingSettings={ isSavingSettings }
+					onChangeField={ onChangeField }
+					setFieldValue={ setFieldValue }
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const selectedSiteSlug = getSelectedSiteSlug( state );
+		const selectedSiteId = getSelectedSiteId( state );
+		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+			state,
+			selectedSiteId,
+			'waf'
+		);
+		const hasRequiredFeature = siteHasFeature( state, selectedSiteId, WPCOM_FEATURES_SCAN );
+
+		return {
+			selectedSiteId,
+			selectedSiteSlug,
+			firewallModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'waf' ),
+			firewallModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+			hasRequiredFeature,
+		};
+	},
+	{
+		activateModule,
+	}
+)( localize( Firewall ) );

--- a/client/my-sites/site-settings/firewall.jsx
+++ b/client/my-sites/site-settings/firewall.jsx
@@ -71,7 +71,9 @@ class Firewall extends Component {
 	};
 
 	automaticRulesLastUpdated = () => {
-		const timestamp = this.props.settings.jetpack_waf_automatic_rules_last_updated_timestamp;
+		const timestamp = parseInt(
+			this.props.settings.jetpack_waf_automatic_rules_last_updated_timestamp
+		);
 		if ( timestamp ) {
 			return moment( timestamp * 1000 ).format( 'MMMM D, YYYY h:mm A' );
 		}

--- a/client/my-sites/site-settings/firewall.jsx
+++ b/client/my-sites/site-settings/firewall.jsx
@@ -186,37 +186,34 @@ class Firewall extends Component {
 				/>
 
 				{ /* IP Block List */ }
-				{ this.wafModuleSupported() &&
-					this.props.settings.jetpack_waf_ip_block_list_enabled !== undefined && (
-						<Card>
-							<FormFieldset>
-								<ToggleControl
-									disabled={ this.disableWafForm() }
-									onChange={ this.handleBlockListToggle }
-									checked={ !! fields.jetpack_waf_ip_block_list_enabled }
-									label={ translate( 'Block specific IP addresses' ) }
-								/>
-								<FormSettingExplanation isIndented>
-									{ translate(
-										'IP addresses added to this list will be blocked from accessing your site.'
-									) }
-								</FormSettingExplanation>
-								{ fields.jetpack_waf_ip_block_list_enabled && (
-									<div className="site-settings__child-settings">
-										<FormTextarea
-											id="jetpack_waf_ip_block_list"
-											value={ fields.jetpack_waf_ip_block_list }
-											onChange={ onChangeField( 'jetpack_waf_ip_block_list' ) }
-											disabled={
-												this.disableWafForm() || ! fields.jetpack_waf_ip_block_list_enabled
-											}
-											placeholder={ translate( 'Example: 12.12.12.1-12.12.12.100' ) }
-										/>
-									</div>
+				{ this.wafModuleSupported() && settings.jetpack_waf_ip_block_list_enabled !== undefined && (
+					<Card>
+						<FormFieldset>
+							<ToggleControl
+								disabled={ this.disableWafForm() }
+								onChange={ this.handleBlockListToggle }
+								checked={ !! fields.jetpack_waf_ip_block_list_enabled }
+								label={ translate( 'Block specific IP addresses' ) }
+							/>
+							<FormSettingExplanation isIndented>
+								{ translate(
+									'IP addresses added to this list will be blocked from accessing your site.'
 								) }
-							</FormFieldset>
-						</Card>
-					) }
+							</FormSettingExplanation>
+							{ fields.jetpack_waf_ip_block_list_enabled && (
+								<div className="site-settings__child-settings">
+									<FormTextarea
+										id="jetpack_waf_ip_block_list"
+										value={ fields.jetpack_waf_ip_block_list }
+										onChange={ onChangeField( 'jetpack_waf_ip_block_list' ) }
+										disabled={ this.disableWafForm() || ! fields.jetpack_waf_ip_block_list_enabled }
+										placeholder={ translate( 'Example: 12.12.12.1-12.12.12.100' ) }
+									/>
+								</div>
+							) }
+						</FormFieldset>
+					</Card>
+				) }
 
 				{ /* IP Allow List */ }
 				<AllowList

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -131,6 +131,8 @@ const getFormSettings = ( settings ) =>
 		'protect',
 		'jetpack_protect_global_whitelist',
 		'jetpack_waf_automatic_rules',
+		'jetpack_waf_ip_allow_list',
+		'jetpack_waf_ip_allow_list_enabled',
 		'jetpack_waf_ip_block_list',
 		'jetpack_waf_ip_block_list_enabled',
 		'jetpack_waf_automatic_rules_last_updated_timestamp',

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -10,6 +10,7 @@ import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Firewall from './firewall';
 import SpamFilteringSettings from './spam-filtering-settings';
@@ -25,6 +26,7 @@ class SiteSettingsFormSecurity extends Component {
 			handleAutosavingToggle,
 			handleSubmitForm,
 			isAtomic,
+			isSimple,
 			isVip,
 			isRequestingSettings,
 			isSavingSettings,
@@ -62,6 +64,7 @@ class SiteSettingsFormSecurity extends Component {
 					disableProtect={ disableProtect }
 					activateModule={ activateModule }
 					isAtomic={ isAtomic }
+					isSimple={ isSimple }
 					isVip={ isVip }
 				/>
 
@@ -101,6 +104,7 @@ class SiteSettingsFormSecurity extends Component {
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+	const isSimple = isSimpleSite( state, siteId );
 	const isVip = isVipSite( state, siteId );
 	const protectModuleActive = !! isJetpackModuleActive( state, siteId, 'protect' );
 	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, siteId );
@@ -118,6 +122,7 @@ const connectComponent = connect( ( state ) => {
 	return {
 		siteId,
 		isAtomic,
+		isSimple,
 		isVip,
 		protectModuleActive,
 		protectModuleUnavailable: siteInDevMode && protectIsUnavailableInDevMode,

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -9,8 +9,9 @@ import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-act
 import isJetpackModuleUnavailableInDevelopmentMode from 'calypso/state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'calypso/state/selectors/is-jetpack-site-in-development-mode';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import Protect from './protect';
+import Firewall from './firewall';
 import SpamFilteringSettings from './spam-filtering-settings';
 import Sso from './sso';
 import wrapSettingsForm from './wrap-settings-form';
@@ -24,6 +25,7 @@ class SiteSettingsFormSecurity extends Component {
 			handleAutosavingToggle,
 			handleSubmitForm,
 			isAtomic,
+			isVip,
 			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
@@ -33,6 +35,7 @@ class SiteSettingsFormSecurity extends Component {
 			settings,
 			siteId,
 			translate,
+			activateModule,
 		} = this.props;
 		const disableProtect = ! protectModuleActive || protectModuleUnavailable;
 		const disableSpamFiltering = ! fields.akismet || akismetUnavailable;
@@ -44,23 +47,23 @@ class SiteSettingsFormSecurity extends Component {
 				className="site-settings__security-settings"
 			>
 				<QueryJetpackModules siteId={ siteId } />
+				<QueryJetpackSettings siteId={ siteId } />
 
-				<SettingsSectionHeader
-					disabled={ isRequestingSettings || isSavingSettings || disableProtect }
-					isSaving={ isSavingSettings }
-					onButtonClick={ handleSubmitForm }
-					showButton
-					title={ translate( 'Prevent brute force login attacks' ) }
-				/>
-				<Protect
+				<Firewall
+					settings={ settings }
 					fields={ fields }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					onChangeField={ onChangeField }
 					setFieldValue={ setFieldValue }
+					handleAutosavingToggle={ handleAutosavingToggle }
+					handleSubmitForm={ handleSubmitForm }
+					dirtyFields={ dirtyFields }
+					disableProtect={ disableProtect }
+					activateModule={ activateModule }
+					isAtomic={ isAtomic }
+					isVip={ isVip }
 				/>
-
-				<QueryJetpackSettings siteId={ siteId } />
 
 				{ ! isAtomic && (
 					<div>
@@ -98,6 +101,7 @@ class SiteSettingsFormSecurity extends Component {
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+	const isVip = isVipSite( state, siteId );
 	const protectModuleActive = !! isJetpackModuleActive( state, siteId, 'protect' );
 	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, siteId );
 	const protectIsUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
@@ -114,6 +118,7 @@ const connectComponent = connect( ( state ) => {
 	return {
 		siteId,
 		isAtomic,
+		isVip,
 		protectModuleActive,
 		protectModuleUnavailable: siteInDevMode && protectIsUnavailableInDevMode,
 		akismetUnavailable: siteInDevMode && akismetIsUnavailableInDevMode,
@@ -125,6 +130,10 @@ const getFormSettings = ( settings ) =>
 		'akismet',
 		'protect',
 		'jetpack_protect_global_whitelist',
+		'jetpack_waf_automatic_rules',
+		'jetpack_waf_ip_block_list',
+		'jetpack_waf_ip_block_list_enabled',
+		'jetpack_waf_automatic_rules_last_updated_timestamp',
 		'sso',
 		'jetpack_sso_match_by_email',
 		'jetpack_sso_require_two_step',

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -753,3 +753,12 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 .verbum-comments-toggle {
 	flex-direction: column;
 }
+
+.site-settings__firewall-settings .card:not(:last-child) {
+	margin-bottom: 0;
+}
+
+.site-settings__security-settings-firewall-nudge {
+	margin-bottom: 0;
+	z-index: 1;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-scan-team/issues/1228

Depends on https://github.com/Automattic/jetpack-scan-team/issues/1321

## Proposed Changes

* Adds a "Web Application Firewall (WAF)" setting card to `/settings/security/[site]`.
* If the user does not have access to automatic rules, an upgrade prompt is displayed.
* Merges the Brute Force Protection and IP Allow List settings into the new Firewall card.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See peb6dq-2v0-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this PR in your local Jetpack repo: https://github.com/Automattic/jetpack/pull/38580
- Boot up your local monorepo site with `jetpack docker up -d` and `jetpack docker jt-up`
- Visit your site's `wp-admin` and ensure Jetpack is connected
- Test this PR using the Calypso live link below, and your local test site running through Jurassic Tube.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Screenshots

<img width="745" alt="Screenshot 2024-07-23 at 6 01 43 PM" src="https://github.com/user-attachments/assets/67d843fd-2fcc-419e-bfa3-b1b5e2973d1e">

<img width="747" alt="Screenshot 2024-07-23 at 6 03 52 PM" src="https://github.com/user-attachments/assets/a3219115-4bec-414b-8400-ac64564396cd">