### PR TITLE
`DotcomSitesDataViews`:  Show `All sites` by default on the filter

### DIFF
--- a/client/sites-dashboard-v2/sites-dashboard.tsx
+++ b/client/sites-dashboard-v2/sites-dashboard.tsx
@@ -121,16 +121,13 @@ const SitesDashboardV2 = ( {
 			addDummyDataViewPrefix( 'last-interacted' ),
 			addDummyDataViewPrefix( 'status' ),
 		],
-		filters:
-			status === 'all'
-				? []
-				: [
-						{
-							field: addDummyDataViewPrefix( 'status' ),
-							operator: 'in',
-							value: siteStatusGroups.find( ( item ) => item.slug === status )?.value || 1,
-						},
-				  ],
+		filters: [
+			{
+				field: addDummyDataViewPrefix( 'status' ),
+				operator: 'in',
+				value: siteStatusGroups.find( ( item ) => item.slug === status )?.value || 1,
+			},
+		],
 		selectedItem: selectedSite,
 		type: selectedSite ? DATAVIEWS_LIST : DATAVIEWS_TABLE,
 	} as DataViewsState;

--- a/client/sites-dashboard-v2/sites-dataviews/index.tsx
+++ b/client/sites-dashboard-v2/sites-dataviews/index.tsx
@@ -35,6 +35,7 @@ type Props = {
 };
 
 export const siteStatusGroups = [
+	{ value: 1, label: __( 'All sites' ), slug: 'all' },
 	{ value: 2, label: __( 'Public' ), slug: 'public' },
 	{ value: 3, label: __( 'Private' ), slug: 'private' },
 	{ value: 4, label: __( 'Coming soon' ), slug: 'coming-soon' },

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -113,3 +113,8 @@
 		outline-offset: 2px;
 	}
 }
+
+// Hide the reset filters button
+.sites-overview__content .dataviews-wrapper [class*="PolymorphicDiv-Flex-base-ItemsRow"]:not(dataviews-filters__view-actions) button:nth-of-type(3) {
+	display: none;
+}

--- a/client/sites-dashboard-v2/sites-dataviews/style.scss
+++ b/client/sites-dashboard-v2/sites-dataviews/style.scss
@@ -115,6 +115,6 @@
 }
 
 // Hide the reset filters button
-.sites-overview__content .dataviews-wrapper [class*="PolymorphicDiv-Flex-base-ItemsRow"]:not(dataviews-filters__view-actions) button:nth-of-type(3) {
+.sites-overview__content .dataviews-wrapper .dataviews-filters__view-actions .components-h-stack button:nth-of-type(3) {
 	display: none;
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6872

## Proposed Changes

* Show the `All sites` option by default on the sites dashboard filter.

## Why are these changes being made?

* This helps provide clarity at a glance as to what you're looking at, even when no filter is selected.

## Testing Instructions

* Open the live preview
* Go to `/sites`
* Check that the filter says `Status is All sites`, and that the `Reset filters` button is not visible

|Before|After|
|---|---|
|![image](https://github.com/Automattic/wp-calypso/assets/8511199/1795911f-9592-4b16-8466-1c9811100319)|![image](https://github.com/Automattic/wp-calypso/assets/8511199/63d0abbf-8546-420f-bc97-6e4480fa3860)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
