### PR TITLE
Reader full post - introduce back button to content frame in desktop view, fix issues with mobile.

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -121,7 +121,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 .reader-full-post__story {
 	max-width: var(--reader-full-post-story-max-width);
-	padding: 0 var(--reader-full-post-story-padding);
+	padding: 32px var(--reader-full-post-story-padding);
 	margin: 0 auto;
 	@media (min-width: $reader-full-post-desktop-min) {
 		margin: 0;
@@ -173,20 +173,21 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 .reader-full-post .back-button {
 	border: none;
-	display: none;
 	position: absolute;
 	top: 0;
 	left: 0;
 	right: unset;
 	background-color: transparent;
 
-	// We will display this when the sidebar disappears @781 px.
-	@media (max-width: 781px) {
-		display: inline-block;
+	button.is-compact.is-borderless {
+		margin: 2px;
+		@media (max-width: 781px) {
+			padding-top: 12px;
+			padding-bottom: 12px;
+		}
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
-		top: 4px;
 		left: 14px;
 	}
 }
@@ -478,12 +479,8 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	font-size: $font-title-medium;
 	font-weight: 700;
 	line-height: 34px;
-	margin: 56px 0 0;
 	max-width: 750px;
 
-	@include breakpoint-deprecated( "<1280px" ) {
-		margin-top: 32px;
-	}
 
 	@include breakpoint-deprecated( ">960px" ) {
 		font-size: $font-headline-small;
@@ -495,9 +492,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 		line-height: 40px;
 	}
 
-	@include breakpoint-deprecated( "<660px" ) {
-		margin: 8px 0 0 32px;
-	}
 
 	.reader-full-post__header-title-link {
 		display: block;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to feedback from p1719586659045439-slack-C029GN3KD

## Proposed Changes

* Reintroduces the back button inside the content frame of full post view.
* Fixes the layout on some tablet/mobile breakpoints.


### BEFORE
<img width="1493" alt="Screenshot 2024-06-28 at 1 19 15 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/674b6f5d-70a5-4a7a-8899-df800d111f25">

No back button at the above viewport width.

<img width="728" alt="Screenshot 2024-06-28 at 1 19 32 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/aadceadc-8fab-4386-a2c2-8a9be9cf042a">

Back button hidden under title at this viewport width.

<img width="492" alt="Screenshot 2024-06-28 at 1 19 37 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/292ea634-f899-4fe5-a9b2-52c74dad8643">

Back button and title alignment feel off at this viewport width.


### AFTER
<img width="1427" alt="Screenshot 2024-06-28 at 1 18 13 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/525bac60-1bab-4c7a-aea8-2ae8f4485841">
<img width="933" alt="Screenshot 2024-06-28 at 1 18 26 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/0882277b-213e-4bb8-a7f1-edda24399268">

Back button reintroduced at the above widths in the content frame.

<img width="726" alt="Screenshot 2024-06-28 at 1 18 34 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/1f62d907-3c7c-4432-8d83-e5540f802fc9">
<img width="497" alt="Screenshot 2024-06-28 at 1 18 43 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a5d5e069-9d6e-4c7b-b95e-423ab4e3fff7">
Back button has better positioning at these widths.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It is unclear for users that the back button in the global sidebar will work this way, and thus unclear how to go back from full post view.
* The back button is obsctructed on some viewport widths.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the full post page view in the reader at different viewport widths/browsers and verify the back button is available and layout looks good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?