### PR TITLE
Newsletter Settings: Redirect to jetpack for atomic sites with classic admin interface

### DIFF
--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -1,9 +1,29 @@
 import page from '@automattic/calypso-router';
 import titlecase from 'to-title-case';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
+import { navigate } from 'calypso/lib/navigate';
 import { sectionify } from 'calypso/lib/route';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { getSiteOption, getSiteUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function redirectToJetpackNewsletterSettingsIfNeeded( context, next ) {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const siteUrl = getSiteUrl( state, siteId );
+
+	const isAtomic = isSiteWpcomAtomic( state, siteId );
+	const hasClassicAdminInterfaceStyle =
+		getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
+
+	if ( hasClassicAdminInterfaceStyle && isAtomic ) {
+		navigate( `${ siteUrl }/wp-admin/admin.php?page=jetpack#/newsletter` );
+		return;
+	}
+
+	next();
+}
 
 export function siteSettings( context, next ) {
 	let analyticsPageTitle = 'Site Settings';

--- a/client/my-sites/site-settings/settings-newsletter/index.ts
+++ b/client/my-sites/site-settings/settings-newsletter/index.ts
@@ -1,13 +1,17 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection } from 'calypso/my-sites/controller';
-import { siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
+import {
+	redirectToJetpackNewsletterSettingsIfNeeded,
+	siteSettings,
+} from 'calypso/my-sites/site-settings/settings-controller';
 import { createNewsletterSettings } from './controller';
 
 export default function () {
 	page(
 		'/settings/newsletter/:site_id',
 		siteSelection,
+		redirectToJetpackNewsletterSettingsIfNeeded,
 		navigation,
 		siteSettings,
 		createNewsletterSettings,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7833

## Proposed Changes

* `/settings/newsletter/{site}` redirects to Jetpack newsletter settings page for Atomic sites with Classic View enabled, while Simple Classic sites can still access the Calypso settings page.

## Testing Instructions

1. On an atomic site, go to `/settings/general/{siteId}`
2. Under `Admin interface style`, choose `Classic style` and save changes
3. Go to `/settings/newsletter/{siteId}`, check that you are redirected to `{siteId}/wp-admin/admin.php?page=jetpack#/newsletter`

With a simple site, repeat the previous steps and check that you get to stay on `/settings/newsletter/{siteId}`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
