### PR TITLE
Fix a duplicate tracks event triggered in the signup flows domains step

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1269,10 +1269,7 @@ export class RenderDomainsStep extends Component {
 		}
 
 		return (
-			<div
-				key={ this.props.step + this.props.stepSectionName }
-				className="domains__step-content domains__step-content-domain-step"
-			>
+			<div className="domains__step-content domains__step-content-domain-step">
 				{ this.props.isSideContentExperimentLoading ? (
 					<Spinner width="100" />
 				) : (


### PR DESCRIPTION
We got a report that the event `calypso_domain_search_pageview` event is fired twice in some cases. What happens here is that the `RegisterDomainStep` component is unmounted and mounted twice. Eventually me and @gius80 paired on this and he found out what the reason for this is - there's a `key` attribute for the `div` that contains the `RegisterDomainStep` component. As the page is loaded the properties of the parent component change and that changes the `key` attribute which forces react to unmount the component and mount a new component in its place and that triggers the double tracks event. We don't need that key at all so removing it fixes the issue.

see: p1717127367228929-slack-C4BJFJVPF
see: #27353 - this is the first place where that key was introduced - not sure if that `key` was needed there either

## Proposed Changes

* remove the `key` attribute 

## Why are these changes being made?

* on initial with clear local data the event was triggered twice (it might have been slower too)

## Testing Instructions

* go to /start/domains
* `localStorage.setItem('debug', 'calypso:analytics')`
* clear the local indexdb
* reload the page and verify that you only see one event recorded for `calypso_domain_search_pageview`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?