### PR TITLE
Stats: Adding empty state component for Countries

### DIFF
--- a/client/my-sites/stats/features/modules/stats-countries/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-countries';

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -81,7 +81,7 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 					showSummaryLink
 					className={ className }
 				>
-					<Geochart query={ period } />
+					<Geochart query={ query } />
 				</StatsModule>
 			) }
 		</>

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -3,7 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { mapMarker } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector } from 'calypso/state';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
@@ -37,7 +37,7 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsCountryViews';
 
-	const requesting = useSelector( ( state: any ) =>
+	const requesting = useSelector( ( state ) =>
 		isRequestingSiteStatsForQuery( state, siteId, statType, query )
 	);
 	const data = useSelector( ( state ) =>

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -1,6 +1,6 @@
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { megaphone } from '@wordpress/icons';
+import { mapMarker } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -54,9 +54,9 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 					isEmpty
 					emptyMessage={
 						<EmptyModuleCard
-							icon={ megaphone }
+							icon={ mapMarker }
 							description={ translate(
-								'Stats on visitors and their {{link}}viewing location{{link}} will appear here',
+								'Stats on visitors and their {{link}}viewing location{{link}} will appear here to learn from where you are getting visits.',
 								{
 									components: {
 										link: <a href={ localizeUrl( `${ SUPPORT_URL }#countries` ) } />,

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -50,7 +50,7 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 			{ ( ! data || ! data?.length ) && (
 				<StatsCard
 					className={ className }
-					title={ translate( 'Country Views' ) }
+					title={ translate( 'Locations' ) }
 					isEmpty
 					emptyMessage={
 						<EmptyModuleCard

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -67,7 +67,9 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 							) }
 						/>
 					}
-				></StatsCard>
+				>
+					<></>
+				</StatsCard>
 			) }
 			{ data && !! data.length && (
 				<StatsModule

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -71,10 +71,9 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 					<></>
 				</StatsCard>
 			) }
-			{ /* { data && !! data.length && ( */ }
-			{ data && (
+			{ data && !! data.length && (
 				<StatsModule
-					path="countries"
+					path="countryviews"
 					moduleStrings={ moduleStrings }
 					period={ period }
 					query={ query }

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -75,8 +75,7 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 					period={ period }
 					query={ period }
 					statType="statsCountryViews"
-					// showSummaryLink={!summary}
-					// hideSummaryLink={!!summary}
+					showSummaryLink
 					className={ className }
 				>
 					<Geochart query={ period } />

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -1,0 +1,89 @@
+import { StatsCard } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { megaphone } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { SUPPORT_URL } from '../../../const';
+import Geochart from '../../../geochart';
+import StatsModule from '../../../stats-module';
+import StatsModulePlaceholder from '../../../stats-module/placeholder';
+
+type StatCountriesProps = {
+	className?: string;
+	period: string;
+	query: string;
+	moduleStrings: {
+		title: string;
+		item: string;
+		value: string;
+		empty: string;
+	};
+};
+
+const StatCountries: React.FC< StatCountriesProps > = ( {
+	period,
+	query,
+	moduleStrings,
+	className,
+} ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsCountryViews';
+
+	const requesting = useSelector( ( state: any ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	return (
+		<>
+			{ requesting && <StatsModulePlaceholder isLoading={ requesting } /> }
+			{ ( ! data || ! data?.length ) && (
+				<StatsCard
+					className={ className }
+					title={ translate( 'Country Views' ) }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ megaphone }
+							description={ translate(
+								'Stats on visitors and their {{link}}viewing location{{link}} will appear here',
+								{
+									components: {
+										link: <a href={ localizeUrl( `${ SUPPORT_URL }#countries` ) } />,
+									},
+								}
+							) }
+						/>
+					}
+					children={ undefined }
+				/>
+			) }
+			{ data && !! data.length && (
+				<StatsModule
+					path="countries"
+					moduleStrings={ moduleStrings }
+					period={ period }
+					query={ period }
+					statType="statsCountryViews"
+					// showSummaryLink={!summary}
+					// hideSummaryLink={!!summary}
+					className={ className }
+				>
+					<Geochart query={ period } />
+				</StatsModule>
+			) }
+		</>
+	);
+};
+
+export default StatCountries;

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -33,8 +33,6 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 	moduleStrings,
 	className,
 } ) => {
-	// eslint-disable-next-line no-console
-	console.log( query, 'new module' ); // This line logs the query prop for testing purposes
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsCountryViews';

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -71,7 +71,8 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 					<></>
 				</StatsCard>
 			) }
-			{ data && !! data.length && (
+			{ /* { data && !! data.length && ( */ }
+			{ data && (
 				<StatsModule
 					path="countries"
 					moduleStrings={ moduleStrings }

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -67,8 +67,7 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 							) }
 						/>
 					}
-					children={ undefined }
-				/>
+				></StatsCard>
 			) }
 			{ data && !! data.length && (
 				<StatsModule

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -77,7 +77,7 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 					moduleStrings={ moduleStrings }
 					period={ period }
 					query={ period }
-					statType="statsCountryViews"
+					statType={ statType }
 					showSummaryLink
 					className={ className }
 				>

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -76,7 +76,7 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 					path="countries"
 					moduleStrings={ moduleStrings }
 					period={ period }
-					query={ period }
+					query={ query }
 					statType={ statType }
 					showSummaryLink
 					className={ className }

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -33,6 +33,8 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 	moduleStrings,
 	className,
 } ) => {
+	// eslint-disable-next-line no-console
+	console.log( query, 'new module' ); // This line logs the query prop for testing purposes
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsCountryViews';

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -56,11 +56,13 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 						<EmptyModuleCard
 							icon={ mapMarker }
 							description={ translate(
-								'Stats on visitors and their {{link}}viewing location{{link}} will appear here to learn from where you are getting visits.',
+								'Stats on visitors and their {{link}}viewing location{{/link}} will appear here to learn from where you are getting visits.',
 								{
+									comment: '{{link}} links to support documentation.',
 									components: {
 										link: <a href={ localizeUrl( `${ SUPPORT_URL }#countries` ) } />,
 									},
+									context: 'Stats: Info box label when the Countries module is empty',
 								}
 							) }
 						/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -44,6 +44,7 @@ import { getModuleSettings } from 'calypso/state/stats/module-settings/selectors
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import StatsModuleCountries from './features/modules/stats-countries';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
 import HighlightsSection from './highlights-section';
 import MiniCarousel from './mini-carousel';
@@ -430,13 +431,24 @@ class StatsSite extends Component {
 							) }
 						/>
 
-						<Countries
-							path="countries"
-							period={ this.props.period }
-							query={ query }
-							summary={ false }
-							className={ clsx( 'stats__flexible-grid-item--full' ) }
-						/>
+						{ ! isNewStateEnabled && (
+							<Countries
+								path="countries"
+								period={ this.props.period }
+								query={ query }
+								summary={ false }
+								className={ clsx( 'stats__flexible-grid-item--full' ) }
+							/>
+						) }
+						{ isNewStateEnabled && (
+							<StatsModuleCountries
+								moduleStrings={ moduleStrings.countries }
+								period={ this.props.period }
+								query={ query }
+								summary={ false }
+								className={ clsx( 'stats__flexible-grid-item--full' ) }
+							/>
+						) }
 
 						{ /* If UTM if supported display the module or update Jetpack plugin card */ }
 						{ supportsUTMStats && ! isOldJetpack && (

--- a/client/my-sites/stats/stats-countries/index.jsx
+++ b/client/my-sites/stats/stats-countries/index.jsx
@@ -21,8 +21,6 @@ class StatCountries extends Component {
 
 	render() {
 		const { summary, query, period, listItemClassName, className } = this.props;
-		// eslint-disable-next-line no-console
-		console.log( query, 'old module' ); // This line logs the query prop for testing purposes
 		const moduleStrings = statsStrings();
 
 		return (

--- a/client/my-sites/stats/stats-countries/index.jsx
+++ b/client/my-sites/stats/stats-countries/index.jsx
@@ -7,6 +7,8 @@ import statsStrings from '../stats-strings';
 
 import './style.scss';
 
+// TODO: to delete if/when cleaning feature flag stats/empty-module-traffic
+
 class StatCountries extends Component {
 	static propTypes = {
 		summary: PropTypes.bool,

--- a/client/my-sites/stats/stats-countries/index.jsx
+++ b/client/my-sites/stats/stats-countries/index.jsx
@@ -21,6 +21,8 @@ class StatCountries extends Component {
 
 	render() {
 		const { summary, query, period, listItemClassName, className } = this.props;
+		// eslint-disable-next-line no-console
+		console.log( query, 'old module' ); // This line logs the query prop for testing purposes
 		const moduleStrings = statsStrings();
 
 		return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#71](https://github.com/Automattic/red-team/issues/71)

## Proposed Changes

* adds a new empty state for Countries


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply `stats/empty-module-traffic` feature flag
* verify that a page with empty Locations/Country views component works with and without the feature flag
* repeat for blogs with data

![image](https://github.com/Automattic/wp-calypso/assets/30754158/22f5fe6e-42fb-497e-b63a-1b309a94d7ca)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
