### PR TITLE
A4A: Update the referral object schema and UI to match the latest APIs

### DIFF
--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -36,7 +36,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 
 	const onConfirm = () => {
 		cancelSubscription( {
-			licenseKey: subscription.license_key,
+			licenseKey: subscription.license.license_key,
 		} );
 		dispatch( recordTracksEvent( 'calypso_a8c_client_subscription_cancel_confirmed' ) );
 	};

--- a/client/a8c-for-agencies/sections/client/hooks/use-fetch-client-subscriptions.ts
+++ b/client/a8c-for-agencies/sections/client/hooks/use-fetch-client-subscriptions.ts
@@ -7,7 +7,6 @@ const getClientSubscriptions = ( subscriptions: SubscriptionAPIResponse[] ) => {
 		curr.products.forEach( ( product ) => {
 			acc.push( {
 				...product,
-				status: curr.status,
 				referral_id: curr.id,
 				// id is a combination of referral_id and product_id because none of them are unique
 				id: parseInt( `${ curr.id }${ product.product_id }` ),

--- a/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
@@ -3,23 +3,23 @@ export const getSubscriptionStatus = (
 	translate: ( key: string ) => string
 ): {
 	children: string | undefined;
-	type: 'success' | 'warning' | undefined;
+	type: 'success' | 'warning' | 'info' | undefined;
 } => {
 	switch ( status ) {
-		case 'active':
-			return {
-				children: translate( 'Active' ),
-				type: 'success',
-			};
 		case 'pending':
 			return {
 				children: translate( 'Pending' ),
 				type: 'warning',
 			};
-		case 'overdue':
+		case 'active':
 			return {
-				children: translate( 'Overdue' ),
-				type: 'warning',
+				children: translate( 'Active' ),
+				type: 'success',
+			};
+		case 'canceled':
+			return {
+				children: translate( 'Canceled' ),
+				type: 'info',
 			};
 		default:
 			return {

--- a/client/a8c-for-agencies/sections/client/types.ts
+++ b/client/a8c-for-agencies/sections/client/types.ts
@@ -1,9 +1,10 @@
 export interface ReferralProduct {
-	date_assigned: string;
-	license_id: number;
-	license_key: string;
+	status: string;
 	product_id: number;
 	quantity: number;
+	license: {
+		license_key: string;
+	};
 	site_assigned: string;
 }
 

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
@@ -12,7 +12,6 @@ const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
 	const clients = referrals.reduce< { [ key: string ]: Referral } >( ( acc, referral ) => {
 		const purchases = referral.products.map( ( product ) => ( {
 			...product,
-			status: referral.status,
 			referral_id: referral.id, // referral id is needed for the purchase to be unique
 		} ) );
 		if ( ! acc[ referral.client.id ] ) {

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { BadgeType, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { addQueryArgs, urlToSlug } from 'calypso/lib/url';
@@ -13,18 +13,36 @@ type Props = {
 	data?: APIProductFamilyProduct[];
 };
 
+function getPurchaseStatus(
+	purchase: ReferralPurchase,
+	translate: ReturnType< typeof useTranslate >
+): [ BadgeType, React.ReactNode ] {
+	if ( purchase.status === 'active' ) {
+		if ( purchase.site_assigned ) {
+			return [ 'success', translate( 'Assigned' ) ];
+		}
+		return [ 'warning', translate( 'Unassigned' ) ];
+	}
+
+	if ( purchase.status === 'canceled' ) {
+		return [ 'info', translate( 'Canceled' ) ];
+	}
+
+	return [ 'warning', translate( 'Awaiting payment' ) ];
+}
+
 const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props ) => {
 	const translate = useTranslate();
 	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
 	const isWPCOMLicense = product?.family_slug === 'wpcom-hosting';
 	const redirectUrl =
-		purchase.license_key &&
+		purchase.license &&
 		( isWPCOMLicense
-			? addQueryArgs( { license_key: purchase.license_key }, A4A_SITES_LINK_NEEDS_SETUP )
-			: addQueryArgs( { key: purchase.license_key }, '/marketplace/assign-license' ) );
+			? addQueryArgs( { license_key: purchase.license.license_key }, A4A_SITES_LINK_NEEDS_SETUP )
+			: addQueryArgs( { key: purchase.license.license_key }, '/marketplace/assign-license' ) );
 
 	const showAssignButton = purchase.status === 'active' && redirectUrl;
-	const isAwaitingPayment = purchase.status === 'pending';
+	const [ statusType, statusText ] = getPurchaseStatus( purchase, translate );
 
 	return purchase.site_assigned ? (
 		<Button
@@ -38,8 +56,8 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 		<>
 			<StatusBadge
 				statusProps={ {
-					children: isAwaitingPayment ? translate( 'Awaiting payment' ) : translate( 'Unassigned' ),
-					type: 'warning',
+					children: statusText,
+					type: statusType,
 				} }
 			/>
 			{ showAssignButton && (

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/date.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/date.tsx
@@ -6,8 +6,8 @@ type Props = {
 };
 
 const DateAssigned = ( { purchase }: Props ) => {
-	return purchase.date_assigned ? (
-		new Date( purchase.date_assigned ).toLocaleDateString()
+	return purchase.license?.attached_at ? (
+		new Date( purchase.license.attached_at ).toLocaleDateString()
 	) : (
 		<Gridicon icon="minus" />
 	);

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -1,10 +1,13 @@
 interface ReferralPurchaseAPIResponse {
-	license_id: number;
-	quantity: number;
+	status: string;
 	product_id: number;
-	date_assigned: string;
+	quantity: number;
+	license: {
+		license_key: string;
+		attached_at: string | null;
+		revoked_at: string | null;
+	};
 	site_assigned: string;
-	license_key: string;
 }
 export interface ReferralPurchase extends ReferralPurchaseAPIResponse {
 	status: string;


### PR DESCRIPTION
Related to D152547-code

## Proposed Changes

* A4A: Update the referral schema for agencies and clients to match the latest changes to the API.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you create several new referrals before testing as data stored for referrals has changed.
* Make sure you check out some of the referrals and revoke some of the licenses to test all states.
* Make sure referrals and products are displayed correctly on http://agencies.localhost:3000/referrals/dashboard
* Make sure referrals and products are displayed correctly on http://agencies.localhost:3000/client/subscriptions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?