### PR TITLE
Frictionless Email Subscriptions: Enable email subscription flow in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -172,7 +172,7 @@
 		"signup/professional-email-step": false,
 		"signup/social": true,
 		"signup/social-first": true,
-		"signup/email-subscription-flow": false,
+		"signup/email-subscription-flow": true,
 		"site-indicator": true,
 		"site-profiler/metrics": false,
 		"ssr/prefetch-timebox": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3098

## Proposed Changes

* The email subscription flow has been hidden so far by a feature flag.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We will now show the email subscription flow in staging to provide access to it for those that don't have a development environment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/start/email-subscription/subscribe?user_email=test1016@gmail.com&redirect_to=wordpress.com%2Flearn&mailing_list=learn` in the WordPress staging environment
* Instead of being redirected to `/start/domains`, you should land on the email subscription flow and then be redirected to wordpress.com/learn

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
