### PR TITLE
Plans (Storage): Migrate storage add-on slugs to AddOns data-store

### DIFF
--- a/client/landing/stepper/utils/get-quantity-from-storage-slug.ts
+++ b/client/landing/stepper/utils/get-quantity-from-storage-slug.ts
@@ -1,7 +1,4 @@
-import {
-	FEATURE_50GB_STORAGE_ADD_ON,
-	FEATURE_100GB_STORAGE_ADD_ON,
-} from '@automattic/calypso-products';
+import { AddOns } from '@automattic/data-stores';
 
 /**
  * Since 50GB and 100GB storage addons are essentially a 1GB space product with
@@ -12,9 +9,9 @@ import {
  */
 function getQuantityFromStorageType( storageAddonSlug: string ): number {
 	switch ( storageAddonSlug ) {
-		case FEATURE_50GB_STORAGE_ADD_ON:
+		case AddOns.ADD_ON_50GB_STORAGE:
 			return 50;
-		case FEATURE_100GB_STORAGE_ADD_ON:
+		case AddOns.ADD_ON_100GB_STORAGE:
 			return 100;
 	}
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -3,15 +3,13 @@ import config from '@automattic/calypso-config';
 import {
 	WPCOM_DIFM_LITE,
 	planHasFeature,
-	FEATURE_50GB_STORAGE_ADD_ON,
-	FEATURE_100GB_STORAGE_ADD_ON,
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	PRODUCT_1GB_SPACE,
 	isEcommerce,
 	isDomainTransfer,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
-import { Site } from '@automattic/data-stores';
+import { Site, AddOns } from '@automattic/data-stores';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { isOnboardingGuidedFlow } from '@automattic/onboarding';
@@ -1237,26 +1235,26 @@ export function maybeAddStorageAddonToCart( stepName, defaultDependencies, nextP
 	const selectedStorage = get( getSignupDependencyStore( state ), 'storage', null );
 
 	switch ( selectedStorage ) {
-		case FEATURE_50GB_STORAGE_ADD_ON:
+		case AddOns.ADD_ON_50GB_STORAGE:
 			cartItem.push( {
 				product_slug: PRODUCT_1GB_SPACE,
 				quantity: 50,
 				volume: 1,
-				extra: { feature_slug: FEATURE_50GB_STORAGE_ADD_ON },
+				extra: { feature_slug: AddOns.ADD_ON_50GB_STORAGE },
 			} );
 			recordTracksEvent( 'calypso_signup_storage_add_on_selected', {
-				add_on_slug: FEATURE_50GB_STORAGE_ADD_ON,
+				add_on_slug: AddOns.ADD_ON_50GB_STORAGE,
 			} );
 			break;
-		case FEATURE_100GB_STORAGE_ADD_ON:
+		case AddOns.ADD_ON_100GB_STORAGE:
 			cartItem.push( {
 				product_slug: PRODUCT_1GB_SPACE,
 				quantity: 100,
 				volume: 1,
-				extra: { feature_slug: FEATURE_100GB_STORAGE_ADD_ON },
+				extra: { feature_slug: AddOns.ADD_ON_100GB_STORAGE },
 			} );
 			recordTracksEvent( 'calypso_signup_storage_add_on_selected', {
-				add_on_slug: FEATURE_100GB_STORAGE_ADD_ON,
+				add_on_slug: AddOns.ADD_ON_100GB_STORAGE,
 			} );
 			break;
 	}

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -5,7 +5,6 @@ import {
 	isFreePlan,
 	isPersonalPlan,
 	PLAN_PERSONAL,
-	WPComStorageAddOnSlug,
 	PLAN_FREE,
 	type PlanSlug,
 	UrlFriendlyTermType,
@@ -603,7 +602,7 @@ const PlansFeaturesMain = ( {
 	 * TODO: `handleStorageAddOnClick` no longer necessary. Tracking can be done from the grid components directly.
 	 */
 	const handleStorageAddOnClick = useCallback(
-		( addOnSlug: WPComStorageAddOnSlug ) =>
+		( addOnSlug: AddOns.StorageAddOnSlug ) =>
 			recordTracksEvent( 'calypso_signup_storage_add_on_dropdown_option_click', {
 				add_on_slug: addOnSlug,
 			} ),

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -435,7 +435,9 @@ export const FEATURE_INVENTORY_MGMT = 'inventory-mgmt';
 export const FEATURE_STREAMLINED_CHECKOUT = 'streamlined-checkout';
 export const FEATURE_SELL_60_COUNTRIES = 'sell-60-countries';
 export const FEATURE_SHIPPING_INTEGRATIONS = 'shipping-integrations';
+// TODO clk REMOVE
 export const FEATURE_50GB_STORAGE_ADD_ON = '50gb-storage-add-on';
+// TODO clk REMOVE
 export const FEATURE_100GB_STORAGE_ADD_ON = '100gb-storage-add-on';
 export const FEATURE_UNLIMITED_TRAFFIC = 'unlimited-traffic';
 export const FEATURE_TIERED_STORAGE_PLANS_AVAILABLE = 'tiered-storage-plans-available';

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -435,10 +435,6 @@ export const FEATURE_INVENTORY_MGMT = 'inventory-mgmt';
 export const FEATURE_STREAMLINED_CHECKOUT = 'streamlined-checkout';
 export const FEATURE_SELL_60_COUNTRIES = 'sell-60-countries';
 export const FEATURE_SHIPPING_INTEGRATIONS = 'shipping-integrations';
-// TODO clk REMOVE
-export const FEATURE_50GB_STORAGE_ADD_ON = '50gb-storage-add-on';
-// TODO clk REMOVE
-export const FEATURE_100GB_STORAGE_ADD_ON = '100gb-storage-add-on';
 export const FEATURE_UNLIMITED_TRAFFIC = 'unlimited-traffic';
 export const FEATURE_TIERED_STORAGE_PLANS_AVAILABLE = 'tiered-storage-plans-available';
 export const FEATURE_FAST_SUPPORT_FROM_EXPERTS = 'fast-support-from-experts';

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -85,6 +85,8 @@ export type FeatureList = {
  * features via their `featuresSlugs` prop. So `WPCOM_STORAGE_ADD_ONS` being a list of feature slugs
  * used to individually refer to actual Add-Ons is likely a mistake.
  */
+
+// TODO clk REMOVE
 const WPCOM_STORAGE_ADD_ONS = < const >[
 	FEATURE_50GB_STORAGE_ADD_ON,
 	FEATURE_100GB_STORAGE_ADD_ON,
@@ -105,6 +107,7 @@ export type WPComProductSlug = ( typeof WPCOM_PRODUCTS )[ number ];
 export type WPComPlanSlug = ( typeof WPCOM_PLANS )[ number ];
 export type WPComPlanStorageFeatureSlug = ( typeof WPCOM_PLAN_STORAGE_FEATURES )[ number ];
 export type WPComPurchasableItemSlug = WPComProductSlug | WPComPlanSlug;
+// TODO clk REMOVE
 export type WPComStorageAddOnSlug = ( typeof WPCOM_STORAGE_ADD_ONS )[ number ];
 // WPCOM Space Upgrade Products
 // - Special products that do not yet map to the exported `PRODUCTS_LIST` in @automattic/calypso-products

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -31,8 +31,6 @@ import {
 	type WPCOM_SPACE_UPGRADE_PRODUCTS,
 	type WPCOM_OTHER_PRODUCTS,
 	type JETPACK_ALIAS_LIST,
-	FEATURE_50GB_STORAGE_ADD_ON,
-	FEATURE_100GB_STORAGE_ADD_ON,
 	FEATURE_GROUP_WEBSITE_BUILDING,
 	FEATURE_GROUP_MANAGED_WP_HOSTING,
 	FEATURE_GROUP_ECOMMERCE,
@@ -78,20 +76,6 @@ export type FeatureList = {
 /**
  * WPCOM
  */
-
-/**
- * !WARNING! The following type is suspicious, how there is a reference to an Add-On slug that
- * links to a defined feature slug. Add-Ons have been defined to refer internally to a set of
- * features via their `featuresSlugs` prop. So `WPCOM_STORAGE_ADD_ONS` being a list of feature slugs
- * used to individually refer to actual Add-Ons is likely a mistake.
- */
-
-// TODO clk REMOVE
-const WPCOM_STORAGE_ADD_ONS = < const >[
-	FEATURE_50GB_STORAGE_ADD_ON,
-	FEATURE_100GB_STORAGE_ADD_ON,
-];
-
 const WPCOM_PLAN_STORAGE_FEATURES = < const >[
 	FEATURE_1GB_STORAGE,
 	FEATURE_3GB_STORAGE,
@@ -107,8 +91,7 @@ export type WPComProductSlug = ( typeof WPCOM_PRODUCTS )[ number ];
 export type WPComPlanSlug = ( typeof WPCOM_PLANS )[ number ];
 export type WPComPlanStorageFeatureSlug = ( typeof WPCOM_PLAN_STORAGE_FEATURES )[ number ];
 export type WPComPurchasableItemSlug = WPComProductSlug | WPComPlanSlug;
-// TODO clk REMOVE
-export type WPComStorageAddOnSlug = ( typeof WPCOM_STORAGE_ADD_ONS )[ number ];
+
 // WPCOM Space Upgrade Products
 // - Special products that do not yet map to the exported `PRODUCTS_LIST` in @automattic/calypso-products
 export type WPComSpaceUpgradeProductSlug = ( typeof WPCOM_SPACE_UPGRADE_PRODUCTS )[ number ];

--- a/packages/data-stores/src/add-ons/constants.ts
+++ b/packages/data-stores/src/add-ons/constants.ts
@@ -1,3 +1,5 @@
 export const STORAGE_LIMIT = 200;
 export const ADD_ON_50GB_STORAGE = '50gb-storage-add-on';
 export const ADD_ON_100GB_STORAGE = '100gb-storage-add-on';
+
+export const STORAGE_ADD_ONS = < const >[ ADD_ON_50GB_STORAGE, ADD_ON_100GB_STORAGE ];

--- a/packages/data-stores/src/add-ons/constants.ts
+++ b/packages/data-stores/src/add-ons/constants.ts
@@ -1,1 +1,3 @@
 export const STORAGE_LIMIT = 200;
+export const ADD_ON_50GB_STORAGE = '50gb-storage-add-on';
+export const ADD_ON_100GB_STORAGE = '100gb-storage-add-on';

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-feature-slugs.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-feature-slugs.ts
@@ -5,11 +5,10 @@ import {
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 	WPCOM_FEATURES_CUSTOM_DESIGN,
 	WPCOM_FEATURES_NO_ADVERTS,
-	FEATURE_50GB_STORAGE_ADD_ON,
-	FEATURE_100GB_STORAGE_ADD_ON,
 	PRODUCT_1GB_SPACE,
 } from '@automattic/calypso-products';
 import { useMemo } from '@wordpress/element';
+import { ADD_ON_100GB_STORAGE, ADD_ON_50GB_STORAGE } from '../constants';
 
 /**
  * Returns any relevant feature slugs for a given add-on.
@@ -26,9 +25,9 @@ const useAddOnFeatureSlugs = ( addOnProductSlug: string, quantity?: number ) => 
 				return [ WPCOM_FEATURES_NO_ADVERTS ];
 			case PRODUCT_1GB_SPACE:
 				if ( quantity === 50 ) {
-					return [ FEATURE_50GB_STORAGE_ADD_ON ];
+					return [ ADD_ON_50GB_STORAGE ];
 				} else if ( quantity === 100 ) {
-					return [ FEATURE_100GB_STORAGE_ADD_ON ];
+					return [ ADD_ON_100GB_STORAGE ];
 				}
 			default:
 				return null;

--- a/packages/data-stores/src/add-ons/types.ts
+++ b/packages/data-stores/src/add-ons/types.ts
@@ -1,4 +1,5 @@
 import { TranslateResult } from 'i18n-calypso';
+import { STORAGE_ADD_ONS } from './constants';
 import type { StoreProductSlug } from '../products-list';
 
 export interface AddOnMeta {
@@ -21,3 +22,5 @@ export interface AddOnMeta {
 	checkoutLink?: string;
 	exceedsSiteStorageLimits?: boolean;
 }
+
+export type StorageAddOnSlug = ( typeof STORAGE_ADD_ONS )[ number ];

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -1,8 +1,5 @@
-import type {
-	PlanSlug,
-	WPComPlanStorageFeatureSlug,
-	WPComStorageAddOnSlug,
-} from '@automattic/calypso-products';
+import type { StorageAddOnSlug } from '../add-ons/types';
+import type { PlanSlug, WPComPlanStorageFeatureSlug } from '@automattic/calypso-products';
 
 export const setShowDomainUpsellDialog = ( show: boolean ) =>
 	( {
@@ -20,7 +17,7 @@ export const setSelectedStorageOptionForPlan = ( {
 	planSlug,
 	siteId,
 }: {
-	addOnSlug: WPComStorageAddOnSlug | WPComPlanStorageFeatureSlug;
+	addOnSlug: StorageAddOnSlug | WPComPlanStorageFeatureSlug;
 	planSlug: PlanSlug;
 	siteId?: number | null;
 } ) =>

--- a/packages/data-stores/src/wpcom-plans-ui/types.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/types.ts
@@ -1,8 +1,5 @@
-import type {
-	PlanSlug,
-	WPComPlanStorageFeatureSlug,
-	WPComStorageAddOnSlug,
-} from '@automattic/calypso-products';
+import type { StorageAddOnSlug } from '../add-ons/types';
+import type { PlanSlug, WPComPlanStorageFeatureSlug } from '@automattic/calypso-products';
 
 export interface DomainUpsellDialog {
 	show: boolean;
@@ -12,6 +9,6 @@ type SiteId = string;
 
 export interface SelectedStorageOptionForPlan {
 	[ key: SiteId ]: {
-		[ key in PlanSlug ]: WPComStorageAddOnSlug | WPComPlanStorageFeatureSlug;
+		[ key in PlanSlug ]: StorageAddOnSlug | WPComPlanStorageFeatureSlug;
 	};
 }

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -5,6 +5,7 @@ import {
 	getPlans,
 } from '@automattic/calypso-products';
 import { Gridicon, JetpackLogo } from '@automattic/components';
+import { AddOns } from '@automattic/data-stores';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useMemo } from '@wordpress/element';
@@ -48,7 +49,6 @@ import type {
 	Feature,
 	FeatureGroup,
 	PlanSlug,
-	WPComStorageAddOnSlug,
 	FeatureGroupMap,
 } from '@automattic/calypso-products';
 
@@ -534,7 +534,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 	showUpgradeableStorage: boolean;
 	activeTooltipId: string;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 } > = ( {
 	feature,
 	visibleGridPlans,
@@ -683,7 +683,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 	showUpgradeableStorage: boolean;
 	activeTooltipId: string;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 } > = ( {
 	feature,
 	isHiddenInMobile,
@@ -805,7 +805,7 @@ const FeatureGroup = ( {
 	activeTooltipId: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 	showUpgradeableStorage: boolean;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	featureGroupMap: Partial< FeatureGroupMap >;
 	visibleGridPlans: GridPlan[];
 	planFeatureFootnotes: {

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -2,11 +2,11 @@ import {
 	getPlanClass,
 	isWpcomEnterpriseGridPlan,
 	isFreePlan,
-	type WPComStorageAddOnSlug,
 	type FeatureGroupSlug,
 	FEATURE_GROUP_STORAGE,
 } from '@automattic/calypso-products';
 import { FoldableCard } from '@automattic/components';
+import { AddOns } from '@automattic/data-stores';
 import { useMemo } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -34,7 +34,7 @@ type MobileViewProps = {
 	hideUnavailableFeatures?: boolean;
 	isCustomDomainAllowedOnFreePlan: boolean;
 	isInSignup: boolean;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	paidDomainName?: string;
 	planActionOverrides?: PlanActionOverrides;
 	planUpgradeCreditsApplicable?: number | null;
@@ -185,7 +185,7 @@ type TabletViewProps = {
 	hideUnavailableFeatures?: boolean;
 	isCustomDomainAllowedOnFreePlan: boolean;
 	isInSignup: boolean;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	paidDomainName?: string;
 	planActionOverrides?: PlanActionOverrides;
 	planUpgradeCreditsApplicable?: number | null;

--- a/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-features-list.tsx
@@ -3,9 +3,9 @@ import {
 	isWpcomEnterpriseGridPlan,
 	FEATURE_GROUP_STORAGE,
 	FEATURE_GROUP_ALL_FEATURES,
-	WPComStorageAddOnSlug,
 } from '@automattic/calypso-products';
 import { JetpackLogo } from '@automattic/components';
+import { AddOns } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { usePlansGridContext } from '../../grid-context';
@@ -37,7 +37,7 @@ type PlanFeaturesListProps = {
 		isTableCell?: boolean;
 	};
 	featureGroupSlug?: FeatureGroupSlug;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	showUpgradeableStorage: boolean;
 };
 

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -1,9 +1,5 @@
-import {
-	FEATURE_GROUP_STORAGE,
-	WPComStorageAddOnSlug,
-	getPlanClass,
-	isFreePlan,
-} from '@automattic/calypso-products';
+import { FEATURE_GROUP_STORAGE, getPlanClass, isFreePlan } from '@automattic/calypso-products';
+import { AddOns } from '@automattic/data-stores';
 import clsx from 'clsx';
 import { GridPlan, PlanActionOverrides } from '../../types';
 import BillingTimeframes from './billing-timeframes';
@@ -18,7 +14,7 @@ type SpotlightPlanProps = {
 	currentSitePlanSlug?: string | null;
 	gridPlanForSpotlight?: GridPlan;
 	isInSignup: boolean;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	planActionOverrides?: PlanActionOverrides;
 	planUpgradeCreditsApplicable?: number | null;
 	showUpgradeableStorage: boolean;

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -1,3 +1,4 @@
+import { AddOns } from '@automattic/data-stores';
 import { useMemo } from '@wordpress/element';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -13,7 +14,7 @@ import PlanPrice from './plan-price';
 import PlanTagline from './plan-tagline';
 import PreviousFeaturesIncludedTitle from './previous-features-included-title';
 import TopButtons from './top-buttons';
-import type { FeatureGroupSlug, WPComStorageAddOnSlug } from '@automattic/calypso-products';
+import type { FeatureGroupSlug } from '@automattic/calypso-products';
 
 type TableProps = {
 	currentSitePlanSlug?: string | null;
@@ -22,7 +23,7 @@ type TableProps = {
 	hideUnavailableFeatures?: boolean;
 	isCustomDomainAllowedOnFreePlan: boolean;
 	isInSignup: boolean;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	paidDomainName?: string;
 	planActionOverrides?: PlanActionOverrides;
 	planUpgradeCreditsApplicable?: number | null;

--- a/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
@@ -1,8 +1,4 @@
-import {
-	type PlanSlug,
-	WPComStorageAddOnSlug,
-	isWpcomEnterpriseGridPlan,
-} from '@automattic/calypso-products';
+import { type PlanSlug, isWpcomEnterpriseGridPlan } from '@automattic/calypso-products';
 import { AddOns } from '@automattic/data-stores';
 import { usePlansGridContext } from '../../../../grid-context';
 import { ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE } from '../constants';
@@ -10,7 +6,7 @@ import StorageDropdown from './storage-dropdown';
 import StorageFeatureLabel from './storage-feature-label';
 
 type Props = {
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	showUpgradeableStorage: boolean;
 	planSlug: PlanSlug;
 	options?: {

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
@@ -9,29 +9,24 @@ import DropdownOption from '../../../dropdown-option';
 import useAvailableStorageOptions from '../hooks/use-available-storage-dropdown-options';
 import useDefaultStorageOption from '../hooks/use-default-storage-option';
 import useStorageStringFromFeature from '../hooks/use-storage-string-from-feature';
-import type {
-	PlanSlug,
-	WPComPlanStorageFeatureSlug,
-	WPComStorageAddOnSlug,
-} from '@automattic/calypso-products';
-import type { AddOnMeta } from '@automattic/data-stores';
+import type { PlanSlug, WPComPlanStorageFeatureSlug } from '@automattic/calypso-products';
 
 type StorageDropdownProps = {
 	planSlug: PlanSlug;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	priceOnSeparateLine?: boolean;
 };
 
 type StorageDropdownOptionProps = {
 	planSlug: PlanSlug;
 	price?: string;
-	storageSlug: WPComStorageAddOnSlug | WPComPlanStorageFeatureSlug;
+	storageSlug: AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug;
 	isLargeCurrency?: boolean;
 	priceOnSeparateLine?: boolean;
 };
 
 const getStorageOptionPrice = (
-	storageAddOnsForPlan: ( AddOnMeta | null )[] | null,
+	storageAddOnsForPlan: ( AddOns.AddOnMeta | null )[] | null,
 	storageOptionSlug: string
 ) => {
 	return storageAddOnsForPlan?.find(
@@ -147,7 +142,7 @@ const StorageDropdown = ( {
 	};
 
 	const handleOnChange = useCallback(
-		( { selectedItem }: { selectedItem: { key: WPComStorageAddOnSlug } } ) => {
+		( { selectedItem }: { selectedItem: { key: AddOns.StorageAddOnSlug } } ) => {
 			const addOnSlug = selectedItem?.key;
 
 			if ( addOnSlug ) {

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-available-storage-dropdown-options.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-available-storage-dropdown-options.ts
@@ -1,6 +1,5 @@
 import {
 	PlanSlug,
-	WPComStorageAddOnSlug,
 	WPComPlanStorageFeatureSlug,
 } from '@automattic/calypso-products';
 import { AddOns } from '@automattic/data-stores';
@@ -20,7 +19,7 @@ interface Props {
  */
 const useAvailableStorageDropdownOptions = ( {
 	planSlug,
-}: Props ): ( WPComStorageAddOnSlug | WPComPlanStorageFeatureSlug )[] | null => {
+}: Props ): ( AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug )[] | null => {
 	const { siteId, gridPlansIndex } = usePlansGridContext();
 	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId } );
 
@@ -39,7 +38,7 @@ const useAvailableStorageDropdownOptions = ( {
 					 */
 					...( ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE.includes( planSlug ) && availableStorageAddOns
 						? availableStorageAddOns.map(
-								( addOn ) => addOn?.featureSlugs?.[ 0 ] as WPComStorageAddOnSlug
+								( addOn ) => addOn?.featureSlugs?.[ 0 ] as AddOns.StorageAddOnSlug
 						  )
 						: [] ),
 			  ]

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-available-storage-dropdown-options.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-available-storage-dropdown-options.ts
@@ -1,7 +1,4 @@
-import {
-	PlanSlug,
-	WPComPlanStorageFeatureSlug,
-} from '@automattic/calypso-products';
+import { PlanSlug, WPComPlanStorageFeatureSlug } from '@automattic/calypso-products';
 import { AddOns } from '@automattic/data-stores';
 import { useMemo } from '@wordpress/element';
 import { usePlansGridContext } from '../../../../grid-context';

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-default-storage-option.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-default-storage-option.ts
@@ -1,6 +1,5 @@
 import {
 	type PlanSlug,
-	type WPComStorageAddOnSlug,
 	type WPComPlanStorageFeatureSlug,
 } from '@automattic/calypso-products';
 import { AddOns } from '@automattic/data-stores';
@@ -19,7 +18,7 @@ type Props = {
  */
 export default function useDefaultStorageOption( {
 	planSlug,
-}: Props ): WPComStorageAddOnSlug | WPComPlanStorageFeatureSlug | undefined {
+}: Props ): AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug | undefined {
 	const { siteId, gridPlansIndex } = usePlansGridContext();
 	const {
 		features: { storageFeature },
@@ -28,6 +27,6 @@ export default function useDefaultStorageOption( {
 	const purchasedAddOn = storageAddOns?.find( ( storageAddOn ) => storageAddOn?.purchased );
 
 	return purchasedAddOn && ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE.includes( planSlug )
-		? ( purchasedAddOn?.featureSlugs?.[ 0 ] as WPComStorageAddOnSlug )
+		? ( purchasedAddOn?.featureSlugs?.[ 0 ] as AddOns.StorageAddOnSlug )
 		: ( storageFeature?.getSlug() as WPComPlanStorageFeatureSlug );
 }

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-default-storage-option.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-default-storage-option.ts
@@ -1,7 +1,4 @@
-import {
-	type PlanSlug,
-	type WPComPlanStorageFeatureSlug,
-} from '@automattic/calypso-products';
+import { type PlanSlug, type WPComPlanStorageFeatureSlug } from '@automattic/calypso-products';
 import { AddOns } from '@automattic/data-stores';
 import { usePlansGridContext } from '../../../../grid-context';
 import { ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE } from '../constants';

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-storage-string-from-feature.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-storage-string-from-feature.ts
@@ -4,8 +4,6 @@ import {
 	FEATURE_13GB_STORAGE,
 	FEATURE_50GB_STORAGE,
 	FEATURE_200GB_STORAGE,
-	FEATURE_50GB_STORAGE_ADD_ON,
-	FEATURE_100GB_STORAGE_ADD_ON,
 	FEATURE_P2_3GB_STORAGE,
 	FEATURE_P2_13GB_STORAGE,
 	PRODUCT_1GB_SPACE,
@@ -13,7 +11,7 @@ import {
 	WPComStorageAddOnSlug,
 	WPComPlanStorageFeatureSlug,
 } from '@automattic/calypso-products';
-import { Purchases } from '@automattic/data-stores';
+import { Purchases, AddOns } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE } from '../constants';
 
@@ -62,7 +60,7 @@ const useStorageStringFromFeature = ( {
 		// TODO: Remove when upgradeable storage is released in plans 2023
 		case FEATURE_200GB_STORAGE:
 			return translate( '200 GB' );
-		case FEATURE_50GB_STORAGE_ADD_ON:
+		case AddOns.ADD_ON_50GB_STORAGE:
 			/**
 			 * Displayed string is: purchased storage + default 50GB storage + Add-On
 			 * TODO: the default 50GB should be coming from plan context, not hardcoded here
@@ -72,7 +70,7 @@ const useStorageStringFromFeature = ( {
 					quantity: purchasedQuantityTotal + 50 + 50,
 				},
 			} );
-		case FEATURE_100GB_STORAGE_ADD_ON:
+		case AddOns.ADD_ON_100GB_STORAGE:
 			/**
 			 * Displayed string is: purchased storage + default 50GB storage + Add-On
 			 * TODO: the default 50GB should be coming from plan context, not hardcoded here

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-storage-string-from-feature.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-storage-string-from-feature.ts
@@ -8,7 +8,6 @@ import {
 	FEATURE_P2_13GB_STORAGE,
 	PRODUCT_1GB_SPACE,
 	PlanSlug,
-	WPComStorageAddOnSlug,
 	WPComPlanStorageFeatureSlug,
 } from '@automattic/calypso-products';
 import { Purchases, AddOns } from '@automattic/data-stores';
@@ -20,7 +19,7 @@ const useStorageStringFromFeature = ( {
 	siteId,
 	planSlug,
 }: {
-	storageSlug?: WPComStorageAddOnSlug | WPComPlanStorageFeatureSlug;
+	storageSlug?: AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug;
 	siteId?: null | number | string;
 	planSlug: PlanSlug;
 } ) => {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -4,7 +4,6 @@ import type {
 	UrlFriendlyTermType,
 	PlanSlug,
 	FeatureList,
-	WPComStorageAddOnSlug,
 	FeatureObject,
 	FeatureGroupMap,
 	Feature,
@@ -105,7 +104,7 @@ export interface CommonGridProps {
 	isInSignup: boolean;
 	isInAdmin: boolean;
 	isReskinned?: boolean;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	currentSitePlanSlug?: string | null;
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
 	planActionOverrides?: PlanActionOverrides;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Follow up to https://github.com/Automattic/wp-calypso/pull/91937 to remove `WPComStorageAddOnSlug` type (and associated slugs) from `@automattic/calypso-products` and redefine the slugs and types in the AddOns data-store `@automattic/data-stores`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of a series of refactors on the storage add-ons implementation. This will allow us next to extend the add-ons store slugs to re-index the structure into a key-value form. At that point, we won't be conflating add-on slugs in the `featureSlugs` array (which was put in place to reference feature slugs associated with a site or plan).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure storage add-ons work as previously - `/start/plans`
* Ensure current plan in `/plans/[ site ]` is upgradeable with storage once (upgrade , then revisit `/plans` - it should show the upgraded volume along with additional cost)
* Ensure storage is automatically added to the cart when in query param e.g. `/start/business/?storage=50gb-storage-add-on`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
