### PR TITLE
A4A > Referral: Add "/mo" abbreviation for "per month"  in pricing summary

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -45,6 +45,11 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 							{ formatCurrency( actualCost, item.currency ) }
 						</span>
 					) }
+					<span>
+						{ translate( '/mo', {
+							comment: 'Abbreviation for per month',
+						} ) }
+					</span>
 				</div>
 			</div>
 			{ onRemoveItem && (

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
@@ -49,7 +49,7 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-start;
 	gap: 4px;
 	margin-block-end: 8px;
 }

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
@@ -62,10 +62,6 @@
 	font-size: 0.875rem;
 	line-height: 1.7;
 	font-weight: 400;
-
-	@include break-medium {
-		flex-direction: row;
-	}
 }
 
 .shopping-cart__menu-list-item-price-actual {


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/418

## Proposed Changes

This PR adds "/mo" abbreviation for "per month"  in pricing summary & use a different layout for displaying the items

## Testing Instructions

- Open A4A live link
- Visit the Marketplace > Add a few products > Verify that the checkout items are displayed as shown below

| Before | After |
|--------|--------|
| <img width="581" alt="Screenshot 2024-06-26 at 4 43 25 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2e447f86-2ec8-4010-a89b-19d96e822123"> |<img width="581" alt="Screenshot 2024-06-26 at 4 17 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/84570822-fb5f-43f8-940f-e34612bbf0a8"> | 

- Go to checkout > Verify that the checkout items are displayed as shown below

| Before | After |
|--------|--------|
| <img width="581" alt="Screenshot 2024-06-26 at 4 43 16 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4a24ce7c-1f4e-4960-8614-1cd18fe9bfdf"> | <img width="581" alt="Screenshot 2024-06-26 at 4 49 03 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4cfdec68-838c-45de-82eb-3645a866b7ff">| 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
