### PR TITLE
Migration Instructions: Add hosting badge

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/index.tsx
@@ -1,0 +1,17 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC } from 'react';
+import './style.scss';
+
+interface HostingBadgeProps {
+	hostingName: string;
+}
+
+export const HostingBadge: FC< HostingBadgeProps > = ( { hostingName } ) => {
+	const translate = useTranslate();
+
+	return (
+		<span className="migration-instructions-hosting-badge">
+			{ translate( 'Hosted with %(hostingName)s', { args: { hostingName } } ) }
+		</span>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/style.scss
@@ -3,8 +3,8 @@
 	border-radius: 4px;
 	font-size: 0.75rem;
 	font-weight: 500;
-	line-height: 20px;
+	line-height: 1.5;
 	margin: 0 0 20px auto;
-	padding: 0 10px;
+	padding: 1px 10px;
 	width: fit-content;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/style.scss
@@ -1,10 +1,10 @@
 .migration-instructions-hosting-badge {
-	width: fit-content;
-	margin: 0 0 20px auto;
-	padding: 0 10px;
+	background-color: #d6ddf9;
+	border-radius: 4px;
 	font-size: 0.75rem;
 	font-weight: 500;
 	line-height: 20px;
-	background-color: #d6ddf9;
-	border-radius: 4px;
+	margin: 0 0 20px auto;
+	padding: 0 10px;
+	width: fit-content;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/style.scss
@@ -1,0 +1,10 @@
+.migration-instructions-hosting-badge {
+	width: fit-content;
+	margin: 0 0 20px auto;
+	padding: 0 10px;
+	font-size: 0.75rem;
+	font-weight: 500;
+	line-height: 20px;
+	background-color: #d6ddf9;
+	border-radius: 4px;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/hosting-badge/test/index.tsx
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { HostingBadge } from '..';
+
+describe( 'HostingBadge', () => {
+	it( 'renders the hosting badge', () => {
+		render( <HostingBadge hostingName="WordPress.com" /> );
+
+		expect( screen.queryByText( /WordPress.com/ ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,7 +1,10 @@
 import { LaunchpadContainer } from '@automattic/launchpad';
 import { StepContainer } from '@automattic/onboarding';
+import { getQueryArg } from '@wordpress/url';
 import React from 'react';
+import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { HostingBadge } from './hosting-badge';
 import { Questions } from './questions';
 import { Sidebar } from './sidebar';
 import { SitePreview } from './site-preview';
@@ -9,10 +12,15 @@ import type { Step } from '../../types';
 import './style.scss';
 
 const SiteMigrationInstructions: Step = function () {
-	const sidebar = <Sidebar />;
+	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
+	const { data: hostingDetails } = useHostingProviderUrlDetails( importSiteQueryParam );
+	const showHostingBadge = ! hostingDetails.is_unknown && ! hostingDetails.is_a8c;
 
+	const sidebar = <Sidebar />;
 	const stepContent = (
 		<LaunchpadContainer sidebar={ sidebar }>
+			{ showHostingBadge && <HostingBadge hostingName={ hostingDetails.name } /> }
+
 			<SitePreview />
 		</LaunchpadContainer>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,8 +1,8 @@
 import { LaunchpadContainer } from '@automattic/launchpad';
 import { StepContainer } from '@automattic/onboarding';
-import { getQueryArg } from '@wordpress/url';
 import React from 'react';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { HostingBadge } from './hosting-badge';
 import { Questions } from './questions';
@@ -12,7 +12,8 @@ import type { Step } from '../../types';
 import './style.scss';
 
 const SiteMigrationInstructions: Step = function () {
-	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
+	const queryParams = useQuery();
+	const importSiteQueryParam = queryParams.get( 'from' ) ?? '';
 	const { data: hostingDetails } = useHostingProviderUrlDetails( importSiteQueryParam );
 	const showHostingBadge = ! hostingDetails.is_unknown && ! hostingDetails.is_a8c;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -14,54 +14,25 @@ const render = ( props?: Partial< StepProps > ) => {
 jest.mock( 'calypso/data/site-profiler/use-hosting-provider-url-details' );
 
 describe( 'SiteMigrationInstructions', () => {
-	it( 'shows the hosting badge when the host is known and not a8c', async () => {
-		useHostingProviderUrlDetails.mockReturnValue( {
-			data: {
-				name: 'WP Engine',
-				is_unknown: false,
-				is_a8c: false,
-			},
-		} );
+	it.each( [
+		{ hostingName: 'WP Engine', isUnknown: false, isA8c: false, expected: true },
+		{ hostingName: 'WordPress.com', isUnknown: false, isA8c: true, expected: false },
+		{ hostingName: 'Unknown', isUnknown: true, isA8c: false, expected: false },
+	] )(
+		'renders the hosting badge only when the hosting is known and not A8C',
+		async ( { hostingName, isUnknown, isA8c, expected } ) => {
+			useHostingProviderUrlDetails.mockReturnValue( {
+				data: {
+					name: hostingName,
+					is_unknown: isUnknown,
+					is_a8c: isA8c,
+				},
+			} );
 
-		const { container, queryByText } = render();
+			const { queryByText } = render();
 
-		expect( container.querySelectorAll( '.migration-instructions-hosting-badge' ) ).toHaveLength(
-			1
-		);
-		expect( queryByText( /WP Engine/ ) ).toBeInTheDocument();
-	} );
-
-	it( "doesn't show the hosting badge when the host is a8c", async () => {
-		useHostingProviderUrlDetails.mockReturnValue( {
-			data: {
-				name: 'WordPress.com',
-				is_unknown: false,
-				is_a8c: true,
-			},
-		} );
-
-		const { container, queryByText } = render();
-
-		expect( container.querySelectorAll( '.migration-instructions-hosting-badge' ) ).toHaveLength(
-			0
-		);
-		expect( queryByText( /WordPress.com/ ) ).not.toBeInTheDocument();
-	} );
-
-	it( "doesn't show the hosting badge when the host is unknown", async () => {
-		useHostingProviderUrlDetails.mockReturnValue( {
-			data: {
-				name: 'unknown',
-				is_unknown: true,
-				is_a8c: false,
-			},
-		} );
-
-		const { container, queryByText } = render();
-
-		expect( container.querySelectorAll( '.migration-instructions-hosting-badge' ) ).toHaveLength(
-			0
-		);
-		expect( queryByText( /unknown/ ) ).not.toBeInTheDocument();
-	} );
+			const maybeExpect = ( arg, exp ) => ( exp ? expect( arg ) : expect( arg ).not );
+			maybeExpect( queryByText( `Hosted with ${ hostingName }` ), expected ).toBeInTheDocument();
+		}
+	);
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
+import SiteMigrationInstructions from '..';
+import { StepProps } from '../../../types';
+import { renderStep, mockStepProps } from '../../test/helpers';
+
+const render = ( props?: Partial< StepProps > ) => {
+	const combinedProps = { ...mockStepProps( props ) };
+	return renderStep( <SiteMigrationInstructions { ...combinedProps } /> );
+};
+
+jest.mock( 'calypso/data/site-profiler/use-hosting-provider-url-details' );
+
+describe( 'SiteMigrationInstructions', () => {
+	it( 'shows the hosting badge when the host is known and not a8c', async () => {
+		useHostingProviderUrlDetails.mockReturnValue( {
+			data: {
+				name: 'WP Engine',
+				is_unknown: false,
+				is_a8c: false,
+			},
+		} );
+
+		const { container, queryByText } = render();
+
+		expect( container.querySelectorAll( '.migration-instructions-hosting-badge' ) ).toHaveLength(
+			1
+		);
+		expect( queryByText( /WP Engine/ ) ).toBeInTheDocument();
+	} );
+
+	it( "doesn't show the hosting badge when the host is a8c", async () => {
+		useHostingProviderUrlDetails.mockReturnValue( {
+			data: {
+				name: 'WordPress.com',
+				is_unknown: false,
+				is_a8c: true,
+			},
+		} );
+
+		const { container, queryByText } = render();
+
+		expect( container.querySelectorAll( '.migration-instructions-hosting-badge' ) ).toHaveLength(
+			0
+		);
+		expect( queryByText( /WordPress.com/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( "doesn't show the hosting badge when the host is unknown", async () => {
+		useHostingProviderUrlDetails.mockReturnValue( {
+			data: {
+				name: 'unknown',
+				is_unknown: true,
+				is_a8c: false,
+			},
+		} );
+
+		const { container, queryByText } = render();
+
+		expect( container.querySelectorAll( '.migration-instructions-hosting-badge' ) ).toHaveLength(
+			0
+		);
+		expect( queryByText( /unknown/ ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/91778

## Proposed Changes

* Shows a hosting badge when the imported site is known and not a8c.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `migration-flow/new-migration-instructions-step` feature flag by adding the following to your `.env` file: `ACTIVE_FEATURE_FLAGS="migration-flow/new-migration-instructions-step"`
* Go to migration flow and use a site where the host is known and not a8c, e. g. https://minlovecat.sg/ (hostinger).
* Follow the flow until you reach the migration instructions.
* Make sure the host badge is there.
* Repeat the flow with a Jurrasic ninja site (a8c host) and make sure the host badge is not shown.

![image](https://github.com/Automattic/wp-calypso/assets/1612178/28afdcfb-5709-40d8-aa6f-ce042120f59d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
