### PR TITLE
Dotcom: update font in Navigation Header

### DIFF
--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -15,7 +15,6 @@
 	.breadcrumbs {
 		li {
 			color: var(--studio-gray-60, #50575e);
-			font-family: "SF Pro Text", $sans;
 			font-size: $font-body-small;
 			font-style: normal;
 			font-weight: 400;
@@ -58,7 +57,6 @@
 	}
 
 	.formatted-header__title {
-		font-family: "SF Pro Display", $sans;
 		font-size: $font-title-small;
 		font-weight: 500;
 		line-height: 26px;


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/91798

## Proposed Changes

* Removes instances of “SF Pro” in Dotcom's navigation header in favor of the system font stack.

## Why are these changes being made?

"SF Pro” corresponds to the system font in Apple (`-apple-system`), so we should always use the system font stack defined here:

https://github.com/Automattic/wp-calypso/blob/a1b36280a13857334ca6afd7a3d93ad357f0e053/packages/components/src/styles/_typography.scss#L1

Plus, the “Display”/“Text” variants of “SF Pro” is deprecated and should not be used.

## Testing Instructions

* Fire up this PR.
* Open Dotcom.
* Make sure the headers in the new dashboard look good and that nothing is breaking.

## Screenshots

Before | After
--|--
<img width="641" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/5ac5a2cc-0085-4687-8bea-427ad93fe904"> | <img width="628" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/cfd4f042-17af-4346-8513-106bfe375cae">
