### PR TITLE
Stats: Use My Jetpack purchases endpoint

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -23,9 +23,8 @@ async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
 	return wpcom.req
 		.get( {
 			path: getApiPath( '/site/purchases', { siteId } ),
-			apiNamespace: getApiNamespace(),
+			apiNamespace: getApiNamespace( 'my-jetpack/v1' ),
 		} )
-		.then( ( res: { data: string } ) => JSON.parse( res.data ) )
 		.catch( ( error: APIError ) => error );
 }
 /**
@@ -63,26 +62,11 @@ export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number 
 		}
 
 		if ( isError( purchases ) || hasOtherErrors ) {
-			if ( ( purchases as APIError ).status !== 403 ) {
-				// Dispatch to the Purchases reducer for error status
-				reduxDispatch( {
-					type: PURCHASES_SITE_FETCH_FAILED,
-					error: 'purchase_fetch_failed',
-				} );
-			} else {
-				// TODO: Remove this after fixing the API permission issue from Jetpack.
-				reduxDispatch( {
-					type: PURCHASES_SITE_FETCH_COMPLETED,
-					siteId,
-					purchases: [
-						{
-							expiry_status: 'active',
-							product_slug: 'jetpack_stats_pwyw_yearly',
-							blog_id: siteId,
-						},
-					],
-				} );
-			}
+			// Dispatch to the Purchases reducer for error status
+			reduxDispatch( {
+				type: PURCHASES_SITE_FETCH_FAILED,
+				error: 'purchase_fetch_failed',
+			} );
 		} else {
 			// Dispatch to the Purchases reducer for consistent requesting status
 			reduxDispatch( {

--- a/apps/odyssey-stats/src/lib/get-api.ts
+++ b/apps/odyssey-stats/src/lib/get-api.ts
@@ -5,8 +5,8 @@ import config from '@automattic/calypso-config';
  * This is needed as WP.com Simple Classic is loading Odyssey Stats, which we will use the public-api.wordpress.com APIs.
  * @returns {string} The API namespace to use.
  */
-export const getApiNamespace = (): string => {
-	return config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1';
+export const getApiNamespace = ( namespace = 'jetpack/v4' ): string => {
+	return config.isEnabled( 'is_running_in_jetpack_site' ) ? namespace : 'rest/v1.1';
 };
 
 /**


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/58

## Proposed Changes

The purchases API from My Jetpack allow access from non-admin users, we might just use it. In addition, the endpoint is there from the first day of Odyssey, so we don't have to handle compatibility checks.



## Why are these changes being made?

I wanted to add a purchases endpoint for Stats as a ultimate solution, but I'm not particularly sure now, as we'll always have My Jetpack everywhere. We'll probably still add an endpoint when we start working on the standalone plugin tho. The reason why I didn’t use it was that I thought it wouldn’t work for Simple - no my jetpack there apparently - however if we switch API on the go like what’s proposed in the PR, it works beautifully. 
 
## Testing Instructions

* Build Odyssey Stats and Jetpack locally
  * `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
  * `jetpack build plugins/jetpack`
* Purchase a commercial license for your local site not yet 
* Open /wp-admin/ and switch to a non-admin user with Stats access
  * Grant access for roles here: `/wp-admin/admin.php?page=jetpack#/traffic` 
* Switch to the user
* Open `/wp-admin/admin.php?page=stats`
* Ensure you are able to view the advance modules, including Devices, UTM, and Date Picker.

**Note: Please install on sandbox and test on Simple sites too.**

- Install the build on sandbox `bin/install-plugin.sh odyssey-stats update/use-my-jetpack-purchases-api`
- Sandbox `widgets.wp.com`
- Enable Classic WP-Admin for a simple site
- Open `/wp-admin/admin.php?page=stats`
- Ensure Stats works as it was

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?