### PR TITLE
Stats: Paywall Stats Traffic modules with upsell in StatsModule

### DIFF
--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -34,6 +34,7 @@ export const STAT_TYPE_STREAK = 'statsStreak';
 export const STAT_TYPE_SUMMARY = 'statsSummary';
 export const STAT_TYPE_TAGS = 'statsTags';
 export const STAT_TYPE_TOP_AUTHORS = 'statsTopAuthors';
+export const STAT_TYPE_EMAILS_SUMMARY = 'statsEmailsSummary';
 export const STAT_TYPE_TOP_POSTS = 'statsTopPosts';
 export const STAT_TYPE_VIDEO_PLAYS = 'statsVideoPlays';
 export const STAT_TYPE_VISITS = 'statsVisits';

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -11,6 +11,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import EmptyStateAction from '../../../components/empty-state-action';
 import { SUPPORT_URL } from '../../../const';
+import { useShouldGateStats } from '../../../hooks/use-should-gate-stats';
 import StatsModule from '../../../stats-module';
 import StatsModulePlaceholder from '../../../stats-module/placeholder';
 
@@ -40,6 +41,8 @@ const StatsTopPosts: React.FC< StatsTopPostsProps > = ( {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsTopPosts';
+	// Use StatsModule to display paywall upsell.
+	const shouldGateStatsTopPosts = useShouldGateStats( statType );
 
 	// TODO: sort out the state shape.
 	const requesting = useSelector( ( state: any ) =>
@@ -85,7 +88,18 @@ const StatsTopPosts: React.FC< StatsTopPostsProps > = ( {
 		<>
 			{ /* This will be replaced with ghost loaders, fallback to the current implementation until then. */ }
 			{ requesting && <StatsModulePlaceholder isLoading={ requesting } /> }
-			{ ( ! data || ! data?.length ) && (
+			{ /* TODO: consider supressing <StatsModule /> empty state */ }
+			{ ( data && !! data.length ) || shouldGateStatsTopPosts ? (
+				<StatsModule
+					path="posts"
+					moduleStrings={ moduleStrings }
+					period={ period }
+					query={ query }
+					statType={ statType }
+					showSummaryLink
+					className={ className } // TODO: extend with a base class after adding skeleton loaders
+				/>
+			) : (
 				<StatsCard
 					className={ className }
 					title={ moduleStrings.title }
@@ -117,18 +131,6 @@ const StatsTopPosts: React.FC< StatsTopPostsProps > = ( {
 				>
 					<div>empty</div>
 				</StatsCard>
-			) }
-			{ /* TODO: consider supressing <StatsModule /> empty state */ }
-			{ data && !! data.length && (
-				<StatsModule
-					path="posts"
-					moduleStrings={ moduleStrings }
-					period={ period }
-					query={ query }
-					statType={ statType }
-					showSummaryLink
-					className={ className } // TODO: extend with a base class after adding skeleton loaders
-				/>
 			) }
 		</>
 	);

--- a/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
@@ -224,6 +224,8 @@ describe( 'shouldGateStats in Odyssey stats', () => {
 					return true;
 				case 'is_running_in_jetpack_site':
 					return true;
+				case 'stats/restricted-dashboard':
+					return true;
 			}
 		} );
 	} );
@@ -259,7 +261,7 @@ describe( 'shouldGateStats in Odyssey stats', () => {
 		expect( isGatedStats ).toBe( false );
 	} );
 
-	it( 'should not gate stats for jetpack sites without feature', () => {
+	it( 'should not gate stats for exisiting jetpack sites created before 2024-01-31 without feature', () => {
 		const mockState = {
 			sites: {
 				features: {
@@ -273,6 +275,7 @@ describe( 'shouldGateStats in Odyssey stats', () => {
 					[ siteId ]: {
 						jetpack: true,
 						options: {
+							created_at: '2024-01-30',
 							is_wpcom_atomic: false,
 						},
 					},
@@ -284,5 +287,33 @@ describe( 'shouldGateStats in Odyssey stats', () => {
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
 		expect( isGatedStats ).toBe( false );
+	} );
+
+	it( 'should gate stats for new jetpack sites created after 2024-01-31 without feature', () => {
+		const mockState = {
+			sites: {
+				features: {
+					[ siteId ]: {
+						data: {
+							active: [],
+						},
+					},
+				},
+				items: {
+					[ siteId ]: {
+						jetpack: true,
+						options: {
+							created_at: '2024-02-01',
+							is_wpcom_atomic: false,
+						},
+					},
+				},
+			},
+			purchases: {
+				data: [],
+			},
+		};
+		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
+		expect( isGatedStats ).toBe( true );
 	} );
 } );

--- a/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
@@ -45,6 +45,9 @@ describe( 'shouldGateStats in Calypso', () => {
 					},
 				},
 			},
+			purchases: {
+				data: [],
+			},
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
 		expect( isGatedStats ).toBe( false );
@@ -68,6 +71,9 @@ describe( 'shouldGateStats in Calypso', () => {
 						},
 					},
 				},
+			},
+			purchases: {
+				data: [],
 			},
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
@@ -93,6 +99,9 @@ describe( 'shouldGateStats in Calypso', () => {
 					},
 				},
 			},
+			purchases: {
+				data: [],
+			},
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
 		expect( isGatedStats ).toBe( false );
@@ -116,6 +125,9 @@ describe( 'shouldGateStats in Calypso', () => {
 						},
 					},
 				},
+			},
+			purchases: {
+				data: [],
 			},
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
@@ -141,6 +153,9 @@ describe( 'shouldGateStats in Calypso', () => {
 					},
 				},
 			},
+			purchases: {
+				data: [],
+			},
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, notGatedStatType );
 		expect( isGatedStats ).toBe( false );
@@ -165,6 +180,9 @@ describe( 'shouldGateStats in Calypso', () => {
 					},
 				},
 			},
+			purchases: {
+				data: [],
+			},
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, notGatedStatType );
 		expect( isGatedStats ).toBe( false );
@@ -188,6 +206,9 @@ describe( 'shouldGateStats in Calypso', () => {
 						},
 					},
 				},
+			},
+			purchases: {
+				data: [],
 			},
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
@@ -230,6 +251,9 @@ describe( 'shouldGateStats in Odyssey stats', () => {
 					},
 				},
 			},
