### PR TITLE
Sync admin interface changes to the settings ui

### DIFF
--- a/client/my-sites/site-settings/site-admin-interface/index.js
+++ b/client/my-sites/site-settings/site-admin-interface/index.js
@@ -4,7 +4,7 @@ import { Card, FormLabel } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate, localize } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
@@ -79,6 +79,12 @@ const SiteAdminInterface = ( { siteId, siteSlug, isHosting = false } ) => {
 	} );
 
 	const [ selectedAdminInterface, setSelectedAdminInterface ] = useState( adminInterface );
+
+	// When switching from Classic to Default, adminInterface will initially reflect the cached state 'wp-admin'.
+	// It will then be updated to 'calypso', so we need to sync the change to selectedAdminInterface.
+	useEffect( () => {
+		setSelectedAdminInterface( adminInterface );
+	}, [ adminInterface ] );
 
 	const handleSubmitForm = ( value ) => {
 		if ( isHosting ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7760

## Proposed Changes

Context: https://github.com/Automattic/jetpack/pull/37921#issuecomment-2177427032
* Make sure we sync the latest change from the API so it can be reflected correctly in the settings


https://github.com/Automattic/wp-calypso/assets/6586048/dd263628-3eaa-4e80-be71-b8d21bae288c



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In Classic mode, when we set the admin interface back to Default, we want to redirect back to the Default Settings page for a smooth UX
* Currently, if a cached value is present locally, `selectedAdminInterface` will use that value and not be updated if `adminInterface` updates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test it fully, you can apply this Diff D153415-code in your sandbox (this redirects back to `calypso.localhost:3000`)
* Sandbox the simple site
* Set the Admin interface from Default -> Classic -> Default, and see if the UX is smooth
* Try to break it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?