### PR TITLE
Remove the admin interface style banner in /me and /me/account

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
-import { Banner } from 'calypso/components/banner';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
@@ -879,19 +878,6 @@ class Account extends Component {
 							components: {
 								learnMoreLink: (
 									<InlineSupportLink supportContext="account-settings" showIcon={ false } />
-								),
-							},
-						}
-					) }
-				/>
-				<Banner
-					disableHref
-					title={ this.props.translate(
-						'These settings are applied to sites using the Default admin interface style. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: (
-									<InlineSupportLink supportContext="admin-interface-style" showIcon={ false } />
 								),
 							},
 						}

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -6,7 +6,6 @@ import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import EditGravatar from 'calypso/blocks/edit-gravatar';
-import { Banner } from 'calypso/components/banner';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -61,19 +60,6 @@ class Profile extends Component {
 							components: {
 								learnMoreLink: (
 									<InlineSupportLink supportContext="manage-profile" showIcon={ false } />
-								),
-							},
-						}
-					) }
-				/>
-				<Banner
-					disableHref
-					title={ this.props.translate(
-						'These settings are applied to sites using the Default admin interface style. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: (
-									<InlineSupportLink supportContext="admin-interface-style" showIcon={ false } />
 								),
 							},
 						}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7970

## Proposed Changes

* Remove the banners for /me and /me/account

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To not confuse users as most users are still with the Default Admin

| Page | Before  | After |
| :-------------: | :-------------: | :-------------: |
| /me/account | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/72945958-0cdf-40f7-ab7c-ebb7aa1c7035">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/5fa797bc-6233-4761-b3b2-f56091bdfec3">|
| /me| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/7807506e-e852-4492-bfc1-59c71ad156e9">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/9dea5a80-ca8e-4ab0-b31f-93d27356374b">|



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me and /me/account
* The banner should not be present anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
