### PR TITLE
Mark PHP 7.4 as deprecated in the hosting configuration

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -208,6 +208,7 @@ const WebServerSettingsCard = ( {
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: '7.4',
+				disabled: true, // EOL 1st July, 2024
 			},
 			{
 				label: '8.0',


### PR DESCRIPTION
## Proposed Changes

* Mark PHP 7.4 as deprecated

![CleanShot 2024-06-27 at 09 56 45@2x](https://github.com/Automattic/wp-calypso/assets/528287/d0292bfa-668d-400b-829c-8a6e650f5ed3)

If site is still using it:

![CleanShot 2024-06-27 at 09 56 37@2x](https://github.com/Automattic/wp-calypso/assets/528287/8201b73f-f64d-43c6-99a8-4c379a7ab811)



## Testing Instructions

1. Apply PR
2. Visit http://calypso.localhost:3000/hosting-config/<site>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
