### PR TITLE
Store Sandbox UI: Show an indicator when store sandbox can't be toggled

### DIFF
--- a/client/data/store-sandbox/use-store-sandbox-status.ts
+++ b/client/data/store-sandbox/use-store-sandbox-status.ts
@@ -1,15 +1,13 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 interface useStoreSandboxStatusQueryResponse {
 	sandbox_status: boolean;
+	is_editable: boolean;
+	reason_not_editable: string;
 }
 
-function mapResult( response: useStoreSandboxStatusQueryResponse ): boolean {
-	return response.sandbox_status;
-}
-
-export default function useStoreSandboxStatusQuery() {
+export default function useStoreSandboxStatusQuery(): UseQueryResult< useStoreSandboxStatusQueryResponse > {
 	return useQuery( {
 		queryKey: [ 'store-sandbox' ],
 		queryFn: () =>
@@ -17,7 +15,6 @@ export default function useStoreSandboxStatusQuery() {
 				path: '/store-sandbox/status',
 				apiNamespace: 'wpcom/v2',
 			} ),
-		select: mapResult,
 		retry: false,
 		refetchOnWindowFocus: true,
 	} );

--- a/client/lib/store-sandbox-helper/index.tsx
+++ b/client/lib/store-sandbox-helper/index.tsx
@@ -14,7 +14,14 @@ interface StoreSandboxQueryResponse {
 }
 
 export function StoreSandboxHelper() {
-	const { data: isSandboxed = false } = useStoreSandboxStatusQuery();
+	const { data: storeSandboxStatus, isLoading: isLoading } = useStoreSandboxStatusQuery();
+	const isSandboxed = storeSandboxStatus?.sandbox_status ?? false;
+	const isEditable = storeSandboxStatus?.is_editable ?? false;
+	const reasonNotEditable = storeSandboxStatus?.reason_not_editable
+		? storeSandboxStatus.reason_not_editable
+		: null;
+	const reasonNotEditableText = isLoading ? 'Loading...' : reasonNotEditable;
+
 	const [ isStoreSandboxed, setIsStoreSandboxed ] = useState( isSandboxed );
 	const [ responseError, setResponseError ] = useState< string | null >( null );
 
@@ -57,8 +64,9 @@ export function StoreSandboxHelper() {
 				<ToggleControl
 					label="Store Sandbox"
 					checked={ isStoreSandboxed || false }
+					disabled={ ! isEditable }
 					onChange={ onToggleStoreSandbox }
-					help={ responseError ? responseError : popoverStatus }
+					help={ responseError ?? reasonNotEditableText ?? popoverStatus }
 				/>
 			</div>
 		</>


### PR DESCRIPTION
When Store sandbox isn't editable in Calypso, currently there is no indication given and the Store sandbox toggle just appears to be broken.

This pull request disables the toggle in that scenario (and displays a message explaining why).

Example when Store sandbox is editable (same as before this pull request):

![store-sandbox-editable](https://github.com/Automattic/wp-calypso/assets/235183/af579764-bd4e-4713-ad27-d4aba0ea8d35)

Example when Store sandbox is not editable, as implemented via this pull request (this is an example message; note that a different one might be shown instead):

![store-sandbox-not-editable](https://github.com/Automattic/wp-calypso/assets/235183/e0cd4899-da66-4c09-a37f-1ce26f024038)

See: https://github.com/Automattic/payments-shilling/issues/2891.
Requires: D153215-code

## Testing Instructions

- With D153215-code applied, sandbox `public-api.wordpress.com`
- Hover over the environment badge, go to the "Store sandbox" section and make sure the toggle works the same as before
- If the Store sandbox setting isn't editable (see D153215-code for instructions on how to do that) make sure the toggle is disabled with a message explaining why

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?