### PR TITLE
Stats: Updating UTM builder text

### DIFF
--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -36,7 +36,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName } ) => {
 			</Button>
 			{ isOpen && (
 				<Modal
-					title={ translate( 'UTM Builder' ) }
+					title={ translate( 'URL Builder' ) }
 					onRequestClose={ closeModal }
 					overlayClassName="stats-utm-builder__overlay"
 				>

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -50,7 +50,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName } ) => {
 						<div className="stats-utm-builder__help">
 							<div className="stats-utm-builder__help-bg"></div>
 							<div className="stats-utm-builder__description">
-								{ translate( 'More information and parameter example.' ) }
+								{ translate( 'Parameter descriptions and examples.' ) }
 							</div>
 							<section>
 								<div className="stats-utm-builder__label">{ translate( 'Campaign Source' ) }</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to n/a

## Proposed Changes

* Replace text inside UTM builder modal

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p1719331254833639-slack-C82FZ5T4G

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch and go to a page with UTM
* click on the builder button and verify that text inside matches the screenshot


![SCR-20240626-lhzm](https://github.com/Automattic/wp-calypso/assets/112354940/91d63ae8-7680-4856-9cb7-5c3d09926e98)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?