### PR TITLE
Close the plugins "Manage sites" modal instantly when requested

### DIFF
--- a/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
+++ b/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
@@ -29,29 +29,32 @@ export const ManageSitePluginsDialog = ( { isVisible, onClose, plugin } ) => {
 	const isLoading = useSelector( ( state ) => isWporgPluginFetchingSelector( state, plugin.slug ) );
 
 	return (
-		<Dialog
-			className="manage-site-plugins-dialog__container"
-			isVisible={ isVisible }
-			onClose={ onClose }
-			shouldCloseOnEsc
-		>
-			<SitesWithInstalledPluginsList
-				isWpCom
-				sites={ sitesWithPlugin }
-				isLoading={ isLoading }
-				plugin={ plugin }
-			/>
+		<>
+			{ isVisible && (
+				<Dialog
+					className="manage-site-plugins-dialog__container"
+					isVisible={ isVisible }
+					onClose={ onClose }
+					shouldCloseOnEsc
+				>
+					<SitesWithInstalledPluginsList
+						isWpCom
+						sites={ sitesWithPlugin }
+						isLoading={ isLoading }
+						plugin={ plugin }
+					/>
 
-			<PluginAvailableOnSitesList
-				sites={ sitesWithoutPlugin }
-				isLoading={ isLoading }
-				plugin={ plugin }
-			/>
-
-			<Button className="manage-site-plugins-dialog__finish-button" onClick={ onClose } primary>
-				{ translate( 'Close' ) }
-			</Button>
-		</Dialog>
+					<PluginAvailableOnSitesList
+						sites={ sitesWithoutPlugin }
+						isLoading={ isLoading }
+						plugin={ plugin }
+					/>
+					<Button className="manage-site-plugins-dialog__finish-button" onClick={ onClose } primary>
+						{ translate( 'Close' ) }
+					</Button>
+				</Dialog>
+			) }
+		</>
 	);
 };
 

--- a/client/my-sites/plugins/manage-site-plugins-dialog/style.scss
+++ b/client/my-sites/plugins/manage-site-plugins-dialog/style.scss
@@ -1,5 +1,6 @@
 
 .manage-site-plugins-dialog__container {
+	padding-top: 0;
 	width: 900px;
 
 	@media screen and (max-width: 1040px) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92239

## Proposed Changes

* This PR adjusts the "Manage sites" button modal to close instantly when requested.
* It also adjusts the modal's `padding-top`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Go to /plugins
*  Click a plugin
*  Click "Manage sites" in the top right
*  Try to close the modal by clicking outside the modal, the "Close" button on the bottom, or by pressing ESC, and see how slow it is to respond.
* Load this PR with Calypso live
*  Try to close the modal by clicking outside the modal, the "Close" button on the bottom, or by pressing ESC, and see how the modal closes instantly.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
