### PR TITLE
A4A: Eliminate some runts in the Referrals FAQs page.

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -106,15 +106,11 @@ export default function CommissionOverview( {
 								<div className="commission-overview__heading">
 									<img src={ pressableIcon } alt="Pressable" />
 									<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
-									{ translate(
-										'Hosting revenue share{{br/}}{{nbsp/}}(WordPress.com and Pressable)',
-										{
-											components: {
-												br: <br />,
-												nbsp: <>&nbsp;</>,
-											},
-										}
-									) }
+									{ translate( 'Hosting revenue share (WordPress.com and{{nbsp/}}Pressable)', {
+										components: {
+											nbsp: <>&nbsp;</>,
+										},
+									} ) }
 								</div>
 							}
 							expanded
@@ -131,9 +127,8 @@ export default function CommissionOverview( {
 								<div className="commission-overview__heading">
 									<JetpackLogo className="jetpack-logo" size={ 24 } />
 									<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
-									{ translate( 'Jetpack products and{{br/}}{{nbsp/}}Woo-owned extensions', {
+									{ translate( 'Jetpack products and Woo-owned{{nbsp/}}extensions', {
 										components: {
-											br: <br />,
 											nbsp: <>&nbsp;</>,
 										},
 									} ) }

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -106,7 +106,15 @@ export default function CommissionOverview( {
 								<div className="commission-overview__heading">
 									<img src={ pressableIcon } alt="Pressable" />
 									<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
-									{ translate( 'Hosting revenue share (WordPress.com and Pressable)' ) }
+									{ translate(
+										'Hosting revenue share{{br/}}{{nbsp/}}(WordPress.com and Pressable)',
+										{
+											components: {
+												br: <br />,
+												nbsp: <>&nbsp;</>,
+											},
+										}
+									) }
 								</div>
 							}
 							expanded
@@ -123,7 +131,12 @@ export default function CommissionOverview( {
 								<div className="commission-overview__heading">
 									<JetpackLogo className="jetpack-logo" size={ 24 } />
 									<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
-									{ translate( 'Jetpack products and Woo-owned extensions' ) }
+									{ translate( 'Jetpack products and{{br/}}{{nbsp/}}Woo-owned extensions', {
+										components: {
+											br: <br />,
+											nbsp: <>&nbsp;</>,
+										},
+									} ) }
 								</div>
 							}
 							expanded

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -127,9 +127,10 @@ export default function CommissionOverview( {
 								<div className="commission-overview__heading">
 									<JetpackLogo className="jetpack-logo" size={ 24 } />
 									<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
-									{ translate( 'Jetpack products and Woo-owned{{nbsp/}}extensions', {
+									{ translate( 'Jetpack products and Woo{{8209/}}owned{{nbsp/}}extensions', {
 										components: {
 											nbsp: <>&nbsp;</>,
+											8209: <>&#8209;</>,
 										},
 									} ) }
 								</div>


### PR DESCRIPTION
This PR eliminates the "runts" in the FAQs section titles.

| Before | After |
|--------|--------|
| <img width="733" alt="Screenshot 2024-06-20 at 8 44 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/edcc7a2e-3250-48ae-826c-63f5b9cf3911"> | <img width="729" alt="Screenshot 2024-06-20 at 9 02 01 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/2b32d45c-048b-4c69-b867-5fe5364eb04b"> | 

Closes https://github.com/Automattic/jetpack-genesis/issues/402

## Proposed Changes

* Insert `&nbsp;` to ensure titles do not produce runts.


## Testing Instructions

* Use the A4A live link and go to `/referrals/faq` page
* confirm that the title do not have runts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
