### PR TITLE
Guided Onboarding: Update segment logic for blogger and nonprofit

### DIFF
--- a/client/my-sites/plans/utils/get-segmented-intent.tsx
+++ b/client/my-sites/plans/utils/get-segmented-intent.tsx
@@ -30,10 +30,10 @@ export function getSegmentedIntent( answers: SurveyData ): SegmentedIntent {
 		if ( surveyedGoals?.includes( 'sell' ) && ! surveyedGoals?.includes( 'difm' ) ) {
 			return { segmentSlug: 'plans-guided-segment-merchant', segment: 'merchant' };
 		}
-		if ( surveyedGoals?.includes( 'write' ) ) {
+		if ( surveyedGoals?.includes( 'write' ) && surveyedGoals?.length === 1 ) {
 			return { segmentSlug: 'plans-guided-segment-blogger', segment: 'blogger' };
 		}
-		if ( surveyedGoals?.includes( 'educational-or-nonprofit' ) ) {
+		if ( surveyedGoals?.includes( 'educational-or-nonprofit' ) && surveyedGoals?.length === 1 ) {
 			return { segmentSlug: 'plans-guided-segment-nonprofit', segment: 'nonprofit' };
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1718986129885889-slack-C02T4NVL4JJ

## Proposed Changes

* Update logic for nonprofit and blogger segments. The user segment should be set to `nonprofit` if Q2 `Build a site for school or nonprofit` is the **only** option selected. The user segment should be set to `blogger if Q2 `Publish a blog` is the **only** option selected.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ensure segments are set correctly based on selected segmentation options.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or live link
* Navigate to `/start/guided?flags=onboarding/guided`
* Select the first option for Q1, only select `Publish a blog` for Q2, verify the segment is set to `blogger`.
* Go back to Q1 and only select `Build a site for school or nonprofit`, verify the segment is set to `nonprofit`.
* Go back to Q1 and select `Build a site for school or nonprofit` and `Promote my business`, verify the segment is not set `nonprofit`.
* Go back to Q1 and select `Publish a blog` and `Promote my business`, verify the segment is not set `blogger`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?