### PR TITLE
Stepper: Update `assembler-first` flow to use the new login strategy

### DIFF
--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -5,13 +5,12 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
-import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getTheme } from 'calypso/state/themes/selectors';
 import { useSiteData } from '../hooks/use-site-data';
 import { ONBOARD_STORE, SITE_STORE } from '../stores';
-import { useLoginUrl } from '../utils/path';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
@@ -63,7 +62,7 @@ const assemblerFirstFlow: Flow = {
 	},
 
 	useSteps() {
-		return [
+		return stepsWithRequiredLogin( [
 			STEPS.CHECK_SITES,
 			STEPS.NEW_OR_EXISTING_SITE,
 			STEPS.SITE_PICKER,
@@ -77,7 +76,7 @@ const assemblerFirstFlow: Flow = {
 			STEPS.DOMAINS,
 			STEPS.SITE_LAUNCH,
 			STEPS.CELEBRATION,
-		];
+		] );
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
@@ -284,29 +283,14 @@ const assemblerFirstFlow: Flow = {
 			currentPath.includes( `setup/${ flowName }/check-sites` );
 		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
 
-		const locale = useFlowLocale();
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: window.location.href.replace( window.location.origin, '' ),
-			locale,
-		} );
-
 		useEffect( () => {
-			if ( ! isLoggedIn ) {
-				window.location.assign( logInUrl );
-			} else if ( isCreateSite && ! userAlreadyHasSites ) {
+			if ( isLoggedIn && isCreateSite && ! userAlreadyHasSites ) {
 				window.location.assign( `/setup/${ flowName }/create-site` );
 			}
 		}, [] );
 
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
-
-		if ( ! isLoggedIn ) {
-			result = {
-				state: AssertConditionState.CHECKING,
-				message: `${ flowName } requires a logged in user`,
-			};
-		} else if ( isCreateSite && ! userAlreadyHasSites ) {
+		if ( isLoggedIn && isCreateSite && ! userAlreadyHasSites ) {
 			result = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } with no preexisting sites`,


### PR DESCRIPTION
Part of #92291

## Proposed Changes
* Replace all code related to managing the login to use stepsWithRequiredLogin 

## Why are these changes being made?
As explained on #92291 we are updating all flows to use the new stepper login capabilities.
This flow is the first one we are migrating that requires custom parameters when we redirect the user to the login flow.

## Testing Instructions
Flow: `/setup/assembler-first`
Scenario 1: Redirect to the login page
- Open a new browser where you don't have a WordPress.com session
- Try to access the flow or any of the flow steps (E.g `setup/assembler-first/check-sites`)
- Please ensure you have been redirected to the login page.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
