### PR TITLE
Reader full post excerpt - update fade-out for new background color

### DIFF
--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -33,7 +33,7 @@
 			right: 0;
 			width: 50%;
 			height: 24px;
-			background: linear-gradient(to right, rgba(var(--color-neutral-0-rgb), 0), var(--color-neutral-0) 50%);
+			background: linear-gradient(to right, rgba(var(--studio-white-rgb), 0), var(--studio-white) 50%);
 
 			@include breakpoint-deprecated( "<480px" ) {
 				height: 22px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Updates the fade out for post excerpts to use the updated white background color.

BEFORE
<img width="322" alt="Screenshot 2024-06-27 at 11 40 05 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/91406f70-2580-4822-8bc4-a67e46cf50b1">


AFTER

<img width="417" alt="Screenshot 2024-06-27 at 11 39 59 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/f400a040-74b1-4834-8975-c51b78272fba">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Looks kind of broken fading into the old background color, we dont want to see that boxy gray nonsense.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View a post excerpt in the reader, ex `*/read/feeds/94290539/posts/5280460775`
* verify the fade-out at the end of the excerpt blends into the background instead of having a gray box.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
