### PR TITLE
Frictionless Email Subscriptions: Switch emails if user continues through flow as logged in user

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -197,7 +197,7 @@ function ContinueAsUser( {
 				<Button
 					busy={ isLoading }
 					primary
-					href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
+					href={ validatedRedirectPath || validatedRedirectUrlFromQuery || '/' }
 				>
 					{ translate( 'Continue' ) }
 				</Button>

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -10,6 +10,7 @@ function SubscribeEmailStepContent( props ) {
 		handleCreateAccountError,
 		handleCreateAccountSuccess,
 		isPending,
+		redirectToAfterLoginUrl,
 		redirectUrl,
 		step,
 		stepName,
@@ -31,17 +32,17 @@ function SubscribeEmailStepContent( props ) {
 				handleCreateAccountError={ handleCreateAccountError }
 				handleCreateAccountSuccess={ handleCreateAccountSuccess }
 				disableBlurValidation
-				disableContinueAsUser
 				isPasswordless
 				isReskinned
 				isSocialFirst={ false }
 				isSocialSignupEnabled={ false }
 				labelText={ translate( 'Your email' ) }
 				queryArgs={ { user_email: email, redirect_to: redirectUrl } }
+				redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
 				shouldDisplayUserExistsError
 				step={ step }
 				stepName={ stepName }
-				submitButtonLabel={ translate( 'Subscribe email' ) }
+				submitButtonLabel={ translate( 'Subscribe' ) }
 				submitButtonLoadingLabel={ translate( 'Subscribing…' ) }
 				suggestedUsername=""
 			/>

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -10,6 +10,8 @@ import { isRedirectAllowed } from 'calypso/lib/url/is-redirect-allowed';
 import useCreateNewAccountMutation from 'calypso/signup/hooks/use-create-new-account';
 import useSubscribeToMailingList from 'calypso/signup/hooks/use-subscribe-to-mailing-list';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SubscribeEmailStepContent from './content';
 
@@ -30,15 +32,22 @@ function sanitizeRedirectUrl( redirect ) {
  * into a single step.
  */
 function SubscribeEmailStep( props ) {
-	const { flowName, goToNextStep, queryParams, stepName } = props;
-	const redirectUrl = sanitizeRedirectUrl( queryParams.redirect_to );
-	const email = typeof queryParams.user_email === 'string' ? queryParams.user_email.trim() : '';
+	const { currentUser, flowName, goToNextStep, queryArguments, stepName, translate } = props;
+
+	const email =
+		typeof queryArguments.user_email === 'string' ? queryArguments.user_email.trim() : '';
+
+	const redirectUrl = sanitizeRedirectUrl( queryArguments.redirect_to );
+
+	const redirectToAfterLoginUrl = currentUser
+		? addQueryArgs( window.location.href, { user_email: currentUser?.email } )
+		: '';
 
 	const { mutate: subscribeToMailingList, isPending: isSubscribeToMailingListPending } =
 		useSubscribeToMailingList( {
 			onSuccess: () => {
 				recordTracksEvent( 'calypso_signup_email_subscription_success', {
-					mailing_list: queryParams.mailing_list,
+					mailing_list: queryArguments.mailing_list,
 				} );
 				props.submitSignupStep( { stepName: 'subscribe' }, { redirect: redirectUrl } );
 				goToNextStep();
@@ -66,23 +75,23 @@ function SubscribeEmailStep( props ) {
 
 				subscribeToMailingList( {
 					email_address: email,
-					mailing_list_category: queryParams.mailing_list,
-					from: queryParams.from,
+					mailing_list_category: queryArguments.mailing_list,
+					from: queryArguments.from,
 				} );
 			},
 			onError: ( error ) => {
 				if ( isExistingAccountError( error.error ) ) {
 					subscribeToMailingList( {
 						email_address: email,
-						mailing_list_category: queryParams.mailing_list,
-						from: queryParams.from,
+						mailing_list_category: queryArguments.mailing_list,
+						from: queryArguments.from,
 					} );
 				}
 			},
 		} );
 
 	useEffect( () => {
-		if ( emailValidator.validate( email ) ) {
+		if ( emailValidator.validate( email ) && ! currentUser ) {
 			createNewAccount( {
 				userData: {
 					email,
@@ -91,27 +100,39 @@ function SubscribeEmailStep( props ) {
 				isPasswordless: true,
 			} );
 		}
-	}, [ createNewAccount, flowName, email ] );
+
+		if ( currentUser?.email === email ) {
+			subscribeToMailingList( {
+				email_address: email,
+				mailing_list_category: queryArguments.mailing_list,
+				from: queryArguments.from,
+			} );
+		}
+	}, [ createNewAccount, currentUser, flowName, email ] );
 
 	return (
 		<div className="subscribe-email">
 			<StepWrapper
 				flowName={ flowName }
+				fallbackHeaderText={
+					currentUser ? translate( 'Is this you?' ) : translate( 'Subscribe to our email list' )
+				}
+				hideFormattedHeader={ isCreateNewAccountPending || isSubscribeToMailingListPending }
 				hideBack
-				hideFormattedHeader
 				stepContent={
 					<SubscribeEmailStepContent
 						{ ...props }
 						email={ email }
 						isPending={ isCreateNewAccountPending || isSubscribeToMailingListPending }
+						redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
 						redirectUrl={ redirectUrl }
 						subscribeToMailingList={ subscribeToMailingList }
 						handleCreateAccountError={ ( error, submittedEmail ) => {
 							if ( isExistingAccountError( error.error ) ) {
 								subscribeToMailingList( {
 									email_address: submittedEmail,
-									mailing_list_category: queryParams.mailing_list,
-									from: queryParams.from,
+									mailing_list_category: queryArguments.mailing_list,
+									from: queryArguments.from,
 								} );
 							}
 						} }
@@ -124,8 +145,8 @@ function SubscribeEmailStep( props ) {
 
 							subscribeToMailingList( {
 								email_address: userData.email,
-								mailing_list_category: queryParams.mailing_list,
-								from: queryParams.from,
+								mailing_list_category: queryArguments.mailing_list,
+								from: queryArguments.from,
 							} );
 						} }
 					/>
@@ -136,4 +157,14 @@ function SubscribeEmailStep( props ) {
 	);
 }
 
-export default connect( null, { submitSignupStep } )( localize( SubscribeEmailStep ) );
+export default connect(
+	( state ) => {
+		const queryArguments = getCurrentQueryArguments( state );
+
+		return {
+			currentUser: getCurrentUser( state ),
+			queryArguments: queryArguments,
+		};
+	},
+	{ submitSignupStep }
+)( localize( SubscribeEmailStep ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3098

## Proposed Changes

* Making requests to the `/users/new` endpoint as a logged in user will attempt to reset the logged in user's email
* Because of this, we now show a continue as user page to logged in users. The user can either can continue with their account, at which point their own email will be subscribed to guides.
* Otherwise they are logged out and whatever email they originally submitted will be subscribed to guides instead

![2024-06-28 15 25 42](https://github.com/Automattic/wp-calypso/assets/5414230/9b7e03e1-e7c1-43e1-a280-42d4713ad3df)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When someone subscribes to an email campaign on a landing page like wordpress.com/learn, we'd like to manage outbound communication with Guides. Guides, however, requires a `user_id` and a WordPress account.

In the past, if the user wanted to subscribe on a landing page and wasn't already logged in, they'd be redirected to the `/log-in` page. If they didn't have an account, they'd be prompted to create one. Once completed, they'd be redirected to the original landing page.

To polish this experience, we're creating a custom email subscription "signup" flow. For the happy path, the user should be able to subscribe with one click, and the technical implementation should look something like p5uIfZ-f11-p2#comment-22793.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log into wordpress.com
* With these PR changes, navigate to `/start/email-subscription/subscribe?user_email=test1016@gmail.com&redirect_to=wordpress.com%2Flearn&mailing_list=learn` in the WordPress staging environment
* Verify that you see the continue as user page
* Verify that clicking continue subscribes the current user to the email subscription ( instead of whatever was originally in the user_email query param ). You can confirm this through the dev console `/pigeon` request
* Verify that clicking on "another account" logs out the current user and subscribes the original user_email query param to `/pigeon`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?