### PR TITLE
Try: Add paid newsletter importer

### DIFF
--- a/client/components/forms/form-text-input-with-action/index.d.ts
+++ b/client/components/forms/form-text-input-with-action/index.d.ts
@@ -9,7 +9,7 @@ export interface FormTextInputWithActionProps {
 	onBlur?: () => void;
 	onKeyDown?: () => void;
 	onChange?: ( param: string ) => void;
-	onAction?: () => void;
+	onAction?: ( param: string ) => void;
 	defaultValue?: string;
 	disabled?: boolean;
 	isError?: boolean;

--- a/client/components/step-progress/style.scss
+++ b/client/components/step-progress/style.scss
@@ -41,6 +41,7 @@
 	font-style: normal;
 	font-weight: normal;
 	margin-top: 9px;
+	text-align: center;
 }
 
 .step-progress__element-button {

--- a/client/lib/importer/url-validation.js
+++ b/client/lib/importer/url-validation.js
@@ -15,19 +15,11 @@ export const hasTld = function ( hostname ) {
 };
 
 export function validateImportUrl( value ) {
-	let parsedUrl;
-	try {
-		parsedUrl = parseUrl( value );
-	} catch ( error ) {
+	if ( ! isValidUrl( value ) ) {
 		return translate( 'Please enter a valid URL.' );
 	}
 
-	// `isURL` considers `http://a` valid, so check for a top level domain name as well.
-	if ( ! parsedUrl || ! hasTld( parsedUrl.hostname ) ) {
-		return translate( 'Please enter a valid URL.' );
-	}
-
-	const { hostname, pathname } = parsedUrl;
+	const { hostname, pathname } = parseUrl( value );
 
 	if ( hostname === 'editor.wix.com' || hostname === 'www.wix.com' ) {
 		return translate(
@@ -47,4 +39,20 @@ export function validateImportUrl( value ) {
 	}
 
 	return null;
+}
+
+export function isValidUrl( value ) {
+	let parsedUrl;
+	try {
+		parsedUrl = parseUrl( value );
+	} catch ( error ) {
+		return false;
+	}
+
+	// `isURL` considers `http://a` valid, so check for a top level domain name as well.
+	if ( ! parsedUrl || ! hasTld( parsedUrl.hostname ) ) {
+		return false;
+	}
+
+	return true;
 }

--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -97,7 +97,7 @@ export function importerList( context, next ) {
 	next();
 }
 
-export function importNewsletterSite( context, next ) {
+export function importSubstackSite( context, next ) {
 	if ( ! config.isEnabled( 'importers/newsletter' ) ) {
 		page.redirect( '/import' );
 		return;

--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { camelCase } from 'lodash';
 import { BrowserRouter } from 'react-router-dom';
@@ -90,6 +91,23 @@ export function importerList( context, next ) {
 					} }
 				/>
 			</div>
+		</BrowserRouter>
+	);
+	next();
+}
+
+export function importNewsletterSite( context, next ) {
+	if ( ! config.isEnabled( 'importers/newsletter' ) ) {
+		page.redirect( '/import' );
+		return;
+	}
+
+	const state = context.store.getState();
+	const siteSlug = getSelectedSiteSlug( state );
+
+	context.primary = (
+		<BrowserRouter>
+			<div className="import__onboarding-page">Howdy substacker! { siteSlug }</div>
 		</BrowserRouter>
 	);
 	next();

--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -6,6 +6,7 @@ import CaptureScreen from 'calypso/blocks/import/capture';
 import ImporterList from 'calypso/blocks/import/list';
 import { getFinalImporterUrl } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/helper';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
+import NewsletterImporter from 'calypso/my-sites/importer/newsletter/importer';
 import SectionImport from 'calypso/my-sites/importer/section-import';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import 'calypso/blocks/import/style/base.scss';
@@ -107,7 +108,7 @@ export function importNewsletterSite( context, next ) {
 
 	context.primary = (
 		<BrowserRouter>
-			<div className="import__onboarding-page">Howdy substacker! { siteSlug }</div>
+			<NewsletterImporter siteSlug={ siteSlug } engine="substack" step={ context.params.step } />
 		</BrowserRouter>
 	);
 	next();

--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -2,11 +2,7 @@ import page from '@automattic/calypso-router';
 import { get } from 'lodash';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'calypso/my-sites/controller';
-import {
-	importSite,
-	importerList,
-	importNewsletterSite,
-} from 'calypso/my-sites/importer/controller';
+import { importSite, importerList, importSubstackSite } from 'calypso/my-sites/importer/controller';
 
 export default function () {
 	page( '/import', siteSelection, navigation, sites, makeLayout, clientRender );
@@ -26,7 +22,7 @@ export default function () {
 		siteSelection,
 		navigation,
 		redirectWithoutSite( '/import' ),
-		importNewsletterSite,
+		importSubstackSite,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -22,7 +22,7 @@ export default function () {
 	);
 
 	page(
-		'/import/newsletter/substack/:site_id',
+		'/import/newsletter/substack/:site_id/:step?',
 		siteSelection,
 		navigation,
 		redirectWithoutSite( '/import' ),

--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -2,7 +2,11 @@ import page from '@automattic/calypso-router';
 import { get } from 'lodash';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'calypso/my-sites/controller';
-import { importSite, importerList } from 'calypso/my-sites/importer/controller';
+import {
+	importSite,
+	importerList,
+	importNewsletterSite,
+} from 'calypso/my-sites/importer/controller';
 
 export default function () {
 	page( '/import', siteSelection, navigation, sites, makeLayout, clientRender );
@@ -13,6 +17,16 @@ export default function () {
 		navigation,
 		redirectWithoutSite( '/import' ),
 		importSite,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/import/newsletter/substack/:site_id',
+		siteSelection,
+		navigation,
+		redirectWithoutSite( '/import' ),
+		importNewsletterSite,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -1,0 +1,20 @@
+import { Card, Button } from '@automattic/components';
+
+export default function Content( { nextStepUrl } ) {
+	return (
+		<Card>
+			<h2>Step 1: Export your content from Substack</h2>
+			<p>
+				To generate a ZIP file of all your Substack posts, go to Settings { '>' } Exports and click
+				'Create a new export.' Once the ZIP file is downloaded, upload it in the next step.
+			</p>
+			<Button>Export content</Button>
+			<hr />
+			<h2>Step 2: Import your content to WordPress.com (2/2)</h2>
+			<Button href={ nextStepUrl } primary>
+				Continue
+			</Button>{ ' ' }
+			<Button href={ nextStepUrl }>Skip for now</Button>
+		</Card>
+	);
+}

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -12,8 +12,6 @@ export default function Content( { nextStepUrl, selectedSite, siteSlug } ) {
 
 	const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
 
-	useEffect( () => {} );
-
 	const dispatch = useDispatch();
 	function fetchImporters() {
 		siteId && dispatch( fetchImporterState( siteId ) );

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -5,10 +5,17 @@ import SubstackImporter from 'calypso/my-sites/importer/importer-substack';
 import { useDispatch, useSelector } from 'calypso/state';
 import { fetchImporterState, startImport } from 'calypso/state/imports/actions';
 import { getImporterStatusForSiteId } from 'calypso/state/imports/selectors';
+import type { SiteDetails } from '@automattic/data-stores';
+type Props = {
+	nextStepUrl: string;
+	selectedSite: null | SiteDetails;
+	siteSlug: string;
+	newsletterUrl?: string;
+};
 
-export default function Content( { nextStepUrl, selectedSite, siteSlug, newsletterUrl } ) {
-	const siteTitle = selectedSite.title;
-	const siteId = selectedSite.ID;
+export default function Content( { nextStepUrl, selectedSite, siteSlug, newsletterUrl }: Props ) {
+	const siteTitle = selectedSite?.title;
+	const siteId = selectedSite?.ID;
 
 	const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
 
@@ -19,6 +26,10 @@ export default function Content( { nextStepUrl, selectedSite, siteSlug, newslett
 
 	useEffect( fetchImporters, [ siteId, dispatch ] );
 	useEffect( startImporting, [ siteId, dispatch, siteImports ] );
+
+	if ( ! selectedSite ) {
+		return null;
+	}
 
 	function startImporting() {
 		siteId && siteImports.length === 0 && dispatch( startImport( siteId ) );

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { fetchImporterState, startImport } from 'calypso/state/imports/actions';
 import { getImporterStatusForSiteId } from 'calypso/state/imports/selectors';
 
-export default function Content( { nextStepUrl, selectedSite, siteSlug } ) {
+export default function Content( { nextStepUrl, selectedSite, siteSlug, newsletterUrl } ) {
 	const siteTitle = selectedSite.title;
 	const siteId = selectedSite.ID;
 
@@ -37,9 +37,9 @@ export default function Content( { nextStepUrl, selectedSite, siteSlug } ) {
 				To generate a ZIP file of all your Substack posts, go to Settings { '>' } Exports and click
 				'Create a new export.' Once the ZIP file is downloaded, upload it in the next step.
 			</p>
-			<Button href="https://substack.com/home">Export content</Button>
+			<Button href={ `https://${ newsletterUrl }/publish/settings#exports` }>Export content</Button>
 			<hr />
-			<h2>Step 2: Import your content to WordPress.com (2/2)</h2>
+			<h2>Step 2: Import your content to WordPress.com</h2>
 			{ importerStatus && (
 				<SubstackImporter
 					site={ selectedSite }

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -1,4 +1,5 @@
 import { Card, Button } from '@automattic/components';
+import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
 import { useEffect } from 'react';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import SubstackImporter from 'calypso/my-sites/importer/importer-substack';
@@ -6,14 +7,20 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { fetchImporterState, startImport } from 'calypso/state/imports/actions';
 import { getImporterStatusForSiteId } from 'calypso/state/imports/selectors';
 import type { SiteDetails } from '@automattic/data-stores';
-type Props = {
+
+type ContentProps = {
 	nextStepUrl: string;
-	selectedSite: null | SiteDetails;
+	selectedSite?: SiteDetails;
 	siteSlug: string;
-	newsletterUrl?: string;
+	newsletterUrl: QueryArgParsed;
 };
 
-export default function Content( { nextStepUrl, selectedSite, siteSlug, newsletterUrl }: Props ) {
+export default function Content( {
+	nextStepUrl,
+	selectedSite,
+	siteSlug,
+	newsletterUrl,
+}: ContentProps ) {
 	const siteTitle = selectedSite?.title;
 	const siteId = selectedSite?.ID;
 

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -1,16 +1,55 @@
 import { Card, Button } from '@automattic/components';
+import { useEffect } from 'react';
+import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
+import SubstackImporter from 'calypso/my-sites/importer/importer-substack';
+import { useDispatch, useSelector } from 'calypso/state';
+import { fetchImporterState, startImport } from 'calypso/state/imports/actions';
+import { getImporterStatusForSiteId } from 'calypso/state/imports/selectors';
 
-export default function Content( { nextStepUrl } ) {
+export default function Content( { nextStepUrl, selectedSite, siteSlug } ) {
+	const siteTitle = selectedSite.title;
+	const siteId = selectedSite.ID;
+
+	const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
+
+	useEffect( () => {} );
+
+	const dispatch = useDispatch();
+	function fetchImporters() {
+		siteId && dispatch( fetchImporterState( siteId ) );
+	}
+
+	useEffect( fetchImporters, [ siteId, dispatch ] );
+	useEffect( startImporting, [ siteId, dispatch, siteImports ] );
+
+	function startImporting() {
+		siteId && siteImports.length === 0 && dispatch( startImport( siteId ) );
+	}
+
+	const importerStatus = siteImports[ 0 ];
+	if ( importerStatus ) {
+		importerStatus.type = 'importer-type-substack';
+	}
+
 	return (
 		<Card>
+			<Interval onTick={ fetchImporters } period={ EVERY_FIVE_SECONDS } />
 			<h2>Step 1: Export your content from Substack</h2>
 			<p>
 				To generate a ZIP file of all your Substack posts, go to Settings { '>' } Exports and click
 				'Create a new export.' Once the ZIP file is downloaded, upload it in the next step.
 			</p>
-			<Button>Export content</Button>
+			<Button href="https://substack.com/home">Export content</Button>
 			<hr />
 			<h2>Step 2: Import your content to WordPress.com (2/2)</h2>
+			{ importerStatus && (
+				<SubstackImporter
+					site={ selectedSite }
+					siteSlug={ siteSlug }
+					siteTitle={ siteTitle }
+					importerStatus={ importerStatus }
+				/>
+			) }
 			<Button href={ nextStepUrl } primary>
 				Continue
 			</Button>{ ' ' }

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -1,5 +1,5 @@
 .newsletter-importer {
-	margin: 0 auto;
+	margin: 24px auto 0;
 	max-width: 720px;
 
 	.step-progress {
@@ -46,19 +46,38 @@
 }
 
 .logo-chain__logo {
-	width: 56px;
-	height: 56px;
+	width: 48px;
+	height: 48px;
 	margin: 0 -16px 0 0;
 	border-radius: 50%;
 	overflow: hidden;
+	position: relative;
 }
 
 .logo-chain__logo .importer__service-icon.wordpress {
 	background-color: #3858e9;
+	width: 46px;
+	height: 46px;
+	min-width: 46px;
+	position: absolute;
+	left: 1px;
+	top: 1px;
 }
 
 .logo-chain__logo .importer__service-icon.substack-logo {
 	width: 46px;
+	min-width: 46px;
 	height: 46px;
-	margin-top: 5px;
+	position: absolute;
+	left: 1px;
+	top: 1px;
+}
+
+.select-newsletter-form__help {
+	margin-top: 8px;
+	font-size: 0.75rem;
+
+	&.is-error {
+		color: var(--color-error);
+	}
 }

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -27,6 +27,16 @@
 			background-color: var(--studio-gray-5);
 		}
 	}
+
+	.importer-header {
+		display: none;
+	}
+
+	.importer__file-importer-card.card {
+		padding: 0;
+		margin: 0;
+		box-shadow: none;
+	}
 }
 
 .logo-chain {

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -37,6 +37,11 @@
 		margin: 0;
 		box-shadow: none;
 	}
+
+	.summary__content p {
+		display: flex;
+		gap: 8px;
+	}
 }
 
 .logo-chain {

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -1,0 +1,54 @@
+.newsletter-importer {
+	margin: 0 auto;
+	max-width: 720px;
+
+	.step-progress {
+		margin-bottom: 20px;
+	}
+
+	.card {
+		h2 {
+			font-size: rem(16px);
+			font-weight: 500;
+			line-height: 19px;
+			letter-spacing: 0.15px;
+			padding-bottom: 20px;
+		}
+
+		p {
+			font-size: rem(14px);
+			line-height: 20px;
+			color: var(--studio-gray-50);
+		}
+
+		hr {
+			margin: 32px 0;
+			color: var(--studio-gray-5);
+			background-color: var(--studio-gray-5);
+		}
+	}
+}
+
+.logo-chain {
+	display: flex;
+	justify-content: center;
+	margin-bottom: 20px;
+}
+
+.logo-chain__logo {
+	width: 56px;
+	height: 56px;
+	margin: 0 -16px 0 0;
+	border-radius: 50%;
+	overflow: hidden;
+}
+
+.logo-chain__logo .importer__service-icon.wordpress {
+	background-color: #3858e9;
+}
+
+.logo-chain__logo .importer__service-icon.substack-logo {
+	width: 46px;
+	height: 46px;
+	margin-top: 5px;
+}

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -6,13 +6,20 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ImporterLogo from '../importer-logo';
 import Content from './content';
 import PaidSubscribers from './paid-subscribers';
-import SelectNewsletterForm from './select-newsletter-form.tsx';
+import SelectNewsletterForm from './select-newsletter-form';
 import Subscribers from './subscribers';
 import Summary from './summary';
 
 import './importer.scss';
 
-function LogoChain( { logos } ) {
+type Logo = {
+	name: string;
+	color: string;
+};
+type LogoChainProps = {
+	logos: Logo[];
+};
+function LogoChain( { logos }: LogoChainProps ) {
 	return (
 		<div className="logo-chain">
 			{ logos.map( ( logo ) => (
@@ -28,8 +35,14 @@ const steps = [ Content, Subscribers, PaidSubscribers, Summary ];
 
 const stepSlugs = [ 'content', 'subscribers', 'paid-subscribers', 'summary' ];
 
-export default function NewsletterImporter( { siteSlug, engine, step } ) {
-	const selectedSite = useSelector( getSelectedSite );
+type NewsletterImporterProps = {
+	siteSlug: string;
+	engine: string;
+	step: string;
+};
+
+export default function NewsletterImporter( { siteSlug, engine, step }: NewsletterImporterProps ) {
+	const selectedSite = useSelector( getSelectedSite ) ?? undefined;
 
 	const stepsProgress = [ 'Content', 'Subscribers', 'Paid Subscribers', 'Summary' ];
 
@@ -41,11 +54,10 @@ export default function NewsletterImporter( { siteSlug, engine, step } ) {
 			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
 		}
 	} );
-	const newsletterUrl = getQueryArg( window.location.href, 'newsletter' );
+	const newsletterUrl = getQueryArg( window.location.href, 'newsletter' ) ?? undefined;
 	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {
 		newsletter: newsletterUrl,
 	} );
-
 	const Step = steps[ stepIndex ] || steps[ 0 ];
 	return (
 		<div className="newsletter-importer">

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -54,7 +54,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
 		}
 	} );
-	const newsletterUrl = getQueryArg( window.location.href, 'newsletter' ) ?? undefined;
+	const newsletterUrl = getQueryArg( window.location.href, 'newsletter' ) ?? null;
 	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {
 		newsletter: newsletterUrl,
 	} );
@@ -69,7 +69,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 			/>
 
 			<FormattedHeader headerText="Import your newsletter" />
-			{ ! step && <SelectNewsletterForm nextStepUrl={ nextStepUrl } /> }
+			{ ( ! step || ! newsletterUrl ) && <SelectNewsletterForm nextStepUrl={ nextStepUrl } /> }
 			{ step && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
 			{ step && (
 				<Step

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -1,3 +1,4 @@
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import FormattedHeader from 'calypso/components/formatted-header';
 import StepProgress from 'calypso/components/step-progress';
 import { useSelector } from 'calypso/state';
@@ -5,6 +6,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ImporterLogo from '../importer-logo';
 import Content from './content';
 import PaidSubscribers from './paid-subscribers';
+import SelectNewsletterForm from './select-newsletter-form.tsx';
 import Subscribers from './subscribers';
 import Summary from './summary';
 
@@ -27,26 +29,22 @@ const steps = [ Content, Subscribers, PaidSubscribers, Summary ];
 const stepSlugs = [ 'content', 'subscribers', 'paid-subscribers', 'summary' ];
 
 export default function NewsletterImporter( { siteSlug, engine, step } ) {
-
 	const selectedSite = useSelector( getSelectedSite );
 
-	const stepsProgress = [
-		'Content',
-		'Subscribers',
-		'Paid Subscribers',
-		'Summary',
-	];
+	const stepsProgress = [ 'Content', 'Subscribers', 'Paid Subscribers', 'Summary' ];
 
 	let stepIndex = 0;
-	let nextStep = stepSlugs[ 1 ];
+	let nextStep = stepSlugs[ 0 ];
 	stepSlugs.forEach( ( stepName, index ) => {
 		if ( stepName === step ) {
 			stepIndex = index;
 			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
 		}
 	} );
-
-	const nextStepUrl = `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`;
+	const newsletterUrl = getQueryArg( window.location.href, 'newsletter' );
+	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {
+		newsletter: newsletterUrl,
+	} );
 
 	const Step = steps[ stepIndex ] || steps[ 0 ];
 	return (
@@ -59,8 +57,16 @@ export default function NewsletterImporter( { siteSlug, engine, step } ) {
 			/>
 
 			<FormattedHeader headerText="Import your newsletter" />
-			<StepProgress steps={ stepsProgress } currentStep={ stepIndex } />
-			<Step siteSlug={ siteSlug } nextStepUrl={ nextStepUrl } selectedSite={ selectedSite } />
+			{ ! step && <SelectNewsletterForm nextStepUrl={ nextStepUrl } /> }
+			{ step && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
+			{ step && (
+				<Step
+					siteSlug={ siteSlug }
+					nextStepUrl={ nextStepUrl }
+					selectedSite={ selectedSite }
+					newsletterUrl={ newsletterUrl }
+				/>
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -71,7 +71,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 			<FormattedHeader headerText="Import your newsletter" />
 			{ ( ! step || ! newsletterUrl ) && <SelectNewsletterForm nextStepUrl={ nextStepUrl } /> }
 			{ step && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
-			{ step && (
+			{ step && newsletterUrl && (
 				<Step
 					siteSlug={ siteSlug }
 					nextStepUrl={ nextStepUrl }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -1,6 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import StepProgress from 'calypso/components/step-progress';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ImporterLogo from '../importer-logo';
 import Content from './content';
 import PaidSubscribers from './paid-subscribers';
@@ -13,7 +15,7 @@ function LogoChain( { logos } ) {
 	return (
 		<div className="logo-chain">
 			{ logos.map( ( logo ) => (
-				<div className="logo-chain__logo" style={ { background: logo.color } }>
+				<div key={ logo.name } className="logo-chain__logo" style={ { background: logo.color } }>
 					<ImporterLogo key={ logo.name } icon={ logo.name } />
 				</div>
 			) ) }
@@ -27,6 +29,8 @@ const stepSlugs = [ 'content', 'subscribers', 'paid-subscribers', 'summary' ];
 
 export default function NewsletterImporter( { siteSlug, engine, step } ) {
 	const translate = useTranslate();
+
+	const selectedSite = useSelector( getSelectedSite );
 
 	const stepsProgress = [
 		translate( 'Content' ),
@@ -56,9 +60,9 @@ export default function NewsletterImporter( { siteSlug, engine, step } ) {
 				] }
 			/>
 
-			<FormattedHeader headerText="Import your newsletter" />
+			<FormattedHeader headerText={ translate( 'Import your newsletter' ) } />
 			<StepProgress steps={ stepsProgress } currentStep={ stepIndex } />
-			<Step siteSlug nextStepUrl={ nextStepUrl } />
+			<Step siteSlug={ siteSlug } nextStepUrl={ nextStepUrl } selectedSite={ selectedSite } />
 		</div>
 	);
 }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -1,4 +1,3 @@
-import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import StepProgress from 'calypso/components/step-progress';
 import { useSelector } from 'calypso/state';
@@ -28,15 +27,14 @@ const steps = [ Content, Subscribers, PaidSubscribers, Summary ];
 const stepSlugs = [ 'content', 'subscribers', 'paid-subscribers', 'summary' ];
 
 export default function NewsletterImporter( { siteSlug, engine, step } ) {
-	const translate = useTranslate();
 
 	const selectedSite = useSelector( getSelectedSite );
 
 	const stepsProgress = [
-		translate( 'Content' ),
-		translate( 'Subscribers' ),
-		translate( 'Paid Subscribers' ),
-		translate( 'Summary' ),
+		'Content',
+		'Subscribers',
+		'Paid Subscribers',
+		'Summary',
 	];
 
 	let stepIndex = 0;
@@ -60,7 +58,7 @@ export default function NewsletterImporter( { siteSlug, engine, step } ) {
 				] }
 			/>
 
-			<FormattedHeader headerText={ translate( 'Import your newsletter' ) } />
+			<FormattedHeader headerText="Import your newsletter" />
 			<StepProgress steps={ stepsProgress } currentStep={ stepIndex } />
 			<Step siteSlug={ siteSlug } nextStepUrl={ nextStepUrl } selectedSite={ selectedSite } />
 		</div>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -1,0 +1,64 @@
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import StepProgress from 'calypso/components/step-progress';
+import ImporterLogo from '../importer-logo';
+import Content from './content';
+import PaidSubscribers from './paid-subscribers';
+import Subscribers from './subscribers';
+import Summary from './summary';
+
+import './importer.scss';
+
+function LogoChain( { logos } ) {
+	return (
+		<div className="logo-chain">
+			{ logos.map( ( logo ) => (
+				<div className="logo-chain__logo" style={ { background: logo.color } }>
+					<ImporterLogo key={ logo.name } icon={ logo.name } />
+				</div>
+			) ) }
+		</div>
+	);
+}
+
+const steps = [ Content, Subscribers, PaidSubscribers, Summary ];
+
+const stepSlugs = [ 'content', 'subscribers', 'paid-subscribers', 'summary' ];
+
+export default function NewsletterImporter( { siteSlug, engine, step } ) {
+	const translate = useTranslate();
+
+	const stepsProgress = [
+		translate( 'Content' ),
+		translate( 'Subscribers' ),
+		translate( 'Paid Subscribers' ),
+		translate( 'Summary' ),
+	];
+
+	let stepIndex = 0;
+	let nextStep = stepSlugs[ 1 ];
+	stepSlugs.forEach( ( stepName, index ) => {
+		if ( stepName === step ) {
+			stepIndex = index;
+			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
+		}
+	} );
+
+	const nextStepUrl = `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`;
+
+	const Step = steps[ stepIndex ] || steps[ 0 ];
+	return (
+		<div className="newsletter-importer">
+			<LogoChain
+				logos={ [
+					{ name: 'substack', color: 'var(--color-substack)' },
+					{ name: 'wordpress', color: '#3858E9' },
+				] }
+			/>
+
+			<FormattedHeader headerText="Import your newsletter" />
+			<StepProgress steps={ stepsProgress } currentStep={ stepIndex } />
+			<Step siteSlug nextStepUrl={ nextStepUrl } />
+		</div>
+	);
+}

--- a/client/my-sites/importer/newsletter/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers.tsx
@@ -1,0 +1,15 @@
+import { Card, Button } from '@automattic/components';
+
+export default function PaidSubscribers( { nextStepUrl } ) {
+	return (
+		<Card>
+			<h2>Connect your Stripe account</h2>
+			<p>
+				To migrate your paid subscribers, ensure you're connecting the same Stripe account used with
+				your current provider.
+			</p>
+			<Button primary>Connect with Stripe</Button>{ ' ' }
+			<Button href={ nextStepUrl }>Skip for now</Button>
+		</Card>
+	);
+}

--- a/client/my-sites/importer/newsletter/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers.tsx
@@ -1,6 +1,10 @@
 import { Card, Button } from '@automattic/components';
 
-export default function PaidSubscribers( { nextStepUrl } ) {
+type Props = {
+	nextStepUrl: string;
+};
+
+export default function PaidSubscribers( { nextStepUrl }: Props ) {
 	return (
 		<Card>
 			<h2>Connect your Stripe account</h2>

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -1,0 +1,42 @@
+import page from '@automattic/calypso-router';
+import { Card } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
+import { useState } from 'react';
+import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
+import { isValidUrl, parseUrl } from 'calypso/lib/importer/url-validation';
+
+export default function SelectNewsletterForm( { nextStepUrl } ) {
+	const [ hasError, setHasError ] = useState( false );
+
+	const handleAction = ( newsletterUrl: string ) => {
+		if ( ! isValidUrl( newsletterUrl ) ) {
+			setHasError( true );
+			return;
+		}
+
+		const { hostname } = parseUrl( newsletterUrl );
+		page( addQueryArgs( nextStepUrl, { newsletter: hostname } ) );
+		return;
+	};
+
+	return (
+		<Card>
+			<div className="select-newsletter-form">
+				<FormTextInputWithAction
+					onAction={ handleAction }
+					placeholder="http://example.substack.com"
+					action="Continue"
+					isError={ hasError }
+				/>
+				{ hasError && (
+					<p className="select-newsletter-form__help is-error">Please enter a valid URL.</p>
+				) }
+				{ ! hasError && (
+					<p className="select-newsletter-form__help">
+						Enter the URL of the substack newsletter that you wish to import.
+					</p>
+				) }
+			</div>
+		</Card>
+	);
+}

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -5,7 +5,10 @@ import { useState } from 'react';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
 import { isValidUrl, parseUrl } from 'calypso/lib/importer/url-validation';
 
-export default function SelectNewsletterForm( { nextStepUrl } ) {
+type Props = {
+	nextStepUrl: string;
+};
+export default function SelectNewsletterForm( { nextStepUrl }: Props ) {
 	const [ hasError, setHasError ] = useState( false );
 
 	const handleAction = ( newsletterUrl: string ) => {

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -13,7 +13,7 @@ type Props = {
 export default function Subscribers( { nextStepUrl, selectedSite, newsletterUrl }: Props ) {
 	const isUserEligibleForSubscriberImporter = useIsEligibleSubscriberImporter();
 
-	if ( selectedSite === null ) {
+	if ( ! selectedSite ) {
 		return null;
 	}
 	return (

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -1,12 +1,13 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button } from '@automattic/components';
 import { AddSubscriberForm } from '@automattic/subscriber';
+import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
 import { useIsEligibleSubscriberImporter } from 'calypso/landing/stepper/hooks/use-is-eligible-subscriber-importer';
 import type { SiteDetails } from '@automattic/data-stores';
 type Props = {
 	nextStepUrl: string;
-	selectedSite: null | SiteDetails;
-	newsletterUrl: string;
+	selectedSite?: SiteDetails;
+	newsletterUrl: QueryArgParsed;
 };
 
 export default function Subscribers( { nextStepUrl, selectedSite, newsletterUrl }: Props ) {

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -2,9 +2,19 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button } from '@automattic/components';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { useIsEligibleSubscriberImporter } from 'calypso/landing/stepper/hooks/use-is-eligible-subscriber-importer';
+import type { SiteDetails } from '@automattic/data-stores';
+type Props = {
+	nextStepUrl: string;
+	selectedSite: null | SiteDetails;
+	newsletterUrl: string;
+};
 
-export default function Subscribers( { nextStepUrl, newsletterUrl, selectedSite } ) {
+export default function Subscribers( { nextStepUrl, selectedSite, newsletterUrl }: Props ) {
 	const isUserEligibleForSubscriberImporter = useIsEligibleSubscriberImporter();
+
+	if ( selectedSite === null ) {
+		return null;
+	}
 	return (
 		<Card>
 			<h2>Step 1: Export your subscribers from Substack</h2>

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -1,0 +1,20 @@
+import { Card, Button } from '@automattic/components';
+
+export default function Subscribers( { nextStepUrl } ) {
+	return (
+		<Card>
+			<h2>Step 1: Export your subscribers from Substack</h2>
+			<p>
+				To generate a CSV file of all your Substack subscribers, go to the Subscribers tab and click
+				'Export.' Once the CSV file is downloaded, upload it in the next step.
+			</p>
+			<Button>Export subscribers</Button>
+			<hr />
+			<h2>Step 2: Import your subscribers to WordPress.com</h2>
+			<Button href={ nextStepUrl } primary>
+				Continue
+			</Button>{ ' ' }
+			<Button href={ nextStepUrl }>Skip for now</Button>
+		</Card>
+	);
+}

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -1,6 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button } from '@automattic/components';
+import { AddSubscriberForm } from '@automattic/subscriber';
+import { useIsEligibleSubscriberImporter } from 'calypso/landing/stepper/hooks/use-is-eligible-subscriber-importer';
 
-export default function Subscribers( { nextStepUrl } ) {
+export default function Subscribers( { nextStepUrl, newsletterUrl, selectedSite } ) {
+	const isUserEligibleForSubscriberImporter = useIsEligibleSubscriberImporter();
 	return (
 		<Card>
 			<h2>Step 1: Export your subscribers from Substack</h2>
@@ -8,9 +12,15 @@ export default function Subscribers( { nextStepUrl } ) {
 				To generate a CSV file of all your Substack subscribers, go to the Subscribers tab and click
 				'Export.' Once the CSV file is downloaded, upload it in the next step.
 			</p>
-			<Button>Export subscribers</Button>
+			<Button href={ `https://${ newsletterUrl }/publish/subscribers` }>Export subscribers</Button>
 			<hr />
 			<h2>Step 2: Import your subscribers to WordPress.com</h2>
+			<AddSubscriberForm
+				siteId={ selectedSite.ID }
+				showTitle={ false }
+				manualListEmailInviting={ ! isUserEligibleForSubscriberImporter }
+				showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
+			/>
 			<Button href={ nextStepUrl } primary>
 				Continue
 			</Button>{ ' ' }

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,5 +1,5 @@
 import { Card, ConfettiAnimation } from '@automattic/components';
-import { Icon } from '@wordpress/components';
+import { Icon, post, people, currencyDollar } from '@wordpress/icons';
 
 export default function Summary() {
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
@@ -8,19 +8,21 @@ export default function Summary() {
 		<Card>
 			<ConfettiAnimation trigger={ ! prefersReducedMotion } />
 			<h2>Success!</h2>
-			<p>Here's an overview of what you'll migrate:</p>
-			<p>
-				<Icon icon="post" />
-				<strong>47</strong> posts
-			</p>
-			<p>
-				<Icon icon="people" />
-				<strong>99</strong> subscribers
-			</p>
-			<p>
-				<Icon icon="currencyDollar" />
-				<strong>17</strong> 17 paid subscribers
-			</p>
+			<div className="summary__content">
+				<p>Here's an overview of what you'll migrate:</p>
+				<p>
+					<Icon icon={ post } />
+					<strong>47</strong> posts
+				</p>
+				<p>
+					<Icon icon={ people } />
+					<strong>99</strong> subscribers
+				</p>
+				<p>
+					<Icon icon={ currencyDollar } />
+					<strong>17</strong>paid subscribers
+				</p>
+			</div>
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/summary.tsx
+++ b/client/my-sites/importer/newsletter/summary.tsx
@@ -1,0 +1,26 @@
+import { Card, ConfettiAnimation } from '@automattic/components';
+import { Icon } from '@wordpress/components';
+
+export default function Summary() {
+	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
+	return (
+		<Card>
+			<ConfettiAnimation trigger={ ! prefersReducedMotion } />
+			<h2>Success!</h2>
+			<p>Here's an overview of what you'll migrate:</p>
+			<p>
+				<Icon icon="post" />
+				<strong>47</strong> posts
+			</p>
+			<p>
+				<Icon icon="people" />
+				<strong>99</strong> subscribers
+			</p>
+			<p>
+				<Icon icon="currencyDollar" />
+				<strong>17</strong> 17 paid subscribers
+			</p>
+		</Card>
+	);
+}

--- a/config/development.json
+++ b/config/development.json
@@ -81,6 +81,7 @@
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,
 		"importer/unified": true,
+		"importers/newsletter": true,
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -46,6 +46,7 @@
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,
 		"importer/unified": true,
+		"importers/newsletter": false,
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/ai-assistant-request-limit": true,

--- a/config/production.json
+++ b/config/production.json
@@ -56,6 +56,7 @@
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,
 		"importer/unified": true,
+		"importers/newsletter": false,
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"is_running_in_jetpack_site": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -54,6 +54,7 @@
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,
 		"importer/unified": true,
+		"importers/newsletter": false,
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,

--- a/config/test.json
+++ b/config/test.json
@@ -43,6 +43,7 @@
 		"cookie-banner": false,
 		"google-my-business": false,
 		"help": true,
+		"importers/newsletter": true,
 		"importers/substack": true,
 		"individual-subscriber-stats": false,
 		"jetpack/agency-dashboard": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -63,6 +63,7 @@
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,
 		"importer/unified": true,
+		"importers/newsletter": true,
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,


### PR DESCRIPTION
## Proposed Changes

* Add special Paid Importer flow for substack. 
* This is a just a skeleton flag PR that we can then user to build other things on top. 

## Why are these changes being made?
See p9Jlb4-cwn-p2


## Testing Instructions
visit 
/import/newsletter/substack/$site
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?