### PR TITLE
A4A > Referral: Update Refer client success message

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
@@ -20,10 +20,14 @@ export default function NewReferralOrderNotification( { email, onClose }: Props 
 	return (
 		showBanner && (
 			<LayoutBanner level="success" onClose={ onCloseClick }>
-				{ translate( 'Your referral order was emailed to %(referralEmail)s for payment.', {
-					args: { referralEmail: email },
-					comment: 'The %(referralEmail)s is the email where referral order was sent.',
-				} ) }
+				{ translate(
+					'Your referral order was emailed to %(referralEmail)s for payment.{{br/}}Once they pay you can assign the items that were purchased.',
+					{
+						components: { br: <br /> },
+						args: { referralEmail: email },
+						comment: 'The %(referralEmail)s is the email where referral order was sent.',
+					}
+				) }
 			</LayoutBanner>
 		)
 	);


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/400

## Proposed Changes

This PR updates the refer client success message.

## Testing Instructions

- Open A4A live link
- Refer a product to a client
- Verify that the success message appears as shown below

<img width="1578" alt="Screenshot 2024-06-20 at 5 16 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/62137679-c0b5-44f4-90a6-998ac4371d8a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
