### PR TITLE
A4A-Partner Directory: Add to step 3 a publish CTA button

### DIFF
--- a/client/a8c-for-agencies/data/partner-directory/use-submit-partner-directory-application.ts
+++ b/client/a8c-for-agencies/data/partner-directory/use-submit-partner-directory-application.ts
@@ -33,6 +33,7 @@ function mutationSubmitPartnerDirectoryApplication(
 				note,
 			} ) ),
 			feedback_url: application.feedbackUrl,
+			is_published: application.isPublished,
 		},
 	} );
 }

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
@@ -29,12 +29,11 @@ export default function useDetailsForm( { initialFormData }: Props ) {
 		(): boolean =>
 			formData.name.length > 0 &&
 			formData.email.length > 0 &&
-			formData.website.length > 0 &&
+			validateURL( formData.website ) &&
 			formData.bioDescription.length > 0 &&
-			formData.logoUrl.length > 0 &&
 			validateURL( formData.logoUrl ) &&
-			formData.landingPageUrl.length > 0 &&
-			validateURL( formData.landingPageUrl ) &&
+			// landingPageUrl is optional
+			( formData.landingPageUrl.length === 0 || validateURL( formData.landingPageUrl ) ) &&
 			formData.country?.length > 0 &&
 			formData.industry.length > 0 &&
 			formData.services.length > 0 &&

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { AgencyDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
+import { validateURL } from '../../utils/tools';
 
 type Props = {
 	initialFormData?: AgencyDetails | null;
@@ -31,6 +32,9 @@ export default function useDetailsForm( { initialFormData }: Props ) {
 			formData.website.length > 0 &&
 			formData.bioDescription.length > 0 &&
 			formData.logoUrl.length > 0 &&
+			validateURL( formData.logoUrl ) &&
+			formData.landingPageUrl.length > 0 &&
+			validateURL( formData.landingPageUrl ) &&
 			formData.country?.length > 0 &&
 			formData.industry.length > 0 &&
 			formData.services.length > 0 &&

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -55,7 +55,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 		);
 	}, [ page, reduxDispatch, translate ] );
 
-	const { formData, setFormData, isValidFormData } = useDetailsForm( {
+	const { formData, setFormData } = useDetailsForm( {
 		initialFormData,
 	} );
 	const { countryOptions } = useCountryList();
@@ -210,7 +210,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			</div>
 
 			<div className="partner-directory-agency-cta__footer">
-				<Button primary onClick={ onSubmit } disabled={ ! isValidFormData || isSubmitting }>
+				<Button primary onClick={ onSubmit } disabled={ isSubmitting }>
 					{ translate( 'Save public profile' ) }
 				</Button>
 			</div>

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
@@ -1,18 +1,10 @@
 import { useCallback, useMemo, useState } from 'react';
 import { AgencyDirectoryApplication, DirectoryApplicationType } from '../../types';
+import { validateURL, areURLsUnique } from '../../utils/tools';
 
 type Props = {
 	initialFormData?: AgencyDirectoryApplication | null;
 };
-
-function validateURL( url: string ) {
-	return /^(https?:\/\/)?([a-z0-9-]+\.)*[a-z0-9-]+\.[a-z]+(:[0-9]+)?(\/[a-z0-9-]*)*$/.test( url );
-}
-
-function areURLsUnique( urls: string[] ) {
-	const urlSet = new Set( urls );
-	return urlSet.size === urls.length;
-}
 
 export default function useExpertiseForm( { initialFormData }: Props ) {
 	const [ formData, setFormData ] = useState< AgencyDirectoryApplication >(

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
@@ -25,16 +25,9 @@ export default function useSubmitForm( { formData, onSubmitSuccess, onSubmitErro
 		}
 	);
 
-	const onSubmit = useCallback(
-		( application?: AgencyDirectoryApplication ) => {
-			if ( application ) {
-				submit( application );
-			} else {
-				formData && submit( formData );
-			}
-		},
-		[ formData, submit ]
-	);
+	const onSubmit = useCallback( () => {
+		formData && submit( formData );
+	}, [ formData, submit ] );
 
 	return {
 		onSubmit,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-submit-form.ts
@@ -4,7 +4,7 @@ import { Agency } from 'calypso/state/a8c-for-agencies/types';
 import { AgencyDirectoryApplication } from '../../types';
 
 type Props = {
-	formData: AgencyDirectoryApplication;
+	formData: AgencyDirectoryApplication | null;
 	onSubmitSuccess?: ( data: Agency ) => void;
 	onSubmitError?: () => void;
 };
@@ -25,9 +25,16 @@ export default function useSubmitForm( { formData, onSubmitSuccess, onSubmitErro
 		}
 	);
 
-	const onSubmit = useCallback( () => {
-		submit( formData );
-	}, [ formData, submit ] );
+	const onSubmit = useCallback(
+		( application?: AgencyDirectoryApplication ) => {
+			if ( application ) {
+				submit( application );
+			} else {
+				formData && submit( formData );
+			}
+		},
+		[ formData, submit ]
+	);
 
 	return {
 		onSubmit,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -85,7 +85,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 				duration: 6000,
 			} )
 		);
-	}, [ page, reduxDispatch, translate ] );
+	}, [ reduxDispatch, translate ] );
 
 	const {
 		formData,

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -305,7 +305,7 @@ const PartnerDirectoryDashboard = () => {
 						`When approved, add details to your agency's public profile for clients to see.`
 					) }
 					buttonProps={ {
-						children: translate( 'Finish profile' ),
+						children: isValidFormData ? translate( 'Edit profile' ) : translate( 'Finish profile' ),
 						href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
 						onClick: onFinishProfileClick,
 						primary: isSubmitted,

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -50,9 +50,15 @@ const PartnerDirectoryDashboard = () => {
 
 	const agency = useSelector( getActiveAgency );
 
-	const [ applicationData, setApplicationData ] = useState( (): AgencyDirectoryApplication | null =>
-		mapApplicationFormData( agency )
+	const [ applicationData, setApplicationData ] = useState< AgencyDirectoryApplication | null >(
+		null
 	);
+
+	useEffect( () => {
+		if ( agency ) {
+			setApplicationData( mapApplicationFormData( agency ) );
+		}
+	}, [ agency ] );
 
 	const applicationWasSubmitted = applicationData?.status !== 'completed';
 

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -84,6 +84,10 @@ const PartnerDirectoryDashboard = () => {
 		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_finish_profile_click' ) );
 	}, [ dispatch ] );
 
+	const onPublishProfileClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_publish_profile_click' ) );
+	}, [ dispatch ] );
+
 	const onEditExpertiseClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_edit_expertise_click' ) );
 	}, [ dispatch ] );

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -316,6 +316,13 @@ const PartnerDirectoryDashboard = () => {
 					description={ translate(
 						'Your agency will appear in the partner directories you select and get approved for, including WordPress.com, Woo.com, Pressable.com, and Jetpack.com.'
 					) }
+					buttonProps={ {
+						children: translate( 'Publish' ),
+						onClick: onPublishProfileClick,
+						primary: isSubmitted,
+						disabled: ! isSubmitted || ! showFinishProfileButton || ! isValidFormData,
+						compact: true,
+					} }
 				/>
 			</StepSection>
 			{ displayProgramLinks && programLinks }

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -2,24 +2,26 @@ import { BadgeType, Button } from '@automattic/components';
 import { Icon, external, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useDetailsForm from 'calypso/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form';
-import { useFormSelectors } from 'calypso/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors';
-import {
-	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
-	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
-} from 'calypso/a8c-for-agencies/sections/partner-directory/constants';
-import {
-	mapAgencyDetailsFormData,
-	mapApplicationFormData,
-} from 'calypso/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data';
+import { AgencyDirectoryApplication } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import StepSection from '../../referrals/common/step-section';
 import StepSectionItem from '../../referrals/common/step-section-item';
+import useDetailsForm from '../agency-details/hooks/use-details-form';
+import useSubmitExpertiseForm from '../agency-expertise/hooks/use-submit-form';
+import { useFormSelectors } from '../components/hooks/use-form-selectors';
+import {
+	PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
+} from '../constants';
 import { getBrandMeta } from '../lib/get-brand-meta';
+import {
+	mapAgencyDetailsFormData,
+	mapApplicationFormData,
+} from '../utils/map-application-form-data';
 import DashboardStatusBadge from './status-badge';
 
 import './style.scss';
@@ -43,7 +45,12 @@ const PartnerDirectoryDashboard = () => {
 
 	const agency = useSelector( getActiveAgency );
 
-	const applicationData = useMemo( () => mapApplicationFormData( agency ), [ agency ] );
+	const [ applicationData, setApplicationData ] = useState( (): AgencyDirectoryApplication | null =>
+		mapApplicationFormData( agency )
+	);
+
+	const applicationWasSubmitted = applicationData?.status !== 'completed';
+
 	const agencyDetailsData = useMemo( () => mapAgencyDetailsFormData( agency ), [ agency ] );
 
 	const applicationStatusTypeMap = useMemo( (): Record< string, StatusBadge > => {
@@ -76,6 +83,10 @@ const PartnerDirectoryDashboard = () => {
 		};
 	}, [ translate ] );
 
+	const { onSubmit: submitPublishProfile } = useSubmitExpertiseForm( {
+		formData: applicationData,
+	} );
+
 	const onApplyNowClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_apply_now_click' ) );
 	}, [ dispatch ] );
@@ -85,8 +96,21 @@ const PartnerDirectoryDashboard = () => {
 	}, [ dispatch ] );
 
 	const onPublishProfileClick = useCallback( () => {
+		setApplicationData( ( state ) => {
+			if ( state === null ) {
+				return state;
+			}
+			const newState = {
+				...state,
+				isPublished: true,
+			};
+			submitPublishProfile( newState );
+
+			return newState;
+		} );
+
 		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_publish_profile_click' ) );
-	}, [ dispatch ] );
+	}, [ dispatch, setApplicationData ] );
 
 	const onEditExpertiseClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_edit_expertise_click' ) );
