### PR TITLE
Expand plugins sidebar menu when browsing categories

### DIFF
--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -40,6 +40,10 @@ export const itemLinkMatches = ( path, currentPath ) => {
 	}
 
 	if ( pathIncludes( currentPath, 'plugins', 1 ) ) {
+		if ( pathIncludes( currentPath, 'browse', 2 ) ) {
+			return pathIncludes( path, 'plugins', 1 ) && ! pathIncludes( path, 'scheduled-updates', 2 );
+		}
+
 		return pathIncludes( path, 'plugins', 1 ) && fragmentIsEqual( path, currentPath, 2 );
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7491

## Proposed Changes

* When the user is on `/plugins/{siteId}` and clicks on a category, the plugins sidebar menu is collapsed instead of staying expanded and highlighting `Marketplace`. This PR fixes that.

## Why are these changes being made?

* This was discussed on slack with @lucasmendes-design whiile working on https://github.com/Automattic/wp-calypso/pull/91946

![image](https://github.com/Automattic/wp-calypso/assets/8511199/1bf2d5c8-cd70-4a14-9446-7a4abc8b0fdf)

## Testing Instructions

* Open the live preview
* Go to `/plugins/{siteId}`
* Check that on the sidebar, the plugins menu is expanded and highlighting `Marketplace`
* Click on any of the plugins'  categories
* Repeat the previous check

|Before|After|
|---|---|
|![image](https://github.com/Automattic/wp-calypso/assets/8511199/6195e6c3-d451-485e-8fca-c770a425bd78)|![image](https://github.com/Automattic/wp-calypso/assets/8511199/13e4929f-f1c6-4915-8c70-0784832c73a1)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
