### PR TITLE
A4A > Referral: Add tooltip for Awaiting payment badge

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -44,6 +44,16 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 	const showAssignButton = purchase.status === 'active' && redirectUrl;
 	const [ statusType, statusText ] = getPurchaseStatus( purchase, translate );
 
+	let tooltip = '';
+
+	const isAwaitingPayment = purchase.status === 'pending';
+
+	if ( isAwaitingPayment ) {
+		tooltip = isWPCOMLicense
+			? translate( 'When your client pays, you can initiate this site.' )
+			: translate( 'When your client pays, you can assign this product to a site.' );
+	}
+
 	return purchase.site_assigned ? (
 		<Button
 			className="referrals-purchases__assign-button"
@@ -58,6 +68,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 				statusProps={ {
 					children: statusText,
 					type: statusType,
+					tooltip,
 				} }
 			/>
 			{ showAssignButton && (


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/401

## Proposed Changes

This PR updates the client checkout success message.

## Testing Instructions

- Open live link
- Refer products (WPCOM hosting & Jetpack product) to a client
- Once in the Referrals dashboard > Open the client that you referred > In the Purchases, verify that the Awaiting payment badge shows a tooltip

- For `Create site`

<img width="423" alt="Screenshot 2024-06-19 at 7 32 03 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/110287d5-d858-4356-b4c2-a509d55ab762">

- For `Assign to site`
- 
<img width="423" alt="Screenshot 2024-06-19 at 7 32 08 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/44e8e3cc-3aed-4d59-9939-c5ebf085ae4a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
