### PR TITLE
A4A > Site Selector & Importer: Update links for hosting menu items

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -3,14 +3,21 @@ import { Icon, navigation } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
+import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import A4ALogo from '../a4a-logo';
-import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from '../sidebar-menu/lib/constants';
+import {
+	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+	A4A_SITES_LINK_NEEDS_SETUP,
+} from '../sidebar-menu/lib/constants';
 
 import './style.scss';
 
 const ICON_SIZE = 32;
+
+type PendingSite = { features: { wpcom_atomic: { state: string; license_key: string } } };
 
 export default function SiteSelectorAndImporter( {
 	showMainButtonLabel,
@@ -58,6 +65,16 @@ export default function SiteSelectorAndImporter( {
 	const chevronIcon = isMenuVisible ? 'chevron-up' : 'chevron-down';
 
 	const pressableOwnership = usePressableOwnershipType();
+
+	const { data: pendingSites } = useFetchPendingSites();
+
+	const allAvailableSites =
+		pendingSites?.filter(
+			( { features }: PendingSite ) =>
+				features.wpcom_atomic.state === 'pending' && !! features.wpcom_atomic.license_key
+		) ?? [];
+
+	const hasPendingWPCOMSites = allAvailableSites.length > 0;
 
 	return (
 		<>
@@ -124,6 +141,11 @@ export default function SiteSelectorAndImporter( {
 							icon: <WordPressLogo />,
 							heading: translate( 'WordPress.com' ),
 							description: translate( 'Best for large-scale businesses and major eCommerce sites' ),
+							buttonProps: {
+								href: hasPendingWPCOMSites
+									? A4A_SITES_LINK_NEEDS_SETUP
+									: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+							},
 						} ) }
 					</div>
 				</div>

--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -40,12 +40,14 @@ export default function SiteSelectorAndImporter( {
 		heading,
 		description,
 		buttonProps,
+		extraContent,
 	}: {
 		icon: JSX.Element;
 		iconClassName?: string;
 		heading: string;
 		description: string;
 		buttonProps?: React.ComponentProps< typeof Button >;
+		extraContent?: JSX.Element;
 	} ) => {
 		return (
 			<Button { ...buttonProps } className="site-selector-and-importer__popover-button" borderless>
@@ -57,6 +59,7 @@ export default function SiteSelectorAndImporter( {
 					<div className="site-selector-and-importer__popover-button-description">
 						{ description }
 					</div>
+					{ extraContent }
 				</div>
 			</Button>
 		);
@@ -126,6 +129,31 @@ export default function SiteSelectorAndImporter( {
 							{ translate( 'Add a new site' ).toUpperCase() }
 						</div>
 						{ menuItem( {
+							icon: <WordPressLogo />,
+							heading: translate( 'WordPress.com' ),
+							description: translate( 'Best for large-scale businesses and major eCommerce sites' ),
+							buttonProps: {
+								href: hasPendingWPCOMSites
+									? A4A_SITES_LINK_NEEDS_SETUP
+									: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+							},
+							extraContent: hasPendingWPCOMSites ? (
+								<div className="site-selector-and-importer__popover-site-count">
+									{ translate(
+										'%(pendingSites)d site available',
+										'%(pendingSites)d sites available',
+										{
+											args: {
+												pendingSites: allAvailableSites.length,
+											},
+											count: allAvailableSites.length,
+											comment: '%(pendingSites)s is the number of sites available.',
+										}
+									) }
+								</div>
+							) : undefined,
+						} ) }
+						{ menuItem( {
 							icon: <img src={ pressableIcon } alt="" />,
 							heading: translate( 'Pressable' ),
 							description: translate( 'Optimized and hassle-free hosting for business websites' ),
@@ -135,16 +163,6 @@ export default function SiteSelectorAndImporter( {
 										? 'https://my.pressable.com/agency/auth'
 										: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 								target: pressableOwnership === 'regular' ? '_blank' : '_self',
-							},
-						} ) }
-						{ menuItem( {
-							icon: <WordPressLogo />,
-							heading: translate( 'WordPress.com' ),
-							description: translate( 'Best for large-scale businesses and major eCommerce sites' ),
-							buttonProps: {
-								href: hasPendingWPCOMSites
-									? A4A_SITES_LINK_NEEDS_SETUP
-									: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
 							},
 						} ) }
 					</div>

--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -3,8 +3,10 @@ import { Icon, navigation } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
+import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import A4ALogo from '../a4a-logo';
+import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from '../sidebar-menu/lib/constants';
 
 import './style.scss';
 
@@ -54,6 +56,8 @@ export default function SiteSelectorAndImporter( {
 	};
 
 	const chevronIcon = isMenuVisible ? 'chevron-up' : 'chevron-down';
+
+	const pressableOwnership = usePressableOwnershipType();
 
 	return (
 		<>
@@ -108,6 +112,13 @@ export default function SiteSelectorAndImporter( {
 							icon: <img src={ pressableIcon } alt="" />,
 							heading: translate( 'Pressable' ),
 							description: translate( 'Optimized and hassle-free hosting for business websites' ),
+							buttonProps: {
+								href:
+									pressableOwnership === 'regular'
+										? 'https://my.pressable.com/agency/auth'
+										: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+								target: pressableOwnership === 'regular' ? '_blank' : '_self',
+							},
 						} ) }
 						{ menuItem( {
 							icon: <WordPressLogo />,

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -97,3 +97,9 @@
 		color: var(--color-accent);
 	}
 }
+
+.site-selector-and-importer__popover-site-count {
+	font-size: rem(12px);
+	font-style: italic;
+	color: var(--color-accent-100);
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function usePressableOwnershipType() {
+	const activeAgency = useSelector( getActiveAgency );
+
+	const pressableOwnership = useMemo( () => {
+		// Agencies can have pressable through A4A Licenses or via Pressable itself
+		const hasPressablePlan = !! activeAgency?.third_party?.pressable?.pressable_id;
+
+		if ( ! hasPressablePlan ) {
+			return 'none';
+		}
+
+		// If the agency has a regular Pressable plan (not brought through A4A marketplace), A4A id is null.
+		const hasRegularPressablePlan =
+			hasPressablePlan && activeAgency?.third_party?.pressable?.a4a_id === null;
+
+		return hasRegularPressablePlan ? 'regular' : 'agency';
+	}, [ activeAgency ] );
+
+	return pressableOwnership;
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -3,10 +3,8 @@ import { Card } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState, useContext } from 'react';
-import { useSelector } from 'react-redux';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { APIProductFamily } from 'calypso/state/partner-portal/types';
 import SimpleList from '../../common/simple-list';
 import { MarketplaceTypeContext } from '../../context';
@@ -14,6 +12,7 @@ import useProductAndPlans from '../../hooks/use-product-and-plans';
 import { getCheapestPlan, getWPCOMCreatorPlan } from '../../lib/hosting';
 import ListingSection from '../../listing-section';
 import wpcomBulkOptions from '../../wpcom-overview/lib/wpcom-bulk-options';
+import usePressableOwnershipType from '../hooks/use-pressable-ownership-type';
 import HostingCard from '../hosting-card';
 
 import './style.scss';
@@ -24,7 +23,6 @@ interface Props {
 
 export default function HostingList( { selectedSite }: Props ) {
 	const translate = useTranslate();
-	const activeAgency = useSelector( getActiveAgency );
 
 	const { data } = useProductsQuery( false, true );
 
@@ -42,20 +40,7 @@ export default function HostingList( { selectedSite }: Props ) {
 
 	const wpcomOptions = wpcomBulkOptions( wpcomProducts?.discounts?.tiers );
 
-	const pressableOwnership = useMemo( () => {
-		// Agencies can have pressable through A4A Licenses or via Pressable itself
-		const hasPressablePlan = !! activeAgency?.third_party?.pressable?.pressable_id;
-
-		if ( ! hasPressablePlan ) {
-			return 'none';
-		}
-
-		// If the agency has a regular Pressable plan (not brought through A4A marketplace), A4A id is null.
-		const hasRegularPressablePlan =
-			hasPressablePlan && activeAgency?.third_party?.pressable?.a4a_id === null;
-
-		return hasRegularPressablePlan ? 'regular' : 'agency';
-	}, [ activeAgency ] );
+	const pressableOwnership = usePressableOwnershipType();
 
 	const { isLoadingProducts, pressablePlans, wpcomPlans } = useProductAndPlans( {
 		selectedSite,


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/681

## Proposed Changes

This PR updates links for hosting menu items.

## Testing Instructions

1. Open the A4A live link.
2. Click the `Add sites` button > Verify the Pressable & WordPress.com items under `ADD A NEW SITE` section works as expected:

<img width="906" alt="Screenshot 2024-07-02 at 4 10 08 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/873f3620-76aa-4e6b-a396-12a6e8371ccb">



Links:

**Pressable**

- Agencies who purchased a Pressable plan for the first time through A4A. (Must be redirected to `/marketplace/hosting/pressable`)
- Agencies who have a pre-A4A Pressable account. (Must be redirected https://my.pressable.com/agency/auth)
WordPress.com

**WordPress.com**

Agencies who have available WPCOM sites (pending) (Must be redirected to `/sites/need-setup`)
Agencies who do not have available WPCOM sites (Must be redirected to `/marketplace/hosting/wpcom`)

Note: The other menu items don't work at the moment.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
