### PR TITLE
A4A > Marketplace: Fix the hosting card overlap issues

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -100,22 +100,6 @@ export default function HostingCard( {
 		return translate( 'USD' );
 	}, [ plan.price_interval, translate ] );
 
-	const exploreButtonText = useMemo( () => {
-		return marketplaceType === 'referral'
-			? translate( 'Explore %(hosting)s', {
-					args: {
-						hosting: name,
-					},
-					comment: '%(hosting)s is the name of the hosting provider.',
-			  } )
-			: translate( 'Explore %(hosting)s plans', {
-					args: {
-						hosting: name,
-					},
-					comment: '%(hosting)s is the name of the hosting provider.',
-			  } );
-	}, [ marketplaceType, name, translate ] );
-
 	// Call `setPriceHeight` when the component mounts and when the window is resized,
 	// to keep the height of the card consistent with others.
 	useEffect( () => {
@@ -173,17 +157,15 @@ export default function HostingCard( {
 				onClick={ onExploreClick }
 				primary
 			>
-				{ exploreButtonText }
+				{ translate( 'Explore %(hosting)s', {
+					args: {
+						hosting: name,
+					},
+					comment: '%(hosting)s is the name of the hosting provider.',
+				} ) }
 			</Button>
 		);
-	}, [
-		onExploreClick,
-		onVipDemoClick,
-		plan.family_slug,
-		pressableOwnership,
-		exploreButtonText,
-		translate,
-	] );
+	}, [ name, onExploreClick, onVipDemoClick, plan.family_slug, pressableOwnership, translate ] );
 
 	return (
 		<div className={ clsx( 'hosting-card', className ) }>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -144,7 +144,7 @@ export default function HostingCard( {
 					rel="norefferer nooppener"
 					href={ pressableUrl }
 				>
-					{ translate( 'Manage in your Pressable account' ) }
+					{ translate( 'Manage in Pressable' ) }
 					<Icon icon={ external } size={ 18 } />
 				</Button>
 			);

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -12,6 +12,7 @@
 
 		.button {
 			width: 100%;
+			text-wrap: balance;
 		}
 
 		.woo-logo {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/729

## Proposed Changes

This PR fixes the hosting card overlap issues.

## Testing Instructions

- Open A4A live link
- Visit the Marketplace > Verify the hosting cards don't overlap at 1280px when the agency has a non-A4A pressable license, and the button text is changed to `Manage in Pressable`

<img width="673" alt="Screenshot 2024-07-02 at 9 23 33 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3fc33014-e937-4b20-8182-b45299af92aa">

- When there are no active plans:

<img width="673" alt="Screenshot 2024-07-02 at 9 25 13 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2a933a0c-c8bf-495b-887d-e71582abaea7">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
