### PR TITLE
Site Migration: Remove live chat from site migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -9,7 +9,6 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
 import wpcom from 'calypso/lib/wp';
 import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
 import type { Step } from '../../types';
@@ -195,8 +194,6 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 
 		return ( shouldHideBasedOnRef || shouldHideBasedOnVariant ) && ! shouldNotHideBasedOnRef;
 	};
-
-	usePresalesChat( 'wpcom', true, true );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -8,7 +8,6 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import type { Step } from '../../types';
 import './style.scss';
@@ -111,8 +110,6 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 			</div>
 		</>
 	);
-
-	usePresalesChat( 'wpcom', true, true );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx
@@ -9,7 +9,6 @@ import { usePrepareSiteForMigration } from 'calypso/landing/stepper/hooks/use-pr
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
 import { MaybeLink } from './maybe-link';
 import { PendingActions } from './pending-actions';
 import { ShowHideInput } from './show-hide-input';
@@ -222,8 +221,6 @@ const SiteMigrationInstructions: Step = function ( { flow } ) {
 			{ showSupportMessage && <ContactSupportMessage /> }
 		</div>
 	);
-
-	usePresalesChat( 'wpcom', true, true );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -15,7 +15,6 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { usePresalesChat } from 'calypso/lib/presales-chat';
 import { MigrationAssistanceModal } from '../../components/migration-assistance-modal';
 import type { Step } from '../../types';
 
@@ -34,8 +33,6 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 	const plan = selectedPlanPathSlug
 		? getPlanByPathSlug( selectedPlanPathSlug )
 		: getPlan( PLAN_BUSINESS );
-
-	usePresalesChat( 'wpcom', true, true );
 
 	if ( ! siteItem || ! siteSlug || ! plan ) {
 		return;

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -59,7 +59,6 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 	const group = getGroupName( keyType );
 
 	const { data: canConnectToZendesk } = useCanConnectToZendesk();
-
 	const isEligibleForPresalesChat =
 		enabled && isEnglishLocale && canConnectToZendesk && ! isWpMobileAppUser;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Remove Live Chat from the site migration flow; it's creating too much spam for HEs.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* paYKcK-4NQ-p2#comment-3641 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On calypso.live or locally, go to `/setup/hosted-site-migration` and `/setup/site-migration` to ensure the flows load and there is no live chat icon present in the bottom right.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?