### PR TITLE
A4A > Partner Directory: Fix brand meta data

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -28,10 +28,6 @@ export default function NoticeSummary( { type }: Props ) {
 		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_client_terms_click' ) );
 	}, [ dispatch ] );
 
-	const handleAgencyTermsClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_agency_terms_click' ) );
-	}, [ dispatch ] );
-
 	const handleSubscriptionInfoLinkClick = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_client_checkout_subscription_info_link_click' ) );
 	}, [ dispatch ] );
@@ -113,7 +109,6 @@ export default function NoticeSummary( { type }: Props ) {
 				return [];
 		}
 	}, [
-		handleAgencyTermsClick,
 		handleCancellationInfoLinkClick,
 		handleClientTermsClick,
 		handleSubscriptionInfoLinkClick,

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -1,4 +1,3 @@
-import page from '@automattic/calypso-router';
 import { BadgeType, Button } from '@automattic/components';
 import { Icon, external, check } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -107,7 +106,7 @@ const PartnerDirectoryDashboard = () => {
 				} )
 			);
 		},
-		[ page, reduxDispatch, translate ]
+		[ translate ]
 	);
 
 	const { onSubmit: submitPublishProfile, isSubmitting: isSubmittingPublishProfile } =
@@ -209,7 +208,7 @@ const PartnerDirectoryDashboard = () => {
 		}
 		// Initial application status: no application has been submitted
 		return 0;
-	}, [ isValidFormData, isCompleted, applicationWasSubmitted ] );
+	}, [ isCompleted, hasDirectoryApproval, isValidFormData, applicationWasSubmitted ] );
 
 	// todo: to remove this when we have the links.
 	const displayProgramLinks = false;
@@ -264,13 +263,18 @@ const PartnerDirectoryDashboard = () => {
 								icon={ brandMeta.icon }
 								heading={ brand }
 								description={
-									// FIXME: Add links to all the buttons
 									key === 'approved' ? (
 										<>
-											<Button className="a8c-blue-link" borderless href={ brandMeta.url }>
+											<Button
+												className="a8c-blue-link"
+												borderless
+												href={ brandMeta.url }
+												target="_blank"
+											>
 												{ translate( '%(brand)s Partner Directory', {
 													args: { brand },
 												} ) }
+												<Icon icon={ external } size={ 18 } />
 											</Button>
 											<br />
 											<Button

--- a/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
@@ -7,7 +7,7 @@ export const getBrandMeta = ( brand: string ) => {
 	let url = '';
 
 	switch ( brand ) {
-		case 'WordPress':
+		case 'WordPress.com':
 		case 'WordPress VIP':
 			icon = <WordPressLogo />;
 			url = 'https://wordpress.com/';
@@ -17,11 +17,11 @@ export const getBrandMeta = ( brand: string ) => {
 			className = 'partner-directory-dashboard__woo-icon';
 			url = 'https://woocommerce.com/';
 			break;
-		case 'Pressable':
+		case 'Pressable.com':
 			icon = <img src={ pressableIcon } alt="" />;
 			url = 'https://pressable.com/';
 			break;
-		case 'Jetpack':
+		case 'Jetpack.com':
 			icon = <JetpackLogo />;
 			url = 'https://jetpack.com/';
 			break;


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/734

## Proposed Changes

This PR:

- Fixes the issue with the brand icon not being displayed & brand URL not being set correctly.
- Adds an external icon to the brand URL since it is an external link. CC: @keoshi 
- Removes some unused code and fixes dependency arrays in a few functions

## Testing Instructions

1. Open the A4A live link.
2. Go to Partner Directory - Dashboard 
3. Apply for a few directories
4. Approve at least one of them. Use the MC tool for approve it: /agencies/partner-directory.php?mca4a_agency_id={your_agency_id}
5. Publish the profile
6. Verify the UI looks below when in the final success view, and all the links work and open in a new tab. Please note the correct links will be updated later

<img width="746" alt="Screenshot 2024-06-28 at 11 34 44 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/18ee3086-c0ee-4fbd-b76a-5998cd3a8014">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
