### PR TITLE
A4A > Partner Directory: Limit the selection of services to 5 items

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/components/services-selector.tsx
@@ -8,6 +8,8 @@ type Props = {
 	selectedServices: string[];
 };
 
+const MAX_SERVICES = 5;
+
 const ServicesSelector = ( { setServices, selectedServices }: Props ) => {
 	const { availableServices } = useFormSelectors();
 
@@ -40,7 +42,9 @@ const ServicesSelector = ( { setServices, selectedServices }: Props ) => {
 	return (
 		<FormTokenFieldWrapper
 			onChange={ onServiceLabelsSelected }
-			suggestions={ Object.values( availableServices ).sort() }
+			suggestions={
+				selectedServices.length >= MAX_SERVICES ? [] : Object.values( availableServices ).sort()
+			}
 			value={ selectedServicesByLabel }
 		/>
 	);


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/728

## Proposed Changes

This PR limits the selection of services to 5 items.

## Testing Instructions

1. Open the A4A live link.
2. Go /partner-directory/agency-expertise
3. Verify that you can select only five items for `What services do you offer?`

<img width="743" alt="Screenshot 2024-06-28 at 1 40 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8d9a92b5-f186-483c-9fed-4825cdf9492d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
