### PR TITLE
Stepper: Fix navigation when there is not step on url

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -37,7 +37,7 @@ export const useFlowNavigation = (): FlowNavigation => {
 	const intent = useOnboardingIntent();
 	const { setStepData } = useDispatch( STEPPER_INTERNAL_STORE );
 	const navigate = useNavigate();
-	const match = useMatch( '/:flow/:step/:lang?' );
+	const match = useMatch( '/:flow/:step?/:lang?' );
 	const { flow = null, step: currentStepSlug = null, lang = null } = match?.params || {};
 	const [ currentSearchParams ] = useSearchParams();
 

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/test/index.tsx
@@ -63,6 +63,15 @@ describe( 'useFlowNavigation', () => {
 			expect( screen.getByTestId( 'location-display' ) ).toHaveTextContent( '/some-flow/step2' );
 		} );
 
+		it( 'navigates to the next step when there is not step in the url', () => {
+			const { result } = render( { initialEntry: '/setup/some-flow' } );
+			const navigate = result.current.navigate;
+
+			act( () => navigate( 'step2' ) );
+
+			expect( screen.getByTestId( 'location-display' ) ).toHaveTextContent( '/some-flow/step2' );
+		} );
+
 		it( 'includes the lang when its exists on the current step', () => {
 			const { result } = render( { initialEntry: '/setup/some-flow/some-step/es' } );
 			const navigate = result.current.navigate;


### PR DESCRIPTION
Close #92111

## Proposed Changes
*  Enable useStepNavigation > navigate to the next step when there is not step available on the URL
* Make the step name optional when building the navigate function. 

## Why are these changes being made?
Nowadays,  when we access `/setup/flow-name` with no step available on the URL, the stepper is redirecting the user to the first step flow but the stepper still executes all flow hooks, like `flow.useStepNavigation` and `flow.useSideEffect`.
It is causing an issue because the code that is parsing the URL to mount the `navigate` function was not able to identify the lack of step name, causing a blank step rendering.
  
This issue only happens with flows that are calling the navigate function inside the `useSideEffect` without checking the current step name.  Like the `migration-signup` flow

> [!NOTE]  
> This scenario should not be valid because we have can race conditions between stepper logic and flow logic but we can evaluate it later. 

## Testing Instructions
* Access `/setup/migration-signup`
* Check if a step is rendered. 





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
