### PR TITLE
A4A: Indicate that the prices for the client's subscriptions are based on monthly intervals.

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -1,3 +1,5 @@
+import { formatCurrency } from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import StatusBadge from 'calypso/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge';
 import CancelSubscriptionAction from '../../cancel-subscription-confirmation-dialog';
@@ -13,7 +15,15 @@ export function SubscriptionPurchase( { isFetching, name }: Props & { name?: str
 }
 
 export function SubscriptionPrice( { isFetching, amount }: Props & { amount?: string } ) {
-	return isFetching ? <TextPlaceholder /> : `$${ amount }`;
+	const translate = useTranslate();
+
+	return isFetching ? (
+		<TextPlaceholder />
+	) : (
+		translate( '%(price)s per month', {
+			args: { price: formatCurrency( Number( amount ?? 0 ), 'USD' ) },
+		} )
+	);
 }
 
 export function SubscriptionStatus( {


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1150" alt="Screenshot 2024-06-24 at 6 39 24 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6fe8a948-ef0a-49e4-8bbf-60464b9963a0"> | <img width="1228" alt="Screenshot 2024-06-24 at 6 39 31 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a2eaf2c1-199c-4492-9ebc-331fe11bbbee"> | 

Closes https://github.com/Automattic/jetpack-genesis/issues/409

## Proposed Changes

* Indicate that the prices for the client's subscriptions are based on monthly intervals.

## Why are these changes being made?

* Make sure that the clients are aware they are billed on a monthly interval.

## Testing Instructions

To test this, you need to create a client account.

* Refer some products to your client account using your agency account.
* Login to your client account and go to `/client/subscriptions`
* Confirm that the subscription prices indicates a monthly interval.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
