### PR TITLE
A4A > Partner Directory: Implement redirect to dashboard when there is no approved directory

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-partner-directory-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-partner-directory-menu-items.ts
@@ -8,6 +8,8 @@ import {
 	PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
 } from 'calypso/a8c-for-agencies/sections/partner-directory/constants';
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 const isSelected = ( path: string, links: string[] ) => {
 	return links.includes( path );
@@ -15,6 +17,12 @@ const isSelected = ( path: string, links: string[] ) => {
 
 const usePartnerDirectoryMenuItems = ( path: string ) => {
 	const translate = useTranslate();
+
+	const agency = useSelector( getActiveAgency );
+	const hasDirectoryApproval = agency?.profile?.partner_directory_application?.directories.some(
+		( { status } ) => status === 'approved'
+	);
+
 	const menuItems = useMemo( () => {
 		return [
 			createItem(
@@ -32,24 +40,29 @@ const usePartnerDirectoryMenuItems = ( path: string ) => {
 				},
 				path
 			),
-			createItem(
-				{
-					icon: cog,
-					path: A4A_PARTNER_DIRECTORY_LINK,
-					link: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
-					title: translate( 'Agency details' ),
-					trackEventProps: {
-						menu_item: 'Automattic for Agencies / Partner Directory / Agency details',
-					},
-					isSelected: isSelected( path, [
-						`${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
-						`${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`,
-					] ),
-				},
-				path
-			),
+			// Only show the Agency details menu item if the agency has at least one directory approved
+			...( hasDirectoryApproval
+				? [
+						createItem(
+							{
+								icon: cog,
+								path: A4A_PARTNER_DIRECTORY_LINK,
+								link: `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
+								title: translate( 'Agency details' ),
+								trackEventProps: {
+									menu_item: 'Automattic for Agencies / Partner Directory / Agency details',
+								},
+								isSelected: isSelected( path, [
+									`${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }`,
+									`${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }`,
+								] ),
+							},
+							path
+						),
+				  ]
+				: [] ),
 		];
-	}, [ path, translate ] );
+	}, [ hasDirectoryApproval, path, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -44,7 +44,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			);
 			page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK );
 		},
-		[ page, reduxDispatch, translate ]
+		[ translate ]
 	);
 
 	const onSubmitError = useCallback( () => {
@@ -53,7 +53,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 				duration: 6000,
 			} )
 		);
-	}, [ page, reduxDispatch, translate ] );
+	}, [ translate ] );
 
 	const { formData, setFormData } = useDetailsForm( {
 		initialFormData,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -76,7 +76,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 			);
 			page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK );
 		},
-		[ page, reduxDispatch, translate ]
+		[ translate ]
 	);
 
 	const onSubmitError = useCallback( () => {
@@ -85,7 +85,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 				duration: 6000,
 			} )
 		);
-	}, [ reduxDispatch, translate ] );
+	}, [ translate ] );
 
 	const {
 		formData,

--- a/client/a8c-for-agencies/sections/partner-directory/controller.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/controller.tsx
@@ -2,6 +2,7 @@ import { type Callback } from '@automattic/calypso-router';
 import page from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import PartnerDirectorySideBar from '../../components/sidebar-menu/partner-directory';
 import {
 	PARTNER_DIRECTORY_DASHBOARD_SLUG,
@@ -11,9 +12,16 @@ import {
 import PartnerDirectory from './partner-directory';
 
 export const partnerDirectoryDashboardContext: Callback = ( context, next ) => {
+	const state = context.store.getState();
+	const agency = getActiveAgency( state );
+	const hasDirectoryApproval = agency?.profile?.partner_directory_application?.directories.some(
+		( { status } ) => status === 'approved'
+	);
+
 	const validSections = [
 		PARTNER_DIRECTORY_DASHBOARD_SLUG,
-		PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG,
+		// Agency details is hidden if the agency has no directories approved
+		...( hasDirectoryApproval ? [ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG ] : [] ),
 		PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG,
 	];
 


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/700

## Proposed Changes

This PR implements a redirect to the dashboard when there is no approved directory.

**Note:** This PR requires this diff: D153748-code

## Testing Instructions

1. Open the A4A live link.
2. Go /partner-directory/dashboard
3. Verify that the `Agency details` menu item is hidden and you are redirected to the dashboard if you manually visit `/partner-directory/agency-details`

<img width="1728" alt="Screenshot 2024-07-01 at 1 28 00 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/020b43e2-edd9-4a33-9e20-ffcaff2d6cab">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
