### PR TITLE
Add plan credit notice on migration plan upgrade step

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -8,7 +8,9 @@ import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import useCheckEligibilityMigrationTrialPlan from 'calypso/data/plans/use-check-eligibility-migration-trial-plan';
+import PlanNoticeCreditUpgrade from 'calypso/my-sites/plans-features-main/components/plan-notice-credit-update';
 import UpgradePlanDetails from './upgrade-plan-details';
+import type { PlanSlug } from '@automattic/calypso-products';
 
 import './style.scss';
 
@@ -24,6 +26,7 @@ interface Props {
 	onContentOnlyClick?: () => void;
 	trackingEventsProps?: Record< string, unknown >;
 	hideFreeMigrationTrialForNonVerifiedEmail?: boolean;
+	visiblePlan?: PlanSlug;
 }
 
 export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) => {
@@ -43,6 +46,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		isBusy,
 		trackingEventsProps,
 		hideFreeMigrationTrialForNonVerifiedEmail = false,
+		visiblePlan = PLAN_BUSINESS,
 	} = props;
 	const { data: migrationTrialEligibility } = useCheckEligibilityMigrationTrialPlan( site.ID );
 	const isEligibleForTrialPlan =
@@ -166,6 +170,14 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 							) }
 					</SubTitle>
 				</div>
+			) }
+
+			{ site && site.ID && (
+				<PlanNoticeCreditUpgrade
+					linkTarget="_blank"
+					siteId={ site.ID }
+					visiblePlans={ [ visiblePlan ] }
+				/>
 			) }
 
 			<UpgradePlanDetails>{ renderCTAs() }</UpgradePlanDetails>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -87,6 +87,7 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation, data } ) {
 				} }
 				hideFreeMigrationTrialForNonVerifiedEmail={ hideFreeMigrationTrialForNonVerifiedEmail }
 				trackingEventsProps={ customTracksEventProps }
+				visiblePlan={ plan.getStoreSlug() }
 			/>
 		</>
 	);

