### PR TITLE
DIFM Design Picker: Don't use incorrect constants

### DIFF
--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -22,6 +22,9 @@ const getIncludedWithLabel = ( planSlug ) => {
 		: getPlan( planSlug )?.getTitle();
 };
 
+export const THEME_TIER_PREMIUM = 'premium';
+export const THEME_TIER_PARTNER = 'partner';
+
 /**
  * @typedef {Object} THEME_TIERS
  * @property {Object} [tier] A theme tier mapped to UI-related properties.
@@ -44,12 +47,12 @@ export const THEME_TIERS = {
 		minimumUpsellPlan: PLAN_PERSONAL,
 		isFilterable: true,
 	},
-	premium: {
+	THEME_TIER_PREMIUM: {
 		label: getIncludedWithLabel( PLAN_PREMIUM ),
 		minimumUpsellPlan: PLAN_PREMIUM,
 		isFilterable: true,
 	},
-	partner: {
+	THEME_TIER_PARTNER: {
 		label: translate( 'Partner', {
 			context: 'This theme is developed and supported by a theme partner',
 		} ),

--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -47,12 +47,12 @@ export const THEME_TIERS = {
 		minimumUpsellPlan: PLAN_PERSONAL,
 		isFilterable: true,
 	},
-	THEME_TIER_PREMIUM: {
+	[ THEME_TIER_PREMIUM ]: {
 		label: getIncludedWithLabel( PLAN_PREMIUM ),
 		minimumUpsellPlan: PLAN_PREMIUM,
 		isFilterable: true,
 	},
-	THEME_TIER_PARTNER: {
+	[ THEME_TIER_PARTNER ]: {
 		label: translate( 'Partner', {
 			context: 'This theme is developed and supported by a theme partner',
 		} ),

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -16,6 +16,7 @@ import PropTypes from 'prop-types';
 import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { THEME_TIER_PARTNER, THEME_TIER_PREMIUM } from 'calypso/components/theme-tier/constants';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import AsyncCheckoutModal from 'calypso/my-sites/checkout/modal/async';
@@ -105,8 +106,8 @@ export default function DesignPickerStep( props ) {
 		theme: design?.stylesheet ?? `pub/${ design?.theme }`,
 		template: design?.template,
 		tier: design?.design_tier,
-		is_premium: design?.design_tier === 'premium',
-		is_externally_managed: design?.design_tier === 'partner',
+		is_premium: design?.design_tier === THEME_TIER_PREMIUM,
+		is_externally_managed: design?.design_tier === THEME_TIER_PARTNER,
 		flow: flowName,
 		intent: dependencies.intent,
 	} );

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -7,8 +7,6 @@ import DesignPicker, {
 	isBlankCanvasDesign,
 	useCategorization,
 	useThemeDesignsQuery,
-	PREMIUM_THEME,
-	MARKETPLACE_THEME,
 } from '@automattic/design-picker';
 import { englishLocales } from '@automattic/i18n-utils';
 import { shuffle } from '@automattic/js-utils';
@@ -107,8 +105,8 @@ export default function DesignPickerStep( props ) {
 		theme: design?.stylesheet ?? `pub/${ design?.theme }`,
 		template: design?.template,
 		tier: design?.design_tier,
-		is_premium: design?.design_tier === PREMIUM_THEME,
-		is_externally_managed: design?.design_tier === MARKETPLACE_THEME,
+		is_premium: design?.design_tier === 'premium',
+		is_externally_managed: design?.design_tier === 'partner',
 		flow: flowName,
 		intent: dependencies.intent,
 	} );


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/92107

## Proposed Changes

Use new constants rather than previous ones which were technically incorrect

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

ca95596 changed the way that tracks properties were calculated. To do this it used two constants - PREMIUM_THEME and MARKETPLACE_THEME however these constants are related to theme types rather than tiers.

It hasn't caused a problem in practice - PREMIUM_THEME resolves to 'premium' (the tier name) so that worked, and though MARKETPLACE_THEME resolves to 'marketplace' when the tier is called 'partner', that didn't matter because there are no marketplace themes in the DIFM design picker.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Use calypso live link
2. Go to /start
3. Go through the onboarding process until the intent screen, when you should choose "premium - design the site for me"
4. Go through the process until the design picker screen
5. Monitor the tracks events for e.g. by clicking on a theme.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
