### PR TITLE
Assembler: Increase device switcher computer viewport width to match the thumbnail preview

### DIFF
--- a/packages/components/src/device-switcher/fixed-viewport.tsx
+++ b/packages/components/src/device-switcher/fixed-viewport.tsx
@@ -2,7 +2,7 @@ import { CSSProperties } from 'react';
 import { DEVICE_TYPES } from './constants';
 
 // Device viewport width in pixels
-const DEVICE_COMPUTER_WIDTH = 1080;
+const DEVICE_COMPUTER_WIDTH = 1220;
 const DEVICE_TABLET_WIDTH = 782;
 const DEVICE_PHONE_WIDTH = 480;
 


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85820 https://github.com/Automattic/wp-calypso/pull/86900

## Proposed Changes

* Increase the device switcher computer viewport to 1200px (plus padding 20px) to match the viewport of the pattern thumb previews (1200px)

|BEFORE|AFTER|
|-|-|
|<img width="1725" alt="Screenshot 2567-06-27 at 23 30 01" src="https://github.com/Automattic/wp-calypso/assets/1881481/79a1727d-90e8-4e92-87b4-bf858216ce5b">|<img width="1722" alt="Screenshot 2567-06-27 at 23 37 31" src="https://github.com/Automattic/wp-calypso/assets/1881481/138c282b-c306-4caf-9975-f694d81c48de">|


>[!NOTE]
>The PR https://github.com/Automattic/wp-calypso/pull/86900 updated the previews viewport to 1200px, but we didn't notice that the PR https://github.com/Automattic/wp-calypso/pull/85820 limits it to 1080px.
>
>We can safely update the device switcher computer viewport in `FixedViewport` component because only the Assembler uses it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The previews must use the same viewport width to make patterns look identical on both previews (large and thumb). This is important for the font size, which is calculated using the iframe width.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Assembler `/setup/assembler-first`
* Add the same pattern as in the screenshot and verify the heading "Create anything" uses two lines in the large preview. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
