### PR TITLE
Remove max height on item price for jetpack store products list

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -117,10 +117,6 @@
 	.item-price .display-price {
 		&:not(.is-placeholder) {
 			max-height: none;
-
-			.display-price__billing-time-frame {
-				line-height: 1.2;
-			}
 		}
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -113,6 +113,18 @@
 	}
 }
 
+.jetpack-product-store__products-list {
+	.item-price .display-price {
+		&:not(.is-placeholder) {
+			max-height: none;
+
+			.display-price__billing-time-frame {
+				line-height: 1.2;
+			}
+		}
+	}
+}
+
 .jetpack-product-store__items-tabs [role="tab"] {
 	display: initial;
 	flex-grow: 1;


### PR DESCRIPTION
## Proposed Changes

* Remove max height for item prices within a jetpack product store component

NOTE: It was hard to determine every single place the item price is used, so I felt it best to restrict it to only the ProductStore component as it displays the prices in the same way everywhere, and the line height should be removed in any instance the store is used

## Why are these changes being made?

![image](https://github.com/Automattic/wp-calypso/assets/65001528/f1942507-b9b8-40d1-aab9-879a634ac39a)

Slack: p1719429099159929-slack-C0299DMPG

## Testing Instructions

1. Open the Claypso Blue and Calypso Green live link
2. On Calypso blue go to `/jetpack/connect/store` and make sure the billing term looks okay
![image](https://github.com/Automattic/wp-calypso/assets/65001528/dcd50003-0df5-4127-8e1c-ba5d6de44261)
3. On Calypso green go to `/pricing` and check the same thing
![image](https://github.com/Automattic/wp-calypso/assets/65001528/88747452-a80e-4e1e-8fa2-422e5e36d5af)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?