### PR TITLE
Frictionless Email Subscriptions: Vertically and horizontally center content

### DIFF
--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -47,7 +47,7 @@ function SubscribeEmailStepContent( props ) {
 							link: (
 								<button
 									type="button"
-									id="loginAsAnotherUser"
+									id="subscribeDifferentEmail"
 									className="continue-as-user__change-user-link"
 									onClick={ () => {
 										recordTracksEvent( 'calypso_signup_click_on_change_account' );
@@ -57,7 +57,7 @@ function SubscribeEmailStepContent( props ) {
 							),
 						},
 						args: { email },
-						comment: 'Link to continue login as different user',
+						comment: 'Link to continue subscribe to email list as different user',
 					}
 				) }
 				queryArgs={ { user_email: email, redirect_to: redirectUrl } }

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -16,6 +16,8 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SubscribeEmailStepContent from './content';
 
+import './style.scss';
+
 function sanitizeRedirectUrl( redirect ) {
 	const isHttpOrHttps =
 		!! redirect && ( redirect.startsWith( 'https://' ) || redirect.startsWith( 'http://' ) );

--- a/client/signup/steps/subscribe-email/style.scss
+++ b/client/signup/steps/subscribe-email/style.scss
@@ -1,0 +1,14 @@
+.signup__step {
+	&.is-subscribe {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		min-height: calc(100vh - 96px);
+	}
+
+	.subscribe-email {
+		margin: 0 auto;
+		width: 400px;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3098

## Proposed Changes

Adds a subscribe email flow scss file with styling to center align all content

### Before
<img width="1708" alt="Screenshot 2024-07-01 at 5 32 59 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/48536d1d-39a9-44ad-b7c1-60bac53f2a32">

### After
<img width="1707" alt="Screenshot 2024-07-01 at 5 32 48 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/666814a7-33ba-4fcd-a2d4-e30864c77ef7">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve UI of the subscribe email flow. Now all items are vertically and horizontally centered for a more intuitive interface.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Log into wordpress.com
- With these PR changes, navigate to /start/email-subscription/subscribe?user_email=test1016@gmail.com&redirect_to=wordpress.com%2Flearn&mailing_list=learn in the WordPress staging environment
- Verify that you see the continue as user page with content now centered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
