### PR TITLE
Add new translations in BlazePress

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -24,7 +24,7 @@ const BlazePressStrings = () => {
 	translate( 'Get started' );
 	translate( 'Learn more' );
 	translate( "Don't show me this step again." );
-	translate( 'Uploading images…' );
+	translate( 'Uploading images...' );
 	translate( 'Checking payment information…' );
 	translate( 'Fetching pages…' );
 	translate( 'Fetching products…' );
@@ -36,6 +36,9 @@ const BlazePressStrings = () => {
 	translate( 'No products found.' );
 	translate( 'No posts found.' );
 	translate( 'Select post to promote' );
+	translate(
+		'Blaze is syncing your content as part of first-time setup – this can take up to 15 minutes or a few hours.'
+	);
 	translate( 'Post' );
 	translate( 'Type' );
 	translate( 'SKU' );
@@ -64,7 +67,7 @@ const BlazePressStrings = () => {
 	translate( 'Ad creative' );
 	translate( "Use post's media" );
 	translate( 'Site title' );
-	translate( 'Loading page title…' );
+	translate( 'Loading page title...' );
 	translate( 'Page title' );
 	translate( 'Snippet' );
 	translate(
@@ -72,7 +75,7 @@ const BlazePressStrings = () => {
 		'%(snippetCharactersLeft)s characters remaining',
 		{ count: 1 }
 	);
-	translate( 'Loading ad text…' );
+	translate( 'Loading ad text....' );
 	translate( 'Ad text' );
 	translate( 'Use + / - or simply drag the image to adjust it' );
 	translate( 'Apply' );
@@ -134,8 +137,6 @@ const BlazePressStrings = () => {
 	translate(
 		'We created this campaign to deliver the most valuable traffic, yet you can still make changes before submitting it.'
 	);
-	translate( 'Campaign Objective' );
-	translate( 'Change' );
 	translate( 'Start Date' );
 	translate( 'Duration' );
 	translate( 'Budget' );
@@ -147,24 +148,6 @@ const BlazePressStrings = () => {
 	translate( 'Start typing country, state or city to see available options' );
 	translate( 'No results found' );
 	translate( 'Search for locations' );
-	translate( 'Good for: ' );
-	translate( 'Traffic' );
-	translate( 'Aims to drive more visitors and increase page views.' );
-	translate( 'E-commerce sites, content-driven websites, startups.' );
-	translate( 'Sales' );
-	translate( 'Converts potential customers into buyers by encouraging purchase.' );
-	translate( 'E-commerce, retailers, subscription services.' );
-	translate( 'Awareness' );
-	translate( 'Focuses on increasing brand recognition and visibility.' );
-	translate( 'New businesses, brands launching new products.' );
-	translate( 'Engagement' );
-	translate( 'Encourages your audience to interact and connect with your brand.' );
-	translate( 'Influencers and community builders looking for followers of the same interest.' );
-	translate( 'Choose campaign objective' );
-	translate( 'Continue' );
-	translate( 'Save my selection for future campaigns' );
-	translate( 'Cancel' );
-	translate( 'Good for:' );
 	translate( 'You won’t be charged until the ad is approved and starts running.' );
 	translate( 'You can pause spending at any time.' );
 	translate( 'Could not retrieve countries. Please try again later.' );


### PR DESCRIPTION
Update translations following the instructions on PeeHDf-1VZ-p2.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* New translations. Generated the file through the DSP.

![image](https://github.com/Automattic/wp-calypso/assets/692065/381123a9-eb5e-41a8-8b5d-2a0dd3c5d575)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To use the translated text: "Blaze is syncing your content as part of first-time setup – this can take up to 15 minutes or a few hours."

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?