### PR TITLE
Jetpack: update My Plan page to use Modernized Layout

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -232,15 +232,9 @@ class CurrentPlan extends Component {
 			showExpiryNotice = purchase && isCloseToExpiration( purchase );
 		}
 
-		let planDescription = null;
-
-		if ( isJetpackNotAtomic ) {
-			planDescription = translate( 'Learn about the features included in your Jetpack plan.' );
-		} else {
-			planDescription = translate(
-				'Learn about the features included in your WordPress.com plan.'
-			);
-		}
+		const planDescription = isJetpackNotAtomic
+		    ? translate( 'Learn about the features included in your Jetpack plan.' );
+		    : translate( 'Learn about the features included in your WordPress.com plan.' );
 
 		return (
 			<div>

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -233,8 +233,8 @@ class CurrentPlan extends Component {
 		}
 
 		const planDescription = isJetpackNotAtomic
-		    ? translate( 'Learn about the features included in your Jetpack plan.' );
-		    : translate( 'Learn about the features included in your WordPress.com plan.' );
+			? translate( 'Learn about the features included in your Jetpack plan.' )
+			: translate( 'Learn about the features included in your WordPress.com plan.' );
 
 		return (
 			<div>

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -212,6 +212,7 @@ class CurrentPlan extends Component {
 			shouldShowDomainWarnings,
 			showThankYou,
 			translate,
+			isJetpackNotAtomic,
 		} = this.props;
 
 		const currentPlanSlug = selectedSite?.plan?.product_slug ?? '';
@@ -231,6 +232,16 @@ class CurrentPlan extends Component {
 			showExpiryNotice = purchase && isCloseToExpiration( purchase );
 		}
 
+		let planDescription = null;
+
+		if ( isJetpackNotAtomic ) {
+			planDescription = translate( 'Learn about the features included in your Jetpack plan.' );
+		} else {
+			planDescription = translate(
+				'Learn about the features included in your WordPress.com plan.'
+			);
+		}
+
 		return (
 			<div>
 				<ModernizedLayout />
@@ -248,9 +259,7 @@ class CurrentPlan extends Component {
 						className="plans__section-header"
 						navigationItems={ [] }
 						title={ translate( 'Plans' ) }
-						subtitle={ translate(
-							'Learn about the features included in your WordPress.com plan.'
-						) }
+						subtitle={ planDescription }
 					/>
 					<div className="current-plan current-plan__content">
 						{ showThankYou && ! this.state.hideThankYouModal && (

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -212,7 +212,6 @@ class CurrentPlan extends Component {
 			shouldShowDomainWarnings,
 			showThankYou,
 			translate,
-			isJetpackNotAtomic,
 		} = this.props;
 
 		const currentPlanSlug = selectedSite?.plan?.product_slug ?? '';
@@ -234,7 +233,7 @@ class CurrentPlan extends Component {
 
 		return (
 			<div>
-				{ ! isJetpackNotAtomic && <ModernizedLayout /> }
+				<ModernizedLayout />
 				<DocumentHead title={ translate( 'My Plan' ) } />
 				{ selectedSiteId && (
 					<QueryConciergeInitial key={ selectedSiteId } siteId={ selectedSiteId } />


### PR DESCRIPTION
## Proposed Changes

* Ensures `<ModernizedLayout />` is used in the My Plan (`current-plan`) page for Jetpack sites.

## Why are these changes being made?

* No layout was set on this page, which made the content always stretch to full-width.
* Reported by @bobmatyas in p1715697223243229/1715697108.454709-slack-C06PK2W8F42

## Testing Instructions

* Fire up this PR.
* Select a Jetpack site.
* Go to http://calypso.localhost:3000/plans/my-plan/SITE_URL
* Make sure the layout matches the modernized interfaces in Calypso.
* Make sure that non-Jetpack sites remain unchanged.

## Screenshots

Before | After
--|--
<img width="1687" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/70b252c4-7362-435e-b8ff-7c8099aa3ca7"> | <img width="1687" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/5295ec91-60b5-43c6-85d1-82bf6d43186c">
