### PR TITLE
Assembler: Delete section style variations from Assembler previews until we handle them

### DIFF
--- a/packages/block-renderer/src/components/block-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/block-renderer-provider.tsx
@@ -1,9 +1,7 @@
 import {
-	useSafeGlobalStylesOutputWithConfig,
+	useSafeGlobalStylesOutput,
 	withExperimentalBlockEditorProvider,
-	GlobalStylesContext,
 } from '@automattic/global-styles';
-import { useContext } from '@wordpress/element';
 import { useMemo } from 'react';
 import useBlockRendererSettings from '../hooks/use-block-renderer-settings';
 import BlockRendererContext from './block-renderer-context';
@@ -22,15 +20,7 @@ const useBlockRendererContext = (
 	useInlineStyles = false
 ) => {
 	const { data: settings } = useBlockRendererSettings( siteId, stylesheet, useInlineStyles );
-	const { merged: config } = useContext( GlobalStylesContext );
-	// Remove section style variations until we handle them
-	if ( config?.styles?.blocks ) {
-		delete config.styles.blocks.variations;
-		delete config.styles.blocks[ 'core/group' ]?.variations;
-		delete config.styles.blocks[ 'core/column' ]?.variations;
-		delete config.styles.blocks[ 'core/columns' ]?.variations;
-	}
-	const [ globalStyles ] = useSafeGlobalStylesOutputWithConfig( config );
+	const [ globalStyles ] = useSafeGlobalStylesOutput();
 
 	const context = useMemo(
 		() => ( {

--- a/packages/block-renderer/src/components/block-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/block-renderer-provider.tsx
@@ -1,7 +1,9 @@
 import {
-	useSafeGlobalStylesOutput,
+	useSafeGlobalStylesOutputWithConfig,
 	withExperimentalBlockEditorProvider,
+	GlobalStylesContext,
 } from '@automattic/global-styles';
+import { useContext } from '@wordpress/element';
 import { useMemo } from 'react';
 import useBlockRendererSettings from '../hooks/use-block-renderer-settings';
 import BlockRendererContext from './block-renderer-context';
@@ -20,8 +22,16 @@ const useBlockRendererContext = (
 	useInlineStyles = false
 ) => {
 	const { data: settings } = useBlockRendererSettings( siteId, stylesheet, useInlineStyles );
-
-	const [ globalStyles ] = useSafeGlobalStylesOutput();
+	const { merged: config } = useContext( GlobalStylesContext );
+	// Remove section style variations until we handle them
+	if ( config?.styles?.blocks ) {
+		delete config.styles.blocks.variations;
+		delete config.styles.blocks[ 'core/group' ].variations;
+		delete config.styles.blocks[ 'core/column' ].variations;
+		delete config.styles.blocks[ 'core/columns' ].variations;
+	}
+	const [ globalStyles ] = useSafeGlobalStylesOutputWithConfig( config );
+	//debugger;
 	const context = useMemo(
 		() => ( {
 			isReady: !! settings,

--- a/packages/block-renderer/src/components/block-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/block-renderer-provider.tsx
@@ -31,7 +31,7 @@ const useBlockRendererContext = (
 		delete config.styles.blocks[ 'core/columns' ].variations;
 	}
 	const [ globalStyles ] = useSafeGlobalStylesOutputWithConfig( config );
-	//debugger;
+
 	const context = useMemo(
 		() => ( {
 			isReady: !! settings,

--- a/packages/block-renderer/src/components/block-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/block-renderer-provider.tsx
@@ -26,9 +26,9 @@ const useBlockRendererContext = (
 	// Remove section style variations until we handle them
 	if ( config?.styles?.blocks ) {
 		delete config.styles.blocks.variations;
-		delete config.styles.blocks[ 'core/group' ].variations;
-		delete config.styles.blocks[ 'core/column' ].variations;
-		delete config.styles.blocks[ 'core/columns' ].variations;
+		delete config.styles.blocks[ 'core/group' ]?.variations;
+		delete config.styles.blocks[ 'core/column' ]?.variations;
+		delete config.styles.blocks[ 'core/columns' ]?.variations;
 	}
 	const [ globalStyles ] = useSafeGlobalStylesOutputWithConfig( config );
 

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -45,7 +45,7 @@ const FontPairingVariation = ( {
 			user: fontPairingVariation,
 			base,
 			// When font paring isn't passed, it should be available on the base.
-			merged: ! fontPairingVariation ? base : mergeBaseAndUserConfigs( base, fontPairingVariation ),
+			merged: mergeBaseAndUserConfigs( base, fontPairingVariation ),
 		};
 	}, [ fontPairingVariation, base ] );
 	return (

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -21,6 +21,7 @@ const {
 	ExperimentalBlockEditorProvider,
 	GlobalStylesContext: UntypedGSContext,
 	useGlobalStylesOutput,
+	useGlobalStylesOutputWithConfig,
 	useGlobalSetting,
 	useGlobalStyle,
 } = unlock( blockEditorPrivateApis );
@@ -54,12 +55,24 @@ const useSafeGlobalStylesOutput = () => {
 	}
 };
 
+const useSafeGlobalStylesOutputWithConfig = ( config: GlobalStylesObject | undefined ) => {
+	try {
+		return useGlobalStylesOutputWithConfig( config );
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Error: Unable to get the output of global styles. Reason: %s', error );
+		captureException( error );
+		return [];
+	}
+};
+
 export {
 	cleanEmptyObject,
 	ExperimentalBlockEditorProvider,
 	GlobalStylesContext,
 	transformStyles,
 	useSafeGlobalStylesOutput,
+	useSafeGlobalStylesOutputWithConfig,
 	useGlobalSetting,
 	useGlobalStyle,
 	mergeBaseAndUserConfigs,

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -21,15 +21,24 @@ const {
 	ExperimentalBlockEditorProvider,
 	GlobalStylesContext: UntypedGSContext,
 	useGlobalStylesOutput,
-	useGlobalStylesOutputWithConfig,
 	useGlobalSetting,
 	useGlobalStyle,
 } = unlock( blockEditorPrivateApis );
 
 const GlobalStylesContext: React.Context< GlobalStylesContextObject > = UntypedGSContext;
 
-const mergeBaseAndUserConfigs = ( base: GlobalStylesObject, user: GlobalStylesObject ) => {
-	return deepmerge( base, user, { isMergeableObject: isPlainObject } );
+const mergeBaseAndUserConfigs = ( base: GlobalStylesObject, user?: GlobalStylesObject ) => {
+	const mergedConfig = user ? deepmerge( base, user, { isMergeableObject: isPlainObject } ) : base;
+
+	// Remove section style variations until we handle them
+	if ( mergedConfig?.styles?.blocks ) {
+		delete mergedConfig.styles.blocks.variations;
+		for ( const key in mergedConfig.styles.blocks ) {
+			delete mergedConfig.styles.blocks[ key ].variations;
+		}
+	}
+
+	return mergedConfig;
 };
 
 const withExperimentalBlockEditorProvider = createHigherOrderComponent(
@@ -55,24 +64,12 @@ const useSafeGlobalStylesOutput = () => {
 	}
 };
 
-const useSafeGlobalStylesOutputWithConfig = ( config: GlobalStylesObject | undefined ) => {
-	try {
-		return useGlobalStylesOutputWithConfig( config );
-	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Error: Unable to get the output of global styles. Reason: %s', error );
-		captureException( error );
-		return [];
-	}
-};
-
 export {
 	cleanEmptyObject,
 	ExperimentalBlockEditorProvider,
 	GlobalStylesContext,
 	transformStyles,
 	useSafeGlobalStylesOutput,
-	useSafeGlobalStylesOutputWithConfig,
 	useGlobalSetting,
 	useGlobalStyle,
 	mergeBaseAndUserConfigs,

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -49,6 +49,7 @@ export interface GlobalStylesObject {
 			};
 		};
 		typography?: Typography;
+		blocks?: Record< string, { variations?: object } >;
 	};
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/themes/pull/7897

## Proposed Changes

* Delete section style variations until we handle them
  * Global variations
  * `core/group` variations
  * `core/column` variations 
  * `core/columns` variations

>[!IMPORTANT]
>I think there is a bug in Gutenberg, because those heading variations should not be global.
>Heading variation style declarations should depend on the block selector (`.wp-block-group` or `.wp-block-columns` or `.wp-block-column`) rather than be returned as global selectors `:root :where(h1, h2, h3, h4, h5, h6){color: var(--wp--preset--color--theme-1);}`
>
>The issue only affects variations of inner element styles, not variations of block type styles.
I think the issue is that [blockSelectors](https://github.com/WordPress/gutenberg/blob/b649ec42f8b3a1ee6628b8bc09970c6a05867016/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L1356) have empty variation selectors for inner elements. If the [variationSelector](https://github.com/WordPress/gutenberg/blob/b649ec42f8b3a1ee6628b8bc09970c6a05867016/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L657) is empty, the style declaration is not dependent on a variation and becomes global [here](https://github.com/WordPress/gutenberg/blob/b649ec42f8b3a1ee6628b8bc09970c6a05867016/packages/block-editor/src/components/global-styles/use-global-styles-output.js#L668). 
>

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a bug on Assembler previews that makes them use the color white on the heading because the variations use global selectors that overwrite each other. See p1719376857528589-slack-CRWCHQGUB

![image](https://github.com/Automattic/wp-calypso/assets/1881481/c10088e6-9822-4c13-82c6-3720269add13)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Assembler https://wordpress.com/setup/assembler-first
* Explore patterns to verify the headings are visible

|BEFORE|AFTER|
|-|-|
|<img width="1728" alt="Screenshot 2567-06-26 at 12 11 29" src="https://github.com/Automattic/themes/assets/1881481/55e8ee69-e216-447e-970e-824f5a757bf2">|<img width="1728" alt="Screenshot 2567-06-26 at 12 18 50" src="https://github.com/Automattic/themes/assets/1881481/f07ec29a-765d-4466-a15e-481d8b48746f">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?