### PR TITLE
RTS: Apply style variation during site creation

### DIFF
--- a/client/state/themes/hooks/use-theme-details.ts
+++ b/client/state/themes/hooks/use-theme-details.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import type { GlobalStylesObject } from '@automattic/global-styles';
 
 type Theme = {
 	id: string;
@@ -17,6 +18,7 @@ type Theme = {
 		slug: string;
 		platform: string;
 	};
+	style_variations: GlobalStylesObject[];
 };
 
 export function useThemeDetails( slug = '' ): UseQueryResult< Theme > {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7944

## Proposed Changes

Updates the RT onboarding flow to apply the style variation used by the RT to the new site.

Before | After
--- | ---
<img width="1392" alt="Screenshot 2024-06-26 at 17 23 34" src="https://github.com/Automattic/wp-calypso/assets/1233880/988d0d1a-0e82-4ebf-8fd1-c8ebd4ff9b9c"> | <img width="1392" alt="Screenshot 2024-06-26 at 17 35 08" src="https://github.com/Automattic/wp-calypso/assets/1233880/0906881a-5eb5-4645-9453-27bd6927df14">



## Why are these changes being made?

Because RTs might be designed with specific style variations that should be applied to the site

## Testing Instructions

- Use the Calypso live link below
- Go to `/patterns`
- Scroll down to the site layouts section
- Select the first example
- Click on the "Pick this layout" button
- Once you land in the site editor, make sure the "Emerald" style variation has been applied
- Go back to `/patterns` and select another RT
- This time, once you land in the site editor, no style variations should be applied (i.e. you get the "Default" style variation)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
