### PR TITLE
Plans (Storage): Show total storage volume + additional cost for all plans

### DIFF
--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-dropdown.tsx
@@ -18,7 +18,6 @@ type StorageDropdownProps = {
 };
 
 type StorageDropdownOptionProps = {
-	planSlug: PlanSlug;
 	price?: string;
 	storageSlug: AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug;
 	isLargeCurrency?: boolean;
@@ -35,7 +34,6 @@ const getStorageOptionPrice = (
 };
 
 const StorageDropdownOption = ( {
-	planSlug,
 	price,
 	storageSlug,
 	isLargeCurrency = false,
@@ -43,7 +41,7 @@ const StorageDropdownOption = ( {
 }: StorageDropdownOptionProps ) => {
 	const translate = useTranslate();
 	const { siteId } = usePlansGridContext();
-	const title = useStorageStringFromFeature( { storageSlug, siteId, planSlug } ) ?? '';
+	const title = useStorageStringFromFeature( { storageSlug, siteId } ) ?? '';
 
 	return (
 		<>
@@ -118,7 +116,6 @@ const StorageDropdown = ( {
 			key: slug,
 			name: (
 				<StorageDropdownOption
-					planSlug={ planSlug }
 					price={ getStorageOptionPrice( storageAddOns, slug ) }
 					storageSlug={ slug }
 				/>
@@ -132,7 +129,6 @@ const StorageDropdown = ( {
 		key: selectedStorageOptionForPlan,
 		name: (
 			<StorageDropdownOption
-				planSlug={ planSlug }
 				price={ selectedOptionPrice }
 				storageSlug={ selectedStorageOptionForPlan }
 				isLargeCurrency={ isLargeCurrency }

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../../grid-context';
 import useIsLargeCurrency from '../../../../hooks/use-is-large-currency';
-import { ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE } from '../constants';
 import useStorageStringFromFeature from '../hooks/use-storage-string-from-feature';
 
 interface Props {
@@ -23,7 +22,6 @@ const StorageFeatureLabel = ( { planSlug }: Props ) => {
 	const storageStringFromFeature = useStorageStringFromFeature( {
 		siteId,
 		storageSlug,
-		planSlug,
 	} );
 	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
 	const storageAddOnsPurchased = storageAddOns.filter( ( addOn ) => addOn?.purchased );
@@ -52,7 +50,7 @@ const StorageFeatureLabel = ( { planSlug }: Props ) => {
 		</div>
 	);
 
-	return formattedMonthlyAddedCost && ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE.includes( planSlug ) ? (
+	return formattedMonthlyAddedCost ? (
 		<div className={ containerClasses }>
 			{ volumeJSX }
 			<div className="plans-grid-next-storage-feature-label__offset-price">

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-storage-string-from-feature.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-storage-string-from-feature.ts
@@ -7,21 +7,53 @@ import {
 	FEATURE_P2_3GB_STORAGE,
 	FEATURE_P2_13GB_STORAGE,
 	PRODUCT_1GB_SPACE,
-	PlanSlug,
 	WPComPlanStorageFeatureSlug,
 } from '@automattic/calypso-products';
 import { Purchases, AddOns } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE } from '../constants';
+
+const getIntegerVolume = (
+	storageSlug?: AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug
+) => {
+	switch ( storageSlug ) {
+		case FEATURE_1GB_STORAGE:
+			return 1;
+		case FEATURE_6GB_STORAGE:
+			return 6;
+		case FEATURE_13GB_STORAGE:
+			return 13;
+		case FEATURE_50GB_STORAGE:
+			return 50;
+		case FEATURE_P2_3GB_STORAGE:
+			return 3;
+		case FEATURE_P2_13GB_STORAGE:
+			return 13;
+		// TODO: Remove when upgradeable storage is released in plans 2023
+		case FEATURE_200GB_STORAGE:
+			return 200;
+		case AddOns.ADD_ON_50GB_STORAGE:
+			/**
+			 * Displayed string is: purchased storage + default 50GB storage + Add-On
+			 * TODO: the default 50GB should be coming from plan context, not hardcoded here
+			 */
+			return 100;
+		case AddOns.ADD_ON_100GB_STORAGE:
+			/**
+			 * Displayed string is: purchased storage + default 50GB storage + Add-On
+			 * TODO: the default 50GB should be coming from plan context, not hardcoded here
+			 */
+			return 150;
+		default:
+			return 0;
+	}
+};
 
 const useStorageStringFromFeature = ( {
 	storageSlug,
 	siteId,
-	planSlug,
 }: {
 	storageSlug?: AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug;
 	siteId?: null | number | string;
-	planSlug: PlanSlug;
 } ) => {
 	const translate = useTranslate();
 	const spaceUpgradesPurchased = Purchases.useSitePurchasesByProductSlug( {
@@ -34,54 +66,11 @@ const useStorageStringFromFeature = ( {
 		  }, 0 )
 		: 0;
 
-	switch ( storageSlug ) {
-		case FEATURE_1GB_STORAGE:
-			return translate( '1 GB' );
-		case FEATURE_6GB_STORAGE:
-			return translate( '6 GB' );
-		case FEATURE_13GB_STORAGE:
-			return translate( '13 GB' );
-		case FEATURE_50GB_STORAGE:
-			/**
-			 * TODO: Don't do this here. Diverge and show the version with the green pricing next
-			 */
-			return translate( '%(quantity)d GB', {
-				args: {
-					quantity: ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE.includes( planSlug )
-						? purchasedQuantityTotal + 50
-						: 50,
-				},
-			} );
-		case FEATURE_P2_3GB_STORAGE:
-			return translate( '3 GB' );
-		case FEATURE_P2_13GB_STORAGE:
-			return translate( '13 GB' );
-		// TODO: Remove when upgradeable storage is released in plans 2023
-		case FEATURE_200GB_STORAGE:
-			return translate( '200 GB' );
-		case AddOns.ADD_ON_50GB_STORAGE:
-			/**
-			 * Displayed string is: purchased storage + default 50GB storage + Add-On
-			 * TODO: the default 50GB should be coming from plan context, not hardcoded here
-			 */
-			return translate( '%(quantity)d GB', {
-				args: {
-					quantity: purchasedQuantityTotal + 50 + 50,
-				},
-			} );
-		case AddOns.ADD_ON_100GB_STORAGE:
-			/**
-			 * Displayed string is: purchased storage + default 50GB storage + Add-On
-			 * TODO: the default 50GB should be coming from plan context, not hardcoded here
-			 */
-			return translate( '%(quantity)d GB', {
-				args: {
-					quantity: purchasedQuantityTotal + 50 + 100,
-				},
-			} );
-		default:
-			return null;
-	}
+	return translate( '%(quantity)d GB', {
+		args: {
+			quantity: purchasedQuantityTotal + getIntegerVolume( storageSlug ),
+		},
+	} );
 };
 
 export default useStorageStringFromFeature;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR relaxes the condition of showing the updated storage volume (with the "+ additional cost" string) to apply to all plans. So when user purchases 100GB storage add-on while on Personal plan, the storage viewable in the grid will be of the form `106GB + €76.67/month`. Applies to all the plans. So far we've only showed this for Business & Commerce plans.

Other considerations: Only show the updated volume+price string on the current/spotlight plan (if for whatever reason we feel it might detract users from upgrading if they see the total volume on these other lower-tier plans - see img below). @southp - if you have any thoughts

Props to @oswian for bumping on this while testing https://github.com/Automattic/wp-calypso/pull/92020#pullrequestreview-2146719253

### Media

<img width="617" alt="Screenshot 2024-06-28 at 1 01 18 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/154ec88f-fa27-45d4-bf1a-5df19784e5ac">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Missing functionality from a recent update that feels very much like a bug. Technically a follow-up to https://github.com/Automattic/wp-calypso/pull/91050 where we introduced the updated storage volumes in the grid (to account for purchased volume)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and confirm storage add-ons work as before for Business/Commerce
* Purchase a lower-tier plan like "Personal"
* Confirm that `/plans/[ site ]` does not allow storage selection for the current plan (only for Business/Commerce)
* On `/add-ons/[ site ]` purchase a storage add-on
* Go to `/plans/[ site ]` and confirm the grid and spotlight card show the "volume + additional cost" strings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
