### PR TITLE
A4A: Hide social login links when coming from A4A and is a referral client

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -766,7 +766,11 @@ export class LoginForm extends Component {
 		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
 		const isCoreProfilerLostPasswordFlow = isWooCoreProfilerFlow && currentQuery.lostpassword_flow;
-		const isFromAutomatticForAgenciesReferralClient = isA4AOAuth2Client( oauth2Client );
+		const isFromAutomatticForAgenciesReferralClient =
+			isA4AOAuth2Client( oauth2Client ) &&
+			currentQuery &&
+			currentQuery.redirect_to &&
+			currentQuery.redirect_to.includes( '/client/' );
 
 		const signupUrl = this.getSignupUrl();
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -824,11 +824,6 @@ export class LoginForm extends Component {
 			} );
 		}
 
-		// eslint-disable-next-line no-console
-		console.log( 'CURRENT QUERY' );
-		// eslint-disable-next-line no-console
-		console.log( currentQuery );
-
 		return (
 			<form
 				className={ clsx( {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -31,7 +31,11 @@ import {
 	canDoMagicLogin,
 	getLoginLinkPageUrl,
 } from 'calypso/lib/login';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isCrowdsignalOAuth2Client,
+	isWooOAuth2Client,
+	isA4AOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -762,6 +766,7 @@ export class LoginForm extends Component {
 		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
 		const isCoreProfilerLostPasswordFlow = isWooCoreProfilerFlow && currentQuery.lostpassword_flow;
+		const isFromAutomatticForAgenciesReferralClient = isA4AOAuth2Client( oauth2Client );
 
 		const signupUrl = this.getSignupUrl();
 
@@ -1032,26 +1037,28 @@ export class LoginForm extends Component {
 					) }
 				</Card>
 
-				{ config.isEnabled( 'signup/social' ) && ! isCoreProfilerLostPasswordFlow && (
-					<Fragment>
-						<FormDivider />
-						<SocialLoginForm
-							linkingSocialService={
-								this.props.socialAccountIsLinking ? this.props.socialAccountLinkService : null
-							}
-							onSuccess={ this.props.onSuccess }
-							socialService={ this.props.socialService }
-							socialServiceResponse={ this.props.socialServiceResponse }
-							uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
-							shouldRenderToS={
-								this.props.isWoo && ! isPartnerSignup && ! this.props.isWooPasswordless
-							}
-							isSocialFirst={ isSocialFirst }
-						>
-							{ loginButtons }
-						</SocialLoginForm>
-					</Fragment>
-				) }
+				{ ! isFromAutomatticForAgenciesReferralClient &&
+					config.isEnabled( 'signup/social' ) &&
+					! isCoreProfilerLostPasswordFlow && (
+						<Fragment>
+							<FormDivider />
+							<SocialLoginForm
+								linkingSocialService={
+									this.props.socialAccountIsLinking ? this.props.socialAccountLinkService : null
+								}
+								onSuccess={ this.props.onSuccess }
+								socialService={ this.props.socialService }
+								socialServiceResponse={ this.props.socialServiceResponse }
+								uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
+								shouldRenderToS={
+									this.props.isWoo && ! isPartnerSignup && ! this.props.isWooPasswordless
+								}
+								isSocialFirst={ isSocialFirst }
+							>
+								{ loginButtons }
+							</SocialLoginForm>
+						</Fragment>
+					) }
 
 				{ this.showJetpackConnectSiteOnly() && (
 					<JetpackConnectSiteOnly

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -824,6 +824,11 @@ export class LoginForm extends Component {
 			} );
 		}
 
+		// eslint-disable-next-line no-console
+		console.log( 'CURRENT QUERY' );
+		// eslint-disable-next-line no-console
+		console.log( currentQuery );
+
 		return (
 			<form
 				className={ clsx( {


### PR DESCRIPTION
Related to #

## Proposed Changes

* This PR hides the social links for referral clients in A4A.
* Related Thread: p1718889076817089-slack-C03Q2D22DGV
* Somewhat related to https://github.com/Automattic/jetpack-genesis/issues/406

## Why are these changes being made?

* They are being made to avoid confusion when referral clients try to log in.

## Testing Instructions

* Open Automattic for Agencies live link on a new private/incognito window
* In the URL, replace `/log-in?redirect_to=%2Flanding` with `/client/checkout?debug=1`
* Verify that no social login links are presented

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?