### PR TITLE
Theme Tiers: Added support for theme tiers v2 features

### DIFF
--- a/client/data/themes/types.ts
+++ b/client/data/themes/types.ts
@@ -1,5 +1,6 @@
 export type ThemeTier = {
 	slug: string;
-	feature: string | null;
+	feature?: string | null;
+	featureList?: string[];
 	platform: string;
 };

--- a/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
+++ b/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
@@ -6,16 +6,23 @@ import { getThemeTierForTheme } from 'calypso/state/themes/selectors';
 export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string ) {
 	const isThemeAllowed = useSelector( ( state ) => {
 		const themeTier = getThemeTierForTheme( state, themeId );
-		const features = themeTier?.featureList ?? [ themeTier?.feature ] ?? [];
-		return features.some( ( feature: string ) => siteHasFeature( state, siteId, feature ) );
+		const features = themeTier?.featureList ?? [ themeTier?.feature ] ?? [ null ];
+
+		return features.some(
+			( feature: string ) => ! feature || siteHasFeature( state, siteId, feature )
+		);
 	} );
 
 	const retainedBenefits = useTierRetainedBenefitsQuery( siteId, themeId );
 
 	const hasFeature = useSelector( ( state ) => {
-		const retainedFeatures =
-			retainedBenefits?.tier?.featureList ?? [ retainedBenefits?.tier?.feature ] ?? [];
-		return retainedFeatures.some( ( feature: string ) => siteHasFeature( state, siteId, feature ) );
+		const retainedFeatures = retainedBenefits?.tier?.featureList ?? [
+				retainedBenefits?.tier?.feature,
+			] ?? [ null ];
+
+		return retainedFeatures.some(
+			( feature: string ) => ! feature || siteHasFeature( state, siteId, feature )
+		);
 	} );
 
 	if ( isThemeAllowed ) {

--- a/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
+++ b/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
@@ -6,13 +6,17 @@ import { getThemeTierForTheme } from 'calypso/state/themes/selectors';
 export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string ) {
 	const isThemeAllowed = useSelector( ( state ) => {
 		const themeTier = getThemeTierForTheme( state, themeId );
-		return themeTier?.feature ? siteHasFeature( state, siteId, themeTier.feature ) : true;
+		const features = themeTier?.featureList ?? [ themeTier?.feature ] ?? [];
+		return features.some( ( feature: string ) => siteHasFeature( state, siteId, feature ) );
 	} );
 
 	const retainedBenefits = useTierRetainedBenefitsQuery( siteId, themeId );
-	const hasFeature = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, retainedBenefits?.tier.feature ?? '' )
-	);
+
+	const hasFeature = useSelector( ( state ) => {
+		const retainedFeatures =
+			retainedBenefits?.tier?.featureList ?? [ retainedBenefits?.tier?.feature ] ?? [];
+		return retainedFeatures.some( ( feature: string ) => siteHasFeature( state, siteId, feature ) );
+	} );
 
 	if ( isThemeAllowed ) {
 		return true;

--- a/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
+++ b/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
@@ -9,7 +9,7 @@ export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string 
 		const features = themeTier?.featureList ?? [ themeTier?.feature ] ?? [ null ];
 
 		return features.some(
-			( feature: string ) => ! feature || siteHasFeature( state, siteId, feature )
+			( feature: string | null ) => ! feature || siteHasFeature( state, siteId, feature )
 		);
 	} );
 
@@ -21,7 +21,7 @@ export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string 
 			] ?? [ null ];
 
 		return retainedFeatures.some(
-			( feature: string ) => ! feature || siteHasFeature( state, siteId, feature )
+			( feature: string | null ) => ! feature || siteHasFeature( state, siteId, feature )
 		);
 	} );
 

--- a/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
+++ b/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
@@ -6,7 +6,7 @@ import { getThemeTierForTheme } from 'calypso/state/themes/selectors';
 export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string ) {
 	const isThemeAllowed = useSelector( ( state ) => {
 		const themeTier = getThemeTierForTheme( state, themeId );
-		const features = themeTier?.featureList ?? [ themeTier?.feature ] ?? [ null ];
+		const features = themeTier?.featureList ?? [ themeTier?.feature ?? null ];
 
 		return features.some(
 			( feature: string | null | undefined ) =>
@@ -18,8 +18,8 @@ export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string 
 
 	const hasFeature = useSelector( ( state ) => {
 		const retainedFeatures = retainedBenefits?.tier?.featureList ?? [
-				retainedBenefits?.tier?.feature,
-			] ?? [ null ];
+			retainedBenefits?.tier?.feature ?? null,
+		];
 
 		return retainedFeatures.some(
 			( feature: string | null | undefined ) =>

--- a/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
+++ b/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
@@ -9,7 +9,8 @@ export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string 
 		const features = themeTier?.featureList ?? [ themeTier?.feature ] ?? [ null ];
 
 		return features.some(
-			( feature: string | null ) => ! feature || siteHasFeature( state, siteId, feature )
+			( feature: string | null | undefined ) =>
+				! feature || siteHasFeature( state, siteId, feature )
 		);
 	} );
 
@@ -21,7 +22,8 @@ export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string 
 			] ?? [ null ];
 
 		return retainedFeatures.some(
-			( feature: string | null ) => ! feature || siteHasFeature( state, siteId, feature )
+			( feature: string | null | undefined ) =>
+				! feature || siteHasFeature( state, siteId, feature )
 		);
 	} );
 

--- a/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
+++ b/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
@@ -6,7 +6,7 @@ import { getThemeTierForTheme } from 'calypso/state/themes/selectors';
 export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string ) {
 	const isThemeAllowed = useSelector( ( state ) => {
 		const themeTier = getThemeTierForTheme( state, themeId );
-		const features = themeTier?.featureList ?? [ themeTier?.feature ?? null ];
+		const features = themeTier?.featureList ?? [ themeTier?.feature ];
 
 		return features.some(
 			( feature: string | null | undefined ) =>
@@ -18,7 +18,7 @@ export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string 
 
 	const hasFeature = useSelector( ( state ) => {
 		const retainedFeatures = retainedBenefits?.tier?.featureList ?? [
-			retainedBenefits?.tier?.feature ?? null,
+			retainedBenefits?.tier?.feature,
 		];
 
 		return retainedFeatures.some(

--- a/client/types.ts
+++ b/client/types.ts
@@ -55,7 +55,8 @@ export interface Theme {
 	theme_uri: string;
 	theme_tier: {
 		slug: string;
-		feature: string;
+		feature?: string;
+		featureList?: string[];
 		platform: string;
 	};
 	trending_rank: number;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/6352

## Proposed Changes

* Implemented the necessary changes to make Calypso aware of the v2 features of Theme Tiers

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to restore the WooCommerce theme tier since we implemented a workaround so that it would work with WooCommerce trial sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Apply the patch found here: D152645-code
* Open the Calypso live link
* Start the WooCommerce trial flow and create a trial site with: `{live-link}/setup/entrepreneur/start/?ref=woo-hosting-solutions-lp`
* You can advance to your site's wp-admin.
* You should be able to switch between WooCommerce tier themes without needing to upgrade.
* Check normal themes for regressions.


https://github.com/Automattic/wp-calypso/assets/1989914/111fa1cd-4021-4f19-914b-087598dd1219



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
