### PR TITLE
Help Center App: make TeamCity compliant

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -43,6 +43,7 @@ object WPComPlugins : Project({
 					"o2-blocks-release-build",
 					"happy-blocks-release-build",
 					"command-palette-wp-admin-release-build",
+					"help-center-release-build",
 				)
 			}
 			dataToKeep = everything()

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -125,6 +125,7 @@ object CalypsoApps: BuildType({
 		apps/happy-blocks/release-files => happy-blocks.zip
 		apps/editing-toolkit/editing-toolkit-plugin => editing-toolkit.zip
 		apps/command-palette-wp-admin/dist => command-palette-wp-admin.zip
+		apps/help-center/dist => help-center.zip
 	""".trimIndent()
 
 	steps {

--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -22,7 +22,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "rm -rf dist",
-		"teamcity:build-app": "yarn run build && yarn run translate",
+		"teamcity:build-app": "yarn run build",
 		"build": "NODE_ENV=production yarn dev",
 		"build:app": "calypso-build && yarn run translate",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/help-center",

--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -22,6 +22,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "rm -rf dist",
+		"teamcity:build-app": "yarn run build && yarn run translate",
 		"build": "NODE_ENV=production yarn dev",
 		"build:app": "calypso-build && yarn run translate",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/help-center",

--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -30,12 +30,10 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			'help-center-wp-admin': path.join( __dirname, 'help-center-wp-admin.js' ),
 			'help-center-gutenberg-disconnected': path.join(
 				__dirname,
-
 				'help-center-gutenberg-disconnected.js'
 			),
 			'help-center-wp-admin-disconnected': path.join(
 				__dirname,
-
 				'help-center-wp-admin-disconnected.js'
 			),
 		},


### PR DESCRIPTION
This makes the newly-added Help Center app compliant to Calypso App Build in TeamCity.