### PR TITLE
Site Migration: Add buttons to allow users to exit the Do-it-for-me flow dead-end

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -93,10 +93,10 @@ const ImporterMigrateMessage: Step = () => {
 						{ __( `We'll help you with the domain changes after the migration is completed.` ) }
 					</div>
 					<div className="migration-message__actions">
-						<Button onClick={ () => {} } primary transparent href={ `/home/${ siteSlug }` }>
+						<Button primary transparent href={ `/home/${ siteSlug }` }>
 							{ __( 'Let me explore' ) }
 						</Button>
-						<Button onClick={ () => {} } primary transparent href="/support">
+						<Button primary transparent href="/support">
 							{ __( 'Help me learn' ) }
 						</Button>
 					</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';
@@ -90,6 +91,14 @@ const ImporterMigrateMessage: Step = () => {
 							<Icon icon={ globe } />
 						</span>
 						{ __( `We'll help you with the domain changes after the migration is completed.` ) }
+					</div>
+					<div className="migration-message__actions">
+						<Button onClick={ () => {} } primary transparent href={ `/home/${ siteSlug }` }>
+							{ __( 'Let me explore' ) }
+						</Button>
+						<Button onClick={ () => {} } primary transparent href="/support">
+							{ __( 'Help me learn' ) }
+						</Button>
 					</div>
 				</>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
@@ -57,6 +57,7 @@
 
 	.migration-message__actions {
 		display: flex;
-		gap: 1em;
+		gap: 2em;
+		margin-top: 3em; /* could also work with padding-top */
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
@@ -54,4 +54,9 @@
 		margin: auto;
 		padding: 8px 0;
 	}
+
+	.migration-message__actions {
+		display: flex;
+		gap: 1em;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92260

## Proposed Changes

* Add two actions to the instruction step of the Assisted Migration flow to allow the users to explore our tools.
* As a subsequent work, when the strings are translated, we should also deploy https://github.com/Automattic/wp-calypso/pull/92289.

#### Before

![Captura de Tela 2024-07-02 às 12 09 18](https://github.com/Automattic/wp-calypso/assets/1234758/3083d59a-588c-4b04-92ae-add87d78fe3d)

#### After

![Captura de Tela 2024-07-02 às 12 33 11](https://github.com/Automattic/wp-calypso/assets/1234758/deecb87f-cf67-4ed3-b239-4d56c87c521f)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We noticed that the instruction step after the Assisted Migration flow would leave the user on a Dead-end step without the possibility of redirecting them to further exploration of our platform.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local environment or use the Calypso Live link below
* Navigate to `/start` and go through the migration flow until you reach the "What do you want to do?" step.
* Select "Migrate site"
* On the "How to migrate" step, select the "Do it for me" option
* Go through the checkout in case you are testing on a free site
* You should land on the assisted migration instruction step
* You should now see two buttons on the bottom. Click on both of them and check that you are being redirected to the Customer Home page and the Support page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
