### PR TITLE
Site Migration: Add the possibility of exiting the Instructions step in the Assisted Migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -94,7 +94,6 @@ const ImporterMigrateMessage: Step = () => {
 						</span>
 						{ __( `We'll help you with the domain changes after the migration is completed.` ) }
 					</div>
-
 					<div className="migration-message__actions">
 						<FlowCard
 							title={ __( 'Let me explore' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -15,6 +15,8 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { UserData } from 'calypso/lib/user/user';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import FlowCard from '../components/flow-card';
+import { redirect } from '../import/util';
 import { useSubmitMigrationTicket } from './hooks/use-submit-migration-ticket';
 
 const ImporterMigrateMessage: Step = () => {
@@ -92,13 +94,22 @@ const ImporterMigrateMessage: Step = () => {
 						</span>
 						{ __( `We'll help you with the domain changes after the migration is completed.` ) }
 					</div>
+
 					<div className="migration-message__actions">
-						<Button primary transparent href={ `/home/${ siteSlug }` }>
-							{ __( 'Let me explore' ) }
-						</Button>
-						<Button primary transparent href="/support">
-							{ __( 'Help me learn' ) }
-						</Button>
+						<FlowCard
+							title={ __( 'Let me explore' ) }
+							text={ __(
+								'Discover more features and options available on WordPress.com on your own.'
+							) }
+							onClick={ () => redirect( `/home/${ siteSlug }` ) }
+						/>
+						<FlowCard
+							title={ __( 'Help me learn' ) }
+							text={ __(
+								'Access guides and tutorials to better understand how to use WordPress.com.'
+							) }
+							onClick={ () => redirect( '/support' ) }
+						/>
 					</div>
 				</>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
@@ -57,7 +57,7 @@
 
 	.migration-message__actions {
 		display: flex;
-		gap: 2em;
-		margin-top: 3em; /* could also work with padding-top */
+		justify-content: center;
+		margin: 0 -10px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92260

## Proposed Changes

* This PR adds two cards to offer the possibility of the user exiting the Instruction step after they go through the Assisted Migration flow.
* This PR should be shipped after: https://github.com/Automattic/wp-calypso/pull/92290

#### Before

![Captura de Tela 2024-07-02 às 12 09 18](https://github.com/Automattic/wp-calypso/assets/1234758/aa2c18e7-f4af-4142-8d17-1d1701399a03)

#### After

![Captura de Tela 2024-07-02 às 12 07 47](https://github.com/Automattic/wp-calypso/assets/1234758/6586f1dd-e116-4cb9-8c6b-81748538519c)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We noticed that the instruction step after the Assisted Migration flow would leave the user on a Dead-end step without the possibility of redirecting them to further exploration of our platform.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local environment or use the Calypso Live link below
* Navigate to `/start` and go through the migration flow until you reach the "What do you want to do?" step.
* Select "Migrate site"
* On the "How to migrate" step, select the "Do it for me" option
* Go through the checkout in case you are testing on a free site
* You should land on the assisted migration instruction step
* You should now see two cards on the bottom. Click on both of them and check that you are being redirected to the Customer Home page and the Support page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
