### PR TITLE
Updated how we're checking for proxied access to agencies panel

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -66,11 +67,11 @@ export const JetpackSitesDataViews = ( {
 		[]
 	);
 
-	const isProxied = window.configData?.env_id !== 'a8c-for-agencies-production';
+	const isNotProduction = config( 'env_id' ) !== 'a8c-for-agencies-production';
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
-			if ( site.sticker?.includes( 'migration-in-progress' ) && ! isProxied ) {
+			if ( site.sticker?.includes( 'migration-in-progress' ) && ! isNotProduction ) {
 				return;
 			}
 
@@ -387,7 +388,7 @@ export const JetpackSitesDataViews = ( {
 								onKeyDown={ ( e: KeyboardEvent ) => e.stopPropagation() }
 							>
 								{ ( ! item.site.value.sticker?.includes( 'migration-in-progress' ) ||
-									isProxied ) && (
+									isNotProduction ) && (
 									<>
 										<SiteActions
 											isLargeScreen={ isLargeScreen }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -22,9 +22,6 @@ import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-o
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
-import { useSelector } from 'calypso/state';
-import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
 import useFormattedSites from '../../hooks/use-formatted-sites';
 import { AllowedTypes, Site, SiteData } from '../../types';
@@ -69,12 +66,11 @@ export const JetpackSitesDataViews = ( {
 		[]
 	);
 
-	const teams = useSelector( getReaderTeams );
-	const isTeamMember = isAutomatticTeamMember( teams );
+	const isProxied = window.configData?.env_id !== 'a8c-for-agencies-production';
 
 	const openSitePreviewPane = useCallback(
 		( site: Site ) => {
-			if ( site.sticker?.includes( 'migration-in-progress' ) && ! isTeamMember ) {
+			if ( site.sticker?.includes( 'migration-in-progress' ) && ! isProxied ) {
 				return;
 			}
 
@@ -391,7 +387,7 @@ export const JetpackSitesDataViews = ( {
 								onKeyDown={ ( e: KeyboardEvent ) => e.stopPropagation() }
 							>
 								{ ( ! item.site.value.sticker?.includes( 'migration-in-progress' ) ||
-									isTeamMember ) && (
+									isProxied ) && (
 									<>
 										<SiteActions
 											isLargeScreen={ isLargeScreen }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/92010

## Proposed Changes

* HE uses session login to access Agency /sites, so we need to check if we're not in production (any a8n on proxy)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
