### PR TITLE
A4A > Referrals: Fix the runt by using nbsp

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -293,9 +293,14 @@ export default function LayoutBodyContent( {
 								description={
 									isAutomatedReferral ? (
 										<>
-											{ translate( 'Receive a revenue share of 5 basis points on the' ) }
-											<br />
-											{ translate( 'total payments volume.' ) }
+											{ translate(
+												'Receive a revenue share of 5 basis points on the total payments{{nbsp/}}volume.',
+												{
+													components: {
+														nbsp: <>&nbsp;</>,
+													},
+												}
+											) }
 										</>
 									) : (
 										translate(


### PR DESCRIPTION
## Proposed Changes

This PR fixes the runt by using &nbsp; instead of <br/> as mentioned here: https://github.com/Automattic/wp-calypso/pull/91959#discussion_r1647803274

## Testing Instructions

- Open A4A live link
- Go to Referrals > Dashboard and verify that the text on the Install WooPayments sections looks as shown below. Basically the last word shouldn't be hanging alone. 

<img width="803" alt="Screenshot 2024-06-27 at 2 01 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/364f4491-d67a-40e3-a90a-7cb8cc26c63e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
