### PR TITLE
Social Previews | Fix Threads preview to add support for caption

### DIFF
--- a/client/components/share/threads-share-preview/index.jsx
+++ b/client/components/share/threads-share-preview/index.jsx
@@ -1,6 +1,6 @@
 import { ThreadsPreviews } from '@automattic/social-previews';
 import { PureComponent } from 'react';
-import { decodeEntities } from 'calypso/lib/formatting';
+import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 
 export class ThreadsSharePreview extends PureComponent {
 	render() {
@@ -11,23 +11,42 @@ export class ThreadsSharePreview extends PureComponent {
 			message,
 			imageUrl,
 			seoTitle,
-			articleSummary,
+			articleContent,
 			hidePostPreview,
 			media,
 		} = this.props;
+
+		let caption = seoTitle;
+
+		if ( message ) {
+			caption = message;
+		} else if ( seoTitle && articleContent ) {
+			caption = `${ seoTitle }\n\n${ articleContent }`;
+		}
+
+		const captionLength =
+			// 500 characters
+			500 -
+			// Number of characters in the article URL
+			articleUrl.length -
+			// 2 characters for line break
+			2;
+
+		caption = stripHTML( decodeEntities( caption ) ).slice( 0, captionLength );
+
+		caption += `\n\n${ articleUrl }`;
 
 		return (
 			<div className="threads-share-preview">
 				<ThreadsPreviews
 					posts={ [
 						{
-							description: decodeEntities( articleSummary ),
 							title: decodeEntities( seoTitle ),
 							image: imageUrl,
 							url: articleUrl,
 							name: externalName,
 							profileImage: externalProfilePicture,
-							text: message,
+							caption,
 							media,
 						},
 					] }

--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v2.1.0
 
 - Added Threads preview
-- Fixed media image URL for Tumblr preview
+- Fixed media image URL for Tumblr and Instagram previews
 
 ## v2.0.1 (2024-06-10)
 

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.1.0-beta.5",
+	"version": "2.1.0-beta.6",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/instagram-preview/post-preview.tsx
+++ b/packages/social-previews/src/instagram-preview/post-preview.tsx
@@ -45,7 +45,7 @@ export function InstagramPostPreview( {
 									<source src={ mediaItem.url } type={ mediaItem.type } />
 								</video>
 							) : (
-								<img className="instagram-preview__media--image" src={ image } alt="" />
+								<img className="instagram-preview__media--image" src={ mediaItem.url } alt="" />
 							) }
 						</div>
 					) : (

--- a/packages/social-previews/src/threads-preview/helpers.ts
+++ b/packages/social-previews/src/threads-preview/helpers.ts
@@ -2,6 +2,8 @@ import { firstValid, hardTruncation, shortEnough, stripHtmlTags, Formatter } fro
 
 const TITLE_LENGTH = 120;
 
+export const CAPTION_MAX_CHARS = 500;
+
 export const threadsTitle: Formatter = ( text ) =>
 	firstValid(
 		shortEnough( TITLE_LENGTH ),

--- a/packages/social-previews/src/threads-preview/link-preview.tsx
+++ b/packages/social-previews/src/threads-preview/link-preview.tsx
@@ -6,7 +6,7 @@ export const ThreadsLinkPreview: React.FC< ThreadsPreviewProps > = ( props ) => 
 		<ThreadsPostPreview
 			{ ...props }
 			// Override the props that are irrelevant to link preview
-			text=""
+			caption=""
 			media={ undefined }
 		/>
 	);

--- a/packages/social-previews/src/threads-preview/post-preview.tsx
+++ b/packages/social-previews/src/threads-preview/post-preview.tsx
@@ -2,6 +2,7 @@ import { preparePreviewText } from '../helpers';
 import { Card } from './card';
 import { Footer } from './footer';
 import { Header } from './header';
+import { CAPTION_MAX_CHARS } from './helpers';
 import { Media } from './media';
 import { Sidebar } from './sidebar';
 import { ThreadsPreviewProps } from './types';
@@ -9,28 +10,19 @@ import { ThreadsPreviewProps } from './types';
 import './style.scss';
 
 export const ThreadsPostPreview: React.FC< ThreadsPreviewProps > = ( {
+	caption,
 	date,
-	description,
 	image,
 	media,
 	name,
 	profileImage,
 	showThreadConnector,
-	text,
 	title,
 	url,
 } ) => {
 	const hasMedia = !! media?.length;
 
 	const displayAsCard = url && image && ! hasMedia;
-
-	let textToDisplay = text || title;
-
-	// Attach the URL to the text if not displaying as a card and it's not already in the text.
-	textToDisplay =
-		! displayAsCard && textToDisplay && url && ! textToDisplay.includes( url )
-			? `${ textToDisplay } ${ url }`
-			: textToDisplay;
 
 	return (
 		<div className="threads-preview__wrapper">
@@ -39,20 +31,16 @@ export const ThreadsPostPreview: React.FC< ThreadsPreviewProps > = ( {
 				<div className="threads-preview__main">
 					<Header name={ name } date={ date } />
 					<div className="threads-preview__content">
-						{ textToDisplay ? (
+						{ caption ? (
 							<div className="threads-preview__text">
-								{ preparePreviewText( textToDisplay, { platform: 'threads' } ) }
+								{ preparePreviewText( caption, {
+									platform: 'threads',
+									maxChars: CAPTION_MAX_CHARS,
+								} ) }
 							</div>
 						) : null }
 						{ hasMedia ? <Media media={ media } /> : null }
-						{ displayAsCard ? (
-							<Card
-								description={ description || '' }
-								image={ image }
-								title={ title || '' }
-								url={ url }
-							/>
-						) : null }
+						{ displayAsCard ? <Card image={ image } title={ title || '' } url={ url } /> : null }
 					</div>
 					<Footer />
 				</div>

--- a/packages/social-previews/src/threads-preview/types.ts
+++ b/packages/social-previews/src/threads-preview/types.ts
@@ -4,7 +4,7 @@ export type ThreadsPreviewsProps = SocialPreviewsBaseProps & {
 	posts: Array< ThreadsPreviewProps >;
 };
 
-export type ThreadsCardProps = SocialPreviewBaseProps;
+export type ThreadsCardProps = Omit< SocialPreviewBaseProps, 'description' >;
 
 export type SidebarProps = {
 	showThreadConnector?: boolean;
@@ -20,11 +20,4 @@ export type MediaProps = {
 	media: Array< MediaItem >;
 };
 
-export type TextProps = {
-	text: string;
-	url: string;
-};
-
-export type ThreadsPreviewProps = SidebarProps &
-	HeaderProps &
-	Partial< ThreadsCardProps & Pick< TextProps, 'text' > >;
+export type ThreadsPreviewProps = SidebarProps & HeaderProps & Partial< ThreadsCardProps >;

--- a/packages/social-previews/src/types.ts
+++ b/packages/social-previews/src/types.ts
@@ -25,6 +25,11 @@ export interface SocialPreviewBaseProps {
 	 * The array of media items to use in the preview.
 	 */
 	media?: Array< MediaItem >;
+
+	/**
+	 * The caption.
+	 */
+	caption?: string;
 }
 
 export interface SocialPreviewsBaseProps {


### PR DESCRIPTION
Right now our Threads preview does not reflect what Publicize sends out. So it needs to be fixed.

## Proposed Changes

* Update Threads preview to add support for explicit caption. This allows the consumer component to control the way caption is displayed.
* Fix media URL for Instagram posts

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to make Social Previews consistent with what Jetpack Social sends out.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add the blog sticker to your site `add_blog_sticker('jetpack-social-threads-connection', null, null, <blog-id>);`
* Create a post and add a featured image to it
* Goto `/posts/:site`
* Click on options (3 dots) for the post
* Select "Share" and click on Preview
* Confirm that the Threads preview works as expected - has title, excerpt and the URL.
* Also test https://github.com/Automattic/jetpack/pull/38138

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>
<img width="1080" alt="Screenshot 2024-07-01 at 5 34 02 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/98ab2a09-bdc3-47ae-9c77-6bc28c85fd07">
</td>
            <td>
<img width="1082" alt="Screenshot 2024-07-01 at 5 32 57 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/e75c2e2f-02fb-4dbf-a84e-9fc85fd66d9a">
</td>
        </tr>
    </tbody>
</table>
