### PR TITLE
Stats: Show upgrade notices for commercial sites with PWYW plans

### DIFF
--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -112,6 +112,7 @@ function shouldShowCommercialSiteUpgradeNotice( {
 	hasPaidStats,
 	isSiteJetpackNotAtomic,
 	isCommercial,
+	hasPWYWPlanOnly,
 }: StatsNoticeProps ) {
 	// Log all the things!
 	// eslint-disable-next-line no-console, prefer-rest-params
@@ -126,7 +127,6 @@ function shouldShowCommercialSiteUpgradeNotice( {
 
 	// Test specific to self-hosted sites with PWYW plans.
 	// They should see the upgrade notice!
-	const hasPWYWPlanOnly = true;
 	if ( showUpgradeNoticeOnOdyssey || showUpgradeNoticeForJetpackNotAtomic ) {
 		if ( isCommercial && hasPWYWPlanOnly ) {
 			return true;

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -34,34 +34,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: CommercialSiteUpgradeNotice,
 		noticeId: 'commercial_site_upgrade',
-		isVisibleFunc: ( {
-			isOdysseyStats,
-			isWpcom,
-			isVip,
-			isP2,
-			isOwnedByTeam51,
-			hasPaidStats,
-			isSiteJetpackNotAtomic,
-			isCommercial,
-		}: StatsNoticeProps ) => {
-			const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
-
-			// Show the notice if the site is Jetpack or it is Odyssey Stats.
-			const showUpgradeNoticeOnOdyssey = isOdysseyStats;
-
-			const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
-
-			return !! (
-				( showUpgradeNoticeOnOdyssey ||
-					showUpgradeNoticeForJetpackNotAtomic ||
-					showUpgradeNoticeForWpcomSites ) &&
-				// Show the notice if the site has not purchased the paid stats product.
-				! hasPaidStats &&
-				// Show the notice only if the site is commercial.
-				isCommercial &&
-				! isVip
-			);
-		},
+		isVisibleFunc: shouldShowCommercialSiteUpgradeNotice,
 		disabled: false,
 	},
 	{
@@ -129,5 +102,38 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		disabled: false,
 	},
 ];
+
+function shouldShowCommercialSiteUpgradeNotice( {
+	isOdysseyStats,
+	isWpcom,
+	isVip,
+	isP2,
+	isOwnedByTeam51,
+	hasPaidStats,
+	isSiteJetpackNotAtomic,
+	isCommercial,
+}: StatsNoticeProps ) {
+	// Log all the things!
+	// eslint-disable-next-line no-console, prefer-rest-params
+	console.log( 'args: ', arguments );
+
+	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
+
+	// Show the notice if the site is Jetpack or it is Odyssey Stats.
+	const showUpgradeNoticeOnOdyssey = isOdysseyStats;
+
+	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
+
+	return !! (
+		( showUpgradeNoticeOnOdyssey ||
+			showUpgradeNoticeForJetpackNotAtomic ||
+			showUpgradeNoticeForWpcomSites ) &&
+		// Show the notice if the site has not purchased the paid stats product.
+		! hasPaidStats &&
+		// Show the notice only if the site is commercial.
+		isCommercial &&
+		! isVip
+	);
+}
 
 export default ALL_STATS_NOTICES;

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -114,18 +114,11 @@ function shouldShowCommercialSiteUpgradeNotice( {
 	isCommercial,
 	hasPWYWPlanOnly,
 }: StatsNoticeProps ) {
-	// Log all the things!
-	// eslint-disable-next-line no-console, prefer-rest-params
-	console.log( 'args: ', arguments );
-
 	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
-
-	// Show the notice if the site is Jetpack or it is Odyssey Stats.
 	const showUpgradeNoticeOnOdyssey = isOdysseyStats;
-
 	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
 
-	// Test specific to self-hosted sites with PWYW plans.
+	// Test specific to commercial self-hosted sites with PWYW plans.
 	// They should see the upgrade notice!
 	if ( showUpgradeNoticeOnOdyssey || showUpgradeNoticeForJetpackNotAtomic ) {
 		if ( isCommercial && hasPWYWPlanOnly ) {

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -124,6 +124,15 @@ function shouldShowCommercialSiteUpgradeNotice( {
 
 	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
 
+	// Test specific to self-hosted sites with PWYW plans.
+	// They should see the upgrade notice!
+	const hasPWYWPlanOnly = true;
+	if ( showUpgradeNoticeOnOdyssey || showUpgradeNoticeForJetpackNotAtomic ) {
+		if ( isCommercial && hasPWYWPlanOnly ) {
+			return true;
+		}
+	}
+
 	return !! (
 		( showUpgradeNoticeOnOdyssey ||
 			showUpgradeNoticeForJetpackNotAtomic ||

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -91,6 +91,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 
 	const { isRequestingSitePurchases, isCommercialOwned } = useStatsPurchases( siteId );
 
+	// Looks like we'll need a new selector to check for this state.
+	const hasPWYWPlanOnly = true;
+
 	const noticeOptions = {
 		siteId,
 		isOdysseyStats,
@@ -104,6 +107,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		statsPurchaseSuccess,
 		isCommercial,
 		isCommercialOwned,
+		hasPWYWPlanOnly,
 	};
 
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -18,6 +18,7 @@ import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-e
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import hasSiteProductJetpackStatsFree from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-free';
 import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
+import hasSiteProductJetpackStatsPWYWOnly from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import useStatsPurchases from '../hooks/use-stats-purchases';
@@ -91,8 +92,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 
 	const { isRequestingSitePurchases, isCommercialOwned } = useStatsPurchases( siteId );
 
-	// Looks like we'll need a new selector to check for this state.
-	const hasPWYWPlanOnly = true;
+	const hasPWYWPlanOnly = useSelector( ( state ) =>
+		hasSiteProductJetpackStatsPWYWOnly( state, siteId )
+	);
 
 	const noticeOptions = {
 		siteId,

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -19,6 +19,7 @@ export interface StatsNoticeProps {
 	statsPurchaseSuccess?: string;
 	isCommercial?: boolean;
 	isCommercialOwned?: boolean;
+	hasPWYWPlanOnly?: boolean;
 }
 
 export interface NoticeBodyProps {

--- a/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
+++ b/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
@@ -1,0 +1,15 @@
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { AppState } from 'calypso/types';
+
+function hasSiteProductJetpackStatsPWYWOnly(
+	state: AppState,
+	siteId = getSelectedSiteId( state )
+): boolean {
+	const sitePurchases = getSitePurchases( state, siteId );
+	console.log( 'sitePurchases: ', sitePurchases.length );
+
+	return true;
+}
+
+export default hasSiteProductJetpackStatsPWYWOnly;

--- a/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
+++ b/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
@@ -4,40 +4,6 @@ import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 
-function hasSiteProductJetpackStatsPWYWOnlyX(
-	state: AppState,
-	siteId = getSelectedSiteId( state )
-): boolean {
-	const sitePurchases = getSitePurchases( state, siteId );
-
-	// Get listing of all plans that support stats in some way and qualify as "paid" plans.
-	const plansSupportingStats = sitePurchases?.filter(
-		( product ) =>
-			productHasStats( camelOrSnakeSlug( product ), true ) && product.expiryStatus !== 'expired'
-	);
-
-	if ( plansSupportingStats.length === 0 ) {
-		return false;
-	}
-
-	// Check for one or more PWYW plans.
-	const plansPWYWStats = plansSupportingStats?.filter( ( product ) =>
-		product.productSlug.includes( 'pwyw' )
-	);
-
-	if ( plansPWYWStats.length === 0 ) {
-		return false;
-	}
-
-	// PWYW plan confirmed. Check for additional paid plans.
-	const plansExcludingPWYWStats = plansSupportingStats?.filter(
-		( product ) => ! product.productSlug.includes( 'pwyw' )
-	);
-
-	// If we have any plans remaining, the site has paid stats.
-	return plansPWYWStats.length > 0 && plansExcludingPWYWStats.length === 0;
-}
-
 function hasSiteProductJetpackStatsPWYWOnly(
 	state: AppState,
 	siteId = getSelectedSiteId( state )

--- a/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
+++ b/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
@@ -1,3 +1,5 @@
+import { camelOrSnakeSlug } from '@automattic/calypso-products';
+import { productHasStats } from 'calypso/blocks/jetpack-benefits/feature-checks';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
@@ -7,9 +9,33 @@ function hasSiteProductJetpackStatsPWYWOnly(
 	siteId = getSelectedSiteId( state )
 ): boolean {
 	const sitePurchases = getSitePurchases( state, siteId );
-	console.log( 'sitePurchases: ', sitePurchases.length );
 
-	return true;
+	// Get listing of all plans that support stats in some way and qualify as "paid" plans.
+	const plansSupportingStats = sitePurchases?.filter(
+		( product ) =>
+			productHasStats( camelOrSnakeSlug( product ), true ) && product.expiryStatus !== 'expired'
+	);
+
+	if ( plansSupportingStats.length === 0 ) {
+		return false;
+	}
+
+	// Check for one or more PWYW plans.
+	const plansPWYWStats = plansSupportingStats?.filter( ( product ) =>
+		product.productSlug.includes( 'pwyw' )
+	);
+
+	if ( plansPWYWStats.length === 0 ) {
+		return false;
+	}
+
+	// PWYW plan confirmed. Check for additional paid plans.
+	const plansExcludingPWYWStats = plansSupportingStats?.filter(
+		( product ) => ! product.productSlug.includes( 'pwyw' )
+	);
+
+	// If we have any plans remaining, the site has paid stats.
+	return plansPWYWStats.length > 0 && plansExcludingPWYWStats.length === 0;
 }
 
 export default hasSiteProductJetpackStatsPWYWOnly;

--- a/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
+++ b/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
@@ -15,7 +15,6 @@ function hasSiteProductJetpackStatsPWYWOnly(
 		( product ) =>
 			productHasStats( camelOrSnakeSlug( product ), true ) && product.expiryStatus !== 'expired'
 	);
-	console.log( 'plansSupportingStats: ', plansSupportingStats.length );
 
 	if ( plansSupportingStats.length === 0 ) {
 		return false;
@@ -25,7 +24,6 @@ function hasSiteProductJetpackStatsPWYWOnly(
 	const plansPWYWStats = plansSupportingStats?.filter( ( product ) =>
 		product.productSlug.includes( 'pwyw' )
 	);
-	console.log( 'plansPWYWStats: ', plansPWYWStats.length );
 
 	// If the arrays are equal, the site has only PWYW stats.
 	return plansSupportingStats.length === plansPWYWStats.length;

--- a/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
+++ b/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
@@ -4,7 +4,7 @@ import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 
-function hasSiteProductJetpackStatsPWYWOnly(
+function hasSiteProductJetpackStatsPWYWOnlyX(
 	state: AppState,
 	siteId = getSelectedSiteId( state )
 ): boolean {
@@ -36,6 +36,33 @@ function hasSiteProductJetpackStatsPWYWOnly(
 
 	// If we have any plans remaining, the site has paid stats.
 	return plansPWYWStats.length > 0 && plansExcludingPWYWStats.length === 0;
+}
+
+function hasSiteProductJetpackStatsPWYWOnly(
+	state: AppState,
+	siteId = getSelectedSiteId( state )
+): boolean {
+	const sitePurchases = getSitePurchases( state, siteId );
+
+	// Get listing of all plans that support stats in some way and qualify as "paid" plans.
+	const plansSupportingStats = sitePurchases?.filter(
+		( product ) =>
+			productHasStats( camelOrSnakeSlug( product ), true ) && product.expiryStatus !== 'expired'
+	);
+	console.log( 'plansSupportingStats: ', plansSupportingStats.length );
+
+	if ( plansSupportingStats.length === 0 ) {
+		return false;
+	}
+
+	// Check for one or more PWYW plans.
+	const plansPWYWStats = plansSupportingStats?.filter( ( product ) =>
+		product.productSlug.includes( 'pwyw' )
+	);
+	console.log( 'plansPWYWStats: ', plansPWYWStats.length );
+
+	// If the arrays are equal, the site has only PWYW stats.
+	return plansSupportingStats.length === plansPWYWStats.length;
 }
 
 export default hasSiteProductJetpackStatsPWYWOnly;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81361.

## Proposed Changes

Show the commercial upgrade notice on any site flagged as `isCommercial` that has a PWYW plan. Previously we didn't show the notice to these sites.

<img width="883" alt="SCR-20240614-rcmz" src="https://github.com/Automattic/wp-calypso/assets/40267301/cb4c7c0c-887f-4a8b-9c28-092bb2d40204">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The PWYW plans are meant for non-commercial sites. It's possible to purchase one if the site has not been classified or if the site's classification changes over time. We want to make sure we surface notices to upgrade to the correct license if we find a mismatch of classification & license type.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a PWYW plan to your test site.
* Force the site to commercial status using the "jetpack-site-is-commercial-override" override on the Blog RC tool.
* Visit the Stats page and confirm the notice is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
