### PR TITLE
Stats: Minor refactor notice visibility 2

### DIFF
--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -40,56 +40,13 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 	{
 		component: DoYouLoveJetpackStatsNotice,
 		noticeId: 'do_you_love_jetpack_stats',
-		isVisibleFunc: ( {
-			isOdysseyStats,
-			isWpcom,
-			isVip,
-			isP2,
-			isOwnedByTeam51,
-			hasPaidStats,
-			isSiteJetpackNotAtomic,
-			isCommercial,
-		}: StatsNoticeProps ) => {
-			const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
-
-			// Show the notice if the site is Jetpack or it is Odyssey Stats.
-			const showUpgradeNoticeOnOdyssey = isOdysseyStats;
-
-			const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
-
-			return !! (
-				( showUpgradeNoticeOnOdyssey ||
-					showUpgradeNoticeForJetpackNotAtomic ||
-					showUpgradeNoticeForWpcomSites ) &&
-				// Show the notice if the site has not purchased the paid stats product.
-				! hasPaidStats &&
-				// Show the notice if the site is not commercial.
-				! isCommercial &&
-				! isVip
-			);
-		},
+		isVisibleFunc: shouldShowDoYouLoveJetpackStatsNotice,
 		disabled: false,
 	},
 	{
 		component: TierUpgradeNotice,
 		noticeId: 'tier_upgrade',
-		isVisibleFunc: ( {
-			isOdysseyStats,
-			isWpcom,
-			isCommercialOwned,
-			isSiteJetpackNotAtomic,
-		}: StatsNoticeProps ) => {
-			// Show the notice if the site is Jetpack or it is Odyssey Stats.
-			const showTierUpgradeNoticeOnOdyssey = isOdysseyStats;
-			const showTierUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
-			// We don't show the notice for WPCOM sites for now.
-			return !! (
-				! isWpcom &&
-				( showTierUpgradeNoticeOnOdyssey || showTierUpgradeNoticeForJetpackNotAtomic ) &&
-				config.isEnabled( 'stats/tier-upgrade-slider' ) &&
-				isCommercialOwned
-			);
-		},
+		isVisibleFunc: shouldShowTierUpgradeNotice,
 		disabled: false,
 	},
 	{
@@ -135,6 +92,53 @@ function shouldShowCommercialSiteUpgradeNotice( {
 		// Show the notice only if the site is commercial.
 		isCommercial &&
 		! isVip
+	);
+}
+
+function shouldShowDoYouLoveJetpackStatsNotice( {
+	isOdysseyStats,
+	isWpcom,
+	isVip,
+	isP2,
+	isOwnedByTeam51,
+	hasPaidStats,
+	isSiteJetpackNotAtomic,
+	isCommercial,
+}: StatsNoticeProps ) {
+	const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
+
+	// Show the notice if the site is Jetpack or it is Odyssey Stats.
+	const showUpgradeNoticeOnOdyssey = isOdysseyStats;
+
+	const showUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
+
+	return !! (
+		( showUpgradeNoticeOnOdyssey ||
+			showUpgradeNoticeForJetpackNotAtomic ||
+			showUpgradeNoticeForWpcomSites ) &&
+		// Show the notice if the site has not purchased the paid stats product.
+		! hasPaidStats &&
+		// Show the notice if the site is not commercial.
+		! isCommercial &&
+		! isVip
+	);
+}
+
+function shouldShowTierUpgradeNotice( {
+	isOdysseyStats,
+	isWpcom,
+	isCommercialOwned,
+	isSiteJetpackNotAtomic,
+}: StatsNoticeProps ) {
+	// Show the notice if the site is Jetpack or it is Odyssey Stats.
+	const showTierUpgradeNoticeOnOdyssey = isOdysseyStats;
+	const showTierUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
+	// We don't show the notice for WPCOM sites for now.
+	return !! (
+		! isWpcom &&
+		( showTierUpgradeNoticeOnOdyssey || showTierUpgradeNoticeForJetpackNotAtomic ) &&
+		config.isEnabled( 'stats/tier-upgrade-slider' ) &&
+		isCommercialOwned
 	);
 }
 

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -95,7 +95,24 @@ function shouldShowCommercialSiteUpgradeNotice( {
 	);
 }
 
-function shouldShowDoYouLoveJetpackStatsNotice( {
+function shouldShowDoYouLoveJetpackStatsNotice( state: StatsNoticeProps ) {
+	// Base considerations for notice eligibility.
+	const { isCommercial, isWpcom, isP2, isOwnedByTeam51 } = state;
+	if ( isCommercial || isWpcom || isP2 || isOwnedByTeam51 ) {
+		return false;
+	}
+
+	// Test for paid plans.
+	const { hasPaidStats } = state;
+	if ( hasPaidStats ) {
+		return false;
+	}
+
+	// return true;
+	return shouldShowDoYouLoveJetpackStatsNotice2( state );
+}
+
+function shouldShowDoYouLoveJetpackStatsNotice2( {
 	isOdysseyStats,
 	isWpcom,
 	isVip,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
