### PR TITLE
Update core profiler jetpack connection page

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -119,6 +119,7 @@ class SignupForm extends Component {
 		horizontal: PropTypes.bool,
 		shouldDisplayUserExistsError: PropTypes.bool,
 		submitForm: PropTypes.func,
+		disableTosText: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -1043,7 +1044,7 @@ class SignupForm extends Component {
 
 		return (
 			<LoggedOutFormFooter isBlended={ this.props.isSocialSignupEnabled }>
-				{ this.termsOfServiceLink() }
+				{ ! this.props.disableTosText && this.termsOfServiceLink() }
 				<FormButton
 					className={ clsx(
 						'signup-form__submit',
@@ -1292,6 +1293,7 @@ class SignupForm extends Component {
 						flowName={ this.props.flowName }
 						goToNextStep={ this.props.goToNextStep }
 						renderTerms={ this.termsOfServiceLink }
+						disableTosText={ this.props.disableTosText }
 						submitForm={ this.handlePasswordlessSubmit }
 						logInUrl={ logInUrl }
 						disabled={ this.props.disabled }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -30,6 +30,7 @@ class PasswordlessSignupForm extends Component {
 		onInputBlur: PropTypes.func,
 		onInputChange: PropTypes.func,
 		onCreateAccountError: PropTypes.func,
+		disableTosText: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -331,7 +332,7 @@ class PasswordlessSignupForm extends Component {
 						/>
 						{ this.props.children }
 					</ValidationFieldset>
-					{ this.props.renderTerms?.() }
+					{ ! this.props.disableTosText && this.props.renderTerms?.() }
 					{ this.formFooter() }
 				</LoggedOutForm>
 			</div>

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -27,6 +27,7 @@ export class AuthFormHeader extends Component {
 		// Connected props
 		translate: PropTypes.func.isRequired,
 		user: PropTypes.object,
+		hideSiteCard: PropTypes.bool,
 	};
 
 	getState() {
@@ -299,7 +300,7 @@ export class AuthFormHeader extends Component {
 					headerText={ this.getHeaderText() }
 					subHeaderText={ this.getSubHeaderText() }
 				/>
-				{ this.getSiteCard() }
+				{ ! this.props.hideSiteCard && this.getSiteCard() }
 			</div>
 		);
 	}

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -166,7 +166,7 @@ export class AuthFormHeader extends Component {
 			const pluginNames = {
 				'jetpack-ai': 'Jetpack AI',
 				'jetpack-boost': 'Jetpack Boost',
-				default: 'Jetpack',
+				default: 'Jetpack and WooPayments',
 			};
 
 			const pluginName = pluginNames[ this.props.authQuery.plugin_name ] || pluginNames.default;

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -192,7 +192,7 @@ export class AuthFormHeader extends Component {
 			switch ( currentState ) {
 				case 'logged-out':
 					return translate(
-						"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+						"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to create a WordPress.com account.{{br/}} Already have one? {{a}}Log in{{/a}}",
 						translateParams
 					);
 				default:

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -852,10 +852,7 @@ export class JetpackAuthorize extends Component {
 		if ( this.isWooCoreProfiler() ) {
 			return (
 				<>
-					{ translate( 'Connecting as %(user)s', {
-						args: { user: this.props.user.display_name },
-					} ) }
-					<br />
+					<strong>{ this.props.user.display_name }</strong>
 					<small>{ this.props.user.email }</small>
 				</>
 			);

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -5,7 +5,7 @@ import {
 	getJetpackProductOrPlanDisplayName,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
-import { Button, Card, FormLabel, Gridicon, Spinner, JetpackLogo } from '@automattic/components';
+import { Button, Card, FormLabel, Gridicon, Spinner } from '@automattic/components';
 import { Spinner as WPSpinner, Modal } from '@wordpress/components';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -75,7 +75,6 @@ import {
 	REMOTE_PATH_AUTH,
 } from './constants';
 import Disclaimer from './disclaimer';
-import { JetpackFeatures } from './features';
 import { OFFER_RESET_FLOW_TYPES } from './flow-types';
 import HelpButton from './help-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
@@ -1003,34 +1002,6 @@ export class JetpackAuthorize extends Component {
 	renderContent() {
 		const { translate, user, authQuery } = this.props;
 		if ( this.isWooCoreProfiler() ) {
-			let col1Features = [];
-			let col2Features = [];
-			if ( authQuery.plugin_name === 'jetpack-boost' ) {
-				col1Features = [
-					translate( 'Speed up your store' ),
-					translate( 'Optimize CSS loading' ),
-					translate( 'Defer non-essential Javascript' ),
-				];
-				col2Features = [
-					translate( 'Lazy image loading' ),
-					translate( 'Site performance scores' ),
-					translate( 'Improve SEO' ),
-				];
-			} else {
-				col1Features = [
-					translate( 'Speed up content creation' ),
-					translate( 'Prompt based AI assistant' ),
-					translate( 'Adaptive tone adjustment' ),
-					translate( 'Generate text, tables, and lists' ),
-				];
-				col2Features = [
-					translate( 'Quota of 20 requests' ),
-					translate( 'Title and summary generation' ),
-					translate( 'Translate content to multiple languages' ),
-					translate( 'Spelling and grammar correction' ),
-				];
-			}
-
 			return (
 				<Fragment>
 					<div className="jetpack-connect__logged-in-content">
@@ -1052,16 +1023,11 @@ export class JetpackAuthorize extends Component {
 						</Card>
 						<div className="jetpack-connect__logged-in-bottom">
 							{ this.renderStateAction() }
-							<JetpackFeatures col1Features={ col1Features } col2Features={ col2Features } />
 							<Disclaimer
 								siteName={ decodeEntities( authQuery.blogname ) }
 								companyName={ this.getCompanyName() }
 								from={ authQuery.from }
 							/>
-							<div className="jetpack-connect__jetpack-logo-wrapper">
-								<JetpackLogo monochrome size={ 18 } />{ ' ' }
-								<span>{ translate( 'Jetpack powered' ) }</span>
-							</div>
 						</div>
 					</div>
 					{ authQuery.installedExtSuccess && <WooInstallExtSuccessNotice /> }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -514,6 +514,7 @@ export class JetpackSignup extends Component {
 					/>
 					<SignupForm
 						disabled={ isCreatingAccount }
+						isPasswordless={ isWooCoreProfiler }
 						email={ this.props.authQuery.userEmail }
 						footerLink={ this.renderFooterLink() }
 						handleSocialResponse={ this.handleSocialResponse }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -515,6 +515,7 @@ export class JetpackSignup extends Component {
 					<SignupForm
 						disabled={ isCreatingAccount }
 						isPasswordless={ isWooCoreProfiler }
+						disableTosText={ isWooCoreProfiler }
 						email={ this.props.authQuery.userEmail }
 						footerLink={ this.renderFooterLink() }
 						handleSocialResponse={ this.handleSocialResponse }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -510,6 +510,7 @@ export class JetpackSignup extends Component {
 						isWooOnboarding={ this.isWooOnboarding() }
 						isWooCoreProfiler={ this.isWooCoreProfiler() }
 						isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
+						hideSiteCard={ isWooCoreProfiler }
 					/>
 					<SignupForm
 						disabled={ isCreatingAccount }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -7,7 +7,7 @@
  */
 
 import { isEnabled } from '@automattic/calypso-config';
-import { Gridicon, JetpackLogo } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { Button, Card, Modal } from '@wordpress/components';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -536,12 +536,6 @@ export class JetpackSignup extends Component {
 				</div>
 				{ isWooCoreProfiler && this.props.authQuery.installedExtSuccess && (
 					<WooInstallExtSuccessNotice />
-				) }
-				{ isWooCoreProfiler && (
-					<div className="jetpack-connect__jetpack-logo-wrapper">
-						<JetpackLogo monochrome size={ 18 } />{ ' ' }
-						<span>{ this.props.translate( 'Jetpack powered' ) }</span>
-					</div>
 				) }
 			</MainWrapper>
 		);

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -530,6 +530,7 @@ export class JetpackSignup extends Component {
 								? this.props.translate( 'Create an account' )
 								: this.props.translate( 'Create your account' )
 						}
+						labelText={ isWooCoreProfiler ? this.props.translate( 'Email address' ) : null }
 						submitForm={ this.handleSubmitSignup }
 						submitting={ isCreatingAccount }
 						suggestedUsername=""

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1120,7 +1120,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.jetpack-connect__site.card {
-		border: 1px solid $gray-400;
+		border: 1px solid $gray-300;
 		border-radius: 2px;
 		background: #fff;
 		display: flex;
@@ -1142,7 +1142,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 
 		.site-icon {
-			border-radius: 50%;
+			border-radius: 4px;
 			margin-right: 16px;
 			height: 40px !important;
 			width: 40px !important;
@@ -1164,14 +1164,48 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			line-height: 24px;
 			color: $gray-700;
 		}
+
+		img.gravatar {
+			width: 80px;
+			height: 80px;
+		}
+
+		.jetpack-connect__logged-in-form-user {
+			flex-direction: column;
+		}
+
+		a.logged-out-form__link-item {
+			margin: 0;
+			font-size: 0.875rem;
+			font-weight: 400;
+			line-height: 24px;
+		}
+
+		.jetpack-connect__logged-in-form-user-text {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			margin-bottom: 13.5px;
+			strong {
+				font-size: 1rem;
+				font-weight: 500;
+				line-height: 24px;
+				letter-spacing: -0.008px;
+			}
+			small {
+				font-size: 0.875rem;
+				font-weight: 400;
+				line-height: 24px;
+			}
+		}
 	}
 
 	.jetpack-connect__logged-in-card {
 		display: flex;
 		flex-direction: column;
-		padding: 16px 24px;
+		padding: 32px 24px;
 		background: #fff;
-		border: 1px solid $gray-400;
+		border: 1px solid $gray-300;
 		border-radius: 2px;
 		max-width: 405px;
 		margin: 0;
@@ -1234,7 +1268,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.jetpack-connect__tos-link {
-		margin: 40px auto 70px;
+		margin: 24px auto 70px;
 		letter-spacing: -0.08px;
 		line-height: 18px;
 		color: $gray-700;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1125,9 +1125,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				background-color: var(--wp-admin-theme-color);
 				border-radius: 0;
 			}
-			.signup-form__terms-of-service-link {
-				display: none;
-			}
 			.logged-out-form__footer {
 				padding: 0;
 			}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1120,6 +1120,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.signup-form {
+		max-width: 327px;
+		padding-top: 48px;
 		.signup-form__passwordless-form-wrapper {
 			button.is-primary {
 				background-color: var(--wp-admin-theme-color);

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1134,7 +1134,9 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				margin-bottom: 24px;
 			}
 		}
-
+		input.signup-form__passwordless-email {
+			margin-bottom: 0;
+		}
 		.auth-form__social {
 			padding-top: 0;
 			.auth-form__social-buttons {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1164,40 +1164,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			line-height: 24px;
 			color: $gray-700;
 		}
-
-		img.gravatar {
-			width: 80px;
-			height: 80px;
-		}
-
-		.jetpack-connect__logged-in-form-user {
-			flex-direction: column;
-		}
-
-		a.logged-out-form__link-item {
-			margin: 0;
-			font-size: 0.875rem;
-			font-weight: 400;
-			line-height: 24px;
-		}
-
-		.jetpack-connect__logged-in-form-user-text {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			margin-bottom: 13.5px;
-			strong {
-				font-size: 1rem;
-				font-weight: 500;
-				line-height: 24px;
-				letter-spacing: -0.008px;
-			}
-			small {
-				font-size: 0.875rem;
-				font-weight: 400;
-				line-height: 24px;
-			}
-		}
 	}
 
 	.jetpack-connect__logged-in-card {
@@ -1205,6 +1171,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		flex-direction: column;
 		padding: 32px 24px;
 		background: #fff;
+		align-items: center;
 		border: 1px solid $gray-300;
 		border-radius: 2px;
 		max-width: 405px;
@@ -1214,10 +1181,23 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			max-width: 100%;
 		}
 
+		a.logged-out-form__link-item {
+			margin: 0;
+			font-size: 0.875rem;
+			font-weight: 400;
+			line-height: 24px;
+		}
+
+		img.gravatar {
+			width: 80px;
+			height: 80px;
+		}
+
 		.jetpack-connect__logged-in-form-user {
 			display: flex;
 			gap: 16px;
 			align-items: center;
+			flex-direction: column;
 		}
 
 		.gravatar {
@@ -1225,6 +1205,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 
 		.jetpack-connect__logged-in-form-user-text {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			margin-bottom: 13.5px;
 			color: var(--studio-gray-100);
 			font-size: 1rem;
 			font-weight: 500;
@@ -1235,6 +1219,14 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				line-height: 24px;
 				font-weight: 400;
 				color: $gray-700;
+			}
+
+			strong {
+				font-size: 1rem;
+				font-weight: 500;
+				line-height: 24px;
+				letter-spacing: -0.008px;
+				display: block;
 			}
 		}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1132,6 +1132,32 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				margin-bottom: 24px;
 			}
 		}
+
+		.auth-form__social {
+			padding-top: 0;
+			.auth-form__social-buttons {
+				width: 100%;
+				.social-buttons__button {
+					width: 100%;
+					border: 1px solid #a7aaad;
+					border-radius: 2px;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					svg {
+						border-radius: 0;
+						border: none;
+						flex-shrink: 0;
+					}
+					span {
+						flex-grow: 1;
+						text-align: center;
+						// icon width * 2
+						margin-left: -40px;
+					}
+				}
+			}
+		}
 	}
 
 	.jetpack-connect__site.card {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1119,6 +1119,24 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		max-width: 615px;
 	}
 
+	.signup-form {
+		.signup-form__passwordless-form-wrapper {
+			button.is-primary {
+				background-color: var(--wp-admin-theme-color);
+				border-radius: 0;
+			}
+			.signup-form__terms-of-service-link {
+				display: none;
+			}
+			.logged-out-form__footer {
+				padding: 0;
+			}
+			.form-fieldset {
+				margin-bottom: 24px;
+			}
+		}
+	}
+
 	.jetpack-connect__site.card {
 		border: 1px solid $gray-300;
 		border-radius: 2px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #92103 

## Proposed Changes

* Implement the new `One last step!` design for both signed-in and signed-out users
* Removed Jetpack logo 
* Updated copy text
* Updated logged-in card design




## Testing Instructions

1. [Create](https://jurassic.ninja/create/?woocommerce-beta-tester&woocommerce) a new JN site with the latest WooCommerce
2. Make sure you're signed-in on https://wordpress.com
3. Proceed with the core profiler.
4. Select `Jetpack` on the extensions page and continue.
5. On the Jetpack connection page, copy the URL.
6. Replace https://wordpress.com domain with your local calypso URL (it's most likely http://calypso.localhost:3000)
7. Confirm the visual changes (refer to the original issue or Figma linked in the original issue)


**Signed-in current**:

![Screen Shot 2024-06-26 at 2 50 12 PM](https://github.com/Automattic/wp-calypso/assets/4723145/dadc5f48-1566-4ff1-ba89-b8977403bbd9)


**Signed-in New**:
![Screen Shot 2024-06-26 at 2 49 33 PM](https://github.com/Automattic/wp-calypso/assets/4723145/7d97372f-f974-4de8-8669-07bde01001aa)


**Signed-out current**:

![Screen Shot 2024-06-27 at 1 15 35 PM](https://github.com/Automattic/wp-calypso/assets/4723145/be2dd20d-e5f0-41c4-aa72-bcf9d0db5977)

**Signed-out new**

![Screen Shot 2024-06-27 at 1 22 44 PM](https://github.com/Automattic/wp-calypso/assets/4723145/2a1d874a-0de3-4624-9680-ba5ee1f746c4)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
