### PR TITLE
Stepper: Enable to defined extra params on the login url

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -115,6 +115,12 @@ export type Flow = {
 	 */
 	isSignupFlow: boolean;
 	useSignupStartEventProps?: () => Record< string, string | number >;
+
+	/**
+	 *  You can use this hook to add extra params to the login url.
+	 * @returns An object describing extra params should be sent to the login page.
+	 */
+	useLoginParams?: () => Record< string, string | number >;
 	useSteps: UseStepsHook;
 	useStepNavigation: UseStepNavigationHook< ReturnType< Flow[ 'useSteps' ] > >;
 	useAssertConditions?: UseAssertConditionsHook< ReturnType< Flow[ 'useSteps' ] > >;

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -117,10 +117,11 @@ export type Flow = {
 	useSignupStartEventProps?: () => Record< string, string | number >;
 
 	/**
-	 *  You can use this hook to add extra params to the login url.
-	 * @returns An object describing extra params should be sent to the login page.
+	 *  You can use this hook to configure the login url.
+	 * @returns An object describing the configuration.
+	 * For now only extraQueryParams is supported.
 	 */
-	useLoginParams?: () => Record< string, string | number >;
+	useLoginParams?: () => { extraQueryParams: Record< string, string | number > };
 	useSteps: UseStepsHook;
 	useStepNavigation: UseStepNavigationHook< ReturnType< Flow[ 'useSteps' ] > >;
 	useAssertConditions?: UseAssertConditionsHook< ReturnType< Flow[ 'useSteps' ] > >;

--- a/client/landing/stepper/hooks/test/use-login-url-for-flow.tsx
+++ b/client/landing/stepper/hooks/test/use-login-url-for-flow.tsx
@@ -41,8 +41,10 @@ describe( 'useLoginUrlForFlow', () => {
 		const flowWithExtraParams = {
 			...flow,
 			useLoginParams: () => ( {
-				foo: 'bar',
-				bar: 'baz',
+				extraQueryParams: {
+					foo: 'bar',
+					bar: 'baz',
+				},
 			} ),
 		} satisfies Flow;
 

--- a/client/landing/stepper/hooks/test/use-login-url-for-flow.tsx
+++ b/client/landing/stepper/hooks/test/use-login-url-for-flow.tsx
@@ -40,6 +40,34 @@ describe( 'useLoginUrlForFlow', () => {
 		);
 	} );
 
+	it( 'returns the login with with extra params', () => {
+		const flowWithExtraParams = {
+			...flow,
+			useLoginParams: () => ( {
+				foo: 'bar',
+				bar: 'baz',
+			} ),
+		} satisfies Flow;
+
+		const { result } = renderHookWithProvider(
+			() => useLoginUrlForFlow( { flow: flowWithExtraParams } ),
+			{
+				wrapper: Wrapper( 'setup' ),
+			}
+		);
+
+		expect( result.current ).toEqual(
+			addQueryArgs( '/start/account/user-social', {
+				variationName: 'some-flow',
+				redirect_to: '/setup/site-migration-flow',
+				pageTitle: 'some-title',
+				toStepper: true,
+				foo: 'bar',
+				bar: 'baz',
+			} )
+		);
+	} );
+
 	// Inside the react-router-dom the useLocation.pathname doesn't include the basename
 	it( 'returns the login URL for the flow considering the basename', () => {
 		const { result } = renderHookWithProvider( () => useLoginUrlForFlow( { flow } ), {

--- a/client/landing/stepper/hooks/test/use-login-url-for-flow.tsx
+++ b/client/landing/stepper/hooks/test/use-login-url-for-flow.tsx
@@ -1,10 +1,10 @@
 /**
  * @jest-environment jsdom
  */
+import { addQueryArgs } from '@wordpress/url';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
-import { addQueryArgs } from '../../../../lib/route';
 import { type Flow } from '../../declarative-flow/internals/types';
 import { useLoginUrlForFlow } from '../use-login-url-for-flow';
 
@@ -28,15 +28,12 @@ describe( 'useLoginUrlForFlow', () => {
 		} );
 
 		expect( result.current ).toEqual(
-			addQueryArgs(
-				{
-					variationName: 'some-flow',
-					redirect_to: '/setup/site-migration-flow',
-					pageTitle: 'some-title',
-					toStepper: true,
-				},
-				'/start/account/user-social'
-			)
+			addQueryArgs( '/start/account/user-social', {
+				variationName: 'some-flow',
+				redirect_to: '/setup/site-migration-flow',
+				pageTitle: 'some-title',
+				toStepper: true,
+			} )
 		);
 	} );
 
@@ -75,15 +72,12 @@ describe( 'useLoginUrlForFlow', () => {
 		} );
 
 		expect( result.current ).toEqual(
-			addQueryArgs(
-				{
-					variationName: 'some-flow',
-					redirect_to: '/crazy-setup/site-migration-flow',
-					pageTitle: 'some-title',
-					toStepper: true,
-				},
-				'/start/account/user-social'
-			)
+			addQueryArgs( '/start/account/user-social', {
+				variationName: 'some-flow',
+				redirect_to: '/crazy-setup/site-migration-flow',
+				pageTitle: 'some-title',
+				toStepper: true,
+			} )
 		);
 	} );
 } );

--- a/client/landing/stepper/hooks/use-login-url-for-flow.ts
+++ b/client/landing/stepper/hooks/use-login-url-for-flow.ts
@@ -14,6 +14,7 @@ export function useLoginUrlForFlow( { flow }: UseLoginUrlForFlowProps ): string 
 	const location = useLocation();
 	const { siteId, siteSlug } = useSiteData();
 	const path = useHref( location.pathname );
+	const extra = flow.useLoginParams?.() ?? {};
 
 	const redirectTo = addQueryArgs( path, {
 		...( locale && locale !== 'en' ? { locale } : {} ),
@@ -27,5 +28,6 @@ export function useLoginUrlForFlow( { flow }: UseLoginUrlForFlowProps ): string 
 		pageTitle: flow.title,
 		locale,
 		redirectTo,
+		extra,
 	} );
 }

