### PR TITLE
Stats: Minor refactor for notice visibility

### DIFF
--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -115,21 +115,15 @@ function shouldShowCommercialSiteUpgradeNotice( {
 	hasPWYWPlanOnly,
 }: StatsNoticeProps ) {
 	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
-	const showUpgradeNoticeOnOdyssey = isOdysseyStats;
-	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
+	const showUpgradeNoticeForJetpackSites = isOdysseyStats || isSiteJetpackNotAtomic;
 
 	// Test specific to commercial self-hosted sites with PWYW plans.
-	// They should see the upgrade notice!
-	if ( showUpgradeNoticeOnOdyssey || showUpgradeNoticeForJetpackNotAtomic ) {
-		if ( isCommercial && hasPWYWPlanOnly ) {
-			return true;
-		}
+	if ( showUpgradeNoticeForJetpackSites && isCommercial && hasPWYWPlanOnly ) {
+		return true;
 	}
 
 	return !! (
-		( showUpgradeNoticeOnOdyssey ||
-			showUpgradeNoticeForJetpackNotAtomic ||
-			showUpgradeNoticeForWpcomSites ) &&
+		( showUpgradeNoticeForJetpackSites || showUpgradeNoticeForWpcomSites ) &&
 		// Show the notice if the site has not purchased the paid stats product.
 		! hasPaidStats &&
 		// Show the notice only if the site is commercial.

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -34,7 +34,34 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: CommercialSiteUpgradeNotice,
 		noticeId: 'commercial_site_upgrade',
-		isVisibleFunc: shouldShowCommercialSiteUpgradeNotice,
+		isVisibleFunc: ( {
+			isOdysseyStats,
+			isWpcom,
+			isVip,
+			isP2,
+			isOwnedByTeam51,
+			hasPaidStats,
+			isSiteJetpackNotAtomic,
+			isCommercial,
+			hasPWYWPlanOnly,
+		}: StatsNoticeProps ) => {
+			const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
+			const showUpgradeNoticeForJetpackSites = isOdysseyStats || isSiteJetpackNotAtomic;
+
+			// Test specific to commercial self-hosted sites with PWYW plans.
+			if ( showUpgradeNoticeForJetpackSites && isCommercial && hasPWYWPlanOnly ) {
+				return true;
+			}
+
+			return !! (
+				( showUpgradeNoticeForJetpackSites || showUpgradeNoticeForWpcomSites ) &&
+				// Show the notice if the site has not purchased the paid stats product.
+				! hasPaidStats &&
+				// Show the notice only if the site is commercial.
+				isCommercial &&
+				! isVip
+			);
+		},
 		disabled: false,
 	},
 	{
@@ -102,34 +129,5 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		disabled: false,
 	},
 ];
-
-function shouldShowCommercialSiteUpgradeNotice( {
-	isOdysseyStats,
-	isWpcom,
-	isVip,
-	isP2,
-	isOwnedByTeam51,
-	hasPaidStats,
-	isSiteJetpackNotAtomic,
-	isCommercial,
-	hasPWYWPlanOnly,
-}: StatsNoticeProps ) {
-	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
-	const showUpgradeNoticeForJetpackSites = isOdysseyStats || isSiteJetpackNotAtomic;
-
-	// Test specific to commercial self-hosted sites with PWYW plans.
-	if ( showUpgradeNoticeForJetpackSites && isCommercial && hasPWYWPlanOnly ) {
-		return true;
-	}
-
-	return !! (
-		( showUpgradeNoticeForJetpackSites || showUpgradeNoticeForWpcomSites ) &&
-		// Show the notice if the site has not purchased the paid stats product.
-		! hasPaidStats &&
-		// Show the notice only if the site is commercial.
-		isCommercial &&
-		! isVip
-	);
-}
 
 export default ALL_STATS_NOTICES;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/wp-calypso/pull/92040

## Proposed Changes

Addressing feedback from above PR. Simplifying a conditional and inlining the code again.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* n/a

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No functional changes. Testing instructions in linked ticket still apply.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
