### PR TITLE
A4A > Site Selector & Importer: Implement "Add sites" button with popover menu items

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -40,7 +40,7 @@ const AddNewSiteButton = ( {
 	const isSiteSelectorAndImportedEnabled = config.isEnabled( 'a4a-site-selector-and-importer' );
 
 	if ( isSiteSelectorAndImportedEnabled ) {
-		return <SiteSelectorAndImporter />;
+		return <SiteSelectorAndImporter showMainButtonLabel={ showMainButtonLabel } />;
 	}
 
 	return (

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -6,6 +6,7 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
 import A4ALogo, { LOGO_COLOR_SECONDARY_ALT } from '../a4a-logo';
 import { A4A_SITES_CONNECT_URL_LINK } from '../sidebar-menu/lib/constants';
+import SiteSelectorAndImporter from './site-selector-and-importer';
 import type { MutableRefObject } from 'react';
 
 type Props = {
@@ -35,6 +36,12 @@ const AddNewSiteButton = ( {
 	const showAddSitesFromWPCOMAccount = config.isEnabled(
 		'a8c-for-agencies/import-site-from-wpcom'
 	);
+
+	const isSiteSelectorAndImportedEnabled = config.isEnabled( 'a4a-site-selector-and-importer' );
+
+	if ( isSiteSelectorAndImportedEnabled ) {
+		return <SiteSelectorAndImporter />;
+	}
 
 	return (
 		<SplitButton

--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -1,0 +1,115 @@
+import { Popover, Gridicon, Button, WordPressLogo, JetpackLogo } from '@automattic/components';
+import { Icon, navigation } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
+import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import A4ALogo from '../a4a-logo';
+
+import './style.scss';
+
+const ICON_SIZE = 32;
+
+export default function SiteSelectorAndImporter() {
+	const translate = useTranslate();
+
+	const [ isMenuVisible, setMenuVisible ] = useState( false );
+
+	const toggleMenu = ( isMenuVisible: boolean ) => {
+		setMenuVisible( isMenuVisible );
+	};
+
+	const popoverMenuContext = useRef( null );
+
+	const buttonContent = ( {
+		icon,
+		iconClassName,
+		heading,
+		description,
+	}: {
+		icon: JSX.Element;
+		iconClassName?: string;
+		heading: string;
+		description: string;
+	} ) => {
+		return (
+			<div className="site-selector-and-importer__popover-button">
+				<div className={ clsx( 'site-selector-and-importer__popover-button-icon', iconClassName ) }>
+					<Icon className="sidebar__menu-icon" icon={ icon } size={ ICON_SIZE } />
+				</div>
+				<div className="site-selector-and-importer__popover-button-content">
+					<div className="site-selector-and-importer__popover-button-heading">{ heading }</div>
+					<div className="site-selector-and-importer__popover-button-description">
+						{ description }
+					</div>
+				</div>
+			</div>
+		);
+	};
+
+	return (
+		<>
+			<Button
+				className="site-selector-and-importer__button"
+				ref={ popoverMenuContext }
+				onClick={ () => toggleMenu( true ) }
+			>
+				{ translate( 'Add sites' ) }
+				<Gridicon icon={ isMenuVisible ? 'chevron-up' : 'chevron-down' } />
+			</Button>
+			<Popover
+				className="site-selector-and-importer__popover"
+				context={ popoverMenuContext?.current }
+				position="bottom right"
+				isVisible={ isMenuVisible }
+				closeOnEsc
+				onClose={ () => toggleMenu( false ) }
+			>
+				<div className="site-selector-and-importer__popover-content">
+					<div className="site-selector-and-importer__popover-column">
+						<div className="site-selector-and-importer__popover-column-heading">
+							{ translate( 'Import existing sites' ).toUpperCase() }
+						</div>
+
+						{ buttonContent( {
+							icon: <WordPressLogo />,
+							heading: translate( 'Via WordPress.com' ),
+							description: translate( 'Import sites bought on WordPress.com' ),
+						} ) }
+						{ buttonContent( {
+							icon: <A4ALogo />,
+							heading: translate( 'Via the Automattic plugin' ),
+							description: translate( 'Connect with the Automattic for Agencies plugin' ),
+						} ) }
+						{ buttonContent( {
+							icon: <JetpackLogo />,
+							heading: translate( 'Via Jetpack' ),
+							description: translate( 'Import one or more Jetpack connected sites' ),
+						} ) }
+						{ buttonContent( {
+							icon: navigation,
+							iconClassName: 'site-selector-and-importer__popover-button-wp-icon',
+							heading: translate( 'Via URL' ),
+							description: translate( 'Type in the address of your site' ),
+						} ) }
+					</div>
+					<div className="site-selector-and-importer__popover-column">
+						<div className="site-selector-and-importer__popover-column-heading">
+							{ translate( 'Add a new site' ).toUpperCase() }
+						</div>
+						{ buttonContent( {
+							icon: <img src={ pressableIcon } alt="" />,
+							heading: translate( 'Pressable' ),
+							description: translate( 'Optimized and hassle-free hosting for business websites' ),
+						} ) }
+						{ buttonContent( {
+							icon: <WordPressLogo />,
+							heading: translate( 'WordPress.com' ),
+							description: translate( 'Best for large-scale businesses and major eCommerce sites' ),
+						} ) }
+					</div>
+				</div>
+			</Popover>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -10,30 +10,36 @@ import './style.scss';
 
 const ICON_SIZE = 32;
 
-export default function SiteSelectorAndImporter() {
+export default function SiteSelectorAndImporter( {
+	showMainButtonLabel,
+}: {
+	showMainButtonLabel: boolean;
+} ) {
 	const translate = useTranslate();
 
 	const [ isMenuVisible, setMenuVisible ] = useState( false );
 
-	const toggleMenu = ( isMenuVisible: boolean ) => {
-		setMenuVisible( isMenuVisible );
+	const toggleMenu = () => {
+		setMenuVisible( ( isVisible ) => ! isVisible );
 	};
 
 	const popoverMenuContext = useRef( null );
 
-	const buttonContent = ( {
+	const menuItem = ( {
 		icon,
 		iconClassName,
 		heading,
 		description,
+		buttonProps,
 	}: {
 		icon: JSX.Element;
 		iconClassName?: string;
 		heading: string;
 		description: string;
+		buttonProps?: React.ComponentProps< typeof Button >;
 	} ) => {
 		return (
-			<div className="site-selector-and-importer__popover-button">
+			<Button { ...buttonProps } className="site-selector-and-importer__popover-button" borderless>
 				<div className={ clsx( 'site-selector-and-importer__popover-button-icon', iconClassName ) }>
 					<Icon className="sidebar__menu-icon" icon={ icon } size={ ICON_SIZE } />
 				</div>
@@ -43,19 +49,21 @@ export default function SiteSelectorAndImporter() {
 						{ description }
 					</div>
 				</div>
-			</div>
+			</Button>
 		);
 	};
+
+	const chevronIcon = isMenuVisible ? 'chevron-up' : 'chevron-down';
 
 	return (
 		<>
 			<Button
 				className="site-selector-and-importer__button"
 				ref={ popoverMenuContext }
-				onClick={ () => toggleMenu( true ) }
+				onClick={ toggleMenu }
 			>
-				{ translate( 'Add sites' ) }
-				<Gridicon icon={ isMenuVisible ? 'chevron-up' : 'chevron-down' } />
+				{ showMainButtonLabel ? translate( 'Add sites' ) : null }
+				<Gridicon icon={ showMainButtonLabel ? chevronIcon : 'plus' } />
 			</Button>
 			<Popover
 				className="site-selector-and-importer__popover"
@@ -63,30 +71,29 @@ export default function SiteSelectorAndImporter() {
 				position="bottom right"
 				isVisible={ isMenuVisible }
 				closeOnEsc
-				onClose={ () => toggleMenu( false ) }
+				onClose={ toggleMenu }
 			>
 				<div className="site-selector-and-importer__popover-content">
 					<div className="site-selector-and-importer__popover-column">
 						<div className="site-selector-and-importer__popover-column-heading">
 							{ translate( 'Import existing sites' ).toUpperCase() }
 						</div>
-
-						{ buttonContent( {
+						{ menuItem( {
 							icon: <WordPressLogo />,
 							heading: translate( 'Via WordPress.com' ),
 							description: translate( 'Import sites bought on WordPress.com' ),
 						} ) }
-						{ buttonContent( {
+						{ menuItem( {
 							icon: <A4ALogo />,
 							heading: translate( 'Via the Automattic plugin' ),
 							description: translate( 'Connect with the Automattic for Agencies plugin' ),
 						} ) }
-						{ buttonContent( {
+						{ menuItem( {
 							icon: <JetpackLogo />,
 							heading: translate( 'Via Jetpack' ),
 							description: translate( 'Import one or more Jetpack connected sites' ),
 						} ) }
-						{ buttonContent( {
+						{ menuItem( {
 							icon: navigation,
 							iconClassName: 'site-selector-and-importer__popover-button-wp-icon',
 							heading: translate( 'Via URL' ),
@@ -97,12 +104,12 @@ export default function SiteSelectorAndImporter() {
 						<div className="site-selector-and-importer__popover-column-heading">
 							{ translate( 'Add a new site' ).toUpperCase() }
 						</div>
-						{ buttonContent( {
+						{ menuItem( {
 							icon: <img src={ pressableIcon } alt="" />,
 							heading: translate( 'Pressable' ),
 							description: translate( 'Optimized and hassle-free hosting for business websites' ),
 						} ) }
-						{ buttonContent( {
+						{ menuItem( {
 							icon: <WordPressLogo />,
 							heading: translate( 'WordPress.com' ),
 							description: translate( 'Best for large-scale businesses and major eCommerce sites' ),

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -9,8 +9,12 @@
 }
 .site-selector-and-importer__popover {
 	.popover__inner {
-		width: 650px;
+		width: 280px;
 		text-align: unset;
+
+		@include break-large {
+			width: 650px;
+		}
 	}
 }
 
@@ -41,13 +45,19 @@
 	margin-block-end: 8px;
 }
 
-
-.site-selector-and-importer__popover-button {
-	padding: 8px;
+.theme-a8c-for-agencies  .button.site-selector-and-importer__popover-button {
+	padding: 0 8px;
+	white-space: unset;
+	text-align: unset;
+	margin-block: 16px;
+	width: 100%;
+	border-radius: 0;
 
 	@include break-large {
 		display: flex;
 		gap: 8px;
+		align-items: unset;
+		justify-content: unset;
 	}
 
 	.site-selector-and-importer__popover-button-icon {
@@ -64,6 +74,7 @@
 		}
 	}
 
+	// This is a workaround to make all the buttons the same dimensions
 	.site-selector-and-importer__popover-button-wp-icon {
 		.sidebar__menu-icon {
 			width: 36px;

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -1,0 +1,88 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.site-selector-and-importer__button {
+	.gridicon {
+		margin-left: 6px;
+		top: 2px;
+	}
+}
+.site-selector-and-importer__popover {
+	.popover__inner {
+		width: 650px;
+		text-align: unset;
+	}
+}
+
+.site-selector-and-importer__popover-content {
+	display: flex;
+	flex-direction: column;
+	padding: 28px 32px;
+	gap: 32px;
+
+	@include break-large {
+		flex-direction: row;
+	}
+
+	.site-selector-and-importer__popover-column {
+		&:first-child {
+			flex: 1.4;
+		}
+		&:last-child {
+			flex: 1;
+		}
+	}
+}
+
+.site-selector-and-importer__popover-column-heading {
+	color: var(--color-accent-40);
+	font-size: rem(12px);
+	font-weight: 500;
+	margin-block-end: 8px;
+}
+
+
+.site-selector-and-importer__popover-button {
+	padding: 8px;
+
+	@include break-large {
+		display: flex;
+		gap: 8px;
+	}
+
+	.site-selector-and-importer__popover-button-icon {
+		display: none;
+
+		@include break-large {
+			display: block;
+		}
+
+		.sidebar__menu-icon {
+			width: 24px;
+			height: 24px;
+			max-width: fit-content;
+		}
+	}
+
+	.site-selector-and-importer__popover-button-wp-icon {
+		.sidebar__menu-icon {
+			width: 36px;
+			height: 36px;
+			position: relative;
+			left: 6px;
+			top: -6px;
+			margin-left: -12px;
+		}
+	}
+
+	.site-selector-and-importer__popover-button-heading {
+		font-size: rem(14px);
+		font-weight: 600;
+	}
+
+	.site-selector-and-importer__popover-button-description {
+		font-size: rem(12px);
+		line-height: 1.7;
+		color: var(--color-accent);
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/676

## Proposed Changes

This PR implements the "Add sites" button with popover menu items.

Note: Adding an overlay to the popover is not readily available, and I'm not sure how easy it is to implement. We can try to implement it later if we have enough time. 

## Testing Instructions

1. Open the A4A live link.
2. Visit /sites & append the URL with `?flags=-a4a-site-selector-and-importer` and verify the Add site experience isn't changed by comparing it with production.
3. Remove the feature flag > Verify that the button to Add sites looks like this:

<img width="673" alt="Screenshot 2024-07-02 at 10 49 48 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f6090e5e-d98e-4ab1-aa5b-488b47067f7b">

4. Click the button & verify the menu is displayed as shown below: 

Note: The menu items don't work at the moment.

<img width="906" alt="Screenshot 2024-07-02 at 10 51 10 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9ed51fda-b3f5-413a-a886-fec7ce081263">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
