### PR TITLE
Support: Open help search links in Help Center

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -4,6 +4,7 @@ import { getContextResults } from '@automattic/data-stores';
 import { useHelpSearchQuery } from '@automattic/help-center';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { speak } from '@wordpress/a11y';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { Icon, page as pageIcon, arrowRight } from '@wordpress/icons';
 import { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { debounce } from 'lodash';
@@ -105,31 +106,39 @@ function HelpSearchResults( {
 		}
 	}, [ isSearching, hasAPIResults, searchQuery ] );
 
+	const { setShowSupportDoc } = useDataStoreDispatch( 'automattic/help-center' );
+
 	const onLinkClickHandler = ( event, result, type ) => {
-		const { link } = result;
-		// check and catch admin section links.
-		if ( type === SUPPORT_TYPE_ADMIN_SECTION && link ) {
-			// record track-event.
-			dispatch(
-				recordTracksEvent( 'calypso_inlinehelp_admin_section_visit', {
-					link: link,
-					search_term: searchQuery,
-					location,
-					section: sectionName,
-				} )
-			);
-
-			// push state only if it's internal link.
-			if ( ! /^http/.test( link ) ) {
-				event.preventDefault();
-				openAdminInNewTab ? window.open( 'https://wordpress.com' + link, '_blank' ) : page( link );
-				onAdminSectionSelect( event );
-			}
-
+		const { link, post_id: postId } = result;
+		if ( ! link ) {
+			onSelect( event, result );
 			return;
 		}
 
-		onSelect( event, result );
+		if ( type !== SUPPORT_TYPE_ADMIN_SECTION ) {
+			if ( type === SUPPORT_TYPE_API_HELP ) {
+				event.preventDefault();
+
+				setShowSupportDoc( link, postId );
+			}
+			onSelect( event, result );
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_inlinehelp_admin_section_visit', {
+				link: link,
+				search_term: searchQuery,
+				location,
+				section: sectionName,
+			} )
+		);
+
+		if ( ! /^http/.test( link ) ) {
+			event.preventDefault();
+			openAdminInNewTab ? window.open( 'https://wordpress.com' + link, '_blank' ) : page( link );
+			onAdminSectionSelect( event );
+		}
 	};
 
 	const renderHelpLink = ( result, type ) => {

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -124,6 +124,7 @@ export const setShowSupportDoc = function* ( link: string, postId: number, blogI
 		cacheBuster: String( Date.now() ),
 	} );
 	yield setInitialRoute( `/post/?${ params }` );
+	yield setIsMinimized( false );
 	yield setShowHelpCenter( true );
 };
 


### PR DESCRIPTION
As reported on pbvpgB-53O-p2

Previous related PR: https://github.com/Automattic/wp-calypso/pull/79741

Related to #

## Proposed Changes

* Links in the "Get help" section in `/home` should open in Help Center, not in a new tab.

## Why are these changes being made?

* We want the user to stay in the context of the admin dashboard, with support docs at hand for easy reference.

## Testing Instructions

<img width="714" alt="Screenshot 2024-07-02 at 12 17 39" src="https://github.com/Automattic/wp-calypso/assets/3392497/f138e7a7-e4e4-416b-acc4-58814ee22d34">

- Visit `/home` for any of your sites.
- Click on any support doc links in `Get help` section. Support docs should open in Help Center.
- Search for anything (`paypal`, for example). Verify the search results open in Help Center too.
- Search for something that will trigger an admin section shortcut, like `learn`. Click the link in `Show me where to` section - it should navigate you to the appropriate admin section.

<img width="712" alt="Screenshot 2024-07-02 at 12 17 18" src="https://github.com/Automattic/wp-calypso/assets/3392497/98c56cb6-ab09-460f-8f0a-6ebf3bcbb585">

Try to put Help Center in different states (initiate a search inside Help Center first, start chatting with Wapuu, etc.) and verify that the support docs still show up as expected when triggered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
