### PR TITLE
Stats: Fix GDPR notice title typo

### DIFF
--- a/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
+++ b/client/my-sites/stats/stats-notices/gdpr-cookie-consent-notice.tsx
@@ -60,7 +60,7 @@ const GDPRCookieConsentNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps )
 		<div className={ classNames }>
 			<NoticeBanner
 				level="info"
-				title={ translate( 'Complianz - GDBR/CCPA Cookie Consent plugin impact on site stats' ) }
+				title={ translate( 'Complianz - GDPR/CCPA Cookie Consent plugin impact on site stats' ) }
 				onClose={ dismissNotice }
 			>
 				<p>{ bannerBody }</p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/91762#discussion_r1647719263

## Proposed Changes

* Fix `GDPRCookieConsentNotice` title typo.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions of https://github.com/Automattic/wp-calypso/pull/91762.
* Ensure the title typo is fixed.

<img width="1289" alt="截圖 2024-06-21 上午12 00 50" src="https://github.com/Automattic/wp-calypso/assets/6869813/758d7c41-919f-4437-965b-3135d387162e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
