### PR TITLE
Stats: Set focus on UTM Builder

### DIFF
--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -1,6 +1,6 @@
 import { FormLabel } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import StatsButton from '../components/stats-button';
@@ -14,6 +14,7 @@ type InputFieldProps = {
 	placeholder: string;
 	value: string;
 	onChange: ( e: React.ChangeEvent< HTMLInputElement > ) => void;
+	inputReference?: React.RefObject< HTMLInputElement >;
 };
 
 const utmKeys = [ 'url', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term' ];
@@ -30,6 +31,7 @@ const InputField: React.FC< InputFieldProps > = ( {
 	placeholder,
 	value,
 	onChange,
+	inputReference,
 } ) => {
 	return (
 		<div className="stats-utm-builder__form-field">
@@ -41,6 +43,7 @@ const InputField: React.FC< InputFieldProps > = ( {
 				value={ value }
 				onChange={ onChange }
 				placeholder={ placeholder }
+				inputRef={ inputReference }
 			/>
 		</div>
 	);
@@ -54,6 +57,12 @@ const UtmBuilder: React.FC = () => {
 		utm_medium: '',
 		utm_campaign: '',
 	} );
+	// Focus the initial input field when rendered.
+	const initialInputReference = useRef< HTMLInputElement >( null );
+
+	useEffect( () => {
+		initialInputReference.current!.focus();
+	}, [] );
 
 	const fromLabels: formLabelsType = {
 		url: {
@@ -106,6 +115,7 @@ const UtmBuilder: React.FC = () => {
 						placeholder={ fromLabels.url.placeholder }
 						value={ url }
 						onChange={ ( e ) => setUrl( e.target.value ) }
+						inputReference={ initialInputReference }
 					/>
 					{ Object.keys( inputValues ).map( ( key ) => (
 						<InputField


### PR DESCRIPTION
Sets the first input field as active when displaying the form.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91827.

## Proposed Changes

Small addition to focus the first input field when displaying the UTM Builder.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Makes for slightly better keyboard navigation if we focus an input field by default.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Bring up the UTM Builder and confirm the first text field is focused.
- Confirm tabbing still works as expected.
- Close and reopen to confirm the first field is focused again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
