### PR TITLE
DIFM Design picker: Align tracks props with tiers

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -7,6 +7,8 @@ import DesignPicker, {
 	isBlankCanvasDesign,
 	useCategorization,
 	useThemeDesignsQuery,
+	PREMIUM_THEME,
+	MARKETPLACE_THEME,
 } from '@automattic/design-picker';
 import { englishLocales } from '@automattic/i18n-utils';
 import { shuffle } from '@automattic/js-utils';
@@ -104,8 +106,9 @@ export default function DesignPickerStep( props ) {
 	const getEventPropsByDesign = ( design ) => ( {
 		theme: design?.stylesheet ?? `pub/${ design?.theme }`,
 		template: design?.template,
-		is_premium: design?.is_premium,
-		is_externally_managed: design?.is_externally_managed,
+		tier: design?.design_tier,
+		is_premium: design?.design_tier === PREMIUM_THEME,
+		is_externally_managed: design?.design_tier === MARKETPLACE_THEME,
 		flow: flowName,
 		intent: dependencies.intent,
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6349

## Proposed Changes

Calculate the `is_premium` and `is_externally_managed` event props from the theme tier, as well as recording the theme tier directly.



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

New funnels etc should really use the newly added `tier` property but for compatibilities sake, the `is_premium` prop has been kept too.

Calculating `is_premium` from the designs `is_premium` property uses the old way of checking whether a theme is premium and so was returning false for themes that were in the pub/ directory and had a premium tier. The new calculation assumes that `is_premium` means is in the premium tier, rather than as part of the (non-free) starter tier.

Similarly, the `is_externally_managed` prop basically meant "is this a partner theme from the marketplace" and has been updated accordingly. There are no partner themes available in the DIFM design picker at this time anyway.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Use calypso live link
 2. Go to /start
 3. Go through the onboarding process until the intent screen, when you should choose "premium - design the site for me"
 4. Go through the process until the design picker screen
 5. Monitor the tracks events for e.g. by clicking on a theme.

Compare the events with what happens in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
