### PR TITLE
Use the correct percentage sign in translations

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -257,7 +257,7 @@ export default function HostingCard( {
 						</div>
 						{ shouldShowDiscount ? (
 							<div className="hosting-card__price-discount">
-								{ translate( 'Volume savings up to %(highestDiscountPercentage)s%', {
+								{ translate( 'Volume savings up to %(highestDiscountPercentage)s%%', {
 									args: { highestDiscountPercentage: Math.trunc( highestDiscountPercentage ) },
 								} ) }
 							</div>

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
@@ -49,7 +49,7 @@ export default function ProductPriceWithDiscount( {
 							) }
 
 							<span className="product-price-with-discount__price-discount">
-								{ translate( 'Save %(discountPercentage)s%', {
+								{ translate( 'Save %(discountPercentage)s%%', {
 									args: {
 										discountPercentage,
 									},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#831

## Proposed Changes

* Use `%%` rather than `%` to display the percentage sign in strings that need to be translated. PCYsg-3hI-p2 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?