### PR TITLE
Social Previews | Fix media image URL for Tumblr preview

### DIFF
--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.1.0
 
 - Added Threads preview
+- Fixed media image URL for Tumblr preview
 
 ## v2.0.1 (2024-06-10)
 

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.1.0-beta.4",
+	"version": "2.1.0-beta.5",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.1.0-beta.3",
+	"version": "2.1.0-beta.4",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/mastodon-preview/link-preview.tsx
+++ b/packages/social-previews/src/mastodon-preview/link-preview.tsx
@@ -13,7 +13,7 @@ export const MastodonLinkPreview: React.FC< MastodonPreviewProps > = ( props ) =
 		<div className="mastodon-preview__post">
 			<MastodonPostHeader user={ user } />
 			<MastonPostBody { ...props } />
-			<MastodonPostCard { ...props } />
+			<MastodonPostCard { ...props } customImage="" />
 			<MastodonPostActions />
 		</div>
 	);

--- a/packages/social-previews/src/tumblr-preview/post-preview.tsx
+++ b/packages/social-previews/src/tumblr-preview/post-preview.tsx
@@ -38,7 +38,7 @@ export const TumblrPostPreview: React.FC< TumblrPreviewProps > = ( {
 									<source src={ mediaItem.url } type={ mediaItem.type } />
 								</video>
 							) : (
-								<img className="tumblr-preview__image" src={ image } alt="" />
+								<img className="tumblr-preview__image" src={ mediaItem.url } alt="" />
 							) }
 						</div>
 					) : (


### PR DESCRIPTION
Fixes the issue reported [here](https://github.com/Automattic/jetpack/pull/37964#issuecomment-2188679385) for Tumblr social preview

## Proposed Changes

* Fix the media URL for Tumble in social preview

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The media image is not correctly displayed in Tumblr preview

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can test the Tumblr preview with custom media in https://github.com/Automattic/jetpack/pull/37964

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
