### PR TITLE
DIFM: fix support link on in-progress page

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -20,10 +20,9 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import { useGetWebsiteContentQuery } from 'calypso/state/signup/steps/website-content/hooks/use-get-website-content-query';
-import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { AppState, SiteId, SiteSlug } from 'calypso/types';
-import type { PropsWithChildren } from 'react';
 
 import './difm-lite-in-progress.scss';
 
@@ -37,13 +36,11 @@ type Props = {
 	siteId?: SiteId;
 };
 
-function SupportLink( { siteId, children }: PropsWithChildren< { siteId?: number } > ) {
+function SupportLink( { children }: { children?: JSX.Element } ) {
 	const translate = useTranslate();
 	// Create URLSearchParams for send feedback by email command
-	const { setInitialRoute, setShowHelpCenter, setSubject, setSite } =
+	const { setInitialRoute, setShowHelpCenter, setSubject } =
 		useDataStoreDispatch( HELP_CENTER_STORE );
-
-	const site = useSelector( ( state ) => getSite( state, siteId ) );
 
 	const emailUrl = `/contact-form?${ new URLSearchParams( {
 		mode: 'EMAIL',
@@ -57,7 +54,6 @@ function SupportLink( { siteId, children }: PropsWithChildren< { siteId?: number
 			className="difm-lite-in-progress__help-button"
 			onClick={ () => {
 				setInitialRoute( emailUrl );
-				setSite( site );
 				setSubject( translate( 'I have a question about my project' ) );
 				setShowHelpCenter( true );
 			} }
@@ -109,7 +105,7 @@ function WebsiteContentSubmissionPending( { siteId, siteSlug }: Props ) {
 						'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
 						{
 							components: {
-								SupportLink: <SupportLink siteId={ siteId } />,
+								SupportLink: <SupportLink />,
 							},
 						}
 					) }
@@ -124,7 +120,7 @@ function WebsiteContentSubmissionPending( { siteId, siteSlug }: Props ) {
 	);
 }
 
-function WebsiteContentSubmitted( { primaryDomain, siteSlug, siteId }: Props ) {
+function WebsiteContentSubmitted( { primaryDomain, siteSlug }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { currentRoute } = useCurrentRoute();
@@ -159,7 +155,7 @@ function WebsiteContentSubmitted( { primaryDomain, siteSlug, siteId }: Props ) {
 						'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
 						{
 							components: {
-								SupportLink: <SupportLink siteId={ siteId } />,
+								SupportLink: <SupportLink />,
 							},
 						}
 					) }
@@ -205,13 +201,7 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 	}
 
 	if ( websiteContentQueryResult?.isWebsiteContentSubmitted ) {
-		return (
-			<WebsiteContentSubmitted
-				primaryDomain={ primaryDomain }
-				siteSlug={ siteSlug }
-				siteId={ siteId }
-			/>
-		);
+		return <WebsiteContentSubmitted primaryDomain={ primaryDomain } siteSlug={ siteSlug } />;
 	}
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1719411338927889-slack-C02KVCAL7GX

## Proposed Changes

* In #92008, the `setSite` action was removed, causing the support link on the DIFM in-progress page not to open. This PR removes the usage of `setSite` since it is no longer required.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as #89573

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?