### PR TITLE
Domains: Show more informative message when trying to transfer an unsupported premium domain

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -57,6 +57,8 @@ export function getAvailabilityErrorMessage( { availabilityData, domainName, sel
 		site,
 		maintenanceEndTime,
 		isSiteDomainOnly,
+		cannot_transfer_due_to_unsupported_premium_tld:
+			availabilityData?.cannot_transfer_due_to_unsupported_premium_tld,
 	} );
 	return errorData?.message || null;
 }

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -36,6 +36,7 @@ type DomainLockResponse = {
 	currency_code?: string;
 	tld?: string;
 	is_price_limit_exceeded?: boolean;
+	cannot_transfer_due_to_unsupported_premium_tld?: boolean;
 };
 
 type DomainCodePair = { domain: string; auth: string };
@@ -72,6 +73,8 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 						unlocked: false,
 						transferrability: availability.transferrability,
 						is_price_limit_exceeded: availability?.is_price_limit_exceeded,
+						cannot_transfer_due_to_unsupported_premium_tld:
+							availability?.cannot_transfer_due_to_unsupported_premium_tld,
 					};
 				}
 
@@ -91,6 +94,8 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 					raw_price: availability.raw_price,
 					sale_cost: availability.sale_cost,
 					currency_code: availability.currency_code,
