### PR TITLE
Guided Onboarding: Redirect to newsletter flow if its the only option selected

### DIFF
--- a/client/my-sites/plans/utils/get-segmented-intent.tsx
+++ b/client/my-sites/plans/utils/get-segmented-intent.tsx
@@ -37,7 +37,7 @@ export function getSegmentedIntent( answers: SurveyData ): SegmentedIntent {
 			return { segmentSlug: 'plans-guided-segment-nonprofit', segment: 'nonprofit' };
 		}
 
-		if ( surveyedGoals?.includes( 'newsletter' ) ) {
+		if ( surveyedGoals?.includes( 'newsletter' ) && surveyedGoals?.length === 1 ) {
 			return { segmentSlug: undefined, segment: 'newsletter' };
 		}
 

--- a/client/signup/steps/initial-intent/index.tsx
+++ b/client/signup/steps/initial-intent/index.tsx
@@ -73,7 +73,7 @@ export default function InitialIntentStep( props: Props ) {
 			redirect = '/start/do-it-for-me-store';
 		} else if ( _answerKeys.includes( 'difm' ) ) {
 			redirect = '/start/do-it-for-me';
-		} else if ( _answerKeys.includes( 'newsletter' ) ) {
+		} else if ( _answerKeys.includes( 'newsletter' ) && _answerKeys.length === 1 ) {
 			redirect = `/setup/${ NEWSLETTER_FLOW }/newsletterSetup`;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-2JK-p2#comment-5176

## Proposed Changes

* Changes Q2 redirection logic if `Create a newsletter` is the only option selected

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Previously, we redirected to the newsletter flow if `Create a newsletter` was one of the Q2 options selected. Instead, we only want to navigate to the newsletter flow if `Create a newsletter` is the **only** option selected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/start/guided?flags=onboarding/guided`, select `Create a site for myself, a business, a friend` for Q1.
* For Q2, select `Create a newsletter` and any other option. Verify that you are **NOT** navigated to the newsletter flow.
* Go back to Q2 and **only** select `Create a newsletter` option. Verify you are navigated to the newsletter flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?