### PR TITLE
Plans (Pricing): Use data-store pricing for migrate section / upgrade step

### DIFF
--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -165,7 +165,7 @@ const WrappedStepUpgrade = ( props ) => {
 	const pricingMeta = Plans.usePricingMetaForGridPlans( {
 		planSlugs: [ planSlug ],
 		coupon: undefined,
-		siteId: null,
+		siteId: null, // null site ID means we're fetching global (non-site-specific) pricing
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );
@@ -176,7 +176,10 @@ const WrappedStepUpgrade = ( props ) => {
 			isEcommerceTrial={ isEcommerceTrial }
 			billingTimeFrame={ plan.getBillingTimeFrame() }
 			currencyCode={ pricingMeta[ planSlug ]?.currencyCode }
-			planPrice={ pricingMeta[ planSlug ]?.originalPrice?.monthly }
+			planPrice={
+				pricingMeta[ planSlug ]?.discountedPrice?.monthly ??
+				pricingMeta[ planSlug ]?.originalPrice?.monthly
+			}
 		/>
 	);
 };

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -165,7 +165,12 @@ const WrappedStepUpgrade = ( props ) => {
 	const pricingMeta = Plans.usePricingMetaForGridPlans( {
 		planSlugs: [ planSlug ],
 		coupon: undefined,
-		siteId: null, // null site ID means we're fetching global (non-site-specific) pricing
+		/**
+		 * null site ID means we're fetching global (non-site-specific) pricing.
+		 * once https://github.com/Automattic/martech/issues/3142 is addressed, we should be able
+		 * to grab currency discounts with a site ID.
+		 */
+		siteId: null,
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	getPlan,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
@@ -5,17 +6,14 @@ import {
 	PLAN_WOOEXPRESS_SMALL,
 } from '@automattic/calypso-products';
 import { CompactCard, ProductIcon, Gridicon, PlanPrice } from '@automattic/components';
+import { Plans } from '@automattic/data-stores';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
-import QueryPlans from 'calypso/components/data/query-plans';
 import HeaderCake from 'calypso/components/header-cake';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getPlanRawPrice } from 'calypso/state/plans/selectors';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import MigrateButton from './migrate-button.jsx';
 
 import './section-migrate.scss';
@@ -26,10 +24,11 @@ class StepUpgrade extends Component {
 		sourceSite: PropTypes.object.isRequired,
 		startMigration: PropTypes.func.isRequired,
 		targetSite: PropTypes.object.isRequired,
+		isEcommerceTrial: PropTypes.bool.isRequired,
 	};
 
 	componentDidMount() {
-		this.props.recordTracksEvent( 'calypso_site_migration_business_viewed' );
+		recordTracksEvent( 'calypso_site_migration_business_viewed' );
 	}
 
 	getHeadingText( isEcommerceTrial, upsellPlanName ) {
@@ -53,7 +52,7 @@ class StepUpgrade extends Component {
 	render() {
 		const {
 			billingTimeFrame,
-			currency,
+			currencyCode,
 			planPrice,
 			plugins,
 			sourceSite,
@@ -62,19 +61,17 @@ class StepUpgrade extends Component {
 			targetSiteSlug,
 			themes,
 			translate,
+			isEcommerceTrial,
 		} = this.props;
 		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
 		const backHref = `/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }`;
-		const currentPlanSlug = get( targetSite, 'plan.product_slug' );
-		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 		const upsellPlanName = isEcommerceTrial
 			? getPlan( PLAN_WOOEXPRESS_SMALL )?.getTitle()
 			: getPlan( PLAN_BUSINESS )?.getTitle();
 
 		return (
 			<>
-				<QueryPlans />
 				<HeaderCake backHref={ backHref }>{ translate( 'Import Everything' ) }</HeaderCake>
 
 				<CompactCard>
@@ -141,7 +138,7 @@ class StepUpgrade extends Component {
 									}
 								</div>
 								<div className="migrate__plan-price">
-									<PlanPrice rawPrice={ planPrice } currencyCode={ currency } />
+									<PlanPrice rawPrice={ planPrice } currencyCode={ currencyCode } isSmallestUnit />
 								</div>
 								<div className="migrate__plan-billing-time-frame">{ billingTimeFrame }</div>
 							</div>
@@ -159,18 +156,29 @@ class StepUpgrade extends Component {
 	}
 }
 
-export default connect(
-	( state, ownProps ) => {
-		const { targetSite } = ownProps;
-		const currentPlanSlug = get( targetSite, 'plan.product_slug' );
-		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
-		const plan = isEcommerceTrial ? getPlan( PLAN_WOOEXPRESS_SMALL ) : getPlan( PLAN_BUSINESS );
-		const planId = plan.getProductId();
-		return {
-			billingTimeFrame: plan.getBillingTimeFrame(),
-			currency: getCurrentUserCurrencyCode( state ),
-			planPrice: getPlanRawPrice( state, planId, true ),
-		};
-	},
-	{ recordTracksEvent }
-)( localize( StepUpgrade ) );
+const WrappedStepUpgrade = ( props ) => {
+	const { targetSite } = props;
+	const currentPlanSlug = get( targetSite, 'plan.product_slug' );
+	const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+	const plan = isEcommerceTrial ? getPlan( PLAN_WOOEXPRESS_SMALL ) : getPlan( PLAN_BUSINESS );
+	const planSlug = plan.getProductId();
+	const pricingMeta = Plans.usePricingMetaForGridPlans( {
+		planSlugs: [ planSlug ],
+		coupon: undefined,
+		siteId: null,
+		storageAddOns: null,
+		useCheckPlanAvailabilityForPurchase,
+	} );
+
+	return (
+		<StepUpgrade
+			{ ...props }
+			isEcommerceTrial={ isEcommerceTrial }
+			billingTimeFrame={ plan.getBillingTimeFrame() }
+			currencyCode={ pricingMeta[ planSlug ]?.currencyCode }
+			planPrice={ pricingMeta[ planSlug ]?.originalPrice?.monthly }
+		/>
+	);
+};
+
+export default localize( WrappedStepUpgrade );

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -161,7 +161,7 @@ const WrappedStepUpgrade = ( props ) => {
 	const currentPlanSlug = get( targetSite, 'plan.product_slug' );
 	const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 	const plan = isEcommerceTrial ? getPlan( PLAN_WOOEXPRESS_SMALL ) : getPlan( PLAN_BUSINESS );
-	const planSlug = plan.getProductId();
+	const planSlug = plan.getStoreSlug();
 	const pricingMeta = Plans.usePricingMetaForGridPlans( {
 		planSlugs: [ planSlug ],
 		coupon: undefined,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

Update the upgrade step in the migrate section to utilise pricing from Plans data-store for the plan upsells on the final step/confirmation.

### Media

- with WooExpress trial

<img width="500" alt="Screenshot 2024-07-02 at 2 07 48 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/cc054118-64ca-4632-8c2c-fdeb93800fd3">

- with other/simple site

<img width="500" alt="Screenshot 2024-07-02 at 2 07 24 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/9c1186ef-12bc-493b-be7b-3e08b978817c">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We only need one form of handling plan pricing in the code base, more so one framework. Anything else risks having alternative and differing views of the same data propagating across the code base.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are two upsells, as in the media.

- Create a site from `/start/plans` or `/setup/wooexpress` to trigger both
- Go to `/migrate/[ site ]`
- Type in a source site you want to migrate from, you can use a JN site here
- Establish Jetpack connection and choose `import everything` and click continue
- Ensure the plan pricing is shown correctly on the screen for Essential (in case of WooExpress site) and Business plan (other site)
- Click `Upgrade and import` and make sure the correct plan is in the cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
