### PR TITLE
Move store population to site setup without goals flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -35,7 +35,6 @@ import type {
 } from '@automattic/data-stores';
 
 const SiteIntent = Onboard.SiteIntent;
-const { goalsToIntent } = Onboard.utils;
 
 type ExitFlowOptions = {
 	skipLaunchpad?: boolean;
@@ -61,25 +60,6 @@ const siteSetupFlow: Flow = {
 				navigate( 'goals' );
 			}
 		}, [] );
-
-		const { site } = useSiteData();
-		const { setIntent, setGoals } = useDispatch( ONBOARD_STORE );
-
-		const goals = useSelect(
-			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
-			[]
-		);
-
-		useEffect( () => {
-			if ( goals.length ) {
-				return;
-			}
-
-			if ( site?.options?.site_goals?.length ) {
-				setIntent( goalsToIntent( site.options.site_goals ) );
-				setGoals( site.options.site_goals );
-			}
-		}, [ site, setIntent, setGoals, goals ] );
 	},
 
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-wg-flow.ts
@@ -1,5 +1,12 @@
+import { Onboard } from '@automattic/data-stores';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { useSiteData } from '../hooks/use-site-data';
+import { ONBOARD_STORE } from '../stores';
 import { Flow } from './internals/types';
 import siteSetup from './site-setup-flow';
+
+const { goalsToIntent } = Onboard.utils;
 
 /**
  * A variant of site-setup flow without goals step.
@@ -18,6 +25,17 @@ const siteSetupWithoutGoalsFlow: Flow = {
 			delete navigation.goBack;
 		}
 		return navigation;
+	},
+	useSideEffect( currentStep, navigate ) {
+		const { setIntent, setGoals } = useDispatch( ONBOARD_STORE );
+		const { site } = useSiteData();
+
+		useEffect( () => {
+			setIntent( goalsToIntent( site?.options?.site_goals ?? [] ) );
+			setGoals( site?.options?.site_goals ?? [] );
+		}, [ site, setIntent, setGoals ] );
+
+		return siteSetup.useSideEffect?.( currentStep, navigate );
 	},
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Following the initial-setup flow several times, once as a blogger and once as a merchant can lead to issues with how the intents and goals are managed.

**Before**

https://github.com/Automattic/wp-calypso/assets/7000684/13f62fcc-32c1-4f1a-83a7-30069658ac03

**After**

https://github.com/Automattic/wp-calypso/assets/7000684/3b75175c-c1b3-4550-9684-6f39824553a5

This PR moves the code to infer the intent and goals to live only in the `site-setup-wg` flow.

Related to #
https://github.com/Automattic/wp-calypso/pull/91711

## Proposed Changes

* Move code to site setup wg flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions
- Visit `/start` 
-  Select `Creating a site for myself, a business, or a friend` then `Publish a blog`
- Choose free domain and free plan to create your site
- You should end up on the `options` step with header `First, let's give your blog a name`
- Visit `/start` 
-  Select `Creating a site for myself, a business, or a friend` then `Sell something`
- Choose free domain and free plan to create your site
- You should end up on the `options` step with header `First, let's give your store a name`


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
