### PR TITLE
Color scheme: Fix Classic Bright menu & submenu colors

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1063,7 +1063,6 @@ a.masterbar__quick-language-switcher {
 	.masterbar__item-all-sites {
 		gap: 2px;
 
-
 		@media only screen and (min-width: 783px) {
 			padding: 0 8px 0 4px;
 		}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1063,12 +1063,15 @@ a.masterbar__quick-language-switcher {
 	.masterbar__item-all-sites {
 		gap: 2px;
 
+
 		@media only screen and (min-width: 783px) {
 			padding: 0 8px 0 4px;
 		}
 
 		svg {
 			fill: var(--color-masterbar-icon);
+			width: 20px;
+			padding-inline: 2px;
 		}
 
 		&:hover {

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-bright.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-bright.scss
@@ -1,5 +1,6 @@
 .color-scheme.is-classic-bright {
 	/* Theme Properties */
+	--theme-text-color: #044b7a; /* Direct from wp-admin */
 	--color-primary: var(--studio-blue-50);
 	--color-primary-rgb: var(--studio-blue-50-rgb);
 	--color-primary-dark: var(--studio-blue-70);
@@ -101,6 +102,12 @@
 	--color-sidebar-submenu-text: var(--studio-blue-70);
 	--color-sidebar-submenu-hover-text: var(--color-accent);
 	--color-sidebar-submenu-selected-text: var(--color-accent);
+
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--color-accent);
+	--color-navredesign-sidebar-submenu-hover-text: var(--color-accent);
 
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--studio-pink-50);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7825

## Proposed Changes

Update sidebar colors of Classic Bright color scheme when selected Classic Interface.
Also fixes `All sites` icon size (follow up https://github.com/Automattic/jetpack/pull/37832)

| wp-admin | Calypso Before | Calypso After |
| --- | --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/7565bd2b-697c-46aa-8c41-f8ba9f7ec1c1) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/5d531fab-db62-41c2-9ab7-4727752bc93d) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/fdc52db3-080f-4cac-a22e-a49d53fa2821) |

## Why are these changes being made?
Colors of menu submenu doesn't match with wp-admin

## Testing Instructions

* Using a classic interface site
* Choose the `Classic Bright` color scheme in `/wp-admin/profile.php`
* Check the colors of the menu & submenu in wp-admin and Calypso
* Also compare the `All Sites` icon size in wp-admin and Calypso
