### PR TITLE
Theme Tiers: Add Community tier based on API

### DIFF
--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -6,7 +6,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { THEMES_REQUEST, THEMES_REQUEST_FAILURE } from 'calypso/state/themes/action-types';
 import { receiveThemes } from 'calypso/state/themes/actions/receive-themes';
-import { prependThemeFilterKeys } from 'calypso/state/themes/selectors';
+import { getThemeTier, prependThemeFilterKeys } from 'calypso/state/themes/selectors';
 import {
 	normalizeJetpackTheme,
 	normalizeWpcomTheme,
@@ -82,7 +82,8 @@ export function requestThemes( siteId, query = {}, locale ) {
 			.then( ( { themes: rawThemes, info: { results } = {}, found = results } ) => {
 				let themes;
 				if ( siteId === 'wporg' ) {
-					themes = map( rawThemes, normalizeWporgTheme );
+					const communityThemeTier = getThemeTier( getState(), 'community' );
+					themes = map( rawThemes, ( theme ) => normalizeWporgTheme( theme, communityThemeTier ) );
 				} else if ( siteId === 'wpcom' ) {
 					themes = map( rawThemes, normalizeWpcomTheme );
 				} else if ( isAtomic || isJetpack ) {

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -77,10 +77,11 @@ export function normalizeWpcomTheme( theme ) {
 
 /**
  * Normalizes a theme obtained from the WordPress.org REST API
- * @param  {Object} theme  Theme object
+ * @param   {Object} theme   Theme object
+ * @param   {Object} tier     Theme tier that wporg themes belong to.
  * @returns {Object}        Normalized theme object
  */
-export function normalizeWporgTheme( theme ) {
+export function normalizeWporgTheme( theme, tier ) {
 	if ( ! theme ) {
 		return {};
 	}
@@ -109,9 +110,7 @@ export function normalizeWporgTheme( theme ) {
 		normalizedTheme.author = author;
 	}
 
-	// Manually add the theme_tier for tracking purposes.
-	// @TODO: Replace this with the real tier definition from a new endpoint.
-	normalizedTheme.theme_tier = { slug: 'community' };
+	normalizedTheme.theme_tier = tier ?? { slug: 'community' };
 
 	if ( ! normalizedTheme.tags ) {
 		return normalizedTheme;


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/6353

## Proposed Changes

* Changed from a hardcoded Community Tier to assigning the community tier we receive from the server.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are hardcoding the community theme tier definition instead of using the real definition. If the definition changes Calypso would break and not show community themes to users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Open a creator site
* Go to the theme showcase and search for a community theme
* The community theme should work as expected (same as in prod)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
