### PR TITLE
Plans Grid: fix billing timeframe with upgrade credits

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -436,7 +436,11 @@ const ComparisonGridHeaderCell = ( {
 				visibleGridPlans={ visibleGridPlans }
 			/>
 			<div className="plan-comparison-grid__billing-info">
-				<BillingTimeframe planSlug={ planSlug } showRefundPeriod={ showRefundPeriod } />
+				<BillingTimeframe
+					planSlug={ planSlug }
+					showRefundPeriod={ showRefundPeriod }
+					planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
+				/>
 			</div>
 			<PlanFeatures2023GridActions
 				currentSitePlanSlug={ currentSitePlanSlug }

--- a/packages/plans-grid-next/src/components/features-grid/billing-timeframes.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/billing-timeframes.tsx
@@ -9,12 +9,14 @@ type BillingTimeframesProps = {
 	options?: {
 		isTableCell?: boolean;
 	};
+	planUpgradeCreditsApplicable?: number | null;
 };
 
 const BillingTimeframes = ( {
 	options,
 	renderedGridPlans,
 	showRefundPeriod,
+	planUpgradeCreditsApplicable,
 }: BillingTimeframesProps ) => {
 	return renderedGridPlans.map( ( { planSlug } ) => {
 		const classes = clsx(
@@ -28,7 +30,11 @@ const BillingTimeframes = ( {
 				isTableCell={ options?.isTableCell }
 				key={ planSlug }
 			>
-				<BillingTimeframe planSlug={ planSlug } showRefundPeriod={ showRefundPeriod } />
+				<BillingTimeframe
+					planSlug={ planSlug }
+					showRefundPeriod={ showRefundPeriod }
+					planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
+				/>
 			</PlanDivOrTdContainer>
 		);
 	} );

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -111,7 +111,12 @@ const MobileView = ( {
 							currentSitePlanSlug={ currentSitePlanSlug }
 						/>
 					) }
-					{ isNotFreePlan && <BillingTimeframes renderedGridPlans={ [ gridPlan ] } /> }
+					{ isNotFreePlan && (
+						<BillingTimeframes
+							renderedGridPlans={ [ gridPlan ] }
+							planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
+						/>
+					) }
 					<MobileFreeDomain gridPlan={ gridPlan } paidDomainName={ paidDomainName } />
 					{ storageFeatureGroup && (
 						<>

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -59,7 +59,12 @@ const SpotlightPlan = ( {
 					currentSitePlanSlug={ currentSitePlanSlug }
 				/>
 			) }
-			{ isNotFreePlan && <BillingTimeframes renderedGridPlans={ [ gridPlanForSpotlight ] } /> }
+			{ isNotFreePlan && (
+				<BillingTimeframes
+					renderedGridPlans={ [ gridPlanForSpotlight ] }
+					planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
+				/>
+			) }
 			<PlanFeaturesList
 				renderedGridPlans={ [ gridPlanForSpotlight ] }
 				featureGroupSlug={ FEATURE_GROUP_STORAGE }

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -119,6 +119,7 @@ const Table = ( {
 						renderedGridPlans={ gridPlansWithoutSpotlight }
 						showRefundPeriod={ showRefundPeriod }
 						options={ { isTableCell: true } }
+						planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 					/>
 				</tr>
 				<StickyContainer

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -48,9 +48,14 @@ const RefundNotice = ( { planSlug, showRefundPeriod, billingPeriod }: RefundNoti
 interface Props {
 	planSlug: PlanSlug;
 	showRefundPeriod?: boolean;
+	planUpgradeCreditsApplicable?: number | null;
 }
 
-const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
+const BillingTimeframe = ( {
+	showRefundPeriod,
+	planSlug,
+	planUpgradeCreditsApplicable,
+}: Props ) => {
 	const translate = useTranslate();
 	const { helpers, gridPlansIndex, coupon, siteId } = usePlansGridContext();
 	const { isMonthlyPlan, billingTimeframe, pricing } = gridPlansIndex[ planSlug ];
@@ -64,6 +69,7 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 		isMonthlyPlan,
 		storageAddOnsForPlan: storageAddOns,
 		coupon,
+		planUpgradeCreditsApplicable,
 		useCheckPlanAvailabilityForPurchase: helpers?.useCheckPlanAvailabilityForPurchase,
 	} );
 	const description = planBillingDescription || billingTimeframe;

--- a/packages/plans-grid-next/src/components/test/billing-timeframe.tsx
+++ b/packages/plans-grid-next/src/components/test/billing-timeframe.tsx
@@ -173,6 +173,40 @@ describe( 'BillingTimeframe', () => {
 		);
 	} );
 
+	test( 'should show original price when plan is annual and upgrade credits are available', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: 60, monthly: 5 },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_BUSINESS ]: {
+					isMonthlyPlan: false,
+					pricing,
+				},
+			},
+		} ) );
+
+		const { container } = render(
+			<BillingTimeframe
+				{ ...defaultProps }
+				planSlug={ PLAN_BUSINESS }
+				planUpgradeCreditsApplicable={ 100 }
+			/>
+		);
+
+		const originalPrice = formatCurrency( pricing.originalPrice.full, 'USD', {
+			stripZeros: true,
+			isSmallestUnit: true,
+		} );
+		expect( container ).toHaveTextContent(
+			`per month, ${ originalPrice } billed annually, excl. taxes`
+		);
+	} );
+
 	test( 'should show full-term price when plan is yearly', () => {
 		const pricing = {
 			currencyCode: 'USD',

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -21,6 +21,7 @@ interface UsePlanBillingDescriptionProps {
 	isMonthlyPlan?: boolean;
 	storageAddOnsForPlan: ( AddOns.AddOnMeta | null )[] | null;
 	coupon?: string;
+	planUpgradeCreditsApplicable?: number | null;
 	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase;
 }
 
@@ -31,6 +32,7 @@ export default function usePlanBillingDescription( {
 	storageAddOnsForPlan,
 	isMonthlyPlan,
 	coupon,
+	planUpgradeCreditsApplicable,
 	useCheckPlanAvailabilityForPurchase,
 }: UsePlanBillingDescriptionProps ) {
 	const translate = useTranslate();
@@ -207,7 +209,11 @@ export default function usePlanBillingDescription( {
 		return null;
 	}
 
-	if ( discountedPriceFullTermText ) {
+	/**
+	 * If this discount is related to a `Plan upgrade credit`
+	 * then we do not show any discount messaging as per Automattic/martech#1927
+	 */
+	if ( discountedPriceFullTermText && ! planUpgradeCreditsApplicable ) {
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 			return translate(
 				'per month, %(fullTermDiscountedPriceText)s for the first year, excl. taxes',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbOQVh-4Wn-p2

## Proposed Changes

* When upgrade credits are available, discounted pricing should not be shown on the pricing grid. We fixed this for the `< PlanFeatures2023GridHeaderPrice />` component via #86860, but the same logic was not applied for the billing timeframe.
* In this PR, we add this check to the `usePlanBillingDescription` hook.

**Note**: When working on this PR, I realized that this bit of logic is critical to how plan prices are shown and probably should not be the responsibility of the components that display pricing. Going forward, if we add another way to display prices, the same logic would have to be repeated. IMO, this logic should be centralized and should be a part of the `usePricingMetaForGridPlans` hook. If upgrade credits are available, this hook should always return discounted prices as `null`.
EDIT: A recent manifestation of the issue: https://github.com/Automattic/wp-calypso/issues/92210

We can ship this PR for now as a temporary fix and then iterate on adding this logic to `usePricingMetaForGridPlans` or wherever it is most appropriate.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix for pbOQVh-4Wn-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* **IMP**: Disable the store sandbox if it is enabled. (34e98-pb)
* Switch currency to INR.
* Go to `/plans/<site slug>` for a site on the Creator monthly plan.
* In the interval dropdown, select the yearly option.
* Confirm that the billing timeframe shows the correct price.

| Production | This PR |
|--------|--------|
|<img width="1336" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/03c64a6e-0892-4ce3-a6ad-9eef277adf1f">| <img width="1263" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/565f810e-4757-4726-9b69-e442ede69f77"> | 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?