### PR TITLE
Hide Color Scheme settings in /me/account behind feature flag

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -953,7 +953,12 @@ class Account extends Component {
 
 						{ this.props.canDisplayCommunityTranslator && this.communityTranslator() }
 
-						<FormFieldset className="account__settings-admin-home">
+						<FormFieldset
+							className="account__settings-admin-home"
+							style={
+								config.isEnabled( 'layout/site-level-user-profile' ) ? { marginBottom: 0 } : {}
+							}
+						>
 							<FormLabel id="account__default_landing_page">
 								{ translate( 'Admin home' ) }
 							</FormLabel>
@@ -961,6 +966,7 @@ class Account extends Component {
 						</FormFieldset>
 
 						{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
+							! config.isEnabled( 'layout/site-level-user-profile' ) &&
 							supportsCssCustomProperties() && (
 								<FormFieldset>
 									<FormLabel id="account__color_scheme" htmlFor="color_scheme">


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7972

## Proposed Changes

/me/account page:

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/8913c211-01d6-490b-85f9-9d3d62168033">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/d6ca6952-e113-4348-af26-55bc4ab728ac">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Context: pfsHM7-1hH-p2
* We want to set the color scheme at a per site per user level and not in /me/account

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/account and apply the `flags=layout/site-level-user-profile`
* Should not see the color scheme picker
* Remove the flag and test again, color picker shows and everything still works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?