### PR TITLE
A4A: Fix background color bug on the Contact support form.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-themed-modal/style.scss
+++ b/client/a8c-for-agencies/components/a4a-themed-modal/style.scss
@@ -13,7 +13,7 @@
 	}
 }
 
-.components-modal__content.hide-header {
+.a4a-themed-modal .components-modal__content.hide-header {
 	background: var(--color-primary-100);
 	border-radius: 4px;
 	padding: 8px;


### PR DESCRIPTION
This PR fixes an issue with the A4A modal background color changing to primary instead of white.

| Before | After |
|--------|--------|
| <img width="874" alt="Screenshot 2024-07-02 at 9 25 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a1892340-f5bc-453d-aa85-c9d5630d6e8a"> | <img width="860" alt="Screenshot 2024-07-02 at 9 26 03 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8c752176-4a83-4ec9-841f-dc647bf13559"> | 

## Proposed Changes

* Ensure the A4A-themed modal styling is applied only to the themed modal.



## Testing Instructions

* Use the A4A live link and go to `/overview` page.
* Click the 'Contact sales' menu in the sidebar.
* Confirm the Contact support modal is not broken.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
