### PR TITLE
Notifications: enable `position: sticky` for chromium

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -553,18 +553,7 @@ $with-sidebar-min-page-width: 1114px;
 				padding-right: 8px;
 				color: var(--color-neutral-40, #787c82);
 			}
-
-			.wpnc__keyboard-shortcuts-popover-anchor {
-				position: absolute;
-				right: 0;
-				top: 45px;
-				height: 18px;
-			}
 		}
-	}
-
-	.disable-sticky .wpnc__time-group-wrap {
-		position: static;
 	}
 
 	.wpnc__undo-item {

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -557,7 +557,7 @@ $with-sidebar-min-page-width: 1114px;
 			.wpnc__keyboard-shortcuts-popover-anchor {
 				position: absolute;
 				right: 0;
-				top: 45px;
+				top: calc(var(--masterbar-height) + 12px);
 				height: 18px;
 			}
 		}

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -559,9 +559,12 @@ $with-sidebar-min-page-width: 1114px;
 				right: 0;
 				top: 45px;
 				height: 18px;
+			}
 
-				&::after {
-					content: "";
+			@supports (-moz-appearance:none) {
+				/* Specific styles for Firefox */
+				.wpnc__keyboard-shortcuts-popover-anchor {
+					top: 0;
 				}
 			}
 		}

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -555,9 +555,14 @@ $with-sidebar-min-page-width: 1114px;
 			}
 
 			.wpnc__keyboard-shortcuts-popover-anchor {
-				display: inline-block;
-				vertical-align: baseline;
-				margin-left: auto;
+				position: absolute;
+				right: 0;
+				top: 45px;
+				height: 18px;
+
+				&::after {
+					content: "";
+				}
 			}
 		}
 	}

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -560,13 +560,6 @@ $with-sidebar-min-page-width: 1114px;
 				top: 45px;
 				height: 18px;
 			}
-
-			@supports (-moz-appearance:none) {
-				/* Specific styles for Firefox */
-				.wpnc__keyboard-shortcuts-popover-anchor {
-					top: 0;
-				}
-			}
 		}
 	}
 

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -555,10 +555,9 @@ $with-sidebar-min-page-width: 1114px;
 			}
 
 			.wpnc__keyboard-shortcuts-popover-anchor {
-				position: absolute;
-				right: 0;
-				top: calc(var(--masterbar-height) + 12px);
-				height: 18px;
+				display: inline-block;
+				vertical-align: baseline;
+				margin-left: auto;
 			}
 		}
 	}

--- a/apps/notifications/src/panel/templates/list-header.jsx
+++ b/apps/notifications/src/panel/templates/list-header.jsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { useRef } from 'react';
 import { connect } from 'react-redux';
 import actions from '../state/actions';
 import Gridicon from './gridicons';
