### PR TITLE
Frictionless Email Subscriptions: Add customizable not you text to continue as user page

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -43,10 +43,10 @@ function ContinueAsUser( {
 	redirectUrlFromQuery,
 	onChangeAccount,
 	redirectPath,
-	isSignUpFlow,
 	isWooOAuth2Client,
 	isWooPasswordless,
 	isBlazePro,
+	notYouText,
 } ) {
 	const translate = useTranslate();
 	const { url: validatedRedirectUrlFromQuery, loading: validatingQueryURL } =
@@ -63,26 +63,20 @@ function ContinueAsUser( {
 	// like that, but it is better than the alternative, and in practice it should happen quicker than
 	// the user can notice.
 
-	const translationComponents = {
-		br: <br />,
-		link: (
-			<button
-				type="button"
-				id="loginAsAnotherUser"
-				className="continue-as-user__change-user-link"
-				onClick={ onChangeAccount }
-			/>
-		),
-	};
-
-	const notYouText = isSignUpFlow
-		? translate( 'Not you?{{br/}} Sign out or log in with {{link}}another account{{/link}}', {
-				components: translationComponents,
-				args: { userName },
-				comment: 'Link to continue login as different user',
-		  } )
+	const notYouDisplayedText = notYouText
+		? notYouText
 		: translate( 'Not you?{{br/}}Log in with {{link}}another account{{/link}}', {
-				components: translationComponents,
+				components: {
+					br: <br />,
+					link: (
+						<button
+							type="button"
+							id="loginAsAnotherUser"
+							className="continue-as-user__change-user-link"
+							onClick={ onChangeAccount }
+						/>
+					),
+				},
 				args: { userName },
 				comment: 'Link to continue login as different user',
 		  } );
@@ -202,7 +196,7 @@ function ContinueAsUser( {
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>
-			<div className="continue-as-user__not-you">{ notYouText }</div>
+			<div className="continue-as-user__not-you">{ notYouDisplayedText }</div>
 		</div>
 	);
 }

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -125,7 +125,7 @@ class SignupForm extends Component {
 		shouldDisplayUserExistsError: PropTypes.bool,
 		submitForm: PropTypes.func,
 		handleCreateAccountError: PropTypes.func,
-		notYouText: PropTypes.string,
+		notYouText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 
 		// Connected props
 		oauth2Client: PropTypes.object,

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -125,6 +125,7 @@ class SignupForm extends Component {
 		shouldDisplayUserExistsError: PropTypes.bool,
 		submitForm: PropTypes.func,
 		handleCreateAccountError: PropTypes.func,
+		notYouText: PropTypes.string,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -1196,7 +1197,29 @@ class SignupForm extends Component {
 				<ContinueAsUser
 					redirectPath={ this.props.redirectToAfterLoginUrl }
 					onChangeAccount={ this.handleOnChangeAccount }
-					isSignUpFlow
+					notYouText={
+						this.props.notYouText ||
+						this.props.translate(
+							'Not you?{{br/}} Sign out or log in with {{link}}another account{{/link}}',
+							{
+								components: {
+									br: <br />,
+									link: (
+										<button
+											type="button"
+											id="loginAsAnotherUser"
+											className="continue-as-user__change-user-link"
+											onClick={ this.handleOnChangeAccount }
+										/>
+									),
+								},
+								args: {
+									userName: this.props.currentUser.display_name || this.props.currentUser.username,
+								},
+								comment: 'Link to continue login as different user',
+							}
+						)
+					}
 				/>
 			);
 		}

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -37,6 +37,27 @@ function SubscribeEmailStepContent( props ) {
 				isSocialFirst={ false }
 				isSocialSignupEnabled={ false }
 				labelText={ translate( 'Your email' ) }
+				notYouText={ translate(
+					'Not you?{{br/}}Log out and {{link}}subscribe with %(email)s{{/link}}',
+					{
+						components: {
+							br: <br />,
+							link: (
+								<button
+									type="button"
+									id="loginAsAnotherUser"
+									className="continue-as-user__change-user-link"
+									onClick={ () => {
+										props.recordTracksEvent( 'calypso_signup_click_on_change_account' );
+										props.redirectToLogout( window.location.href );
+									} }
+								/>
+							),
+						},
+						args: { email },
+						comment: 'Link to continue login as different user',
+					}
+				) }
 				queryArgs={ { user_email: email, redirect_to: redirectUrl } }
 				redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
 				shouldDisplayUserExistsError

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localize } from 'i18n-calypso';
 import SignupForm from 'calypso/blocks/signup-form';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
@@ -11,6 +12,7 @@ function SubscribeEmailStepContent( props ) {
 		handleCreateAccountSuccess,
 		isPending,
 		redirectToAfterLoginUrl,
+		redirectToLogout,
 		redirectUrl,
 		step,
 		stepName,
@@ -48,8 +50,8 @@ function SubscribeEmailStepContent( props ) {
 									id="loginAsAnotherUser"
 									className="continue-as-user__change-user-link"
 									onClick={ () => {
-										props.recordTracksEvent( 'calypso_signup_click_on_change_account' );
-										props.redirectToLogout( window.location.href );
+										recordTracksEvent( 'calypso_signup_click_on_change_account' );
+										redirectToLogout( window.location.href );
 									} }
 								/>
 							),

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -10,6 +10,7 @@ import { isRedirectAllowed } from 'calypso/lib/url/is-redirect-allowed';
 import useCreateNewAccountMutation from 'calypso/signup/hooks/use-create-new-account';
 import useSubscribeToMailingList from 'calypso/signup/hooks/use-subscribe-to-mailing-list';
 import StepWrapper from 'calypso/signup/step-wrapper';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -108,7 +109,15 @@ function SubscribeEmailStep( props ) {
 				from: queryArguments.from,
 			} );
 		}
-	}, [ createNewAccount, currentUser, flowName, email ] );
+	}, [
+		createNewAccount,
+		currentUser,
+		email,
+		flowName,
+		queryArguments.from,
+		queryArguments.mailing_list,
+		subscribeToMailingList,
+	] );
 
 	return (
 		<div className="subscribe-email">
@@ -166,5 +175,5 @@ export default connect(
 			queryArguments: queryArguments,
 		};
 	},
-	{ submitSignupStep }
+	{ redirectToLogout, submitSignupStep }
 )( localize( SubscribeEmailStep ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/92222#issuecomment-2198875579

## Proposed Changes

* Customize "not you" text to better suit email subscription flow

<img width="1697" alt="Screenshot 2024-07-01 at 2 33 14 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/aff860b6-f7c3-4452-9a50-2dbd563596e5">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The default "not you" text is specific to login and signup pages. They're not applicable to email subscription flow. We refactor logic to create messaging that better suits subscribing to an email list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in to a WordPress account
* Navigate to http://calypso.localhost:3000/start/email-subscription/subscribe?user_email=test1053@gmail.com&redirect_to=wordpress.com%2Flearn&mailing_list=learn&from=/learn
* Verify that the continue as user page is shown
* Verify that clicking on the Log out and subscribe anchor tag does several things
  * Logs out the current user
  * Subscribes the test1053@gmail.com user to the email list ( as specified by the mailing_list url query param )
  * Redirects the user to the redirect_to url query param wordpress.com/learn

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
