### PR TITLE
Fix "React keys must be passed directly to JSX without using spread"

### DIFF
--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -288,7 +288,7 @@ export class NoteList extends Component {
 		let [ notes ] = Object.entries( noteGroups ).reduce(
 			( [ list, isFirst ], [ timeGroupKey, timeGroupNotes ] ) => {
 				const title = groupTitles[ timeGroupKey ];
-				const header = <ListHeader { ...{ key: title, title, isFirst } } />;
+				const header = <ListHeader key={ title } title={ title } isFirst={ isFirst } />;
 
 				return [ [ ...list, header, ...timeGroupNotes.map( createNoteComponent ) ], false ];
 			},

--- a/client/blocks/post-share/connections-list.jsx
+++ b/client/blocks/post-share/connections-list.jsx
@@ -38,11 +38,11 @@ class ConnectionsList extends PureComponent {
 			<div className="post-share__connections">
 				{ connections.map( ( connection ) => (
 					<Connection
+						key={ connection.keyring_connection_ID }
 						{ ...{
 							connection,
 							onToggle,
 							isActive: connection.isActive,
-							key: connection.keyring_connection_ID,
 						} }
 					/>
 				) ) }

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -189,7 +189,7 @@ class SharingPreviewPane extends PureComponent {
 					</div>
 					<VerticalMenu onClick={ this.selectPreview } initialItemIndex={ initialMenuItemIndex }>
 						{ services.map( ( service ) => (
-							<SocialItem { ...{ key: service, service } } />
+							<SocialItem key={ service } service={ service } />
 						) ) }
 					</VerticalMenu>
 				</div>

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -222,7 +222,7 @@ export class SeoPreviewPane extends PureComponent {
 					</div>
 					<VerticalMenu onClick={ this.selectPreview }>
 						{ services.map( ( service ) => (
-							<SocialItem { ...{ key: service, service } } />
+							<SocialItem key={ service } service={ service } />
 						) ) }
 					</VerticalMenu>
 				</div>

--- a/packages/eslint-plugin-wpcalypso/lib/configs/react.js
+++ b/packages/eslint-plugin-wpcalypso/lib/configs/react.js
@@ -10,6 +10,7 @@ module.exports = {
 	plugins: [ 'react', 'react-hooks' ],
 	rules: {
 		'react/jsx-curly-spacing': [ 2, 'always' ],
+		'react/jsx-key': 1,
 		'react/jsx-no-duplicate-props': 2,
 		'react/jsx-no-target-blank': 2,
 		'react/jsx-no-undef': 2,


### PR DESCRIPTION
Currently there is this warning at a few places

```
Warning: A props object containing a "key" prop is being spread into JSX:
...
React keys must be passed directly to JSX without using spread
```

![image](https://github.com/Automattic/wp-calypso/assets/18226415/2317c957-d9d1-43a7-8305-ac4188c14bfc)

Related discussion: p1718963631407319/1718963063.488969-slack-C02DQP0FP

## Proposed Changes

* Pass the key directly to JSX
* Added ["react/jsx-key"](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) rule as a warning for now

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the warning in console

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the post share feature in `/posts/:site`
* Confirm that nothing breaks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?