### PR TITLE
Remove unnecessary translation checks for affiliates cards on My Home screen

### DIFF
--- a/client/my-sites/customer-home/cards/education/affiliates/index.jsx
+++ b/client/my-sites/customer-home/cards/education/affiliates/index.jsx
@@ -1,4 +1,3 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import affiliatesIllustration from 'calypso/assets/images/customer-home/illustration--affiliates-icons-small.png';
 import EducationalContent from '../educational-content';
@@ -6,22 +5,12 @@ export const EDUCATION_EARN = 'home-education-earn';
 
 const EducationAffiliates = () => {
 	const translate = useTranslate();
-	const hasTranslation = useHasEnTranslation();
 
 	const title = translate( 'Earn with the Automattic Affiliate Program' );
-	const hasTitleTranslation = hasTranslation( 'Earn with the Automattic Affiliate Program' );
-
 	const description = translate(
 		'Join the Automattic Affiliate Program and get up to 100% payouts by promoting one or more of Automattic’s trusted, profitable products.'
 	);
-	const hasDescriptionTranslation = hasTranslation(
-		'Join the Automattic Affiliate Program and get up to 100% payouts by promoting one or more of Automattic’s trusted, profitable products.'
-	);
 
-	if ( ! hasTitleTranslation || ! hasDescriptionTranslation ) {
-		EducationAffiliates.isDisabled = true;
-		return null;
-	}
 	return (
 		<EducationalContent
 			title={ title }

--- a/client/my-sites/customer-home/cards/tasks/affiliates/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/affiliates/index.jsx
@@ -1,4 +1,3 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import affiliatesIllustration from 'calypso/assets/images/customer-home/illustration--affiliates-growth.png';
 import { TASK_AFFILIATES } from 'calypso/my-sites/customer-home/cards/constants';
@@ -6,22 +5,12 @@ import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 
 const Affiliates = () => {
 	const translate = useTranslate();
-	const hasTranslation = useHasEnTranslation();
 
 	const title = translate( 'Earn with the Automattic Affiliate Program' );
-	const hasTitleTranslation = hasTranslation( 'Earn with the Automattic Affiliate Program' );
-
 	const description = translate(
 		'Get up to 100% payouts with Automattic’s suite of trusted, profitable brands, all with a single dashboard to manage and track your earnings across every product. Promote WordPress.com, WooCommerce, Jetpack, and more to your audience and turn conversions into earnings.'
 	);
-	const hasDescriptionTranslation = hasTranslation(
-		'Get up to 100% payouts with Automattic’s suite of trusted, profitable brands, all with a single dashboard to manage and track your earnings across every product. Promote WordPress.com, WooCommerce, Jetpack, and more to your audience and turn conversions into earnings.'
-	);
 
-	if ( ! hasTitleTranslation || ! hasDescriptionTranslation ) {
-		Affiliates.isDisabled = true;
-		return null;
-	}
 	return (
 		<Task
 			customClass="task__affiliate"

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -88,9 +88,6 @@ const Secondary = ( { cards, siteId, trackFirstCardAsPrimary = false } ) => {
 							onPageSelected={ trackInnerCardImpression }
 						>
 							{ card.map( ( innerCard, innerIndex ) => {
-								if ( CARD_COMPONENTS[ innerCard ].isDisabled === true ) {
-									return null;
-								}
 								return (
 									<SecondaryCard
 										key={ 'my_home_secondary_pager_' + index + '_' + card + '_' + innerIndex }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91551

## Proposed Changes

* This removes unnecessary translations checks added in #91551, now that translations [have been finished](https://translate.wordpress.com/deliverables/overview/14612389).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Steps from #91551 should still apply

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
