### PR TITLE
Jetpack Backup: Hide actions toolbar in the latest backup during copy to staging flow

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -62,6 +62,9 @@ const BackupSuccessful = ( {
 
 	const [ showContent, toggleShowContent ] = useToggleContent();
 
+	const isCloneFlow =
+		availableActions && availableActions.length === 1 && availableActions[ 0 ] === 'clone';
+
 	return (
 		<>
 			<div className="status-card__message-head">
@@ -70,16 +73,18 @@ const BackupSuccessful = ( {
 					{ isToday ? translate( 'Latest backup' ) : translate( 'Latest backup on this day' ) }
 				</div>
 
-				<div className="status-card__toolbar">
-					<Toolbar
-						siteId={ siteId }
-						activity={ backup }
-						isContentExpanded={ showContent }
-						onToggleContent={ toggleShowContent }
-						availableActions={ [ 'download', 'rewind', 'view' ] }
-						onClickClone={ onClickClone }
-					/>
-				</div>
+				{ ! isCloneFlow && (
+					<div className="status-card__toolbar">
+						<Toolbar
+							siteId={ siteId }
+							activity={ backup }
+							isContentExpanded={ showContent }
+							onToggleContent={ toggleShowContent }
+							availableActions={ availableActions }
+							onClickClone={ onClickClone }
+						/>
+					</div>
+				) }
 			</div>
 			<div className="status-card__hide-desktop">
 				<div className="status-card__title">{ displayDate }</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves to https://github.com/Automattic/jetpack-backup-team/issues/549

## Proposed Changes

* Hide `Actions (+)` toolbar in the latest backup during copy to staging flow

| Before | After |
|---|---|
| ![CleanShot 2024-06-28 at 19 30 31@2x](https://github.com/Automattic/wp-calypso/assets/1488641/6f2f1e22-5eaa-4004-bda7-986d75df1610) | ![CleanShot 2024-06-28 at 19 30 00@2x](https://github.com/Automattic/wp-calypso/assets/1488641/754fd85e-2429-4c48-8464-5f43f596c077) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Users drop from the Copy to Staging flow by clicking the `Actions (+)` toolbar and then clicking on `Restore to this point`, `Download backup` or `View files`, then they need to start over.

More details here: https://github.com/Automattic/jetpack-backup-team/issues/549#issuecomment-2178795209

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch
* Navigate to Jetpack Cloud > Backup
* Click on `Copy site` at the top right of the page
* Search a previously configured staging site or set up a new one (the shortest path you have)
* Ensure it displays the latest successful backup on top, without the `Actions (+)` toolbar at the top right of that section.
* Ensure you still see any `Clone from here` on other backups.
  * **Open question:** should we rename it to `Copy from here`?

Now, just let ensure that you can still see the `Actions (+)` toolbar when navigating to the **Activity Log** and **Backup** page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
