### PR TITLE
A4A > Referral: Implement pooling mechanism for fetching stored cards in client checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/lib/get-client-referral-query-args.ts
+++ b/client/a8c-for-agencies/sections/marketplace/lib/get-client-referral-query-args.ts
@@ -4,10 +4,15 @@ export const getClientReferralQueryArgs = () => {
 	const agencyId = getQueryArg( window.location.href, 'agency_id' ) as unknown as number;
 	const referralId = getQueryArg( window.location.href, 'referral_id' ) as unknown as number;
 	const secret = getQueryArg( window.location.href, 'secret' ) as unknown as string;
+	const paymentMethodAdded = getQueryArg(
+		window.location.href,
+		'payment_method_added'
+	) as unknown as boolean;
 
 	return {
 		agencyId,
 		referralId,
 		secret,
+		paymentMethodAdded,
 	};
 };

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method.ts
@@ -1,12 +1,22 @@
+import { useEffect } from 'react';
 import useStoredCards from './use-stored-cards';
 
-export default function usePaymentMethod() {
+export default function usePaymentMethod( refetchInterval?: number ) {
 	// Fetch the stored cards from the cache if they are available.
 	const {
 		data: { allStoredCards },
+		refetch,
 	} = useStoredCards( undefined, true );
 
 	const hasValidPaymentMethod = allStoredCards?.length > 0;
+
+	// Refetch the stored cards every `refetchInterval` milliseconds until a valid payment method is found.
+	useEffect( () => {
+		if ( ! hasValidPaymentMethod && refetchInterval ) {
+			const intervalId = setInterval( refetch, refetchInterval );
+			return () => clearInterval( intervalId );
+		}
+	}, [ hasValidPaymentMethod, refetch, refetchInterval ] );
 
 	return {
 		paymentMethodRequired: ! hasValidPaymentMethod,

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -202,7 +202,14 @@ function PaymentMethodForm() {
 			refetchStoredCards();
 			// If the user is in the client view, we need to redirect to the client view
 			if ( isClientView() && returnQueryArg.startsWith( A4A_CLIENT_CHECKOUT ) ) {
-				page( returnQueryArg );
+				page(
+					addQueryArgs(
+						{
+							payment_method_added: true,
+						},
+						returnQueryArg
+					)
+				);
 			}
 		} else {
 			page( isClientView() ? A4A_CLIENT_PAYMENT_METHODS_LINK : A4A_PAYMENT_METHODS_LINK );


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/391

## Proposed Changes

This PR implements a pooling mechanism for fetching stored cards in the client checkout.

## Testing Instructions

- Refer a product to a client
- Login as a client and go to checkout from the email
- Go to /client/payment-methods in a new window and delete all the payment methods
- Come back to checkout > open the network tab & append the URL with `&payment_method_added=true` and verify that the API call is being made to fetch the payment methods every 2 sec and the payment_method_added query arg is removed from the URL. Refresh the page and verify no API call is being made
- Click on `Add my payment method` > Add card > Verify the URL has `&payment_method_added=true` & gets removed on mount.
- Verify that the pooling mechanism works, i.e., you can see the API is being called until the card data is available. No API call will be made if the data is fetched in the first call.  



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
