### PR TITLE
Fix Blaze Pro from apply global font family

### DIFF
--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -15,7 +15,8 @@
 $inter: Inter, $sans;
 $sfProText: "SF Pro Text", $sans;
 
-* {
+.blaze-pro,
+.is-blaze-pro {
 	font-family: $inter;
 }
 

--- a/config/README.md
+++ b/config/README.md
@@ -29,7 +29,7 @@ You can search for feature flags by partial string or regular expression with th
 
 Run `yarn feature-search [search]` from the root calypso directory to see example searches.
 
-You can also activate feature flags only in your development environment. To do this, create a `.env` file in the root folder of the cloned repository. Add the variable `ACTIVE_FEATURE_FLAGS`, and specify the feature flags you want to activate, as a string separated by commas. For more details of how to create the `.env` file, see https://github.com/mrsteele/dotenv-webpack#create-a-env-file.
+You can also activate feature flags only in your development environment. To do this, create a `.env` file in the root folder of the cloned repository. Add the variable `ACTIVE_FEATURE_FLAGS`, and specify the feature flags you want to activate, as a string separated by commas. For more details of how to create the `.env` file, see <https://github.com/mrsteele/dotenv-webpack#create-a-env-file>.
 
 ### Progression of Environments
 


### PR DESCRIPTION
Slack: p1718907547394219-slack-C06DN6QQVAQ

## Proposed Changes

Move the font-family inside `.blaze-pro, .is-blaze-pro {`

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/15315cd7-5527-4af4-8b84-7c164d740f93) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/b8389f17-6fde-4c9b-af5e-de28a23be51e) |

## Why are these changes being made?
The font was applied globally

## Testing Instructions
* Using a Classic interface site
* Go to a Calypso (Hosting) page and one in wp-admin
* Check the masterbar font on both pages

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?