### PR TITLE
Migration plans step: filter out annual features and show correct refund window

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -1,5 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { getPlan, PLAN_BUSINESS, PLAN_BUSINESS_MONTHLY } from '@automattic/calypso-products';
+import {
+	getPlan,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_MONTHLY,
+	isMonthly,
+} from '@automattic/calypso-products';
 import { CloudLogo, Button, PlanPrice } from '@automattic/components';
 import { Title } from '@automattic/onboarding';
 import { Plans2023Tooltip, useManageTooltipToggle } from '@automattic/plans-grid-next';
@@ -99,7 +104,9 @@ export const UpgradePlanDetails = ( props: Props ) => {
 					<div>
 						<div className="import__upgrade-plan-cta">{ children }</div>
 						<div className="import__upgrade-plan-refund-sub-text">
-							{ __( 'Refundable within 14 days. No questions asked.' ) }
+							{ plan && ! isMonthly( plan.getStoreSlug() )
+								? __( 'Refundable within 14 days. No questions asked.' )
+								: __( 'Refundable within 7 days. No questions asked.' ) }
 						</div>
 					</div>
 

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-feature-list.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-feature-list.tsx
@@ -1,4 +1,10 @@
-import { JetpackPlan, Plan, WPComPlan, getFeatureByKey } from '@automattic/calypso-products';
+import {
+	type JetpackPlan,
+	type Plan,
+	type WPComPlan,
+	getFeatureByKey,
+	isMonthly,
+} from '@automattic/calypso-products';
 import { Badge } from '@automattic/components';
 import { Plans2023Tooltip } from '@automattic/plans-grid-next';
 import { chevronDown, Icon } from '@wordpress/icons';
@@ -18,8 +24,14 @@ export const UpgradePlanFeatureList = ( props: Props ) => {
 	const { plan, showFeatures, setShowFeatures } = props;
 	const [ activeTooltipId, setActiveTooltipId ] = useState( '' );
 
+	const isMonthlyPlan = plan ? isMonthly( plan.getStoreSlug() ) : false;
+	const annualOnlyFeatures = ( plan as WPComPlan )?.getAnnualPlansOnlyFeatures?.() || [];
+
 	const wpcomFeatures = plan
 		?.get2023PricingGridSignupWpcomFeatures?.()
+		.filter( ( feature: string ) =>
+			isMonthlyPlan ? ! annualOnlyFeatures.includes( feature ) : true
+		)
 		.map( ( feature: string ) => getFeatureByKey( feature ) )
 		.filter( ( feature ) => feature?.getTitle() );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92210

## Proposed Changes

* This PR addresses two of the issues raised in https://github.com/Automattic/wp-calypso/issues/92210:
  - The refund window is now correctly shown as 7 days for monthly plans and 14 days for annual plans
  - The full feature list is now filtering out annual-only features for the monthly plan

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We were not showing correct information to users, so this PR fixes the issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run these changes locally or via Calypso.live
* For a free site or a site with a Starter or Explorer plan, navigate to _Tools_ > _Import_
* Select the WordPress option on the page
* On the next page, submit the URL for a WordPress site
* On the next step, choose the option to migrate
* On the next step, choose the option to "Do it myself"
* You should land on the plan upgrade step with the annual Creator plan selected/visible
* Verify that the refund window shows as 14 days
* Expand the feature list below the CTA on the left
* Verify that the features include a free domain and 24/7 support
* Click on the toggle to Pay Monthly
* Verify that the refund window is now shown as 7 days
* Verify that the feature list is shorter, and no longer lists a free domain or 24/7 support as included features

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
