### PR TITLE
Frictionless Email Subscriptions: Add new user creation to email subscription flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1302,16 +1302,11 @@ class SignupForm extends Component {
 						onInputBlur={ this.handleBlur }
 						onInputChange={ this.handleChangeEvent }
 						onCreateAccountError={ ( error, email ) => {
-							if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
-								page(
-									addQueryArgs(
-										{
-											email_address: email,
-											is_signup_existing_account: true,
-										},
-										logInUrl
-									)
-								);
+							// TODO: Determine if there's a better way to handle a custom create account error
+							if ( this.props.onPasswordlessCreateAccountError ) {
+								this.props.onPasswordlessCreateAccountError( error, email );
+								this.setState( { disabled: false, submitting: false } );
+								return;
 							}
 						} }
 						{ ...formProps }

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -48,6 +48,7 @@ import {
 	isGravatarOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
+import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import { addQueryArgs } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import { isP2Flow } from 'calypso/signup/is-flow';
@@ -1142,7 +1143,7 @@ class SignupForm extends Component {
 			return this.props.handleCreateAccountError( error, email );
 		}
 
-		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
+		if ( isExistingAccountError( error.error ) ) {
 			page(
 				addQueryArgs(
 					{

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -119,6 +119,7 @@ class SignupForm extends Component {
 		horizontal: PropTypes.bool,
 		shouldDisplayUserExistsError: PropTypes.bool,
 		submitForm: PropTypes.func,
+		handleCreateAccountError: PropTypes.func,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -1136,6 +1137,24 @@ class SignupForm extends Component {
 			: formState.getFieldValue( this.state.form, 'email' );
 	};
 
+	handleCreateAccountError = ( error, email ) => {
+		if ( this.props.handleCreateAccountError ) {
+			return this.props.handleCreateAccountError( error, email );
+		}
+
+		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
+			page(
+				addQueryArgs(
+					{
+						email_address: email,
+						is_signup_existing_account: true,
+					},
+					this.getLoginLink()
+				)
+			);
+		}
+	};
+
 	render() {
 		if ( this.getUserExistsError( this.props ) && ! this.props.shouldDisplayUserExistsError ) {
 			return null;
@@ -1301,14 +1320,7 @@ class SignupForm extends Component {
 						labelText={ this.props.labelText }
 						onInputBlur={ this.handleBlur }
 						onInputChange={ this.handleChangeEvent }
-						onCreateAccountError={ ( error, email ) => {
-							// TODO: Determine if there's a better way to handle a custom create account error
-							if ( this.props.onPasswordlessCreateAccountError ) {
-								this.props.onPasswordlessCreateAccountError( error, email );
-								this.setState( { disabled: false, submitting: false } );
-								return;
-							}
-						} }
+						onCreateAccountError={ this.handleCreateAccountError }
 						{ ...formProps }
 					>
 						{ emailErrorMessage && (

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -137,6 +137,11 @@ class PasswordlessSignupForm extends Component {
 				isSubmitting: false,
 			} );
 		}
+
+		// TODO: Figure out how to appropriately update submitting property
+		this.setState( {
+			isSubmitting: false,
+		} );
 		this.props.onCreateAccountError?.( error, this.state.email );
 	};
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -134,14 +134,13 @@ class PasswordlessSignupForm extends Component {
 						'Sorry, something went wrong when trying to create your account. Please try again.'
 					),
 				],
-				isSubmitting: false,
 			} );
 		}
 
-		// TODO: Figure out how to appropriately update submitting property
 		this.setState( {
 			isSubmitting: false,
 		} );
+
 		this.props.onCreateAccountError?.( error, this.state.email );
 	};
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -14,6 +14,7 @@ import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import Notice from 'calypso/components/notice';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import wpcom from 'calypso/lib/wp';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -127,7 +128,7 @@ class PasswordlessSignupForm extends Component {
 	createAccountError = async ( error ) => {
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
 
-		if ( ! [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
+		if ( ! isExistingAccountError( error.error ) ) {
 			this.setState( {
 				errorMessages: [
 					this.props.translate(

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -5,6 +5,7 @@ import { useState, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import MailIcon from 'calypso/components/social-icons/mail';
 import { isGravatarOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -170,7 +171,7 @@ const SignupFormSocialFirst = ( {
 						userEmail={ userEmail }
 						renderTerms={ renderEmailStepTermsOfService }
 						onCreateAccountError={ ( error: { error: string }, email: string ) => {
-							if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
+							if ( isExistingAccountError( error.error ) ) {
 								window.location.assign(
 									addQueryArgs(
 										{

--- a/client/lib/signup/api/type.ts
+++ b/client/lib/signup/api/type.ts
@@ -35,6 +35,7 @@ export type CreateAccountParams = {
 	service?: string;
 	access_token?: string;
 	id_token?: string | null;
+	isPasswordless?: boolean;
 	recaptchaDidntLoad: boolean;
 	recaptchaFailed: boolean;
 	recaptchaToken: string;
@@ -42,7 +43,12 @@ export type CreateAccountParams = {
 
 export type CreateWPCOMAccountParams = Pick<
 	CreateAccountParams,
-	'userData' | 'flowName' | 'recaptchaDidntLoad' | 'recaptchaFailed' | 'recaptchaToken'
+	| 'userData'
+	| 'flowName'
+	| 'isPasswordless'
+	| 'recaptchaDidntLoad'
+	| 'recaptchaFailed'
+	| 'recaptchaToken'
 >;
 export type CreateSocialAccountParams = Pick<
 	CreateAccountParams,

--- a/client/lib/signup/is-existing-account-error.ts
+++ b/client/lib/signup/is-existing-account-error.ts
@@ -1,0 +1,3 @@
+export function isExistingAccountError( errorSlug: string ) {
+	return [ 'already_taken', 'already_active', 'email_exists' ].includes( errorSlug );
+}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -49,7 +49,7 @@ const getEmailSubscriptionFlow = () => {
 						'Signup flow that subscripes user to guides appointments for email campaigns',
 					lastModified: '2024-06-17',
 					showRecaptcha: true,
-					providesDependenciesInQuery: [ 'email', 'redirect_to', 'mailing_list' ],
+					providesDependenciesInQuery: [ 'user_email', 'redirect_to', 'mailing_list' ],
 					hideProgressIndicator: true,
 				},
 		  ]

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -44,7 +44,7 @@ const getEmailSubscriptionFlow = () => {
 				{
 					name: 'email-subscription',
 					steps: [ 'subscribing-email' ],
-					destination: '/',
+					destination: ( dependencies ) => `${ dependencies.redirectUrl }`,
 					description:
 						'Signup flow that subscripes user to guides appointments for email campaigns',
 					lastModified: '2024-06-17',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -44,7 +44,7 @@ const getEmailSubscriptionFlow = () => {
 				{
 					name: 'email-subscription',
 					steps: [ 'subscribing-email' ],
-					destination: ( dependencies ) => `${ dependencies.redirectUrl }`,
+					destination: ( dependencies ) => `${ dependencies.redirect }`,
 					description:
 						'Signup flow that subscripes user to guides appointments for email campaigns',
 					lastModified: '2024-06-17',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -394,10 +394,8 @@ export function generateSteps( {
 		},
 		'subscribing-email': {
 			stepName: 'subscribing-email',
-			// apiRequestFunction: createSiteWithCart,
 			dependencies: [ 'email', 'redirect_to', 'mailing_list' ],
-			providesDependencies: [],
-			optionalDependencies: [],
+			providesDependencies: [ 'redirectUrl' ],
 		},
 		mailbox: {
 			stepName: 'mailbox',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -395,7 +395,7 @@ export function generateSteps( {
 		'subscribing-email': {
 			stepName: 'subscribing-email',
 			dependencies: [ 'email', 'redirect_to', 'mailing_list' ],
-			providesDependencies: [ 'redirectUrl' ],
+			providesDependencies: [ 'redirect', 'username', 'marketing_price_group', 'bearer_token' ],
 		},
 		mailbox: {
 			stepName: 'mailbox',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -394,7 +394,6 @@ export function generateSteps( {
 		},
 		'subscribing-email': {
 			stepName: 'subscribing-email',
-			dependencies: [ 'email', 'redirect_to', 'mailing_list' ],
 			providesDependencies: [ 'redirect', 'username', 'marketing_price_group', 'bearer_token' ],
 			optionalDependencies: [ 'username', 'marketing_price_group', 'bearer_token' ],
 		},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -396,6 +396,7 @@ export function generateSteps( {
 			stepName: 'subscribing-email',
 			dependencies: [ 'email', 'redirect_to', 'mailing_list' ],
 			providesDependencies: [ 'redirect', 'username', 'marketing_price_group', 'bearer_token' ],
+			optionalDependencies: [ 'username', 'marketing_price_group', 'bearer_token' ],
 		},
 		mailbox: {
 			stepName: 'mailbox',

--- a/client/signup/hooks/use-create-new-account.ts
+++ b/client/signup/hooks/use-create-new-account.ts
@@ -1,0 +1,42 @@
+import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import { useMutation } from '@tanstack/react-query';
+import { getLocaleSlug } from 'i18n-calypso';
+import { CreateWPCOMAccountParams } from 'calypso/lib/signup/api/type';
+import wpcom from 'calypso/lib/wp';
+
+function mutationCreateNewAccount( {
+	userData,
+	flowName,
+	isPasswordless,
+	recaptchaDidntLoad,
+	recaptchaFailed,
+	recaptchaToken,
+}: CreateWPCOMAccountParams ) {
+	return wpcom.req.post(
+		'/users/new',
+		Object.assign(
+			{},
+			userData,
+			{
+				validate: false,
+				signup_flow_name: flowName,
+				locale: getLocaleSlug(),
+				client_id: config( 'wpcom_signup_id' ),
+				client_secret: config( 'wpcom_signup_key' ),
+				anon_id: getTracksAnonymousUserId(),
+				is_passwordless: isPasswordless,
+			},
+			recaptchaDidntLoad ? { 'g-recaptcha-error': 'recaptcha_didnt_load' } : null,
+			recaptchaFailed ? { 'g-recaptcha-error': 'recaptcha_failed' } : null,
+			recaptchaToken ? { 'g-recaptcha-response': recaptchaToken } : null
+		)
+	);
+}
+
+export default function useCreateNewAccountMutation( options ) {
+	return useMutation( {
+		...options,
+		mutationFn: mutationCreateNewAccount,
+	} );
+}

--- a/client/signup/hooks/use-create-new-account.ts
+++ b/client/signup/hooks/use-create-new-account.ts
@@ -1,9 +1,13 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
 import { getLocaleSlug } from 'i18n-calypso';
 import { CreateWPCOMAccountParams } from 'calypso/lib/signup/api/type';
 import wpcom from 'calypso/lib/wp';
+
+interface APIResponse {
+	success: boolean;
+}
 
 function mutationCreateNewAccount( {
 	userData,
@@ -34,7 +38,9 @@ function mutationCreateNewAccount( {
 	);
 }
 
-export default function useCreateNewAccountMutation( options ) {
+export default function useCreateNewAccountMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, Error, CreateWPCOMAccountParams, TContext >
+): UseMutationResult< APIResponse, Error, CreateWPCOMAccountParams, TContext > {
 	return useMutation( {
 		...options,
 		mutationFn: mutationCreateNewAccount,

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -65,11 +65,7 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 			];
 			break;
 		case 'email-subscription':
-			steps = [
-				{ title: __( 'Turning on the lights' ) },
-				{ title: __( 'Making you cookies' ) },
-				{ title: __( 'Subscribing to magic' ) },
-			];
+			steps = [ { title: __( 'Subscribing to magic' ) }, { title: __( 'Turning on the lights' ) } ];
 			break;
 		default:
 			steps = [

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -65,7 +65,7 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 			];
 			break;
 		case 'email-subscription':
-			steps = [ { title: __( 'Subscribing to magic' ) }, { title: __( 'Turning on the lights' ) } ];
+			steps = [ { title: __( 'Subscribing to magic' ) } ];
 			break;
 		default:
 			steps = [
@@ -91,7 +91,9 @@ export default function ReskinnedProcessingScreen( props ) {
 	const totalSteps = steps.current.length;
 	const shouldShowNewSpinner =
 		isDestinationSetupSiteFlow ||
-		[ 'setup-site', 'do-it-for-me', 'do-it-for-me-store' ].includes( flowName );
+		[ 'setup-site', 'do-it-for-me', 'do-it-for-me-store', 'email-subscription' ].includes(
+			flowName
+		);
 
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 

--- a/client/signup/steps/subscribing-email/content.jsx
+++ b/client/signup/steps/subscribing-email/content.jsx
@@ -5,6 +5,8 @@ import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-scree
 function SubscribingEmailStepContent( props ) {
 	const { flowName, handleSubmitSignup, isLoading, submitting, queryParams } = props;
 
+	const redirectUrl = queryParams?.redirect_to || 'https://wordpress.com';
+
 	if ( isLoading ) {
 		return <ReskinnedProcessingScreen flowName={ flowName } hasPaidDomain={ false } />;
 	}
@@ -14,9 +16,7 @@ function SubscribingEmailStepContent( props ) {
 			<SignupForm
 				step={ props.step }
 				email={ queryParams?.email || '' }
-				// TODO: Implement actual redirect url
-				redirectToAfterLoginUrl="https://wordpress.com"
-				// redirectToAfterLoginUrl={ getRedirectToAfterLoginUrl( this.props ) }
+				redirectToAfterLoginUrl={ redirectUrl }
 				disabled={ submitting }
 				submitting={ submitting }
 				displayUsernameInput={ false }

--- a/client/signup/steps/subscribing-email/content.jsx
+++ b/client/signup/steps/subscribing-email/content.jsx
@@ -1,4 +1,3 @@
-import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import SignupForm from 'calypso/blocks/signup-form';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
@@ -6,18 +5,16 @@ import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-scree
 function SubscribingEmailStepContent( props ) {
 	const {
 		flowName,
+		goToNextStep,
 		handleSubmitSignup,
 		isPending,
-		stepName,
-		step,
-		translate,
 		queryParams,
-		goToNextStep,
+		redirectUrl,
+		step,
+		stepName,
+		translate,
 	} = props;
 
-	const redirect_to = queryParams?.redirect_to
-		? addQueryArgs( queryParams.redirect_to, { subscribed: true } )
-		: 'https://wordpress.com';
 	const user_email = queryParams?.user_email;
 
 	if ( isPending ) {
@@ -27,25 +24,25 @@ function SubscribingEmailStepContent( props ) {
 	return (
 		<>
 			<SignupForm
+				displayUsernameInput={ false }
+				email={ user_email || '' }
+				flowName={ flowName }
+				goToNextStep={ goToNextStep }
+				handleCreateAccountError={ () => {} }
+				isPasswordless
+				isReskinned
+				isSocialFirst={ false }
+				isSocialSignupEnabled={ false }
+				labelText={ translate( 'Your email' ) }
+				queryArgs={ { user_email, redirect_to: redirectUrl } }
+				// recaptchaClientId={ this.state.recaptchaClientId }
+				redirectToAfterLoginUrl={ redirectUrl }
+				shouldDisplayUserExistsError
 				step={ step }
 				stepName={ stepName }
-				flowName={ flowName }
-				email={ user_email || '' }
-				goToNextStep={ goToNextStep }
-				displayUsernameInput={ false }
-				redirectToAfterLoginUrl={ redirect_to }
-				suggestedUsername=""
-				isPasswordless
-				queryArgs={ { user_email, redirect_to } }
-				isSocialSignupEnabled={ false }
-				// recaptchaClientId={ this.state.recaptchaClientId }
-				isReskinned
-				shouldDisplayUserExistsError
-				isSocialFirst={ false }
-				labelText={ translate( 'Your email' ) }
 				submitButtonText={ translate( 'Create an account' ) }
 				submitForm={ handleSubmitSignup }
-				handleCreateAccountError={ () => {} }
+				suggestedUsername=""
 			/>
 		</>
 	);

--- a/client/signup/steps/subscribing-email/content.jsx
+++ b/client/signup/steps/subscribing-email/content.jsx
@@ -3,7 +3,7 @@ import SignupForm from 'calypso/blocks/signup-form';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 
 function SubscribingEmailStepContent( props ) {
-	const { flowName, isLoading, queryParams } = props;
+	const { flowName, handleSubmitSignup, isLoading, submitting, queryParams } = props;
 
 	if ( isLoading ) {
 		return <ReskinnedProcessingScreen flowName={ flowName } hasPaidDomain={ false } />;
@@ -17,15 +17,12 @@ function SubscribingEmailStepContent( props ) {
 				// TODO: Implement actual redirect url
 				redirectToAfterLoginUrl="https://wordpress.com"
 				// redirectToAfterLoginUrl={ getRedirectToAfterLoginUrl( this.props ) }
-				// disabled={ this.userCreationStarted() }
-				// submitting={ this.userCreationStarted() }
-				// save={ this.save }
-				// submitForm={ this.submitForm }
-				// submitButtonText={ this.submitButtonText() }
+				disabled={ submitting }
+				submitting={ submitting }
+				displayUsernameInput={ false }
 				suggestedUsername=""
-				// handleSocialResponse={ this.handleSocialResponse }
 				isPasswordless
-				queryArgs={ props.initialContext?.query || {} }
+				queryArgs={ { user_email: queryParams?.email } || {} }
 				isSocialSignupEnabled={ false }
 				// recaptchaClientId={ this.state.recaptchaClientId }
 				isReskinned
@@ -33,6 +30,7 @@ function SubscribingEmailStepContent( props ) {
 				isSocialFirst={ false }
 				labelText={ props.isWooPasswordless ? props.translate( 'Your email' ) : null }
 				submitButtonText={ props.translate( 'Create an account' ) }
+				submitForm={ handleSubmitSignup }
 			/>
 		</>
 	);

--- a/client/signup/steps/subscribing-email/content.jsx
+++ b/client/signup/steps/subscribing-email/content.jsx
@@ -1,11 +1,23 @@
+import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import SignupForm from 'calypso/blocks/signup-form';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 
 function SubscribingEmailStepContent( props ) {
-	const { flowName, handleSubmitSignup, isLoading, stepName, step, translate, queryParams } = props;
+	const {
+		flowName,
+		handleSubmitSignup,
+		isLoading,
+		stepName,
+		step,
+		translate,
+		queryParams,
+		goToNextStep,
+	} = props;
 
-	const redirectUrl = queryParams?.redirect_to || 'https://wordpress.com';
+	const redirect_to = queryParams?.redirect_to
+		? addQueryArgs( queryParams.redirect_to, { subscribed: true } )
+		: 'https://wordpress.com';
 	const email = queryParams?.email;
 
 	if ( isLoading ) {
@@ -19,11 +31,12 @@ function SubscribingEmailStepContent( props ) {
 				stepName={ stepName }
 				flowName={ flowName }
 				email={ email || '' }
-				redirectToAfterLoginUrl={ redirectUrl }
+				goToNextStep={ goToNextStep }
 				displayUsernameInput={ false }
+				redirectToAfterLoginUrl={ redirect_to }
 				suggestedUsername=""
 				isPasswordless
-				queryArgs={ { user_email: email } || {} }
+				queryArgs={ { user_email: email, redirect_to } || {} }
 				isSocialSignupEnabled={ false }
 				// recaptchaClientId={ this.state.recaptchaClientId }
 				isReskinned
@@ -32,6 +45,9 @@ function SubscribingEmailStepContent( props ) {
 				labelText={ translate( 'Your email' ) }
 				submitButtonText={ translate( 'Create an account' ) }
 				submitForm={ handleSubmitSignup }
+				onPasswordlessCreateAccountError={ () => {} }
+				// TODO: Do we need the save property?
+				save={ () => {} }
 			/>
 		</>
 	);

--- a/client/signup/steps/subscribing-email/content.jsx
+++ b/client/signup/steps/subscribing-email/content.jsx
@@ -36,7 +36,7 @@ function SubscribingEmailStepContent( props ) {
 				redirectToAfterLoginUrl={ redirect_to }
 				suggestedUsername=""
 				isPasswordless
-				queryArgs={ { user_email, redirect_to } || {} }
+				queryArgs={ { user_email, redirect_to } }
 				isSocialSignupEnabled={ false }
 				// recaptchaClientId={ this.state.recaptchaClientId }
 				isReskinned
@@ -45,7 +45,7 @@ function SubscribingEmailStepContent( props ) {
 				labelText={ translate( 'Your email' ) }
 				submitButtonText={ translate( 'Create an account' ) }
 				submitForm={ handleSubmitSignup }
-				onPasswordlessCreateAccountError={ () => {} }
+				handleCreateAccountError={ () => {} }
 			/>
 		</>
 	);

--- a/client/signup/steps/subscribing-email/content.jsx
+++ b/client/signup/steps/subscribing-email/content.jsx
@@ -3,9 +3,10 @@ import SignupForm from 'calypso/blocks/signup-form';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 
 function SubscribingEmailStepContent( props ) {
-	const { flowName, handleSubmitSignup, isLoading, submitting, queryParams } = props;
+	const { flowName, handleSubmitSignup, isLoading, stepName, step, translate, queryParams } = props;
 
 	const redirectUrl = queryParams?.redirect_to || 'https://wordpress.com';
+	const email = queryParams?.email;
 
 	if ( isLoading ) {
 		return <ReskinnedProcessingScreen flowName={ flowName } hasPaidDomain={ false } />;
@@ -14,22 +15,22 @@ function SubscribingEmailStepContent( props ) {
 	return (
 		<>
 			<SignupForm
-				step={ props.step }
-				email={ queryParams?.email || '' }
+				step={ step }
+				stepName={ stepName }
+				flowName={ flowName }
+				email={ email || '' }
 				redirectToAfterLoginUrl={ redirectUrl }
-				disabled={ submitting }
-				submitting={ submitting }
 				displayUsernameInput={ false }
 				suggestedUsername=""
 				isPasswordless
-				queryArgs={ { user_email: queryParams?.email } || {} }
+				queryArgs={ { user_email: email } || {} }
 				isSocialSignupEnabled={ false }
 				// recaptchaClientId={ this.state.recaptchaClientId }
 				isReskinned
 				shouldDisplayUserExistsError
 				isSocialFirst={ false }
-				labelText={ props.isWooPasswordless ? props.translate( 'Your email' ) : null }
-				submitButtonText={ props.translate( 'Create an account' ) }
+				labelText={ translate( 'Your email' ) }
+				submitButtonText={ translate( 'Create an account' ) }
 				submitForm={ handleSubmitSignup }
 			/>
 		</>

--- a/client/signup/steps/subscribing-email/content.jsx
+++ b/client/signup/steps/subscribing-email/content.jsx
@@ -18,7 +18,7 @@ function SubscribingEmailStepContent( props ) {
 	const redirect_to = queryParams?.redirect_to
 		? addQueryArgs( queryParams.redirect_to, { subscribed: true } )
 		: 'https://wordpress.com';
-	const email = queryParams?.email;
+	const user_email = queryParams?.user_email;
 
 	if ( isPending ) {
 		return <ReskinnedProcessingScreen flowName={ flowName } hasPaidDomain={ false } />;
@@ -30,13 +30,13 @@ function SubscribingEmailStepContent( props ) {
 				step={ step }
 				stepName={ stepName }
 				flowName={ flowName }
-				email={ email || '' }
+				email={ user_email || '' }
 				goToNextStep={ goToNextStep }
 				displayUsernameInput={ false }
 				redirectToAfterLoginUrl={ redirect_to }
 				suggestedUsername=""
 				isPasswordless
-				queryArgs={ { user_email: email, redirect_to } || {} }
+				queryArgs={ { user_email, redirect_to } || {} }
 				isSocialSignupEnabled={ false }
 				// recaptchaClientId={ this.state.recaptchaClientId }
 				isReskinned

--- a/client/signup/steps/subscribing-email/content.jsx
+++ b/client/signup/steps/subscribing-email/content.jsx
@@ -46,8 +46,6 @@ function SubscribingEmailStepContent( props ) {
 				submitButtonText={ translate( 'Create an account' ) }
 				submitForm={ handleSubmitSignup }
 				onPasswordlessCreateAccountError={ () => {} }
-				// TODO: Do we need the save property?
-				save={ () => {} }
 			/>
 		</>
 	);

--- a/client/signup/steps/subscribing-email/content.jsx
+++ b/client/signup/steps/subscribing-email/content.jsx
@@ -7,7 +7,7 @@ function SubscribingEmailStepContent( props ) {
 	const {
 		flowName,
 		handleSubmitSignup,
-		isLoading,
+		isPending,
 		stepName,
 		step,
 		translate,
@@ -20,7 +20,7 @@ function SubscribingEmailStepContent( props ) {
 		: 'https://wordpress.com';
 	const email = queryParams?.email;
 
-	if ( isLoading ) {
+	if ( isPending ) {
 		return <ReskinnedProcessingScreen flowName={ flowName } hasPaidDomain={ false } />;
 	}
 

--- a/client/signup/steps/subscribing-email/index.jsx
+++ b/client/signup/steps/subscribing-email/index.jsx
@@ -1,86 +1,60 @@
-import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { getLocaleSlug } from 'calypso/lib/i18n-utils';
-// import { isExternal } from 'calypso/lib/url';
+import useCreateNewAccountMutation from 'calypso/signup/hooks/use-create-new-account';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SubscribingEmailStepContent from './content';
 
-const createNewAccount = async ( {
-	queryParams,
-	flowName,
-	goToNextStep,
-	// recordTracksEvent,
-	setIsLoading,
-	// submitSignupStep,
-} ) => {
-	const { email, mailing_list, redirect_to } = queryParams;
-
-	try {
-		// eslint-disable-next-line no-undef
-		await wpcom.req.post( '/users/new', {
-			email: typeof email === 'string' ? email.trim() : '',
-			is_passwordless: true,
-			signup_flow_name: flowName,
-			validate: false,
-			locale: getLocaleSlug(),
-			client_id: config( 'wpcom_signup_id' ),
-			client_secret: config( 'wpcom_signup_key' ),
-			anon_id: getTracksAnonymousUserId(),
-		} );
-		recordTracksEvent( 'calypso_signup_new_email_subscription_success', {
-			mailing_list,
-		} );
-		submitSignupStep(
-			{ stepName: 'subscribing-email' },
-			{ redirect: addQueryArgs( redirect_to, { subscribed: true } ) }
-		);
-		goToNextStep();
-		return;
-	} catch ( error ) {
-		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
-			// TODO: Subscribe existing user to guides emails through API endpoint https://github.com/Automattic/martech/issues/3090
-
-			recordTracksEvent( 'calypso_signup_existing_email_subscription_success', {
-				mailing_list,
-			} );
-
-			submitSignupStep(
-				{ stepName: 'subscribing-email' },
-				{ redirect: addQueryArgs( redirect_to, { subscribed: true } ) }
-			);
-			goToNextStep();
-		}
-
-		setIsLoading( false );
-	}
-};
-
 function SubscribingEmailStep( props ) {
-	const { flowName, queryParams, stepName } = props;
-
-	const [ isLoading, setIsLoading ] = useState( true );
+	const { flowName, goToNextStep, queryParams, stepName } = props;
+	const mutation = useCreateNewAccountMutation();
 
 	useEffect( () => {
 		if ( emailValidator.validate( queryParams.email ) ) {
-			createNewAccount( { ...props, setIsLoading } );
-		} else {
-			setIsLoading( false );
+			mutation.mutate( {
+				userData: { email: typeof queryParams.email === 'string' ? queryParams.email.trim() : '' },
+				flowName,
+				isPasswordless: true,
+			} );
 		}
 	}, [] );
+
+	if ( mutation.isSuccess ) {
+		props.recordTracksEvent( 'calypso_signup_new_email_subscription_success', {
+			mailing_list: queryParams.mailing_list,
+		} );
+		props.submitSignupStep(
+			{ stepName: 'subscribing-email' },
+			{ redirect: addQueryArgs( queryParams.redirect_to, { subscribed: true } ) }
+		);
+		goToNextStep();
+	} else if ( mutation.isError ) {
+		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( mutation.error.error ) ) {
+			// TODO: Subscribe existing user to guides emails through API endpoint https://github.com/Automattic/martech/issues/3090
+
+			props.recordTracksEvent( 'calypso_signup_existing_email_subscription_success', {
+				mailing_list: queryParams.mailing_list,
+			} );
+			props.submitSignupStep(
+				{ stepName: 'subscribing-email' },
+				{ redirect: addQueryArgs( queryParams.redirect_to, { subscribed: true } ) }
+			);
+			goToNextStep();
+		}
+	}
 
 	return (
 		<div className="subscribing-email">
 			<StepWrapper
 				flowName={ flowName }
 				hideFormattedHeader
-				stepContent={ <SubscribingEmailStepContent { ...props } isLoading={ isLoading } /> }
+				stepContent={
+					<SubscribingEmailStepContent { ...props } isPending={ mutation.isPending } />
+				}
 				stepName={ stepName }
 			/>
 		</div>

--- a/client/signup/steps/subscribing-email/index.jsx
+++ b/client/signup/steps/subscribing-email/index.jsx
@@ -18,7 +18,7 @@ const createNewAccount = async ( {
 	goToNextStep,
 	// recordTracksEvent,
 	setIsLoading,
-	submitSignupStep,
+	// submitSignupStep,
 } ) => {
 	const { email, mailing_list, redirect_to } = queryParams;
 
@@ -34,11 +34,9 @@ const createNewAccount = async ( {
 			client_secret: config( 'wpcom_signup_key' ),
 			anon_id: getTracksAnonymousUserId(),
 		} );
-
-		// recordTracksEvent( 'calypso_signup_new_email_subscription_success', {
-		// 	mailing_list,
-		// } );
-
+		recordTracksEvent( 'calypso_signup_new_email_subscription_success', {
+			mailing_list,
+		} );
 		submitSignupStep(
 			{ stepName: 'subscribing-email' },
 			{ redirectUrl: addQueryArgs( redirect_to, { subscribed: true } ) }
@@ -68,7 +66,6 @@ function SubscribingEmailStep( props ) {
 	const { flowName, queryParams, stepName } = props;
 
 	const [ isLoading, setIsLoading ] = useState( true );
-	const [ submitting, setSubmitting ] = useState( false );
 
 	useEffect( () => {
 		if ( emailValidator.validate( queryParams.email ) ) {
@@ -83,17 +80,7 @@ function SubscribingEmailStep( props ) {
 			<StepWrapper
 				flowName={ flowName }
 				hideFormattedHeader
-				stepContent={
-					<SubscribingEmailStepContent
-						{ ...props }
-						handleSubmitSignup={ () => {
-							// setSubmitting( true );
-							// createNewAccount( { ...props, email: form.email }, setIsLoading, setSubmitting );
-						} }
-						isLoading={ isLoading }
-						submitting={ submitting }
-					/>
-				}
+				stepContent={ <SubscribingEmailStepContent { ...props } isLoading={ isLoading } /> }
 				stepName={ stepName }
 			/>
 		</div>

--- a/client/signup/steps/subscribing-email/index.jsx
+++ b/client/signup/steps/subscribing-email/index.jsx
@@ -3,6 +3,7 @@ import { addQueryArgs } from '@wordpress/url';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import useCreateNewAccountMutation from 'calypso/signup/hooks/use-create-new-account';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -49,7 +50,7 @@ function SubscribingEmailStep( props ) {
 		props.submitSignupStep( { stepName: 'subscribing-email' }, { redirect: redirectUrl } );
 		goToNextStep();
 	} else if ( isError ) {
-		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
+		if ( isExistingAccountError( error.error ) ) {
 			// TODO: Subscribe existing user to guides emails through API endpoint https://github.com/Automattic/martech/issues/3090
 
 			props.recordTracksEvent( 'calypso_signup_existing_email_subscription_success', {

--- a/client/signup/steps/subscribing-email/index.jsx
+++ b/client/signup/steps/subscribing-email/index.jsx
@@ -40,6 +40,8 @@ function SubscribingEmailStep( props ) {
 	}, [] );
 
 	if ( isSuccess ) {
+		// TODO: Subscribe existing user to guides emails through API endpoint https://github.com/Automattic/martech/issues/3090
+
 		props.recordTracksEvent( 'calypso_signup_new_email_subscription_success', {
 			mailing_list: queryParams.mailing_list,
 		} );

--- a/client/signup/steps/subscribing-email/index.jsx
+++ b/client/signup/steps/subscribing-email/index.jsx
@@ -1,40 +1,50 @@
-// import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
-// import config from '@automattic/calypso-config';
+import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import { useEffect, useState } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-// import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+import { getLocaleSlug } from 'calypso/lib/i18n-utils';
+import { isExternal } from 'calypso/lib/url';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SubscribingEmailStepContent from './content';
 
-// const createNewAccount = async ( props, setIsLoading, setDisplayUserExistsError ) => {
-// 	const email = props.queryParams.email;
-// 	try {
-// 		// eslint-disable-next-line no-undef
-// 		await wpcom.req.post( '/users/new', {
-// 			email: typeof email === 'string' ? email.trim() : '',
-// 			is_passwordless: true,
-// 			signup_flow_name: props.flowName,
-// 			validate: false,
-// 			locale: getLocaleSlug(),
-// 			client_id: config( 'wpcom_signup_id' ),
-// 			client_secret: config( 'wpcom_signup_key' ),
-// 			anon_id: getTracksAnonymousUserId(),
-// 		} );
-// 		// Do stuff with response and redirect
-// 		props.recordTracksEvent( 'calypso_signup_reader_landing_cta' );
-// 		props.submitSignupStep( { stepName: props.stepName } );
-// 		props.goToNextStep();
-// 	} catch ( error ) {
-// 		if ( ! [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
-// 			// Subscribe existing user to guides emails through API endpoint
-// 		}
-// 		setIsLoading( false );
-// 	}
-// };
+const createNewAccount = async ( props, setIsLoading ) => {
+	const email = props.queryParams.email;
+	const redirectUrl = props.queryParams.redirect_to;
+
+	try {
+		// eslint-disable-next-line no-undef
+		await wpcom.req.post( '/users/new', {
+			email: typeof email === 'string' ? email.trim() : '',
+			is_passwordless: true,
+			signup_flow_name: props.flowName,
+			validate: false,
+			locale: getLocaleSlug(),
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+			anon_id: getTracksAnonymousUserId(),
+		} );
+		// // Do stuff with response and redirect
+		// props.recordTracksEvent( 'calypso_signup_reader_landing_cta' );
+		// props.submitSignupStep( { stepName: props.stepName } );
+		// props.goToNextStep();
+		if ( isExternal( redirectUrl ) ) {
+			window.location.replace( addQueryArgs( redirectUrl, { subscribed: true } ) );
+		}
+		page.redirect( redirectUrl );
+		throw new TypeError( { error: 'already_taken' } );
+	} catch ( error ) {
+		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
+			// Subscribe existing user to guides emails through API endpoint https://github.com/Automattic/martech/issues/3090
+		}
+		setIsLoading( false );
+	}
+};
 
 function SubscribingEmailStep( props ) {
 	const handleButtonClick = async () => {};
@@ -46,9 +56,10 @@ function SubscribingEmailStep( props ) {
 		const email = queryParams.email;
 
 		if ( emailValidator.validate( email ) ) {
-			// TODO: Fetch request to create new account will replace this placeholder timeout
-			setTimeout( () => setIsLoading( false ), 5000 );
+			createNewAccount( props, setIsLoading );
 		}
+
+		setIsLoading( false );
 	}, [] );
 
 	return (

--- a/client/signup/steps/subscribing-email/index.jsx
+++ b/client/signup/steps/subscribing-email/index.jsx
@@ -12,7 +12,7 @@ import SubscribingEmailStepContent from './content';
 function SubscribingEmailStep( props ) {
 	const { flowName, goToNextStep, queryParams, stepName } = props;
 	const {
-		mutate: createNewAccout,
+		mutate: createNewAccount,
 		isError,
 		isSuccess,
 		isPending,
@@ -21,7 +21,7 @@ function SubscribingEmailStep( props ) {
 
 	useEffect( () => {
 		if ( emailValidator.validate( queryParams.email ) ) {
-			createNewAccout( {
+			createNewAccount( {
 				userData: { email: typeof queryParams.email === 'string' ? queryParams.email.trim() : '' },
 				flowName,
 				isPasswordless: true,

--- a/client/signup/steps/subscribing-email/index.jsx
+++ b/client/signup/steps/subscribing-email/index.jsx
@@ -39,7 +39,7 @@ const createNewAccount = async ( {
 		} );
 		submitSignupStep(
 			{ stepName: 'subscribing-email' },
-			{ redirectUrl: addQueryArgs( redirect_to, { subscribed: true } ) }
+			{ redirect: addQueryArgs( redirect_to, { subscribed: true } ) }
 		);
 		goToNextStep();
 		return;
@@ -53,7 +53,7 @@ const createNewAccount = async ( {
 
 			submitSignupStep(
 				{ stepName: 'subscribing-email' },
-				{ redirectUrl: addQueryArgs( redirect_to, { subscribed: true } ) }
+				{ redirect: addQueryArgs( redirect_to, { subscribed: true } ) }
 			);
 			goToNextStep();
 		}

--- a/client/signup/steps/subscribing-email/index.jsx
+++ b/client/signup/steps/subscribing-email/index.jsx
@@ -11,11 +11,17 @@ import SubscribingEmailStepContent from './content';
 
 function SubscribingEmailStep( props ) {
 	const { flowName, goToNextStep, queryParams, stepName } = props;
-	const mutation = useCreateNewAccountMutation();
+	const {
+		mutate: createNewAccout,
+		isError,
+		isSuccess,
+		isPending,
+		error,
+	} = useCreateNewAccountMutation();
 
 	useEffect( () => {
 		if ( emailValidator.validate( queryParams.email ) ) {
-			mutation.mutate( {
+			createNewAccout( {
 				userData: { email: typeof queryParams.email === 'string' ? queryParams.email.trim() : '' },
 				flowName,
 				isPasswordless: true,
@@ -23,7 +29,7 @@ function SubscribingEmailStep( props ) {
 		}
 	}, [] );
 
-	if ( mutation.isSuccess ) {
+	if ( isSuccess ) {
 		props.recordTracksEvent( 'calypso_signup_new_email_subscription_success', {
 			mailing_list: queryParams.mailing_list,
 		} );
@@ -32,8 +38,8 @@ function SubscribingEmailStep( props ) {
 			{ redirect: addQueryArgs( queryParams.redirect_to, { subscribed: true } ) }
 		);
 		goToNextStep();
-	} else if ( mutation.isError ) {
-		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( mutation.error.error ) ) {
+	} else if ( isError ) {
+		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
 			// TODO: Subscribe existing user to guides emails through API endpoint https://github.com/Automattic/martech/issues/3090
 
 			props.recordTracksEvent( 'calypso_signup_existing_email_subscription_success', {
@@ -52,9 +58,7 @@ function SubscribingEmailStep( props ) {
 			<StepWrapper
 				flowName={ flowName }
 				hideFormattedHeader
-				stepContent={
-					<SubscribingEmailStepContent { ...props } isPending={ mutation.isPending } />
-				}
+				stepContent={ <SubscribingEmailStepContent { ...props } isPending={ isPending } /> }
 				stepName={ stepName }
 			/>
 		</div>

--- a/client/signup/steps/subscribing-email/index.jsx
+++ b/client/signup/steps/subscribing-email/index.jsx
@@ -28,10 +28,12 @@ function SubscribingEmailStep( props ) {
 		: addQueryArgs( 'https://' + queryParams.redirect_to, { subscribed: true } );
 
 	useEffect( () => {
-		if ( emailValidator.validate( queryParams.user_email ) ) {
+		const email = typeof queryParams.user_email === 'string' ? queryParams.user_email.trim() : '';
+
+		if ( emailValidator.validate( email ) ) {
 			createNewAccount( {
 				userData: {
-					email: typeof queryParams.user_email === 'string' ? queryParams.user_email.trim() : '',
+					email,
 				},
 				flowName,
 				isPasswordless: true,
@@ -41,7 +43,6 @@ function SubscribingEmailStep( props ) {
 
 	if ( isSuccess ) {
 		// TODO: Subscribe existing user to guides emails through API endpoint https://github.com/Automattic/martech/issues/3090
-
 		props.recordTracksEvent( 'calypso_signup_new_email_subscription_success', {
 			mailing_list: queryParams.mailing_list,
 		} );

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -43,6 +43,7 @@ export const HUNDRED_YEAR_PLAN_FLOW = 'hundred-year-plan';
 export const REBLOGGING_FLOW = 'reblogging';
 export const DOMAIN_FOR_GRAVATAR_FLOW = 'domain-for-gravatar';
 export const ONBOARDING_GUIDED_FLOW = 'onboarding';
+export const EMAIL_SUBSCRIPTION_FLOW = 'email-subscription';
 
 export const isLinkInBioFlow = ( flowName: string | null | undefined ) => {
 	return Boolean(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3098

## Proposed Changes

* Create a new user upon initial rendering of the email subscription flow
* Use `redirect_to` query param and redirect to said url if new user creation is successful
* Add `subscription=true` query param to redirect url
* Show passwordless signup form with email query param autofilled if new user creation is unsuccessful ( Note: passwordless signup form isn't completely functional yet. Will be handled in a follow-up PR )

![2024-06-25 21 21 23](https://github.com/Automattic/wp-calypso/assets/5414230/12d1b1e0-5bfc-4356-9811-dda31940797b)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When someone subscribes to an email campaign on a landing page like wordpress.com/learn, we'd like to manage outbound communication PCYsg-6j2-p2. Guides, however, requires a user_id and a WordPress account.

In the past, if the user wanted to subscribe on a landing page and wasn't already logged in, they'd be redirected to the /log-in page. If they didn't have an account, they'd be prompted to create one. Once completed, they'd be redirected to the original landing page.

To polish this experience, we're creating a custom email subscription "signup" flow. For the happy path, the user should be able to subscribe with one click, and the technical implementation should look something like p5uIfZ-f11-p2#comment-22793.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Set the `signup/email-subscription-flow` flag to true in `config/development.json`
* Start local dev
* Navigate to `/start/email-subscription/subscribing-email/subscribe?user_email={YOUR_NEW_EMAIL}&redirect_to=wordpress.com%2Flearn&mailing_list=test` Note that the query params are required.
* Verify that a loading screen is initially rendered
* Replace the email query param with the email of a brand new user
* Verify that a new user is created when the page is redirected
* Revisit `/start/email-subscription/subscribing-email/subscribe?user_email={YOUR_NEW_EMAIL}&redirect_to=wordpress.com%2Flearn&mailing_list=test` to emulate an email subscription for an existing user. We will subscribe them to guides automatically behind the scenes in a future PR. They should also be redirected to the `redirect_to` query param.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
