### PR TITLE
Update the Breadcrumb component (deprecation warning)

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -95,7 +95,7 @@ interface Props {
 
 const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 	const translate = useTranslate();
-	const { items, mobileItem, compact = false, hideWhenOnlyOneLevel } = props;
+	const { items = [], mobileItem, compact = false, hideWhenOnlyOneLevel } = props;
 
 	if ( items.length === 1 ) {
 		if ( hideWhenOnlyOneLevel ) {

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -97,6 +97,10 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 	const translate = useTranslate();
 	const { items = [], mobileItem, compact = false, hideWhenOnlyOneLevel } = props;
 
+	if ( items.length === 0 ) {
+		return null;
+	}
+
 	if ( items.length === 1 ) {
 		if ( hideWhenOnlyOneLevel ) {
 			return null;
@@ -110,7 +114,7 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 		);
 	}
 
-	if ( compact && items.length > 1 ) {
+	if ( compact ) {
 		const urlBack = mobileItem?.href ?? items[ items.length - 2 ].href;
 		const label = mobileItem?.label ?? translate( 'Back' );
 		return (
@@ -121,25 +125,21 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 		);
 	}
 
-	if ( items.length > 1 ) {
-		return (
-			<StyledUl className="breadcrumbs">
-				{ items.map( ( item: { href?: string; label: string }, index: Key ) => (
-					<StyledLi key={ index }>
-						{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 14 } /> }
-						{ item.href && index !== items.length - 1 ? (
-							<a href={ item.href }>{ item.label }</a>
-						) : (
-							<span>{ item.label }</span>
-						) }
-						{ renderHelpBubble( item ) }
-					</StyledLi>
-				) ) }
-			</StyledUl>
-		);
-	}
-	// Default case -> items: []
-	return null;
+	return (
+		<StyledUl className="breadcrumbs">
+			{ items.map( ( item: { href?: string; label: string }, index: Key ) => (
+				<StyledLi key={ index }>
+					{ index !== 0 && <StyledGridicon icon="chevron-right" size={ 14 } /> }
+					{ item.href && index !== items.length - 1 ? (
+						<a href={ item.href }>{ item.label }</a>
+					) : (
+						<span>{ item.label }</span>
+					) }
+					{ renderHelpBubble( item ) }
+				</StyledLi>
+			) ) }
+		</StyledUl>
+	);
 };
 
 export default Breadcrumb;

--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -142,8 +142,4 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 	return null;
 };
 
-Breadcrumb.defaultProps = {
-	items: [],
-};
-
 export default Breadcrumb;


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/710

## Proposed Changes

This PR fixes a deprecation warning using the Breadcrumb Calypso component:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/cf0d6f40-abe8-43ca-840f-ab6b54a8e6a0)

We have to use Javascript default parameters instead of the defaultProps.

Also, I moved the item size check to the top and updated the rest of the code to simplify the conditionals.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Ensure that the Breadcrumb component is working as before. Take any part of Calypso world where it's in use. For example,  for A4A, Partner Directory section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
