### PR TITLE
Stepper: Fix duplicated calypso_signup_start event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,4 +1,4 @@
-import { SENSEI_FLOW } from '@automattic/onboarding';
+import debugFactory from 'debug';
 import { useEffect, useMemo } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordSignupStart } from 'calypso/lib/analytics/signup';
@@ -11,16 +11,50 @@ interface Props {
 	flow: Flow;
 	currentStepRoute: string;
 }
+const debug = debugFactory( 'calypso:landing:stepper:analytics' );
+export const TRACKING_LOCAL_STORAGE_KEY = 'signed_up_tracked';
 
-export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
-	const steps = flow.useSteps();
+const setTrackingState = ( id: string ) => {
+	const data = JSON.parse( localStorage.getItem( TRACKING_LOCAL_STORAGE_KEY ) || '{}' );
+	const newState = {
+		...data,
+		[ id ]: true,
+	};
+
+	localStorage.setItem( TRACKING_LOCAL_STORAGE_KEY, JSON.stringify( newState ) );
+	return newState;
+};
+
+const getTrackingState = () => {
+	try {
+		return JSON.parse( localStorage.getItem( TRACKING_LOCAL_STORAGE_KEY ) || '{}' );
+	} catch {
+		return {};
+	}
+};
+
+const wasAlreadyTracked = ( flowName: string ) => {
+	try {
+		const state = getTrackingState();
+		return state[ flowName ] === true;
+	} catch ( e ) {
+		debug( 'Error parsing signedUp from localStorage', e );
+		return false;
+	}
+};
+
+function trackSignUpEvent( flow: Flow, ref: string, extraProps: Record< string, unknown > = {} ) {
+	recordSignupStart( flow.name, ref, extraProps || {} );
+	const trackId = flow.variantSlug ?? flow.name;
+
+	debug( 'Recorded signup start tracked', trackId, ref, extraProps );
+	setTrackingState( trackId );
+}
+
+export const useSignUpStartTracking = ( { flow }: Props ) => {
 	const queryParams = useQuery();
 	const ref = queryParams.get( 'ref' ) || '';
-	const signedUp = queryParams.has( 'signed_up' );
 
-	// TODO: Check if we can remove the sensei flow reference from here.
-	const firstStepSlug = ( flow.name === SENSEI_FLOW ? steps[ 1 ] : steps[ 0 ] ).slug;
-	const isFirstStep = firstStepSlug === currentStepRoute;
 	const flowVariant = flow.variantSlug;
 	const signupStartEventProps = flow.useSignupStartEventProps?.();
 
@@ -32,13 +66,15 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 		[ signupStartEventProps, flowVariant ]
 	);
 	const flowName = flow.name;
-	const shouldTrack = flow.isSignupFlow && isFirstStep && ! signedUp;
+	const isSignUpFlow = flow.isSignupFlow;
 
 	useEffect( () => {
-		if ( ! shouldTrack ) {
+		if ( ! isSignUpFlow || wasAlreadyTracked( flowVariant ?? flowName ) ) {
+			debug( 'Track skipped: Tracking already done for this flow' );
 			return;
 		}
 
-		recordSignupStart( flowName, ref, extraProps || {} );
-	}, [ extraProps, flowName, ref, shouldTrack ] );
+		trackSignUpEvent( flow, ref, extraProps );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 };


### PR DESCRIPTION
Related to #

## Proposed Changes
* Use localStorage to track the `calypso_signup_start`  event once by flow. 
* Remove any logic related to the step position.
* Move `useSignUpStartTracking` to a safer position, avoiding race conditions with the flow hooks.

## Why are these changes being made?
Nowadays Stepper is triggering the `calypso_signup_start` multiple times when:
1) User lands on the first flow steps and reload
2) Not logged user arrives in a step that requires login. In this case, an event is triggered before the login and after the login, when the user is redirected to the flow. 

The current logic also fails when the flow has conditions to say which step is the first one, E.g migration-signup that is a sign-up flow but has the `site-identify` step as the first one on the list, but there are cases the flow redirects the user to another step as a first step. 



## Testing Instructions
* Access one of the flows marked as `isSignupFlow`. (E.g: /setup/migration-signup)
* Use Tracks Vigilant to check the calypso_signup_start with the flow name
* Reload the page and check the event was NOT triggered again.
* Access another `sign-up` flow (E.g. /setup/sensei)
* Check if the `calypso_signup_start` was triggered. 

Note: There are automated tests covering these scenarios, but is valid a double check on the browser.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
