### PR TITLE
Site Management Panel: Bring back staging sites in the site list

### DIFF
--- a/client/sites-dashboard-v2/hooks/use-initialize-dataviews-selected-item.ts
+++ b/client/sites-dashboard-v2/hooks/use-initialize-dataviews-selected-item.ts
@@ -12,25 +12,17 @@ export function useInitializeDataViewsSelectedItem( {
 	selectedSite?: SiteDetails | null;
 	paginatedSites: any;
 } ) {
-	const initialized = useRef( false );
+	const initialized = useRef( '' );
 
 	useEffect( () => {
-		if ( initialized.current || ! selectedSite ) {
+		if ( initialized.current === selectedSite?.slug || ! selectedSite ) {
 			return;
 		}
-
-		const selector = selectedSite.is_wpcom_staging_site
-			? '.site-dataviews__staging-site'
-			: '.sites-dataviews__site';
-
-		for ( const site of document.querySelectorAll( selector ) ) {
-			const slug = selectedSite.is_wpcom_staging_site
-				? site.getAttribute( 'data-site-slug' )
-				: ( site.querySelector( '.sites-dataviews__site-url span' ) as HTMLElement )?.innerText;
-
-			if ( selectedSite.slug === slug ) {
+		for ( const site of document.querySelectorAll( '.sites-dataviews__site' ) ) {
+			const slug = site.querySelector( '.sites-dataviews__site-url span' );
+			if ( selectedSite.slug === ( slug as HTMLElement )?.innerText ) {
 				( site as HTMLElement ).click?.();
-				initialized.current = true;
+				initialized.current = selectedSite.slug;
 				break;
 			}
 		}

--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -101,14 +101,9 @@ const SitesDashboardV2 = ( {
 
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
 
-	const { data: allSitesIncludingStagingSites = [], isLoading } = useSiteExcerptsQuery(
+	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
 		[],
 		( site ) => ! site.options?.is_domain_only
-	);
-
-	const allSites = useMemo(
-		() => allSitesIncludingStagingSites.filter( ( site ) => ! site.is_wpcom_staging_site ),
-		[ allSitesIncludingStagingSites ]
 	);
 
 	useShowSiteCreationNotice( allSites, newSiteID );
@@ -254,7 +249,7 @@ const SitesDashboardV2 = ( {
 	);
 
 	const changeSitePreviewPane = ( siteId: number ) => {
-		const targetSite = allSitesIncludingStagingSites.find( ( site ) => site.ID === siteId );
+		const targetSite = allSites.find( ( site ) => site.ID === siteId );
 		if ( targetSite ) {
 			openSitePreviewPane( targetSite );
 		}
@@ -316,7 +311,6 @@ const SitesDashboardV2 = ( {
 						</div>
 					) }
 					<DotcomSitesDataViews
-						selectedSite={ dataViewsState.selectedItem }
 						sites={ paginatedSites }
 						isLoading={ isLoading || ! initialSortApplied }
 						paginationInfo={ getSitesPagination( filteredSites, perPage ) }

--- a/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/dataviews-fields/site-field.tsx
@@ -14,16 +14,19 @@ import { SiteName } from 'calypso/sites-dashboard/components/sites-site-name';
 import { Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
 import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
 import { ThumbnailLink } from 'calypso/sites-dashboard/components/thumbnail-link';
-import { displaySiteUrl, isNotAtomicJetpack, MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
+import {
+	displaySiteUrl,
+	isNotAtomicJetpack,
+	isStagingSite,
+	MEDIA_QUERIES,
+} from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
 import type { SiteExcerptData } from '@automattic/sites';
 
 type Props = {
-	isStagingEnabled: boolean;
 	site: SiteExcerptData;
 	openSitePreviewPane?: ( site: SiteExcerptData ) => void;
 };
@@ -55,7 +58,7 @@ const ListTileTitle = styled.div`
 	align-items: center;
 `;
 
-const SiteField = ( { site, openSitePreviewPane, isStagingEnabled }: Props ) => {
+const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const { __ } = useI18n();
 
 	// Todo: This hook is used by the SiteItemThumbnail component below, in a prop showPlaceholder={ ! inView }.
@@ -70,16 +73,8 @@ const SiteField = ( { site, openSitePreviewPane, isStagingEnabled }: Props ) => 
 	const title = __( 'View Site Details' );
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( site.ID );
 
-	const stagingSiteSlug = useSelector( ( state ) => {
-		const stagingBlogId = site.options?.wpcom_staging_blog_ids?.[ 0 ] ?? null;
-		if ( ! stagingBlogId ) {
-			return false;
-		}
-
-		return getSiteSlug( state, stagingBlogId );
-	} );
-
 	const isP2Site = site.options?.is_wpforteams_site;
+	const isWpcomStagingSite = isStagingSite( site );
 	const isTrialSitePlan = useSelector( ( state ) => isTrialSite( state, site.ID ) );
 
 	const isAdmin = useSelector( ( state ) => canCurrentUser( state, site.ID, 'manage_options' ) );
@@ -121,7 +116,7 @@ const SiteField = ( { site, openSitePreviewPane, isStagingEnabled }: Props ) => 
 							<Truncated>{ site.title }</Truncated>
 						</SiteName>
 						{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
-						{ isStagingEnabled && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
+						{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
 						{ isTrialSitePlan && (
 							<SitesMigrationTrialBadge>{ __( 'Trial' ) }</SitesMigrationTrialBadge>
 						) }
@@ -151,13 +146,6 @@ const SiteField = ( { site, openSitePreviewPane, isStagingEnabled }: Props ) => 
 							<a className="sites-dataviews__site-wp-admin-url" href={ adminUrl }>
 								<Truncated>{ adminLabel }</Truncated>
 							</a>
-							{ stagingSiteSlug && (
-								<button
-									tabIndex={ -1 }
-									data-site-slug={ stagingSiteSlug }
-									className="site-dataviews__staging-site"
-								></button>
-							) }
 						</>
 					)
 				}

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -27,7 +27,6 @@ import type {
 import './style.scss';
 
 type Props = {
-	selectedSite: SiteExcerptData | null;
 	sites: SiteExcerptData[];
 	isLoading: boolean;
 	paginationInfo: DataViewsPaginationInfo;
@@ -44,7 +43,6 @@ export const siteStatusGroups = [
 ];
 
 const DotcomSitesDataViews = ( {
-	selectedSite,
 	sites,
 	isLoading,
 	paginationInfo,
@@ -126,16 +124,7 @@ const DotcomSitesDataViews = ( {
 				width: getSiteNameColWidth( isDesktop, isWide ),
 				getValue: ( { item }: { item: SiteInfo } ) => item.URL,
 				render: ( { item }: { item: SiteInfo } ) => {
-					const isStagingEnabled =
-						!! selectedSite &&
-						!! item.options?.wpcom_staging_blog_ids?.find( ( id ) => id === selectedSite.ID );
-					return (
-						<SiteField
-							site={ item }
-							isStagingEnabled={ isStagingEnabled }
-							openSitePreviewPane={ openSitePreviewPane }
-						/>
-					);
+					return <SiteField site={ item } openSitePreviewPane={ openSitePreviewPane } />;
 				},
 				enableHiding: false,
 				enableSorting: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

After removing the staging sites from the Site list, we've received several user reports about missing staging sites. To avoid this confusion, this PR [re-adds](https://github.com/Automattic/dotcom-forge/issues/7536#issuecomment-2188469449) them in the Site list.

Related to https://github.com/Automattic/dotcom-forge/issues/7536

## Proposed Changes

* Re-add the staging sites in the Site Management Panel

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We've got several user reports that their staging sites disappeared

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Go to Sites
* Search for a staging site (or create one if you don't have one)
* Notice that the Staging sites are appearing again in the site list
* Use the Production/staging dropdown and navigate between environments
* Make sure that when switching between environments, the site is also preselected in the site list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
