### PR TITLE
Fix view cart cta display issue

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -107,6 +107,9 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 	} = props;
 	const finalPrice = ( isNumber( discountedPrice ) ? discountedPrice : originalPrice ) as number;
 	const isDiscounted = !! ( isNumber( finalPrice ) && originalPrice && finalPrice < originalPrice );
+	const discountPercentage = isDiscounted
+		? Math.floor( ( ( originalPrice - finalPrice ) / originalPrice ) * 100 )
+		: 0;
 
 	// Placeholder (while prices are loading)
 	if ( ! currencyCode || ! originalPrice || pricesAreFetching ) {
@@ -146,6 +149,7 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 		<>
 			<PriceAriaLabel
 				{ ...props }
+				discountPercentage={ discountPercentage }
 				currencyCode={ currencyCode }
 				finalPrice={ finalPrice }
 				isDiscounted={ isDiscounted }
@@ -167,6 +171,7 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 							<TimeFrame
 								billingTerm={ billingTerm }
 								discountedPriceDuration={ discountedPriceDuration }
+								discountPercentage={ discountPercentage }
 								formattedOriginalPrice={ formattedOriginalPrice }
 								isDiscounted={ isDiscounted }
 								finalPrice={ finalPrice }

--- a/client/components/jetpack/card/jetpack-product-card/display-price/price-aria-label.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/price-aria-label.tsx
@@ -7,6 +7,7 @@ interface Props {
 	currencyCode: string;
 	billingTerm: Duration;
 	isDiscounted: boolean;
+	discountPercentage?: number;
 	finalPrice: number;
 	originalPrice?: number;
 	formattedOriginalPrice?: string;

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -45,7 +45,7 @@ const RegularTimeFrame: React.FC< RegularTimeFrameProps & A11yProps > = ( {
 	const billingTermText = useMemo( () => {
 		if ( billingTerm === TERM_MONTHLY ) {
 			return {
-				normal: translate( '/month, billed monthly' ),
+				normal: translate( 'per month, billed monthly' ),
 				compact: translate( '/mo, billed monthly', {
 					comment: '/mo should be as compact as possible',
 				} ),
@@ -53,7 +53,7 @@ const RegularTimeFrame: React.FC< RegularTimeFrameProps & A11yProps > = ( {
 		}
 
 		return {
-			normal: translate( '/month, billed yearly' ),
+			normal: translate( 'per month, billed yearly' ),
 			compact: translate( '/mo, billed yearly', {
 				comment: '/mo should be as compact as possible',
 			} ),

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -1,5 +1,5 @@
 import { TERM_MONTHLY } from '@automattic/calypso-products';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import i18n, { TranslateResult, getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
@@ -9,6 +9,7 @@ interface TimeFrameProps {
 	expiryDate?: Moment;
 	billingTerm: Duration;
 	discountedPriceDuration?: number;
+	discountPercentage?: number;
 	formattedOriginalPrice?: string;
 	isDiscounted?: boolean;
 	finalPrice?: number;
@@ -20,6 +21,10 @@ interface RegularTimeFrameProps {
 
 interface ExpiringDateTimeFrameProps {
 	productExpiryDate: Moment;
+}
+
+interface OneYearDiscountTimeFrameProps {
+	discountPercentage: number;
 }
 
 interface PartialDiscountTimeFrameProps {
@@ -159,9 +164,22 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 	return <span className="display-price__billing-time-frame">{ text }</span>;
 };
 
-const OneYearDiscountTimeFrame: React.FC< A11yProps > = ( { forScreenReader } ) => {
+const OneYearDiscountTimeFrame: React.FC< OneYearDiscountTimeFrameProps & A11yProps > = ( {
+	forScreenReader,
+	discountPercentage,
+} ) => {
 	const translate = useTranslate();
-	const text = translate( 'per month for the first year, then billed yearly' );
+	let text: TranslateResult;
+	if ( ! discountPercentage ) {
+		text = translate( 'per month, billed yearly' );
+	} else {
+		text = translate( 'per month, billed yearly. %(discount)d% off the first year.', {
+			args: {
+				discount: discountPercentage,
+			},
+			comment: 'The discount percentage is a number, e.g. "20%".',
+		} );
+	}
 
 	if ( forScreenReader ) {
 		return <>{ text }</>;
@@ -192,6 +210,7 @@ const TimeFrame: React.FC< TimeFrameProps & A11yProps > = ( {
 	expiryDate,
 	billingTerm,
 	discountedPriceDuration,
+	discountPercentage = 0,
 	formattedOriginalPrice,
 	forScreenReader,
 	isDiscounted,
@@ -227,7 +246,12 @@ const TimeFrame: React.FC< TimeFrameProps & A11yProps > = ( {
 			);
 		}
 
-		return <OneYearDiscountTimeFrame forScreenReader={ forScreenReader } />;
+		return (
+			<OneYearDiscountTimeFrame
+				forScreenReader={ forScreenReader }
+				discountPercentage={ discountPercentage }
+			/>
+		);
 	}
 
 	return <RegularTimeFrame billingTerm={ billingTerm } forScreenReader={ forScreenReader } />;

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -91,7 +91,7 @@ const IntroPricingBanner: React.FC = () => {
 						<img className="intro-pricing-banner__item-icon" src={ rocket } alt="" />
 						<span className="intro-pricing-banner__item-label">
 							{ preventWidows(
-								translate( 'Get %(percent)d% off your first year', {
+								translate( 'Get up to %(percent)d% off your first year', {
 									args: { percent: INTRO_PRICING_DISCOUNT_PERCENTAGE },
 								} )
 							) }

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -91,7 +91,7 @@ const IntroPricingBanner: React.FC = () => {
 						<img className="intro-pricing-banner__item-icon" src={ rocket } alt="" />
 						<span className="intro-pricing-banner__item-label">
 							{ preventWidows(
-								translate( 'Get up to %(percent)d% off your first year', {
+								translate( 'Get %(percent)d% off your first year', {
 									args: { percent: INTRO_PRICING_DISCOUNT_PERCENTAGE },
 								} )
 							) }

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -78,7 +78,7 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 		return 1 === discountedPriceDuration
 			? translate( '%(percentOff)d%% off the first month', translateArgs )
 			: translate( '%(percentOff)d%% off the first year', translateArgs );
-	}, [ discountedPrice, product?.productSlug, originalPrice, discountedPriceDuration, translate ] );
+	}, [ discountedPrice, product?.productSlug, discountedPriceDuration, translate, originalPrice ] );
 
 	return (
 		<div className="product-lightbox__variants-plan">
@@ -108,6 +108,7 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 									'is-compact': isCompact,
 								} ) }
 							>
+								{ /* discountPercentage is omitted as we are showing that below the timeframe in this context */ }
 								<TimeFrame
 									billingTerm={ billingTerm }
 									discountedPriceDuration={ discountedPriceDuration }

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
@@ -97,6 +97,12 @@
 .featured-item-card--price {
 	margin-top: 0.25rem;
 	margin-bottom: 0.5rem;
+
+	.item-price > .display-price:not(.is-placeholder) {
+		flex-direction: column;
+		align-items: flex-start;
+		padding-top: 0.5rem;
+	}
 }
 
 .featured-item-card--desc {

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style.scss
@@ -13,6 +13,12 @@
 	@include break-medium {
 		grid-template-columns: repeat(2, 1fr);
 	}
+
+	.item-price > .display-price:not(.is-placeholder) {
+		flex-direction: column;
+		align-items: flex-start;
+		padding-top: 0.5rem;
+	}
 }
 
 .jetpack-product-store__all-items {

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
@@ -99,10 +99,13 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	flex-shrink: 0;
 	font-size: $font-body;
 	min-width: 5.7rem;
 	border-width: 0;
 	line-height: 1.2;
+	white-space: nowrap;
+
 	.gridicon.gridicons-checkmark {
 		transform: rotate(-8.37deg);
 		margin-right: 11.46px;

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
@@ -102,6 +102,7 @@
 	font-size: $font-body;
 	min-width: 5.7rem;
 	border-width: 0;
+	line-height: 1.2;
 	.gridicon.gridicons-checkmark {
 		transform: rotate(-8.37deg);
 		margin-right: 11.46px;

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
@@ -103,7 +103,6 @@
 	font-size: $font-body;
 	min-width: 5.7rem;
 	border-width: 0;
-	line-height: 1.2;
 	white-space: nowrap;
 
 	.gridicon.gridicons-checkmark {


### PR DESCRIPTION
## Proposed Changes

* On the Jetpack pricing page, move the billing timeframe below the price to avoid bad display of the cart CTAs
* Reduce line height on buttons for when they do have to split into two lines (on tablet sized screens) (@ballio2000 suggestion)
* Update billing term language according to p1HpG7-rW0-p2#comment-71343

## Why are these changes being made?

The "View Cart" button was wrapping to two lines on all screen sizes because of the very long billing timeframe copy

![image](https://github.com/Automattic/wp-calypso/assets/65001528/cc8745df-3340-4baa-9ada-5aef1ba09138)


## Testing Instructions

1. Using the Calypso live link, go to `/pricing`
2. Make sure you are logged in and that you have a site in context. To do this you can either manually construct the URL ({base_url}/pricing/{blog_id}) or you can create a jurassic ninja site, connect jetpack, and click "Purchase a plan" from the My Jetpack Footer
3. Add an item to the cart and make sure the "View Cart" button doesn't wrap to two lines even on the largest screensize
![image](https://github.com/Automattic/wp-calypso/assets/65001528/b1ea7f3c-3a87-4ce5-b99c-1fd04735c3d3)
4. On tablet sizes, make sure the text wrapping looks better with less line-height between the words
![image](https://github.com/Automattic/wp-calypso/assets/65001528/b24db109-92c4-409d-87b3-abb96b4e4e09)
5. Make sure it looks good on mobile as well
![image](https://github.com/Automattic/wp-calypso/assets/65001528/970074e6-516b-4ef8-ab9e-e766c7a5ceb4)
6. Make sure the billing term has been updated correctly on the pricing page
![image](https://github.com/Automattic/wp-calypso/assets/65001528/bc5aff74-abc8-4082-b71d-080fc2289902)
7. Make sure the term copy looks good in the lightbox as well
![image](https://github.com/Automattic/wp-calypso/assets/65001528/178cdbf5-2367-4ee3-8659-71e5af65dbbf)
8. If you want, you can check the `/features/comparison` page as well
![image](https://github.com/Automattic/wp-calypso/assets/65001528/11c1316e-473c-488b-9dcc-b69f4e88d355)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/b0c6681a-f53a-4716-8231-1e2ce463c599)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?