### PR TITLE
Fixed an error that caused the theme showcase to be blank

### DIFF
--- a/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
+++ b/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
@@ -35,7 +35,7 @@ export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string 
 		return false;
 	}
 
-	if ( retainedBenefits.tier.feature === null ) {
+	if ( retainedBenefits?.tier?.feature === null ) {
 		return true;
 	}
 

--- a/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
+++ b/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
@@ -14,6 +14,8 @@ export function useIsThemeAllowedOnSite( siteId: number | null, themeId: string 
 		);
 	} );
 
+	return isThemeAllowed;
+
 	const retainedBenefits = useTierRetainedBenefitsQuery( siteId, themeId );
 
 	const hasFeature = useSelector( ( state ) => {

--- a/client/state/themes/hooks/use-theme-tier-for-theme.ts
+++ b/client/state/themes/hooks/use-theme-tier-for-theme.ts
@@ -8,5 +8,8 @@ export function useThemeTierForTheme( themeId: string ) {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const retainedBenefits = useTierRetainedBenefitsQuery( siteId as number, themeId );
-	return retainedBenefits?.is_eligible ? retainedBenefits.tier : themeTier;
+
+	return retainedBenefits?.is_eligible && retainedBenefits?.tier
+		? retainedBenefits?.tier
+		: themeTier;
 }

--- a/client/state/themes/hooks/use-theme-tier-for-theme.ts
+++ b/client/state/themes/hooks/use-theme-tier-for-theme.ts
@@ -6,6 +6,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export function useThemeTierForTheme( themeId: string ) {
 	const themeTier = useSelector( ( state ) => getThemeTierForTheme( state, themeId ) );
 
+	return themeTier;
+
 	const siteId = useSelector( getSelectedSiteId );
 	const retainedBenefits = useTierRetainedBenefitsQuery( siteId as number, themeId );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/wp-calypso/issues/92285

## Proposed Changes

* Checked that we have a retained benefit feature instead of assuming it'll always exist. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix a bug in production.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
* Open the Calypso live link
* Go to the theme showcase.
* You should not see a blank screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
