### PR TITLE
Stats: Fixing issues with data query when switching periods

### DIFF
--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -3,6 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { mapMarker } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { useSelector } from 'calypso/state';
 import {
 	isRequestingSiteStatsForQuery,
@@ -18,7 +19,10 @@ import StatsModulePlaceholder from '../../../stats-module/placeholder';
 type StatCountriesProps = {
 	className?: string;
 	period: string;
-	query: string;
+	query: {
+		date: string;
+		period: string;
+	};
 	moduleStrings: {
 		title: string;
 		item: string;
@@ -46,6 +50,9 @@ const StatCountries: React.FC< StatCountriesProps > = ( {
 
 	return (
 		<>
+			{ siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
 			{ requesting && <StatsModulePlaceholder isLoading={ requesting } /> }
 			{ ( ! data || ! data?.length ) && (
 				<StatsCard

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -4,6 +4,7 @@ import { megaphone } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
@@ -18,7 +19,10 @@ import { StatsEmptyActionSocial } from '../shared';
 type StatsRefeeresProps = {
 	className?: string;
 	period: string;
-	query: string;
+	query: {
+		date: string;
+		period: string;
+	};
 	moduleStrings: {
 		title: string;
 		item: string;
@@ -47,6 +51,9 @@ const StatsRefeeres: React.FC< StatsRefeeresProps > = ( {
 
 	return (
 		<>
+			{ siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
 			{ /* This will be replaced with ghost loaders, fallback to the current implementation until then. */ }
 			{ requesting && <StatsModulePlaceholder isLoading={ requesting } /> }
 			{ ( ! data || ! data?.length ) && (

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -4,6 +4,7 @@ import { trendingUp } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
@@ -18,7 +19,10 @@ import { StatsEmptyActionAI, StatsEmptyActionSocial } from '../shared';
 type StatsTopPostsProps = {
 	className?: string;
 	period: string;
-	query: string;
+	query: {
+		date: string;
+		period: string;
+	};
 	moduleStrings: {
 		title: string;
 		item: string;
@@ -47,6 +51,9 @@ const StatsTopPosts: React.FC< StatsTopPostsProps > = ( {
 
 	return (
 		<>
+			{ siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
 			{ /* This will be replaced with ghost loaders, fallback to the current implementation until then. */ }
 			{ requesting && <StatsModulePlaceholder isLoading={ requesting } /> }
 			{ ( ! data || ! data?.length ) && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/72

## Proposed Changes

* adding data query to fix empty state when switching between periods

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* After adding new empty state modules, when switching between days, the redux store was not properly populated with data. This query component used on the low level Stats Module is resolving it - the same way the previous modules did.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch and to a blog with data
* click on the chart to the days with visitors and posts
* verify that Top posts, Referrers and Countries module update
* (there is a known issue - spinner showing next to the modules that is being worked on)
* navigate to a blog without data - verify that the modules show empty states

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?