### PR TITLE
Square Payments: Enable FE flag

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -120,7 +120,7 @@
 		"readymade-templates/showcase": false,
 		"redirect-fallback-browsers": true,
 		"safari-idb-mitigation": true,
-		"start-with/square-payments": false,
+		"start-with/square-payments": true,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/config/production.json
+++ b/config/production.json
@@ -161,7 +161,7 @@
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
-		"start-with/square-payments": false,
+		"start-with/square-payments": true,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -157,6 +157,7 @@
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
+		"start-with/square-payments": true,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,


### PR DESCRIPTION
## Proposed Changes

Enable the `start-with/square-payments` flag.

## Why are these changes being made?

To make the changes visible for all users.

## Testing Instructions

* Go to `/start-with/square-payments`
* You should be able to see the landing page
* Currently you should be redirected to `/` when trying to access this page
