### PR TITLE
Automatic for Agencies: Add Site Selector & Importer feature flag

### DIFF
--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -40,7 +40,8 @@
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
 		"a4a-logged-out-signup": true,
-		"a4a-automated-referrals": true
+		"a4a-automated-referrals": true,
+		"a4a-site-selector-and-importer": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -32,7 +32,8 @@
 		"oauth": false,
 		"a4a/site-details-pane": true,
 		"a4a-logged-out-signup": true,
-		"a4a-automated-referrals": true
+		"a4a-automated-referrals": true,
+		"a4a-site-selector-and-importer": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/683

## Proposed Changes

* This PR adds and enables the feature flag for the site selector & importer project.


## Testing Instructions

- Verify that the feature flag is enabled only on dev & horizon environments. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
