### PR TITLE
A4A > Referral: Update the delete card confirmation message for client view

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/delete-primary-confirmation/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/delete-primary-confirmation/index.tsx
@@ -1,5 +1,6 @@
 import { PaymentLogo } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
+import { isClientView } from '../../../lib/is-client-view';
 import type { PaymentMethodCard } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 
 import './style.scss';
@@ -12,6 +13,8 @@ interface Props {
 
 const DeletePrimaryCardConfirmation = ( { card, altCard, isFetching }: Props ) => {
 	const translate = useTranslate();
+
+	const isClient = isClientView();
 
 	if ( isFetching ) {
 		return (
@@ -26,9 +29,13 @@ const DeletePrimaryCardConfirmation = ( { card, altCard, isFetching }: Props ) =
 			<div className="delete-primary-card-confirmation">
 				<div className="delete-primary-card-confirmation__card">
 					<p className="delete-primary-card-confirmation__notice">
-						{ translate(
-							'Issuing new licenses will be paused until you add a new primary payment method. Additionally, the existing licenses will be revoked at the end of their respective terms.'
-						) }
+						{ isClient
+							? translate(
+									'Any items that you bought will be canceled and stop working at the end of their terms.'
+							  )
+							: translate(
+									'Issuing new licenses will be paused until you add a new primary payment method. Additionally, the existing licenses will be revoked at the end of their respective terms.'
+							  ) }
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/398

## Proposed Changes

This PR updates the delete card confirmation message for client view

## Testing Instructions

- Login as a client
- Go to client/payment-methods
- Try deleting the card and verify that the confirmation message is changed as shown below:

<img width="704" alt="Screenshot 2024-06-20 at 5 30 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/835fbda0-4ebb-45fa-bd7a-7c811a095779">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
