### PR TITLE
Increase Odie's timeout

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-odie.php
@@ -275,7 +275,7 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 			2,
 			array(
 				'method'  => 'POST',
-				'timeout' => 30,
+				'timeout' => 60,
 			),
 			array(
 				'message' => $request->get_param( 'message' ),


### PR DESCRIPTION
Related to #92187

## Proposed Changes

Increase Odie's timeout to 60s.

## Why are these changes being made?

See discussions in p1719503132827529-slack-C02T4NVL4JJ. Other services related to LLM are set to timeout in 60s, so let's standardize.

## Testing Instructions

Code review should be fine.
