### PR TITLE
Odie: update message request timeout

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
@@ -273,7 +273,10 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 		$body = Client::wpcom_json_api_request_as_user(
 			'/odie/chat/' . $bot_name_slug . '/' . $chat_id,
 			2,
-			array( 'method' => 'POST' ),
+			array(
+				'method'  => 'POST',
+				'timeout' => 30,
+			),
 			array(
 				'message' => $request->get_param( 'message' ),
 				'context' => $request->get_param( 'context' ) ?? array(),


### PR DESCRIPTION
More context here: p1719503132827529-slack-C02T4NVL4JJ

## Proposed Changes

Update the request timeout for `wpcom_json_api_request_as_user` from 10 seconds to 30 seconds.

## Why are these changes being made?

Odie can sometimes take over 10 seconds to receive a response from the server. When this happens the chat returns a 500 error prematurely. This error causes an influx in support requests. If you refresh the page after a failed request the proper response shows up.

By default `wpcom_json_api_request_as_user` sets the request timeout to 10 seconds: https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/class-client.php#L97

Increasing this to 30 allows Odie enough time to respond and alleviates the errors and unnecessary strain on support.

<img width="1020" alt="Markup 2024-06-27 at 19 40 12" src="https://github.com/Automattic/wp-calypso/assets/33258733/46efe648-bae6-42ef-86d7-5cd2dc9a00dd">

## Testing Instructions

1. Download the ETK plugin
2. Add it to an atomic site and go to wp-admin
3. Ask Wapuu a few complicated or verbose questions to push the time it takes to respond.
4. There should be no errors
5. Check the network request to make sure your requests went over 10 seconds.
