### PR TITLE
Fix Jetpack upsell messaging

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -112,14 +112,13 @@ const DoYouLoveJetpackStatsNotice = ( {
 		? translate(
 				'Finesse your scaling-up strategy with detailed insights and data. Upgrade to a %s plan for a richer understanding and smarter decision-making.',
 				{
-					args: {
-						planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
-					},
+					args: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
 				}
 		  )
 		: translate(
 				'Finesse your scaling-up strategy with detailed insights and data. Upgrade to an Explorer plan for a richer understanding and smarter decision-making.'
 		  );
+
 	const description = isWPCOMPaidStatsFlow
 		? paidStatsRemoveHardcoding
 		: translate( 'Upgrade to support future development and stop the upgrade banners.' );


### PR DESCRIPTION
## Proposed Changes

This PR fixes a string being rendered as `[object Object]`. The upsell appears on the stats page for free sites that have not launched:

<img width="1725" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6981253/60d2fcdd-c251-4f32-b588-b2baa6059426">


## Why are these changes being made?
This PR fixes the argument so the correct string is displayed:

<img width="1727" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6981253/6fedfa11-313e-4001-b119-c184e09beabc">


## Testing Instructions
- Create a new site
- Visit the Stats page on a free plan of a new site that has not launched. 
- Check the `Grow faster with Jetpack` upsell and ensure the correct messaging is displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
