### PR TITLE
Reader full post shortkeys - swap shortkeys for next and previous

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -199,14 +199,14 @@ export class FullPostView extends Component {
 				return this.handleLike();
 			}
 
-			// Previous post - j
+			// Next post - j
 			case 74: {
-				return this.goToPreviousPost();
+				return this.goToNextPost();
 			}
 
-			// Next post - k
+			// Previous post - k
 			case 75: {
-				return this.goToNextPost();
+				return this.goToPreviousPost();
 			}
 		}
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Odd functionality i ran into when working in the reader.

## Proposed Changes

* Swaps "j" and "k" shortcuts for viewing next and previous items in the full post reader. This makes it consistent with the shortkeys from the reader stream, before this change these shortkeys do opposite actions between the stream and the full post page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is inconsistent. When viewing a stream, "j" selects the next item and "k" the previous. But once in full post this is backwards. Lets make this consistent...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit reader full post
* Verify j/k shortkeys work and move in the same direction that would happen when using them in the stream.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
