### PR TITLE
A4A > Referral: Update client checkout success message

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -57,7 +57,7 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 		if ( status === 'success' ) {
 			dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_submit_payment_info_success' ) );
 			dispatch(
-				successNotice( translate( 'Payment information submitted successfully.' ), {
+				successNotice( translate( 'Thank you for your purchase!' ), {
 					displayOnNextPage: true,
 				} )
 			);


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/396

## Proposed Changes

This PR updates the client checkout success message.

## Testing Instructions

- Refer a product to a client
- Login as a client and go to checkout from the email
- Submit payment info and verify that the success message is updated as shown below:

<img width="810" alt="Screenshot 2024-06-20 at 9 11 43 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8afb5e3d-a9c1-4fb0-9b65-c14535c60b6d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
