### PR TITLE
A4A: Skip cancellation survey when removing plan

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -17,7 +17,7 @@ import ExternalLink from 'calypso/components/external-link';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import { isRefundable } from 'calypso/lib/purchases';
+import { isAgencyPartnerType, isPartnerPurchase, isRefundable } from 'calypso/lib/purchases';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -68,10 +68,18 @@ class CancelPurchaseForm extends Component {
 	};
 
 	getAllSurveySteps() {
-		const { willAtomicSiteRevert } = this.props;
+		const { willAtomicSiteRevert, purchase } = this.props;
 		let steps = [ FEEDBACK_STEP ];
 
-		if ( ! isPlan( this.props.purchase ) ) {
+		if ( isPartnerPurchase( purchase ) && isAgencyPartnerType( purchase.partnerType ) ) {
+			/**
+			 * We don't want to display the cancellation survey for sites purchased
+			 * through partners (e.g., A4A.)
+			 *
+			 * Let's jump right to the confirmation step.
+			 */
+			steps = [];
+		} else if ( ! isPlan( purchase ) ) {
 			steps = [ NEXT_ADVENTURE_STEP ];
 		} else if ( this.state.upsell ) {
 			steps = [ FEEDBACK_STEP, UPSELL_STEP, NEXT_ADVENTURE_STEP ];

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -706,7 +706,9 @@ export function isRemovable( purchase: Purchase ): boolean {
 	);
 }
 
-export function isPartnerPurchase( purchase: Purchase ): boolean {
+export function isPartnerPurchase(
+	purchase: Purchase
+): purchase is Purchase & { partnerType: string } {
 	return !! purchase.partnerName;
 }
 
@@ -856,6 +858,14 @@ export function paymentLogoType( purchase: Purchase ): string | null | undefined
 	return purchase.payment.type || null;
 }
 
+export function isAgencyPartnerType( partnerType: string ) {
+	if ( ! partnerType ) {
+		return false;
+	}
+
+	return [ 'agency', 'agency_beta', 'a4a_agency' ].includes( partnerType );
+}
+
 export function purchaseType( purchase: Purchase ) {
 	if ( isThemePurchase( purchase ) ) {
 		return i18n.translate( 'Premium Theme' );
@@ -866,15 +876,11 @@ export function purchaseType( purchase: Purchase ) {
 	}
 
 	if ( isPartnerPurchase( purchase ) ) {
-		switch ( purchase.partnerType ) {
-			case 'agency':
-			case 'agency_beta':
-			case 'a4a_agency':
-				return i18n.translate( 'Agency Managed Plan' );
-
-			default:
-				return i18n.translate( 'Host Managed Plan' );
+		if ( isAgencyPartnerType( purchase.partnerType ) ) {
+			return i18n.translate( 'Agency Managed Plan' );
 		}
+
+		return i18n.translate( 'Host Managed Plan' );
 	}
 
 	if ( isPlan( purchase ) ) {


### PR DESCRIPTION
## Proposed Changes

As per https://github.com/Automattic/automattic-for-agencies-dev/issues/660#issuecomment-2183456785, we are not displaying the cancellation survey for Partner sites on WPCOM.

| Click Remove plan | Confirm plan removal |
| ------------------ | ---------------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/dcdfec63-e0d7-4045-9eb5-5619eb5f2248) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/b81a5527-c202-4b17-b34b-308cf37730b9) |

## Testing Instructions

- Buy a license and create a site in A4A
- Go to `http://calypso.localhost:3000/purchases/subscriptions/%s` and click "Remove plan", then acknowledge the decision in the dialog that pops up.

Your site should have the plan removed.