### PR TITLE
Plans (Pricing): Use data-store pricing for EntrepreneurPlan

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
+++ b/client/my-sites/plans/ecommerce-trial/entrepreneur-plan/entrepreneur-plan.tsx
@@ -19,7 +19,6 @@ import './style.scss';
 import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import UpgradeButton from '../../components/upgrade-button/upgrade-button';
 import EcommerceTrialIncluded from '../../current-plan/trials/ecommerce-trial-included';
@@ -36,6 +35,7 @@ interface PlanPriceType {
 	subText?: ReactNode;
 	discount?: number;
 	discountText?: ReactNode;
+	currencyCode?: string;
 }
 type PlanKeys =
 	| 'PLAN_ECOMMERCE'
@@ -64,14 +64,17 @@ const useEntrepreneurPlanPrices = () => {
 		PLAN_ECOMMERCE: {
 			term: translate( 'Pay yearly' ),
 			slug: PLAN_ECOMMERCE,
+			currencyCode: pricingMeta?.[ PLAN_ECOMMERCE ]?.currencyCode,
 		},
 		PLAN_ECOMMERCE_2_YEARS: {
 			term: translate( 'Pay every 2 years' ),
 			slug: PLAN_ECOMMERCE_2_YEARS,
+			currencyCode: pricingMeta?.[ PLAN_ECOMMERCE_2_YEARS ]?.currencyCode,
 		},
 		PLAN_ECOMMERCE_3_YEARS: {
 			term: translate( 'Pay every 3 years' ),
 			slug: PLAN_ECOMMERCE_3_YEARS,
+			currencyCode: pricingMeta?.[ PLAN_ECOMMERCE_3_YEARS ]?.currencyCode,
 		},
 		PLAN_ECOMMERCE_MONTHLY: {
 			term: translate( 'Pay monthly' ),
@@ -82,6 +85,7 @@ const useEntrepreneurPlanPrices = () => {
 				args: { rawPrice: baseMontlyPrice },
 				comment: 'Excl. Taxes is short for excluding taxes',
 			} ),
+			currencyCode: pricingMeta?.[ PLAN_ECOMMERCE_MONTHLY ]?.currencyCode,
 		},
 	};
 	const keys = Object.keys( planPrices ) as PlanKeys[];
@@ -142,7 +146,6 @@ export function EntrepreneurPlan( props: EntrepreneurPlanProps ) {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
 	const plans = useEntrepreneurPlanPrices();
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const isEnglish = useIsEnglishLocale();
 	const [ selectedInterval, setSelectedInterval ] = useState< PlanKeys >( 'PLAN_ECOMMERCE' );
 	const selectedPlan = plans[ selectedInterval ];
@@ -230,7 +233,7 @@ export function EntrepreneurPlan( props: EntrepreneurPlanProps ) {
 					<div className="price-block">
 						<PlanPrice
 							rawPrice={ selectedPlan.montlyPrice }
-							currencyCode={ currencyCode }
+							currencyCode={ selectedPlan.currencyCode }
 							isSmallestUnit
 						/>
 						<p className="card-text">{ selectedPlan.subText }</p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

We update the Entrepreneur Trial Plan's pricing to use the Plans data-store hooks.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We only need one form of handling plan pricing in the code base, more so one framework. Anything else risks having alternative and differing views of the same data propagating across the code base.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See the detailed walkthrough posted below by @ivan-ottinger : https://github.com/Automattic/wp-calypso/pull/92269#pullrequestreview-2155945296 🙌 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
