### PR TITLE
Left sidebar: Fix issue with sidebar re-render during interface change

### DIFF
--- a/client/my-sites/site-settings/site-admin-interface/use-select-interface-mutation.ts
+++ b/client/my-sites/site-settings/site-admin-interface/use-select-interface-mutation.ts
@@ -73,18 +73,20 @@ export const useSiteInterfaceMutation = (
 			if ( ! data?.interface || ! site ) {
 				throw new Error( 'Invalid response from hosting/admin-interface' );
 			}
-			if ( data.interface === 'wp-admin' && siteAdminUrl ) {
-				navigate( addQueryArgs( siteAdminUrl, { 'admin-interface-changed': true } ) );
-			} else {
-				dispatch( requestAdminMenu( siteId ) );
-				setHasSuccessfullyFinished( true );
-			}
+
 			const newOptions = {
 				...( site.options || {} ),
 				wpcom_admin_interface: data.interface,
 			};
 			// Apply the new interface option to the site on redux store
 			dispatch( receiveSite( { ...site, options: newOptions } ) );
+
+			if ( data.interface === 'wp-admin' && siteAdminUrl ) {
+				navigate( addQueryArgs( siteAdminUrl, { 'admin-interface-changed': true } ) );
+			} else {
+				dispatch( requestAdminMenu( siteId ) );
+				setHasSuccessfullyFinished( true );
+			}
 		},
 		onMutate: options?.onMutate,
 		onError( _err: MutationError, _newActive: string, prevValue: unknown ) {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/7741

## Proposed Changes

* Fixes sidebar navigation re-render described in the ticket: https://github.com/Automattic/dotcom-forge/issues/7741
* The issue was a race condition between state update and "navigate" invoke; that's why it was harder to reproduce

## Testing Instructions

- Go to `wordpress.com/start`
- Create a site with a Creator plan
- Change to use the Classic interface
- Go to Hosting features and click Activate now
- Go to any Calypso page like `/settings/general`
- Check if the navigation is the selected one without ~1s switch between calypso <-> wp-admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
