### PR TITLE
Help Center: Handle lack of sites

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -125,7 +125,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 								initialUserMessage={ searchTerm }
 								logger={ trackEvent }
 								loggerEventNamePrefix="calypso_odie"
-								selectedSiteId={ site.ID as number }
+								selectedSiteId={ site?.ID as number }
 								extraContactOptions={
 									<HelpCenterContactPage
 										hideHeaders

--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -28,7 +28,7 @@ const getEnvironmentHostname = () => {
 export const HelpCenterLaunchpad = () => {
 	const { __ } = useI18n();
 	const { sectionName, site } = useHelpCenterContext();
-	const siteIntent = site.options.site_intent;
+	const siteIntent = site?.options.site_intent;
 	const siteSlug = useSiteSlug();
 
 	const { data } = useLaunchpad( siteSlug, siteIntent );

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -26,7 +26,7 @@ type CoreDataPlaceholder = {
 export const HelpCenterMoreResources = () => {
 	const { __ } = useI18n();
 	const { sectionName, site } = useHelpCenterContext();
-	const { data } = useWhatsNewAnnouncementsQuery( site.ID.toString() );
+	const { data } = useWhatsNewAnnouncementsQuery( site?.ID );
 
 	const showWhatsNewItem = data && data.length > 0;
 
@@ -145,8 +145,8 @@ export const HelpCenterMoreResources = () => {
 					</li>
 				) }
 			</ul>
-			{ showGuide && (
-				<WhatsNewGuide onClose={ () => setShowGuide( false ) } siteId={ site.ID.toString() } />
+			{ showGuide && site && (
+				<WhatsNewGuide onClose={ () => setShowGuide( false ) } siteId={ site.ID } />
 			) }
 		</>
 	);

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -187,7 +187,7 @@ function HelpSearchResults( {
 	const adminResults = useAdminResults( searchQuery );
 
 	const isPurchasesSection = [ 'purchases', 'site-purchases' ].includes( sectionName );
-	const siteIntent = site.options?.site_intent;
+	const siteIntent = site?.options.site_intent;
 	const rawContextualResults = useMemo(
 		() => getContextResults( sectionName || 'gutenberg-editor', siteIntent ?? 'build' ),
 		[ sectionName, siteIntent ]

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -46,7 +46,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 		[ setSubject, setMessage, onSearchChange ]
 	);
 
-	const launchpadEnabled = site.options.launchpad_screen === 'full';
+	const launchpadEnabled = site?.options.launchpad_screen === 'full';
 
 	// Search query can be a query param, if the user searches or clears the search field
 	// we need to keep the query param up-to-date with that

--- a/packages/help-center/src/components/help-center-site-picker.tsx
+++ b/packages/help-center/src/components/help-center-site-picker.tsx
@@ -18,22 +18,25 @@ export const HelpCenterSitePicker: React.FC< SitePicker > = ( {
 		return helpCenterSelect.getUserDeclaredSiteUrl();
 	}, [] );
 
+	// The lack of site slug implies the user has no sites at all.
 	const siteSlug = useSiteSlug();
 
 	return (
 		<>
-			<section>
-				<SelectControl
-					label="Site"
-					options={ [
-						{ label: siteSlug, value: 'current' },
-						{ label: __( 'Another site' ), value: 'another_site' },
-					] }
-					onChange={ ( value ) => {
-						onSelfDeclaredSite( value === 'another_site' );
-					} }
-				></SelectControl>
-			</section>
+			{ siteSlug && (
+				<section>
+					<SelectControl
+						label="Site"
+						options={ [
+							{ label: siteSlug, value: 'current' },
+							{ label: __( 'Another site' ), value: 'another_site' },
+						] }
+						onChange={ ( value ) => {
+							onSelfDeclaredSite( value === 'another_site' );
+						} }
+					></SelectControl>
+				</section>
+			) }
 			{ isSelfDeclaredSite && (
 				<section>
 					<TextControl

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -6,7 +6,8 @@ export type HelpCenterRequiredInformation = {
 	locale: string;
 	sectionName: string;
 	currentUser: CurrentUser;
-	site: HelpCenterSite;
+	// some users have no sites at all.
+	site: HelpCenterSite | null;
 	hasPurchases: false;
 	primarySiteId: number;
 	googleMailServiceFamily: string;
@@ -27,26 +28,7 @@ const HelpCenterRequiredContext = React.createContext< HelpCenterRequiredInforma
 		localeVariant: '',
 		site_count: 0,
 	},
-	site: {
-		ID: 0,
-		URL: '',
-		jetpack: false,
-		is_wpcom_atomic: false,
-		name: '',
-		plan: {
-			product_slug: '',
-		},
-		logo: {
-			id: 0,
-			sizes: [],
-			url: '',
-		},
-		options: {
-			launchpad_screen: '',
-			site_intent: '',
-			admin_url: '',
-		},
-	},
+	site: null,
 	hasPurchases: false,
 	primarySiteId: 0,
 	googleMailServiceFamily: '',

--- a/packages/help-center/src/hooks/use-customizer-url.ts
+++ b/packages/help-center/src/hooks/use-customizer-url.ts
@@ -27,7 +27,7 @@ export function useCustomizerUrls() {
 
 	return panels.reduce(
 		( acc, panel ) => {
-			if ( ! site.jetpack && siteSlug ) {
+			if ( ! site?.jetpack && siteSlug ) {
 				const panelPath = panel === 'root' ? '' : panel;
 				const url = [ '' ]
 					.concat( [ 'customize', panelPath, siteSlug ].filter( Boolean ) )
@@ -36,7 +36,7 @@ export function useCustomizerUrls() {
 					return: returnUrl,
 				} );
 			} else {
-				const customizerUrl = site.options.admin_url + 'customize.php';
+				const customizerUrl = site?.options.admin_url + 'customize.php';
 
 				acc[ panel ] = addQueryArgs( customizerUrl, {
 					return: returnUrl,

--- a/packages/whats-new/src/guide.tsx
+++ b/packages/whats-new/src/guide.tsx
@@ -8,7 +8,7 @@ import './style.scss';
 
 interface Props {
 	onClose: () => void;
-	siteId: string;
+	siteId: string | number;
 }
 
 const WhatsNewGuide: React.FC< Props > = ( { onClose, siteId } ) => {

--- a/packages/whats-new/src/hooks/use-whats-new-announcements-query.ts
+++ b/packages/whats-new/src/hooks/use-whats-new-announcements-query.ts
@@ -25,7 +25,7 @@ interface APIFetchOptions {
  * Get the "whats new" announcements
  * @returns Returns the result of querying the "whats new" list endpoint
  */
-export const useWhatsNewAnnouncementsQuery = ( siteId: string ) => {
+export const useWhatsNewAnnouncementsQuery = ( siteId: string | number | undefined ) => {
 	const locale = useLocale();
 
 	return useQuery< WhatsNewAnnouncement[] >( {
@@ -40,6 +40,7 @@ export const useWhatsNewAnnouncementsQuery = ( siteId: string ) => {
 						global: true,
 						path: `/wpcom/v2/block-editor/whats-new-list?_locale=${ locale }&site_id=${ siteId }`,
 				  } as APIFetchOptions ),
+		enabled: !! siteId,
 		refetchOnWindowFocus: false,
 	} );
 };


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/92204

## Proposed Changes

This allows the Help Center to handle the complete lack of sites.

## Why are these changes being made?
Because some users can reach the Help Center without having any sites.

## Testing Instructions

1. Go to https://wordpress.com/wp-login.php?no_calypso.
2. Login using my empty user `dasdasdksjandkj` and use the SSP.
3. Open the Help Center. It should open.
4. Click "Still need help?".
5. It should take you to the forums contact form, and it should not show the sites' dropdown, only allow you to type it in.

There is no need to test in wp-admin as that's impossible.