### PR TITLE
Use a site-aware pricing endpoint instead of a generic one

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -180,7 +180,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 				/>
 			) }
 
-			<UpgradePlanDetails>{ renderCTAs() }</UpgradePlanDetails>
+			<UpgradePlanDetails site={ site }>{ renderCTAs() }</UpgradePlanDetails>
 		</div>
 	);
 };

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -180,7 +180,9 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 				/>
 			) }
 
-			<UpgradePlanDetails siteId={ site.ID }>{ renderCTAs() }</UpgradePlanDetails>
+			<UpgradePlanDetails siteId={ site ? site.ID : undefined }>
+				{ renderCTAs() }
+			</UpgradePlanDetails>
 		</div>
 	);
 };

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -180,7 +180,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 				/>
 			) }
 
-			<UpgradePlanDetails site={ site }>{ renderCTAs() }</UpgradePlanDetails>
+			<UpgradePlanDetails siteId={ site.ID }>{ renderCTAs() }</UpgradePlanDetails>
 		</div>
 	);
 };

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -172,17 +172,13 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 				</div>
 			) }
 
-			{ site && site.ID && (
-				<PlanNoticeCreditUpgrade
-					linkTarget="_blank"
-					siteId={ site.ID }
-					visiblePlans={ [ visiblePlan ] }
-				/>
-			) }
+			<PlanNoticeCreditUpgrade
+				linkTarget="_blank"
+				siteId={ site.ID }
+				visiblePlans={ [ visiblePlan ] }
+			/>
 
-			<UpgradePlanDetails siteId={ site ? site.ID : undefined }>
-				{ renderCTAs() }
-			</UpgradePlanDetails>
+			<UpgradePlanDetails siteId={ site.ID }>{ renderCTAs() }</UpgradePlanDetails>
 		</div>
 	);
 };

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -1,10 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import {
-	getPlan,
-	calculateMonthlyPriceForPlan,
-	PLAN_BUSINESS,
-	PLAN_BUSINESS_MONTHLY,
-} from '@automattic/calypso-products';
+import { getPlan, PLAN_BUSINESS, PLAN_BUSINESS_MONTHLY } from '@automattic/calypso-products';
 import { CloudLogo, Button, PlanPrice } from '@automattic/components';
 import { Title } from '@automattic/onboarding';
 import { Plans2023Tooltip, useManageTooltipToggle } from '@automattic/plans-grid-next';
@@ -15,12 +10,12 @@ import ButtonGroup from 'calypso/components/button-group';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import { useSelectedPlanUpgradeMutation } from 'calypso/data/import-flow/use-selected-plan-upgrade';
 import { useSelector } from 'calypso/state';