@@ -104,8 +128,6 @@ const PartnerDirectoryDashboard = () => {
 	useEffect( () => {
 		document.querySelector( '.partner-directory__body' )?.scrollTo( 0, 0 );
 	}, [] );
-
-	const isSubmitted = applicationData?.status !== 'completed';
 
 	const { isValidFormData } = useDetailsForm( { initialFormData: agencyDetailsData } );
 
@@ -126,6 +148,29 @@ const PartnerDirectoryDashboard = () => {
 			} );
 			return statuses;
 		}, [] ) || [];
+
+	const hasDirectoryApproval = directoryApplicationStatuses.some(
+		( { key } ) => key === 'approved'
+	);
+
+	const currentApplicationStep = useMemo( () => {
+		// Step 3: The application should be finished, not pending directory application.
+		if ( isCompleted ) {
+			return 3;
+		}
+
+		// Step 2: One application should be approved and the form should be valid
+		if ( hasDirectoryApproval && isValidFormData ) {
+			return 2;
+		}
+
+		// Step 1: The application should be submitted
+		if ( applicationWasSubmitted ) {
+			return 1;
+		}
+		// Initial application status: no application has been submitted
+		return 0;
+	}, [ isValidFormData, isCompleted, applicationWasSubmitted ] );
 
 	// todo: to remove this when we have the links.
 	const displayProgramLinks = false;
