### PR TITLE
Subscribers Page: Use custom icon and fix padding right

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_UNLIMITED_SUBSCRIBERS } from '@automattic/calypso-products';
+import { Gridicon } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { AddSubscriberForm } from '@automattic/subscriber';
@@ -106,20 +107,24 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 			{ ! isUploading && isImportInProgress && ! hasStaleImportJobs && (
 				<Notice
 					className="add-subscribers-modal__notice"
+					icon={ <Gridicon icon="info" /> }
 					isCompact
 					isReskinned
 					status="is-info"
 					showDismiss={ false }
 				>
-					{ translate(
-						'Your subscribers are being imported. This may take a few minutes. You can close this window and we’ll notify you when the import is complete.'
-					) }
+					<span className="add-subscribers-modal__notice-text">
+						{ translate(
+							'Your subscribers are being imported. This may take a few minutes. You can close this window and we’ll notify you when the import is complete.'
+						) }
+					</span>
 				</Notice>
 			) }
 
 			{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
 				<Notice
 					className="add-subscribers-modal__notice"
+					icon={ <Gridicon icon="notice" /> }
 					isCompact
 					isReskinned
 					status="is-warning"

--- a/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
@@ -66,6 +66,10 @@
 	.add-subscribers-modal__notice {
 		margin-bottom: 24px !important;
 
+		.notice__content {
+			padding-right: 13px;
+		}
+
 		.add-subscribers-modal__notice-text {
 			margin-right: 6px;
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/85666

## Proposed Changes

* Use custom icons on the import notices
* Fix padding-right on the import notice

<img width="567" alt="Screenshot 2024-06-21 at 12 55 06" src="https://github.com/Automattic/wp-calypso/assets/3113712/a58566ca-b2b4-4ec9-92e2-54eb325f95df">

<img width="565" alt="Screenshot 2024-06-21 at 13 38 36" src="https://github.com/Automattic/wp-calypso/assets/3113712/ae6a39e8-50e4-45a6-9be5-c4aee875ea52">

## Why are these changes being made?

* The default icons on the Notice component have a white bubble as a background, so using a custom icon fixes the issue.

## Testing Instructions

* See instructions here https://github.com/Automattic/wp-calypso/pull/91767#issue-2351507143
* You should see the notice with the updated icon and padding-right

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
