### PR TITLE
A4A: Show Checkout notice summary based on client or agency context.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -26,6 +26,7 @@ import useProductsBySlug from '../hooks/use-products-by-slug';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import { getClientReferralQueryArgs } from '../lib/get-client-referral-query-args';
 import useSubmitForm from '../products-overview/product-listing/hooks/use-submit-form';
+import NoticeSummary from './notice-summary';
 import PricingSummary from './pricing-summary';
 import ProductInfo from './product-info';
 import RequestClientPayment from './request-client-payment';
@@ -121,28 +122,32 @@ function Checkout( { isClient }: { isClient?: boolean } ) {
 	const title = isAutomatedReferrals ? translate( 'Referral checkout' ) : translate( 'Checkout' );
 
 	let actionContent = (
-		<div className="checkout__aside-actions">
-			<Button
-				primary
-				onClick={ onCheckout }
-				disabled={ ! checkoutItems.length || ! isReady }
-				busy={ ! isReady }
-			>
-				{ translate( 'Purchase' ) }
-			</Button>
+		<>
+			<NoticeSummary type="agency-purchase" />
 
-			{ siteId ? (
-				<Button onClick={ cancelPurchase }>{ translate( 'Cancel' ) }</Button>
-			) : (
-				<>
-					<Button onClick={ onContinueShopping }>{ translate( 'Continue shopping' ) }</Button>
+			<div className="checkout__aside-actions">
+				<Button
+					primary
+					onClick={ onCheckout }
+					disabled={ ! checkoutItems.length || ! isReady }
+					busy={ ! isReady }
+				>
+					{ translate( 'Purchase' ) }
+				</Button>
 
-					<Button borderless onClick={ onEmptyCart }>
-						{ translate( 'Empty cart' ) }
-					</Button>
-				</>
-			) }
-		</div>
+				{ siteId ? (
+					<Button onClick={ cancelPurchase }>{ translate( 'Cancel' ) }</Button>
+				) : (
+					<>
+						<Button onClick={ onContinueShopping }>{ translate( 'Continue shopping' ) }</Button>
+
+						<Button borderless onClick={ onEmptyCart }>
+							{ translate( 'Empty cart' ) }
+						</Button>
+					</>
+				) }
+			</div>
+		</>
 	);
 
 	if ( isAutomatedReferrals ) {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -1,0 +1,144 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+type Props = {
+	type: 'client-purchase' | 'agency-purchase' | 'request-client-payment' | 'request-payment-method';
+};
+
+export default function NoticeSummary( { type }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const title = useMemo( () => {
+		switch ( type ) {
+			case 'client-purchase':
+			case 'agency-purchase':
+				return translate( 'When you purchase:' );
+			case 'request-client-payment':
+				return translate( 'When you send this payment request:' );
+			default:
+				return null;
+		}
+	}, [ translate, type ] );
+
+	const handleClientTermsClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_client_terms_click' ) );
+	}, [ dispatch ] );
+
+	const handleAgencyTermsClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_agency_terms_click' ) );
+	}, [ dispatch ] );
+
+	const handleSubscriptionInfoLinkClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_subscription_info_link_click' ) );
+	}, [ dispatch ] );
+
+	const handleCancellationInfoLinkClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_cancellation_info_link_click' ) );
+	}, [ dispatch ] );
+
+	const items = useMemo( () => {
+		switch ( type ) {
+			case 'client-purchase':
+			case 'agency-purchase':
+				return [
+					translate(
+						'You agree to our {{a/}}, and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time.',
+						{
+							components: {
+								a:
+									type === 'client-purchase' ? (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/tos' ) }
+											onClick={ handleClientTermsClick }
+											target="_blank"
+											rel="noreferrer noopener"
+										>
+											{ translate( 'Terms of Service' ) }
+										</a>
+									) : (
+										<a
+											href={ localizeUrl(
+												'https://automattic.com/for-agencies/platform-agreement/'
+											) }
+											onClick={ handleAgencyTermsClick }
+											target="_blank"
+											rel="noreferrer noopener"
+										>
+											{ translate( 'Platform agreement' ) }
+										</a>
+									),
+							},
+						}
+					),
+					translate(
+						'You understand {{subscriptionInfoLink}}how your subscription works{{/subscriptionInfoLink}} and {{cancellationInfoLink}}how to cancel{{/cancellationInfoLink}}.',
+						{
+							components: {
+								subscriptionInfoLink: (
+									<a
+										href={ localizeUrl(
+											'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-subscriptions-work'
+										) }
+										onClick={ handleSubscriptionInfoLinkClick }
+										target="_blank"
+										rel="noreferrer noopener"
+									/>
+								),
+								cancellationInfoLink: (
+									<a
+										href={ localizeUrl(
+											'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-to-cancel'
+										) }
+										onClick={ handleCancellationInfoLinkClick }
+										target="_blank"
+										rel="noreferrer noopener"
+									/>
+								),
+							},
+						}
+					),
+					translate(
+						'You will be billed on the first of every month. Your first bill will include a prorated amount for the current month, depending on which day you purchased these products. '
+					),
+				];
+			case 'request-client-payment':
+				return [
+					translate(
+						"Your client will be sent an invoice where they will be asked to create a WordPress.com account to pay for these products. Once paid, you'll be able to manage these products on behalf of the client."
+					),
+					translate( 'The client can cancel their products at any time.' ),
+				];
+
+			case 'request-payment-method':
+				return [
+					translate(
+						'Add a payment method to proceed with your purchase. You’ll have the opportunity to confirm your purchase after the payment method is added.'
+					),
+				];
+			default:
+				return [];
+		}
+	}, [
+		handleAgencyTermsClick,
+		handleCancellationInfoLinkClick,
+		handleClientTermsClick,
+		handleSubscriptionInfoLinkClick,
+		translate,
+		type,
+	] );
+
+	return (
+		<div className="checkout__summary-notice">
+			{ title && <h3>{ title }</h3> }
+			{ items.map( ( item, index ) => (
+				<div key={ `notice-item-${ index }` } className="checkout__summary-notice-item">
+					{ item }
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -49,28 +49,16 @@ export default function NoticeSummary( { type }: Props ) {
 						'You agree to our {{a/}}, and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time.',
 						{
 							components: {
-								a:
-									type === 'client-purchase' ? (
-										<a
-											href={ localizeUrl( 'https://wordpress.com/tos' ) }
-											onClick={ handleClientTermsClick }
-											target="_blank"
-											rel="noreferrer noopener"
-										>
-											{ translate( 'Terms of Service' ) }
-										</a>
-									) : (
-										<a
-											href={ localizeUrl(
-												'https://automattic.com/for-agencies/platform-agreement/'
-											) }
-											onClick={ handleAgencyTermsClick }
-											target="_blank"
-											rel="noreferrer noopener"
-										>
-											{ translate( 'Platform agreement' ) }
-										</a>
-									),
+								a: (
+									<a
+										href={ localizeUrl( 'https://wordpress.com/tos' ) }
+										onClick={ handleClientTermsClick }
+										target="_blank"
+										rel="noreferrer noopener"
+									>
+										{ translate( 'Terms of Service' ) }
+									</a>
+								),
 							},
 						}
 					),

--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -80,9 +80,11 @@ export default function NoticeSummary( { type }: Props ) {
 							components: {
 								subscriptionInfoLink: (
 									<a
-										href={ localizeUrl(
-											'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-subscriptions-work'
-										) }
+										href={
+											type === 'client-purchase'
+												? 'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-subscriptions-work'
+												: 'https://agencieshelp.automattic.com/knowledge-base/billing-and-payments'
+										}
 										onClick={ handleSubscriptionInfoLinkClick }
 										target="_blank"
 										rel="noreferrer noopener"
@@ -90,9 +92,11 @@ export default function NoticeSummary( { type }: Props ) {
 								),
 								cancellationInfoLink: (
 									<a
-										href={ localizeUrl(
-											'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-to-cancel'
-										) }
+										href={
+											type === 'client-purchase'
+												? 'https://agencieshelp.automattic.com/knowledge-base/client-billing/#how-to-cancel'
+												: 'https://agencieshelp.automattic.com/knowledge-base/purchases/#canceling-purchases'
+										}
 										onClick={ handleCancellationInfoLinkClick }
 										target="_blank"
 										rel="noreferrer noopener"

--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -46,7 +46,7 @@ export default function NoticeSummary( { type }: Props ) {
 			case 'agency-purchase':
 				return [
 					translate(
-						'You agree to our {{a/}}, and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time.',
+						'You agree to our {{a}}Terms of Service{{/a}}, and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time.',
 						{
 							components: {
 								a: (
@@ -55,9 +55,7 @@ export default function NoticeSummary( { type }: Props ) {
 										onClick={ handleClientTermsClick }
 										target="_blank"
 										rel="noreferrer noopener"
-									>
-										{ translate( 'Terms of Service' ) }
-									</a>
+									/>
 								),
 							},
 						}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -1,5 +1,4 @@
 import formatCurrency from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -77,54 +76,6 @@ export default function PricingSummary( {
 					} ) }
 				</span>
 			</div>
-
-			{
-				// Show the notice only if it is agency checkout
-				isAgencyCheckout && (
-					<div className="checkout__summary-notice">
-						<h3>{ translate( 'When you purchase:' ) }</h3>
-						<div className="checkout__summary-notice-item">
-							{ translate(
-								'You agree to our {{a}}Terms of Service{{/a}}, and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time.',
-								{
-									components: {
-										a: (
-											<a
-												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-												target="_blank"
-												rel="noreferrer"
-											/>
-										),
-									},
-								}
-							) }
-						</div>
-						<div className="checkout__summary-notice-item">
-							{ translate(
-								'You understand {{a}}how your subscription works{{/a}} and {{a}}how to cancel{{/a}}.',
-								{
-									components: {
-										a: (
-											<a
-												href={ localizeUrl(
-													'https://agencieshelp.automattic.com/knowledge-base/billing-and-payments/'
-												) }
-												target="_blank"
-												rel="noreferrer"
-											/>
-										),
-									},
-								}
-							) }
-						</div>
-						<div className="checkout__summary-notice-item">
-							{ translate(
-								'You will be billed on the first of every month. Your first bill will include a prorated amount for the current month, depending on which day you purchased these products.'
-							) }
-						</div>
-					</div>
-				)
-			}
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -18,6 +18,7 @@ import withMarketplaceType, {
 } from '../hoc/with-marketplace-type';
 import useRequestClientPaymentMutation from '../hooks/use-request-client-payment-mutation';
 import useShoppingCart from '../hooks/use-shopping-cart';
+import NoticeSummary from './notice-summary';
 import type { ShoppingCartItem } from '../types';
 
 interface Props {
@@ -119,17 +120,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 				</FormFieldset>
 			</div>
 
-			<div className="checkout__summary-notice">
-				<h3>{ translate( 'When you send this payment request:' ) }</h3>
-				<div className="checkout__summary-notice-item">
-					{ translate(
-						"Your client will be sent an invoice where they will be asked to create a WordPress.com account to pay for these products. Once paid, you'll be able to manage these products on behalf of the client."
-					) }
-				</div>
-				<div className="checkout__summary-notice-item">
-					{ translate( 'The client can cancel their products at any time.' ) }
-				</div>
-			</div>
+			<NoticeSummary type="request-client-payment" />
 
 			<div className="checkout__aside-actions">
 				<Button

--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -14,6 +14,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import useSubmitPaymentInfoMutation from '../hooks/use-submit-payment-info-mutation';
 import { getClientReferralQueryArgs } from '../lib/get-client-referral-query-args';
+import NoticeSummary from './notice-summary';
 
 export default function SubmitPaymentInfo( { disableButton }: { disableButton?: boolean } ) {
 	const translate = useTranslate();
@@ -38,12 +39,6 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 			clearInterval( refetchInterval );
 		};
 	}, [ paymentMethodAdded, refetchInterval ] );
-
-	const termsLink = 'https://automattic.com/for-agencies/platform-agreement/';
-
-	const handleTermsClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_terms_click' ) );
-	}, [ dispatch ] );
 
 	const handleSubmitPaymentInfo = useCallback( () => {
 		dispatch(
@@ -103,39 +98,9 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 
 	return (
 		<>
-			{ paymentMethodRequired ? (
-				<div className="checkout__summary-client-payment-notice">
-					{ translate( 'Before making a payment, add your payment{{nbsp/}}method.', {
-						components: {
-							nbsp: <>&nbsp;</>,
-						},
-					} ) }
-				</div>
-			) : (
-				<div className="checkout__summary-notice">
-					{ translate(
-						'By submitting your payment information you agree to the {{br/}} {{a}}Terms and Conditions{{/a}}',
-						{
-							components: {
-								a: (
-									<a
-										href={ termsLink }
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={ handleTermsClick }
-									/>
-								),
-								br: <br />,
-							},
-						}
-					) }
-					<div>
-						{ translate( `Note: You won't pay for the first 30 days.` ) }
-						<br />
-						{ translate( `After that, we'll charge your card every 30 days.` ) }
-					</div>
-				</div>
-			) }
+			<NoticeSummary
+				type={ paymentMethodRequired ? 'request-payment-method' : 'client-purchase' }
+			/>
 
 			<div className="checkout__aside-actions">
 				<Button

--- a/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/submit-payment-info.tsx
@@ -104,14 +104,12 @@ export default function SubmitPaymentInfo( { disableButton }: { disableButton?: 
 
 			<div className="checkout__aside-actions">
 				<Button
-					primary={ ! paymentMethodRequired }
 					onClick={ handleSubmitPaymentInfo }
 					disabled={ isPending || disableButton }
 					busy={ isPending }
+					primary
 				>
-					{ paymentMethodRequired
-						? translate( 'Add my payment method' )
-						: translate( 'Submit purchase' ) }
+					{ paymentMethodRequired ? translate( 'Add payment method' ) : translate( 'Purchase' ) }
 				</Button>
 			</div>
 			<div className="checkout__aside-footer">


### PR DESCRIPTION
Depending on the context, the checkout page will now show a different notice summary. The notice summary will ensure that we always present the Terms of Service agreement to the user when making a purchase. The notice also provides clear guidelines about subscriptions, cancellations, and billing.

| Scenario | Expected Notice |
|--------|--------|
| Agency purchase | <img width="564" alt="Screenshot 2024-06-26 at 7 10 55 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a518114b-bfb2-443b-995f-3ca1572f3b9b"> |
| Client purchase | <img width="406" alt="Screenshot 2024-06-26 at 8 17 30 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/2c15d647-3313-4508-abb5-876814fa56ae"> |
| Request client payment | <img width="516" alt="Screenshot 2024-06-26 at 7 23 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ec5b77e5-18b1-49ff-b3d2-1057ceda4f4f"> |
| Request payment method | <img width="398" alt="Screenshot 2024-06-26 at 8 20 12 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/37de6a8b-70aa-4105-9ccc-274ab4ef71be"> | 

Closes https://github.com/Automattic/jetpack-genesis/issues/416

## Proposed Changes

* Add a **NoticeSummary** component to display various notice items based on different contexts. There are four context types: 
   * client-purchase
   * agency-purchase 
   * request-client-payment
   * request-payment-method

## Testing Instructions

### Agency Purchase
* Use the A4A live link below and go to the `/marketplace/products` page.
* Add items to the cart and press checkout in the cart toggle.
* Confirm that the Checkout page shows the Platform agreement link and information about subscription, cancellation, and billing.

### Request client payment
* Use the A4A live link below and go to the `/marketplace/products` page.
* Toggle refer products to enable referral mode (Make sure you have submitted your Bank details to access the toggle)
* Add items to the referrals and press checkout in the cart toggle.
* Confirm that the Checkout page briefly describes what will happen when requesting payment in the notice summary.

### Request payment method
* Create a referral to your client account (refer to above instruction)
* Make sure you don't have an existing payment method in your client's account.
* Click the magic link to be redirected to the checkout page.
* Confirm that the information about adding payment method is describe in the notice summary.


### Client purchase
* Refer to the instructions above
* Add a payment method to your client account
* Confirm that the Checkout page shows the term of service link and information about subscription, cancellation, and billing.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
