### PR TITLE
Post editor upsell: Add white background hack to hide command button

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/src/domain-upsell-callout.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/src/domain-upsell-callout.scss
@@ -6,13 +6,13 @@
 .wpcom-domain-upsell-callout {
 	font-size: $font-body-extra-small;
 	font-style: normal;
-	padding: 15px 110px;
+	padding: 15px 65px;
 	line-height: normal;
 	position: absolute;
 	display: flex;
 	align-items: center;
 	left: 50%;
-	transform: translateX(-50%);
+	transform: translateX(-60%);
 	top: 0;
 	background: $studio-white;
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/src/domain-upsell-callout.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/src/domain-upsell-callout.scss
@@ -6,7 +6,7 @@
 .wpcom-domain-upsell-callout {
 	font-size: $font-body-extra-small;
 	font-style: normal;
-	padding: 15px;
+	padding: 15px 110px;
 	line-height: normal;
 	position: absolute;
 	display: flex;
@@ -14,6 +14,8 @@
 	left: 50%;
 	transform: translateX(-50%);
 	top: 0;
+	background: $studio-white;
+
 	@media (max-width: $break-xlarge) {
 		display: none;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7824

## Proposed Changes

* Add a temporary fix to hide the command button when the domain upsell is visible.

Before | After
------- | -----

<img width="1097" alt="Screen Shot 2024-06-21 at 4 52 35 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/50a730b9-5805-48c7-9c06-d50b0507c09e"> | <img width="1097" alt="Screen Shot 2024-06-21 at 4 52 22 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/083a86f8-8d49-420f-90a4-5bf661670a6c">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There's an overlap.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site without a custom domain or a plan that includes one, open the post editor.
* Check that the overlap is not visible.
* Check different screen sizes. The upsell doesn't show on mobile sizes.
* Check that header elements like "Save draft" aren't being hidden.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
