### PR TITLE
A4A: Hide social login links when coming from A4A and is a referral client Part 2

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -537,7 +537,11 @@ class Login extends Component {
 
 			if ( isA4AOAuth2Client( oauth2Client ) ) {
 				headerText = translate(
-					'Howdy! Log in to Automattic for Agencies with your WordPress.com account.'
+					'Howdy! Log in to Automattic for Agencies with your WordPress.com{{nbsp/}}account.',
+					{
+						components: { nbsp: <>&nbsp;</> },
+						comment: 'The {{nbsp/}} is a non-breaking space',
+					}
 				);
 				preHeader = (
 					<div>

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -770,7 +770,9 @@ export class LoginForm extends Component {
 			isA4AOAuth2Client( oauth2Client ) &&
 			currentQuery &&
 			currentQuery.redirect_to &&
-			currentQuery.redirect_to.includes( '/client/' );
+			( currentQuery.redirect_to.includes( '/client/' ) ||
+				currentQuery.redirect_to.includes( '%2Fclient%2F' ) ||
+				currentQuery.redirect_to.includes( '%2fclient%2f' ) );
 
 		const signupUrl = this.getSignupUrl();
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -770,9 +770,7 @@ export class LoginForm extends Component {
 			isA4AOAuth2Client( oauth2Client ) &&
 			currentQuery &&
 			currentQuery.redirect_to &&
-			( currentQuery.redirect_to.includes( '/client/' ) ||
-				currentQuery.redirect_to.includes( '%2Fclient%2F' ) ||
-				currentQuery.redirect_to.includes( '%2fclient%2f' ) );
+			decodeURIComponent( currentQuery.redirect_to ).includes( '/client/' );
 
 		const signupUrl = this.getSignupUrl();
 


### PR DESCRIPTION
Related to #

## Proposed Changes

* This PR extends https://github.com/Automattic/wp-calypso/pull/92012 to also compare `/client/` url with encoded slashes 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* See https://github.com/Automattic/wp-calypso/pull/92012

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
