### PR TITLE
 Stats: Empty States: Update empty state for Authors

### DIFF
--- a/client/my-sites/stats/features/modules/stats-authors/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-authors/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-authors';

--- a/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
+++ b/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
@@ -33,7 +33,7 @@ type StatClicksProps = {
 const StatClicks: React.FC< StatClicksProps > = ( { period, query, moduleStrings, className } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const statType = 'statsAuthors';
+	const statType = 'statsTopAuthors';
 
 	const requesting = useSelector( ( state ) =>
 		isRequestingSiteStatsForQuery( state, siteId, statType, query )

--- a/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
+++ b/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
@@ -1,0 +1,90 @@
+import { StatsCard } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { postAuthor } from '@wordpress/icons'; // TODO this isn't quite the right icon. Need to update when we can locate the correct icon
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { useSelector } from 'calypso/state';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { SUPPORT_URL } from '../../../const';
+import StatsModule from '../../../stats-module';
+import StatsModulePlaceholder from '../../../stats-module/placeholder';
+
+type StatClicksProps = {
+	className?: string;
+	period: string;
+	query: {
+		date: string;
+		period: string;
+	};
+	moduleStrings: {
+		title: string;
+		item: string;
+		value: string;
+		empty: string;
+	};
+};
+
+const StatClicks: React.FC< StatClicksProps > = ( { period, query, moduleStrings, className } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsAuthors';
+
+	const requesting = useSelector( ( state ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	return (
+		<>
+			{ siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
+			{ requesting && <StatsModulePlaceholder isLoading={ requesting } /> }
+			{ ( ! data || ! data?.length ) && (
+				<StatsCard
+					className={ className }
+					title={ translate( 'Authors' ) }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ postAuthor }
+							description={ translate(
+								'Learn about your most {{link}}popular authors{{/link}} to better understand how they contribute to grow your site.',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: <a href={ localizeUrl( `${ SUPPORT_URL }#authors` ) } />,
+									},
+									context: 'Stats: Info box label when the Authors module is empty',
+								}
+							) }
+						/>
+					}
+				>
+					<></>
+				</StatsCard>
+			) }
+			{ data && !! data.length && (
+				<StatsModule
+					path="authors"
+					moduleStrings={ moduleStrings }
+					period={ period }
+					query={ query }
+					statType={ statType }
+					showSummaryLink
+					className={ className }
+				></StatsModule>
+			) }
+		</>
+	);
+};
+
+export default StatClicks;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -575,7 +575,8 @@ class StatsSite extends Component {
 										'stats__author-views': ! supportsUTMStats,
 									},
 									'stats__flexible-grid-item--half',
-									'stats__flexible-grid-item--full--large'
+									'stats__flexible-grid-item--full--large',
+									'stats-card--empty-variant'
 								) }
 							/>
 						) }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -564,6 +564,7 @@ class StatsSite extends Component {
 							/>
 						) }
 
+						{ /* Either stacks with Clicks or with Emails depending on UTM */ }
 						{ ! this.isModuleHidden( 'authors' ) && isNewStateEnabled && (
 							<StatsModuleAuthors
 								path="authors"

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -567,11 +567,9 @@ class StatsSite extends Component {
 						{ /* Either stacks with Clicks or with Emails depending on UTM */ }
 						{ ! this.isModuleHidden( 'authors' ) && isNewStateEnabled && (
 							<StatsModuleAuthors
-								path="authors"
 								moduleStrings={ moduleStrings.authors }
 								period={ this.props.period }
 								query={ query }
-								statType="statsTopAuthors"
 								className={ clsx(
 									{
 										'stats__author-views': ! supportsUTMStats,
@@ -579,7 +577,6 @@ class StatsSite extends Component {
 									'stats__flexible-grid-item--half',
 									'stats__flexible-grid-item--full--large'
 								) }
-								showSummaryLink
 							/>
 						) }
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -44,6 +44,7 @@ import { getModuleSettings } from 'calypso/state/stats/module-settings/selectors
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import StatsModuleAuthors from './features/modules/stats-authors';
 import StatsModuleClicks from './features/modules/stats-clicks';
 import StatsModuleCountries from './features/modules/stats-countries';
 import StatsModuleReferrers from './features/modules/stats-referrers';
@@ -545,8 +546,26 @@ class StatsSite extends Component {
 							/>
 						) }
 						{ /* Either stacks with Clicks or with Emails depending on UTM */ }
-						{ ! this.isModuleHidden( 'authors' ) && (
+						{ ! this.isModuleHidden( 'authors' ) && ! isNewStateEnabled && (
 							<StatsModule
+								path="authors"
+								moduleStrings={ moduleStrings.authors }
+								period={ this.props.period }
+								query={ query }
+								statType="statsTopAuthors"
+								className={ clsx(
+									{
+										'stats__author-views': ! supportsUTMStats,
+									},
+									'stats__flexible-grid-item--half',
+									'stats__flexible-grid-item--full--large'
+								) }
+								showSummaryLink
+							/>
+						) }
+
+						{ ! this.isModuleHidden( 'authors' ) && isNewStateEnabled && (
+							<StatsModuleAuthors
 								path="authors"
 								moduleStrings={ moduleStrings.authors }
 								period={ this.props.period }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#64](https://github.com/Automattic/red-team/issues/65)

## Proposed Changes

* adds a new empty state for Authors

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply `stats/empty-module-traffic` feature flag
* verify that a page with empty Authors views component works with and without the feature flag
* repeat for blogs with data
* **NOTE** currently the icon used is very slightly different from the design specs. I am aware of this and will fix it up soon once the correct icon is located. 

![image](https://github.com/Automattic/wp-calypso/assets/30754158/617b4c74-e366-427d-9a2a-973c082656cb)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?