### PR TITLE
Reader full post page - add global sidebar and content frame

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -214,7 +214,7 @@ export class FullPostView extends Component {
 
 	handleBack = ( event ) => {
 		event.preventDefault();
-		this.props.onClose && this.props.onClose( this.props.post );
+		this.props.onClose && this.props.onClose();
 	};
 
 	handleCommentClick = () => {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -498,191 +498,194 @@ export class FullPostView extends Component {
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */
 		return (
-			<ReaderMain className={ clsx( classes ) }>
-				{ site && <QueryPostLikes siteId={ post.site_ID } postId={ post.ID } /> }
-				{ ! post || post._state === 'pending' ? (
-					<DocumentHead title={ translate( 'Loading' ) } />
-				) : (
-					<DocumentHead title={ `${ post.title } ‹ ${ siteName } ‹ Reader` } />
-				) }
-				{ post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
-				{ post && ! post.is_external && post.site_ID && (
-					<QueryReaderSite siteId={ +post.site_ID } />
-				) }
-				{ referral && ! referralPost && <QueryReaderPost postKey={ referral } /> }
-				{ ! post || ( isLoading && <QueryReaderPost postKey={ postKey } /> ) }
-				<BackButton onClick={ this.handleBack } />
-				<div className="reader-full-post__visit-site-container">
-					<ExternalLink
-						icon
-						href={ post.URL }
-						onClick={ this.handleVisitSiteClick }
-						target="_blank"
-					>
-						<span className="reader-full-post__visit-site-label">
-							{ translate( 'Visit Site' ) }
-						</span>
-					</ExternalLink>
-				</div>
-				<div className="reader-full-post__content">
-					<div className="reader-full-post__sidebar">
-						{ isLoading && <AuthorCompactProfile author={ null } /> }
-						{ ! isLoading && post.author && (
-							<AuthorCompactProfile
-								author={ post.author }
-								siteIcon={ get( site, 'icon.img' ) }
-								feedIcon={ feedIcon }
-								siteName={ siteName }
-								siteUrl={ post.site_URL }
-								feedUrl={ get( post, 'feed_URL' ) }
-								followCount={ site && site.subscribers_count }
-								onFollowToggle={ this.openSuggestedFollowsModal }
-								feedId={ +post.feed_ID }
-								siteId={ +post.site_ID }
-								post={ post }
-							/>
-						) }
-						<div className="reader-full-post__sidebar-comment-like">
-							{ userCan( 'edit_post', post ) && (
-								<PostEditButton
+			// add extra div wrapper for consistent content frame layout/styling for reader.
+			<div>
+				<ReaderMain className={ clsx( classes ) }>
+					{ site && <QueryPostLikes siteId={ post.site_ID } postId={ post.ID } /> }
+					{ ! post || post._state === 'pending' ? (
+						<DocumentHead title={ translate( 'Loading' ) } />
+					) : (
+						<DocumentHead title={ `${ post.title } ‹ ${ siteName } ‹ Reader` } />
+					) }
+					{ post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
+					{ post && ! post.is_external && post.site_ID && (
+						<QueryReaderSite siteId={ +post.site_ID } />
+					) }
+					{ referral && ! referralPost && <QueryReaderPost postKey={ referral } /> }
+					{ ! post || ( isLoading && <QueryReaderPost postKey={ postKey } /> ) }
+					<BackButton onClick={ this.handleBack } />
+					<div className="reader-full-post__visit-site-container">
+						<ExternalLink
+							icon
+							href={ post.URL }
+							onClick={ this.handleVisitSiteClick }
+							target="_blank"
+						>
+							<span className="reader-full-post__visit-site-label">
+								{ translate( 'Visit Site' ) }
+							</span>
+						</ExternalLink>
+					</div>
+					<div className="reader-full-post__content">
+						<div className="reader-full-post__sidebar">
+							{ isLoading && <AuthorCompactProfile author={ null } /> }
+							{ ! isLoading && post.author && (
+								<AuthorCompactProfile
+									author={ post.author }
+									siteIcon={ get( site, 'icon.img' ) }
+									feedIcon={ feedIcon }
+									siteName={ siteName }
+									siteUrl={ post.site_URL }
+									feedUrl={ get( post, 'feed_URL' ) }
+									followCount={ site && site.subscribers_count }
+									onFollowToggle={ this.openSuggestedFollowsModal }
+									feedId={ +post.feed_ID }
+									siteId={ +post.site_ID }
 									post={ post }
-									site={ site }
-									iconSize={ 20 }
-									onClick={ this.onEditClick }
 								/>
 							) }
+							<div className="reader-full-post__sidebar-comment-like">
+								{ userCan( 'edit_post', post ) && (
+									<PostEditButton
+										post={ post }
+										site={ site }
+										iconSize={ 20 }
+										onClick={ this.onEditClick }
+									/>
+								) }
 
-							{ shouldShowComments( post ) && (
-								<CommentButton
-									key="comment-button"
-									commentCount={ commentCount }
-									onClick={ this.handleCommentClick }
-									tagName="div"
-									icon={ ReaderCommentIcon( { iconSize: 20 } ) }
+								{ shouldShowComments( post ) && (
+									<CommentButton
+										key="comment-button"
+										commentCount={ commentCount }
+										onClick={ this.handleCommentClick }
+										tagName="div"
+										icon={ ReaderCommentIcon( { iconSize: 20 } ) }
+									/>
+								) }
+
+								{ shouldShowLikes( post ) && (
+									<LikeButton
+										siteId={ +post.site_ID }
+										postId={ +post.ID }
+										fullPost
+										tagName="div"
+										likeSource="reader"
+									/>
+								) }
+
+								{ isEligibleForUnseen( { isWPForTeamsItem, hasOrganization } ) &&
+									canBeMarkedAsSeen( { post } ) &&
+									this.renderMarkAsSenButton() }
+							</div>
+						</div>
+						<article className="reader-full-post__story">
+							<ReaderFullPostHeader post={ post } referralPost={ referralPost } />
+
+							{ post.featured_image && ! isFeaturedImageInContent( post ) && (
+								<ReaderFeaturedImage
+									canonicalMedia={ null }
+									imageUrl={ post.featured_image }
+									href={ getStreamUrlFromPost( post ) }
+									imageWidth={ contentWidth }
+									children={ <div style={ { width: contentWidth } } /> }
 								/>
 							) }
+							{ isLoading && <ReaderFullPostContentPlaceholder /> }
+							{ post.use_excerpt ? (
+								<PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
+							) : (
+								<EmbedContainer>
+									<AutoDirection>
+										<div
+											ref={ this.postContentWrapper }
+											className="reader-full-post__story-content"
+											dangerouslySetInnerHTML={ { __html: post.content } }
+										/>
+									</AutoDirection>
+								</EmbedContainer>
+							) }
 
-							{ shouldShowLikes( post ) && (
-								<LikeButton
+							{ post.use_excerpt && <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> }
+							{ isDailyPostChallengeOrPrompt( post ) && (
+								<DailyPostButton post={ post } site={ site } />
+							) }
+
+							<ReaderPostActions
+								post={ post }
+								site={ site }
+								onCommentClick={ this.handleCommentClick }
+								fullPost
+							/>
+
+							{ ! isLoading && <ReaderPerformanceTrackerStop /> }
+
+							{ showRelatedPosts && (
+								<RelatedPostsFromSameSite
 									siteId={ +post.site_ID }
 									postId={ +post.ID }
-									fullPost
-									tagName="div"
-									likeSource="reader"
+									title={ translate( 'More in {{ siteLink /}}', {
+										components: {
+											siteLink: (
+												<a
+													href={ getStreamUrlFromPost( post ) }
+													/* eslint-disable wpcalypso/jsx-classname-namespace */
+													className="reader-related-card__link"
+													/* eslint-enable wpcalypso/jsx-classname-namespace */
+												>
+													{ siteName }
+												</a>
+											),
+										},
+									} ) }
+									/* eslint-disable wpcalypso/jsx-classname-namespace */
+									className="is-same-site"
+									/* eslint-enable wpcalypso/jsx-classname-namespace */
+									onPostClick={ this.handleRelatedPostFromSameSiteClicked }
 								/>
 							) }
 
-							{ isEligibleForUnseen( { isWPForTeamsItem, hasOrganization } ) &&
-								canBeMarkedAsSeen( { post } ) &&
-								this.renderMarkAsSenButton() }
-						</div>
-					</div>
-					<article className="reader-full-post__story">
-						<ReaderFullPostHeader post={ post } referralPost={ referralPost } />
-
-						{ post.featured_image && ! isFeaturedImageInContent( post ) && (
-							<ReaderFeaturedImage
-								canonicalMedia={ null }
-								imageUrl={ post.featured_image }
-								href={ getStreamUrlFromPost( post ) }
-								imageWidth={ contentWidth }
-								children={ <div style={ { width: contentWidth } } /> }
-							/>
-						) }
-						{ isLoading && <ReaderFullPostContentPlaceholder /> }
-						{ post.use_excerpt ? (
-							<PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
-						) : (
-							<EmbedContainer>
-								<AutoDirection>
-									<div
-										ref={ this.postContentWrapper }
-										className="reader-full-post__story-content"
-										dangerouslySetInnerHTML={ { __html: post.content } }
+							<div className="reader-full-post__comments-wrapper" ref={ this.commentsWrapper }>
+								{ shouldShowComments( post ) && (
+									<Comments
+										showNestingReplyArrow
+										post={ post }
+										initialSize={ startingCommentId ? commentCount : 10 }
+										pageSize={ 25 }
+										startingCommentId={ startingCommentId }
+										commentCount={ commentCount }
+										maxDepth={ 1 }
+										commentsFilterDisplay={ COMMENTS_FILTER_ALL }
+										showConversationFollowButton
+										shouldPollForNewComments={ config.isEnabled( 'reader/comment-polling' ) }
+										shouldHighlightNew
 									/>
-								</AutoDirection>
-							</EmbedContainer>
-						) }
+								) }
+							</div>
 
-						{ post.use_excerpt && <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> }
-						{ isDailyPostChallengeOrPrompt( post ) && (
-							<DailyPostButton post={ post } site={ site } />
-						) }
-
-						<ReaderPostActions
-							post={ post }
-							site={ site }
-							onCommentClick={ this.handleCommentClick }
-							fullPost
-						/>
-
-						{ ! isLoading && <ReaderPerformanceTrackerStop /> }
-
-						{ showRelatedPosts && (
-							<RelatedPostsFromSameSite
-								siteId={ +post.site_ID }
-								postId={ +post.ID }
-								title={ translate( 'More in {{ siteLink /}}', {
-									components: {
-										siteLink: (
-											<a
-												href={ getStreamUrlFromPost( post ) }
-												/* eslint-disable wpcalypso/jsx-classname-namespace */
-												className="reader-related-card__link"
-												/* eslint-enable wpcalypso/jsx-classname-namespace */
-											>
-												{ siteName }
-											</a>
-										),
-									},
-								} ) }
-								/* eslint-disable wpcalypso/jsx-classname-namespace */
-								className="is-same-site"
-								/* eslint-enable wpcalypso/jsx-classname-namespace */
-								onPostClick={ this.handleRelatedPostFromSameSiteClicked }
-							/>
-						) }
-
-						<div className="reader-full-post__comments-wrapper" ref={ this.commentsWrapper }>
-							{ shouldShowComments( post ) && (
-								<Comments
-									showNestingReplyArrow
-									post={ post }
-									initialSize={ startingCommentId ? commentCount : 10 }
-									pageSize={ 25 }
-									startingCommentId={ startingCommentId }
-									commentCount={ commentCount }
-									maxDepth={ 1 }
-									commentsFilterDisplay={ COMMENTS_FILTER_ALL }
-									showConversationFollowButton
-									shouldPollForNewComments={ config.isEnabled( 'reader/comment-polling' ) }
-									shouldHighlightNew
+							{ showRelatedPosts && (
+								<RelatedPostsFromOtherSites
+									siteId={ +post.site_ID }
+									postId={ +post.ID }
+									title={ relatedPostsFromOtherSitesTitle }
+									/* eslint-disable wpcalypso/jsx-classname-namespace */
+									className="is-other-site"
+									/* eslint-enable wpcalypso/jsx-classname-namespace */
+									onPostClick={ this.handleRelatedPostFromOtherSiteClicked }
 								/>
 							) }
-						</div>
-
-						{ showRelatedPosts && (
-							<RelatedPostsFromOtherSites
-								siteId={ +post.site_ID }
-								postId={ +post.ID }
-								title={ relatedPostsFromOtherSitesTitle }
-								/* eslint-disable wpcalypso/jsx-classname-namespace */
-								className="is-other-site"
-								/* eslint-enable wpcalypso/jsx-classname-namespace */
-								onPostClick={ this.handleRelatedPostFromOtherSiteClicked }
-							/>
-						) }
-					</article>
-				</div>
-				{ post.site_ID && (
-					<ReaderSuggestedFollowsDialog
-						onClose={ this.onCloseSuggestedFollowModal }
-						siteId={ +post.site_ID }
-						postId={ +post.ID }
-						isVisible={ this.state.isSuggestedFollowsModalOpen }
-					/>
-				) }
-			</ReaderMain>
+						</article>
+					</div>
+					{ post.site_ID && (
+						<ReaderSuggestedFollowsDialog
+							onClose={ this.onCloseSuggestedFollowModal }
+							siteId={ +post.site_ID }
+							postId={ +post.ID }
+							isVisible={ this.state.isSuggestedFollowsModalOpen }
+						/>
+					) }
+				</ReaderMain>
+			</div>
 		);
 	}
 }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -214,11 +214,7 @@ export class FullPostView extends Component {
 
 	handleBack = ( event ) => {
 		event.preventDefault();
-		recordAction( 'full_post_close' );
-		recordGaEvent( 'Closed Full Post Dialog' );
-		recordTrackForPost( 'calypso_reader_article_closed', this.props.post );
-
-		this.props.onClose && this.props.onClose();
+		this.props.onClose && this.props.onClose( this.props.post );
 	};
 
 	handleCommentClick = () => {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -111,7 +111,8 @@
 	text-align: center;
 	margin-top: 55px;
 
-	@media (max-width: 1270px) {
+	// hide the sidebar when it cannot fit to the side of the content.
+	@media (max-width: 1282px) {
 		display: none;
 	}
 
@@ -199,8 +200,13 @@
 }
 
 .reader-full-post .back-button {
-	@include breakpoint-deprecated( "<660px" ) {
-		display: none;
+	display: none;
+	position: absolute;
+	top: 0;
+
+	// We will display this when the sidebar disappears @781 px.
+	@media (max-width: 781px) {
+		display: inline-block;
 	}
 }
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -19,6 +19,10 @@
 
 .reader-full-post__content {
 	margin: 0 auto;
+	display: flex;
+	width: auto;
+	justify-content: space-around;
+	flex-wrap: wrap;
 
 	.comment-button__icon path,
 	.conversation-follow-button path {
@@ -26,23 +30,23 @@
 	}
 
 	@include breakpoint-deprecated( ">1280px" ) {
-		width: 720px;
-		padding-left: 260px;
+		// width: 720px;
+		// padding-left: 260px;
 	}
 
 	@include breakpoint-deprecated( "1040px-1280px" ) {
-		width: 720px;
-		padding-left: 240px;
+		// width: 720px;
+		// padding-left: 240px;
 	}
 
 	@include breakpoint-deprecated( "660px-1040px" ) {
-		width: auto;
+		// width: auto;
 		margin: 0;
-		padding-left: 240px;
+		// padding-left: 240px;
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
-		width: auto;
+		// width: auto;
 		padding: 0 20px;
 
 		.reader-post-card__tags {
@@ -103,7 +107,7 @@
 
 .reader-full-post__sidebar {
 	width: 220px;
-	position: fixed;
+	// position: fixed;
 	text-align: center;
 
 	@include breakpoint-deprecated( ">1280px" ) {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -21,6 +21,8 @@
 	display: flex;
 	justify-content: space-around;
 	flex-wrap: wrap;
+	max-width: 1200px;
+	margin: 0 auto;
 
 	.comment-button__icon path,
 	.conversation-follow-button path {
@@ -107,6 +109,7 @@
 	width: 220px;
 	// position: fixed;
 	text-align: center;
+	margin-top: 55px;
 
 	@media (max-width: 1270px) {
 		display: none;
@@ -146,7 +149,7 @@
 
 .reader-full-post__story {
 	max-width: 720px;
-	padding: 0 10px;
+	padding: 0 16px;
 
 	@include breakpoint-deprecated( "<480px" ) {
 		font-size: $font-body;
@@ -154,7 +157,7 @@
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
-		margin-top: -35px;
+		// margin-top: -35px;
 	}
 	.comment-button__label {
 		position: relative;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -203,6 +203,8 @@
 	display: none;
 	position: absolute;
 	top: 0;
+	left: 0;
+	right: unset;
 
 	// We will display this when the sidebar disappears @781 px.
 	@media (max-width: 781px) {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -108,21 +108,25 @@
 	// position: fixed;
 	text-align: center;
 
-	@include breakpoint-deprecated( ">1280px" ) {
-		left: calc(50% - 490px);
-	}
-
-	@include breakpoint-deprecated( "1040px-1280px" ) {
-		left: calc(50% - 480px);
-	}
-
-	@include breakpoint-deprecated( "660px-1040px" ) {
-		left: 20px;
-	}
-
-	@include breakpoint-deprecated( "<660px" ) {
+	@media (max-width: 1270px) {
 		display: none;
 	}
+
+	// @include breakpoint-deprecated( ">1270px" ) {
+	// 	left: calc(50% - 490px);
+	// }
+
+	// @include breakpoint-deprecated( "1040px-1280px" ) {
+	// 	left: calc(50% - 480px);
+	// }
+
+	// @include breakpoint-deprecated( "660px-1040px" ) {
+	// 	left: 20px;
+	// }
+
+	// @include breakpoint-deprecated( "<660px" ) {
+	// 	display: none;
+	// }
 }
 
 .reader-full-post__seen-button {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -154,6 +154,7 @@
 }
 
 .reader-full-post .back-button {
+	border: none;
 	display: none;
 	position: absolute;
 	top: 0;
@@ -163,6 +164,11 @@
 	// We will display this when the sidebar disappears @781 px.
 	@media (max-width: 781px) {
 		display: inline-block;
+	}
+
+	@include breakpoint-deprecated( "<660px" ) {
+		top: 4px;
+		left: 14px;
 	}
 }
 
@@ -456,6 +462,10 @@
 	margin: 56px 0 0;
 	max-width: 750px;
 
+	@include breakpoint-deprecated( "<1280px" ) {
+		margin-top: 32px;
+	}
+
 	@include breakpoint-deprecated( ">960px" ) {
 		font-size: $font-headline-small;
 		line-height: 46px;
@@ -467,7 +477,7 @@
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
-		margin-top: 8px;
+		margin: 8px 0 0 32px;
 	}
 
 	.reader-full-post__header-title-link {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -28,15 +28,6 @@
 	.conversation-follow-button path {
 		fill: var(--color-neutral-0);
 	}
-
-	@include breakpoint-deprecated( "<660px" ) {
-		padding: 0 20px;
-
-		.reader-post-card__tags {
-			margin-left: 0;
-			width: 100%;
-		}
-	}
 }
 
 .reader-full-post__visit-site-container {
@@ -94,7 +85,7 @@
 	margin-top: 55px;
 
 	// hide the sidebar when it cannot fit to the side of the content.
-	@media (max-width: 1282px) {
+	@media (max-width: 1298px) {
 		display: none;
 	}
 }
@@ -116,7 +107,7 @@
 
 .reader-full-post__story {
 	max-width: 720px;
-	padding: 0 16px;
+	padding: 0 24px;
 
 	@include breakpoint-deprecated( "<480px" ) {
 		font-size: $font-body;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -29,24 +29,7 @@
 		fill: var(--color-neutral-0);
 	}
 
-	@include breakpoint-deprecated( ">1280px" ) {
-		// width: 720px;
-		// padding-left: 260px;
-	}
-
-	@include breakpoint-deprecated( "1040px-1280px" ) {
-		// width: 720px;
-		// padding-left: 240px;
-	}
-
-	@include breakpoint-deprecated( "660px-1040px" ) {
-		// width: auto;
-		margin: 0;
-		// padding-left: 240px;
-	}
-
 	@include breakpoint-deprecated( "<660px" ) {
-		// width: auto;
 		padding: 0 20px;
 
 		.reader-post-card__tags {
@@ -107,7 +90,6 @@
 
 .reader-full-post__sidebar {
 	width: 220px;
-	// position: fixed;
 	text-align: center;
 	margin-top: 55px;
 
@@ -115,22 +97,6 @@
 	@media (max-width: 1282px) {
 		display: none;
 	}
-
-	// @include breakpoint-deprecated( ">1270px" ) {
-	// 	left: calc(50% - 490px);
-	// }
-
-	// @include breakpoint-deprecated( "1040px-1280px" ) {
-	// 	left: calc(50% - 480px);
-	// }
-
-	// @include breakpoint-deprecated( "660px-1040px" ) {
-	// 	left: 20px;
-	// }
-
-	// @include breakpoint-deprecated( "<660px" ) {
-	// 	display: none;
-	// }
 }
 
 .reader-full-post__seen-button {
@@ -157,9 +123,6 @@
 		line-height: 24px;
 	}
 
-	@include breakpoint-deprecated( "<660px" ) {
-		// margin-top: -35px;
-	}
 	.comment-button__label {
 		position: relative;
 		top: -1px;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -18,9 +18,7 @@
 }
 
 .reader-full-post__content {
-	margin: 0 auto;
 	display: flex;
-	width: auto;
 	justify-content: space-around;
 	flex-wrap: wrap;
 
@@ -144,6 +142,7 @@
 
 .reader-full-post__story {
 	max-width: 720px;
+	padding: 0 10px;
 
 	@include breakpoint-deprecated( "<480px" ) {
 		font-size: $font-body;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -480,6 +480,10 @@
 	padding: 0 9px 2px;
 	background-color: var(--color-neutral-0);
 	align-self: center;
+
+	&:first-child {
+		padding-left: 0;
+	}
 }
 
 .reader-post-card__byline .reader-avatar {

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -95,9 +95,7 @@
 	.reader-related-card__meta {
 		display: grid;
 		grid-template-columns: auto 1fr auto;
-		// display: flex;
 		height: 38px;
-		// justify-content: flex-start;
 		margin-bottom: 13px;
 		z-index: z-index(".reader-related-card.card", ".reader-related-card__meta");
 		width: 100%;
@@ -231,7 +229,6 @@
 	font-size: $font-body-small;
 	margin-top: 4px;
 	min-height: 38px;
-	// width: calc(100% - 70px);
 	overflow: hidden;
 	white-space: nowrap;
 }

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -93,9 +93,11 @@
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
 
 	.reader-related-card__meta {
-		display: flex;
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		// display: flex;
 		height: 38px;
-		justify-content: flex-start;
+		// justify-content: flex-start;
 		margin-bottom: 13px;
 		z-index: z-index(".reader-related-card.card", ".reader-related-card__meta");
 		width: 100%;
@@ -229,7 +231,7 @@
 	font-size: $font-body-small;
 	margin-top: 4px;
 	min-height: 38px;
-	width: calc(100% - 70px);
+	// width: calc(100% - 70px);
 	overflow: hidden;
 	white-space: nowrap;
 }

--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -42,8 +42,13 @@ const GlobalSidebar = ( {
 		}
 	}, [] );
 
-	const handleBackLinkClick = () => {
+	const handleBackLinkClick = ( ev ) => {
 		recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.MENU_BACK_CLICK, { path } );
+		if ( props.onClose ) {
+			ev.preventDefault();
+			ev.stopPropagation();
+			props.onClose();
+		}
 	};
 
 	const getBackLinkFromURL = () => {

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { defer } from 'lodash';
 import AsyncLoad from 'calypso/components/async-load';
 import { trackPageLoad } from 'calypso/reader/controller-helper';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const analyticsPageTitle = 'Reader';
@@ -27,7 +28,11 @@ export function blogPost( context, next ) {
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
 	const lastRoute = context.lastRoute || '/';
-	function closer() {
+	function closer( post ) {
+		recordAction( 'full_post_close' );
+		recordGaEvent( 'Closed Full Post Dialog' );
+		recordTrackForPost( 'calypso_reader_article_closed', post );
+
 		page.back( lastRoute );
 	}
 
@@ -50,6 +55,8 @@ export function blogPost( context, next ) {
 				placeholder={ null }
 				returnPath={ lastRoute }
 				onClose={ closer }
+				postId={ postId }
+				blogId={ blogId }
 			/>
 		);
 	}
@@ -67,7 +74,11 @@ export function feedPost( context, next ) {
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
 	const lastRoute = context.lastRoute || '/';
-	function closer() {
+	function closer( post ) {
+		recordAction( 'full_post_close' );
+		recordGaEvent( 'Closed Full Post Dialog' );
+		recordTrackForPost( 'calypso_reader_article_closed', post );
+
 		page.back( lastRoute );
 	}
 
@@ -89,6 +100,8 @@ export function feedPost( context, next ) {
 				placeholder={ null }
 				returnPath={ lastRoute }
 				onClose={ closer }
+				postId={ postId }
+				feedId={ feedId }
 			/>
 		);
 	}

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -1,9 +1,10 @@
 import page from '@automattic/calypso-router';
-import { defer } from 'lodash';
+import { defer, pickBy } from 'lodash';
 import AsyncLoad from 'calypso/components/async-load';
 import { trackPageLoad } from 'calypso/reader/controller-helper';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 
 const analyticsPageTitle = 'Reader';
 
@@ -28,11 +29,13 @@ export function blogPost( context, next ) {
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
 	const lastRoute = context.lastRoute || '/';
-	function closer( post ) {
+
+	function closer() {
+		const postKey = pickBy( { blogId: +blogId, postId: +postId } );
+		const post = getPostByKey( context.store.getState(), postKey ) || { _state: 'pending' };
 		recordAction( 'full_post_close' );
 		recordGaEvent( 'Closed Full Post Dialog' );
 		recordTrackForPost( 'calypso_reader_article_closed', post );
-
 		page.back( lastRoute );
 	}
 
@@ -55,8 +58,6 @@ export function blogPost( context, next ) {
 				placeholder={ null }
 				returnPath={ lastRoute }
 				onClose={ closer }
-				postId={ postId }
-				blogId={ blogId }
 			/>
 		);
 	}
@@ -74,11 +75,12 @@ export function feedPost( context, next ) {
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
 	const lastRoute = context.lastRoute || '/';
-	function closer( post ) {
+	function closer() {
+		const postKey = pickBy( { feedId: +feedId, postId: +postId } );
+		const post = getPostByKey( context.store.getState(), postKey ) || { _state: 'pending' };
 		recordAction( 'full_post_close' );
 		recordGaEvent( 'Closed Full Post Dialog' );
 		recordTrackForPost( 'calypso_reader_article_closed', post );
-
 		page.back( lastRoute );
 	}
 
@@ -100,8 +102,6 @@ export function feedPost( context, next ) {
 				placeholder={ null }
 				returnPath={ lastRoute }
 				onClose={ closer }
-				postId={ postId }
-				feedId={ feedId }
 			/>
 		);
 	}

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, redirectLoggedOutToSignup, render as clientRender } from 'calypso/controller';
-import { updateLastRoute, unmountSidebar, blogDiscoveryByFeedId } from 'calypso/reader/controller';
+import { updateLastRoute, blogDiscoveryByFeedId, sidebar } from 'calypso/reader/controller';
 import { blogPost, feedPost } from './controller';
 
 export default function () {
@@ -10,7 +10,7 @@ export default function () {
 		blogDiscoveryByFeedId,
 		redirectLoggedOutToSignup,
 		updateLastRoute,
-		unmountSidebar,
+		sidebar,
 		feedPost,
 		makeLayout,
 		clientRender
@@ -21,7 +21,7 @@ export default function () {
 		'/read/blogs/:blog/posts/:post',
 		redirectLoggedOutToSignup,
 		updateLastRoute,
-		unmountSidebar,
+		sidebar,
 		blogPost,
 		makeLayout,
 		clientRender

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, redirectLoggedOutToSignup, render as clientRender } from 'calypso/controller';
-import { updateLastRoute, blogDiscoveryByFeedId, sidebar } from 'calypso/reader/controller';
+import { updateLastRoute, blogDiscoveryByFeedId } from 'calypso/reader/controller';
 import { blogPost, feedPost } from './controller';
 
 export default function () {
@@ -10,7 +10,6 @@ export default function () {
 		blogDiscoveryByFeedId,
 		redirectLoggedOutToSignup,
 		updateLastRoute,
-		sidebar,
 		feedPost,
 		makeLayout,
 		clientRender
@@ -21,7 +20,6 @@ export default function () {
 		'/read/blogs/:blog/posts/:post',
 		redirectLoggedOutToSignup,
 		updateLastRoute,
-		sidebar,
 		blogPost,
 		makeLayout,
 		clientRender

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { hasTranslation } from '@wordpress/i18n';
 import closest from 'component-closest';
 import i18n, { localize } from 'i18n-calypso';
-import { defer, pickBy, startsWith } from 'lodash';
+import { defer, startsWith } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryReaderLists from 'calypso/components/data/query-reader-lists';
@@ -33,7 +33,6 @@ import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selecto
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { getSubscribedLists } from 'calypso/state/reader/lists/selectors';
 import { getReaderOrganizations } from 'calypso/state/reader/organizations/selectors';
-import { getPostByKey } from 'calypso/state/reader/posts/selectors';
 import {
 	toggleReaderSidebarLists,
 	toggleReaderSidebarTags,
@@ -298,7 +297,7 @@ export class ReaderSidebar extends Component {
 			requireBackLink: true,
 			siteTitle: i18n.translate( 'Reader' ),
 			backLinkHref: this.props.returnPath || '/sites',
-			onClose: this.props.onClose && ( () => this.props.onClose( this.props.post ) ),
+			onClose: this.props.onClose && ( () => this.props.onClose() ),
 		};
 		return (
 			<GlobalSidebar { ...props }>
@@ -334,7 +333,7 @@ export class ReaderSidebar extends Component {
 
 export default withCurrentRoute(
 	connect(
-		( state, { currentSection, postId, blogId, feedId } ) => {
+		( state, { currentSection } ) => {
 			const sectionGroup = currentSection?.group ?? null;
 			const sectionName = currentSection?.name ?? null;
 			const siteId = getSelectedSiteId( state );
@@ -344,8 +343,6 @@ export default withCurrentRoute(
 				sectionGroup,
 				sectionName
 			);
-			const postKey = pickBy( { feedId: +feedId, blogId: +blogId, postId: +postId } );
-			const post = getPostByKey( state, postKey ) || { _state: 'pending' };
 
 			return {
 				isListsOpen: isListsOpen( state ),
@@ -354,7 +351,6 @@ export default withCurrentRoute(
 				teams: getReaderTeams( state ),
 				organizations: getReaderOrganizations( state ),
 				shouldShowGlobalSidebar,
-				post,
 			};
 		},
 		{

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -296,7 +296,8 @@ export class ReaderSidebar extends Component {
 			onClick: this.handleClick,
 			requireBackLink: true,
 			siteTitle: i18n.translate( 'Reader' ),
-			backLinkHref: '/sites',
+			backLinkHref: this.props.returnPath || '/sites',
+			onClose: this.props.onClose,
 		};
 		return (
 			<GlobalSidebar { ...props }>

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -59,10 +59,10 @@ body.is-reader-page,
 .is-reader-page .layout,
 .layout.is-section-reader,
 .layout.is-section-reader .layout__content,
-.is-section-reader:not(.is-reader-full-post) {
+.is-section-reader {
 	background: initial;
 }
-body.is-section-reader:not(.is-reader-full-post) {
+body.is-section-reader {
 	background: var(--studio-gray-0);
 
 	&.rtl .layout__content {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -3,7 +3,7 @@
 
 body.is-section-reader {
 	div.layout.is-global-sidebar-visible {
-		.main {
+		.main:not(.reader-full-post) {
 			@media only screen and (min-width: 600px) and (max-width: 960px) {
 				padding: 24px;
 			}

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-body.is-section-reader:not(.is-reader-full-post) {
+body.is-section-reader {
 	div.layout.is-global-sidebar-visible {
 		.main {
 			@media only screen and (min-width: 600px) and (max-width: 960px) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/92025

## Proposed Changes

* Updates the full post page to use the new global sidebar for reader and new content frame. Removes old admin bar.
* Updates the global sidebar and reader global sidebar to use/pass an optional onClose callback for more contextual back button functionality from the full-post-page (such as firing appropriate tracks/stats events).
* Updates the recommended posts component css to be more consistent with potential site title length.

BEFORE
<img width="1538" alt="Screenshot 2024-06-21 at 1 43 14 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/d184dcd8-3b3e-4b20-886d-42e416a24cbf">


AFTER
<img width="1532" alt="Screenshot 2024-06-21 at 1 42 53 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/f5b20aac-299a-4307-8e61-2c8a13a60bdf">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We updated the global (non-site specific) regions of dotcom to have a new interface with a global sidebar and content area/frame. The full-post-page in the reader was never adapted for this, creating an inconsistent experience between reader streams and full post view.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit full post page for both blogs and feeds. (you can find one through Read vs. the other through discover).
* verify the sidebar is visible and the top admin bar is gone.
* test various breakpoints and ensure the layout and scrolling remains good.
* verify the author details disappear once they no longer fit side-by-side with the article content.
* press j/k shortkeys a couple times to change the posts you are viewing in full post.
* press the back button in the sidebar, ensure it goes back through the posts you were looking at and eventually back to the stream you were one. Once it is at the reader stream level, it should still go back to /sites.
* back on the full post page, verify you can also see the old back button above the post title on lower screen widths when the sidebar becomes toggle-able. verify this functionality is the same as the other.
* verify both of the back buttons are still sending the `article-closed` tracking event with populated post data. you can use tracks-vigilante to help verify.
* on the full post page, scroll down to the bottom for "more on WordPress.com" and look at the recommended post blocks. Update the site title in the meta to be extremely long, verify this no longer changes the width and breaks the layout.
* smoke test the recommended posts blocks elsewhere, such as the recent stream and verify there are no regressions.
* smoke test the sidebar in full post page and the rest of the reader.
* smoke test the reader when logged-out. Currently we do not link to the full-post-page here and go directly to the blog, so there shouldn't be any changes.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