@@ -151,10 +196,6 @@ const PartnerDirectoryDashboard = () => {
 				</Button>
 			}
 		</StepSection>
-	);
-
-	const showFinishProfileButton = directoryApplicationStatuses.some(
-		( { key } ) => key === 'approved'
 	);
 
 	if ( isCompleted ) {
@@ -258,12 +299,14 @@ const PartnerDirectoryDashboard = () => {
 			<StepSection heading={ translate( 'How do I start?' ) }>
 				<StepSectionItem
 					isNewLayout
-					className="partner-directory-dashboard__apply-now-section"
-					icon={ check }
-					stepNumber={ isSubmitted ? undefined : 1 }
+					className={
+						currentApplicationStep > 0 ? 'partner-directory-dashboard__checked-step' : ''
+					}
+					stepNumber={ currentApplicationStep > 0 ? undefined : 1 }
+					icon={ currentApplicationStep > 0 ? check : undefined }
 					heading={ translate( 'Share your expertise' ) }
 					description={
-						isSubmitted && directoryApplicationStatuses.length > 0 ? (
+						applicationWasSubmitted && directoryApplicationStatuses.length > 0 ? (
 							<div className="partner-directory-dashboard__brand-status-section">
 								{ directoryApplicationStatuses.map( ( { brand, status, type } ) => {
 									const showPopoverOnLoad =
@@ -290,16 +333,22 @@ const PartnerDirectoryDashboard = () => {
 						)
 					}
 					buttonProps={ {
-						children: isSubmitted ? translate( 'Edit expertise' ) : translate( 'Apply now' ),
+						children: applicationWasSubmitted
+							? translate( 'Edit expertise' )
+							: translate( 'Apply now' ),
 						href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`,
 						onClick: onApplyNowClick,
-						primary: ! isSubmitted,
+						primary: ! applicationWasSubmitted,
 						compact: true,
 					} }
 				/>
 				<StepSectionItem
 					isNewLayout
-					stepNumber={ 2 }
+					className={
+						currentApplicationStep > 1 ? 'partner-directory-dashboard__checked-step' : ''
+					}
+					stepNumber={ currentApplicationStep > 1 ? undefined : 2 }
+					icon={ currentApplicationStep > 1 ? check : undefined }
 					heading={ translate( 'Finish adding details to your public profile' ) }
 					description={ translate(
 						`When approved, add details to your agency's public profile for clients to see.`
@@ -308,14 +357,15 @@ const PartnerDirectoryDashboard = () => {
 						children: isValidFormData ? translate( 'Edit profile' ) : translate( 'Finish profile' ),
 						href: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
 						onClick: onFinishProfileClick,
-						primary: isSubmitted,
-						disabled: ! isSubmitted || ! showFinishProfileButton,
+						primary: applicationWasSubmitted && hasDirectoryApproval && ! isValidFormData,
+						disabled: ! applicationWasSubmitted || ! hasDirectoryApproval,
 						compact: true,
 					} }
 				/>
 				<StepSectionItem
 					isNewLayout
-					stepNumber={ 3 }
+					stepNumber={ currentApplicationStep > 2 ? undefined : 3 }
+					icon={ currentApplicationStep > 2 ? check : undefined }
 					heading={ translate( 'New clients will find you' ) }
 					description={ translate(
 						'Your agency will appear in the partner directories you select and get approved for, including WordPress.com, Woo.com, Pressable.com, and Jetpack.com.'
@@ -323,8 +373,8 @@ const PartnerDirectoryDashboard = () => {
 					buttonProps={ {
 						children: translate( 'Publish' ),
 						onClick: onPublishProfileClick,
-						primary: isSubmitted,
-						disabled: ! isSubmitted || ! showFinishProfileButton || ! isValidFormData,
+						primary: applicationWasSubmitted,
+						disabled: ! applicationWasSubmitted || ! hasDirectoryApproval || ! isValidFormData,
 						compact: true,
 					} }
 				/>

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -252,6 +252,7 @@ const PartnerDirectoryDashboard = () => {
 							directoryApplicationStatuses.filter( ( { key } ) => key === 'rejected' ).length === 1;
 						return (
 							<StepSectionItem
+								key={ brand }
 								isNewLayout
 								iconClassName={ clsx( brandMeta.className ) }
 								icon={ brandMeta.icon }

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
@@ -3,7 +3,7 @@
 		max-width: 700px;
 	}
 
-	.partner-directory-dashboard__apply-now-section svg.sidebar__menu-icon {
+	.partner-directory-dashboard__checked-step svg.sidebar__menu-icon {
 		width: 20px;
 		height: 20px;
 		padding: 2px;

--- a/client/a8c-for-agencies/sections/partner-directory/types.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/types.ts
@@ -8,6 +8,7 @@ export interface AgencyDirectoryApplication {
 	directories: DirectoryApplication[];
 	feedbackUrl: string;
 	status?: AgencyDirectoryApplicationStatus;
+	isPublished?: boolean;
 }
 
 export interface DirectoryApplication {

--- a/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
@@ -21,6 +21,7 @@ export function mapApplicationFormData( agency: Agency | null ): AgencyDirectory
 			} )
 		),
 		feedbackUrl: agency.profile.partner_directory_application.feedback_url,
+		isPublished: !! agency.profile.partner_directory_application.is_published,
 	};
 }
 

--- a/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
@@ -12,10 +12,10 @@ export function mapApplicationFormData( agency: Agency | null ): AgencyDirectory
 		products: agency.profile.listing_details.products ?? [],
 		services: agency.profile.listing_details.services ?? [],
 		directories: agency.profile.partner_directory_application.directories.map(
-			( { status, directory, published, urls, note } ) => ( {
+			( { status, directory, is_published, urls, note } ) => ( {
 				status: status,
 				directory: directory,
-				published: published,
+				isPublished: is_published,
 				urls: urls,
 				note: note,
 			} )

--- a/client/a8c-for-agencies/sections/partner-directory/utils/tools.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/tools.ts
@@ -1,0 +1,8 @@
+export function validateURL( url: string ) {
+	return /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(:[0-9]{1,5})?(\/[^\s]*)?$/i.test( url );
+}
+
+export function areURLsUnique( urls: string[] ) {
+	const urlSet = new Set( urls );
+	return urlSet.size === urls.length;
+}

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -58,6 +58,7 @@ export interface Agency {
 				is_published?: boolean;
 			}[];
 			feedback_url: string;
+			is_published?: boolean;
 		};
 	};
 }

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -52,7 +52,6 @@ export interface Agency {
 			directories: {
 				status: 'pending' | 'approved' | 'rejected' | 'closed';
 				directory: 'wordpress' | 'jetpack' | 'woocommerce' | 'pressable';
-				published: boolean;
 				urls: string[];
 				note: string;
 				is_published?: boolean;


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/699
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/701

## Proposed Changes

This PR adds the step-3 Publish button:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/40f71e01-2054-4543-b165-267f14096b24)

- Extract and apply some validation code (URLs) as tools
- Allow to save the agency details at any time, without the required fields.
- Shows step 1 when it's the first time the agency is applying.
- Add the Publish button in step 3. Once the agency completes the steps 1 and 2, they can publish the application.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Apply for a few directories
- Get approved from at least one of them. Use the MC tool for approve it: `/agencies/partner-directory.php?mca4a_agency_id={your_agency_id}`
- You can restore your application using the endpoint directly: `PUT https://public-api.wordpress.com/wpcom/v2/agency/{your_agency_id}/profile/application`

Dummy data:

```
{
    "products": [
        "woocommerce",
        "jetpack"
    ],
	  "services": ["content_strategy_development"],
    "directories": [
        {
					"directory": "wordpress",
					"urls": [
						"https:\/\/example11.com",
						"https:\/\/example2.com",
						"https:\/\/example3.com",
						"https:\/\/example4.com",
						"https:\/\/example5.com"
					],
					"note": "My WordPress.com application",
					"is_published": false,
					"status": "pending"
        },
        {
					"directory": "jetpack",
					"urls": [
						"https:\/\/example1.com",
						"https:\/\/example2.com",
						"https:\/\/example3.com",
						"https:\/\/example4.com",
						"https:\/\/example55.com"
					],
					"note": "My Jetpack.com application",
					"is_published": false,
					"status": "pending"
				}
    ],
    "status": "in-progress",
    "feedback_url": "https://example3.com",
		"is_published": false
}

```
- Edit agency expertise
- Edit agency profile
- Click on the Publish button:
- You will see:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/35aec1d2-9556-45e4-bb72-39f7bb1d17f7)

and the summary Congratulation page:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/7416af26-3b7a-479c-8ec6-9754e1879f5b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
