### PR TITLE
A4A: Implement site configurations form on modal

### DIFF
--- a/client/a8c-for-agencies/components/form/field/index.tsx
+++ b/client/a8c-for-agencies/components/form/field/index.tsx
@@ -6,7 +6,7 @@ import './style.scss';
 type Props = {
 	label: string;
 	sub?: string;
-	description?: string;
+	description?: string | ReactNode;
 	showOptionalLabel?: boolean;
 	children: ReactNode;
 	isRequired?: boolean;

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Modal } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -20,6 +19,7 @@ import SitesHeaderActions from '../sites-header-actions';
 import ClientSite from './client-site';
 import { AvailablePlans } from './plan-field';
 import PurchaseConfirmationMessage from './purchase-confirmation-message';
+import SiteConfigurationsModal from './site-configurations-modal';
 import NeedSetupTable from './table';
 import type { ReferralAPIResponse } from '../../referrals/types';
 
@@ -187,11 +187,7 @@ export default function NeedSetup( { licenseKey }: Props ) {
 						</Actions>
 					</LayoutHeader>
 				</LayoutTop>
-				{ displaySiteConfigurationModal && (
-					<Modal title={ translate( 'Configure your site' ) } onRequestClose={ toggleModal }>
-						<h1>Configure your site placeholder modal</h1>
-					</Modal>
-				) }
+				{ displaySiteConfigurationModal && <SiteConfigurationsModal toggleModal={ toggleModal } /> }
 				<NeedSetupTable
 					availablePlans={ availablePlans }
 					isLoading={ isFetching }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -1,0 +1,129 @@
+import { Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { CheckboxControl, Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import FormField from 'calypso/a8c-for-agencies/components/form/field';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSelect from 'calypso/components/forms/form-select';
+import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
+import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
+import { usePhpVersions } from 'calypso/data/php-versions/use-php-versions';
+
+import './style.scss';
+
+type SiteConfigurationsModalProps = {
+	toggleModal: () => void;
+};
+
+export default function SiteConfigurationsModal( { toggleModal }: SiteConfigurationsModalProps ) {
+	const [ allowClientsToUseSiteHelpCenter, setAllowClientsToUseSiteHelpCenter ] = useState( true );
+	const translate = useTranslate();
+	const dataCenterOptions = useDataCenterOptions();
+	const { phpVersions } = usePhpVersions();
+
+	const toggleAllowClientsToUseSiteHelpCenter = () =>
+		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );
+
+	const phpVersionsElements = phpVersions.map( ( version ) => {
+		if ( version.disabled ) {
+			return null;
+		}
+
+		return (
+			<option value={ version.value } key={ version.value }>
+				{ version.label }
+			</option>
+		);
+	} );
+
+	const dataCenterOptionsElements = (
+		Object.keys( dataCenterOptions ) as Array< keyof typeof dataCenterOptions >
+	 ).map( ( key ) => (
+		<option key={ key } value={ key }>
+			{ dataCenterOptions[ key ] }
+		</option>
+	) );
+
+	return (
+		<Modal
+			title={ translate( 'Configure your site' ) }
+			onRequestClose={ toggleModal }
+			className="configure-your-site-modal-form"
+		>
+			<FormFieldset className="configure-your-site-modal-form__main">
+				<FormField
+					label={ translate( 'Site address' ) }
+					description={ translate(
+						'Once the site is created, you can connect a custom domain to your site and make that your site address instead.'
+					) }
+				>
+					<FormTextInputWithAffixes suffix=".wpcomstaging.com" noWrap />
+				</FormField>
+				<FormField
+					label={ translate( 'PHP Version' ) }
+					description={ translate(
+						'The PHP version can be changed after your site is created via {{a}}Web Server Settings{{/a}}.',
+						{
+							components: {
+								a: (
+									<a href="https://developer.wordpress.com/docs/developer-tools/web-server-settings/" />
+								),
+							},
+						}
+					) }
+				>
+					<FormSelect
+						className="configure-your-site-modal-form__php-version-select"
+						name="product"
+						onChange={ () => {} }
+					>
+						{ phpVersionsElements }
+					</FormSelect>
+				</FormField>
+				<FormField label={ translate( 'Primary Data Center' ) }>
+					<FormSelect name="product" id="product" onChange={ () => {} }>
+						{ dataCenterOptionsElements }
+					</FormSelect>
+				</FormField>
+				<FormField label="">
+					<div className="configure-your-site-modal-form__allow-clients-to-use-help-center">
+						<CheckboxControl
+							id="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox"
+							onChange={ toggleAllowClientsToUseSiteHelpCenter }
+							checked={ allowClientsToUseSiteHelpCenter }
+						/>
+						<label htmlFor="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox">
+							{ translate(
+								'Allow clients to use the {{HcLink}}WordPress.com Help Center{{/HcLink}} and {{HfLink}}hosting features.{{/HfLink}}',
+								{
+									components: {
+										HcLink: (
+											<a
+												href={ localizeUrl(
+													'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
+												) }
+											/>
+										),
+										HfLink: (
+											<a
+												href={ localizeUrl(
+													'https://wordpress.com/support/hosting-configuration'
+												) }
+											/>
+										),
+									},
+								}
+							) }
+						</label>
+					</div>
+				</FormField>
+			</FormFieldset>
+			<div className="configure-your-site-modal-form__footer">
+				<Button primary onClick={ () => {} }>
+					{ translate( 'Create site' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
@@ -1,0 +1,32 @@
+.configure-your-site-modal-form {
+	max-width: 600px;
+
+	select {
+		width: fit-content;
+	}
+	.components-modal__content {
+		padding: 0;
+	}
+	.configure-your-site-modal-form__main {
+		padding: 0 30px;
+	}
+
+	.configure-your-site-modal-form__php-version-select {
+		min-width: 200px;
+	}
+	.configure-your-site-modal-form__allow-clients-to-use-help-center {
+		margin-top: 15px;
+		display: flex;
+		font-weight: 400;
+		color: var(--color-neutral-50);
+		font-size: rem(14px);
+		line-height: 1.5;
+	}
+
+	.configure-your-site-modal-form__footer {
+		padding: 24px 40px;
+		text-align: right;
+		background-color: var(--color-neutral-0);
+		border-radius: 4px;
+	}
+}

--- a/client/data/data-center/use-data-center-options.ts
+++ b/client/data/data-center/use-data-center-options.ts
@@ -1,0 +1,11 @@
+import { useTranslate } from 'i18n-calypso';
+
+export const useDataCenterOptions = () => {
+	const translate = useTranslate();
+	return {
+		bur: translate( 'US West (Burbank, California)' ),
+		dfw: translate( 'US Central (Dallas-Fort Worth, Texas)' ),
+		dca: translate( 'US East (Washington, D.C.)' ),
+		ams: translate( 'EU West (Amsterdam, Netherlands)' ),
+	};
+};

--- a/client/data/php-versions/use-php-versions.jsx
+++ b/client/data/php-versions/use-php-versions.jsx
@@ -1,0 +1,44 @@
+import { useTranslate } from 'i18n-calypso';
+
+export const usePhpVersions = () => {
+	const recommendedValue = '8.1';
+	const translate = useTranslate();
+
+	const phpVersions = [
+		{
+			label: '7.3',
+			value: '7.3',
+			disabled: true, // EOL 6th December, 2021
+		},
+		{
+			label: translate( '%s (deprecated)', {
+				args: '7.4',
+				comment: 'PHP Version for a version switcher',
+			} ),
+			value: '7.4',
+			disabled: true, // EOL 1st July, 2024
+		},
+		{
+			label: '8.0',
+			value: '8.0',
+			disabled: true, // EOL 26th November, 2023
+		},
+		{
+			label: translate( '%s (recommended)', {
+				args: '8.1',
+				comment: 'PHP Version for a version switcher',
+			} ),
+			value: recommendedValue,
+		},
+		{
+			label: '8.2',
+			value: '8.2',
+		},
+		{
+			label: '8.3',
+			value: '8.3',
+		},
+	];
+
+	return { recommendedValue, phpVersions };
+};

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -12,6 +12,8 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-card';
+import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
+import { usePhpVersions } from 'calypso/data/php-versions/use-php-versions';
 import {
 	updateAtomicPhpVersion,
 	updateAtomicStaticFile404,
@@ -71,6 +73,8 @@ const WebServerSettingsCard = ( {
 	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState( '' );
 	const [ selectedWpVersion, setSelectedWpVersion ] = useState( '' );
 	const [ selectedStaticFile404, setSelectedStaticFile404 ] = useState( '' );
+	const { recommendedValue, phpVersions } = usePhpVersions();
+	const dataCenterOptions = useDataCenterOptions();
 
 	const isLoading =
 		isGettingGeoAffinity || isGettingPhpVersion || isGettingStaticFile404 || isGettingWpVersion;
@@ -154,12 +158,6 @@ const WebServerSettingsCard = ( {
 			return;
 		}
 
-		const dataCenterOptions = {
-			bur: translate( 'US West (Burbank, California)' ),
-			dfw: translate( 'US Central (Dallas-Fort Worth, Texas)' ),
-			dca: translate( 'US East (Washington, D.C.)' ),
-			ams: translate( 'EU West (Amsterdam, Netherlands)' ),
-		};
 		const displayValue =
 			dataCenterOptions[ geoAffinity ] !== undefined
 				? dataCenterOptions[ geoAffinity ]
@@ -183,8 +181,6 @@ const WebServerSettingsCard = ( {
 		);
 	};
 
-	const recommendedValue = '8.1';
-
 	const changePhpVersion = ( event ) => {
 		const newVersion = event.target.value;
 
@@ -193,44 +189,6 @@ const WebServerSettingsCard = ( {
 
 	const updateVersion = () => {
 		updatePhpVersion( siteId, selectedPhpVersion );
-	};
-
-	const getPhpVersions = () => {
-		return [
-			{
-				label: '7.3',
-				value: '7.3',
-				disabled: true, // EOL 6th December, 2021
-			},
-			{
-				label: translate( '%s (deprecated)', {
-					args: '7.4',
-					comment: 'PHP Version for a version switcher',
-				} ),
-				value: '7.4',
-				disabled: true, // EOL 1st July, 2024
-			},
-			{
-				label: '8.0',
-				value: '8.0',
-				disabled: true, // EOL 26th November, 2023
-			},
-			{
-				label: translate( '%s (recommended)', {
-					args: '8.1',
-					comment: 'PHP Version for a version switcher',
-				} ),
-				value: recommendedValue,
-			},
-			{
-				label: '8.2',
-				value: '8.2',
-			},
-			{
-				label: '8.3',
-				value: '8.3',
-			},
-		];
 	};
 
 	const getPhpVersionContent = () => {
@@ -251,7 +209,7 @@ const WebServerSettingsCard = ( {
 					onChange={ changePhpVersion }
 					value={ selectedPhpVersionValue }
 				>
-					{ getPhpVersions().map( ( option ) => {
+					{ phpVersions.map( ( option ) => {
 						// Show disabled PHP version only if the site is still using it.
 						if ( option.value !== phpVersion && option.disabled ) {
 							return null;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7870

## Proposed Changes
![image](https://github.com/Automattic/wp-calypso/assets/33497086/0469d1ed-e2e3-4f50-a2ae-98e1f7d2f994)

Visual implementation of Site configurations form on modal.
This is just an iteration under `a4a-site-creation-configurations` feature flag.
Form submission and site name logics will be implemented on future PR.

## Testing Instructions

### Calypso regression test - `PHP version` and `Primary Data Center`
Because we moved the PHP versions and Data Center values to a reusable data hook, we should make sure that those still works on the **Server Settings** page `http://calypso.localhost:3000/hosting-config/{your-site}` on regular calipso client.

It is highly probable that the `Primary Data Center` field is hidden for your site. For having a site in which that information is displayed on the setting page, follow this instructions:
https://wordpress.com/support/choose-your-sites-primary-data-center/

![image](https://github.com/Automattic/wp-calypso/assets/33497086/829481f3-4f2e-4bbb-b000-6fdab6151072)

`PHP version` should be a select with a few PHP versions.
It is ok that `Primary Data Center` is disabled, as long it displays the data center value.

### A4A site configurations form 
1 - Open this link: http://agencies.localhost:3000/sites/need-setup?flags=a4a-site-creation-configurations
2 - Click on Create new site button.
3 - You should see the site configurations form  on a modal.
4 - You should be able to edit all fields.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
