### PR TITLE
Stepper: Render flow step only when translation is fully loaded

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
@@ -1,6 +1,6 @@
 import { useLocale } from '@automattic/i18n-utils';
 import {
-	ComponentProps,
+	type ComponentProps,
 	Suspense,
 	useEffect,
 	useState,

--- a/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
@@ -30,6 +30,7 @@ export const Boot: FC< Props > = ( { children, fallback } ) => {
 		}
 	}, [ locale, newLocale, isReady ] );
 
+	// Continue to show the fallback UI while we are still loading the new locale or when we're first transitioning to the new locale (i.e. the transition is still in process)
 	if ( ! isReady || isPending ) {
 		return fallback;
 	}

--- a/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
@@ -1,0 +1,38 @@
+import { useLocale } from '@automattic/i18n-utils';
+import {
+	ComponentProps,
+	Suspense,
+	useEffect,
+	useState,
+	useTransition,
+	type FC,
+	type PropsWithChildren,
+} from 'react';
+import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
+
+interface Props extends PropsWithChildren {
+	fallback: ComponentProps< typeof Suspense >[ 'fallback' ];
+}
+
+//* This component is used to ensure that all required data is loaded before rendering the children.
+export const Boot: FC< Props > = ( { children, fallback } ) => {
+	const [ isReady, setIsReady ] = useState( false );
+	const [ isPending, setTransition ] = useTransition();
+
+	const locale = useLocale();
+	const newLocale = useFlowLocale();
+
+	useEffect( () => {
+		if ( ! isReady && newLocale === locale ) {
+			setTransition( () => {
+				setIsReady( true );
+			} );
+		}
+	}, [ locale, newLocale, isReady ] );
+
+	if ( ! isReady || isPending ) {
+		return fallback;
+	}
+
+	return <Suspense fallback={ fallback }>{ children }</Suspense>;
+};

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -5,7 +5,7 @@ import {
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useEffect, useMemo, Suspense, lazy } from 'react';
+import React, { useEffect, useMemo, lazy } from 'react';
 import Modal from 'react-modal';
 import { Route, Routes } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -17,6 +17,7 @@ import { useSaveQueryParams } from '../../hooks/use-save-query-params';
 import { useSiteData } from '../../hooks/use-site-data';
 import useSyncRoute from '../../hooks/use-sync-route';
 import { StepRoute, StepperLoader } from './components';
+import { Boot } from './components/boot';
 import { RedirectToStep } from './components/redirect-to-step';
 import { useFlowNavigation } from './hooks/use-flow-navigation';
 import { useSignUpStartTracking } from './hooks/use-sign-up-start-tracking';
@@ -141,7 +142,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	useSignUpStartTracking( { flow, currentStepRoute: currentStepRoute } );
 
 	return (
-		<Suspense fallback={ <StepperLoader /> }>
+		<Boot fallback={ <StepperLoader /> }>
 			<DocumentHead title={ getDocumentHeadTitle() } />
 			<Routes>
 				{ flowSteps.map( ( step ) => (
@@ -161,6 +162,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				<Route path="/:flow/:lang?" element={ <RedirectToStep slug={ stepPaths[ 0 ] } /> } />
 			</Routes>
 			<AsyncCheckoutModal siteId={ site?.ID } />
-		</Suspense>
+		</Boot>
 	);
 };


### PR DESCRIPTION
Depends on #91935

## Proposed Changes
* Wrap the stepper with a component that only renders the router setup when the locale is ready to be used.

## Why are these changes being made?
We have a race condition case because we are rendering the step before the locale data is ready to be used, it causes the user can see the content in English before seeing it in its language. This issue happens more intensely based on the CPU processing power.

This issue also affects the code execution causing weird bugs, like redirecting the user to the login page using some wrong languages.  So we can expect more code simplifications based on it. 


> [!NOTE]  
>  This change probably increases the time the user will see the first step rendered but it would be fixed by preloading the language file via the backend. 


----
## Testing Instructions
- Use a not logged-in browser, access `/setup/newsletter/intro/es`, and check if you can see the English version before the Spanish version. 

### Screenshot


### BEFORE CHANGE

**The app rendering English**
<img width="714" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/66244161-5a79-4da7-98a0-c8d92adaaa69">

**The app renders Spanish after some seconds.**

<img width="714" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/41dce00c-17bf-4d99-9d11-32bc15d1939f">

---


### AFTER CHANGE
You can see the browser jumping directly from the loaders to the translated step.
![after change](https://github.com/Automattic/wp-calypso/assets/38718/66cee7c1-f151-41d4-8828-de843abec33e)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
