### PR TITLE
A4A-Partner Directory: Fix the Chrome autocomplete "off" does not work

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/components/form-token-field-wrapper.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/form-token-field-wrapper.tsx
@@ -1,0 +1,41 @@
+import { FormTokenField } from '@wordpress/components';
+import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
+import { useEffect, useRef } from 'react';
+
+type Props = {
+	onChange: ( selectedItems: ( string | TokenItem )[] ) => void;
+	suggestions: string[];
+	value: string[];
+	label?: string;
+};
+
+const FormTokenFieldWrapper = ( { onChange, suggestions, value, label = '' }: Props ) => {
+	const formTokenFieldRef = useRef< HTMLDivElement >( null );
+
+	// Hack to disable the Chrome browser field autocomplete. FormTokenField hardcode it to 'off' but Chrome ignores it.
+	useEffect( () => {
+		if ( formTokenFieldRef.current ) {
+			const inputElement = formTokenFieldRef.current.querySelector( 'input' );
+			if ( inputElement ) {
+				inputElement.setAttribute( 'autocomplete', 'none' );
+			}
+		}
+	}, [] );
+
+	return (
+		<div ref={ formTokenFieldRef }>
+			<FormTokenField
+				__experimentalAutoSelectFirstMatch
+				__experimentalExpandOnFocus
+				__experimentalShowHowTo={ false }
+				__nextHasNoMarginBottom
+				label={ label }
+				onChange={ onChange }
+				suggestions={ suggestions }
+				value={ value }
+			/>
+		</div>
+	);
+};
+
+export default FormTokenFieldWrapper;

--- a/client/a8c-for-agencies/sections/partner-directory/components/languages-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/languages-selector.tsx
@@ -1,13 +1,13 @@
-import { FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
+import FormTokenFieldWrapper from './form-token-field-wrapper';
 import { useFormSelectors } from './hooks/use-form-selectors';
 
 type Props = {
 	setLanguages: ( tokens: ( string | TokenItem )[] ) => void;
-	selectedLanguages: string[] | undefined;
+	selectedLanguages: string[];
 };
 
-const LanguagesSelector = ( { setLanguages, selectedLanguages }: Props ) => {
+const LanguagesSelector = ( { setLanguages, selectedLanguages = [] }: Props ) => {
 	const { availableLanguages } = useFormSelectors();
 
 	// It converts the values selected into their keys
@@ -22,12 +22,7 @@ const LanguagesSelector = ( { setLanguages, selectedLanguages }: Props ) => {
 	};
 
 	return (
-		<FormTokenField
-			__experimentalAutoSelectFirstMatch
-			__experimentalExpandOnFocus
-			__experimentalShowHowTo={ false }
-			__nextHasNoMarginBottom
-			label=""
+		<FormTokenFieldWrapper
 			onChange={ setLanguagesByCode }
 			suggestions={ Object.values( availableLanguages ) }
 			value={ selectedLanguages }

--- a/client/a8c-for-agencies/sections/partner-directory/components/products-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/products-selector.tsx
@@ -1,11 +1,11 @@
-import { FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
 import { useCallback, useMemo } from 'react';
+import FormTokenFieldWrapper from './form-token-field-wrapper';
 import { reverseMap, useFormSelectors } from './hooks/use-form-selectors';
 
 type Props = {
-	setProducts: ( tokens: ( string | TokenItem )[] ) => void;
-	selectedProducts: ( string | TokenItem )[];
+	setProducts: ( tokens: string[] ) => void;
+	selectedProducts: string[];
 };
 
 const ProductsSelector = ( { setProducts, selectedProducts }: Props ) => {
@@ -36,12 +36,7 @@ const ProductsSelector = ( { setProducts, selectedProducts }: Props ) => {
 	);
 
 	return (
-		<FormTokenField
-			__experimentalAutoSelectFirstMatch
-			__experimentalExpandOnFocus
-			__experimentalShowHowTo={ false }
-			__nextHasNoMarginBottom
-			label=""
+		<FormTokenFieldWrapper
 			onChange={ onProductLabelsSelected }
 			suggestions={ Object.values( availableProducts ).sort() }
 			value={ selectedProductsByLabel }

--- a/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
@@ -1,11 +1,11 @@
-import { FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
 import { useCallback, useMemo } from 'react';
+import FormTokenFieldWrapper from './form-token-field-wrapper';
 import { reverseMap, useFormSelectors } from './hooks/use-form-selectors';
 
 type Props = {
-	setServices: ( services: ( string | TokenItem )[] ) => void;
-	selectedServices: ( string | TokenItem )[];
+	setServices: ( services: string[] ) => void;
+	selectedServices: string[];
 };
 
 const ServicesSelector = ( { setServices, selectedServices }: Props ) => {
@@ -38,12 +38,7 @@ const ServicesSelector = ( { setServices, selectedServices }: Props ) => {
 	);
 
 	return (
-		<FormTokenField
-			__experimentalAutoSelectFirstMatch
-			__experimentalExpandOnFocus
-			__experimentalShowHowTo={ false }
-			__nextHasNoMarginBottom
-			label=""
+		<FormTokenFieldWrapper
 			onChange={ onServiceLabelsSelected }
 			suggestions={ Object.values( availableServices ).sort() }
 			value={ selectedServicesByLabel }


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/717

## Proposed Changes

This PR fixes the issue we have with Chrome and the autocomplete attribute. In some cases, it ignores it:

<img width="181" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/0e13d600-0789-41b8-b577-401ab3662467">


The `FormTokenField` component has the autoComplete property, but the final component ignores it and hardcodes it `autocomplete="off"`. We have to set it as `autocomplete="none"`, so we have to wrap the component to update it once it's rendered.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Ensure that on any of the multi-selectors form fields (services, products, languages), the autocomplete functionality is deactivated.

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
