### PR TITLE
Stats: Small refactor of render paths

### DIFF
--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -74,6 +74,12 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		! isLoading && ! skipPaywallFlow && redirectToPurchase && siteSlug && canUserManageOptions;
 	const shouldRenderContent = ! isLoading && ( canUserViewStats || canUserManageOptions );
 
+	// Handle possible render conditions.
+	// Based on render conditions, loading state takes priority.
+	if ( isLoading ) {
+		return <StatsLoader />;
+	}
+
 	// render purchase flow for Jetpack sites created after February 2024
 	if ( shouldRenderPaywall ) {
 		// We need to ensure we pass the irclick id for impact affiliate tracking if its set.
@@ -100,8 +106,6 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		return null;
 	} else if ( shouldRenderContent ) {
 		return <>{ children }</>;
-	} else if ( isLoading ) {
-		return <StatsLoader />;
 	}
 
 	return null;

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -69,14 +69,13 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		}
 	}, [ dispatch, siteId, isLoadingNotices, purchaseNotPostponed ] );
 
+	// Render conditions (for readability).
+	const shouldRenderPaywall =
+		! isLoading && ! skipPaywallFlow && redirectToPurchase && siteSlug && canUserManageOptions;
+	const shouldRenderContent = ! isLoading && ( canUserViewStats || canUserManageOptions );
+
 	// render purchase flow for Jetpack sites created after February 2024
-	if (
-		! isLoading &&
-		! skipPaywallFlow &&
-		redirectToPurchase &&
-		siteSlug &&
-		canUserManageOptions
-	) {
+	if ( shouldRenderPaywall ) {
 		// We need to ensure we pass the irclick id for impact affiliate tracking if its set.
 		const currentParams = new URLSearchParams( window.location.search );
 		const queryParams = new URLSearchParams();
@@ -99,7 +98,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		);
 
 		return null;
-	} else if ( ! isLoading && ( canUserViewStats || canUserManageOptions ) ) {
+	} else if ( shouldRenderContent ) {
 		return <>{ children }</>;
 	} else if ( isLoading ) {
 		return <StatsLoader />;

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -32,6 +32,9 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
 
+	// TODO: Consolidate permissions checks.
+	// This same code is in LoadStatsPage (which calls this component) so
+	// it might not be necessary here.
 	const canUserManageOptions = useSelector( ( state ) =>
 		canCurrentUser( state, siteId, 'manage_options' )
 	);
@@ -115,6 +118,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 
 	// TODO: Render a proper error message.
 	// Should indicate user does not have permissions to view stats.
+	// See note above regarding permissions.
 	return null;
 };
 

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -80,7 +80,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		return <StatsLoader />;
 	}
 
-	// render purchase flow for Jetpack sites created after February 2024
+	// Paywall is dependant on site age, type, & plan as well as user permissions.
 	if ( shouldRenderPaywall ) {
 		// We need to ensure we pass the irclick id for impact affiliate tracking if its set.
 		const currentParams = new URLSearchParams( window.location.search );
@@ -104,10 +104,17 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		);
 
 		return null;
-	} else if ( shouldRenderContent ) {
+	}
+
+	// Default is to show the user some stats.
+	// There are permissions considerations though, in which case we fall
+	// through and show nothing. Feels broken.
+	if ( shouldRenderContent ) {
 		return <>{ children }</>;
 	}
 
+	// TODO: Render a proper error message.
+	// Should indicate user does not have permissions to view stats.
 	return null;
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/73

## Proposed Changes

Refactors render section by priority. ie: showLoading → showPaywall → showContent. Adds some comments around potentially unhandled case (resulting in an empty page if triggered) and notes how permissions are (mostly?) handled in the caller.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Small refactoring following initial work in linked Issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No visible changes.

Same testing instructions as [here](https://github.com/Automattic/wp-calypso/pull/92200).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
