### PR TITLE
Domains: Use correct `flowName` for domain search component

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -560,7 +560,7 @@ function getAvailabilityNotice(
 
 		case 'gravatar_tld_restriction':
 			message = translate(
-				'Gravatar is currently offering free .link domains. Additional domain extensions may become available for a fee in the future.'
+				'Gravatar is currently offering .link domains. Additional domain extensions may become available for a fee in the future.'
 			);
 			severity = 'info';
 			break;

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -74,6 +74,7 @@ const domainSearch = ( context, next ) => {
 				<DomainSearch
 					basePath={ sectionify( context.path ) }
 					context={ context }
+					isAddNewDomainContext={ context.path.includes( 'domains/add' ) }
 					domainAndPlanUpsellFlow={
 						context.query.domainAndPlanPackage !== undefined
 							? context.query.domainAndPlanPackage === 'true'

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -46,6 +46,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isSiteOnMonthlyPlan from 'calypso/state/selectors/is-site-on-monthly-plan';
 import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
+import { setCurrentFlowName } from 'calypso/state/signup/flow/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
 	isSiteOnECommerceTrial,
@@ -120,6 +121,10 @@ class DomainSearch extends Component {
 			document.body.classList.add( 'is-domain-plan-package-flow' );
 		}
 		this.checkSiteIsUpgradeable();
+
+		if ( this.props.isAddNewDomainContext ) {
+			this.props.setCurrentFlowName( 'domains' );
+		}
 
 		this.isMounted = true;
 	}
@@ -449,5 +454,6 @@ export default connect(
 	{
 		recordAddDomainButtonClick,
 		recordRemoveDomainButtonClick,
+		setCurrentFlowName,
 	}
 )( withCartKey( withShoppingCart( localize( DomainSearch ) ) ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
The `flowName` signup property isn't reset if the user navigates to a route that's not part of the signup flows (`/start/*`).
Since one of the domain search components relies on this property to perform some logic, we need to reset it as soon as we mount the component or navigate to it from a different route. This PR fixes this.
Additionally, we also updated the text for the Gravatar notice.

## Why are these changes being made?
If you entered the Gravatar signup flow and left it, the notice added in #... was being displayed in every place where the `DomainSearch` component was used.

## Testing Instructions
There are other ways to test this PR, but this is how I think it's easier:
First, open 3 tabs:
  1. Domains on Gravatar flow (`/start/domain-for-gravatar/domain-only?search=yes`)
  2. Domain management page for a site of yours (`/domains/manage/:site`)
  3. Add a new domain (`/domains/add/:site`);

Then:
- Reload the "Domains on Gravatar" tab (this will dispatch the action for setting the current signup `flowName`) and search for any domain;
- Reload the "Domain management" tab and click the "Add a domain" button;
- Ensure the Gravatar notice isn't displayed
- Finally, reload the "Add a new domain" tab and ensure the Gravatar notice isn't displayed;

Please let me know if I missed anywhere else (that's not a signup flow) where this component is used.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
