### PR TITLE
Newsletter: Add edit context query parameter to the single and index templates links

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/SubscribeNavigationSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeNavigationSetting.tsx
@@ -32,6 +32,7 @@ export const SubscribeNavigationSetting = ( {
 		return addQueryArgs( siteEditorUrl, {
 			postType: 'wp_template',
 			postId: `${ themeSlug }//index`,
+			canvas: 'edit',
 		} );
 	};
 

--- a/client/my-sites/site-settings/settings-newsletter/SubscribePostEndSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribePostEndSetting.tsx
@@ -33,6 +33,7 @@ export const SubscribePostEndSetting = ( {
 		return addQueryArgs( siteEditorUrl, {
 			postType: 'wp_template',
 			postId: `${ themeSlug }//single`,
+			canvas: 'edit',
 		} );
 	};
 

--- a/client/my-sites/site-settings/settings-newsletter/SubscriberLoginNavigationSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscriberLoginNavigationSetting.tsx
@@ -32,6 +32,7 @@ export const SubscriberLoginNavigationSetting = ( {
 		return addQueryArgs( siteEditorUrl, {
 			postType: 'wp_template',
 			postId: `${ themeSlug }//index`,
+			canvas: 'edit',
 		} );
 	};
 


### PR DESCRIPTION
…

This PR updates all the links to include the edit convas query parameter. 
This makes so that the links take the user directly into the index templates 
Where they can edit the template that is being included. 

Previously we just drop the user in the template editor selector. 


## Why are these changes being made?
* To make it easier for users to find the tempaltes that they need to edit. 

## Testing Instructions

* Navigate to /settings/newsletter/example.ca and notice that links now take you to the expected place. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
