### PR TITLE
A4A site configuration modal: Random site name and basic form validation

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -20,6 +20,7 @@ import ClientSite from './client-site';
 import { AvailablePlans } from './plan-field';
 import PurchaseConfirmationMessage from './purchase-confirmation-message';
 import SiteConfigurationsModal from './site-configurations-modal';
+import { useRandomSiteName } from './site-configurations-modal/use-site-name';
 import NeedSetupTable from './table';
 import type { ReferralAPIResponse } from '../../referrals/types';
 
@@ -43,6 +44,7 @@ const isA4aSiteCreationConfigurationsEnabled = config.isEnabled(
 );
 
 export default function NeedSetup( { licenseKey }: Props ) {
+	const { randomSiteName, isRandomSiteNameLoading } = useRandomSiteName();
 	const translate = useTranslate();
 	const [ displaySiteConfigurationModal, setDisplaySiteConfigurationModal ] = useState( false );
 
@@ -187,7 +189,13 @@ export default function NeedSetup( { licenseKey }: Props ) {
 						</Actions>
 					</LayoutHeader>
 				</LayoutTop>
-				{ displaySiteConfigurationModal && <SiteConfigurationsModal toggleModal={ toggleModal } /> }
+				{ displaySiteConfigurationModal && (
+					<SiteConfigurationsModal
+						toggleModal={ toggleModal }
+						randomSiteName={ randomSiteName }
+						isRandomSiteNameLoading={ isRandomSiteNameLoading }
+					/>
+				) }
 				<NeedSetupTable
 					availablePlans={ availablePlans }
 					isLoading={ isFetching }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { CheckboxControl, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -9,6 +9,7 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
 import { usePhpVersions } from 'calypso/data/php-versions/use-php-versions';
+import { useSiteName } from './use-site-name';
 
 import './style.scss';
 
@@ -21,6 +22,7 @@ export default function SiteConfigurationsModal( { toggleModal }: SiteConfigurat
 	const translate = useTranslate();
 	const dataCenterOptions = useDataCenterOptions();
 	const { phpVersions } = usePhpVersions();
+	const siteName = useSiteName();
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>
 		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );
@@ -58,7 +60,42 @@ export default function SiteConfigurationsModal( { toggleModal }: SiteConfigurat
 						'Once the site is created, you can connect a custom domain to your site and make that your site address instead.'
 					) }
 				>
-					<FormTextInputWithAffixes suffix=".wpcomstaging.com" noWrap />
+					<div className="configure-your-site-modal-form__site-name-wrapper">
+						<FormTextInputWithAffixes
+							isError={ siteName.showValidationMessage }
+							value={ siteName.siteName }
+							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+								siteName.setSiteName( event.target.value )
+							}
+							disabled={ siteName.isRandomSiteLoading }
+							suffix=".wpcomstaging.com"
+							noWrap
+							spellcheck="false"
+							placeholder={ siteName.isRandomSiteLoading && '...' }
+						/>
+						<div className="configure-your-site-modal-form__site-name-icon-wrapper">
+							{ ! siteName.showValidationMessage && ! siteName.isRandomSiteLoading && (
+								<Gridicon
+									icon="checkmark-circle"
+									size={ 24 }
+									className="configure-your-site-modal-form__site-name-success"
+								/>
+							) }
+							{ siteName.showValidationMessage && (
+								<Gridicon
+									icon="cross-circle"
+									size={ 24 }
+									className="configure-your-site-modal-form__site-name-fail"
+								/>
+							) }
+						</div>
+					</div>
+					{ siteName.showValidationMessage && (
+						<div className="configure-your-site-modal-form__site-name-validation-message">
+							<Gridicon icon="info-outline" size={ 16 } />
+							{ siteName.validationMessage }
+						</div>
+					) }
 				</FormField>
 				<FormField
 					label={ translate( 'PHP Version' ) }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -15,14 +15,20 @@ import './style.scss';
 
 type SiteConfigurationsModalProps = {
 	toggleModal: () => void;
+	randomSiteName: string;
+	isRandomSiteNameLoading: boolean;
 };
 
-export default function SiteConfigurationsModal( { toggleModal }: SiteConfigurationsModalProps ) {
+export default function SiteConfigurationsModal( {
+	toggleModal,
+	randomSiteName,
+	isRandomSiteNameLoading,
+}: SiteConfigurationsModalProps ) {
 	const [ allowClientsToUseSiteHelpCenter, setAllowClientsToUseSiteHelpCenter ] = useState( true );
 	const translate = useTranslate();
 	const dataCenterOptions = useDataCenterOptions();
 	const { phpVersions } = usePhpVersions();
-	const siteName = useSiteName();
+	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading );
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>
 		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );
@@ -61,20 +67,22 @@ export default function SiteConfigurationsModal( { toggleModal }: SiteConfigurat
 					) }
 				>
 					<div className="configure-your-site-modal-form__site-name-wrapper">
