### PR TITLE
Stepper: add performance tracking

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useLoginUrlForFlow } from 'calypso/landing/stepper/hooks/use-login-url-for-flow';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
+import { StepperPerformanceTrackerStop } from 'calypso/landing/stepper/utils/performance-tracking';
 import SignupHeader from 'calypso/signup/signup-header';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -54,6 +55,7 @@ const StepRoute = ( { step, flow, showWooLogo, renderStep }: StepRouteProps ) =>
 			{ 'videopress' === flow.name && 'intro' === step.slug && <VideoPressIntroBackground /> }
 			{ stepContent && <SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } /> }
 			{ stepContent }
+			{ stepContent && <StepperPerformanceTrackerStop flow={ flow.name } step={ step.slug } /> }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -45,7 +45,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const currentStepRoute = params.step || '';
 
 	// Start tracking performance for this step.
-	useStartStepperPerformanceTracking( flow.name, currentStepRoute );
+	useStartStepperPerformanceTracking( param.flow , currentStepRoute );
 
 	const stepComponents: Record< string, React.FC< StepProps > > = useMemo(
 		() =>

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -45,7 +45,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const currentStepRoute = params.step || '';
 
 	// Start tracking performance for this step.
-	useStartStepperPerformanceTracking( param.flow , currentStepRoute );
+	useStartStepperPerformanceTracking( params.flow || '', currentStepRoute );
 
 	const stepComponents: Record< string, React.FC< StepProps > > = useMemo(
 		() =>

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -16,6 +16,7 @@ import { getSite } from 'calypso/state/sites/selectors';
 import { useSaveQueryParams } from '../../hooks/use-save-query-params';
 import { useSiteData } from '../../hooks/use-site-data';
 import useSyncRoute from '../../hooks/use-sync-route';
+import { useStartStepperPerformanceTracking } from '../../utils/performance-tracking';
 import { StepRoute, StepperLoader } from './components';
 import { Boot } from './components/boot';
 import { RedirectToStep } from './components/redirect-to-step';
@@ -42,6 +43,9 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const stepPaths = flowSteps.map( ( step ) => step.slug );
 	const { navigate, params } = useFlowNavigation();
 	const currentStepRoute = params.step || '';
+
+	// Start tracking performance for this step.
+	useStartStepperPerformanceTracking( flow.name, currentStepRoute );
 
 	const stepComponents: Record< string, React.FC< StepProps > > = useMemo(
 		() =>

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -82,15 +82,15 @@ const initializeHotJar = ( flowName: string ) => {
 };
 
 window.AppBoot = async () => {
-	// Start tracking performance, bearing in mind this is a full page load.
-	startStepperPerformanceTracking( { fullPageLoad: true } );
-
 	const flowName = getFlowFromURL();
 
 	if ( ! flowName ) {
 		// Stop the boot process if we can't determine the flow, reducing the number of edge cases
 		return ( window.location.href = `/setup/${ DEFAULT_FLOW }${ window.location.search }` );
 	}
+
+	// Start tracking performance, bearing in mind this is a full page load.
+	startStepperPerformanceTracking( { fullPageLoad: true } );
 
 	initializeHotJar( flowName );
 	// put the proxy iframe in "all blog access" mode

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -33,6 +33,7 @@ import 'calypso/assets/stylesheets/style.scss';
 import availableFlows from './declarative-flow/registered-flows';
 import { USER_STORE } from './stores';
 import { setupWpDataDebug } from './utils/devtools';
+import { startStepperPerformanceTracking } from './utils/performance-tracking';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
 import type { Flow } from './declarative-flow/internals/types';
 
@@ -81,6 +82,9 @@ const initializeHotJar = ( flowName: string ) => {
 };
 
 window.AppBoot = async () => {
+	// Start tracking performance, bearing in mind this is a full page load.
+	startStepperPerformanceTracking( { fullPageLoad: true } );
+
 	const flowName = getFlowFromURL();
 
 	if ( ! flowName ) {

--- a/client/landing/stepper/utils/performance-tracking.tsx
+++ b/client/landing/stepper/utils/performance-tracking.tsx
@@ -1,0 +1,53 @@
+import { useLayoutEffect, useMemo } from 'react';
+import { useStore } from 'react-redux';
+import {
+	startPerformanceTracking,
+	stopPerformanceTracking,
+} from 'calypso/lib/performance-tracking/lib';
+
+// Manually start performance tracking.
+// Used in the entry point to start data collection as close as possible to boot time.
+export function startStepperPerformanceTracking( {
+	fullPageLoad = false,
+}: {
+	fullPageLoad?: boolean;
+} ) {
+	startPerformanceTracking( 'stepper', { fullPageLoad } );
+}
+
+// This hook starts performance gathering for the Stepper everytime the flow or step change.
+// The library we're using ignores follow-up `start` calls while there's an inflight tracking
+// report, so this hook is always safe, even though the entry point starts its own report on
+// first render.
+export function useStartStepperPerformanceTracking( flow: string, step: string ) {
+	useMemo( () => {
+		startStepperPerformanceTracking( { fullPageLoad: false } );
+		// We need to start tracking again everytime we change flow or step.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ flow, step ] );
+}
+
+function useStepperPerformanceTrackerStop( flow: string, step: string ) {
+	const performanceMetadata = useMemo( () => ( { flow: flow, step: step } ), [ flow, step ] );
+	const store = useStore();
+
+	// Use `useLayoutEffect` + rAF to be as close as possible to the actual rendering.
+	useLayoutEffect( () => {
+		requestAnimationFrame( () => {
+			stopPerformanceTracking( 'stepper', {
+				/// @ts-expect-error State is not properly typed in the performance tracking lib.
+				state: store.getState(),
+				metadata: performanceMetadata,
+			} );
+		} );
+	}, [ store, performanceMetadata ] );
+}
+
+// Stop performance data collection and report.
+// This component is placed at the end of the render tree to indicate completion.
+export function StepperPerformanceTrackerStop( { flow, step }: { flow: string; step: string } ) {
+	useStepperPerformanceTrackerStop( flow, step );
+
+	// Nothing to render, this component is all about side effects
+	return null;
+}

--- a/client/landing/stepper/utils/performance-tracking.tsx
+++ b/client/landing/stepper/utils/performance-tracking.tsx
@@ -39,7 +39,7 @@ function useStepperPerformanceTrackerStop( flow: string, step: string ) {
 				metadata: { flow, step },
 			} );
 		} );
-	}, [ store,  flow, step ] );
+	}, [ store, flow, step ] );
 }
 
 // Stop performance data collection and report.

