### PR TITLE
A4A: sites dashboard sticky action column

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -72,11 +72,25 @@
 		.dataviews-view-table tr td:first-child {
 			padding-left: 64px;
 		}
-		.dataviews-view-table tr th:last-child,
-		.dataviews-view-table tr td:last-child {
-			padding-right: 64px;
-			width: 20px;
-			white-space: nowrap;
+		.dataviews-view-table tr {
+			th:last-child,
+			td:last-child {
+				padding-right: 64px;
+				width: 20px;
+				white-space: nowrap;
+
+				position: sticky;
+				right: 0;
+				z-index: 1;
+				background: linear-gradient(to right, transparent 0%, #fff 25%);
+			}
+
+			&:hover {
+				th:last-child,
+				td:last-child {
+					background: linear-gradient(to right, transparent 0%, var(--color-neutral-0) 25%);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7913

## Proposed Changes

![Screen Capture on 2024-06-26 at 12-59-25](https://github.com/Automattic/wp-calypso/assets/33258733/7685988d-06d9-4c69-bc5e-02a112e4bc66)

Add CSS styling to allow the last column on the Sites Dashboard (action items and chevron to expand) stick to the right edge and overlap when the dashboard is too small.

## Why are these changes being made?

More context here - pfJMWL-7h-p2#comment-192

When the screen is narrow the Site Dashboard is horizontally scrolling to access all the columns. This pushes the important action items and site expander chevron off the screen. Users have mentioned it makes it easy to miss. By making the final column sticky it allows the action items to always be in display.

## Testing Instructions

1. Pull branch
2. Run `yarn start-a8c-for-agencies` and visit `http://agencies.localhost:3000/sites`
3. Adjust the width of the screen to make sure everything works and looks good.