### PR TITLE
`HostingFeatures`: Prevent redirect if current site is atomic and the plan has expired

### DIFF
--- a/client/hosting-features/components/hosting-features.tsx
+++ b/client/hosting-features/components/hosting-features.tsx
@@ -13,7 +13,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 type PromoCardProps = {
@@ -39,10 +39,11 @@ const HostingFeatures = () => {
 	const showActivationModal = searchParams.get( 'activate' ) !== null;
 	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
 	const siteId = useSelector( getSelectedSiteId );
-	const { siteSlug, isSiteAtomic, hasSftpFeature } = useSelector( ( state ) => ( {
+	const { siteSlug, isSiteAtomic, hasSftpFeature, isPlanExpired } = useSelector( ( state ) => ( {
 		siteSlug: getSiteSlug( state, siteId ) || '',
 		isSiteAtomic: isSiteWpcomAtomic( state, siteId as number ),
 		hasSftpFeature: siteHasFeature( state, siteId, FEATURE_SFTP ),
+		isPlanExpired: !! getSelectedSite( state )?.plan?.expired,
 	} ) );
 	// The ref is required to persist the value of redirect_to after renders
 	const redirectUrl = useRef(
@@ -105,7 +106,7 @@ const HostingFeatures = () => {
 		page( `/setup/transferring-hosted-site?${ params }` );
 	};
 
-	if ( isSiteAtomic ) {
+	if ( isSiteAtomic && ! isPlanExpired ) {
 		page.replace( redirectUrl.current );
 		return;
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7544

## Proposed Changes

* Prevent atomic sites from being redirected out of the `HostingFeatures` tab when their plan has expired.

## Why are these changes being made?

* When an atomic site plan has expired, the only tabs shown are `Overview` and `HostingFeatures`. But the `HostingFeatures` tab is not intended for atomic sites, so it has an automatic redirect to `/hosting-config/:siteId` which should not happen when the plan has expired:

![chrome-capture-2024-5-25](https://github.com/Automattic/wp-calypso/assets/8511199/9e3c750b-8173-47dc-a8f5-14158865280f)

## Testing Instructions

* Go to the store admin
* Search for your user
* On one of your atomic sites, update the expiry date so the site has an expired plan
* Open the live preview
* Go to `/sites`
* Select the atomic site with the expired plan
* Check that you can access the `Hosting Features` tab:

![chrome-capture-2024-5-25 (1)](https://github.com/Automattic/wp-calypso/assets/8511199/ea212baf-413c-41af-82bd-715814f1f157)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?