### PR TITLE
E2E: Replace `Twitter` with `X` (`editor__post-basic-flow.ts`)

### DIFF
--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -227,7 +227,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		// Not checking the `Press This` button as it is not available on AT.
 		// @see: paYJgx-1lp-p2
-		it.each( [ { name: 'Twitter' }, { name: 'Facebook' } ] )(
+		it.each( [ { name: 'X' }, { name: 'Facebook' } ] )(
 			'Social sharing button for $name can be clicked',
 			async function ( { name } ) {
 				publishedPostPage = new PublishedPostPage( newPage );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7848.

## Proposed Changes

* Replace `Twitter` with `X` (`editor__post-basic-flow.ts`)

As a part of the fix I also changed the Social Sharing buttons setting on multiple test sites to use `X` instead of `Twitter` sharing button. Previous to this change, some of the test sites were using `X`, some `Twitter`. This caused the `editor__post-basic-flow.ts` test to fail / pass inconsistently depending on the test site used.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* failing tests

## Testing Instructions

1. Check out the branch.
2. Navigate to `tests/e2e` and run `yarn build --watch`.
3. In a separate terminal window run `VIEWPORT_NAME=desktop TEST_ON_ATOMIC=false GUTENBERG_EDGE=false yarn jest specs/editor/editor__post-basic-flow.ts`.
4. The test should pass.
5. Replace the `VIEWPORT_NAME=desktop` with `VIEWPORT_NAME=mobile`, `TEST_ON_ATOMIC=false` with `TEST_ON_ATOMIC=true` and `GUTENBERG_EDGE=false` with `GUTENBERG_EDGE=true` (try different combinations).
6. All the tests should pass.

You may also find the following instructions to set up E2E testing environment helpful: https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/README.md.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
