### PR TITLE
Revert "Remove "Manage Blogs" Link From `/me`"

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -172,6 +172,15 @@ class MeSidebar extends Component {
 					/>
 
 					<SidebarItem
+						link="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs"
+						label={ translate( 'Manage Blogs' ) }
+						materialIcon="apps"
+						onNavigate={ ( event, urlPath ) => {
+							this.handleGlobalSidebarMenuItemClick( urlPath );
+						} }
+					/>
+
+					<SidebarItem
 						selected={ itemLinkMatches( '/notifications', path ) }
 						link="/me/notifications"
 						label={ translate( 'Notification Settings' ) }


### PR DESCRIPTION
Discovered "Leave a blog" is only available in "Manage Blogs" https://wordpress.com/support/invite-people/#leave-a-site-or-blog, so we'll leave this menu link up until we move that feature.

Reverts Automattic/wp-calypso#91992