--- a/client/landing/stepper/hooks/use-login-url-for-flow.ts
+++ b/client/landing/stepper/hooks/use-login-url-for-flow.ts
@@ -14,7 +14,7 @@ export function useLoginUrlForFlow( { flow }: UseLoginUrlForFlowProps ): string 
 	const location = useLocation();
 	const { siteId, siteSlug } = useSiteData();
 	const path = useHref( location.pathname );
-	const extra = flow.useLoginParams?.() ?? {};
+	const { extraQueryParams } = flow.useLoginParams?.() ?? {};
 
 	const redirectTo = addQueryArgs( path, {
 		...( locale && locale !== 'en' ? { locale } : {} ),
@@ -28,6 +28,6 @@ export function useLoginUrlForFlow( { flow }: UseLoginUrlForFlowProps ): string 
 		pageTitle: flow.title,
 		locale,
 		redirectTo,
-		extra,
+		extra: extraQueryParams,
 	} );
 }

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -51,6 +51,7 @@ export const getLoginUrl = ( {
 	pageTitle,
 	locale,
 	customLoginPath,
+	extra = {},
 }: {
 	/**
 	 * Variation name is used to track the relevant login flow in the signup framework as explained in https://github.com/Automattic/wp-calypso/issues/67173
@@ -60,6 +61,7 @@ export const getLoginUrl = ( {
 	pageTitle?: string | null;
 	locale: string;
 	customLoginPath?: string | null;
+	extra?: Record< string, string | number >;
 } ): string => {
 	const defaultLoginPath = `/start/account/${
 		isEnabled( 'signup/social-first' ) ? 'user-social' : 'user'
@@ -73,6 +75,7 @@ export const getLoginUrl = ( {
 		redirect_to: redirectTo,
 		pageTitle,
 		toStepper: true,
+		...extra,
 	} );
 };
 
@@ -82,6 +85,7 @@ export const useLoginUrl = ( {
 	pageTitle,
 	locale,
 	customLoginPath,
+	extra = {},
 }: {
 	/**
 	 * Variation name is used to track the relevant login flow in the signup framework as explained in https://github.com/Automattic/wp-calypso/issues/67173
@@ -91,6 +95,7 @@ export const useLoginUrl = ( {
 	pageTitle?: string | null;
 	locale?: string;
 	customLoginPath?: string | null;
+	extra?: Record< string, string | number >;
 } ): string => {
 	const currentLocale = useFlowLocale();
 	return getLoginUrl( {
@@ -99,5 +104,6 @@ export const useLoginUrl = ( {
 		pageTitle,
 		locale: locale ?? currentLocale,
 		customLoginPath,
+		extra,
 	} );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of https://github.com/Automattic/wp-calypso/issues/92291

## Proposed Changes

* Update test suite to use `@wordpress/URL`
* Add flow hook to defined custom login sign-in params. 

## Why are these changes being made?
* Some flows are defining sending custom params to the login flow, this PR intends to support it.
An example is [sensei using the main_flow query param that is not supported by the current stepper login feature](https://github.com/Automattic/wp-calypso/blob/3cba79e27aed8460b5fdde813d856f6712b7bcdc/client/landing/stepper/declarative-flow/sensei.ts#L21)


## Testing Instructions
* Open the `site-migration-flow.ts`
* Add this hook
```js

useLoginParams() {
return {
        extraQueryParams: {
	  foo: 'bar'
    },
 } 
}
```
* Open a browser without a WP session.
* Try to access `/setup/site-migration` 
 
Check you were redirected to the sign-in page with the `foo=bar` extra param.

Automated tests are checking it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