--- a/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
@@ -1,0 +1,68 @@
+import { formatCurrency } from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import Notice from 'calypso/components/notice';
+import { usePlanUpgradeCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import type { PlanSlug } from '@automattic/calypso-products';
+
+type Props = {
+	className?: string;
+	onDismissClick?: () => void;
+	linkTarget?: string;
+	siteId: number;
+	visiblePlans?: PlanSlug[];
+};
+
+const PlanNoticeCreditUpgrade = ( {
+	className,
+	onDismissClick,
+	linkTarget,
+	siteId,
+	visiblePlans,
+}: Props ) => {
+	const translate = useTranslate();
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+
+	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable( siteId, visiblePlans );
+
+	const upgradeCreditDocsUrl = localizeUrl(
+		'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'
+	);
+
+	return (
+		<>
+			<QuerySitePlans siteId={ siteId } />
+			{ visiblePlans && visiblePlans.length && planUpgradeCreditsApplicable && (
+				<Notice
+					className={ className }
+					showDismiss={ !! onDismissClick }
+					onDismissClick={ onDismissClick }
+					icon="info-outline"
+					status="is-success"
+					isReskinned
+				>
+					{ translate(
+						'You have {{b}}%(amountInCurrency)s{{/b}} in {{a}}upgrade credits{{/a}} available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!',
+						{
+							args: {
+								amountInCurrency: formatCurrency(
+									planUpgradeCreditsApplicable,
+									currencyCode ?? ''
+								),
+							},
+							components: {
+								b: <strong />,
+								a: <a href={ upgradeCreditDocsUrl } target={ linkTarget } />,
+							},
+						}
+					) }
+				</Notice>
+			) }
+		</>
+	);
+};
+
+export default PlanNoticeCreditUpgrade;

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -1,7 +1,5 @@
 import { PlanSlug, isProPlan, isStarterPlan } from '@automattic/calypso-products';
 import { Site, SiteMediaStorage } from '@automattic/data-stores';
-import { formatCurrency } from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
@@ -11,10 +9,10 @@ import { getDiscountByName } from 'calypso/lib/discounts';
 import { ActiveDiscount } from 'calypso/lib/discounts/active-discounts';
 import { usePlanUpgradeCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSitePlan, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
+import PlanNoticeCreditUpgrade from './plan-notice-credit-update';
 
 export type PlanNoticeProps = {
 	siteId: number;
@@ -101,8 +99,6 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 	let activeDiscount =
 		discountInformation &&
 		getDiscountByName( discountInformation.withDiscount, discountInformation.discountEndDate );
-	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable( siteId, visiblePlans );
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	switch ( noticeType ) {
 		case NO_NOTICE:
@@ -169,39 +165,14 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 				</Notice>
 			);
 		case PLAN_UPGRADE_CREDIT_NOTICE:
-			return planUpgradeCreditsApplicable ? (
-				<Notice
+			return (
+				<PlanNoticeCreditUpgrade
 					className="plan-features-main__notice"
-					showDismiss
 					onDismissClick={ handleDismissNotice }
-					icon="info-outline"
-					status="is-success"
-					isReskinned
-				>
-					{ translate(
-						'You have {{b}}%(amountInCurrency)s{{/b}} in {{a}}upgrade credits{{/a}} available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!',
-						{
-							args: {
-								amountInCurrency: formatCurrency(
-									planUpgradeCreditsApplicable,
-									currencyCode ?? ''
-								),
-							},
-							components: {
-								b: <strong />,
-								a: (
-									<a
-										href={ localizeUrl(
-											'https://wordpress.com/support/manage-purchases/upgrade-your-plan/#upgrade-credit'
-										) }
-										className="get-apps__desktop-link"
-									/>
-								),
-							},
-						}
-					) }
-				</Notice>
-			) : null;
+					siteId={ siteId }
+					visiblePlans={ visiblePlans }
+				/>
+			);
 		case PLAN_RETIREMENT_NOTICE:
 			return (
 				<Notice

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -18,7 +18,10 @@ import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-not
 import { usePlanUpgradeCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
-import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
+import {
+	isCurrentUserCurrentPlanOwner,
+	isRequestingSitePlans,
+} from 'calypso/state/sites/plans/selectors';
 import { isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 
@@ -31,6 +34,7 @@ jest.mock( 'calypso/state/purchases/selectors', () => ( {
 } ) );
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	isCurrentUserCurrentPlanOwner: jest.fn(),
+	isRequestingSitePlans: jest.fn(),
 	getCurrentPlan: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/sites/selectors', () => ( {
@@ -64,6 +68,9 @@ const mIsCurrentPlanPaid = isCurrentPlanPaid as jest.MockedFunction< typeof isCu
 const mIsCurrentUserCurrentPlanOwner = isCurrentUserCurrentPlanOwner as jest.MockedFunction<
 	typeof isCurrentUserCurrentPlanOwner
 >;
+const mIsRequestingSitePlans = isRequestingSitePlans as jest.MockedFunction<
+	typeof isRequestingSitePlans
+>;
 const mUsePlanUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable as jest.MockedFunction<
 	typeof usePlanUpgradeCreditsApplicable
 >;
@@ -95,6 +102,7 @@ describe( '<PlanNotice /> Tests', () => {
 		mUseMarketingMessage.mockImplementation( () => [ false, [], () => ( {} ) ] );
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
+		mIsRequestingSitePlans.mockImplementation( () => true );
 		mGetCurrentUserCurrencyCode.mockImplementation( () => 'USD' );
 		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 1 );
 		mGetByPurchaseId.mockImplementation( () => ( { isInAppPurchase: false } ) as Purchase );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92050

## Proposed Changes

* This PR serves as an initial fix for https://github.com/Automattic/wp-calypso/issues/92050 by adding a notice to the Plan Upgrade step to show when a user has an available upgrade credit that can be applied to their purchase.
* At an implementation level, the PR extracts the existing upgrade credit notice from the in-product plans page into a self-contained component that self-determines whether a notice should be displayed based on existing hooks, and uses this component from both the in-product plans page and the `UpgradePlan` component used inside our migration flows

#### Some implementation notes

* It's also worth noting that I removed the `get-apps__desktop-link` CSS class from the inline link that wasn't triggering any specific rules after loading only the plans page. It's possible this may do something different if users load other pages in Calypso first, but that's not a good approach to being consistent or predictable!
* I also exposed a `linkTarget` prop to make it possible to open the support documentation link in a new window -- I think this is appropriate for the migration flow so you are 100% clear on where you were in the flow without needing to navigate anywhere.

### Screenshot

<img width="768" alt="Screenshot 2024-06-25 at 20 10 26" src="https://github.com/Automattic/wp-calypso/assets/3376401/29075428-2f01-484d-b88c-300beef54a1f">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As reported in https://github.com/Automattic/wp-calypso/issues/92050 and discussed internally in this thread - pdxWSz-1yg-p2#comment-465 - for users who have already paid us for a lower-tier plan, we're not showing any indication that they have an upgrade credit that will be applied on checkout.
* This PR mimics the current UX for the in-product plans page as a way to inform users of the credit using an existing UX pattern while we explore whether we can do better

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you have a site with a paid Starter or Explorer plan -- it can be a monthly or annual subscription, but must expire at some point in the future
* Run this branch locally or via Calypso.live
* For your site above, navigate to _Upgrades_ => _Plans_
* Verify that you see a notice about your upgrade credit
* Click on the link in the notice
* Verify that the support documentation for upgrade credits is opened in the same tab
* Navigate back using the browser's back button
* Click on the `x` to dismiss the notice
* Verify that the notice is dismissed
* Now navigate to _Tools_ => _Import_ for your site
* From the list, pick WordPress as your source platform -- this should take you to the `/setup/site-migration` flow
* Enter the URL of a WordPress site and click on the CTA
* On the next step choose the option to migrate your site
* This should take you to the plan upgrade step
* On the plan upgrade step, verify that you see a notice about your upgrade credit, where the notice should not include an `x` to dismiss the notice
* Click on the link for the upgrade credits
* Verify that the support documentation for upgrade credits is opened in a new tab/window

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?