### PR TITLE
Help Center: Fix Alternates on Atomic

### DIFF
--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -8,7 +8,7 @@
 	"sideEffects": [
 		"*.css",
 		"*.scss",
-		"apps/config.js"
+		"./config.js"
 	],
 	"repository": {
 		"type": "git",

--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -77,7 +77,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 				patterns: [
 					{
 						from: path.join( __dirname, 'help-icon.svg' ),
-						to: path.join( __dirname, 'dist', 'apps' ),
+						to: path.join( __dirname, 'dist' ),
 					},
 				],
 			} ),

--- a/packages/help-center/src/components/help-center-article-fetching-content.tsx
+++ b/packages/help-center/src/components/help-center-article-fetching-content.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { useLocale } from '@automattic/i18n-utils';
 import { useEffect } from 'react';
+import { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { SUPPORT_BLOG_ID } from '../constants';
 import { usePostByKey } from '../hooks/use-post-by-key';
 import { useSupportArticleAlternatesQuery } from '../hooks/use-support-article-alternates-query';
@@ -11,8 +12,11 @@ const getPostKey = ( blogId: number, postId: number ) => ( { blogId, postId } );
 
 const useSupportArticleAlternatePostKey = ( blogId: number, postId: number ) => {
 	const locale = useLocale();
-	const supportArticleAlternates = useSupportArticleAlternatesQuery( blogId, postId, locale );
-	if ( supportArticleAlternates.isInitialLoading ) {
+	const supportArticleAlternates = useSupportArticleAlternatesQuery( blogId, postId, locale, {
+		enabled: canAccessWpcomApis(),
+	} );
+	// Alternates don't work on Atomic.
+	if ( supportArticleAlternates.isInitialLoading && canAccessWpcomApis() ) {
 		return null;
 	}
 


### PR DESCRIPTION
Alternates don't work on Atomic sites. Disable the query in that case. 