### PR TITLE
A4A: Signup Form redirect to WPCOM with locale

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-form/hooks/use-handle-wpcom-redirect.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/hooks/use-handle-wpcom-redirect.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { useLocale } from '@automattic/i18n-utils';
 import { useCallback } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -7,6 +8,7 @@ import { AgencyDetailsPayload } from '../../agency-details-form/types';
 
 export function useHandleWPCOMRedirect() {
 	const dispatch = useDispatch();
+	const locale = useLocale();
 	const notificationId = 'a4a-agency-signup-form-wpcom-redirect';
 
 	const handleWPCOMRedirect = useCallback(
@@ -37,13 +39,14 @@ export function useHandleWPCOMRedirect() {
 					client_id: config( 'oauth_client_id' ),
 					redirect_uri: returnUri.toString(),
 					scope: 'global',
+					locale,
 				} ).toString();
 				window.location.replace( authUrl.toString() );
 			} catch ( error ) {
 				dispatch( errorNotice( JSON.stringify( error ), { id: notificationId } ) );
 			}
 		},
-		[ dispatch ]
+		[ dispatch, locale ]
 	);
 
 	return handleWPCOMRedirect;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 823-gh-Automattic/i18n-issues

## Proposed Changes

* Set the locale parameter in the auth redirect URL when submitting the A4A signup form.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The changes are needed in order to preserve the locale parameter from the signup form to the authentication screen.

![d9IJRCdTnUQJl0WI](https://github.com/Automattic/wp-calypso/assets/2722412/045fec61-47f7-4472-8ab9-9622b2d6cf5c)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run A4A dev environment locally with `yarn start-a8c-for-agencies` or use live build.
* Open `/signup?locale=es` (the locale param can be any Mag-16 language slug).
* Fill the form with dummy data and submit.
* Confirm you are being redirected to the authentication URL and with the same locale from signup form.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
