### PR TITLE
Frictionless Email Subscriptions: Update passwordless signup form for email subscription flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -95,6 +95,7 @@ class SignupForm extends Component {
 		disableEmailInput: PropTypes.bool,
 		disableSubmitButton: PropTypes.bool,
 		disableBlurValidation: PropTypes.bool,
+		disableContinueAsUser: PropTypes.bool,
 		disabled: PropTypes.bool,
 		displayNameInput: PropTypes.bool,
 		displayUsernameInput: PropTypes.bool,
@@ -1190,7 +1191,7 @@ class SignupForm extends Component {
 			);
 		}
 
-		if ( this.props.currentUser ) {
+		if ( this.props.currentUser && ! this.props.disableContinueAsUser ) {
 			return (
 				<ContinueAsUser
 					redirectPath={ this.props.redirectToAfterLoginUrl }

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -101,7 +101,7 @@ class SignupForm extends Component {
 		flowName: PropTypes.string,
 		footerLink: PropTypes.node,
 		formHeader: PropTypes.node,
-		redirectToAfterLoginUrl: PropTypes.string.isRequired,
+		redirectToAfterLoginUrl: PropTypes.string,
 		goToNextStep: PropTypes.func,
 		handleLogin: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
@@ -113,7 +113,9 @@ class SignupForm extends Component {
 		save: PropTypes.func,
 		signupDependencies: PropTypes.object,
 		step: PropTypes.object,
-		submitButtonText: PropTypes.string.isRequired,
+		submitButtonText: PropTypes.string,
+		submitButtonLabel: PropTypes.string,
+		submitButtonLoadingLabel: PropTypes.string,
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
@@ -1281,6 +1283,7 @@ class SignupForm extends Component {
 		) {
 			let formProps = {
 				submitButtonLabel: this.props.submitButtonLabel,
+				submitButtonLoadingLabel: this.props.submitButtonLoadingLabel,
 			};
 
 			switch ( true ) {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -438,6 +438,10 @@ class SignupForm extends Component {
 	};
 
 	handleBlur = ( event ) => {
+		if ( this.props.disableBlurValidation ) {
+			return;
+		}
+
 		const fieldId = event.target.id;
 		this.setState( {
 			isFieldDirty: { ...this.state.isFieldDirty, [ fieldId ]: true },

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -94,6 +94,7 @@ class SignupForm extends Component {
 		disableEmailExplanation: PropTypes.string,
 		disableEmailInput: PropTypes.bool,
 		disableSubmitButton: PropTypes.bool,
+		disableBlurValidation: PropTypes.bool,
 		disabled: PropTypes.bool,
 		displayNameInput: PropTypes.bool,
 		displayUsernameInput: PropTypes.bool,
@@ -1329,6 +1330,7 @@ class SignupForm extends Component {
 						onInputBlur={ this.handleBlur }
 						onInputChange={ this.handleChangeEvent }
 						onCreateAccountError={ this.handleCreateAccountError }
+						onCreateAccountSuccess={ this.handleCreateAccountSuccess }
 						{ ...formProps }
 					>
 						{ emailErrorMessage && (

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -31,6 +31,7 @@ class PasswordlessSignupForm extends Component {
 		onInputBlur: PropTypes.func,
 		onInputChange: PropTypes.func,
 		onCreateAccountError: PropTypes.func,
+		onCreateAccountSuccess: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -165,6 +166,10 @@ class PasswordlessSignupForm extends Component {
 		const marketing_price_group = response?.marketing_price_group ?? '';
 		const { flowName, queryArgs = {} } = this.props;
 		const { redirect_to, oauth2_client_id, oauth2_redirect } = queryArgs;
+
+		if ( this.props.onCreateAccountSuccess ) {
+			return this.props.onCreateAccountSuccess( userData );
+		}
 
 		recordRegistration( {
 			userData,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -49,7 +49,7 @@ const getEmailSubscriptionFlow = () => {
 						'Signup flow that subscripes user to guides appointments for email campaigns',
 					lastModified: '2024-06-17',
 					showRecaptcha: true,
-					providesDependenciesInQuery: [ 'user_email', 'redirect_to', 'mailing_list' ],
+					providesDependenciesInQuery: [ 'user_email', 'redirect_to', 'mailing_list', 'from' ],
 					hideProgressIndicator: true,
 				},
 		  ]

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -31,6 +31,7 @@ function SubscribeEmailStepContent( props ) {
 				handleCreateAccountError={ handleCreateAccountError }
 				handleCreateAccountSuccess={ handleCreateAccountSuccess }
 				disableBlurValidation
+				disableContinueAsUser
 				isPasswordless
 				isReskinned
 				isSocialFirst={ false }

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -1,9 +1,11 @@
 import { localize } from 'i18n-calypso';
 import SignupForm from 'calypso/blocks/signup-form';
+import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 
 function SubscribeEmailStepContent( props ) {
 	const {
+		email,
 		flowName,
 		goToNextStep,
 		handleSubmitSignup,
@@ -12,10 +14,9 @@ function SubscribeEmailStepContent( props ) {
 		redirectUrl,
 		step,
 		stepName,
+		subscribeToMailingList,
 		translate,
 	} = props;
-
-	const user_email = queryParams?.user_email;
 
 	if ( isPending ) {
 		return <ReskinnedProcessingScreen flowName={ flowName } hasPaidDomain={ false } />;
@@ -25,16 +26,23 @@ function SubscribeEmailStepContent( props ) {
 		<>
 			<SignupForm
 				displayUsernameInput={ false }
-				email={ user_email || '' }
+				email={ email || '' }
 				flowName={ flowName }
 				goToNextStep={ goToNextStep }
-				handleCreateAccountError={ () => {} }
+				handleCreateAccountError={ ( error, submittedEmail ) => {
+					if ( isExistingAccountError( error.error ) ) {
+						subscribeToMailingList( {
+							email_address: submittedEmail,
+							mailing_list_category: queryParams.mailing_list,
+						} );
+					}
+				} }
 				isPasswordless
 				isReskinned
 				isSocialFirst={ false }
 				isSocialSignupEnabled={ false }
 				labelText={ translate( 'Your email' ) }
-				queryArgs={ { user_email, redirect_to: redirectUrl } }
+				queryArgs={ { user_email: email, redirect_to: redirectUrl } }
 				// recaptchaClientId={ this.state.recaptchaClientId }
 				redirectToAfterLoginUrl={ redirectUrl }
 				shouldDisplayUserExistsError

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -29,6 +29,7 @@ function SubscribeEmailStepContent( props ) {
 				flowName={ flowName }
 				goToNextStep={ goToNextStep }
 				handleCreateAccountError={ handleCreateAccountError }
+				disableBlurValidation
 				isPasswordless
 				isReskinned
 				isSocialFirst={ false }

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -35,12 +35,11 @@ function SubscribeEmailStepContent( props ) {
 				isSocialSignupEnabled={ false }
 				labelText={ translate( 'Your email' ) }
 				queryArgs={ { user_email: email, redirect_to: redirectUrl } }
-				redirectToAfterLoginUrl={ redirectUrl }
 				shouldDisplayUserExistsError
 				step={ step }
 				stepName={ stepName }
-				submitButtonText={ translate( 'Subscribe email' ) }
 				submitButtonLabel={ translate( 'Subscribe email' ) }
+				submitButtonLoadingLabel={ translate( 'Subscribing…' ) }
 				submitForm={ handleSubmitForm }
 				suggestedUsername=""
 			/>

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -8,7 +8,7 @@ function SubscribeEmailStepContent( props ) {
 		flowName,
 		goToNextStep,
 		handleCreateAccountError,
-		handleSubmitForm,
+		handleCreateAccountSuccess,
 		isPending,
 		redirectUrl,
 		step,
@@ -29,6 +29,7 @@ function SubscribeEmailStepContent( props ) {
 				flowName={ flowName }
 				goToNextStep={ goToNextStep }
 				handleCreateAccountError={ handleCreateAccountError }
+				handleCreateAccountSuccess={ handleCreateAccountSuccess }
 				disableBlurValidation
 				isPasswordless
 				isReskinned
@@ -41,7 +42,6 @@ function SubscribeEmailStepContent( props ) {
 				stepName={ stepName }
 				submitButtonLabel={ translate( 'Subscribe email' ) }
 				submitButtonLoadingLabel={ translate( 'Subscribing…' ) }
-				submitForm={ handleSubmitForm }
 				suggestedUsername=""
 			/>
 		</>

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -1,6 +1,5 @@
 import { localize } from 'i18n-calypso';
 import SignupForm from 'calypso/blocks/signup-form';
-import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 
 function SubscribeEmailStepContent( props ) {
@@ -8,13 +7,12 @@ function SubscribeEmailStepContent( props ) {
 		email,
 		flowName,
 		goToNextStep,
-		handleSubmitSignup,
+		handleCreateAccountError,
+		handleSubmitForm,
 		isPending,
-		queryParams,
 		redirectUrl,
 		step,
 		stepName,
-		subscribeToMailingList,
 		translate,
 	} = props;
 
@@ -25,31 +23,25 @@ function SubscribeEmailStepContent( props ) {
 	return (
 		<>
 			<SignupForm
+				// recaptchaClientId={ this.state.recaptchaClientId }
 				displayUsernameInput={ false }
 				email={ email || '' }
 				flowName={ flowName }
 				goToNextStep={ goToNextStep }
-				handleCreateAccountError={ ( error, submittedEmail ) => {
-					if ( isExistingAccountError( error.error ) ) {
-						subscribeToMailingList( {
-							email_address: submittedEmail,
-							mailing_list_category: queryParams.mailing_list,
-						} );
-					}
-				} }
+				handleCreateAccountError={ handleCreateAccountError }
 				isPasswordless
 				isReskinned
 				isSocialFirst={ false }
 				isSocialSignupEnabled={ false }
 				labelText={ translate( 'Your email' ) }
 				queryArgs={ { user_email: email, redirect_to: redirectUrl } }
-				// recaptchaClientId={ this.state.recaptchaClientId }
 				redirectToAfterLoginUrl={ redirectUrl }
 				shouldDisplayUserExistsError
 				step={ step }
 				stepName={ stepName }
-				submitButtonText={ translate( 'Create an account' ) }
-				submitForm={ handleSubmitSignup }
+				submitButtonText={ translate( 'Subscribe email' ) }
+				submitButtonLabel={ translate( 'Subscribe email' ) }
+				submitForm={ handleSubmitForm }
 				suggestedUsername=""
 			/>
 		</>

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -36,7 +36,7 @@ function SubscribeEmailStep( props ) {
 	const { mutate: subscribeToMailingList, isPending: isSubscribeToMailingListPending } =
 		useSubscribeToMailingList( {
 			onSuccess: () => {
-				recordTracksEvent( 'calypso_signup_existing_email_subscription_success', {
+				recordTracksEvent( 'calypso_signup_email_subscription_success', {
 					mailing_list: queryParams.mailing_list,
 				} );
 				props.submitSignupStep( { stepName: 'subscribe' }, { redirect: redirectUrl } );

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useEffect } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import emailValidator from 'email-validator';
@@ -8,7 +9,6 @@ import { isRedirectAllowed } from 'calypso/lib/url/is-redirect-allowed';
 import useCreateNewAccountMutation from 'calypso/signup/hooks/use-create-new-account';
 import useSubscribeToMailingList from 'calypso/signup/hooks/use-subscribe-to-mailing-list';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SubscribeEmailStepContent from './content';
 
@@ -36,7 +36,7 @@ function SubscribeEmailStep( props ) {
 	const { mutate: subscribeToMailingList, isPending: isSubscribeToMailingListPending } =
 		useSubscribeToMailingList( {
 			onSuccess: () => {
-				props.recordTracksEvent( 'calypso_signup_existing_email_subscription_success', {
+				recordTracksEvent( 'calypso_signup_existing_email_subscription_success', {
 					mailing_list: queryParams.mailing_list,
 				} );
 				props.submitSignupStep( { stepName: 'subscribe' }, { redirect: redirectUrl } );
@@ -50,12 +50,14 @@ function SubscribeEmailStep( props ) {
 				subscribeToMailingList( {
 					email_address: email,
 					mailing_list_category: queryParams.mailing_list,
+					from: queryParams.from,
 				} ),
 			onError: ( error ) => {
 				if ( isExistingAccountError( error.error ) ) {
 					subscribeToMailingList( {
 						email_address: email,
 						mailing_list_category: queryParams.mailing_list,
+						from: queryParams.from,
 					} );
 				}
 			},
@@ -93,6 +95,7 @@ function SubscribeEmailStep( props ) {
 								subscribeToMailingList( {
 									email_address: submittedEmail,
 									mailing_list_category: queryParams.mailing_list,
+									from: queryParams.from,
 								} );
 							}
 						} }
@@ -104,6 +107,4 @@ function SubscribeEmailStep( props ) {
 	);
 }
 
-export default connect( null, { recordTracksEvent, submitSignupStep } )(
-	localize( SubscribeEmailStep )
-);
+export default connect( null, { submitSignupStep } )( localize( SubscribeEmailStep ) );

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -79,6 +79,7 @@ function SubscribeEmailStep( props ) {
 		<div className="subscribe-email">
 			<StepWrapper
 				flowName={ flowName }
+				hideBack
 				hideFormattedHeader
 				stepContent={
 					<SubscribeEmailStepContent

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -85,6 +85,17 @@ function SubscribeEmailStep( props ) {
 						isPending={ isCreateNewAccountPending || isSubscribeToMailingListPending }
 						redirectUrl={ redirectUrl }
 						subscribeToMailingList={ subscribeToMailingList }
+						handleSubmitForm={ ( form, passwordLessData ) => {
+							console.log( { form, passwordLessData } );
+						} }
+						handleCreateAccountError={ ( error, submittedEmail ) => {
+							if ( isExistingAccountError( error.error ) ) {
+								subscribeToMailingList( {
+									email_address: submittedEmail,
+									mailing_list_category: queryParams.mailing_list,
+								} );
+							}
+						} }
 					/>
 				}
 				stepName={ stepName }

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -31,6 +31,7 @@ function sanitizeRedirectUrl( redirect ) {
 function SubscribeEmailStep( props ) {
 	const { flowName, goToNextStep, queryParams, stepName } = props;
 	const redirectUrl = sanitizeRedirectUrl( queryParams.redirect_to );
+	const email = typeof queryParams.user_email === 'string' ? queryParams.user_email.trim() : '';
 
 	const { mutate: subscribeToMailingList, isPending: isSubscribeToMailingListPending } =
 		useSubscribeToMailingList( {
@@ -47,13 +48,13 @@ function SubscribeEmailStep( props ) {
 		useCreateNewAccountMutation( {
 			onSuccess: () =>
 				subscribeToMailingList( {
-					email_address: queryParams.user_email,
+					email_address: email,
 					mailing_list_category: queryParams.mailing_list,
 				} ),
 			onError: ( error ) => {
 				if ( isExistingAccountError( error.error ) ) {
 					subscribeToMailingList( {
-						email_address: queryParams.user_email,
+						email_address: email,
 						mailing_list_category: queryParams.mailing_list,
 					} );
 				}
@@ -61,8 +62,6 @@ function SubscribeEmailStep( props ) {
 		} );
 
 	useEffect( () => {
-		const email = typeof queryParams.user_email === 'string' ? queryParams.user_email.trim() : '';
-
 		if ( emailValidator.validate( email ) ) {
 			createNewAccount( {
 				userData: {
@@ -72,7 +71,7 @@ function SubscribeEmailStep( props ) {
 				isPasswordless: true,
 			} );
 		}
-	}, [ createNewAccount, flowName, queryParams.user_email ] );
+	}, [ createNewAccount, flowName, email ] );
 
 	return (
 		<div className="subscribe-email">
@@ -82,8 +81,10 @@ function SubscribeEmailStep( props ) {
 				stepContent={
 					<SubscribeEmailStepContent
 						{ ...props }
+						email={ email }
 						isPending={ isCreateNewAccountPending || isSubscribeToMailingListPending }
 						redirectUrl={ redirectUrl }
+						subscribeToMailingList={ subscribeToMailingList }
 					/>
 				}
 				stepName={ stepName }

--- a/config/development.json
+++ b/config/development.json
@@ -208,7 +208,7 @@
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": false,
+		"signup/email-subscription-flow": true,
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -134,7 +134,7 @@
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": false,
+		"signup/email-subscription-flow": true,
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -170,7 +170,7 @@
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": false,
+		"signup/email-subscription-flow": true,
 		"site-indicator": true,
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3098

## Proposed Changes

* Subscribes email and redirects user if the email that they enter into the passwordless signup form is a new user or if a user already exists

![2024-06-27 16 28 05](https://github.com/Automattic/wp-calypso/assets/5414230/1a8ec6e9-31e2-44e1-8d1a-3d31f60033cf)

TODO:
We'll want to vertically center the passwordless signup form

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When someone subscribes to an email campaign on a landing page like wordpress.com/learn, we'd like to manage outbound communication with Guides. Guides, however, requires a `user_id` and a WordPress account.

In the past, if the user wanted to subscribe on a landing page and wasn't already logged in, they'd be redirected to the `/log-in` page. If they didn't have an account, they'd be prompted to create one. Once completed, they'd be redirected to the original landing page.

To polish this experience, we're creating a custom email subscription "signup" flow. For the happy path, the user should be able to subscribe with one click, and the technical implementation should look something like p5uIfZ-f11-p2#comment-22793.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Set the `signup/email-subscription-flow` flag to true in `config/development.json`
* Start local dev
* Navigate to `/start/email-subscription/subscribe?user_email=test1016gmail.com&redirect_to=wordpress.com%2Flearn&mailing_list=learn&from=/learn` Note that the query params are required.
* We are entering an invalid email without an ampersand. Because of this, the passwordless signup form should be rendered
* Update the email to test1016@gmail.com and click on "Subscribe email"
* Verify that the email is posted to the pigeon endpoint and that the page is redirected to wordpress.com/learn from the `redirect_to` query param
* Revisit `/start/email-subscription/subscribe?user_email=test1016gmail.com&redirect_to=wordpress.com%2Flearn&mailing_list=learn&from=/learn`
* Update the email to some new user, like test1033@gmail.com
* Verify that the email is posted to the pigeon endpoint and that the page is redirected to wordpress.com/learn from the `redirect_to` query param

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?