### PR TITLE
Notifications: update readme to mention the new wordpress.com URL

### DIFF
--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -2,7 +2,7 @@
 
 The _**notifications panel**_ (also known as "masterbar notifications" and "the bell notifications") is a cross-environment app that runs directly inside of Calypso and in an `iframe` on WordPress.com sites which aren't Calypso.
 
-This module is where the code for the notifications panel lives. Calypso views are imported as normal `node` imports while the `iframe` version is served from `https://widgets.wp.com/notes` or `https://widgets.wp.com/notifications`.
+This module is where the code for the notifications panel lives. Calypso views are imported as normal `node` imports while the `iframe` version is served from `https://wordpress.com/widgets/notifications/` or from the legacy URL `https://widgets.wp.com/notifications/`.
 
 This code is developed in the calypso monorepo at <https://github.com/Automattic/wp-calypso/tree/trunk/apps/notifications>.
 


### PR DESCRIPTION
Implementing a suggestion by @eoigal 🙂 and updating the README for Notifications. It mentions the new preferred URL `wordpress.com/widgets/notifications` and removes mention of the `widgets.wp.com/notes` URL.

The `/notes` URL is a reminder that we should remove the `/notes` app completely. It's not related to this React version of Notifications, but actually it ships a 10 years old version written with jQuery and Backbone. And it no longer works at all today because the `/notifications` REST API has changed in the meantime.