### PR TITLE
Stepper: Update the `sensei` flow to use the new login strategy

### DIFF
--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -20,6 +20,14 @@ const sensei: Flow = {
 		return translate( 'Course Creator' );
 	},
 	isSignupFlow: true,
+
+	useLoginParams() {
+		return {
+			extraQueryParams: {
+				main_flow: SENSEI_FLOW,
+			},
+		};
+	},
 	useSteps() {
 		const publicSteps = [
 			{ slug: 'intro', component: Intro },

--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -1,7 +1,5 @@
 import { SENSEI_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import Intro from './internals/steps-repository/intro';
@@ -29,6 +27,7 @@ const sensei: Flow = {
 		};
 	},
 	useSteps() {
+		//TODO: Migrate to use lazy loading `asyncComponent`
 		const publicSteps = [
 			{ slug: 'intro', component: Intro },
 			{ slug: 'senseiSetup', component: SenseiSetup },
@@ -47,7 +46,6 @@ const sensei: Flow = {
 
 	useStepNavigation( _currentStep, navigate ) {
 		const siteSlug = useSiteSlug();
-		const isLoggedIn = useSelector( isUserLoggedIn );
 
 		const submit = ( deps: any, stepResult?: string ) => {
 			if ( stepResult ) {
@@ -58,9 +56,7 @@ const sensei: Flow = {
 				case 'intro':
 					return navigate( 'senseiSetup' );
 				case 'senseiSetup':
-					if ( isLoggedIn ) {
-						return navigate( 'senseiDomain' );
-					}
+					return navigate( 'senseiDomain' );
 				case 'senseiDomain':
 					return navigate( 'senseiPlan' );
 				case 'senseiPurpose':

--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -2,10 +2,8 @@ import { SENSEI_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { useFlowLocale } from '../hooks/use-flow-locale';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
-import { redirect } from './internals/steps-repository/import/util';
 import Intro from './internals/steps-repository/intro';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import SenseiDomain from './internals/steps-repository/sensei-domain';
@@ -15,12 +13,6 @@ import SenseiPurpose from './internals/steps-repository/sensei-purpose';
 import SenseiSetup from './internals/steps-repository/sensei-setup';
 import { Flow } from './internals/types';
 import './internals/sensei.scss';
-
-function getStartUrl( step: string, locale: string ) {
-	const localeUrlPart = locale && locale !== 'en' ? `/${ locale }` : '';
-
-	return `/start/account/user${ localeUrlPart }?redirect_to=/setup/${ SENSEI_FLOW }/${ step }&main_flow=${ SENSEI_FLOW }`;
-}
 
 const sensei: Flow = {
 	name: SENSEI_FLOW,
@@ -46,7 +38,6 @@ const sensei: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
-		const locale = useFlowLocale();
 		const siteSlug = useSiteSlug();
 		const isLoggedIn = useSelector( isUserLoggedIn );
 
@@ -62,8 +53,6 @@ const sensei: Flow = {
 					if ( isLoggedIn ) {
 						return navigate( 'senseiDomain' );
 					}
-
-					return redirect( getStartUrl( 'senseiDomain', locale ) );
 				case 'senseiDomain':
 					return navigate( 'senseiPlan' );
 				case 'senseiPurpose':


### PR DESCRIPTION
Part of #92291

## Proposed Changes
* Replace all code related to managing the login to use stepsWithRequiredLogin 

## Why are these changes being made?
As explained on #92291 we are updating all flows to use the new stepper login capabilities.
This flow is the first one we are migrating that requires custom parameters when we redirect the user to the login flow.

## Testing Instructions
Flow: `/setup/sensei`
Scenario 1: Redirect to the login page
- Open a new browser where you don't have a WordPress.com session
- Try to access the flow or any of the flow steps (E.g `setup/sensei`)
- Follow the steps (some of them are public)
- When arrives on the senseiPlan step the user should be redirected to the login flow.
- After the Login the user should be redirected back to the senseiPlan step.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