+					cannot_transfer_due_to_unsupported_premium_tld:
+						availability?.cannot_transfer_due_to_unsupported_premium_tld,
 				};
 			} catch ( error ) {
 				return {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -178,7 +178,7 @@ function getAvailabilityNotice(
 		case domainAvailability.MAPPED_SAME_SITE_NOT_TRANSFERRABLE:
 			if ( errorData?.cannot_transfer_due_to_unsupported_premium_tld ) {
 				message = translate(
-					"{{strong}}%(domain)s{{/strong}} is already connected to this site and cannot be transferred to WordPress.com because we don't support premium domain transfers for the %(tld)s TLD. {{a}}Learn more{{/a}}.",
+					'{{strong}}%(domain)s{{/strong}} is already connected to this site and cannot be transferred to WordPress.com because premium domain transfers for the %(tld)s TLD are not supported. {{a}}Learn more{{/a}}.',
 					{
 						args: {
 							domain,
@@ -334,7 +334,7 @@ function getAvailabilityNotice(
 			if ( isForTransferOnly ) {
 				if ( errorData?.cannot_transfer_due_to_unsupported_premium_tld ) {
 					message = translate(
-						"This domain cannot be transferred to WordPress.com because it's premium and currently we don't support premium transfers for the %(tld)s TLD. It can be connected instead. {{a}}Learn More.{{/a}}",
+						'Premium domains ending with %(tld)s cannot be transferred to WordPress.com. Please connect your domain instead. {{a}}Learn more.{{/a}}',
 						{
 							args: {
 								tld,
@@ -354,7 +354,7 @@ function getAvailabilityNotice(
 				}
 
 				message = translate(
-					'This domain cannot be transferred to WordPress.com but it can be connected instead. {{a}}Learn More.{{/a}}',
+					'This domain cannot be transferred to WordPress.com but it can be connected instead. {{a}}Learn more.{{/a}}',
 					{
 						components: {
 							a: (

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -308,6 +308,28 @@ function getAvailabilityNotice(
 
 		case domainAvailability.MAPPABLE:
 			if ( isForTransferOnly ) {
+
+				if ( errorData?.cannot_transfer_due_to_unsupported_premium_tld ) {
+					message = translate(
+						"This domain cannot be transferred to WordPress.com because it's premium and currently we don't support premium transfers for the %(tld)s TLD. It can be connected instead. {{a}}Learn More.{{/a}}",
+						{
+							args: {
+								tld,
+							},
+							components: {
+								a: (
+									<a
+										target={ linksTarget }
+										rel="noopener noreferrer"
+										href={ localizeUrl( MAP_EXISTING_DOMAIN ) }
+									/>
+								),
+							},
+						}
+					);
+					break;
+				}
+
 				message = translate(
 					'This domain cannot be transferred to WordPress.com but it can be connected instead. {{a}}Learn More.{{/a}}',
 					{

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -7,6 +7,7 @@ import {
 	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
 	INCOMING_DOMAIN_TRANSFER_SUPPORTED_TLDS,
 	MAP_EXISTING_DOMAIN,
+	PREMIUM_DOMAINS,
 } from '@automattic/urls';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
@@ -175,6 +176,29 @@ function getAvailabilityNotice(
 				break;
 			}
 		case domainAvailability.MAPPED_SAME_SITE_NOT_TRANSFERRABLE:
+			if ( errorData?.cannot_transfer_due_to_unsupported_premium_tld ) {
+				message = translate(
+					"{{strong}}%(domain)s{{/strong}} is already connected to this site and cannot be transferred to WordPress.com because we don't support premium domain transfers for the %(tld)s TLD. {{a}}Learn more{{/a}}.",
+					{
+						args: {
+							domain,
+							tld,
+						},
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									target={ linksTarget }
+									rel="noopener noreferrer"
+									href={ localizeUrl( PREMIUM_DOMAINS ) }
+								/>
+							),
+						},
+					}
+				);
+				break;
+			}
+
 			message = translate(
 				'{{strong}}%(domain)s{{/strong}} is already connected to this site and cannot be transferred to WordPress.com. {{a}}Learn more{{/a}}.',
 				{

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -308,7 +308,6 @@ function getAvailabilityNotice(
 
 		case domainAvailability.MAPPABLE:
 			if ( isForTransferOnly ) {
-
 				if ( errorData?.cannot_transfer_due_to_unsupported_premium_tld ) {
 					message = translate(
 						"This domain cannot be transferred to WordPress.com because it's premium and currently we don't support premium transfers for the %(tld)s TLD. It can be connected instead. {{a}}Learn More.{{/a}}",

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -53,6 +53,7 @@ export const MAP_EXISTING_DOMAIN_UPDATE_A_RECORDS = `${ root }/domains/connect-a
 export const MAP_SUBDOMAIN = `${ root }/domains/connect-subdomain/`;
 export const MAP_SUBDOMAIN_WITH_CNAME_RECORDS = `${ root }/domains/connect-subdomain/#adding-cname-records-with-your-registrar`;
 export const MAP_DOMAIN_CHANGE_NAME_SERVERS = `${ root }/domains/connect-existing-domain/#step-2-change-your-domains-name-servers`;
+export const PREMIUM_DOMAINS = `${ root }/domains/premium-domains/`;
 export const PRIVACY_PROTECTION = `${ root }/domains/domain-registrations-and-privacy/#privacy-protection`;
 export const PUBLIC_VS_PRIVATE = `${ root }/domains/register-domain/#public-versus-private-registration-and-gdpr`;
 export const REFUNDS = `${ root }/refunds/`;


### PR DESCRIPTION
## Proposed Changes

This PR show a more informative message when trying to transfer a premium domain for a TLD that we don't support premiums yet, e.g. `.biz`.

This PR depends on D153680-code.

### Screenshots

| Before | After |
| --- | --- |
| ![Screenshot 2024-06-27 at 16 03 42](https://github.com/Automattic/wp-calypso/assets/5324818/6c4b74f8-3c10-4ad1-80dd-c7e44993ca7f) | ![Screenshot 2024-07-04 at 18 00 26](https://github.com/Automattic/wp-calypso/assets/5324818/80ad6307-d77f-4347-ba40-24a42bd522ad) |
| ![Markup on 2024-07-04 at 18:02:38](https://github.com/Automattic/wp-calypso/assets/5324818/2da36e3f-455d-4dde-9e13-f10c2e79984b) | ![Markup on 2024-07-04 at 18:05:26](https://github.com/Automattic/wp-calypso/assets/5324818/8e9b3751-74ae-4a0b-a15e-d2d84e97a5f1) |

## Why are these changes being made?

As reported in p1709819940847739-slack-C0761SX4K, this is confusing for users that try to transfer premium domains to us and we support the domain's TLD, we just don't support premiums for that TLD.

## Testing Instructions

- Sandbox the public API
- Apply D153680-code to your sandbox
- Go to `/setup/domain-transfer/`
- Test inputting `brainy.biz` and any auth code
- Ensure the new error message is shown

Testing the "Use a domain I own" flow is trickier because you need to have a premium domain connected with one of your sites, but you can hack your backend to simulate that scenario.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?