### PR TITLE
A4A > Referral: Fix the referral status

### DIFF
--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -24,7 +24,11 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 
 	const { mutate: cancelSubscription, isPending } = useCancelClientSubscription( {
 		onSuccess: () => {
-			dispatch( successNotice( translate( 'The subscription was successfully cancelled.' ) ) );
+			dispatch(
+				successNotice( translate( 'The subscription was successfully canceled.' ), {
+					id: 'a8c-cancel-subscription-success',
+				} )
+			);
 			onCancelSubscription?.( subscription );
 			setIsVisible( false );
 		},
@@ -42,7 +46,7 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 	};
 
 	const handleClose = () => {
-		dispatch( recordTracksEvent( 'calypso_a8c_client_subscription_cancel_cancelled' ) );
+		dispatch( recordTracksEvent( 'calypso_a8c_client_subscription_cancel_canceled' ) );
 		setIsVisible( false );
 	};
 

--- a/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/client/cancel-subscription-confirmation-dialog/index.tsx
@@ -42,11 +42,11 @@ export default function CancelSubscriptionAction( { subscription, onCancelSubscr
 		cancelSubscription( {
 			licenseKey: subscription.license.license_key,
 		} );
-		dispatch( recordTracksEvent( 'calypso_a8c_client_subscription_cancel_confirmed' ) );
+		dispatch( recordTracksEvent( 'calypso_a8c_client_subscription_cancel_confirm' ) );
 	};
 
 	const handleClose = () => {
-		dispatch( recordTracksEvent( 'calypso_a8c_client_subscription_cancel_canceled' ) );
+		dispatch( recordTracksEvent( 'calypso_a8c_client_subscription_cancel_dismiss' ) );
 		setIsVisible( false );
 	};
 

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -36,14 +36,14 @@ export function SubscriptionAction( {
 } ) {
 	const status = subscription.status;
 	const isActive = status === 'active';
-	return isActive ? (
-		<span className="action-button">
-			<CancelSubscriptionAction
-				subscription={ subscription }
-				onCancelSubscription={ onCancelSubscription }
-			/>
-		</span>
-	) : (
-		'-'
+	return (
+		isActive && (
+			<span className="action-button">
+				<CancelSubscriptionAction
+					subscription={ subscription }
+					onCancelSubscription={ onCancelSubscription }
+				/>
+			</span>
+		)
 	);
 }

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
@@ -14,6 +14,7 @@ const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
 			...product,
 			referral_id: referral.id, // referral id is needed for the purchase to be unique
 		} ) );
+		const statuses = purchases.map( ( purchase ) => purchase.status );
 		if ( ! acc[ referral.client.id ] ) {
 			acc[ referral.client.id ] = {
 				// id is a combination of client id and referral id to make it unique
@@ -21,12 +22,12 @@ const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
 				client: referral.client,
 				purchases: [ ...purchases ],
 				commissions: referral.commission,
-				statuses: [ referral.status ],
+				statuses: [ ...statuses ],
 			};
 		} else {
 			acc[ referral.client.id ].purchases.push( ...purchases );
 			acc[ referral.client.id ].commissions += referral.commission;
-			acc[ referral.client.id ].statuses.push( referral.status );
+			acc[ referral.client.id ].statuses.push( ...statuses );
 		}
 		return acc;
 	}, {} );

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
@@ -10,34 +10,39 @@ export default function SubscriptionStatus( { item }: { item: Referral } ): Reac
 		item: Referral
 	): {
 		status: string | null;
-		type: 'warning' | 'success' | null;
+		type: 'warning' | 'success' | 'info' | null;
 	} => {
 		const activeStatuses = item.statuses.filter( ( status ) => status === 'active' );
 		const pendingStatuses = item.statuses.filter( ( status ) => status === 'pending' );
+		const canceledStatuses = item.statuses.filter( ( status ) => status === 'canceled' );
 
-		if ( ! item.statuses.length ) {
-			return {
-				status: null,
-				type: null,
-			};
+		switch ( item.statuses.length ) {
+			case 0:
+				return {
+					status: null,
+					type: null,
+				};
+			case activeStatuses.length:
+				return {
+					status: translate( 'Active' ),
+					type: 'success',
+				};
+			case pendingStatuses.length:
+				return {
+					status: translate( 'Pending' ),
+					type: 'warning',
+				};
+			case canceledStatuses.length:
+				return {
+					status: translate( 'Canceled' ),
+					type: 'info',
+				};
+			default:
+				return {
+					status: translate( 'Mixed' ),
+					type: 'warning',
+				};
 		}
-
-		if ( activeStatuses.length === item.statuses.length ) {
-			return {
-				status: translate( 'Active' ),
-				type: 'success',
-			};
-		}
-		if ( pendingStatuses.length === item.statuses.length ) {
-			return {
-				status: translate( 'Pending' ),
-				type: 'warning',
-			};
-		}
-		return {
-			status: translate( 'Mixed' ),
-			type: 'warning',
-		};
 	};
 
 	const { status, type } = getStatus( item );

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
@@ -12,27 +12,33 @@ export default function SubscriptionStatus( { item }: { item: Referral } ): Reac
 		status: string | null;
 		type: 'warning' | 'success' | 'info' | null;
 	} => {
-		const activeStatuses = item.statuses.filter( ( status ) => status === 'active' );
-		const pendingStatuses = item.statuses.filter( ( status ) => status === 'pending' );
-		const canceledStatuses = item.statuses.filter( ( status ) => status === 'canceled' );
+		if ( ! item.statuses.length ) {
+			return {
+				status: null,
+				type: null,
+			};
+		}
 
-		switch ( item.statuses.length ) {
-			case 0:
-				return {
-					status: null,
-					type: null,
-				};
-			case activeStatuses.length:
+		const status = item.statuses.reduce( ( prev, curr ) => {
+			if ( prev === curr ) {
+				return curr;
+			}
+
+			return 'mixed';
+		}, item.statuses[ 0 ] );
+
+		switch ( status ) {
+			case 'active':
 				return {
 					status: translate( 'Active' ),
 					type: 'success',
 				};
-			case pendingStatuses.length:
+			case 'pending':
 				return {
 					status: translate( 'Pending' ),
 					type: 'warning',
 				};
-			case canceledStatuses.length:
+			case 'canceled':
 				return {
 					status: translate( 'Canceled' ),
 					type: 'info',


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/405

## Proposed Changes

This PR fixes the referral status after some API changes were done.

## Testing Instructions

- Refer a product to a client
- Login as a client and go to checkout from the email
- Go to /client/subscriptions > Click on `Cancel the subscription` on any one row and proceed 
- A minor fix has been made to the notification message, verify it is displayed as shown below:

<img width="583" alt="Screenshot 2024-06-20 at 1 53 58 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c300974c-f386-4ff1-ab60-3346431b2a91">

- Verify once the subscription is canceled, the status is displayed as shown below and the button doesn't appear. Verify the same for mobile view:

<img width="1581" alt="Screenshot 2024-06-20 at 1 37 10 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/22bb2717-6a3e-4495-a554-2caeab00ea02">

- Now go to agency view and head to the Referral dashboard (/referrals/dashboard)  and verify that the canceled status is shown on both the list and detailed view 

<img width="1174" alt="Screenshot 2024-06-20 at 1 56 31 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d84b35f7-214c-4b1d-b284-962fef74cc52">

<img width="1578" alt="Screenshot 2024-06-20 at 1 57 19 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/876d0523-22db-4c00-910d-e8d7a3c42005">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
