### PR TITLE
Stats: Adding empty state component for Clicks

### DIFF
--- a/client/my-sites/stats/features/modules/stats-clicks/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-clicks/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-clicks';

--- a/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
+++ b/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
@@ -1,0 +1,87 @@
+import { StatsCard } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { icon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { useSelector } from 'calypso/state';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { SUPPORT_URL } from '../../../const';
+import StatsModule from '../../../stats-module';
+import StatsModulePlaceholder from '../../../stats-module/placeholder';
+
+type StatClicksProps = {
+	className?: string;
+	period: string;
+	query: {
+		date: string;
+		period: string;
+	};
+	moduleStrings: {
+		title: string;
+		item: string;
+		value: string;
+		empty: string;
+	};
+};
+
+const StatClicks: React.FC< StatClicksProps > = ( { period, query, moduleStrings, className } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsType';
+
+	const requesting = useSelector( ( state ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	return (
+		<>
+			{ siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
+			{ requesting && <StatsModulePlaceholder isLoading={ requesting } /> }
+			{ ( ! data || ! data?.length ) && (
+				<StatsCard
+					className={ className }
+					title={ translate( 'Locations' ) }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ icon }
+							description={ translate( 'Description with {{link}}link{{/link}} goes here.', {
+								comment: '{{link}} links to support documentation.',
+								components: {
+									link: <a href={ localizeUrl( `${ SUPPORT_URL }#type` ) } />,
+								},
+								context: 'Stats: Info box label when the **type** module is empty',
+							} ) }
+						/>
+					}
+				>
+					<></>
+				</StatsCard>
+			) }
+			{ data && !! data.length && (
+				<StatsModule
+					path="path"
+					moduleStrings={ moduleStrings }
+					period={ period }
+					query={ query }
+					statType={ statType }
+					showSummaryLink
+					className={ className }
+				></StatsModule>
+			) }
+		</>
+	);
+};
+
+export default StatClicks;

--- a/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
+++ b/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
@@ -1,6 +1,6 @@
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { icon } from '@wordpress/icons';
+import { customLink } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -55,14 +55,17 @@ const StatClicks: React.FC< StatClicksProps > = ( { period, query, moduleStrings
 					isEmpty
 					emptyMessage={
 						<EmptyModuleCard
-							icon={ icon }
-							description={ translate( 'Description with {{link}}link{{/link}} goes here.', {
-								comment: '{{link}} links to support documentation.',
-								components: {
-									link: <a href={ localizeUrl( `${ SUPPORT_URL }#type` ) } />,
-								},
-								context: 'Stats: Info box label when the **type** module is empty',
-							} ) }
+							icon={ customLink }
+							description={ translate(
+								'Learn about your most {{link}}clicked external links{{/link}} to track engaging content.',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: <a href={ localizeUrl( `${ SUPPORT_URL }#clicks` ) } />,
+									},
+									context: 'Stats: Info box label when the Clicks module is empty',
+								}
+							) }
 						/>
 					}
 				>

--- a/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
+++ b/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
@@ -33,7 +33,7 @@ type StatClicksProps = {
 const StatClicks: React.FC< StatClicksProps > = ( { period, query, moduleStrings, className } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const statType = 'statsType';
+	const statType = 'statsClicks';
 
 	const requesting = useSelector( ( state ) =>
 		isRequestingSiteStatsForQuery( state, siteId, statType, query )
@@ -51,7 +51,7 @@ const StatClicks: React.FC< StatClicksProps > = ( { period, query, moduleStrings
 			{ ( ! data || ! data?.length ) && (
 				<StatsCard
 					className={ className }
-					title={ translate( 'Locations' ) }
+					title={ translate( 'Clicks' ) }
 					isEmpty
 					emptyMessage={
 						<EmptyModuleCard
@@ -74,7 +74,7 @@ const StatClicks: React.FC< StatClicksProps > = ( { period, query, moduleStrings
 			) }
 			{ data && !! data.length && (
 				<StatsModule
-					path="path"
+					path="clicks"
 					moduleStrings={ moduleStrings }
 					period={ period }
 					query={ query }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -547,15 +547,10 @@ class StatsSite extends Component {
 								statType="statsTopAuthors"
 								className={ clsx(
 									{
-										'stats__flexible-grid-item--40--once-space': supportsUTMStats,
-										'stats__flexible-grid-item--full--large': supportsUTMStats,
-										'stats__flexible-grid-item--full--medium': supportsUTMStats,
+										'stats__author-views': ! supportsUTMStats,
 									},
-									{
-										'stats__flexible-grid-item--half': ! supportsUTMStats,
-										'stats__flexible-grid-item--full--large': ! supportsUTMStats,
-									},
-									'stats__flexible-grid-item--full--medium'
+									'stats__flexible-grid-item--half',
+									'stats__flexible-grid-item--full--large'
 								) }
 								showSummaryLink
 							/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -508,8 +508,15 @@ class StatsSite extends Component {
 								statType="statsClicks"
 								showSummaryLink
 								className={ clsx(
-									'stats__flexible-grid-item--40--once-space',
-									'stats__flexible-grid-item--full--large',
+									{
+										'stats__flexible-grid-item--40--once-space': supportsUTMStats,
+										'stats__flexible-grid-item--full--large': supportsUTMStats,
+										'stats__flexible-grid-item--full--medium': supportsUTMStats,
+									},
+									{
+										'stats__flexible-grid-item--half': ! supportsUTMStats,
+										'stats__flexible-grid-item--full--large': ! supportsUTMStats,
+									},
 									'stats__flexible-grid-item--full--medium'
 								) }
 							/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -524,8 +524,15 @@ class StatsSite extends Component {
 								statType="statsClicks"
 								showSummaryLink
 								className={ clsx(
-									'stats__flexible-grid-item--40--once-space',
-									'stats__flexible-grid-item--full--large',
+									{
+										'stats__flexible-grid-item--40--once-space': supportsUTMStats,
+										'stats__flexible-grid-item--full--large': supportsUTMStats,
+										'stats__flexible-grid-item--full--medium': supportsUTMStats,
+									},
+									{
+										'stats__flexible-grid-item--half': ! supportsUTMStats,
+										'stats__flexible-grid-item--full--large': ! supportsUTMStats,
+									},
 									'stats__flexible-grid-item--full--medium'
 								) }
 							/>
@@ -540,10 +547,15 @@ class StatsSite extends Component {
 								statType="statsTopAuthors"
 								className={ clsx(
 									{
-										'stats__author-views': ! supportsUTMStats,
+										'stats__flexible-grid-item--40--once-space': supportsUTMStats,
+										'stats__flexible-grid-item--full--large': supportsUTMStats,
+										'stats__flexible-grid-item--full--medium': supportsUTMStats,
 									},
-									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large'
+									{
+										'stats__flexible-grid-item--half': ! supportsUTMStats,
+										'stats__flexible-grid-item--full--large': ! supportsUTMStats,
+									},
+									'stats__flexible-grid-item--full--medium'
 								) }
 								showSummaryLink
 							/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -44,6 +44,7 @@ import { getModuleSettings } from 'calypso/state/stats/module-settings/selectors
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import StatsModuleClicks from './features/modules/stats-clicks';
 import StatsModuleCountries from './features/modules/stats-countries';
 import StatsModuleReferrers from './features/modules/stats-referrers';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
@@ -498,27 +499,37 @@ class StatsSite extends Component {
 						) }
 
 						{ /* If UTM card or update card is not visible, shift "Clicks" and reduct to 1/2 for easier stacking */ }
-						<StatsModule
-							path="clicks"
-							moduleStrings={ moduleStrings.clicks }
-							period={ this.props.period }
-							query={ query }
-							statType="statsClicks"
-							showSummaryLink
-							className={ clsx(
-								{
-									'stats__flexible-grid-item--40--once-space': supportsUTMStats,
-									'stats__flexible-grid-item--full--large': supportsUTMStats,
-									'stats__flexible-grid-item--full--medium': supportsUTMStats,
-								},
-								{
-									'stats__flexible-grid-item--half': ! supportsUTMStats,
-									'stats__flexible-grid-item--full--large': ! supportsUTMStats,
-								},
-								'stats__flexible-grid-item--full--medium'
-							) }
-						/>
+						{ isNewStateEnabled && (
+							<StatsModuleClicks
+								path="clicks"
+								moduleStrings={ moduleStrings.clicks }
+								period={ this.props.period }
+								query={ query }
+								statType="statsClicks"
+								showSummaryLink
+								className={ clsx(
+									'stats__flexible-grid-item--40--once-space',
+									'stats__flexible-grid-item--full--large',
+									'stats__flexible-grid-item--full--medium'
+								) }
+							/>
+						) }
 
+						{ ! isNewStateEnabled && (
+							<StatsModule
+								path="clicks"
+								moduleStrings={ moduleStrings.clicks }
+								period={ this.props.period }
+								query={ query }
+								statType="statsClicks"
+								showSummaryLink
+								className={ clsx(
+									'stats__flexible-grid-item--40--once-space',
+									'stats__flexible-grid-item--full--large',
+									'stats__flexible-grid-item--full--medium'
+								) }
+							/>
+						) }
 						{ /* Either stacks with Clicks or with Emails depending on UTM */ }
 						{ ! this.isModuleHidden( 'authors' ) && (
 							<StatsModule


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#64](https://github.com/Automattic/red-team/issues/64)

## Proposed Changes

* adds a new empty state for Clicks

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply `stats/empty-module-traffic` feature flag
* verify that a page with empty Clicks views component works with and without the feature flag
* repeat for blogs with data

![image](https://github.com/Automattic/wp-calypso/assets/30754158/bc0945ee-d9a6-45ca-b522-a5c7c87e35eb)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?