### PR TITLE
A4A > Referrals: Fix the issue that causes sites not to show up on the Needs Setup page

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -77,46 +77,47 @@ export default function NeedSetup( { licenseKey }: Props ) {
 		  )
 		: [];
 
-	const availablePlans: AvailablePlans[] = availableSites.length
-		? [
-				// If the site license we found by license key has a referral, we should show it first
-				...( hasReferral
-					? [
-							{
-								name: translate( 'WordPress.com' ),
-								available: 1,
-								subTitle: (
-									<ClientSite
-										referral={ foundSiteLicenseByLicenseKey.features.wpcom_atomic.referral }
-									/>
-								),
-								ids: [ foundSiteLicenseByLicenseKey.id ],
-							},
-					  ]
-					: [] ),
-				// If there are other referral sites, we should show them next
-				...( otherReferralSites.length
-					? otherReferralSites.map( ( { features, id }: NeedsSetupSite ) => ( {
-							name: translate( 'WordPress.com' ),
-							available: 1,
-							subTitle: <ClientSite referral={ features.wpcom_atomic.referral } />,
-							ids: [ id ],
-					  } ) )
-					: [] ),
-				// Finally, show the other available sites
-				{
+	const availablePlans: AvailablePlans[] = [
+		// If the site license we found by license key has a referral, we should show it first
+		...( hasReferral
+			? [
+					{
+						name: translate( 'WordPress.com' ),
+						available: 1,
+						subTitle: (
+							<ClientSite
+								referral={ foundSiteLicenseByLicenseKey.features.wpcom_atomic.referral }
+							/>
+						),
+						ids: [ foundSiteLicenseByLicenseKey.id ],
+					},
+			  ]
+			: [] ),
+		// If there are other referral sites, we should show them next
+		...( otherReferralSites.length
+			? otherReferralSites.map( ( { features, id }: NeedsSetupSite ) => ( {
 					name: translate( 'WordPress.com' ),
-					subTitle: translate( '%(count)d site available', '%(count)d sites available', {
-						args: {
+					available: 1,
+					subTitle: <ClientSite referral={ features.wpcom_atomic.referral } />,
+					ids: [ id ],
+			  } ) )
+			: [] ),
+		...( availableSites.length
+			? [
+					{
+						name: translate( 'WordPress.com' ),
+						subTitle: translate( '%(count)d site available', '%(count)d sites available', {
+							args: {
+								count: availableSites.length,
+							},
 							count: availableSites.length,
-						},
-						count: availableSites.length,
-						comment: 'The `count` is the number of available sites.',
-					} ),
-					ids: availableSites.map( ( { id }: { id: number } ) => id ),
-				},
-		  ]
-		: [];
+							comment: 'The `count` is the number of available sites.',
+						} ),
+						ids: availableSites.map( ( { id }: { id: number } ) => id ),
+					},
+			  ]
+			: [] ),
+	];
 
 	const isProvisioning =
 		isCreatingSite ||


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/392

## Proposed Changes

This PR fixes the issue that causes sites not to show up on the Needs Setup page when there are only referred sites.

## Testing Instructions

- Open live link
- Go to /sites/need-setup and make sure you don't have any pending sites to be assigned. It should should `No Sites`
- Refer products (WPCOM) to a client
- Login as a client and go to checkout from the email and submit the payment information.
- As an agency, go to the referral dashboard > open the client details who you referred and click on the `Create site` button next to the WPCOM license > Verify that the referred site is displayed as shown below. Also, remove the query args from the URL (/sites/need-setup) and verify the site is still shown.

<img width="810" alt="Screenshot 2024-06-20 at 12 20 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f41c5701-3bc2-45f3-9389-b52dbf1ef7cb">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
