### PR TITLE
Fix process variable not available

### DIFF
--- a/packages/create-calypso-config/src/index.ts
+++ b/packages/create-calypso-config/src/index.ts
@@ -71,7 +71,7 @@ const isEnabled =
 	( feature: string ): boolean => {
 		// Feature flags activated from environment variables.
 		if (
-			process.env.ACTIVE_FEATURE_FLAGS &&
+			process?.env?.ACTIVE_FEATURE_FLAGS &&
 			typeof process.env.ACTIVE_FEATURE_FLAGS === 'string'
 		) {
 			const env_active_feature_flags = process.env.ACTIVE_FEATURE_FLAGS?.split( ',' );

--- a/packages/create-calypso-config/src/index.ts
+++ b/packages/create-calypso-config/src/index.ts
@@ -71,6 +71,7 @@ const isEnabled =
 	( feature: string ): boolean => {
 		// Feature flags activated from environment variables.
 		if (
+			typeof process !== 'undefined' &&
 			process?.env?.ACTIVE_FEATURE_FLAGS &&
 			typeof process.env.ACTIVE_FEATURE_FLAGS === 'string'
 		) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/91908/files#r1648923043

## Proposed Changes

* Fix issue with `process` variable not available in some environments.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* With https://github.com/Automattic/wp-calypso/pull/91908 an issue was introduced and reported [here](https://github.com/Automattic/wp-calypso/pull/91908/files#r1648923043).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
