### PR TITLE
RTS: Support custom fonts

### DIFF
--- a/client/landing/stepper/declarative-flow/readymade-template.tsx
+++ b/client/landing/stepper/declarative-flow/readymade-template.tsx
@@ -3,6 +3,7 @@ import { getAssemblerDesign } from '@automattic/design-picker';
 import { READYMADE_TEMPLATE_FLOW } from '@automattic/onboarding';
 import { useQuery } from '@tanstack/react-query';
 import { useDispatch, useSelect } from '@wordpress/data';
+import deepmerge from 'deepmerge';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import useUrlQueryParam from 'calypso/a8c-for-agencies/hooks/use-url-query-param';
@@ -337,16 +338,17 @@ function useReadymadeTemplate( templateId: number, options: object = { enabled: 
 		return null;
 	}
 
-	readymadeTemplate.globalStyles = {};
-
-	if ( readymadeTemplate.style_variation ) {
+	const styleVariations = [];
+	Object.values( readymadeTemplate.styles ?? [] ).forEach( ( readymadeTemplateStyleVariation ) => {
 		const styleVariation = assemblerTheme.style_variations.find(
-			( sv ) => sv.title === readymadeTemplate.style_variation
+			( assemblerStyleVariation ) =>
+				assemblerStyleVariation.title === readymadeTemplateStyleVariation
 		);
 		if ( styleVariation ) {
-			readymadeTemplate.globalStyles = styleVariation;
+			styleVariations.push( styleVariation );
 		}
-	}
+	} );
+	readymadeTemplate.globalStyles = deepmerge.all( styleVariations );
 
 	return readymadeTemplate;
 }

--- a/client/landing/stepper/declarative-flow/readymade-template.tsx
+++ b/client/landing/stepper/declarative-flow/readymade-template.tsx
@@ -338,7 +338,7 @@ function useReadymadeTemplate( templateId: number, options: object = { enabled: 
 		return null;
 	}
 
-	const styleVariations = [];
+	const styleVariations = [] as GlobalStylesObject[];
 	Object.values( readymadeTemplate.styles ?? [] ).forEach( ( readymadeTemplateStyleVariation ) => {
 		const styleVariation = assemblerTheme.style_variations.find(
 			( assemblerStyleVariation ) =>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7976

## Proposed Changes

Updates the RT onboarding flow to apply both color and font variations from the Assembler theme

Before | After
--- | ---
<img width="1348" alt="Screenshot 2024-06-27 at 17 45 53" src="https://github.com/Automattic/wp-calypso/assets/1233880/e2e1f89a-6367-42c6-85cc-fdd6182d4f3c"> | <img width="1392" alt="Screenshot 2024-06-27 at 17 50 28" src="https://github.com/Automattic/wp-calypso/assets/1233880/a9c68d5b-5b58-4e7c-898e-501673061eaa">

## Why are these changes being made?

Because we want RTs to support custom fonts

## Testing Instructions

- Apply D153641-code
- Sandbox the API
- Use the Calypso live link below
- Go to `/patterns`
- Select a RT with custom fonts (e.g. Citizen or NeonFit)
- Click on the "Pick this layout" button
- Once you land in the site editor, make sure the custom font has been used

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?