+			purchases: {
+				data: [],
+			},
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
 		expect( isGatedStats ).toBe( false );
@@ -253,6 +277,9 @@ describe( 'shouldGateStats in Odyssey stats', () => {
 						},
 					},
 				},
+			},
+			purchases: {
+				data: [],
 			},
 		};
 		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { FEATURE_STATS_PAID } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
 import getSiteFeatures from 'calypso/state/selectors/get-site-features';
@@ -75,13 +76,14 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 	const siteFeatures = getSiteFeatures( state, siteId );
 	const siteHasPaidStats = siteHasFeature( state, siteId, FEATURE_STATS_PAID );
 
+	const restrictDdashboard = config.isEnabled( 'stats/restricted-dashboard' );
 	const isNewSite = isSiteNew( state, siteId );
 	const hasAnyStatsPlan = hasAnyPlan( state, siteId );
 
 	// Check gated modules for Jetpack sites.
 	if ( jetpackSite && ! atomicSite ) {
 		// TODO: Determine more paywall segments and granular control for paid stats.
-		if ( isNewSite && ! hasAnyStatsPlan ) {
+		if ( restrictDdashboard && isNewSite && ! hasAnyStatsPlan ) {
 			return [ ...paidStatsPaywall ].includes( statType );
 		}
 

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -25,6 +25,8 @@ import {
 	STATS_FEATURE_SUMMARY_LINKS_YEAR,
 	STATS_FEATURE_SUMMARY_LINKS_ALL,
 } from '../constants';
+import { isSiteNew } from './use-site-compulsory-plan-selection-qualified-check';
+import { hasAnyPlan } from './use-stats-purchases';
 
 const paidStatsPaywall = [
 	STAT_TYPE_TOP_POSTS,
@@ -73,9 +75,17 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 	const siteFeatures = getSiteFeatures( state, siteId );
 	const siteHasPaidStats = siteHasFeature( state, siteId, FEATURE_STATS_PAID );
 
-	// check site type
+	const isNewSite = isSiteNew( state, siteId );
+	const hasAnyStatsPlan = hasAnyPlan( state, siteId );
+
+	// Check gated modules for Jetpack sites.
 	if ( jetpackSite && ! atomicSite ) {
-		return [ ...paidStatsPaywall ].includes( statType );
+		// TODO: Determine more paywall segments and granular control for paid stats.
+		if ( isNewSite && ! hasAnyStatsPlan ) {
+			return [ ...paidStatsPaywall ].includes( statType );
+		}
+
+		return false;
 	}
 
 	// check if the site features have loaded and the site has paid stats feature

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -93,5 +93,6 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 export const useShouldGateStats = ( statType: string ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isGatedStats = useSelector( ( state ) => shouldGateStats( state, siteId, statType ) );
-	return { isGatedStats };
+
+	return isGatedStats;
 };

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_STATS_PAID } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
 import getSiteFeatures from 'calypso/state/selectors/get-site-features';
@@ -8,10 +7,14 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	STATS_FEATURE_DOWNLOAD_CSV,
-	STAT_TYPE_SEARCH_TERMS,
-	STAT_TYPE_CLICKS,
+	STAT_TYPE_TOP_POSTS,
 	STAT_TYPE_REFERRERS,
+	STAT_TYPE_COUNTRY_VIEWS,
+	STAT_TYPE_CLICKS,
 	STAT_TYPE_TOP_AUTHORS,
+	STAT_TYPE_EMAILS_SUMMARY,
+	STAT_TYPE_SEARCH_TERMS,
+	STAT_TYPE_VIDEO_PLAYS,
 	STATS_FEATURE_DATE_CONTROL_LAST_90_DAYS,
 	STATS_FEATURE_DATE_CONTROL_LAST_YEAR,
 	STATS_FEATURE_DATE_CONTROL,
@@ -23,11 +26,22 @@ import {
 	STATS_FEATURE_SUMMARY_LINKS_ALL,
 } from '../constants';
 
-const paidStats = [
-	STAT_TYPE_SEARCH_TERMS,
-	STAT_TYPE_CLICKS,
+const paidStatsPaywall = [
+	STAT_TYPE_TOP_POSTS,
+	STAT_TYPE_COUNTRY_VIEWS,
 	STAT_TYPE_REFERRERS,
+	STAT_TYPE_CLICKS,
 	STAT_TYPE_TOP_AUTHORS,
+	STAT_TYPE_EMAILS_SUMMARY,
+	STAT_TYPE_SEARCH_TERMS,
+	STAT_TYPE_VIDEO_PLAYS,
+];
+
+const paidStats = [
+	STAT_TYPE_REFERRERS,
+	STAT_TYPE_CLICKS,
+	STAT_TYPE_TOP_AUTHORS,
+	STAT_TYPE_SEARCH_TERMS,
 ];
 
 const granularControlForPaidStats = [
@@ -50,18 +64,6 @@ const granularControlForPaidStats = [
  * const isGatedStats = shouldGateStats( state, siteId, STAT_TYPE_SEARCH_TERMS );
  */
 export const shouldGateStats = ( state: object, siteId: number | null, statType: string ) => {
-	const isPaidStatsEnabled = isEnabled( 'stats/paid-wpcom-v2' );
-	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
-
-	// check feature flags
-	if ( ! isPaidStatsEnabled ) {
-		return false;
-	}
-	if ( isOdysseyStats ) {
-		// don't gate stats if using Odyssey stats
-		return false;
-	}
-
 	if ( ! siteId ) {
 		return true;
 	}
@@ -73,7 +75,7 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 
 	// check site type
 	if ( jetpackSite && ! atomicSite ) {
-		return false;
+		return [ ...paidStatsPaywall ].includes( statType );
 	}
 
 	// check if the site features have loaded and the site has paid stats feature

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -76,14 +76,14 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 	const siteFeatures = getSiteFeatures( state, siteId );
 	const siteHasPaidStats = siteHasFeature( state, siteId, FEATURE_STATS_PAID );
 
-	const restrictDdashboard = config.isEnabled( 'stats/restricted-dashboard' );
+	const restrictDashboard = config.isEnabled( 'stats/restricted-dashboard' );
 	const isNewSite = isSiteNew( state, siteId );
 	const hasAnyStatsPlan = hasAnyPlan( state, siteId );
 
 	// Check gated modules for Jetpack sites.
 	if ( jetpackSite && ! atomicSite ) {
 		// TODO: Determine more paywall segments and granular control for paid stats.
-		if ( restrictDdashboard && isNewSite && ! hasAnyStatsPlan ) {
+		if ( restrictDashboard && isNewSite && ! hasAnyStatsPlan ) {
 			return [ ...paidStatsPaywall ].includes( statType );
 		}
 

--- a/client/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check.ts
+++ b/client/my-sites/stats/hooks/use-site-compulsory-plan-selection-qualified-check.ts
@@ -5,11 +5,14 @@ import usePlanUsageQuery from './use-plan-usage-query';
 
 const MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL = 1000;
 
-export default function useSiteCompulsoryPlanSelectionQualifiedCheck( siteId: number | null ) {
-	const siteCreatedTimeStamp = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'created_at' )
-	) as string;
+// Targeting new sites
+export const isSiteNew = ( state: object, siteId: number | null ) => {
+	const siteCreatedTimeStamp = getSiteOption( state, siteId, 'created_at' ) as string;
 
+	return siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' );
+};
+
+export default function useSiteCompulsoryPlanSelectionQualifiedCheck( siteId: number | null ) {
 	// `is_vip` option is not set in Odyssey, so we need to check `options.is_vip` as well.
 	const isVip = useSelector(
 		( state ) =>
@@ -18,8 +21,7 @@ export default function useSiteCompulsoryPlanSelectionQualifiedCheck( siteId: nu
 	);
 
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
-	const isNewSite =
-		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' ); // Targeting new sites
+	const isNewSite = useSelector( ( state ) => isSiteNew( state, siteId ) );
 	const isExceedingTrafficThreshold =
 		( usageInfo?.billableMonthlyViews ?? 0 ) > MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL; // Targeting all existing sites with views higher than 1000/mth.
 

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -45,7 +45,7 @@ const getPurchasesBySiteId = createSelector(
 
 // TODO: Consolidate this with the useStatsPurchases hook.
 export const hasAnyPlan = ( state: object, siteId: number | null ) => {
-	const sitePurchases = getPurchasesBySiteId( state, siteId );
+	const sitePurchases = getSitePurchases( state, siteId );
 
 	const isFreeOwned = isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_FREE );
 	const isCommercialOwned = areProductsOwned( sitePurchases, [

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -43,6 +43,25 @@ const getPurchasesBySiteId = createSelector(
 	getPurchases
 );
 
+// TODO: Consolidate this with the useStatsPurchases hook.
+export const hasAnyPlan = ( state: object, siteId: number | null ) => {
+	const sitePurchases = getPurchasesBySiteId( state, siteId );
+
+	const isFreeOwned = isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_FREE );
+	const isCommercialOwned = areProductsOwned( sitePurchases, [
+		...JETPACK_VIDEOPRESS_PRODUCTS,
+		PRODUCT_JETPACK_STATS_MONTHLY,
+		PRODUCT_JETPACK_STATS_YEARLY,
+		PRODUCT_JETPACK_STATS_BI_YEARLY,
+	] );
+	const isPWYWOwned = isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_PWYW_YEARLY );
+	const supportCommercialUse =
+		isCommercialOwned ||
+		JETPACK_COMPLETE_PLANS.some( ( plan ) => isProductOwned( sitePurchases, plan ) );
+
+	return isFreeOwned || isCommercialOwned || isPWYWOwned || supportCommercialUse;
+};
+
 export default function useStatsPurchases( siteId: number | null ) {
 	const sitePurchases = useSelector( ( state ) => getPurchasesBySiteId( state, siteId ) );
 	const isRequestingSitePurchases = useSelector( isFetchingSitePurchases );

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -48,6 +48,8 @@ export const hasAnyPlan = ( state: object, siteId: number | null ) => {
 	const sitePurchases = getSitePurchases( state, siteId );
 
 	const isFreeOwned = isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_FREE );
+	// TODO: After the paywall is removed, we should be able to enable the VideoPress module and page based on their subscription information,
+	// which means the particular logic here wouldn't be necessary anymore.
 	const isCommercialOwned = areProductsOwned( sitePurchases, [
 		...JETPACK_VIDEOPRESS_PRODUCTS,
 		PRODUCT_JETPACK_STATS_MONTHLY,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -49,7 +49,7 @@ import HighlightsSection from './highlights-section';
 import MiniCarousel from './mini-carousel';
 import { StatsGlobalValuesContext } from './pages/providers/global-provider';
 import PromoCards from './promo-cards';
-import StatsCardUpgradeJepackVersion from './stats-card-upsell/stats-card-update-jetpack-version';
+import StatsCardUpdateJetpackVersion from './stats-card-upsell/stats-card-update-jetpack-version';
 import ChartTabs from './stats-chart-tabs';
 import Countries from './stats-countries';
 import DatePicker from './stats-date-picker';
@@ -461,7 +461,7 @@ class StatsSite extends Component {
 									'stats__flexible-grid-item--full--medium'
 								) }
 								overlay={
-									<StatsCardUpgradeJepackVersion
+									<StatsCardUpdateJetpackVersion
 										className="stats-module__upsell stats-module__upgrade"
 										siteId={ siteId }
 										statType="utm"
@@ -628,7 +628,7 @@ class StatsSite extends Component {
 								) }
 								siteId={ siteId }
 								overlay={
-									<StatsCardUpgradeJepackVersion
+									<StatsCardUpdateJetpackVersion
 										className="stats-module__upsell stats-module__upgrade"
 										siteId={ siteId }
 										statType="devices"

--- a/client/my-sites/stats/stats-card-upsell/style.scss
+++ b/client/my-sites/stats/stats-card-upsell/style.scss
@@ -3,6 +3,7 @@
 	height: 100%;
 	font-size: $font-body-small;
 	.stats-card-upsell__content {
+		box-sizing: border-box;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/74

## Proposed Changes

* Utilize the `StatsCardUpsell` inside `StatsModule` to paywall Stats Traffic page modules.
* Paywall Jetpack sites created after `2024-01-31` without any Stats purchase.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Lock Stats Traffic page modules to users with no valid Stats purchases.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new JN site without purchasing any Stats products.
* Spin this change up with the Calypso Live branch.
* Navigate to Stats > `Traffic` page for the new JN site with the feature flag: `/stats/day/{site-slug}?flags=stats/restricted-dashboard`.
* Ensure the modules on the page are all locked.

<img width="1281" alt="截圖 2024-06-29 上午12 12 36" src="https://github.com/Automattic/wp-calypso/assets/6869813/95217707-781f-4d9d-a325-c0772130a064">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
