### PR TITLE
Fix wrong staging sites link in Web Server Settings card

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -25,7 +25,7 @@ import getRequest from 'calypso/state/selectors/get-request';
 import { isFetchingAtomicHostingGeoAffinity } from 'calypso/state/selectors/is-fetching-atomic-hosting-geo-affinity';
 import { isFetchingAtomicHostingWpVersion } from 'calypso/state/selectors/is-fetching-atomic-hosting-wp-version';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -58,6 +58,7 @@ const WebServerSettingsCard = ( {
 	isUpdatingWpVersion,
 	isWpcomStagingSite,
 	siteId,
+	selectedSiteSlug,
 	geoAffinity,
 	staticFile404,
 	translate,
@@ -138,7 +139,7 @@ const WebServerSettingsCard = ( {
 								'For testing purposes, you can switch to the beta version of the next WordPress release on {{a}}your staging site{{/a}}.',
 							{
 								components: {
-									a: <a href="#staging-site" />,
+									a: <a href={ `/staging-site/${ selectedSiteSlug }` } />,
 								},
 							}
 						) }
@@ -431,6 +432,7 @@ export default connect(
 				getRequest( state, updateAtomicWpVersion( siteId, null ) )?.isLoading ?? false,
 			isWpcomStagingSite,
 			siteId,
+			selectedSiteSlug: getSelectedSiteSlug( state ),
 			geoAffinity,
 			staticFile404,
 			phpVersion,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 7844-gh-Automattic/dotcom-forge

## Proposed Changes

Updates the "your staging site" link to load the Staging Site tab (`/staging-site/<site`) instead of the anchor it previously targeted.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The routing logic was updated and the current link is no longer correct

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure you have a site with a Creator plan and all hosting features activated
- Visit **Settings > Hosting Configuration** to pull up the overview
- In the **Web server settings** card, locate and test the "your staging site" link.
- Click the link and confirm that it successfully loads the Staging Site tab.