-						<FormTextInputWithAffixes
-							isError={ siteName.showValidationMessage }
-							value={ siteName.siteName }
-							onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-								siteName.setSiteName( event.target.value )
-							}
-							disabled={ siteName.isRandomSiteLoading }
-							suffix=".wpcomstaging.com"
-							noWrap
-							spellcheck="false"
-							placeholder={ siteName.isRandomSiteLoading && '...' }
-						/>
+						{ isRandomSiteNameLoading ? (
+							<div className="configure-your-site-modal-form__site-name-placeholder" />
+						) : (
+							<FormTextInputWithAffixes
+								isError={ siteName.showValidationMessage }
+								value={ siteName.siteName }
+								onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
+									siteName.setSiteName( event.target.value )
+								}
+								suffix=".wpcomstaging.com"
+								noWrap
+								spellcheck="false"
+							/>
+						) }
 						<div className="configure-your-site-modal-form__site-name-icon-wrapper">
-							{ ! siteName.showValidationMessage && ! siteName.isRandomSiteLoading && (
+							{ ! siteName.showValidationMessage && ! isRandomSiteNameLoading && (
 								<Gridicon
 									icon="checkmark-circle"
 									size={ 24 }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
@@ -29,4 +29,36 @@
 		background-color: var(--color-neutral-0);
 		border-radius: 4px;
 	}
+
+	.configure-your-site-modal-form__site-name-wrapper {
+		display: flex;
+		align-items: center;
+
+		.configure-your-site-modal-form__site-name-icon-wrapper {
+			display: flex;
+			width: 24px;
+			margin-left: 5px;
+		}
+
+		.configure-your-site-modal-form__site-name-success {
+			fill: var(--color-success);
+		}
+
+		.configure-your-site-modal-form__site-name-fail {
+			color: var(--color-error);
+		}
+	}
+
+	.configure-your-site-modal-form__site-name-validation-message {
+		display: flex;
+		align-items: center;
+		font-size: rem(14px);
+		line-height: 1.5;
+		color: var(--color-error);
+
+		svg {
+			margin-right: 5px;
+		}
+	}
+
 }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/mixins";
+
 .configure-your-site-modal-form {
 	max-width: 600px;
 
@@ -28,6 +30,13 @@
 		text-align: right;
 		background-color: var(--color-neutral-0);
 		border-radius: 4px;
+	}
+
+	.configure-your-site-modal-form__site-name-placeholder {
+		@include placeholder( --color-neutral-10 );
+
+		flex: 1;
+		display: block;
 	}
 
 	.configure-your-site-modal-form__site-name-wrapper {

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 
 const SUBDOMAIN_LENGTH_MINIMUM = 4;
@@ -40,6 +40,23 @@ export const useSiteName = () => {
 	const translate = useTranslate();
 	const [ siteName, setSiteName ] = useState( '' );
 	const [ isRandomSiteLoading, setIsRandomSiteLoading ] = useState( true );
+	const specialCharValidationErrorMessage = useMemo(
+		() => translate( 'Your site address can only contain letters and numbers.' ),
+		[ translate ]
+	);
+	const lengthValidationErrorMessage = useMemo(
+		() =>
+			translate(
+				'Your site address should be between %(minimumLength)s and %(maximumLength)s characters in length.',
+				{
+					args: {
+						minimumLength: SUBDOMAIN_LENGTH_MINIMUM,
+						maximumLength: SUBDOMAIN_LENGTH_MAXIMUM,
+					},
+				}
+			),
+		[ translate ]
+	);
 
 	useEffect( () => {
 		getRandomSiteName()
@@ -56,20 +73,12 @@ export const useSiteName = () => {
 	let validationMessage: string | React.ReactNode;
 
 	if ( siteName.match( /[^a-z0-9]/i ) ) {
-		validationMessage = translate( 'Your site address can only contain letters and numbers.' );
+		validationMessage = specialCharValidationErrorMessage;
 	} else if (
 		siteName.length < SUBDOMAIN_LENGTH_MINIMUM ||
 		siteName.length > SUBDOMAIN_LENGTH_MAXIMUM
 	) {
-		validationMessage = translate(
-			'Your site address should be between %(minimumLength)s and %(maximumLength)s characters in length.',
-			{
-				args: {
-					minimumLength: SUBDOMAIN_LENGTH_MINIMUM,
-					maximumLength: SUBDOMAIN_LENGTH_MAXIMUM,
-				},
-			}
-		);
+		validationMessage = lengthValidationErrorMessage;
 	}
 
 	const showValidationMessage = !! validationMessage && ! isRandomSiteLoading;

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -32,14 +32,31 @@ const getRandomSiteName = async () => {
 		}
 	}
 
-	// If all 10 urlSuggestions are taken (very unlikly) return empty '' name as falback
+	// If all 10 urlSuggestions are taken (very unlikely) return empty '' name as falback
 	return '';
 };
 
-export const useSiteName = () => {
+export const useRandomSiteName = () => {
+	const [ randomSiteName, setRandomSiteName ] = useState( '' );
+	const [ isRandomSiteNameLoading, setIsRandomSiteNameLoading ] = useState( true );
+	useEffect( () => {
+		getRandomSiteName()
+			.then( ( randomSiteName ) => {
+				setRandomSiteName( randomSiteName );
+				setIsRandomSiteNameLoading( false );
+			} )
+			.catch( () => {
+				setRandomSiteName( '' );
+				setIsRandomSiteNameLoading( false );
+			} );
+	}, [] );
+
+	return { randomSiteName, isRandomSiteNameLoading };
+};
+
+export const useSiteName = ( randomSiteName: string, isRandomSiteNameLoading: boolean ) => {
 	const translate = useTranslate();
-	const [ siteName, setSiteName ] = useState( '' );
-	const [ isRandomSiteLoading, setIsRandomSiteLoading ] = useState( true );
+	const [ siteName, setSiteName ] = useState( randomSiteName );
 	const specialCharValidationErrorMessage = useMemo(
 		() => translate( 'Your site address can only contain letters and numbers.' ),
 		[ translate ]
@@ -59,16 +76,8 @@ export const useSiteName = () => {
 	);
 
 	useEffect( () => {
-		getRandomSiteName()
-			.then( ( randomSiteName ) => {
-				setSiteName( randomSiteName );
-				setIsRandomSiteLoading( false );
-			} )
-			.catch( () => {
-				setSiteName( '' );
-				setIsRandomSiteLoading( false );
-			} );
-	}, [] );
+		setSiteName( randomSiteName );
+	}, [ randomSiteName ] );
 
 	let validationMessage: string | React.ReactNode;
 
@@ -81,7 +90,7 @@ export const useSiteName = () => {
 		validationMessage = lengthValidationErrorMessage;
 	}
 
-	const showValidationMessage = !! validationMessage && ! isRandomSiteLoading;
+	const showValidationMessage = !! validationMessage && ! isRandomSiteNameLoading;
 
-	return { siteName, setSiteName, validationMessage, showValidationMessage, isRandomSiteLoading };
+	return { siteName, setSiteName, validationMessage, showValidationMessage };
 };

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -1,0 +1,77 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+
+const SUBDOMAIN_LENGTH_MINIMUM = 4;
+const SUBDOMAIN_LENGTH_MAXIMUM = 50;
+
+const checkSiteAvailability = async ( siteName: string ) => {
+	// To do: check site availability on the server
+	if ( siteName ) {
+		return true;
+	}
+};
+
+const getRandomSiteName = async () => {
+	let randomSiteName = '';
+	try {
+		const { suggestions } = await wpcom.req.get( {
+			apiNamespace: 'wpcom/v2',
+			path: `/site-suggestions`,
+		} );
+		const { title } = suggestions[ 0 ];
+
+		const { body: urlSuggestions } = await wpcom.req.get( {
+			apiNamespace: 'rest/v1.1',
+			path: `/domains/suggestions?http_envelope=1&query=${ title }&quantity=10&include_wordpressdotcom=true&include_dotblogsubdomain=false&only_wordpressdotcom=true&vendor=dot&managed_subdomain_quantity=0`,
+		} );
+
+		for ( const { domain_name } of urlSuggestions ) {
+			const siteName = domain_name.split( '.' )[ 0 ];
+			const isAvailable = await checkSiteAvailability( siteName );
+			if ( isAvailable ) {
+				randomSiteName = siteName;
+				break;
+			}
+		}
+	} catch {}
+
+	// If all 10 urlSuggestions are taken (very unlikly) or if any requests fail, use empty '' name as falback
+	return randomSiteName;
+};
+
+export const useSiteName = () => {
+	const translate = useTranslate();
+	const [ siteName, setSiteName ] = useState( '' );
+	const [ isRandomSiteLoading, setIsRandomSiteLoading ] = useState( true );
+
+	useEffect( () => {
+		getRandomSiteName().then( ( randomSiteName ) => {
+			setSiteName( randomSiteName );
+			setIsRandomSiteLoading( false );
+		} );
+	}, [] );
+
+	let validationMessage: string | React.ReactNode;
+
+	if ( siteName.match( /[^a-z0-9]/i ) ) {
+		validationMessage = translate( 'Your site address can only contain letters and numbers.' );
+	} else if (
+		siteName.length < SUBDOMAIN_LENGTH_MINIMUM ||
+		siteName.length > SUBDOMAIN_LENGTH_MAXIMUM
+	) {
+		validationMessage = translate(
+			'Your site address should be between %(minimumLength)s and %(maximumLength)s characters in length.',
+			{
+				args: {
+					minimumLength: SUBDOMAIN_LENGTH_MINIMUM,
+					maximumLength: SUBDOMAIN_LENGTH_MAXIMUM,
+				},
+			}
+		);
+	}
+
+	const showValidationMessage = !! validationMessage && ! isRandomSiteLoading;
+
+	return { siteName, setSiteName, validationMessage, showValidationMessage, isRandomSiteLoading };
+};


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7885

## Proposed Changes

Generates random url suggestion as initial value for site name and adds basic form validation, including:
- Length between 4 and 50 characters in length.
- Only letters and numbers allowed.

## Testing Instructions

This feature is under `a4a-site-creation-configurations` flag.
Before accessing the Create new site button, your account needs to have at least 1 hosting license, ready to be used.
If you are not sure how to get that, read PdDOJh-3ys-p2.

1 - Open this link: http://agencies.localhost:3000/sites/need-setup?flags=a4a-site-creation-configurations
2 - Click on Create new site button.
3 - Site name should be a random generated value.
![image](https://github.com/Automattic/wp-calypso/assets/33497086/726611b2-4f87-457f-b29d-cd748e84e430)

4 - Edit the field and check for the 4 and 50 characters in length validation.
![image](https://github.com/Automattic/wp-calypso/assets/33497086/8cb04524-93b9-407e-952b-4ab0ac21e002)

5 - Insert a special char like `!` and ensure that only letters and numbers allowed.
![image](https://github.com/Automattic/wp-calypso/assets/33497086/205ec0b4-ecfd-423c-8d00-8b581f90d92c)
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?