### PR TITLE
Remove "Manage Blogs" Link From `/me`

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -172,15 +172,6 @@ class MeSidebar extends Component {
 					/>
 
 					<SidebarItem
-						link="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs"
-						label={ translate( 'Manage Blogs' ) }
-						materialIcon="apps"
-						onNavigate={ ( event, urlPath ) => {
-							this.handleGlobalSidebarMenuItemClick( urlPath );
-						} }
-					/>
-
-					<SidebarItem
 						selected={ itemLinkMatches( '/notifications', path ) }
 						link="/me/notifications"
 						label={ translate( 'Notification Settings' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1718828698668019-slack-C06DN6QQVAQ

## Proposed Changes

* This PR removes the "Manage Blogs" link from /me. 

Before | After
--|--
![Screenshot 2024-06-19 at 3 22 11 PM](https://github.com/Automattic/wp-calypso/assets/140841/02932e15-231b-4fcf-ac55-243e40ce3954)  |  <img  alt="Screenshot 2024-06-20 at 9 32 02 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/9c4ab8f7-5539-40c2-842c-ce65f223d0eb">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The features inside `wp-admin/index.php?page=my-blogs` have been made available elsewhere.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the PR and view that the "Manage Blogs" link has been removed from /me.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?