### PR TITLE
Overview: Add storage information for Agency Managed sites

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -244,24 +244,26 @@ const PlanCard: FC = () => {
 							</div>
 						) }
 						{ ! isAgencyPurchase && <PricingSection /> }
-						<PlanStorage
-							className="hosting-overview__plan-storage"
-							hideWhenNoStorage
-							siteId={ site?.ID }
-							StorageBarComponent={ PlanStorageBar }
-						>
-							{ storageAddons.length > 0 && ! isAgencyPurchase && (
-								<div className="hosting-overview__plan-storage-footer">
-									<Button
-										className="hosting-overview__link-button"
-										plain
-										href={ `/add-ons/${ site?.slug }` }
-									>
-										{ translate( 'Need more storage?' ) }
-									</Button>
-								</div>
-							) }
-						</PlanStorage>
+						{ ! isLoading && (
+							<PlanStorage
+								className="hosting-overview__plan-storage"
+								hideWhenNoStorage
+								siteId={ site?.ID }
+								StorageBarComponent={ PlanStorageBar }
+							>
+								{ storageAddons.length > 0 && ! isAgencyPurchase && (
+									<div className="hosting-overview__plan-storage-footer">
+										<Button
+											className="hosting-overview__link-button"
+											plain
+											href={ `/add-ons/${ site?.slug }` }
+										>
+											{ translate( 'Need more storage?' ) }
+										</Button>
+									</div>
+								) }
+							</PlanStorage>
+						) }
 					</>
 				) }
 			</HostingCard>

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -224,16 +224,33 @@ const PlanCard: FC = () => {
 						</>
 					) }
 				</div>
-				{ ! isStaging && ! isAgencyPurchase && (
+				{ ! isStaging && (
 					<>
-						<PricingSection />
+						{ isAgencyPurchase && (
+							<div className="hosting-overview__plan-agency-purchase">
+								<p>
+									{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
+										components: {
+											a: isA4A ? (
+												<a
+													href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
+												></a>
+											) : (
+												<strong></strong>
+											),
+										},
+									} ) }
+								</p>
+							</div>
+						) }
+						{ ! isAgencyPurchase && <PricingSection /> }
 						<PlanStorage
 							className="hosting-overview__plan-storage"
 							hideWhenNoStorage
 							siteId={ site?.ID }
 							StorageBarComponent={ PlanStorageBar }
 						>
-							{ storageAddons.length > 0 && (
+							{ storageAddons.length > 0 && ! isAgencyPurchase && (
 								<div className="hosting-overview__plan-storage-footer">
 									<Button
 										className="hosting-overview__link-button"
@@ -246,23 +263,6 @@ const PlanCard: FC = () => {
 							) }
 						</PlanStorage>
 					</>
-				) }
-				{ isAgencyPurchase && (
-					<div className="hosting-overview__plan-agency-purchase">
-						<p>
-							{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
-								components: {
-									a: isA4A ? (
-										<a
-											href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
-										></a>
-									) : (
-										<strong></strong>
-									),
-								},
-							} ) }
-						</p>
-					</div>
 				) }
 			</HostingCard>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7988

## Proposed Changes

* Adds storage information to Agency Managed sites overview page
* Hides the `Need more storage` link


Link to overview: https://container-serene-ishizaka.calypso.live/overview/agiledevotedly.wpcomstaging.com
|Before | After|
|------------|------------|
|<img width="1325" alt="CleanShot 2024-06-27 at 17 27 39@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/dd8e3719-6894-43ce-9a7b-a6129645d386">|<img width="1325" alt="CleanShot 2024-06-27 at 17 22 02@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/2367b0ae-9677-49ea-bc2b-bee5464dddd3">|



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ensure users can see storage information on the overview page for their agency-managed sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch (`yarn start`) or use live link (`Calypso Live`).
* Login with `A4A Shared Demo` WordPress account ( Retrieve credentials from secret store ) 
* Navigate to `/overview` to see all your sites or `/overview/{SITE_SLUG}` to see the overview for a specific site.
* Compare the overview page for non-agency managed pages with production to ensure the behavior hasn't changed.
* Verify the overview page for agency managed pages includes site storage information and the `Need more storage` link is not visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
