### PR TITLE
Fix ReactDOM.render is no longer supported

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -8,7 +8,7 @@ import { IMPORT_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { BrowserRouter, matchPath } from 'react-router-dom';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
@@ -118,7 +118,8 @@ window.AppBoot = async () => {
 	const flowLoader = determineFlow();
 	const { default: flow } = await flowLoader();
 
-	ReactDom.render(
+	const root = createRoot( document.getElementById( 'wpcom' )! );
+	root.render(
 		<CalypsoI18nProvider i18n={ defaultCalypsoI18n }>
 			<Provider store={ reduxStore }>
 				<QueryClientProvider client={ queryClient }>
@@ -140,7 +141,6 @@ window.AppBoot = async () => {
 					) }
 				</QueryClientProvider>
 			</Provider>
-		</CalypsoI18nProvider>,
-		document.getElementById( 'wpcom' )
+		</CalypsoI18nProvider>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update AppBoot to use the React 18 way of render components, removing the deprecated message.
<img width="1233" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/446a82be-569b-48cb-b489-6f8b6a9683d9">


## Testing Instructions
* Run this branch local
* Access one of the stepper flows (e.g /setup/newsletter/`) 
* Check there is not waring similar to the image above on the developer tools console.
* Check if the step is rendered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
