### PR TITLE
Stats: Remove UTM Builder feature flag

### DIFF
--- a/client/my-sites/stats/stats-module-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -61,7 +60,6 @@ const StatsModuleUTM = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const translate = useTranslate();
-	const isBuilderEnabled = config.isEnabled( 'stats/utm-builder' );
 
 	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.SOURCE_MEDIUM );
 
@@ -148,7 +146,7 @@ const StatsModuleUTM = ( {
 				mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 				toggleControl={
 					<div className="stats-module__extended-toggle">
-						{ isBuilderEnabled && <UTMBuilder /> }
+						<UTMBuilder />
 						<UTMDropdown
 							buttonLabel={ optionLabels[ selectedOption ].selectLabel }
 							onSelect={ setSelectedOption }

--- a/config/client.json
+++ b/config/client.json
@@ -23,7 +23,6 @@
 	"siftscience_key",
 	"signup_url",
 	"stats/tier-upgrade-slider",
-	"stats/utm-builder",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -212,7 +212,6 @@
 		"ssr/prefetch-timebox": false,
 		"stats/paid-wpcom-v2": true,
 		"stats/tier-upgrade-slider": true,
-		"stats/utm-builder": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -138,7 +138,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/tier-upgrade-slider": true,
-		"stats/utm-builder": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -182,7 +182,6 @@
 		"ssr/sample-log-cache-misses": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/tier-upgrade-slider": true,
-		"stats/utm-builder": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -176,7 +176,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/tier-upgrade-slider": true,
-		"stats/utm-builder": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -117,7 +117,6 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/tier-upgrade-slider": true,
-		"stats/utm-builder": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -174,7 +174,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/tier-upgrade-slider": true,
-		"stats/utm-builder": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#61](https://github.com/Automattic/red-team/issues/61)

## Proposed Changes

* removes the UTM Builder feature flag

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* code cleanup

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch
* verify that the UTM builder works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?