### PR TITLE
A4A > Referral: Update the client KB link

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -43,3 +43,5 @@ export const A4A_CLIENT_SUBSCRIPTIONS_LINK = '/client/subscriptions';
 export const A4A_CLIENT_PAYMENT_METHODS_LINK = '/client/payment-methods';
 export const A4A_CLIENT_PAYMENT_METHODS_ADD_LINK = `${ A4A_CLIENT_PAYMENT_METHODS_LINK }/add`;
 export const A4A_CLIENT_CHECKOUT = '/client/checkout';
+export const EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE =
+	'https://agencieshelp.automattic.com/knowledge-base/client-billing/';

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -11,7 +11,11 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { A4A_OVERVIEW_LINK, EXTERNAL_A4A_KNOWLEDGE_BASE } from '../../sidebar-menu/lib/constants';
+import {
+	A4A_OVERVIEW_LINK,
+	EXTERNAL_A4A_KNOWLEDGE_BASE,
+	EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE,
+} from '../../sidebar-menu/lib/constants';
 
 import './style.scss';
 
@@ -50,7 +54,7 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 			<li className="a4a-sidebar__profile-dropdown-menu-item">
 				<Button
 					borderless
-					href={ EXTERNAL_A4A_KNOWLEDGE_BASE }
+					href={ isClient ? EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE : EXTERNAL_A4A_KNOWLEDGE_BASE }
 					target="_blank"
 					rel="noopener noreferrer"
 				>


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/417

## Proposed Changes

This PR updates the client KB link.

## Testing Instructions

- Start the server locally
- Visit http://agencies.localhost:3000/client/subscriptions by logging in as a client
- Click the profile dropdown & verify that clicking on the KB article redirects you to https://agencieshelp.automattic.com/knowledge-base/client-billing/

<img width="503" alt="Screenshot 2024-06-26 at 3 25 33 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/575adf19-643a-4029-b3bd-fbcf9c65aa42">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
