### PR TITLE
A4A: Update suggestions and select options are sorted in Alphabetical order.

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/components/industry-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/industry-selector.tsx
@@ -19,8 +19,32 @@ const IndustrySelector = ( { setIndustry, industry }: Props ) => {
 			value: 'agricultural_services',
 		},
 		{
+			label: translate( 'Business services' ),
+			value: 'business_services',
+		},
+		{
+			label: translate( 'Clothing shops' ),
+			value: 'clothing_shops',
+		},
+		{
 			label: translate( 'Contracted services' ),
 			value: 'contracted_services',
+		},
+		{
+			label: translate( 'Government services' ),
+			value: 'government_services',
+		},
+		{
+			label: translate( 'Miscellaneous shops' ),
+			value: 'miscellaneous_shops',
+		},
+		{
+			label: translate( 'Professional services and membership organisations' ),
+			value: 'professional_services_and_membership_organisations',
+		},
+		{
+			label: translate( 'Retail outlet services' ),
+			value: 'retail_outlet_services',
 		},
 		{
 			label: translate( 'Transportation services' ),
@@ -29,30 +53,6 @@ const IndustrySelector = ( { setIndustry, industry }: Props ) => {
 		{
 			label: translate( 'Utility services' ),
 			value: 'utility_services',
-		},
-		{
-			label: translate( 'Retail outlet services' ),
-			value: 'retail_outlet_services',
-		},
-		{
-			label: translate( 'Clothing shops' ),
-			value: 'clothing_shops',
-		},
-		{
-			label: translate( 'Miscellaneous shops' ),
-			value: 'miscellaneous_shops',
-		},
-		{
-			label: translate( 'Business services' ),
-			value: 'business_services',
-		},
-		{
-			label: translate( 'Professional services and membership organisations' ),
-			value: 'professional_services_and_membership_organisations',
-		},
-		{
-			label: translate( 'Government services' ),
-			value: 'government_services',
 		},
 	];
 

--- a/client/a8c-for-agencies/sections/partner-directory/components/products-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/products-selector.tsx
@@ -43,7 +43,7 @@ const ProductsSelector = ( { setProducts, selectedProducts }: Props ) => {
 			__nextHasNoMarginBottom
 			label=""
 			onChange={ onProductLabelsSelected }
-			suggestions={ Object.values( availableProducts ) }
+			suggestions={ Object.values( availableProducts ).sort() }
 			value={ selectedProductsByLabel }
 		/>
 	);

--- a/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
@@ -44,7 +44,7 @@ const ServicesSelector = ( { setServices, selectedServices }: Props ) => {
 			__nextHasNoMarginBottom
 			label=""
 			onChange={ onServiceLabelsSelected }
-			suggestions={ Object.values( availableServices ) }
+			suggestions={ Object.values( availableServices ).sort() }
 			value={ selectedServicesByLabel }
 		/>
 	);


### PR DESCRIPTION
This PR improves the Partner directory forms by sorting select options to be in alphabetical order.

| Before | After |
|--------|--------|
| <img width="697" alt="Screenshot 2024-06-21 at 1 00 32 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e3f1fa2f-adea-4956-9e85-d90aad2431e6"> | <img width="696" alt="Screenshot 2024-06-21 at 1 00 10 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/4e34c970-b84a-4329-87cb-2ed062660169"> | 


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/706

## Proposed Changes

* Update suggestions and select options are sorted in Alphabetical order.


## Testing Instructions


* Use the A4A live link and go to the `/partner-directory/dashboard` page
* Test both expertise and details and confirm that all selector components have options sorted in Alphabetical order.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
