### PR TITLE
Stepper: Update`import-focused` flow to use the new login strategy 

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -5,7 +5,6 @@ import { useEffect } from 'react';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
-import MigrationError from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/migration-error';
 import { ProcessingResult } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/processing-step/constants';
 import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -13,26 +12,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
-import CreateSite from './internals/steps-repository/create-site';
-import DesignSetup from './internals/steps-repository/design-setup';
-import ImportStep from './internals/steps-repository/import';
-import ImportList from './internals/steps-repository/import-list';
-import ImportReady from './internals/steps-repository/import-ready';
-import ImportReadyNot from './internals/steps-repository/import-ready-not';
-import ImportReadyPreview from './internals/steps-repository/import-ready-preview';
-import ImportReadyWpcom from './internals/steps-repository/import-ready-wpcom';
-import ImportVerifyEmail from './internals/steps-repository/import-verify-email';
-import ImporterBlogger from './internals/steps-repository/importer-blogger';
-import ImporterMedium from './internals/steps-repository/importer-medium';
-import ImporterMigrateMessage from './internals/steps-repository/importer-migrate-message';
-import ImporterSquarespace from './internals/steps-repository/importer-squarespace';
-import ImporterWix from './internals/steps-repository/importer-wix';
-import ImporterWordpress from './internals/steps-repository/importer-wordpress';
-import MigrationHandler from './internals/steps-repository/migration-handler';
-import PatternAssembler from './internals/steps-repository/pattern-assembler';
-import ProcessingStep from './internals/steps-repository/processing-step';
-import SitePickerStep from './internals/steps-repository/site-picker';
-import TrialAcknowledge from './internals/steps-repository/trial-acknowledge';
+import { STEPS } from './internals/steps';
 import {
 	AssertConditionState,
 	Flow,
@@ -48,27 +28,28 @@ const importFlow: Flow = {
 
 	useSteps() {
 		return [
-			{ slug: 'import', component: ImportStep },
-			{ slug: 'importList', component: ImportList },
-			{ slug: 'importReady', component: ImportReady },
-			{ slug: 'importReadyNot', component: ImportReadyNot },
-			{ slug: 'importReadyWpcom', component: ImportReadyWpcom },
-			{ slug: 'importReadyPreview', component: ImportReadyPreview },
-			{ slug: 'importerWix', component: ImporterWix },
-			{ slug: 'importerBlogger', component: ImporterBlogger },
-			{ slug: 'importerMedium', component: ImporterMedium },
-			{ slug: 'importerSquarespace', component: ImporterSquarespace },
-			{ slug: 'importerWordpress', component: ImporterWordpress },
-			{ slug: 'designSetup', component: DesignSetup },
-			{ slug: 'pattern-assembler', component: PatternAssembler },
-			{ slug: 'processing', component: ProcessingStep },
-			{ slug: 'createSite', component: CreateSite },
-			{ slug: 'migrationHandler', component: MigrationHandler },
-			{ slug: 'trialAcknowledge', component: TrialAcknowledge },
-			{ slug: 'sitePicker', component: SitePickerStep },
-			{ slug: 'error', component: MigrationError },
-			{ slug: 'verifyEmail', component: ImportVerifyEmail },
-			{ slug: 'migrateMessage', component: ImporterMigrateMessage },
+			STEPS.IMPORT,
+			STEPS.IMPORT_LIST,
+			STEPS.IMPORT_READY,
+			STEPS.IMPORT_READY_NOT,
+			STEPS.IMPORT_READY_PREVIEW,
+			STEPS.IMPORT_READY_WPCOM,
+			STEPS.IMPORTER_WIX,
+			STEPS.IMPORTER_BLOGGER,
+			STEPS.IMPORTER_MEDIUM,
+			STEPS.IMPORTER_SQUARESPACE,
+			STEPS.IMPORTER_WORDPRESS,
+			STEPS.DESIGN_SETUP,
+			STEPS.PATTERN_ASSEMBLER,
+			STEPS.PROCESSING,
+			STEPS.SITE_CREATION_STEP,
+			STEPS.MIGRATION_HANDLER,
+			STEPS.TRIAL_ACKNOWLEDGE,
+			STEPS.PICK_SITE,
+			STEPS.ERROR,
+			STEPS.VERIFY_EMAIL,
+			STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+			STEPS.MIGRATION_ERROR,
 		];
 	},
 

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -133,6 +133,10 @@ export const STEPS = {
 	},
 
 	LAUNCHPAD: { slug: 'launchpad', asyncComponent: () => import( './steps-repository/launchpad' ) },
+	MIGRATION_HANDLER: {
+		slug: 'migrationHandler',
+		asyncComponent: () => import( './steps-repository/migration-handler' ),
+	},
 
 	OPTIONS: {
 		slug: 'options',


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/7643

## Proposed Changes
* Replace all code related to managing the login to use stepsWithRequiredLogin 
* Use the async steps instead of the inline ones

## Why are these changes being made?
As explained on dotcom-forge/issues/7643 we are updating all flows to use the new stepper login capabilities.
This flow is the first one we are migrating that requires custom parameters when we redirect the user to the login flow.

## Testing Instructions
Scenario 1: Redirect to the login page
- Open a new browser where you don't have a WordPress.com session
- Try to access the flow or any of the [steps](https://github.com/Automattic/wp-calypso/pull/92136/files#diff-fce80dd6e6117b25bd509bc804a326c4c59f543c203e0312aa834ab77ab26a94R32-R53) (E.g `/setup/import-focused/import`)
- Please ensure you have been redirected to the login page.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
