### PR TITLE
A4A: Fix A4A client redirect when user already login.

### DIFF
--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -14,7 +14,11 @@ function isExternalUrl( url ) {
 
 	try {
 		const urlObject = new URL( url );
-		const allowedHostname = [ 'wordpress.com', 'subscribe.wordpress.com' ];
+		const allowedHostname = [
+			'wordpress.com',
+			'subscribe.wordpress.com',
+			'agencies.automattic.com',
+		];
 
 		if ( allowedHostname.includes( urlObject.hostname ) && urlObject.protocol === 'https:' ) {
 			return false;


### PR DESCRIPTION
This pull request addresses an issue where the Magic link for client payment requests does not redirect to the correct page when the user is already signed in. Instead, the user gets redirected to https://wordpress.com/sites or https://wordpress.

Closes https://github.com/Automattic/jetpack-genesis/issues/406

## Proposed Changes

* Add the A4A hostname as an internal host so the login redirect respects the `redirect_to` parameter for A4A-related flows.

## Why are these changes being made?

* This is important to have a smooth client checkout experience.

## Testing Instructions


* Generate a magic link by referring products to the client.
* You should receive an email with the magic link.
* Before opening the link. Open incognito first and log in to your client account.
* Now spin up this branch (`yarn start`)
* Extract the `redirect_to` from the magic URL. You might need to decode the URL.
* Replace the `https://wordpress.com` to `http://calypso.localhost:3000`.
* Paste it to the browser where you have an existing user session.
* Confirm that your URL redirects you to the checkout page.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
