### PR TITLE
A4A: Blocked site selection row when migration is in progress

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -74,7 +74,7 @@ export const JetpackSitesDataViews = ( {
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
-			if ( site.sticker.includes( 'migration-in-progress' ) && ! isTeamMember ) {
+			if ( site.sticker?.includes( 'migration-in-progress' ) && ! isTeamMember ) {
 				return;
 			}
 
@@ -390,7 +390,7 @@ export const JetpackSitesDataViews = ( {
 								onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 								onKeyDown={ ( e: KeyboardEvent ) => e.stopPropagation() }
 							>
-								{ ( ! item.site.value.sticker.includes( 'migration-in-progress' ) ||
+								{ ( ! item.site.value.sticker?.includes( 'migration-in-progress' ) ||
 									isTeamMember ) && (
 									<>
 										<SiteActions

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -68,6 +68,10 @@ export const JetpackSitesDataViews = ( {
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
+			if ( site.sticker.includes( 'migration-in-progress' ) ) {
+				return;
+			}
+
 			if ( site.is_connection_healthy ) {
 				setDataViewsState( ( prevState: DataViewsState ) => ( {
 					...prevState,
@@ -380,19 +384,23 @@ export const JetpackSitesDataViews = ( {
 								onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 								onKeyDown={ ( e: KeyboardEvent ) => e.stopPropagation() }
 							>
-								<SiteActions
-									isLargeScreen={ isLargeScreen }
-									site={ item.site }
-									siteError={ item.site.error }
-								/>
-								<Button
-									onClick={ () => openSitePreviewPane( item.site.value ) }
-									className="site-preview__open"
-									borderless
-									ref={ ( ref ) => setActionsRef( ( current ) => current || ref ) }
-								>
-									<Gridicon icon="chevron-right" />
-								</Button>
+								{ ! item.site.value.sticker.includes( 'migration-in-progress' ) && (
+									<>
+										<SiteActions
+											isLargeScreen={ isLargeScreen }
+											site={ item.site }
+											siteError={ item.site.error }
+										/>
+										<Button
+											onClick={ () => openSitePreviewPane( item.site.value ) }
+											className="site-preview__open"
+											borderless
+											ref={ ( ref ) => setActionsRef( ( current ) => current || ref ) }
+										>
+											<Gridicon icon="chevron-right" />
+										</Button>
+									</>
+								) }
 							</div>
 						</>
 					);

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -22,6 +22,9 @@ import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-o
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import { useSelector } from 'calypso/state';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
 import useFormattedSites from '../../hooks/use-formatted-sites';
 import { AllowedTypes, Site, SiteData } from '../../types';
@@ -66,9 +69,12 @@ export const JetpackSitesDataViews = ( {
 		[]
 	);
 
+	const teams = useSelector( getReaderTeams );
+	const isTeamMember = isAutomatticTeamMember( teams );
+
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
-			if ( site.sticker.includes( 'migration-in-progress' ) ) {
+			if ( site.sticker.includes( 'migration-in-progress' ) && ! isTeamMember ) {
 				return;
 			}
 
@@ -384,7 +390,8 @@ export const JetpackSitesDataViews = ( {
 								onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 								onKeyDown={ ( e: KeyboardEvent ) => e.stopPropagation() }
 							>
-								{ ! item.site.value.sticker.includes( 'migration-in-progress' ) && (
+								{ ( ! item.site.value.sticker.includes( 'migration-in-progress' ) ||
+									isTeamMember ) && (
 									<>
 										<SiteActions
 											isLargeScreen={ isLargeScreen }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -23,6 +23,7 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
 import JetpackSitesDataViews from 'calypso/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerifiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import DashboardDataContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/dashboard-data-context';
@@ -46,7 +47,6 @@ import { updateSitesDashboardUrl } from './update-sites-dashboard-url';
 
 import './style.scss';
 import './sites-dataviews-style.scss';
-
 export default function SitesDashboard() {
 	const jetpackSiteDisconnected = useSelector( checkIfJetpackSiteGotDisconnected );
 	const dispatch = useDispatch();
@@ -246,7 +246,7 @@ export default function SitesDashboard() {
 
 					<SiteNotifications />
 					{ tourId && <GuidedTour defaultTourId={ tourId } /> }
-
+					<QueryReaderTeams />
 					<DashboardDataContext.Provider
 						value={ {
 							verifiedContacts: {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -19,6 +19,10 @@
 	width: 180px;
 	font-weight: 500;
 	font-size: rem(14px);
+
+	.migration-badge {
+		border-radius: 2px;
+	}
 }
 
 .sites-dataviews__site-url {

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button } from '@automattic/components';
+import { translate } from 'i18n-calypso';
 import SiteFavicon from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { Site } from '../types';
@@ -32,7 +33,7 @@ const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProp
 				{ ! migrationInProgress && <div className="sites-dataviews__site-url">{ site.url }</div> }
 				{ migrationInProgress && (
 					<Badge className="migration-badge" type="info-blue">
-						Migration in progress
+						{ translate( 'Migration in progress' ) }
 					</Badge>
 				) }
 			</div>

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -15,7 +15,7 @@ const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProp
 		return <TextPlaceholder />;
 	}
 
-	const migrationInProgress = site.sticker.includes( 'migration-in-progress' );
+	const migrationInProgress = site.sticker?.includes( 'migration-in-progress' );
 
 	return (
 		<Button

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Badge, Button } from '@automattic/components';
 import SiteFavicon from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { Site } from '../types';
@@ -14,15 +14,27 @@ const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProp
 		return <TextPlaceholder />;
 	}
 
+	const migrationInProgress = site.sticker.includes( 'migration-in-progress' );
+
 	return (
-		<Button className="sites-dataviews__site" onClick={ () => onSiteTitleClick( site ) } borderless>
+		<Button
+			disabled={ migrationInProgress }
+			className="sites-dataviews__site"
+			onClick={ () => onSiteTitleClick( site ) }
+			borderless
+		>
 			<SiteFavicon
 				blogId={ site.blog_id }
 				fallback={ site.is_atomic ? 'wordpress-logo' : 'color' }
 			/>
 			<div className="sites-dataviews__site-name">
-				{ site.blogname }
-				<div className="sites-dataviews__site-url">{ site.url }</div>
+				<div>{ site.blogname }</div>
+				{ ! migrationInProgress && <div className="sites-dataviews__site-url">{ site.url }</div> }
+				{ migrationInProgress && (
+					<Badge className="migration-badge" type="info-blue">
+						Migration in progress
+					</Badge>
+				) }
 			</div>
 		</Button>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -119,7 +119,7 @@ export default function ToggleActivateMonitoring( {
 					borderless
 					compact
 					onClick={ handleToggleNotificationSettings }
-					disabled={ isLoading || site.sticker.includes( 'migration-in-progress' ) }
+					disabled={ isLoading || site.sticker?.includes( 'migration-in-progress' ) }
 					aria-label={
 						translate(
 							'The current notification schedule is set to %(currentSchedule)s. Click here to update the settings',
@@ -147,7 +147,7 @@ export default function ToggleActivateMonitoring( {
 		<ToggleControl
 			onChange={ handleToggleActivateMonitoring }
 			checked={ isChecked }
-			disabled={ isLoading || siteError || site.sticker.includes( 'migration-in-progress' ) }
+			disabled={ isLoading || siteError || site.sticker?.includes( 'migration-in-progress' ) }
 			label={ isChecked && currentSettings() }
 		/>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -119,7 +119,7 @@ export default function ToggleActivateMonitoring( {
 					borderless
 					compact
 					onClick={ handleToggleNotificationSettings }
-					disabled={ isLoading }
+					disabled={ isLoading || site.sticker.includes( 'migration-in-progress' ) }
 					aria-label={
 						translate(
 							'The current notification schedule is set to %(currentSchedule)s. Click here to update the settings',
@@ -147,7 +147,7 @@ export default function ToggleActivateMonitoring( {
 		<ToggleControl
 			onChange={ handleToggleActivateMonitoring }
 			checked={ isChecked }
-			disabled={ isLoading || siteError }
+			disabled={ isLoading || siteError || site.sticker.includes( 'migration-in-progress' ) }
 			label={ isChecked && currentSettings() }
 		/>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -42,7 +42,7 @@ export default function SiteBoostColumn( { site, siteError }: Props ) {
 		recordEvent( 'boost_column_get_score_click' );
 	};
 
-	const isSiteMigrationInProgress = site.sticker.includes( 'migration-in-progress' );
+	const isSiteMigrationInProgress = site.sticker?.includes( 'migration-in-progress' );
 
 	const noBoostHrefOption = site.is_atomic ? jetpackHref : addBoostHref;
 	if ( overallScore && ! hasBoost ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -57,7 +57,7 @@ export default function SiteBoostColumn( { site, siteError }: Props ) {
 				}
 				href={ siteError ? '' : noBoostHrefOption }
 				target="_blank"
-				disabled={ siteError }
+				disabled={ siteError || site.sticker.includes( 'migration-in-progress' ) }
 				onClick={ () =>
 					recordEvent( 'boost_column_score_click', {
 						score: overallScore,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -42,6 +42,8 @@ export default function SiteBoostColumn( { site, siteError }: Props ) {
 		recordEvent( 'boost_column_get_score_click' );
 	};
 
+	const isSiteMigrationInProgress = site.sticker.includes( 'migration-in-progress' );
+
 	const noBoostHrefOption = site.is_atomic ? jetpackHref : addBoostHref;
 	if ( overallScore && ! hasBoost ) {
 		return (
@@ -57,7 +59,7 @@ export default function SiteBoostColumn( { site, siteError }: Props ) {
 				}
 				href={ siteError ? '' : noBoostHrefOption }
 				target="_blank"
-				disabled={ siteError || site.sticker.includes( 'migration-in-progress' ) }
+				disabled={ siteError || isSiteMigrationInProgress }
 				onClick={ () =>
 					recordEvent( 'boost_column_score_click', {
 						score: overallScore,
@@ -122,7 +124,7 @@ export default function SiteBoostColumn( { site, siteError }: Props ) {
 		<>
 			<span
 				className={
-					siteError
+					siteError || isSiteMigrationInProgress
 						? 'sites-overview__disabled sites-overview__row-status'
 						: 'sites-overview__row-status'
 				}
@@ -130,7 +132,7 @@ export default function SiteBoostColumn( { site, siteError }: Props ) {
 				<button
 					className="sites-overview__column-action-button"
 					onClick={ handleGetBoostScoreAction }
-					disabled={ siteError }
+					disabled={ siteError || isSiteMigrationInProgress }
 				>
 					<Gridicon icon="plus-small" size={ 16 } />
 					<span>{ translate( 'Add' ) }</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -52,7 +52,7 @@ export default function SiteStatsColumn( { site, stats }: Props ) {
 					translate( '%(totalViews)s views in the last 7 days', { args: { totalViews } } ) as string
 				}
 				onClick={ openStats }
-				disabled={ site?.sticker.includes( 'migration-in-progress' ) }
+				disabled={ site?.sticker?.includes( 'migration-in-progress' ) }
 				className={ clsx(
 					'sites-overview__stats-trend',
 					`sites-overview__stats-trend__${ viewsTrend }`,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-stats-column.tsx
@@ -52,6 +52,7 @@ export default function SiteStatsColumn( { site, stats }: Props ) {
 					translate( '%(totalViews)s views in the last 7 days', { args: { totalViews } } ) as string
 				}
 				onClick={ openStats }
+				disabled={ site?.sticker.includes( 'migration-in-progress' ) }
 				className={ clsx(
 					'sites-overview__stats-trend',
 					`sites-overview__stats-trend__${ viewsTrend }`,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
@@ -45,6 +45,10 @@ export default function SiteStatusColumn( { type, rows, metadata, disabled }: Pr
 		isSupported,
 	} = metadata;
 
+	if ( rows.site.value.sticker?.includes( 'migration-in-progress' ) ) {
+		disabled = true;
+	}
+
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -1,6 +1,7 @@
 import { Icon, starFilled, info } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useContext, useState, forwardRef, Ref } from 'react';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import AddNewSiteTourStep2 from 'calypso/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import './style.scss';
@@ -42,6 +43,7 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 
 	return (
 		<>
+			<QueryReaderTeams />
 			<table ref={ ref } className="site-table__table">
 				<thead>
 					<tr>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -1,7 +1,6 @@
 import { Icon, starFilled, info } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useContext, useState, forwardRef, Ref } from 'react';
-import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import AddNewSiteTourStep2 from 'calypso/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import './style.scss';
@@ -43,7 +42,6 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 
 	return (
 		<>
-			<QueryReaderTeams />
 			<table ref={ ref } className="site-table__table">
 				<thead>
 					<tr>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -18,6 +18,8 @@ jest.mock(
 	() => 'span'
 );
 
+jest.mock( 'calypso/components/data/query-reader-teams', () => 'span' );
+
 describe( '<SiteTable>', () => {
 	beforeAll( () => {
 		window.matchMedia = jest.fn().mockImplementation( ( query ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7838

## Proposed Changes

* Blocked site selection row when migration is in progress
* Hided the site domain

## Testing in staging

* Open [the agencies.automattic.com staging link](https://calypso.live/?image=registry.a8c.com/calypso/app:build-111835&env=a8c-for-agencies)
* Select an agency site that is listing on /sites and on its blog RC mark it as `migration-in-progress`: 

	<img width="720" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/5a2e260f-64b2-4643-9d00-cfb83c12f055">

* When refreshing the /sites list, you'll notice that the site is now in a "disabled" and users won't be able to see its URL and will see a badge. **Note**: On the staging server, you can still click on it, but this only works for a11n. Once it's in prod, normal users won't be able to click on it:

<img width="1348" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/550c01df-96ec-45a2-b67c-72ae035ae42c">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use these instructions to prepare your Agency environment: p4TIVU-aUy-p2
* Mark a site as `migration-in-progress` in its blog RC
* Open the Agency sites list and ensure the desired site is in `migration` state and doesn't allow you to discover its domain or see more information:

<img width="1314" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/c37e2f5e-41f4-4726-9e80-02ac791a8c0d">

-----------------

Ensure the navigation won't work for `migration` state sites:

<img width="899" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/efa7ee96-8a65-4dcf-90e5-06076a718710">


-------------

* Set [the isTeamMember variable](https://github.com/Automattic/wp-calypso/blob/update/agencies-dashboard-migration-in-progress/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx#L73) to false and ensure you can now navigate and see site details:

<img width="909" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/eff726aa-119a-4716-bd67-d5446c6c9e75">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?