### PR TITLE
Site Migration: Hide the 'Do it for me' modal when the user selects the same option previously

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -399,6 +399,15 @@ const siteMigration: Flow = {
 						);
 					}
 
+					// If the user selected the "Do it for me" option, we should take them back to the how to migrate step skipping
+					// the modal.
+					if (
+						config.isEnabled( 'migration-flow/enable-migration-assistant' ) &&
+						urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME
+					) {
+						return navigate( `${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?${ urlQueryParams }` );
+					}
+
 					if ( isFromSiteWordPress ) {
 						urlQueryParams.set( 'showModal', 'true' );
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/91856
* https://github.com/Automattic/dotcom-forge/issues/7723

More context: paYKcK-4V1-p2#comment-3677

## Proposed Changes

* Displays the Assistance Offer modal only when the user selects the "I'll do it myself" option, which was introduced on https://github.com/Automattic/wp-calypso/pull/91856.
* This modal is displayed when the user presses the Back button on the upgrade step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We discussed on paYKcK-4V1-p2 that maybe the Assistance modal was not necessary when the user selects the "Do it for me" option on the step introduced on https://github.com/Automattic/wp-calypso/pull/91856, as they consciously expressed that they already want the assisted migration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local environment or use the Calypso Live link below.
* Create a free site through the `/start` flow.
* On the Goal step, select the import option
* Go through the flow until you reach the "How to migrate" step
* Select the "Do it for me" option.
* Once you land on the upgrade step, click on the Stepper Back button and ensure the Assistance modal is **not** displayed anymore.
* Now select the "I'll do it myself" option.
* Once you land on the upgrade step, click on the Stepper Back button and ensure the Assistance modal **is** displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?