### PR TITLE
Replace the icon of the button "close checkout" from `chevron-left` to `cross`

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -93,7 +93,7 @@ const CheckoutMasterbar = ( {
 			<div className="masterbar__secure-checkout">
 				{ showCloseButton && (
 					<Item
-						icon="chevron-left"
+						icon="cross"
 						className="masterbar__close-button"
 						onClick={ clickClose }
 						tooltip={ String( translate( 'Close Checkout' ) ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#7674

## Proposed Changes

This PR updates the "close checkout" button icon from `chevron-left` to `cross`:

| In production | In this PR |
| --------------|----------|
| ![CleanShot 2024-06-28 at 18 49 46@2x](https://github.com/Automattic/wp-calypso/assets/1842898/33b3026a-0bd0-4eb6-bca8-71ade7ce1e72) | ![CleanShot 2024-06-27 at 18 57 28@2x](https://github.com/Automattic/wp-calypso/assets/1842898/49783eca-d419-4c67-8f87-450e6e6e71a7) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
Using the `chevron-left` icon may lead to false expectation of what the button does like what we saw in the discussion in Automattic/dotcom-forge#7674. It looks like a back navigation button, while it's actually a close button if we hover on it:
![CleanShot 2024-06-28 at 18 50 33@2x](https://github.com/Automattic/wp-calypso/assets/1842898/8fbda590-b16c-4d23-8371-ab7de8a4332b)

The `cross` icon matches the intended behavior better in this case.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to the checkout screen and confirm that the icon has been updated accordingly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
