### PR TITLE
Remove the domain upsell callout in editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -346,12 +346,3 @@ function load_wpcom_global_styles() {
 	require_once __DIR__ . '/wpcom-global-styles/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_global_styles' );
-
-/**
- * WP.com-specific Site Editor changes.
- * (Core Full Site Editing)
- */
-function load_wpcom_domain_upsell_callout() {
-	require_once __DIR__ . '/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php';
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_domain_upsell_callout' );


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7824

> [!NOTE]  
> This PR focuses on removing loading the domain upsell code. Will create a follow-up PR to remove the domain upsell code itself.

## Proposed Changes

* Do not load the domain upsell callout, so it doesn't cover up the command bar

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/a52f575b-47fd-4506-9f53-b6826d165eb9">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/2d7731fc-ec9a-4548-977e-7f5e2a1d6310">|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Related Slack thread: p1718976804291679-slack-C029GN3KD

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Simple sites
* Sandbox the site
* Go to /apps/editing-toolkit
* Run yarn dev --sync
* In Calypso, create/edit post/page
* Should not see the upsell

* Turn on Classic mode or go to :site/wp-admin/post-new.php
* Should not see the upsell

### Atomic sites
* Follow the instructions: PCYsg-ly5-p2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?