### PR TITLE
PAO - Square: Use redirect_to when redirecting to Entrepreneur from Signup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -44,7 +44,9 @@ const entrepreneurFlow: Flow = {
 
 		const params = new URLSearchParams( window.location.search );
 		const partnerBundle = params.get( 'partnerBundle' );
-		setPartnerBundle( partnerBundle );
+		if ( partnerBundle ) {
+			setPartnerBundle( partnerBundle );
+		}
 
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -646,8 +646,8 @@ export function generateFlows( {
 			description: 'Entrepreneur Trial signup flow that goes through the trialAcknowledge step',
 			lastModified: '2024-05-29',
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'toStepper' ],
-			optionalDependenciesInQuery: [ 'toStepper' ],
+			providesDependenciesInQuery: [ 'toStepper', 'redirect_to' ],
+			optionalDependenciesInQuery: [ 'toStepper', 'redirect_to' ],
 			hideProgressIndicator: true,
 		},
 		{

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -241,8 +241,8 @@ function getHostingFlowDestination( { stepperHostingFlow } ) {
 	return `/setup/${ stepperHostingFlow }`;
 }
 
-function getEntrepreneurFlowDestination() {
-	return '/setup/entrepreneur/trialAcknowledge';
+function getEntrepreneurFlowDestination( { redirect_to } ) {
+	return redirect_to || '/setup/entrepreneur/trialAcknowledge';
 }
 
 function getGuidedOnboardingFlowDestination( dependencies ) {


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/7829

## Proposed Changes

* When calling `signup` flow if the user is logged-out, pass the `redirect_to` param as a dependency
* Use this `redirect_to` param to redirect the `signup` when completed
* Keeps the previous value as a default if the `redirect_to` is falsy

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To allow onboarding partners if the user is logged-out

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions in the PR https://github.com/Automattic/wp-calypso/pull/91899 for **logged-out** user
* Ensure the result is the same after log-in

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- ~~[ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~
