### PR TITLE
Square Payments: redirect all non-existing routes to a not found page

### DIFF
--- a/client/start-with/controller.tsx
+++ b/client/start-with/controller.tsx
@@ -1,5 +1,7 @@
 import config from '@automattic/calypso-config';
 import page, { Context } from '@automattic/calypso-router';
+import { translate } from 'i18n-calypso';
+import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import { StartWithSquarePayments } from './square-payments';
 
@@ -18,7 +20,22 @@ export function startWithSquarePaymentsContext( context: Context, next: () => vo
 	next();
 }
 
-export function redirectToSquarePayments(): void {
-	page.redirect( '/start-with/square-payments' );
-	return;
-}
+export const notFound = ( context: Context, next: () => void ) => {
+	if ( ! config.isEnabled( 'start-with/square-payments' ) ) {
+		page.redirect( '/' );
+		return;
+	}
+
+	context.primary = (
+		<EmptyContent
+			className="content-404"
+			illustration="/calypso/images/illustrations/illustration-404.svg"
+			title={ translate( 'Uh oh. Page not found.' ) }
+			line={ translate( "Sorry, the page you were looking for doesn't exist or has been moved." ) }
+			action={ translate( 'Return Home' ) }
+			actionURL="/"
+		/>
+	);
+
+	next();
+};

--- a/client/start-with/index.web.ts
+++ b/client/start-with/index.web.ts
@@ -6,6 +6,6 @@ import {
 } from 'calypso/start-with/controller';
 
 export default function () {
-	page( '/start-with', redirectToSquarePayments );
 	page( '/start-with/square-payments', startWithSquarePaymentsContext, makeLayout, clientRender );
+	page( '/start-with*', redirectToSquarePayments );
 }

--- a/client/start-with/index.web.ts
+++ b/client/start-with/index.web.ts
@@ -1,11 +1,8 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import {
-	redirectToSquarePayments,
-	startWithSquarePaymentsContext,
-} from 'calypso/start-with/controller';
+import { notFound, startWithSquarePaymentsContext } from 'calypso/start-with/controller';
 
 export default function () {
 	page( '/start-with/square-payments', startWithSquarePaymentsContext, makeLayout, clientRender );
-	page( '/start-with*', redirectToSquarePayments );
+	page( '/start-with*', notFound, makeLayout, clientRender );
 }


### PR DESCRIPTION
## Proposed Changes

Send all routes starting with `/start-with` to `/start-with/square-payments`

## Why are these changes being made?
To catch all routes pointing to start-with

## Testing Instructions

* Go to `/start-with/square-payments` and check if the landing page is shown
* Go to `/start-with` and verify if it shows a not found page
* Go to `/start-with/anything` and verify it shows a not found page


| Landing page  | Not found |
| ------------- | ------------- |
|![CleanShot 2024-06-21 at 13 01 59@2x](https://github.com/Automattic/wp-calypso/assets/5039531/7e218036-4d8b-4099-8e85-19dff0afebf9)|![CleanShot 2024-06-21 at 12 59 53@2x](https://github.com/Automattic/wp-calypso/assets/5039531/e1419395-63c2-42bf-b36c-ee7ce861dce7)|


