### PR TITLE
Fix cart icon alignment in masterbar

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -1393,6 +1393,7 @@
 		.header__sections-list {
 			& ~ .header__jetpack-masterbar-cart {
 				display: flex;
+				align-items: center;
 			}
 		}
 
@@ -1415,7 +1416,8 @@
 			& > .header__jetpack-masterbar-cart {
 				justify-content: flex-end;
 				flex: unset;
-				margin-right: 16px;
+				margin-right: 0.5rem;
+				align-items: center;
 			}
 			.header__home-link {
 				flex: 1;


### PR DESCRIPTION
## Proposed Changes

* Center align cart icon in masterbar

## Why are these changes being made?

Icon was off-center vertically
![image](https://github.com/Automattic/wp-calypso/assets/65001528/5c156879-4aa6-4292-b8df-5b41251089c3)


## Testing Instructions

1. Create a JN site and connect your site
2. Go to `Purchase a Plan` in My Jetpack
![image](https://github.com/Automattic/wp-calypso/assets/65001528/053bda01-79cd-4197-b7cd-4c1a1879e5f6)
3. Replace `cloud.jetpack.com` with the calypso live link domain or `http://jetpack.cloud.localhost:3000` if you're doing this locally
4. Make sure you can see the cart icon and make sure that it is now center aligned
![image](https://github.com/Automattic/wp-calypso/assets/65001528/5520fcb2-d904-44f3-b73b-685ce8b0ba90)
5. Check all screen sizes to make sure the icon looks good
![image](https://github.com/Automattic/wp-calypso/assets/65001528/c4c88af5-be28-4710-a417-a6b3f76d1941)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
