### PR TITLE
PAO Landing: Add title and update padding in mobile view

### DIFF
--- a/client/start-with/square-payments/index.tsx
+++ b/client/start-with/square-payments/index.tsx
@@ -14,6 +14,7 @@ import TechCrunchImage from 'calypso/assets/images/start-with/Tech_Crunch.svg';
 import TimeLogo from 'calypso/assets/images/start-with/Time.svg';
 import USATodayImage from 'calypso/assets/images/start-with/USA_Today.svg';
 import DotcomWooSquareImage from 'calypso/assets/images/start-with/dotcom-woo-square.png';
+import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import 'calypso/start-with/style.scss';
 
@@ -26,6 +27,7 @@ export const StartWithSquarePayments: React.FC = () => {
 
 	return (
 		<div className="container">
+			<DocumentHead title={ translate( 'Square Payments' ) } />
 			<PageViewTracker path="/start-with/square-payments" title="Start with > Square Payments" />
 			<div className="content">
 				<div className="left-column">

--- a/client/start-with/style.scss
+++ b/client/start-with/style.scss
@@ -228,7 +228,7 @@
 				gap: 5px;
 
 				.left-column {
-					gap: 10px;
+					gap: 16px;
 
 					.title {
 						font-size: $font-headline-small;
@@ -260,9 +260,10 @@
 
 	@media (max-height: $break-medium) {
 		.container .content {
-			.left-column {
-				padding-top: 60px;
-			}
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			height: 100%;
 
 			.right-column {
 				display: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/7935

## Proposed Changes

* Add a document title to Square Payments landing page
* Update styles in mobile view to center the main content

|Before | After|
|-------|------|
| ![CleanShot 2024-06-25 at 17 10 55@2x](https://github.com/Automattic/wp-calypso/assets/3519124/37678fa0-87f8-490f-bae8-257f4fca8c23)| ![CleanShot 2024-06-25 at 17 00 54@2x](https://github.com/Automattic/wp-calypso/assets/3519124/8bee38e2-42d6-4954-bc4f-66ab9894291d)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve visual appearance and accessibility

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/start-with/square-payments`
* Check that the page has a title  <img src="https://github.com/Automattic/wp-calypso/assets/3519124/d019d273-fdce-45e4-902b-cdbb09dad3b6" width=300 />

* Open developer tools and select different devices
* Ensure the content looks nice, and that there is some padding on top of the main title
* Check for both logged-in and logged-out scenarios

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- ~~[ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- ~~[ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~~
