### PR TITLE
ShortcutsPopover: Only render HotkeyContainer for `i` when the panel is open

### DIFF
--- a/apps/notifications/src/panel/templates/shortcuts-popover.jsx
+++ b/apps/notifications/src/panel/templates/shortcuts-popover.jsx
@@ -107,14 +107,7 @@ export const ShortcutsPopover = ( {
 	return (
 		<>
 			{ ! isMobile && (
-				<HotkeyContainer
-					shortcuts={ [
-						{
-							hotkey: 73, // i key number
-							action: toggleShortcutsPopover,
-						},
-					] }
-				>
+				<HotkeyContainer shortcuts={ [] }>
 					<button
 						className={ clsx( 'wpnc__keyboard-shortcuts-button', {
 							'active-action': isShortcutsPopoverOpen,

--- a/apps/notifications/src/panel/templates/shortcuts-popover.jsx
+++ b/apps/notifications/src/panel/templates/shortcuts-popover.jsx
@@ -103,7 +103,14 @@ export const ShortcutsPopover = ( {
 	return (
 		<>
 			{ ! isMobile && (
-				<HotkeyContainer shortcuts={ [] }>
+				<HotkeyContainer
+					shortcuts={ [
+						{
+							hotkey: 73, // i key number
+							action: toggleShortcutsPopover,
+						},
+					] }
+				>
 					<button
 						className={ clsx( 'wpnc__keyboard-shortcuts-button', {
 							'active-action': isShortcutsPopoverOpen,

--- a/apps/notifications/src/panel/templates/shortcuts-popover.jsx
+++ b/apps/notifications/src/panel/templates/shortcuts-popover.jsx
@@ -94,6 +94,10 @@ export const ShortcutsPopover = ( {
 							<span className="description">{ translate( 'View Likes' ) }</span>
 							<span className="shortcut letter">l</span>
 						</li>
+						<li>
+							<span className="description">{ translate( 'Toggle Shortcuts Menu' ) }</span>
+							<span className="shortcut letter">i</span>
+						</li>
 					</ul>
 				</div>
 			</Popover>

--- a/apps/notifications/src/panel/templates/shortcuts-popover.jsx
+++ b/apps/notifications/src/panel/templates/shortcuts-popover.jsx
@@ -106,7 +106,7 @@ export const ShortcutsPopover = ( {
 
 	return (
 		<>
-			{ ! isMobile && (
+			{ ! isMobile && isPanelOpen && (
 				<HotkeyContainer
 					shortcuts={ [
 						{

--- a/apps/notifications/src/panel/templates/shortcuts-popover.jsx
+++ b/apps/notifications/src/panel/templates/shortcuts-popover.jsx
@@ -94,10 +94,6 @@ export const ShortcutsPopover = ( {
 							<span className="description">{ translate( 'View Likes' ) }</span>
 							<span className="shortcut letter">l</span>
 						</li>
-						<li>
-							<span className="description">{ translate( 'Toggle Shortcuts Menu' ) }</span>
-							<span className="shortcut letter">i</span>
-						</li>
 					</ul>
 				</div>
 			</Popover>


### PR DESCRIPTION
## Proposed Changes

* ShortcutsPopover: Only render HotkeyContainer for `i` when the panel is open

## Why are these changes being made?

* Prevent an issue with `i` not working in input fields sometimes

## Testing Instructions

TRUNK:

*    Go to any posts page in calypso. (IE: `https://wordpress.com/posts/(sitename)` )
*    Click the search and type. the "i" key works.
*    Click the bell to look at your notifications, then click again to close notifications.
*    Try to type into the post search again. The "i" key no longer works.

On this patch, it should work.

TRUNK + PATCH:

* Click the bell to look at your notifications.
* Press `i` to open and close the help popup.

Should work both before and after this patch.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
