### PR TITLE
Plans Grid: fix previous plan text

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/previous-features-included-title.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/previous-features-included-title.tsx
@@ -6,6 +6,7 @@ import {
 import { useMemo } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { usePlansGridContext } from '../../grid-context';
 import { GridPlan } from '../../types';
 import PlanDivOrTdContainer from '../plan-div-td-container';
 
@@ -32,14 +33,16 @@ const PreviousFeaturesIncludedTitle = ( {
 		);
 	}, [ renderedGridPlans ] );
 
+	const { gridPlans } = usePlansGridContext();
+
 	return plansWithFeatures.map( ( { planSlug } ) => {
 		const shouldShowFeatureTitle = ! isWpComFreePlan( planSlug );
-		const indexInGridPlansForFeaturesGrid = renderedGridPlans.findIndex(
+		const indexInGridPlansForFeaturesGrid = gridPlans.findIndex(
 			( { planSlug: slug } ) => slug === planSlug
 		);
 		const previousProductName =
 			indexInGridPlansForFeaturesGrid > 0
-				? renderedGridPlans[ indexInGridPlansForFeaturesGrid - 1 ].productNameShort
+				? gridPlans[ indexInGridPlansForFeaturesGrid - 1 ].productNameShort
 				: null;
 		const title =
 			previousProductName &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91867

## Proposed Changes

* Please see #91867 for details about the bug. This PR fixes the "Everything in <previous plan>" text on the plans grid so that it always refers to the plan before it.
* The `renderedGridPlans` array passed to the `<PreviousFeaturesIncludedTitle />` component varies according to the place where it is rendered.
  * Desktop: `renderedGridPlans` does not have the spotlight plan.
  * Tablet: `renderedGridPlans` is a list of 2/3 plans for the first row, which excludes the spotlight plan, and then again a list of leftover plans for the second row.
  * Mobile: `renderedGridPlans` is an array of a single `GridPlan`.
* In this PR, we access the `gridPlans` value from the Plans context, which contains a list of all plans that are rendered on the grid and check this array for the name of the previous plan.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix for #91867.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/<site slug>` for a site on the Creator plan.
* On desktop, confirm that the Entrepreneur plan contains the text "Everything in Creator, plus":
* <img width="1268" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/eae4052b-369a-4c98-b19d-6edd9cdb61a7">
* On tablet, confirm that the Entrepreneur plan in the second row contains the text "Everything in Creator, plus":
* <img width="843" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/201710c7-b2dc-4932-9c2a-fabbbbc01d6b">
* On mobile, expand the feature list for every plan and confirm that it contains the text "Everything in <previous plan>, plus" and that the previous plan's name is correct:
* <img width="482" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/9197e38f-e81a-421f-a7ba-b9d337068bc9">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
