### PR TITLE
Stats: Update checkout type for purchase flows

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -24,11 +24,6 @@ function getStatsCheckoutURL(
 	adminUrl?: string,
 	isUpgrade?: boolean
 ) {
-	// eslint-disable-next-line no-console
-	console.log( 'from: ', from );
-	// eslint-disable-next-line no-console, prefer-rest-params
-	console.log( 'arguments: ', arguments );
-
 	const useLoggedOutFlow = from === 'jetpack-my-jetpack' || from === 'jetpack-stats-upgrade-notice';
 	// const isFromJetpack = from?.startsWith( 'jetpack' );
 	// Get the checkout URL for the product, or the siteless checkout URL if from Jetpack or no siteSlug is provided
@@ -187,17 +182,6 @@ const gotoCheckoutPage = ( {
 	const redirectUrl = getRedirectUrl( { from, type, adminUrl, redirectUri, siteSlug } );
 	const checkoutBackUrl = getCheckoutBackUrl( { from, adminUrl, siteSlug } );
 
-	const newCheckoutURL = getStatsCheckoutURL(
-		siteSlug,
-		product,
-		redirectUrl,
-		checkoutBackUrl,
-		from,
-		adminUrl,
-		isUpgrade
-	);
-	console.log( 'newCheckoutURL: ', newCheckoutURL );
-	return;
 	// Allow some time for the event to be recorded before redirecting.
 	setTimeout(
 		() =>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -28,7 +28,7 @@ const getStatsCheckoutURL = (
 	// The following cases get the logged out flow:
 	// - If the user is coming from My Jetpack
 	// - If no siteSlug is provided
-	// - If it's not an upgrade (currently causes errors in the logged in flow)
+	// - If it's not an upgrade (currently causes errors in the logged out flow)
 	const useLoggedOutFlow = from === 'jetpack-my-jetpack' || from === 'jetpack-stats-upgrade-notice';
 	const checkoutType = ( useLoggedOutFlow && ! isUpgrade ) || ! siteSlug ? 'jetpack' : siteSlug;
 	const checkoutProductUrl = new URL(

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -15,7 +15,7 @@ const setUrlParam = ( url: URL, paramName: string, paramValue?: string | null ):
 	}
 };
 
-const getStatsCheckoutURL = (
+function getStatsCheckoutURL(
 	siteSlug: string,
 	product: string,
 	redirectUrl: string,
@@ -23,8 +23,12 @@ const getStatsCheckoutURL = (
 	from?: string,
 	adminUrl?: string,
 	isUpgrade?: boolean
-) => {
-	const isFromJetpack = from?.startsWith( 'jetpack' );
+) {
+	// eslint-disable-next-line no-console
+	console.log( 'from: ', from );
+	// eslint-disable-next-line no-console, prefer-rest-params
+	console.log( 'arguments: ', arguments );
+
 	// Get the checkout URL for the product, or the siteless checkout URL if from Jetpack or no siteSlug is provided
 	const checkoutType = ( isFromJetpack && ! isUpgrade ) || ! siteSlug ? 'jetpack' : siteSlug;
 	const checkoutProductUrl = new URL(
@@ -43,7 +47,7 @@ const getStatsCheckoutURL = (
 	}
 
 	return checkoutProductUrl.toString();
-};
+}
 
 const getYearlyPrice = ( monthlyPrice: number ) => {
 	return monthlyPrice * 12;
@@ -181,6 +185,17 @@ const gotoCheckoutPage = ( {
 	const redirectUrl = getRedirectUrl( { from, type, adminUrl, redirectUri, siteSlug } );
 	const checkoutBackUrl = getCheckoutBackUrl( { from, adminUrl, siteSlug } );
 
+	const newCheckoutURL = getStatsCheckoutURL(
+		siteSlug,
+		product,
+		redirectUrl,
+		checkoutBackUrl,
+		from,
+		adminUrl,
+		isUpgrade
+	);
+	console.log( 'newCheckoutURL: ', newCheckoutURL );
+	return;
 	// Allow some time for the event to be recorded before redirecting.
 	setTimeout(
 		() =>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -15,7 +15,7 @@ const setUrlParam = ( url: URL, paramName: string, paramValue?: string | null ):
 	}
 };
 
-function getStatsCheckoutURL(
+const getStatsCheckoutURL = (
 	siteSlug: string,
 	product: string,
 	redirectUrl: string,
@@ -23,7 +23,7 @@ function getStatsCheckoutURL(
 	from?: string,
 	adminUrl?: string,
 	isUpgrade?: boolean
-) {
+) => {
 	// Get the checkout URL for the product.
 	// The following cases get the logged out flow:
 	// - If the user is coming from My Jetpack
@@ -47,7 +47,7 @@ function getStatsCheckoutURL(
 	}
 
 	return checkoutProductUrl.toString();
-}
+};
 
 const getYearlyPrice = ( monthlyPrice: number ) => {
 	return monthlyPrice * 12;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -29,8 +29,10 @@ function getStatsCheckoutURL(
 	// eslint-disable-next-line no-console, prefer-rest-params
 	console.log( 'arguments: ', arguments );
 
+	const useLoggedOutFlow = from === 'jetpack-my-jetpack' || from === 'jetpack-stats-upgrade-notice';
+	// const isFromJetpack = from?.startsWith( 'jetpack' );
 	// Get the checkout URL for the product, or the siteless checkout URL if from Jetpack or no siteSlug is provided
-	const checkoutType = ( isFromJetpack && ! isUpgrade ) || ! siteSlug ? 'jetpack' : siteSlug;
+	const checkoutType = ( useLoggedOutFlow && ! isUpgrade ) || ! siteSlug ? 'jetpack' : siteSlug;
 	const checkoutProductUrl = new URL(
 		`/checkout/${ checkoutType }/${ product }`,
 		'https://wordpress.com'
@@ -40,7 +42,7 @@ function getStatsCheckoutURL(
 	setUrlParam( checkoutProductUrl, 'redirect_to', redirectUrl );
 	setUrlParam( checkoutProductUrl, 'checkoutBackUrl', checkoutBackUrl );
 
-	if ( isFromJetpack && siteSlug ) {
+	if ( useLoggedOutFlow && siteSlug ) {
 		setUrlParam( checkoutProductUrl, 'connect_after_checkout', 'true' );
 		setUrlParam( checkoutProductUrl, 'admin_url', adminUrl );
 		setUrlParam( checkoutProductUrl, 'from_site_slug', siteSlug );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -24,9 +24,12 @@ function getStatsCheckoutURL(
 	adminUrl?: string,
 	isUpgrade?: boolean
 ) {
+	// Get the checkout URL for the product.
+	// The following cases get the logged out flow:
+	// - If the user is coming from My Jetpack
+	// - If no siteSlug is provided
+	// - If it's not an upgrade (currently causes errors in the logged in flow)
 	const useLoggedOutFlow = from === 'jetpack-my-jetpack' || from === 'jetpack-stats-upgrade-notice';
-	// const isFromJetpack = from?.startsWith( 'jetpack' );
-	// Get the checkout URL for the product, or the siteless checkout URL if from Jetpack or no siteSlug is provided
 	const checkoutType = ( useLoggedOutFlow && ! isUpgrade ) || ! siteSlug ? 'jetpack' : siteSlug;
 	const checkoutProductUrl = new URL(
 		`/checkout/${ checkoutType }/${ product }`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/56

## Proposed Changes

Limit the logged-out checkout flow to clicks from My Jetpack or the initial upgrade banner. That flow doesn't currently handle upgrades or cross-grades (from free to paid license) so we want to avoid it for those scenarios.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* see above

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### My Jetpack

* Spin up a new JN test site.
* Set up the Jetpack connection.
* Visit the My Jetpack dashboard and click the Upgrade button on the Stats module.
* Click through the checkout flow to the cart.
* Confirm the URL is in the form of `/checkout/jetpack` — logged out flow

### Upgrade banner

On an existing site (pre-dates paywall) without any plans and classified as personal:

* Visit Stats page.
* Click on top banner prompting to upgrade.
* Click through the checkout flow to the cart.
* Confirm the URL is in the form of `/checkout/jetpack` — logged out flow

### Other upgrade prompts

* Visit Stats page.
* Click on any other upgrade prompt.
* Click through the checkout flow to the cart.
* Confirm the URL is in the form of `/checkout/SITE-URL` — logged in flow

These flows need to be logged in for upgrades/cross-grades to work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
