### PR TITLE
A4A > Signup: Fix the agreement link text & url on the signup page

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon, FormLabel } from '@automattic/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
@@ -47,6 +48,8 @@ export default function AgencyDetailsForm( {
 	submitLabel,
 }: Props ) {
 	const translate = useTranslate();
+	const localizeUrl = useLocalizeUrl();
+
 	const { countryOptions, stateOptionsMap } = useCountriesAndStates();
 	const showCountryFields = countryOptions.length > 0;
 
@@ -419,20 +422,21 @@ export default function AgencyDetailsForm( {
 					<div className="company-details-form__tos">
 						<p>
 							{ translate(
-								'By clicking ‘Continue’, you agree to the{{break}}{{/break}}{{link}}%(link_text)s{{icon}}{{/icon}}{{/link}}.',
+								"By clicking 'Continue', you agree to the{{break}}{{/break}}{{link}}Terms of the Automattic for Agencies Platform Agreement{{icon}}{{/icon}}{{/link}}.",
 								{
 									components: {
 										break: <br />,
 										link: (
 											<a
-												href="https://automattic.com/for/agencies/partnership-agreement"
+												href={ localizeUrl(
+													'https://automattic.com/for-agencies/platform-agreement/'
+												) }
 												target="_blank"
 												rel="noopener noreferrer"
 											></a>
 										),
 										icon: <Gridicon icon="external" size={ 18 } />,
 									},
-									args: { link_text: 'Terms of the Automattic for Agencies Partnership Agreement' },
 								}
 							) }
 						</p>


### PR DESCRIPTION
Closes https://github.com/Automattic/i18n-issues/issues/822

## Proposed Changes

This PR:

- Fixes the issues mentioned https://github.com/Automattic/i18n-issues/issues/822
- Fixed the terms link URL that was being redirected to a page that was not found.
- Uses `useLocalizeUrl` as a good practice. 

## Testing Instructions

- Visit the A4A signup page (/signup)
- Verify that the terms link's URL redirects you to the correct page: Platform Agreement: https://automattic.com/for-agencies/platform-agreement/

- Verify that the terms link's text is changed as shown below

| Before | After |
|--------|--------|
| <img width="681" alt="Screenshot 2024-06-27 at 3 28 03 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3847512d-2187-4ab1-8747-3eb16ebcce80"> | <img width="681" alt="Screenshot 2024-06-27 at 3 26 28 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/59d714ef-b9f1-4f6a-aaa7-28ab0383f78d"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
