### PR TITLE
Frictionless Email Subscriptions: Fix subscribe email flow new user creation

### DIFF
--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -53,6 +53,7 @@ function SubscribeEmailStep( props ) {
 	const redirectToAfterLoginUrl = currentUser
 		? addQueryArgs( window.location.href, { user_email: currentUser?.email } )
 		: '';
+
 	const { mutate: subscribeToMailingList, isPending: isSubscribeToMailingListPending } =
 		useSubscribeToMailingList( {
 			onSuccess: () => {
@@ -77,7 +78,7 @@ function SubscribeEmailStep( props ) {
 					userData: {
 						ID: userId,
 						username: username,
-						email: this.state.email,
+						email,
 					},
 					flow: flowName,
 					type: 'passwordless',

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useEffect } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
+import DOMPurify from 'dompurify';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -17,6 +18,14 @@ import { submitSignupStep } from 'calypso/state/signup/progress/actions';
 import SubscribeEmailStepContent from './content';
 
 import './style.scss';
+
+function sanitizeEmail( email ) {
+	if ( typeof email !== 'string' ) {
+		return '';
+	}
+
+	return DOMPurify.sanitize( email ).trim();
+}
 
 function sanitizeRedirectUrl( redirect ) {
 	const isHttpOrHttps =
@@ -37,15 +46,13 @@ function sanitizeRedirectUrl( redirect ) {
 function SubscribeEmailStep( props ) {
 	const { currentUser, flowName, goToNextStep, queryArguments, stepName, translate } = props;
 
-	const email =
-		typeof queryArguments.user_email === 'string' ? queryArguments.user_email.trim() : '';
+	const email = sanitizeEmail( queryArguments.user_email );
 
 	const redirectUrl = sanitizeRedirectUrl( queryArguments.redirect_to );
 
 	const redirectToAfterLoginUrl = currentUser
 		? addQueryArgs( window.location.href, { user_email: currentUser?.email } )
 		: '';
-
 	const { mutate: subscribeToMailingList, isPending: isSubscribeToMailingListPending } =
 		useSubscribeToMailingList( {
 			onSuccess: () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3098

## Proposed Changes

* At times, new user creation was throwing an exception which was short circuiting the email subscription process ( even if new user creation was successful ). It would then kick the user out to the passwordless signup form.
* This is because, in copying `recordRegistration` from another component, we had inadvertently left a stray `this` keyword.

### Before
![2024-07-02 11 47 47](https://github.com/Automattic/wp-calypso/assets/5414230/a0bc9746-1453-4ae6-b217-77712016c276)

### After
![2024-07-02 11 45 49](https://github.com/Automattic/wp-calypso/assets/5414230/30716362-e6e1-4ee8-8e87-d06a8aa0a99f)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* New user creation was incorrectly short circuiting in certain circumstances even if the new user was successfully created. It would then prevent subscription to an email list and redirection to the redirect_url

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log into wordpress.com
* With these PR changes, navigate to `/start/email-subscription/subscribe?user_email=test1161@gmail.com&redirect_to=wordpress.com%2Flearn&mailing_list=learn` in the WordPress staging environment
* Switch the email value in the user_email query_param to a value that would violate sanitization rules ( Ex. <script>test@gmail.com</script>
* Verify that the violating email string text is stripped from the Not you text at the bottom of the screen
* Switch the email value in the user_email query param again. It should be a brand new user and account to WordPress.com.
* Verify that clicking on "subscribe with {email}" logs out the current user and subscribes the new user_email query param to `/pigeon`
* Verify that user is redirected to the `redirect_url` query param

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
