### PR TITLE
Plans: Remove `plans-paid-media` intent properly. Fix monthly term in toggle

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
+++ b/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
@@ -5,19 +5,18 @@ import {
 	URL_FRIENDLY_TERMS_MAPPING,
 	UrlFriendlyTermType,
 } from '@automattic/calypso-products';
-import { PlansIntent } from '@automattic/plans-grid-next';
 import { useMemo } from 'react';
 import { useFCCARestrictions } from './use-fcca-restrictions';
 
 interface Props {
-	intent?: PlansIntent;
+	flowName?: string | null;
 	displayedIntervals: UrlFriendlyTermType[];
 	paidDomainName?: string;
 	productSlug?: string;
 }
 
 const useFilteredDisplayedIntervals = ( {
-	intent,
+	flowName,
 	displayedIntervals,
 	paidDomainName,
 	productSlug,
@@ -43,7 +42,7 @@ const useFilteredDisplayedIntervals = ( {
 			} );
 		}
 
-		if ( intent === 'plans-paid-media' ) {
+		if ( 'onboarding-pm' === flowName ) {
 			// Monetizing free domain users is hard. From experience, users who choose a free domain
 			// have very low intent to purchase something during signup. We show a cheaper and flexible
 			// monthly option for this specific segment, but hide it if a custom domain is selected.
@@ -57,7 +56,7 @@ const useFilteredDisplayedIntervals = ( {
 		}
 
 		return filteredIntervals;
-	}, [ productSlug, displayedIntervals, intent, paidDomainName, is3yearlyRestricted ] );
+	}, [ productSlug, displayedIntervals, flowName, paidDomainName, is3yearlyRestricted ] );
 };
 
 export default useFilteredDisplayedIntervals;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -460,7 +460,7 @@ const PlansFeaturesMain = ( {
 	const filteredDisplayedIntervals = useFilteredDisplayedIntervals( {
 		productSlug: currentPlan?.productSlug,
 		displayedIntervals,
-		intent,
+		flowName,
 		paidDomainName,
 	} );
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -349,7 +349,6 @@ PlansStep.propTypes = {
 		'plans-plugins',
 		'plans-jetpack-app',
 		'plans-import',
-		'plans-paid-media',
 		'default',
 	] ),
 };

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -66,7 +66,6 @@ export type PlansIntent =
 	| 'plans-jetpack-app-site-creation'
 	| 'plans-import'
 	| 'plans-woocommerce'
-	| 'plans-paid-media'
 	| 'plans-p2'
 	| 'plans-default-wpcom'
 	| 'plans-business-trial'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/3096

## Proposed Changes

Fixes the monthly term appearing in the term toggle on the plans signup step when a paid domain has been selected in the domains step previously. The monthly option should not be visible in that case. This is only applicable to `/start/onboarding-pm` flow.

Cause: The plans `intent` was removed from the step configuration in https://github.com/Automattic/wp-calypso/pull/89395 but lingered in the `PlansIntent` type and conditions like the one resolved here. It's probably best/safer to start _from_ the type when doing this type of refactoring.

I debated whether to re-introduce the intent, instead of conditioning on `flowName`. Not sure what approach would be best. `intent` is more holistic and can be accessible outside of signup flows (whenever that need arises). 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Cleanup. Fixes bug https://github.com/Automattic/martech/issues/3096

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/onboarding-pm`
* Pick a free domain and proceed to the plans step - monthly term should be selectable in the toggle
* Go back and pick a paid domain - monthly term should not be selectable in the toggle
* `/start/plans` should work like before (with monthly selectable at all times)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
