### PR TITLE
Domains: Add notice for Gravatar flow allowed TLDs

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1061,6 +1061,7 @@ class RegisterDomainStep extends Component {
 		if ( this.props.flowName === 'domain-for-gravatar' ) {
 			// Skips availability check for the Gravatar flow - so TLDs that are
 			// available but not eligible for Gravatar won't be displayed
+			this.showSuggestionErrorMessage( domain, 'gravatar_tld_restriction', {} );
 			return;
 		}
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -558,6 +558,11 @@ function getAvailabilityNotice(
 			);
 			break;
 
+		case 'gravatar_tld_restriction':
+			message = translate( 'Gravatar only supports .link domains right now.' );
+			severity = 'info';
+			break;
+
 		default:
 			message = translate(
 				'Sorry, there was a problem processing your request. Please try again in a few minutes.'

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -559,7 +559,9 @@ function getAvailabilityNotice(
 			break;
 
 		case 'gravatar_tld_restriction':
-			message = translate( 'Gravatar only supports .link domains right now.' );
+			message = translate(
+				'Gravatar is currently offering free .link domains. Additional domain extensions may become available for a fee in the future.'
+			);
 			severity = 'info';
 			break;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
Includes a notice to let users know the allowed TLDs for Gravatar domains - currently, if they search for a TLD that's not eligible, we don't show either the FQDN or the result/message, this can lead to confusion. This PR adds it so users know what TLDs are allowed. It's currently static, but we will later adapt it to use what's returned from the suggestions endpoint.

## Preview
![image](https://github.com/Automattic/wp-calypso/assets/18705930/4a8d88a9-5321-41a1-9a94-4154a4fb15a4)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Go to the Gravatar flow (`/start/domain-for-gravatar/domain-only?search=yes&new=your-test-domain.com`);
- Type any valid domain name and ensure you get the same message as displayed in the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
