### PR TITLE
Gravatar: Open magic code to users & Fix i18n notice styles

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -95,17 +95,13 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 	}
 
 	if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
-		const isGravatarMagicCode =
-			isGravatarOAuth2Client( oauth2Client ) && get( currentQuery, 'gravatar_magic_code' );
-
 		// Gravatar powered clients signup via the magic login page
 		return login( {
 			locale,
 			twoFactorAuthType: 'link',
 			oauth2ClientId: oauth2Client.id,
 			redirectTo: redirectTo,
-			gravatarMagicCode: isGravatarMagicCode,
-			gravatarFrom: isGravatarMagicCode && 'signup',
+			gravatarFrom: isGravatarOAuth2Client( oauth2Client ) && 'signup',
 		} );
 	}
 

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -110,7 +110,7 @@ describe( 'getSignupUrl', () => {
 			url: 'https://gravatar.com/',
 		};
 		expect( getSignupUrl( currentQuery, currentRoute, oauth2Client, 'en', '' ) ).toEqual(
-			'/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D1234%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854'
+			'/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D1234%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854&gravatar_from=signup'
 		);
 	} );
 

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -40,7 +40,6 @@ export function login( {
 	action = undefined,
 	lostpasswordFlow = undefined,
 	usernameOnly = undefined,
-	gravatarMagicCode = undefined,
 	gravatarFrom = undefined,
 } = {} ) {
 	let url = '/log-in';
@@ -111,10 +110,6 @@ export function login( {
 
 	if ( usernameOnly ) {
 		url = addQueryArgs( { username_only: true }, url );
-	}
-
-	if ( gravatarMagicCode ) {
-		url = addQueryArgs( { gravatar_magic_code: true }, url );
 	}
 
 	if ( gravatarFrom ) {

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -496,7 +496,7 @@ class MagicLogin extends Component {
 	};
 
 	renderGravPoweredMagicLoginTos() {
-		const { oauth2Client, translate, query } = this.props;
+		const { oauth2Client, translate } = this.props;
 
 		const textOptions = {
 			components: {
@@ -524,24 +524,19 @@ class MagicLogin extends Component {
 			},
 		};
 
-		let tosText = translate(
-			`By clicking “Send me sign in link“, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, have read our {{privacyLink}}Privacy Policy{{/privacyLink}}, and understand that you're creating {{wpAccountLink}}a WordPress.com account{{/wpAccountLink}} if you don't already have one.`,
-			textOptions
+		return (
+			<div className="grav-powered-magic-login__tos">
+				{ isGravatarOAuth2Client( oauth2Client )
+					? translate(
+							`By clicking “Continue“, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, have read our {{privacyLink}}Privacy Policy{{/privacyLink}}, and understand that you're creating {{wpAccountLink}}a WordPress.com account{{/wpAccountLink}} if you don't already have one.`,
+							textOptions
+					  )
+					: translate(
+							`By clicking “Send me sign in link“, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, have read our {{privacyLink}}Privacy Policy{{/privacyLink}}, and understand that you're creating a Gravatar account if you don't already have one.`,
+							textOptions
+					  ) }
+			</div>
 		);
-
-		if ( isGravatarOAuth2Client( oauth2Client ) && query.gravatar_magic_code === 'true' ) {
-			tosText = translate(
-				`By clicking “Continue“, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, have read our {{privacyLink}}Privacy Policy{{/privacyLink}}, and understand that you're creating {{wpAccountLink}}a WordPress.com account{{/wpAccountLink}} if you don't already have one.`,
-				textOptions
-			);
-		} else if ( isWPJobManagerOAuth2Client( oauth2Client ) ) {
-			translate(
-				`By clicking “Send me sign in link“, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, have read our {{privacyLink}}Privacy Policy{{/privacyLink}}, and understand that you're creating a Gravatar account if you don't already have one.`,
-				textOptions
-			);
-		}
-
-		return <div className="grav-powered-magic-login__tos">{ tosText }</div>;
 	}
 
 	resendEmailCountdownId = null;
@@ -924,19 +919,17 @@ class MagicLogin extends Component {
 		const { isRequestingEmail, requestEmailErrorMessage } = this.state;
 
 		const isGravatar = isGravatarOAuth2Client( oauth2Client );
-		const isGravatarMagicCode = isGravatar && query.gravatar_magic_code === 'true';
-		const submitButtonLabel = isGravatarMagicCode
+		const submitButtonLabel = isGravatar
 			? translate( 'Continue' )
 			: translate( 'Send me sign in link' );
 		const loginUrl = login( {
 			locale,
 			redirectTo: query?.redirect_to,
 			oauth2ClientId: query?.client_id,
-			gravatarMagicCode: isGravatarMagicCode,
 		} );
 		let headerText = translate( 'Sign in with your email' );
 
-		if ( isGravatarMagicCode ) {
+		if ( isGravatar ) {
 			headerText =
 				query?.gravatar_from === 'signup'
 					? translate( 'Create your Profile' )
@@ -955,8 +948,8 @@ class MagicLogin extends Component {
 						hideSubHeaderText
 						inputPlaceholder={ translate( 'Enter your email address' ) }
 						submitButtonLabel={ submitButtonLabel }
-						tosComponent={ ! isGravatarMagicCode && this.renderGravPoweredMagicLoginTos() }
-						onSubmitEmail={ isGravatarMagicCode ? this.handleGravPoweredEmailSubmit : undefined }
+						tosComponent={ ! isGravatar && this.renderGravPoweredMagicLoginTos() }
+						onSubmitEmail={ isGravatar ? this.handleGravPoweredEmailSubmit : undefined }
 						onSendEmailLogin={ ( usernameOrEmail ) => this.setState( { usernameOrEmail } ) }
 						createAccountForNewUser
 						errorMessage={ requestEmailErrorMessage }
@@ -966,7 +959,7 @@ class MagicLogin extends Component {
 						isSubmitButtonDisabled={ isRequestingEmail || !! requestEmailErrorMessage }
 						isSubmitButtonBusy={ isRequestingEmail }
 					/>
-					{ isGravatarMagicCode && (
+					{ isGravatar && (
 						<div className="grav-powered-magic-login__feature-items">
 							<div className="grav-powered-magic-login__feature-item">
 								<svg
@@ -1071,7 +1064,7 @@ class MagicLogin extends Component {
 							</div>
 						</div>
 					) }
-					{ ! isGravatarMagicCode && (
+					{ ! isGravatar && (
 						<hr className="grav-powered-magic-login__divider grav-powered-magic-login__divider--email-form" />
 					) }
 					<footer className="grav-powered-magic-login__footer grav-powered-magic-login__footer--email-form">
@@ -1183,8 +1176,6 @@ class MagicLogin extends Component {
 				<Main
 					className={ clsx( 'grav-powered-magic-login', {
 						'grav-powered-magic-login--wp-job-manager': isWPJobManagerOAuth2Client( oauth2Client ),
-						'grav-powered-magic-login--gravatar-magic-link':
-							isGravatarOAuth2Client( oauth2Client ) && query.gravatar_magic_code !== 'true',
 					} ) }
 				>
 					{ renderContent }

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -312,7 +312,6 @@
 	font-size: 14px;
 	line-height: 1.5;
 
-	&.grav-powered-magic-login--gravatar-magic-link,
 	&.grav-powered-magic-login--wp-job-manager {
 		max-width: 560px;
 		font-size: 16px;
@@ -342,6 +341,14 @@
 			padding-left: 30px;
 			padding-right: 30px;
 			border-radius: 2px;
+
+			.notice__icon-wrapper {
+				display: flex;
+			}
+
+			.notice__content {
+				padding-left: 13px;
+			}
 		}
 
 		.grav-powered-magic-login__header,
@@ -356,14 +363,6 @@
 
 		.grav-powered-magic-login__sub-header {
 			margin-bottom: 52px;
-		}
-
-		.notice__icon-wrapper {
-			display: flex;
-		}
-
-		.notice__content {
-			padding-left: 13px;
 		}
 
 		.grav-powered-magic-login__tos {
@@ -397,27 +396,6 @@
 		}
 	}
 
-	&.grav-powered-magic-login--gravatar-magic-link {
-		a,
-		.grav-powered-magic-login__content a,
-		.grav-powered-magic-login__footer button {
-			color: #1d4fc4;
-		}
-
-		.magic-login__form-action button[type="submit"].form-button.is-primary {
-			&,
-			&:disabled {
-				background-color: #1d4fc4;
-			}
-
-			&:hover:not(&:disabled),
-			&:focus {
-				background-color: darken(#1d4fc4, 10%);
-			}
-		}
-
-	}
-
 	button[type="submit"].form-button.is-primary,
 	.magic-login__form-action button[type="submit"].form-button.is-primary {
 		width: 100%;
@@ -447,6 +425,14 @@
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 8px;
 		padding: 20px;
+
+		.notice__icon-wrapper {
+			display: none;
+		}
+
+		.notice__content {
+			padding-left: 0;
+		}
 
 		a {
 			color: #1d4fc4;
@@ -525,14 +511,6 @@
 		&::placeholder {
 			color: #9ea4a8;
 		}
-	}
-
-	.notice__icon-wrapper {
-		display: none;
-	}
-
-	.notice__content {
-		padding-left: 0;
 	}
 
 	.grav-powered-magic-login__tos {
@@ -672,7 +650,6 @@
 	}
 
 	@include break-small {
-		&.grav-powered-magic-login--gravatar-magic-link,
 		&.grav-powered-magic-login--wp-job-manager {
 			.grav-powered-magic-login__content {
 				padding-left: 56px;

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -242,14 +242,11 @@ export class Login extends Component {
 	renderGravPoweredLoginBlockFooter() {
 		const { oauth2Client, translate, locale, currentQuery, currentRoute } = this.props;
 
-		const isGravatarMagicCode =
-			isGravatarOAuth2Client( oauth2Client ) && currentQuery.gravatar_magic_code === 'true';
 		const magicLoginUrl = login( {
 			locale,
 			twoFactorAuthType: 'link',
 			oauth2ClientId: currentQuery?.client_id,
 			redirectTo: currentQuery?.redirect_to,
-			gravatarMagicCode: isGravatarMagicCode,
 		} );
 		const currentUrl = new URL( window.location.href );
 		currentUrl.searchParams.append( 'lostpassword_flow', true );
@@ -272,7 +269,7 @@ export class Login extends Component {
 							this.props.recordTracksEvent( 'calypso_login_magic_login_request_click' )
 						}
 					>
-						{ isGravatarMagicCode
+						{ isGravatarOAuth2Client( oauth2Client )
 							? translate( 'Email me a login code.' )
 							: translate( 'Email me a login link.' ) }
 					</a>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to 108156-gh-Automattic/gravatar
- Related to 108213-gh-Automattic/gravatar

## Proposed Changes

* Remove gravatar magic code relevant flags
* Fix the styles of the i18n notice
* Update the `getSignupUrl()` case for Gravatar

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Please refer to: p8Slzc-3ot-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Preparation

* [Setup Calypso](https://github.com/Automattic/wp-calypso?tab=readme-ov-file#getting-started)
* Check out this PR, and run `yarn start`
* (IMPORTANT) Allow the browsers' 3rd-party cookies (e.g. [Google Chrome](https://support.google.com/accounts/answer/61416?hl=en&co=GENIE.Platform%3DDesktop))

### For The Login Flow

* Gravatar Magic Code
  * [Dev](http://calypso.localhost:3000/log-in/link?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D7cb30c204432e20253ec71dda82f83c915bc16d2b1cb057d131cdf48eaecf958%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1)
  * [Prod](https://wordpress.com/log-in/link?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D0ed6fe174c184792b709a49ec6e5ef6366d2739d7f9df738f76f0ec801e407eb%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1)

* WP Job Manager
  * [Dev](http://calypso.localhost:3000/log-in/link?client_id=90057&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redirect_uri%3Dhttps%253A%252F%252Fwpjobmanager.com%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback%26blog_id%3D0%26from-calypso%3D1)
  * [Prod](https://wordpress.com/log-in/link?client_id=90057&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthenticate%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3D01b7d7bfcfd126450053529ce09fefb5%26redirect_uri%3Dhttp%253A%252F%252Fwpjobmanagercom.vipdev.lndo.site%253A8000%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback&create_account=1)

* WP.com
   * [Dev](http://calypso.localhost:3000/log-in/link)
   * [Prod](https://wordpress.com/log-in/link)

* Woo
  * [Dev](http://calypso.localhost:3000/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dfe6b7fe71924cbd378654e8165ab2b6bf0f2d658065cd27bf038faf6b49a8e9a%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916)
  * [Prod](https://wordpress.com/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dfe6b7fe71924cbd378654e8165ab2b6bf0f2d658065cd27bf038faf6b49a8e9a%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916)
    
* Jetpack
  * [Dev](http://calypso.localhost:3000/log-in/link?client_id=69040&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252Fpricing%25253Futm_source%25253Dgoogle%252526utm_medium%25253Dcpc%252526utm_campaign%25253D20732627996%252526utm_content%25253D592794838992%252526utm_term%25253Djetpack%252526utm_term%25253Djetpack%252526utm_campaign%25253Dgoogle_jetpack_search_BRAND_other_countries%252526utm_source%25253Dadwords%252526utm_medium%25253Dppc%252526hsa_acc%25253D6173802314%252526hsa_cam%25253D20732627996%252526hsa_grp%25253D160816494928%252526hsa_ad%25253D592794838992%252526hsa_src%25253Dg%252526hsa_tgt%25253Dkwd-298987025683%252526hsa_kw%25253Djetpack%252526hsa_mt%25253De%252526hsa_net%25253Dadwords%252526hsa_ver%25253D3%252526gad_source%25253D1%252526gclid%25253DEAIaIQobChMIl_2KwY3qhgMV2sJMAh0OZgfnEAAYASAAEgIDEvD_BwE%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1)
  * [Prod](https://wordpress.com/log-in/link?client_id=69040&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252Fpricing%25253Futm_source%25253Dgoogle%252526utm_medium%25253Dcpc%252526utm_campaign%25253D20732627996%252526utm_content%25253D592794838992%252526utm_term%25253Djetpack%252526utm_term%25253Djetpack%252526utm_campaign%25253Dgoogle_jetpack_search_BRAND_other_countries%252526utm_source%25253Dadwords%252526utm_medium%25253Dppc%252526hsa_acc%25253D6173802314%252526hsa_cam%25253D20732627996%252526hsa_grp%25253D160816494928%252526hsa_ad%25253D592794838992%252526hsa_src%25253Dg%252526hsa_tgt%25253Dkwd-298987025683%252526hsa_kw%25253Djetpack%252526hsa_mt%25253De%252526hsa_net%25253Dadwords%252526hsa_ver%25253D3%252526gad_source%25253D1%252526gclid%25253DEAIaIQobChMIl_2KwY3qhgMV2sJMAh0OZgfnEAAYASAAEgIDEvD_BwE%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1)

### For The i18n Notice

- Go to [this URL](http://calypso.localhost:3000/log-in/link?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D7cb30c204432e20253ec71dda82f83c915bc16d2b1cb057d131cdf48eaecf958%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1). The wrong i18n notice styles should be fixed:

| Before | After |
| - | - |
| <img width="549" alt="截圖 2024-07-02 下午3 57 35" src="https://github.com/Automattic/wp-calypso/assets/21308003/db54a47f-9b69-45f2-bfd7-e9df227078be"> | <img width="555" alt="截圖 2024-07-02 下午3 49 09" src="https://github.com/Automattic/wp-calypso/assets/21308003/684d0e91-f65a-4096-8c3d-b1aee99969fb"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
