### PR TITLE
Make sure the signup flows will reach the same destination after closing the checkout.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -42,7 +42,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 	// the domain only flow has special rule. Ideally they should also be configurable in flows-pure.
 	if ( [ 'domain', 'domain-for-gravatar' ].includes( flowName ) ) {
 		isDomainOnly = 1;
-		destination = 'start/${ flowName }/domain-only';
+		destination = `/start/${ flowName }/domain-only`;
 	}
 
 	// checkoutBackUrl is required to be a complete URL, and will be further sanitized within the checkout package.

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -37,28 +37,25 @@ function getCheckoutUrl( dependencies, localeSlug, flowName, destination ) {
 		checkoutURL += `/${ localeSlug }`;
 	}
 
-	let isDomainOnly;
-	// TODO:
-	// the domain only flow has special rule. Ideally they should also be configurable in flows-pure.
-	if ( [ 'domain', 'domain-for-gravatar' ].includes( flowName ) ) {
-		isDomainOnly = 1;
-		destination = `/start/${ flowName }/domain-only`;
-	}
+	const isDomainOnly = [ 'domain', 'domain-for-gravatar' ].includes( flowName );
 
 	// checkoutBackUrl is required to be a complete URL, and will be further sanitized within the checkout package.
 	// Due to historical reason, `destination` can be either a path or a complete URL.
 	// Thus, if it is determined as not an URL, we assume it as a path here. We can surely make it more comprehensive,
 	// but the required effort and computation cost might outweigh the gain.
+	//
+	// TODO:
+	// the domain only flow has special rule. Ideally they should also be configurable in flows-pure.
 	const checkoutBackUrl = isURL( destination )
 		? destination
-		: constructBackUrlFromPath( destination );
+		: constructBackUrlFromPath( isDomainOnly ? `/start/${ flowName }/domain-only` : destination );
 
 	return addQueryArgs(
 		{
 			signup: 1,
 			ref: getQueryArgs()?.ref,
 			...( dependencies.coupon && { coupon: dependencies.coupon } ),
-			isDomainOnly,
+			...( isDomainOnly && { isDomainOnly: 1 } ),
 			checkoutBackUrl,
 		},
 		checkoutURL


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#7674

## Proposed Changes

This PR wires the desired destination of a sign-up flow on the classic signup framework to the redirect of checkout closing. That way, the flow destination won't be affected whether there is a checkout step or not.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As I outlined in https://github.com/Automattic/dotcom-forge/issues/7674#issuecomment-2181860408 and @escapemanuele further expanded in pdDR7T-1Dy-p2, there are two issues of the closing checkout button.

1. It looks like the back navigation button, while it is not.
2. When there is a checkout step introduced because there is a paid item in the cart, clicking that button will lead the users to the admin dashboard directly, which is both confusing and drive people away from the desired flow destination, e.g. the launch pad. 

The 1st issue will be fixed by https://github.com/Automattic/wp-calypso/pull/92169, and this PR will resolve the 2nd.

For example, in the main onboarding flow:

In production:

https://github.com/Automattic/wp-calypso/assets/1842898/c431de52-a360-46a4-b667-896a85442bb8 

In this PR:

https://github.com/Automattic/wp-calypso/assets/1842898/047c4d8e-6358-4bb6-a3cb-beee9e28fa99 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### The main onboarding flow
* Go through /start and make sure to pick paid domain or a paid plan
* Clicking the close checkout button, the launch pad should be arrived
* Do the same without a paid item; the launch pad should be arrived.

#### The guided flow

* Hard-code a line of `return;` here: https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/signup/step-actions/index.js#L1194, so the initial intent step will be presented.
* Pick "Creating a site for myself", and then "Publish a blog"
* Pick a paid domain or a paid plan
* Closing the checkout, you shoud arrive `/setup/site-setup-wg`.

#### The domain-only flow
As the inlined comment suggested, this flow contains special case so we need to make sure it works as it is.

* Go though `/start/domain` and pick a paid domain.
* Pick "just buy domains"
* When you arrive the the checkout with `isDomainOnly=1` query string added. 
* Closing the checkout, you should arrive `/start/domain/domain-only` ~with `isDomainOnly=1` query string added~.

#### The admin dashboard

* When logged-in, go to /plans, pick a paid plan and go to the checkout.
* Clicking the close checkout button, you should be directed back to the admin dashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
