### PR TITLE
Fix: Remove a4a social login

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -31,11 +31,7 @@ import {
 	canDoMagicLogin,
 	getLoginLinkPageUrl,
 } from 'calypso/lib/login';
-import {
-	isCrowdsignalOAuth2Client,
-	isWooOAuth2Client,
-	isA4AOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -73,7 +69,7 @@ import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import ErrorNotice from './error-notice';
 import SocialLoginForm from './social';
-
+import { isA4AReferralClient } from './utils/is-a4a-referral-for-client';
 import './login-form.scss';
 
 export class LoginForm extends Component {
@@ -766,11 +762,10 @@ export class LoginForm extends Component {
 		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
 		const isCoreProfilerLostPasswordFlow = isWooCoreProfilerFlow && currentQuery.lostpassword_flow;
-		const isFromAutomatticForAgenciesReferralClient =
-			isA4AOAuth2Client( oauth2Client ) &&
-			currentQuery &&
-			currentQuery.redirect_to &&
-			decodeURIComponent( currentQuery.redirect_to ).includes( '/client/' );
+		const isFromAutomatticForAgenciesReferralClient = isA4AReferralClient(
+			currentQuery,
+			oauth2Client
+		);
 
 		const signupUrl = this.getSignupUrl();
 

--- a/client/blocks/login/utils/is-a4a-referral-for-client.js
+++ b/client/blocks/login/utils/is-a4a-referral-for-client.js
@@ -1,0 +1,14 @@
+import { getQueryArg } from '@wordpress/url';
+import { isA4AOAuth2Client } from 'calypso/lib/oauth2-clients';
+
+export function isA4AReferralClient( query, oauth2Client ) {
+	if ( ! isA4AOAuth2Client( oauth2Client ) ) {
+		return false;
+	}
+
+	const redirectTo = decodeURI( query.redirect_to );
+	// redirectTo has `redirect_uri` encoded inside it.
+	const params = getQueryArg( redirectTo, 'redirect_uri' );
+
+	return params.includes( '/client/' );
+}

--- a/client/blocks/login/utils/is-a4a-referral-for-client.js
+++ b/client/blocks/login/utils/is-a4a-referral-for-client.js
@@ -2,13 +2,12 @@ import { getQueryArg } from '@wordpress/url';
 import { isA4AOAuth2Client } from 'calypso/lib/oauth2-clients';
 
 export function isA4AReferralClient( query, oauth2Client ) {
-	if ( ! isA4AOAuth2Client( oauth2Client ) ) {
+	if ( ! isA4AOAuth2Client( oauth2Client ) || ! query?.redirect_to ) {
 		return false;
 	}
 
 	const redirectTo = decodeURI( query.redirect_to );
 	// redirectTo has `redirect_uri` encoded inside it.
-	const params = getQueryArg( redirectTo, 'redirect_uri' );
-
-	return params.includes( '/client/' );
+	const redirectUri = getQueryArg( redirectTo, 'redirect_uri' );
+	return redirectUri?.includes( '/client/' );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR improves https://github.com/Automattic/wp-calypso/pull/92012

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/wp-calypso/pull/92012

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See https://github.com/Automattic/wp-calypso/pull/92012

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
