### PR TITLE
Login Assistance: Update the "migrate CTA when login fails" experiment

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -906,7 +906,7 @@ export class LoginForm extends Component {
 
 								{ 'unknown_user' === requestError.code && ! isRecognizedLogin() && (
 									<Experiment
-										name="calypso_login_failed_show_migrate_cta_202406"
+										name="calypso_login_failed_show_migrate_cta_202407_v2"
 										defaultExperience={ null }
 										loadingExperience={ null }
 										treatmentExperience={

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -28,6 +28,7 @@ import {
 	getSignupUrl,
 	pathWithLeadingSlash,
 	isReactLostPasswordScreenEnabled,
+	isRecognizedLogin,
 	canDoMagicLogin,
 	getLoginLinkPageUrl,
 } from 'calypso/lib/login';
@@ -903,17 +904,19 @@ export class LoginForm extends Component {
 										) }
 								</FormInputValidation>
 
-								<Experiment
-									name="calypso_login_failed_show_migrate_cta_202406"
-									defaultExperience={ null }
-									loadingExperience={ null }
-									treatmentExperience={
-										<MigrateNotice
-											translate={ this.props.translate }
-											recordTracksEvent={ this.props.recordTracksEvent }
-										/>
-									}
-								/>
+								{ 'unknown_user' === requestError.code && ! isRecognizedLogin() && (
+									<Experiment
+										name="calypso_login_failed_show_migrate_cta_202406"
+										defaultExperience={ null }
+										loadingExperience={ null }
+										treatmentExperience={
+											<MigrateNotice
+												translate={ this.props.translate }
+												recordTracksEvent={ this.props.recordTracksEvent }
+											/>
+										}
+									/>
+								) }
 							</Fragment>
 						) }
 

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -15,6 +15,10 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 
+function getCookies() {
+	return typeof document === 'undefined' ? {} : cookie.parse( document.cookie );
+}
+
 export function getSocialServiceFromClientId( clientId ) {
 	if ( ! clientId ) {
 		return null;
@@ -177,7 +181,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 }
 
 export const isReactLostPasswordScreenEnabled = () => {
-	const cookies = typeof document === 'undefined' ? {} : cookie.parse( document.cookie );
+	const cookies = getCookies();
 	return (
 		config.isEnabled( 'login/react-lost-password-screen' ) ||
 		cookies.enable_react_password_screen === 'yes'
@@ -230,4 +234,10 @@ export const getLoginLinkPageUrl = ( {
 	}
 
 	return login( loginParameters );
+};
+
+export const isRecognizedLogin = () => {
+	const cookies = getCookies();
+
+	return Boolean( cookies.recognized_logins );
 };

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -1,4 +1,8 @@
-import { pathWithLeadingSlash, getSignupUrl } from 'calypso/lib/login';
+/**
+ * @jest-environment jsdom
+ */
+
+import { pathWithLeadingSlash, getSignupUrl, isRecognizedLogin } from 'calypso/lib/login';
 
 describe( 'pathWithLeadingSlash', () => {
 	test( 'should add leading slash', () => {
@@ -212,5 +216,17 @@ describe( 'getSignupUrl', () => {
 		).toEqual(
 			'/start/account?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify'
 		);
+	} );
+} );
+
+describe( 'isRecognizedLogin', () => {
+	it( 'should return false when the `recognized_logins` cookie is not set', () => {
+		expect( isRecognizedLogin() ).toBe( false );
+	} );
+
+	it( 'should return true when the `recognized_logins` cookie is set', () => {
+		document.cookie = 'recognized_logins=foo';
+
+		expect( isRecognizedLogin() ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/92246

## Proposed Changes

* Use the `recognized_logins` cookie to detect existing users and don't show them the CTA.
* Make sure the CTA is displayed only when the form responds with `unknown_user`. This fixes a bug where the CTA is displayed when an empty form is submitted and the `calypso_login_block_login_form_get_auth_type_failure` (`error_code: unknown_user`) experiment exposure event was fired previously.
* Update the experiment name.

![image](https://github.com/Automattic/wp-calypso/assets/1612178/dc6975b8-96aa-4f33-bee5-ace7f70dc096)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to re-run the previous experiment with a few updates. More context can be found here: pdxWSz-1yz-p2#comment-488

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an incognito window, go to http://calypso.localhost:3000/log-in and enter a non-existing email.
* Verify that a "User does not exist." error is displayed.
* Close and re-open the page.
* Now manually assign yourself to the "Treatment" group of the 21864-explat-experiment following this guide: PCYsg-SwK-p2 (Manually assign with Abacus assignment bookmarklet). Check the video below to see how it works. Note that you may have to restart the incognito session if the bookmarklet doesn't work.
* After assigning yourself to the "Treatment" group, enter a non-existing email again.
* Verify that you see the "User does not exist." error and the migration notice.
* Verify that the migration notice CTA points to https://wordpress.com/move/.
* Manually add a `recognized_logins` cookie with some value to the calypso.localhost domain.
* Refresh the page, enter a non-existing email again, and make sure the CTA is not displayed.
* If you want to do a proper test for the `recognized_logins` cookie, setup your local Calypso to run on wordpress.com (where the cookie is set by the public api) following this guide: PCYsg-5YE-p2. Or change the domain where the cookie is set on your sandbox.


https://github.com/Automattic/wp-calypso/assets/1612178/a8d64f76-c52b-4826-a350-0cd52f125993



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?