### PR TITLE
A4A-Partner Directory: Update the WordPress product to WordPress.com

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
@@ -27,7 +27,7 @@ export function useFormSelectors() {
 	};
 
 	const availableProducts: Record< string, string > = {
-		wordpress: 'WordPress',
+		wordpress: 'WordPress.com',
 		woocommerce: 'WooCommerce',
 		jetpack: 'Jetpack',
 		wordpress_vip: 'WordPress VIP',


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/735

## Proposed Changes

This PR updates the `WordPress` product name to `WordPress.com`.

Reference: p1719420396106999-slack-C072ZPV99RS

<img width="681" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/4230801a-a097-4558-b0b3-d7b56389a760">


Discussion: 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Check that you see WordPress.com in the product list selector.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?