### PR TITLE
A4A: Change Referral purchases 'Date' column label to 'Assign on'.

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
@@ -39,16 +39,6 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 				enableSorting: false,
 			},
 			{
-				id: 'date',
-				header: translate( 'Date' ).toUpperCase(),
-				getValue: () => '-',
-				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
-					return <DateAssigned purchase={ item } />;
-				},
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
 				id: 'assigned-to',
 				header: translate( 'Assigned to' ).toUpperCase(),
 				getValue: () => '-',
@@ -61,6 +51,16 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 							isFetching={ isFetching }
 						/>
 					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'date',
+				header: translate( 'Assigned on' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: ReferralPurchase } ): ReactNode => {
+					return <DateAssigned purchase={ item } />;
 				},
 				enableHiding: false,
 				enableSorting: false,


### PR DESCRIPTION

| Before | After |
|--------|--------|
| <img width="1791" alt="Screenshot 2024-06-20 at 7 37 17 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b26509a1-cfcf-4703-a736-b26fdbc636aa"> | <img width="1787" alt="Screenshot 2024-06-20 at 7 36 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/20b3e01f-d62b-4dbf-9d3c-b45a6a886e0b"> | 


Closes https://github.com/Automattic/jetpack-genesis/issues/394

## Proposed Changes

* Rename the 'Date' column to 'Assign on' in the Referral's purchases table.

## Why are these changes being made?


* Make the date column in the referral purchases table clearer.

## Testing Instructions


* Use the A4A live link below and go to `/marketplace/products`
* Create some new referrals.
* Once redirected to the Referrals dashboard, expand the referral to see the purchases table.
* Confirm that the Date column is now in the 3 column with the 'Assign on' label.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
