### PR TITLE
Storybook: move the stories towards more calypso-agnostic

### DIFF
--- a/packages/calypso-products/src/experiments.ts
+++ b/packages/calypso-products/src/experiments.ts
@@ -22,9 +22,3 @@ export const setPlansListExperiment = ( experimentName: string, variation: strin
 export const getPlansListExperiment = ( experimentName: string ): string | undefined => {
 	return getExperiment( PLANS_LIST_NAMESPACE, experimentName );
 };
-
-export type TrailMapVariantType = 'control' | 'treatment';
-
-export const setTrailMapExperiment = ( variation: TrailMapVariantType ): void => {
-	setExperiment( PLANS_LIST_NAMESPACE, 'wpcom_trail_map_feature_structure_experiment', variation );
-};

--- a/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
@@ -77,7 +77,7 @@ export default meta;
 type Story = StoryObj< typeof meta >;
 
 export const DefaultComparisonGrid = {
-	name: 'Default comparison grid',
+	name: 'Default',
 	args: {
 		...defaultProps,
 	},

--- a/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
@@ -1,17 +1,11 @@
 import {
-	TrailMapVariantType,
 	getFeaturesList,
 	getPlanFeaturesGroupedForComparisonGrid,
-	setTrailMapExperiment,
 } from '@automattic/calypso-products';
 import { ComparisonGrid, ComparisonGridExternalProps, useGridPlansForComparisonGrid } from '../..';
 import type { Meta, StoryObj } from '@storybook/react';
 
-const ComponentWrapper = (
-	props: Omit< ComparisonGridExternalProps, 'gridPlans' > & {
-		trailMapVariant?: TrailMapVariantType;
-	}
-) => {
+const ComponentWrapper = ( props: Omit< ComparisonGridExternalProps, 'gridPlans' > ) => {
 	const gridPlans = useGridPlansForComparisonGrid( {
 		eligibleForFreeHostingTrial: true,
 		hasRedeemedDomainCredit: undefined,
@@ -76,37 +70,23 @@ const defaultProps = {
 const meta = {
 	title: 'ComparisonGrid',
 	component: ComponentWrapper,
-	decorators: [
-		( Story, { args: { trailMapVariant } } ) => {
-			trailMapVariant && setTrailMapExperiment( trailMapVariant );
-			return <Story />;
-		},
-	],
 } satisfies Meta< typeof ComponentWrapper >;
 
 export default meta;
 
 type Story = StoryObj< typeof meta >;
 
-export const Start = {
-	name: '/start',
+export const DefaultComparisonGrid = {
+	name: 'Default comparison grid',
 	args: {
 		...defaultProps,
-		intent: 'plans-default-wpcom',
 	},
 } satisfies Story;
 
-export const TrailMapControl = {
+export const HideUnsupportedFeatures = {
+	name: 'Hide unsupported features',
 	args: {
-		...Start.args,
-		trailMapVariant: 'control',
-	},
-} satisfies Story;
-
-export const TrailMapCopyAndStructure = {
-	args: {
-		...TrailMapControl.args,
-		trailMapVariant: 'treatment',
+		...defaultProps,
 		hideUnsupportedFeatures: true,
 	},
 } satisfies Story;

--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -49,7 +49,6 @@ const ComponentWrapper = ( props: Omit< FeaturesGridExternalProps, 'gridPlans' >
 				gridPlanForSpotlight={
 					'gridPlanForSpotlight' in props ? props.gridPlanForSpotlight : gridPlanForSpotlight
 				}
-				featureGroupMap={ getPlanFeaturesGroupedForFeaturesGrid() }
 			/>
 		)
 	);
@@ -59,6 +58,7 @@ const defaultProps = {
 	allFeaturesList: getFeaturesList(),
 	coupon: undefined,
 	currentSitePlanSlug: undefined,
+	featureGroupMap: getPlanFeaturesGroupedForFeaturesGrid(),
 	generatedWPComSubdomain: {
 		isLoading: false,
 		result: { domain_name: 'zzz.wordpress.com' },
@@ -96,8 +96,8 @@ export default meta;
 
 type Story = StoryObj< typeof meta >;
 
-export const Plans = {
-	name: 'Default features grid',
+export const PlansInAdmin = {
+	name: 'Default in admin',
 	args: {
 		...defaultProps,
 		intent: 'plans-default-wpcom',
@@ -107,10 +107,19 @@ export const Plans = {
 	},
 } satisfies Story;
 
+export const PlansInSignup = {
+	name: 'Default in signup',
+	args: {
+		...defaultProps,
+		intent: 'plans-default-wpcom',
+		isInSignup: true,
+	},
+} satisfies Story;
+
 export const CategorizedFeatures = {
 	name: 'Categorized features grid',
 	args: {
-		...Plans.args,
+		...PlansInSignup.args,
 		gridPlanForSpotlight: undefined,
 
 		// to better show the effect of the categories, here we use the one from the comparison grid instead
@@ -119,8 +128,8 @@ export const CategorizedFeatures = {
 	},
 } satisfies Story;
 
-export const IntentWithNonDefaultPlanMix = {
-	name: 'Non-default plan mix configured by intent',
+export const CuratedPlanMixByIntent = {
+	name: 'Curated plan mix configured by intent',
 	args: {
 		...defaultProps,
 		intent: 'plans-newsletter',

--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -1,8 +1,7 @@
 import {
-	TrailMapVariantType,
 	getFeaturesList,
 	getPlanFeaturesGroupedForFeaturesGrid,
-	setTrailMapExperiment,
+	getPlanFeaturesGroupedForComparisonGrid,
 } from '@automattic/calypso-products';
 import {
 	FeaturesGrid,
@@ -12,11 +11,7 @@ import {
 } from '../..';
 import type { Meta, StoryObj } from '@storybook/react';
 
-const ComponentWrapper = (
-	props: Omit< FeaturesGridExternalProps, 'gridPlans' > & {
-		trailMapVariant?: TrailMapVariantType;
-	}
-) => {
+const ComponentWrapper = ( props: Omit< FeaturesGridExternalProps, 'gridPlans' > ) => {
 	const gridPlans = useGridPlansForFeaturesGrid( {
 		eligibleForFreeHostingTrial: true,
 		hasRedeemedDomainCredit: undefined,
@@ -95,12 +90,6 @@ const defaultProps = {
 const meta = {
 	title: 'FeaturesGrid',
 	component: ComponentWrapper,
-	decorators: [
-		( Story, { args: { trailMapVariant } } ) => {
-			trailMapVariant && setTrailMapExperiment( trailMapVariant );
-			return <Story />;
-		},
-	],
 } satisfies Meta< typeof ComponentWrapper >;
 
 export default meta;
@@ -108,7 +97,7 @@ export default meta;
 type Story = StoryObj< typeof meta >;
 
 export const Plans = {
-	name: '/plans',
+	name: 'Default features grid',
 	args: {
 		...defaultProps,
 		intent: 'plans-default-wpcom',
@@ -118,27 +107,22 @@ export const Plans = {
 	},
 } satisfies Story;
 
-export const Newsletter = {
-	name: '/setup/newsletter',
+export const CategorizedFeatures = {
+	name: 'Categorized features grid',
+	args: {
+		...Plans.args,
+		gridPlanForSpotlight: undefined,
+
+		// to better show the effect of the categories, here we use the one from the comparison grid instead
+		featureGroupMap: getPlanFeaturesGroupedForComparisonGrid(),
+		enableCategorisedFeatures: true,
+	},
+} satisfies Story;
+
+export const IntentWithNonDefaultPlanMix = {
+	name: 'Non-default plan mix configured by intent',
 	args: {
 		...defaultProps,
 		intent: 'plans-newsletter',
-	},
-} satisfies Story;
-
-export const TrailMapControl = {
-	args: {
-		...Plans.args,
-		trailMapVariant: 'control',
-		gridPlanForSpotlight: undefined,
-	},
-} satisfies Story;
-
-export const TrailMapCopyAndStructure = {
-	args: {
-		...Plans.args,
-		trailMapVariant: 'treatment',
-		gridPlanForSpotlight: undefined,
-		enableCategorisedFeatures: true,
 	},
 } satisfies Story;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #90826 and #89692 

## Proposed Changes

This PR cleans up the Trail Map references in the stories of `plans-grid-next`. The final reference to the trail map related functions in `experiments.ts` is also removed together.

On top of it, since we previously discussed how the current setup has brought in too much calypso context([the thread](https://github.com/Automattic/wp-calypso/pull/90691#issuecomment-2111573272), and [the follow-up issue](https://github.com/Automattic/wp-calypso/issues/90826)), in this PR I've also attempted to update the stories more referring to the functionalities of the components, instead of specific use cases in calypso:

|Current |  In this PR |
| -------| ----------|
| ![CleanShot 2024-06-27 at 14 47 32@2x](https://github.com/Automattic/wp-calypso/assets/1842898/9cc813b1-f9e8-4144-b80d-f16acb00463c)| ![CleanShot 2024-06-27 at 14 35 37@2x](https://github.com/Automattic/wp-calypso/assets/1842898/17efa367-fc20-46dd-a88b-b18cd59ce13b) |

* Features grid
    * `Default in admin`: `isInAdmin` is true, `gridPlanForSpotlight` is assigned
    * `Default in signup`: `isInSignup` is true, `gridPlanForSpotlight` is null
    * `Categorized feature grid`: demonstrate the categorized layout by assigning the feature group map and set `enableCategorisedFeatures` as true.
    * `Curated plan mix configured by intent`: demonstrate the 3-plan line-up by assigning a non-default intent value.
* Comparison grid 
    * `Default`: the most commonly used setup
    * `Hide unsupported feature`: `hideUnsupportedFeatures` is set as true. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `yarn workspace @automattic/plans-grid-next storybook`
* Confirm each story works as expected 
* Confirm if this newly proposed setup make sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