--- a/client/landing/stepper/utils/performance-tracking.tsx
+++ b/client/landing/stepper/utils/performance-tracking.tsx
@@ -28,7 +28,6 @@ export function useStartStepperPerformanceTracking( flow: string, step: string )
 }
 
 function useStepperPerformanceTrackerStop( flow: string, step: string ) {
-	const performanceMetadata = useMemo( () => ( { flow: flow, step: step } ), [ flow, step ] );
 	const store = useStore();
 
 	// Use `useLayoutEffect` + rAF to be as close as possible to the actual rendering.
@@ -37,10 +36,10 @@ function useStepperPerformanceTrackerStop( flow: string, step: string ) {
 			stopPerformanceTracking( 'stepper', {
 				/// @ts-expect-error State is not properly typed in the performance tracking lib.
 				state: store.getState(),
-				metadata: performanceMetadata,
+				metadata: { flow, step },
 			} );
 		} );
-	}, [ store, performanceMetadata ] );
+	}, [ store,  flow, step ] );
 }
 
 // Stop performance data collection and report.

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -51,7 +51,7 @@ const buildMetadataCollector = ( metadata = {} ) => {
 	};
 };
 
-const isPerformanceTrackingEnabled = () => {
+export const isPerformanceTrackingEnabled = () => {
 	return config.isEnabled( 'rum-tracking/logstash' );
 };
 


### PR DESCRIPTION
This PR adds performance tracking to Stepper, based on `lib/performance-tracking`.

It reports the id as `stepper` for every flow and step, but includes those as properties in the report, so that data can be segmented properly.

Related to #92066

## Proposed Changes

* Create new helpers for performance tracking in Stepper. These were necessary because the base Calypso ones assume `page.js` is being used, which is not the case in Stepper.
* Add performance helpers to entry point and declarative flow.

## Why are these changes being made?

It would be useful to have performance tracking in place to analyse the performance impact of any future changes to the Stepper framework.

## Testing Instructions

* Smoke-test these changes and ensure they don't break anything.
* Navigate flows and steps in Stepper and ensure that the generated records are correct. Please pay particular attention to the values of the `fullPage`, `step`, and `flow` properties.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
