### PR TITLE
A4A: Improved automated referral copies and links.

### DIFF
--- a/client/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide.tsx
+++ b/client/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide.tsx
@@ -39,7 +39,7 @@ function useReferralsGuide() {
 			{
 				title: translate( 'Review your selection during checkout' ),
 				description: translate(
-					`During checkout, add your clients' email address and a note about the invoice for the selected products.`
+					`During checkout, add your client's email address and a note about the invoice for the selected products.`
 				),
 				preview: (
 					<video

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
@@ -123,6 +123,13 @@ export default function ProductCard( props: Props ) {
 		return isSelected ? translate( 'Added to cart' ) : translate( 'Add to cart' );
 	}, [ asReferral, isSelected, translate ] );
 
+	const ctaLightboxLabel = useMemo( () => {
+		if ( asReferral ) {
+			return isSelected ? translate( 'Remove from referral' ) : translate( 'Add to referral' );
+		}
+		return isSelected ? translate( 'Remove from cart' ) : translate( 'Add to cart' );
+	}, [ asReferral, isSelected, translate ] );
+
 	return (
 		<>
 			<div
@@ -181,7 +188,7 @@ export default function ProductCard( props: Props ) {
 				<LicenseLightbox
 					product={ product }
 					quantity={ quantity }
-					ctaLabel={ isSelected ? translate( 'Remove from cart' ) : translate( 'Add to cart' ) }
+					ctaLabel={ ctaLightboxLabel }
 					isCTAPrimary={ ! isSelected }
 					isDisabled={ isDisabled }
 					onActivate={ onSelectProduct }


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/412
Closes https://github.com/Automattic/jetpack-genesis/issues/413

## Proposed Changes

* [Update product lightbox cta label for referrals.](https://github.com/Automattic/wp-calypso/commit/357a628650c5e9d1a61f3d557714f6f13c0d974f)

| Before | After |
|--------|--------|
| <img width="1834" alt="Screenshot 2024-06-24 at 7 55 13 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/74796922-25e5-43b4-bbdd-752b43c4ab81"> | <img width="1932" alt="Screenshot 2024-06-24 at 7 52 47 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e16a17b1-5245-4232-95da-a6b44a12ce68"> | 
| <img width="1824" alt="Screenshot 2024-06-24 at 7 55 24 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/001d2f13-7e51-402d-81c3-60d663d8e761"> | <img width="1834" alt="Screenshot 2024-06-24 at 7 53 04 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/83ef49c6-c9a0-44f9-b65c-5a6917955c64"> |


* [Fix grammatical error on referrals guided tour.](https://github.com/Automattic/wp-calypso/commit/23884eb500f08b4d65165314894a0f9b83bfbced)

| Before | After |
|--------|--------|
| <img width="423" alt="Screenshot 2024-06-24 at 7 57 49 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6136ef9a-21eb-4737-a727-785df7ff5127"> | <img width="422" alt="Screenshot 2024-06-24 at 7 58 09 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/1749d6cb-ad0d-4ac0-adb2-66209efc49e2"> | 

## Testing Instructions


* Test the lightbox on referral mode in the Marketplace products section and confirm the correct CTA label is displayed.
* Test the Automated referrals onboarding by clicking the help tooltip in the **refer products** in the Marketplace pages and confirm section number 3 has the correct text.
* Test the client's checkout and confirm the correct TOS and billing texts and links.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
