### PR TITLE
Fix Staging site link in ellipsis menu

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -303,7 +303,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 			{
 				condition: hasStagingSitesFeature,
 				label: __( 'Staging site' ),
-				href: `/hosting-config/${ siteSlug }#staging-site`,
+				href: `/staging-site/${ siteSlug }`,
 				sectionName: 'staging_site',
 			},
 			{


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7862

## Proposed Changes

* Update the staging site links in the ellipsis menu

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Before, staging sites were on `/hosting-config/${ siteSlug }#staging-site`, but we've updated it to `/staging-site/${ siteSlug }`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the ellipsis menu for an atomic site
![image](https://github.com/Automattic/wp-calypso/assets/6586048/50371dce-d639-4a01-9b5f-460810ad37e5)
* Make sure it points to the staging site tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
