### PR TITLE
A4A: Add a global contact support widget.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
@@ -1,0 +1,39 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import UserContactSupportModalForm from '../user-contact-support-modal-form';
+
+export const CONTACT_URL_HASH_FRAGMENT = '#contact-support';
+export const CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT = '#contact-support-migration-offer';
+
+export default function A4AContactSupportWidget() {
+	const translate = useTranslate();
+
+	const hashSupportFormHash =
+		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
+		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
+
+	const [ showUserSupportForm, setShowUserSupportForm ] = useState( hashSupportFormHash );
+
+	const onCloseUserSupportForm = useCallback( () => {
+		// Remove any hash from the URL.
+		history.pushState( null, '', window.location.pathname + window.location.search );
+		setShowUserSupportForm( false );
+	}, [] );
+
+	// We need make sure to set this to true when we have the support form hash fragment.
+	if ( hashSupportFormHash && ! showUserSupportForm ) {
+		setShowUserSupportForm( true );
+	}
+
+	return (
+		<UserContactSupportModalForm
+			show={ showUserSupportForm }
+			onClose={ onCloseUserSupportForm }
+			defaultMessage={
+				window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT
+					? translate( "I'd like to chat more about the migration offer." )
+					: undefined
+			}
+		/>
+	);
+}

--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -1,8 +1,7 @@
-import page from '@automattic/calypso-router';
 import { Button, FoldableCard } from '@automattic/components';
 import { Icon, reusableBlock, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { A4A_OVERVIEW_LINK } from '../sidebar-menu/lib/constants';
+import { CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT } from '../a4a-contact-support-widget';
 
 import './style.scss';
 type Props = {
@@ -29,12 +28,7 @@ const MigrationOfferBody = () => {
 	return (
 		<>
 			<p className="a4a-migration-offer__description">{ description }</p>
-			<Button
-				onClick={ () => {
-					page( `${ A4A_OVERVIEW_LINK }#contact-support-migration-offer` );
-				} }
-				primary
-			>
+			<Button href={ CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT } primary>
 				{ translate( 'Contact us' ) }
 				<Icon icon={ external } size={ 18 } />
 			</Button>

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -1,18 +1,16 @@
-import page from '@automattic/calypso-router';
 import { Button, Gridicon, Gravatar } from '@automattic/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
-import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/overview/sidebar/contact-support';
 import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
 import useOutsideClickCallback from 'calypso/lib/use-outside-click-callback';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { CONTACT_URL_HASH_FRAGMENT } from '../../a4a-contact-support-widget';
 import {
-	A4A_OVERVIEW_LINK,
 	EXTERNAL_A4A_KNOWLEDGE_BASE,
 	EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE,
 } from '../../sidebar-menu/lib/constants';
@@ -28,7 +26,6 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 	const translate = useTranslate();
 
 	const onGetHelp = useCallback( () => {
-		page( A4A_OVERVIEW_LINK + CONTACT_URL_HASH_FRAGMENT );
 		setMenuExpanded( false );
 		dispatch( recordTracksEvent( 'calypso_a4a_sidebar_gethelp' ) );
 	}, [ dispatch, setMenuExpanded ] );
@@ -45,7 +42,7 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 				// Show the "Contact support" button if the user is not a client
 				! isClient && (
 					<li className="a4a-sidebar__profile-dropdown-menu-item">
-						<Button borderless onClick={ onGetHelp }>
+						<Button borderless onClick={ onGetHelp } href={ CONTACT_URL_HASH_FRAGMENT }>
 							{ translate( 'Contact support' ) }
 						</Button>
 					</li>

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -2,9 +2,7 @@ import page from '@automattic/calypso-router';
 import { Icon, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
-import UserContactSupportModalForm from 'calypso/a8c-for-agencies/components/user-contact-support-modal-form';
-import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/sections/overview/sidebar/contact-support';
+import { useCallback } from 'react';
 import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import Sidebar, {
@@ -16,7 +14,7 @@ import Sidebar, {
 } from 'calypso/layout/sidebar-v2';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { A4A_OVERVIEW_LINK, A4A_CLIENT_SUBSCRIPTIONS_LINK } from '../sidebar-menu/lib/constants';
+import A4AContactSupportWidget, { CONTACT_URL_HASH_FRAGMENT } from '../a4a-contact-support-widget';
 import SidebarHeader from './header';
 import ProfileDropdown from './header/profile-dropdown';
 
@@ -63,22 +61,10 @@ const A4ASidebar = ( {
 
 	const isClient = isClientView();
 
-	const [ showUserSupportForm, setShowUserSupportForm ] = useState( false );
-
 	const onShowUserSupportForm = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_share_product_feedback_click' ) );
-		setShowUserSupportForm( true );
 	}, [ dispatch ] );
 
-	const onCloseUserSupportForm = useCallback( () => {
-		// Remove any hash from the URL.
-		history.pushState( null, '', window.location.pathname + window.location.search );
-		setShowUserSupportForm( false );
-	}, [] );
-
-	const contactUsUrl = isClient
-		? A4A_CLIENT_SUBSCRIPTIONS_LINK + '#contact-support'
-		: A4A_OVERVIEW_LINK + '#contact-sales';
 	const contactUsText = isClient ? translate( 'Contact support' ) : translate( 'Contact sales' );
 
 	return (
@@ -121,7 +107,7 @@ const A4ASidebar = ( {
 							path=""
 							icon={ <JetpackIcons icon="help" /> }
 							onClickMenuItem={ () => {
-								page( A4A_OVERVIEW_LINK + CONTACT_URL_HASH_FRAGMENT );
+								page( CONTACT_URL_HASH_FRAGMENT );
 								dispatch(
 									recordTracksEvent( 'calypso_a4a_sidebar_menu_click', {
 										menu_item: 'A4A / Support',
@@ -133,7 +119,7 @@ const A4ASidebar = ( {
 
 					<SidebarNavigatorMenuItem
 						title={ contactUsText }
-						link={ contactUsUrl }
+						link={ CONTACT_URL_HASH_FRAGMENT }
 						path=""
 						icon={ <Icon icon={ starEmpty } /> }
 						onClickMenuItem={ onShowUserSupportForm }
@@ -143,10 +129,7 @@ const A4ASidebar = ( {
 				</ul>
 			</SidebarFooter>
 
-			<UserContactSupportModalForm
-				show={ showUserSupportForm }
-				onClose={ onCloseUserSupportForm }
-			/>
+			<A4AContactSupportWidget />
 		</Sidebar>
 	);
 };

--- a/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/contact-support/index.tsx
@@ -1,66 +1,27 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
-import UserContactSupportModalForm from 'calypso/a8c-for-agencies/components/user-contact-support-modal-form';
+import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 
-export const CONTACT_URL_HASH_FRAGMENT = '#contact-support';
-export const CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT = '#contact-support-migration-offer';
-
 export default function OverviewSidebarContactSupport() {
 	const translate = useTranslate();
 
-	const hashSupportFormHash =
-		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
-		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
-
-	const [ showUserSupportForm, setShowUserSupportForm ] = useState( hashSupportFormHash );
 	const dispatch = useDispatch();
 
 	const toggleContactForm = () => {
-		setShowUserSupportForm( ( prevState ) => {
-			const nextState = ! prevState;
-
-			const hashFragment = nextState ? CONTACT_URL_HASH_FRAGMENT : '';
-
-			window.history.replaceState(
-				null,
-				'',
-				window.location.pathname + window.location.search + hashFragment
-			);
-			dispatch( recordTracksEvent( 'calypso_a4a_overview_contact_support_click' ) );
-			return nextState;
-		} );
+		dispatch( recordTracksEvent( 'calypso_a4a_overview_contact_support_click' ) );
 	};
 
-	const onCloseUserSupportForm = useCallback( () => {
-		// Remove any hash from the URL.
-		history.pushState( null, '', window.location.pathname + window.location.search );
-		setShowUserSupportForm( false );
-	}, [] );
-
-	// We need make sure to set this to true when we have the support form hash fragment.
-	if ( hashSupportFormHash && ! showUserSupportForm ) {
-		setShowUserSupportForm( true );
-	}
-
 	return (
-		<>
-			<Button className="overview__contact-support-button" onClick={ toggleContactForm }>
-				{ translate( 'Contact sales & support' ) }
-			</Button>
-			<UserContactSupportModalForm
-				show={ showUserSupportForm }
-				onClose={ onCloseUserSupportForm }
-				defaultMessage={
-					window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT
-						? translate( "I'd like to chat more about the migration offer." )
-						: undefined
-				}
-			/>
-		</>
+		<Button
+			className="overview__contact-support-button"
+			onClick={ toggleContactForm }
+			href={ CONTACT_URL_HASH_FRAGMENT }
+		>
+			{ translate( 'Contact sales & support' ) }
+		</Button>
 	);
 }


### PR DESCRIPTION
We currently have a few components that trigger a contact support form. The current process involves redirecting users to the Overview page to render the form, as this is the only page where this component exists. This negatively impacts user experience as it forces users to move to a different page. 

This pull request introduces a global contact support form that is located in the sidebar and can be triggered through a hash fragment. Components that rely on the form will only need to update the URL.

<img width="871" alt="Screenshot 2024-06-24 at 10 56 19 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9c46e546-4233-4d04-9dd2-d00b8a63c1d9">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/644

## Proposed Changes

* This pull request introduces a `ContactSupportWidget` component that encapsulates the UserFeedbackForm component with the required hooks to monitor changes in the URL hash fragment, which will act as the display flag. The widget will be placed in the Sidebar component since it is a common component present on all pages. This will enable triggering the form display by simply updating the URL with the contact support hash fragment anywhere in the A4A platform.


## Testing Instructions

* Go to the `/overview` page.
* Confirm that when clicking the **Contact us** button in the Migration offer card or **Contact sales and support** button in the aside section triggers the **Contact support** display.
* Confirm that the sidebar's contact sales button or the User profile down contact support button triggers the **Contact support form** display. 
* Go to the `/marketplace/hosting` page.
* Click the **Contact Us** support from the Migration offer banner.
* Confirm that it triggers the Contact support form.
* Confirm that you did not redirect to the overview page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
