### PR TITLE
Square Payments: Add breakpoints for landing responsiveness

### DIFF
--- a/client/start-with/square-payments/index.tsx
+++ b/client/start-with/square-payments/index.tsx
@@ -42,10 +42,13 @@ export const StartWithSquarePayments: React.FC = () => {
 					</Button>
 				</div>
 				<div className="right-column">
-					<img src={ DotcomWooSquareImage } width={ 500 } alt="" />
+					<img
+						src={ DotcomWooSquareImage }
+						alt={ translate( 'WordPress.com, Square and Woocommerce partneship logo' ) }
+					/>
 				</div>
 			</div>
-			<div className="footer">
+			<footer className="footer">
 				<div className="text">{ translate( 'Trusted by 160 million worldwide' ) }</div>
 				<div className="brands">
 					<div className="brands-container">
@@ -61,7 +64,7 @@ export const StartWithSquarePayments: React.FC = () => {
 						<img src={ CondeNast } alt={ translate( 'Conde Nast Logo' ) } />
 					</div>
 				</div>
-			</div>
+			</footer>
 		</div>
 	);
 };

--- a/client/start-with/style.scss
+++ b/client/start-with/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/breakpoints";
 
 .layout.is-section-start-with {
 	height: 100%;
@@ -119,7 +120,7 @@
 	}
 	// stylelint-enable declaration-property-unit-allowed-list
 
-	@media (max-width: 1380px) {
+	@media (max-width: $break-huge) {
 		.container {
 			.content {
 				max-width: calc(100vw - 100px);
@@ -151,7 +152,7 @@
 	}
 
 
-	@media (max-width: 1192px) {
+	@media (max-width: $break-wide) {
 		.container {
 			.footer {
 				.text {
@@ -167,7 +168,7 @@
 		}
 	}
 
-	@media (max-width: 1060px) {
+	@media (max-width: $break-xlarge) {
 		.container {
 			.footer {
 				.text {
@@ -183,7 +184,7 @@
 		}
 	}
 
-	@media (max-width: 980px) {
+	@media (max-width: $break-large) {
 		.container {
 			.content {
 				flex-direction: column-reverse;
@@ -221,7 +222,7 @@
 		}
 	}
 
-	@media (max-width: 720px) {
+	@media (max-width: $break-medium) {
 		.container {
 			.content {
 				gap: 5px;
@@ -257,7 +258,7 @@
 		}
 	}
 
-	@media (max-height: 740px) {
+	@media (max-height: $break-medium) {
 		.container .content {
 			.left-column {
 				padding-top: 60px;

--- a/client/start-with/style.scss
+++ b/client/start-with/style.scss
@@ -24,13 +24,11 @@
 		}
 	}
 
-
 	// stylelint-disable declaration-property-unit-allowed-list
 	.container {
 		height: 100%;
 		display: grid;
-		align-items: center;
-		justify-items: center;
+		place-items: center;
 		grid-template-rows: 1fr 128px;
 
 		.content {
@@ -54,6 +52,7 @@
 					color: #000;
 					font-family: $font-sf-pro-display;
 					font-size: $font-body;
+					text-wrap: pretty;
 					font-style: normal;
 					line-height: 162.5%;
 					width: 530px;
@@ -74,6 +73,10 @@
 
 			.right-column {
 				flex-shrink: 0;
+
+				img {
+					width: 500px;
+				}
 			}
 		}
 
@@ -105,7 +108,6 @@
 
 
 				.brands-container {
-					width: 1380px;
 					padding: 25px 0;
 					display: flex;
 					justify-content: center;
@@ -117,4 +119,154 @@
 	}
 	// stylelint-enable declaration-property-unit-allowed-list
 
+	@media (max-width: 1380px) {
+		.container {
+			.content {
+				max-width: calc(100vw - 100px);
+				.left-column {
+					.title {
+						font-size: $font-headline-large;
+					}
+				}
+
+				.right-column {
+					img {
+						width: 400px;
+					}
+				}
+			}
+
+			.footer {
+				.text {
+					width: 1182px;
+				}
+
+				.brands .brands-container {
+					img:nth-last-of-type(-n+1) {
+						display: none;
+					}
+				}
+			}
+		}
+	}
+
+
+	@media (max-width: 1192px) {
+		.container {
+			.footer {
+				.text {
+					width: 1020px;
+				}
+
+				.brands .brands-container {
+					img:nth-last-of-type(-n+2) {
+						display: none;
+					}
+				}
+			}
+		}
+	}
+
+	@media (max-width: 1060px) {
+		.container {
+			.footer {
+				.text {
+					width: 884px;
+				}
+
+				.brands .brands-container {
+					img:nth-last-of-type(-n+3) {
+						display: none;
+					}
+				}
+			}
+		}
+	}
+
+	@media (max-width: 980px) {
+		.container {
+			.content {
+				flex-direction: column-reverse;
+				align-items: center;
+				gap: 100px;
+				align-self: start;
+
+				.left-column {
+					padding-bottom: 20px;
+
+					.title {
+						width: calc(100vw - 100px);
+						font-size: $font-headline-medium;
+					}
+
+					.subtitle {
+						width: calc(100vw - 100px);
+					}
+				}
+
+				.right-column {
+					padding-top: 100px;
+				}
+			}
+
+			.footer {
+				.text {
+					width: 708px;
+				}
+
+				.brands .brands-container {
+					gap: 20px;
+				}
+			}
+		}
+	}
+
+	@media (max-width: 720px) {
+		.container {
+			.content {
+				gap: 5px;
+
+				.left-column {
+					gap: 10px;
+
+					.title {
+						font-size: $font-headline-small;
+					}
+
+					img {
+						width: 250px;
+					}
+				}
+
+				.right-column {
+					padding-top: 30px;
+				}
+			}
+
+			.footer {
+				.text {
+					width: 330px;
+				}
+
+				.brands .brands-container {
+					img:nth-last-of-type(-n+6) {
+						display: none;
+					}
+				}
+			}
+		}
+	}
+
+	@media (max-height: 740px) {
+		.container .content {
+			.left-column {
+				padding-top: 60px;
+			}
+
+			.right-column {
+				display: none;
+			}
+		}
+	}
 }
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7781

## Proposed Changes

Update the responsiveness strategy for the landing page for Square Payments partnership:

- The main content (text and image) will have a smaller width as the page size decreases
  - Until it gets to a point where the image will go to the top of the page 
- The brands on the footer will have less items as the page size decreases
- For cases where the page height is smaller, the image will be hidden


https://github.com/Automattic/wp-calypso/assets/5039531/b3fb54fd-1e64-4fd2-955a-c0c3f395ce0f



## Why are these changes being made?
To make the landing page adapt to various sizes of screens

## Testing Instructions


* Go to `/start-with/square-payments`
* Open the developer tools and resize the screen to different sizes
* Guarantee the main information (text and CTA) are always visible independent of screen size

