### PR TITLE
Create the 'Configure your site' modal

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -1,9 +1,10 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import { Modal } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
@@ -37,8 +38,15 @@ type NeedsSetupSite = {
 	id: number;
 };
 
+const isA4aSiteCreationConfigurationsEnabled = config.isEnabled(
+	'a4a-site-creation-configurations'
+);
+
 export default function NeedSetup( { licenseKey }: Props ) {
 	const translate = useTranslate();
+	const [ displaySiteConfigurationModal, setDisplaySiteConfigurationModal ] = useState( false );
+
+	const toggleModal = () => setDisplaySiteConfigurationModal( ! displaySiteConfigurationModal );
 
 	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
 
@@ -179,12 +187,16 @@ export default function NeedSetup( { licenseKey }: Props ) {
 						</Actions>
 					</LayoutHeader>
 				</LayoutTop>
-
+				{ displaySiteConfigurationModal && (
+					<Modal title={ translate( 'Configure your site' ) } onRequestClose={ toggleModal }>
+						<h1>Configure your site placeholder modal</h1>
+					</Modal>
+				) }
 				<NeedSetupTable
 					availablePlans={ availablePlans }
 					isLoading={ isFetching }
 					provisioning={ isProvisioning }
-					onCreateSite={ onCreateSite }
+					onCreateSite={ isA4aSiteCreationConfigurationsEnabled ? toggleModal : onCreateSite }
 					onMigrateSite={ onMigrateSite }
 				/>
 			</LayoutColumn>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7857

## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/33497086/ff3da41a-2167-4023-8b0f-10ff5f402ae2)

This is our first step on **A4A Site Creation Configuration**.
On A4A, when clicking on `Create new site` button, we should open a modal instead creating the site right away.


## Testing Instructions

This feature is under `a4a-site-creation-configurations` flag.
Before accessing the `Create new site` button, your account needs to have at least 1 hosting license, ready to be used.
If you are not sure how to get that, read PdDOJh-3ys-p2.

1- Open this link: http://agencies.localhost:3000/sites/need-setup?flags=a4a-site-creation-configurations
2 - Click on `Create new site` button.
3 - You should see a placeholder modal. Your site should not be created.
4 - Click on the closing icon, or outside of the modal. It should close the modal.

Repeat the test without the feature flag:  http://agencies.localhost:3000/sites/need-setup
It should create the site instead opening the modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?