### PR TITLE
Reader: fix inline emojis on full post pages

### DIFF
--- a/client/lib/post-normalizer/rule-add-image-wrapper-element.js
+++ b/client/lib/post-normalizer/rule-add-image-wrapper-element.js
@@ -80,8 +80,8 @@ export default function addImageWrapperElement( post, dom ) {
 
 	const images = dom.querySelectorAll( 'img[src]' );
 	forEach( images, ( image ) => {
-		if ( image.classList.contains( 'wp-smiley' ) ) {
-			// filter images that have the class wp-smiley
+		if ( image.classList.contains( 'wp-smiley' ) || image.classList.contains( 'emoji' ) ) {
+			// filter images that have the class wp-smiley or emoji
 			// these are emoji images and should not be wrapped
 			return;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/92062

We need to add a image wrapper to images on Reader to allow us to style them in a specific way. We don't want to wrap emojis however. We were looking for images with `wp-smiley` class to let us know what emoji images to not add an image wrapper to but it looks like we need to also look for images with the `emoji` class too.

## Before

<img width="1032" alt="Screenshot 2024-06-26 at 10 56 01" src="https://github.com/Automattic/wp-calypso/assets/5560595/d50f1891-86f6-4f88-9bd0-9af7ad8e3344">

## After

<img width="1032" alt="Screenshot 2024-06-26 at 10 54 32" src="https://github.com/Automattic/wp-calypso/assets/5560595/8986c50b-c61a-4b54-8119-23619161e4ea">

## Proposed Changes

* Add check for `emoji` class on inline images

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the reading experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/read/blogs/205338712/posts/3714 to see the issue
* Go to calyso.live version and confirm issue is fixed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