-import { getSitePlan } from 'calypso/state/sites/plans/selectors';
+import { getSitePlan, getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
 import { UpgradePlanFeatureList } from './upgrade-plan-feature-list';
 import { UpgradePlanHostingDetails } from './upgrade-plan-hosting-details';
 
 interface Props {
-	siteId: number | undefined;
+	siteId: number;
 	children: React.ReactNode;
 }
 
@@ -39,9 +34,9 @@ export const UpgradePlanDetails = ( props: Props ) => {
 		siteId ? getSitePlan( state, siteId, selectedPlan ) : null
 	);
 
-	const rawPrice = planDetails
-		? calculateMonthlyPriceForPlan( selectedPlan, planDetails?.rawPrice )
-		: undefined;
+	const rawPrice = useSelector( ( state ) =>
+		getSitePlanRawPrice( state, siteId, selectedPlan, { returnMonthly: true } )
+	);
 
 	const { mutate: setSelectedPlanSlug } = useSelectedPlanUpgradeMutation();
 

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -20,7 +20,7 @@ import { UpgradePlanFeatureList } from './upgrade-plan-feature-list';
 import { UpgradePlanHostingDetails } from './upgrade-plan-hosting-details';
 
 interface Props {
-	siteId: number;
+	siteId: number | undefined;
 	children: React.ReactNode;
 }
 

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -1,8 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { getPlan, PLAN_BUSINESS, PLAN_BUSINESS_MONTHLY } from '@automattic/calypso-products';
 import { CloudLogo, Button, PlanPrice } from '@automattic/components';
-import { SiteDetails } from '@automattic/data-stores';
-import { useSitePlans } from '@automattic/data-stores/src/plans';
+import { SiteDetails, Plans } from '@automattic/data-stores';
 import { Title } from '@automattic/onboarding';
 import { Plans2023Tooltip, useManageTooltipToggle } from '@automattic/plans-grid-next';
 import { useI18n } from '@wordpress/react-i18n';
@@ -22,11 +21,13 @@ export const UpgradePlanDetails = ( props: Props ) => {
 	const { __ } = useI18n();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const [ showFeatures, setShowFeatures ] = useState( false );
-
-	const { children, site } = props;
 	const [ selectedPlan, setSelectedPlan ] = useState<
 		typeof PLAN_BUSINESS | typeof PLAN_BUSINESS_MONTHLY
 	>( PLAN_BUSINESS );
+
+	const { children, site } = props;
+	const { useSitePlans } = Plans;
+
 	const plan = getPlan( selectedPlan );
 	const sitePlans = useSitePlans( { siteId: site.ID } );
 	const pricing = sitePlans?.data ? sitePlans?.data[ selectedPlan ].pricing : undefined;

--- a/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
@@ -27,18 +27,21 @@ const PlanNoticeCreditUpgrade = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable( siteId, visiblePlans );
-	if ( ! planUpgradeCreditsApplicable ) {
-		return null;
-	}
 
 	const upgradeCreditDocsUrl = localizeUrl(
 		'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'
 	);
 
+	const showNotice =
+		visiblePlans &&
+		visiblePlans.length > 0 &&
+		planUpgradeCreditsApplicable !== null &&
+		planUpgradeCreditsApplicable > 0;
+
 	return (
 		<>
 			<QuerySitePlans siteId={ siteId } />
-			{ visiblePlans && visiblePlans.length && planUpgradeCreditsApplicable && (
+			{ showNotice && (
 				<Notice
 					className={ className }
 					showDismiss={ !! onDismissClick }

--- a/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
@@ -27,6 +27,9 @@ const PlanNoticeCreditUpgrade = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable( siteId, visiblePlans );
+	if ( ! planUpgradeCreditsApplicable ) {
+		return null;
+	}
 
 	const upgradeCreditDocsUrl = localizeUrl(
 		'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'


### PR DESCRIPTION
Related to #91787

## Proposed Changes

* Use a site-aware pricing enpoint instead of a generic one

## Why are these changes being made?

* The generic pricing endpoint doesn't take into account the current plan for the website, and doesn't provide information about introductory offers.
* The site-aware endpoint solves both problems.

## Testing Instructions

* Go to http://calypso.localhost:3000/start
  * Choose a domain and a free plan
  * Check "Import existing content or website" 
  * Enter the site address to migrate
  * Choose "Migrate site"
* On the Upgrade step ("The plan you need"):
  * Make sure there is a request to `https://public-api.wordpress.com/rest/v1.3/sites/{site-id}/plans?http_envelope=1`
  * Make sure there are no requests to `https://public-api.wordpress.com/rest/v1.5/plans?http_envelope=1`
  * Switch the period from "Pay annually" to "Pay monthly".
    * Make sure you see correct prices (USD 25 and 40).
    * Make sure the period switch doesn't produce new requests to `https://public-api.wordpress.com/rest/v1.3/sites/{site-id}/plans?http_envelope=1`
  * Go to https://wordpress.com/me/account and switch your language to another one (I use Spanish).
    * Make sure everything looks good (and translated).
  * Change currency for your account (you can do it in SA).
    * > Note: switching currencies <...> will switch the currency for all of your current subscriptions, so it’s not a bad idea to do this on a test account.
    * Check the Upgrade step:
      * Make sure you see prices in proper currency (check both annual and monthly payments).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
