### PR TITLE
Stepper: Update the `start-writing` flow to use the new login strategy

### DIFF
--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -21,7 +21,7 @@ import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 const startWriting: Flow = {
 	name: START_WRITING_FLOW,
 	get title() {
-		return translate( 'Blog' );
+		return translate( 'Start writing' );
 	},
 	isSignupFlow: true,
 	useSteps() {

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -11,13 +11,12 @@ import {
 	type Flow,
 	type ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useSiteData } from '../hooks/use-site-data';
-import { useLoginUrl } from '../utils/path';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 
 const startWriting: Flow = {
 	name: START_WRITING_FLOW,
@@ -26,7 +25,8 @@ const startWriting: Flow = {
 	},
 	isSignupFlow: true,
 	useSteps() {
-		return [
+		//TODO: Migrate to use the STEPS from the steps.ts file
+		return stepsWithRequiredLogin( [
 			{
 				slug: 'check-sites',
 				asyncComponent: () => import( './internals/steps-repository/sites-checker' ),
@@ -72,7 +72,7 @@ const startWriting: Flow = {
 				slug: 'celebration-step',
 				asyncComponent: () => import( './internals/steps-repository/celebration-step' ),
 			},
-		];
+		] );
 	},
 
 	useStepNavigation( currentStep, navigate ) {
@@ -233,35 +233,15 @@ const startWriting: Flow = {
 			currentPath.includes( 'setup/start-writing/check-sites' );
 		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
 
-		const locale = useFlowLocale();
-
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: `/setup/${ flowName }`,
-			pageTitle: translate( 'Start writing' ),
-			locale,
-		} );
-		// Despite sending a CHECKING state, this function gets called again with the
-		// /setup/start-writing/create-site route which has no locale in the path so we need to
-		// redirect off of the first render.
-		// This effects both /setup/start-writing/<locale> starting points and /setup/start-writing/create-site/<locale> urls.
-		// The double call also hapens on urls without locale.
 		useEffect( () => {
-			if ( ! isLoggedIn ) {
-				redirect( logInUrl );
-			} else if ( isCreateSite && ! userAlreadyHasSites ) {
+			if ( isLoggedIn && isCreateSite && ! userAlreadyHasSites ) {
 				redirect( '/setup/start-writing/create-site' );
 			}
 		}, [] );
 
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
-		if ( ! isLoggedIn ) {
-			result = {
-				state: AssertConditionState.CHECKING,
-				message: `${ flowName } requires a logged in user`,
-			};
-		} else if ( isCreateSite && ! userAlreadyHasSites ) {
+		if ( isLoggedIn && isCreateSite && ! userAlreadyHasSites ) {
 			result = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } with no preexisting sites`,


### PR DESCRIPTION
Part of #92291

## Proposed Changes
* Replace all code related to managing the login to use stepsWithRequiredLogin 

## Why are these changes being made?
As explained on #92291 we are updating all flows to use the new stepper login capabilities.
This flow is the first one we are migrating that requires custom parameters when we redirect the user to the login flow.

## Testing Instructions
Flow: `/setup/start-writing`
Scenario 1: Redirect to the login page
- Open a new browser where you don't have a WordPress.com session
- Try to access the flow or any of the flow steps (E.g `setup/start-writing/check-sites`)
- Please ensure you have been redirected to the login page.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
