### PR TITLE
A4A > Referral: Update the client referral checkout summary notes

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -53,8 +53,6 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 
 	const hasCompletedForm = !! email && !! message;
 
-	const learnMoreLink = 'https://agencieshelp.automattic.com/knowledge-base/billing-and-payments';
-
 	const productIds = checkoutItems.map( ( item ) => item.product_id ).join( ',' );
 
 	const handleRequestPayment = useCallback( () => {
@@ -70,10 +68,6 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 		);
 		requestPayment( { client_email: email, client_message: message, product_ids: productIds } );
 	}, [ dispatch, email, hasCompletedForm, message, productIds, requestPayment, translate ] );
-
-	const onClickLearnMore = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_learn_more_click' ) );
-	}, [ dispatch ] );
 
 	useEffect( () => {
 		if ( isSuccess && !! email ) {
@@ -124,6 +118,19 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 					/>
 				</FormFieldset>
 			</div>
+
+			<div className="checkout__summary-notice">
+				<h3>{ translate( 'When you send this payment request:' ) }</h3>
+				<div className="checkout__summary-notice-item">
+					{ translate(
+						"Your client will be sent an invoice where they will be asked to create a WordPress.com account to pay for these products. Once paid, you'll be able to manage these products on behalf of the client."
+					) }
+				</div>
+				<div className="checkout__summary-notice-item">
+					{ translate( 'The client can cancel their products at any time.' ) }
+				</div>
+			</div>
+
 			<div className="checkout__aside-actions">
 				<Button
 					primary
@@ -133,24 +140,6 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 				>
 					{ translate( 'Request payment from client' ) }
 				</Button>
-			</div>
-
-			<div className="checkout__summary-notice margin-top">
-				{ translate(
-					'The client will be billed at the end of every month. The first month may be less than the above amount. {{a}}Learn more{{/a}}',
-					{
-						components: {
-							a: (
-								<a
-									href={ learnMoreLink }
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ onClickLearnMore }
-								/>
-							),
-						},
-					}
-				) }
 			</div>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -45,8 +45,6 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 							{ formatCurrency( actualCost, item.currency ) }
 						</span>
 					) }
-					{ /* translators: means per month (eg $25/mo)*/ }
-					<span>{ translate( '/mo' ) }</span>
 				</div>
 			</div>
 			{ onRemoveItem && (

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -45,6 +45,8 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 							{ formatCurrency( actualCost, item.currency ) }
 						</span>
 					) }
+					{ /* translators: means per month (eg $25/mo)*/ }
+					<span>{ translate( '/mo' ) }</span>
 				</div>
 			</div>
 			{ onRemoveItem && (


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/415

## Proposed Changes

This PR updates the client referral checkout summary notes

## Testing Instructions

- Open A4A live link
- Refer a product to a client
- Verify the checkout is updated as shown below:

| Before | After |
|--------|--------|
| <img width="1384" alt="Screenshot 2024-06-26 at 1 16 51 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/1ed85f83-2cc7-4356-819e-e664dd48bce6"> |<img width="1384" alt="Screenshot 2024-06-26 at 1 08 59 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/950168ef-8474-4394-ac72-8a72a739fc35"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