@@ -8,12 +7,8 @@ import ShortcutsPopover from './shortcuts-popover';
 export const ListHeader = ( { isFirst, title, viewSettings } ) => {
 	const translate = useTranslate();
 
-	// create context for the keyboard shortcuts popover icon
-	const popoverAnchorRef = useRef();
 	return (
 		<li className="wpnc__time-group-wrap">
-			{ /* Attach the popover to this anchor instead of the button, so we can have retain position with scrolling. */ }
-			<div className="wpnc__keyboard-shortcuts-popover-anchor" ref={ popoverAnchorRef } />
 			<div className="wpnc__time-group-title">
 				<Gridicon icon="time" size={ 18 } />
 				{ title }
@@ -33,7 +28,7 @@ export const ListHeader = ( { isFirst, title, viewSettings } ) => {
 						>
 							<Gridicon icon="cog" size={ 18 } />
 						</span>
-						<ShortcutsPopover popoverAnchorRef={ popoverAnchorRef } />
+						<ShortcutsPopover />
 					</>
 				) }
 			</div>

--- a/apps/notifications/src/panel/templates/list-header.jsx
+++ b/apps/notifications/src/panel/templates/list-header.jsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
 import { connect } from 'react-redux';
 import actions from '../state/actions';
 import Gridicon from './gridicons';
@@ -7,8 +8,12 @@ import ShortcutsPopover from './shortcuts-popover';
 export const ListHeader = ( { isFirst, title, viewSettings } ) => {
 	const translate = useTranslate();
 
+	// create context for the keyboard shortcuts popover icon
+	const popoverAnchorRef = useRef();
 	return (
 		<li className="wpnc__time-group-wrap">
+			{ /* Attach the popover to this anchor instead of the button, so we can have retain position with scrolling. */ }
+			<div className="wpnc__keyboard-shortcuts-popover-anchor" ref={ popoverAnchorRef } />
 			<div className="wpnc__time-group-title">
 				<Gridicon icon="time" size={ 18 } />
 				{ title }
@@ -28,7 +33,7 @@ export const ListHeader = ( { isFirst, title, viewSettings } ) => {
 						>
 							<Gridicon icon="cog" size={ 18 } />
 						</span>
-						<ShortcutsPopover />
+						<ShortcutsPopover popoverAnchorRef={ popoverAnchorRef } />
 					</>
 				) }
 			</div>

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -332,7 +332,6 @@ export class NoteList extends Component {
 		}
 
 		const classes = clsx( 'wpnc__note-list', {
-			'disable-sticky': !! window.chrome || !! window.electron, // position: sticky doesn't work in Chrome – `window.chrome` does not exist in electron
 			'is-note-open': !! this.props.selectedNoteId,
 		} );
 

--- a/apps/notifications/src/panel/templates/shortcuts-popover.jsx
+++ b/apps/notifications/src/panel/templates/shortcuts-popover.jsx
@@ -17,11 +17,10 @@ export const ShortcutsPopover = ( {
 	toggleShortcutsPopover,
 	isPanelOpen,
 	isShortcutsPopoverOpen,
+	popoverAnchorRef,
 } ) => {
 	const translate = useTranslate();
 
-	// create context for the keyboard shortcuts popover icon
-	const popoverAnchorRef = useRef();
 	const spanRef = useRef();
 	const { isMobile } = userAgent;
 
@@ -115,8 +114,6 @@ export const ShortcutsPopover = ( {
 						},
 					] }
 				>
-					{ /* Attach the popover to this anchor instead of the button, so we can have retain position with scrolling. */ }
-					<div className="wpnc__keyboard-shortcuts-popover-anchor" ref={ popoverAnchorRef } />
 					<button
 						className={ clsx( 'wpnc__keyboard-shortcuts-button', {
 							'active-action': isShortcutsPopoverOpen,

--- a/apps/notifications/src/panel/templates/shortcuts-popover.jsx
+++ b/apps/notifications/src/panel/templates/shortcuts-popover.jsx
@@ -115,8 +115,6 @@ export const ShortcutsPopover = ( {
 						},
 					] }
 				>
-					{ /* Attach the popover to this anchor instead of the button, so we can have retain position with scrolling. */ }
-					<div className="wpnc__keyboard-shortcuts-popover-anchor" ref={ popoverAnchorRef } />
 					<button
 						className={ clsx( 'wpnc__keyboard-shortcuts-button', {
 							'active-action': isShortcutsPopoverOpen,
@@ -129,6 +127,8 @@ export const ShortcutsPopover = ( {
 						} }
 						ref={ spanRef }
 					>
+						{ /* Attach the popover to this anchor instead of the button, so we can have retain position with scrolling. */ }
+						<div className="wpnc__keyboard-shortcuts-popover-anchor" ref={ popoverAnchorRef } />
 						<Gridicon icon="info-outline" size={ 18 } />
 					</button>
 				</HotkeyContainer>

--- a/apps/notifications/src/panel/templates/shortcuts-popover.jsx
+++ b/apps/notifications/src/panel/templates/shortcuts-popover.jsx
@@ -17,10 +17,11 @@ export const ShortcutsPopover = ( {
 	toggleShortcutsPopover,
 	isPanelOpen,
 	isShortcutsPopoverOpen,
-	popoverAnchorRef,
 } ) => {
 	const translate = useTranslate();
 
+	// create context for the keyboard shortcuts popover icon
+	const popoverAnchorRef = useRef();
 	const spanRef = useRef();
 	const { isMobile } = userAgent;
 
@@ -114,6 +115,8 @@ export const ShortcutsPopover = ( {
 						},
 					] }
 				>
+					{ /* Attach the popover to this anchor instead of the button, so we can have retain position with scrolling. */ }
+					<div className="wpnc__keyboard-shortcuts-popover-anchor" ref={ popoverAnchorRef } />
 					<button
 						className={ clsx( 'wpnc__keyboard-shortcuts-button', {
 							'active-action': isShortcutsPopoverOpen,

--- a/apps/notifications/src/panel/templates/shortcuts-popover.jsx
+++ b/apps/notifications/src/panel/templates/shortcuts-popover.jsx
@@ -127,9 +127,7 @@ export const ShortcutsPopover = ( {
 						} }
 						ref={ spanRef }
 					>
-						{ /* Attach the popover to this anchor instead of the button, so we can have retain position with scrolling. */ }
-						<div className="wpnc__keyboard-shortcuts-popover-anchor" ref={ popoverAnchorRef } />
-						<Gridicon icon="info-outline" size={ 18 } />
+						<Gridicon icon="info-outline" size={ 18 } ref={ popoverAnchorRef } />
 					</button>
 				</HotkeyContainer>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/91995

The top position on Firefox appears to cause the keyboard shortcuts popover to position itself differently to Chrome.

I suspect it has to do with the admin bar.

## Proposed Changes

* Allows `position: sticky` for chrome/electron. This restriction was added 6 years ago when it was not supported, but it seems to be supported now.
* Removes the extra anchor div for the popover that is no longer necessary after this change.

BEFORE (chrome)
![chrome-before](https://github.com/Automattic/wp-calypso/assets/28742426/a816becb-5b9d-442e-a491-f04ebd602943)

Notice above the group headings dont stay sticky underneath the tabs when scrolling.

BEFORE (firefox)
<img width="398" alt="Screenshot 2024-07-01 at 1 30 16 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/c36b2924-009e-4bb3-9d22-a94f740cce6b">

Notice the popover position is ~50px below where it should be.

AFTER (both)
![notes-fix](https://github.com/Automattic/wp-calypso/assets/28742426/bd15568f-8cf3-4605-b447-9bef359c92b5)

Position is consistent between the two, and chrome now gets the sticky group header behavior that was supported by other browsers.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is now supported in chrome.
* This restriction makes inconsistency with layout between browsers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test notes in both firefox and chrome.
* Verify the positioning of the info popover is stable and in the correct place on both.
* On chrome, verify the group headers are now 'sticky' when scrolling down through notifications.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
