### PR TITLE
Stats: Add stats/restricted-dashboard feature flag

### DIFF
--- a/config/client.json
+++ b/config/client.json
@@ -23,6 +23,7 @@
 	"siftscience_key",
 	"signup_url",
 	"stats/empty-module-traffic",
+	"stats/restricted-dashboard",
 	"stats/tier-upgrade-slider",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",

--- a/config/development.json
+++ b/config/development.json
@@ -214,6 +214,7 @@
 		"ssr/prefetch-timebox": false,
 		"stats/empty-module-traffic": true,
 		"stats/paid-wpcom-v2": true,
+		"stats/restricted-dashboard": true,
 		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -140,6 +140,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": false,
 		"stats/paid-wpcom-v2": true,
+		"stats/restricted-dashboard": false,
 		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -184,6 +184,7 @@
 		"ssr/sample-log-cache-misses": true,
 		"stats/empty-module-traffic": false,
 		"stats/paid-wpcom-v2": true,
+		"stats/restricted-dashboard": false,
 		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -178,6 +178,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": false,
 		"stats/paid-wpcom-v2": true,
+		"stats/restricted-dashboard": false,
 		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/test.json
+++ b/config/test.json
@@ -118,6 +118,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": false,
+		"stats/restricted-dashboard": false,
 		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -175,6 +175,7 @@
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
 		"stats/paid-wpcom-v2": true,
+		"stats/restricted-dashboard": false,
 		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/73

## Proposed Changes

Adds the `stats/restricted-dashboard` feature flag to the environment. Currently only enabled in "development" configuration.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

First step to opening up the Stats paywall.

pejTkB-1t3-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No front end changes to test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?