### PR TITLE
Untangling: allow reading site-level admin color for (Simple and Atomic) Default sites

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -437,7 +437,8 @@ class Layout extends Component {
 				) }
 				<QueryPreferences />
 				<QuerySiteFeatures siteIds={ [ this.props.siteId ] } />
-				{ this.props.isUnifiedSiteSidebarVisible && (
+				{ ( this.props.isUnifiedSiteSidebarVisible ||
+					config.isEnabled( 'layout/site-level-user-profile' ) ) && (
 					<QuerySiteAdminColor siteId={ this.props.siteId } />
 				) }
 				{ config.isEnabled( 'layout/query-selected-editor' ) && (
@@ -584,7 +585,10 @@ export default withCurrentRoute(
 
 		const calypsoColorScheme = getPreference( state, 'colorScheme' );
 		const siteColorScheme = getAdminColor( state, siteId ) ?? calypsoColorScheme;
-		const colorScheme = shouldShowUnifiedSiteSidebar ? siteColorScheme : calypsoColorScheme;
+		const colorScheme =
+			shouldShowUnifiedSiteSidebar || config.isEnabled( 'layout/site-level-user-profile' )
+				? siteColorScheme
+				: calypsoColorScheme;
 
 		return {
 			masterbarIsHidden,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7980

## Proposed Changes

This PR allows reading site-level admin color for Simple and Atomic Default sites.

## Why are these changes being made?

pfsHM7-1hH-p2

## Testing Instructions

See D153596-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?