### PR TITLE
Theme Tiers cleanup: Calculate tracks props

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -42,7 +42,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
 
-	if ( design.is_externally_managed && design.screenshot ) {
+	if ( design?.design_tier === 'partner' && design.screenshot ) {
 		const fit = '479,360';
 		// We're stubbing out the high res version here as part of a size reduction experiment.
 		// See #88786 and TODO for discussion / info.
@@ -140,13 +140,13 @@ const useTrackDesignView = ( {
 
 				recordTracksEvent( 'calypso_design_picker_design_display', {
 					category: trackingCategory,
-					design_type: design.design_type,
 					...( design?.design_tier && { design_tier: design.design_tier } ),
-					is_premium: design.is_premium,
+					is_premium: design?.design_tier === 'premium',
+					// TODO: Better to track whether already available on this sites plan.
 					is_premium_available: isPremiumThemeAvailable,
 					slug: design.slug,
 					is_virtual: design.is_virtual,
-					is_externally_managed: design.is_externally_managed,
+					is_externally_managed: design?.design_tier === 'partner',
 				} );
 
 				if ( category ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6349

## Proposed Changes

Calculate the tracks props from the design's tier, and remove the redundant `design_type` prop.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As part of the theme tiers clean-up, redundant properties are being removed from the design object. This removes one such usage in the onboarding design picker

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 1. Use calypso live link
 2. Go to /start 
 3. Open up the browser network requests
 4. Work your way through to the design picker (choose a theme) page
 5. You should see that each displayed theme in the grid triggers a `calypso_design_picker_design_display` tracks event.
 6. This tracks event should not have a `design_type` property, but should otherwise work pretty much as in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
