### PR TITLE
A4A: update legal wording during regular checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -83,7 +83,7 @@ export default function PricingSummary( {
 				isAgencyCheckout && (
 					<div className="checkout__summary-notice">
 						<h3>{ translate( 'When you purchase:' ) }</h3>
-						<p>
+						<div className="checkout__summary-notice-item">
 							{ translate(
 								'You agree to our {{a}}Terms of Service{{/a}}, and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time.',
 								{
@@ -98,8 +98,8 @@ export default function PricingSummary( {
 									},
 								}
 							) }
-						</p>
-						<p>
+						</div>
+						<div className="checkout__summary-notice-item">
 							{ translate(
 								'You understand {{a}}how your subscription works{{/a}} and {{a}}how to cancel{{/a}}.',
 								{
@@ -116,12 +116,12 @@ export default function PricingSummary( {
 									},
 								}
 							) }
-						</p>
-						<p>
+						</div>
+						<div className="checkout__summary-notice-item">
 							{ translate(
 								'You will be billed on the first of every month. Your first bill will include a prorated amount for the current month, depending on which day you purchased these products.'
 							) }
-						</p>
+						</div>
 					</div>
 				)
 			}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -1,8 +1,7 @@
 import formatCurrency from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import ShoppingCartMenuItem from '../shopping-cart/shopping-cart-menu/item';
 import { useTotalInvoiceValue } from '../wpcom-overview/hooks/use-total-invoice-value';
@@ -22,7 +21,6 @@ export default function PricingSummary( {
 	isClient,
 }: Props ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
 	const userProducts = useSelector( getProductsList );
 
@@ -31,14 +29,6 @@ export default function PricingSummary( {
 	const { discountedCost, actualCost } = getTotalInvoiceValue( userProducts, items );
 
 	const currency = items[ 0 ]?.currency ?? 'USD'; // FIXME: Fix if multiple currencies are supported
-
-	const learnMoreLink = ''; //FIXME: Add link for A4A;
-
-	const onClickLearnMore = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_checkout_learn_more_click' ) );
-	}, [ dispatch ] );
-
-	const showLearnMoreLink = false; // FIXME: Remove this once the correct link is added
 
 	// Show actual cost if the agency is referring a client
 	const totalCost = isAutomatedReferrals ? actualCost : discountedCost;
@@ -92,25 +82,46 @@ export default function PricingSummary( {
 				// Show the notice only if it is agency checkout
 				isAgencyCheckout && (
 					<div className="checkout__summary-notice">
-						{ showLearnMoreLink
-							? translate(
-									'You will be billed at the end of every month. Your first month may be less than the above amount. {{a}}Learn more{{/a}}',
-									{
-										components: {
-											a: (
-												<a
-													href={ learnMoreLink }
-													target="_blank"
-													rel="noopener noreferrer"
-													onClick={ onClickLearnMore }
-												/>
-											),
-										},
-									}
-							  )
-							: translate(
-									'You will be billed at the end of every month. Your first month may be less than the above amount.'
-							  ) }
+						<h3>{ translate( 'When you purchase:' ) }</h3>
+						<p>
+							{ translate(
+								'You agree to our {{a}}Terms of Service{{/a}}, and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time.',
+								{
+									components: {
+										a: (
+											<a
+												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+												target="_blank"
+												rel="noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								'You understand {{a}}how your subscription works{{/a}} and {{a}}how to cancel{{/a}}.',
+								{
+									components: {
+										a: (
+											<a
+												href={ localizeUrl(
+													'https://agencieshelp.automattic.com/knowledge-base/billing-and-payments/'
+												) }
+												target="_blank"
+												rel="noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								'You will be billed on the first of every month. Your first bill will include a prorated amount for the current month, depending on which day you purchased these products.'
+							) }
+						</p>
 					</div>
 				)
 			}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -172,14 +172,13 @@
 	}
 
 	h3 {
-		margin-block-start: 2rem;
-		margin-block-end: 1rem;
+		margin-block: 24px;
 		font-weight: 500;
 		font-size: 1rem;
 		color: var(--color-neutral-70);
 	}
 
-	p {
+	.checkout__summary-notice-item {
 		font-size: 0.75rem;
 		color: var(--color-neutral-50);
 		margin-block-end: 0.5rem;

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -160,20 +160,33 @@
 .checkout__summary-notice {
 	color: var(--color-neutral-50);
 	font-size: rem(12px);
-	margin-block-end: 16px;
+	margin-block-end: 1rem;
 
 	a {
 		text-decoration: underline;
-		color: var(--color-black);
+		color: var(--color-text-black);
 	}
 
 	&.margin-top {
 		margin-block-start: 16px;
 	}
+
+	h3 {
+		margin-block-start: 2rem;
+		margin-block-end: 1rem;
+		font-weight: 500;
+		font-size: 1rem;
+		color: var(--color-neutral-70);
+	}
+
+	p {
+		font-size: 0.75rem;
+		color: var(--color-neutral-50);
+		margin-block-end: 0.5rem;
+	}
 }
 
 .checkout__aside-actions {
-	margin-block-start: 32px;
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -45,8 +45,6 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 							{ formatCurrency( actualCost, item.currency ) }
 						</span>
 					) }
-					{ /* translators: means per month (eg $25/mo)*/ }
-					<span>{ translate( '/mo' ) }</span>
 				</div>
 			</div>
 			{ onRemoveItem && (

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -45,6 +45,8 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 							{ formatCurrency( actualCost, item.currency ) }
 						</span>
 					) }
+					{ /* translators: means per month (eg $25/mo)*/ }
+					<span>{ translate( '/mo' ) }</span>
 				</div>
 			</div>
 			{ onRemoveItem && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-genesis/issues/411
More context: p1719355127460079-slack-C03Q2D22DGV

## Proposed Changes

Update wording on Agency checkout

<img width="1384" alt="Screenshot 2024-06-26 at 1 11 21 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4856b547-1d83-49b8-b31e-d421ac5c6b14">



@jeffgolenski as mentioned there sometimes issues with break line

<img width="446" alt="Screenshot 2024-06-25 at 5 24 46 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/e5b966c5-c0a3-496f-b963-62459f6c2634">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to marketplace and add items to your cart
- Navigate to checkout and check wording and links

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?