### PR TITLE
A4A > Marketplace: Remove USD from the pricing interval

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -90,11 +90,11 @@ export default function HostingCard( {
 
 	const priceIntervalDescription = useMemo< string >( () => {
 		if ( plan.price_interval === 'day' ) {
-			return translate( 'USD per plan per day' );
+			return translate( 'per plan per day' );
 		}
 
 		if ( plan.price_interval === 'month' ) {
-			return translate( 'USD per plan per month' );
+			return translate( 'per plan per month' );
 		}
 
 		return translate( 'USD' );

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/index.tsx
@@ -82,8 +82,8 @@ export default function WPCOMPlanCard( { plan, quantity, discount, onSelect, isL
 								</>
 							) }
 							<div className="wpcom-plan-card__price-interval">
-								{ plan.price_interval === 'day' && translate( 'USD per day' ) }
-								{ plan.price_interval === 'month' && translate( 'USD per month' ) }
+								{ plan.price_interval === 'day' && translate( 'per day' ) }
+								{ plan.price_interval === 'month' && translate( 'per month' ) }
 							</div>
 						</div>
 					) }

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
@@ -69,13 +69,11 @@ export default function ProductPriceWithDiscount( {
 			</div>
 			<div className="product-price-with-discount__price-interval">
 				{ isDailyPricing &&
-					( isBundle
-						? translate( '/USD per bundle per day' )
-						: translate( '/USD per license per day' ) ) }
+					( isBundle ? translate( 'per bundle per day' ) : translate( 'per license per day' ) ) }
 				{ product.price_interval === 'month' &&
 					( isBundle
-						? translate( '/USD per bundle per month' )
-						: translate( '/USD per license per month' ) ) }
+						? translate( 'per bundle per month' )
+						: translate( 'per license per month' ) ) }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/723

## Proposed Changes

This PR removes USD from the pricing interval.

## Testing Instructions

- Open A4A live link
- Visit the Marketplace > Verify the hosting cards don't have "USD" in the pricing interval

| Before | After |
|--------|--------|
| <img width="517" alt="Screenshot 2024-06-27 at 10 33 55 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/dcead39c-7f12-4266-ab40-100938ea2b90"> |<img width="517" alt="Screenshot 2024-06-27 at 10 33 59 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0d26245a-2973-48aa-b3e0-6ea18ab55a51"> | 

- Click the `Explore WordPress.com` plans button  > Verify the product cards don't have "USD" in the pricing interval

| Before | After |
|--------|--------|
| <img width="517" alt="Screenshot 2024-06-27 at 10 34 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/08dde6d3-669d-4624-9be0-08666251fee9"> | <img width="517" alt="Screenshot 2024-06-27 at 10 34 30 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f988e8a1-e291-4645-9630-4d4f4ee0195b">| 


- Click on Products > Verify the product cards don't have "USD" in the pricing interval

| Before | After |
|--------|--------|
| <img width="545" alt="Screenshot 2024-06-27 at 10 33 29 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/79b9fe89-3703-40b5-8ce8-4c7e9316c3d8"> | <img width="545" alt="Screenshot 2024-06-27 at 10 33 33 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/37a1b2f7-babc-4220-99e9-64fec787628d">| 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
