### PR TITLE
Stats: Use stats built-in API for purchases whenever possible

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -8,22 +8,30 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
 import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
+import { useSelector } from 'calypso/state';
 import {
 	PURCHASES_SITE_FETCH,
 	PURCHASES_SITE_FETCH_COMPLETED,
 	PURCHASES_SITE_FETCH_FAILED,
 } from 'calypso/state/action-types';
-import { getApiNamespace, getApiPath } from '../lib/get-api';
+import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
+import { getApiPath } from '../lib/get-api';
 
-async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
+async function queryOdysseyQuerySitePurchases(
+	siteId: number | null,
+	shouldUsePurchasesApiInJetpack: boolean
+) {
 	if ( ! siteId ) {
 		return;
 	}
 
+	const apiPath = shouldUsePurchasesApiInJetpack
+		? `/sites/${ siteId }/purchases`
+		: '/site/purchases';
+
 	return wpcom.req
 		.get( {
-			path: getApiPath( '/site/purchases', { siteId } ),
-			apiNamespace: getApiNamespace( 'my-jetpack/v1' ),
+			path: getApiPath( apiPath, { siteId } ),
 		} )
 		.catch( ( error: APIError ) => error );
 }
@@ -31,11 +39,14 @@ async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
  * Update site products in the Redux store by fetching purchases via API for Odyssey Stats.
  */
 
-const useOdysseyQuerySitePurchases = ( siteId: number | null ) => {
+const useOdysseyQuerySitePurchases = (
+	siteId: number | null,
+	shouldUsePurchasesApiInJetpack = false
+) => {
 	return useQuery( {
 		...getDefaultQueryParams(),
 		queryKey: [ 'odyssey-stats', 'site-purchases', siteId ],
-		queryFn: () => queryOdysseyQuerySitePurchases( siteId ),
+		queryFn: () => queryOdysseyQuerySitePurchases( siteId, shouldUsePurchasesApiInJetpack ),
 		staleTime: 10 * 1000,
 		// If the module is not active, we don't want to retry the query.
 		retry: false,
@@ -43,11 +54,14 @@ const useOdysseyQuerySitePurchases = ( siteId: number | null ) => {
 };
 
 export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number | null } ) {
+	const { shouldUsePurchasesApiInJetpack } = useSelector( ( state ) =>
+		getEnvStatsFeatureSupportChecks( state, siteId )
+	);
 	const {
 		data: purchases,
 		isFetching,
 		isError: hasOtherErrors,
-	} = useOdysseyQuerySitePurchases( siteId );
+	} = useOdysseyQuerySitePurchases( siteId, shouldUsePurchasesApiInJetpack );
 	const reduxDispatch = useDispatch();
 
 	useEffect( () => {

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -37,7 +37,12 @@ async function queryOdysseyQuerySitePurchases(
 			} )
 			// Endpoint `site/purchases` returns a stringified JSON object as data.
 			// Our own endpoint `/sites/${ siteId }/purchases` returns a JSON object.
-			.then( ( res: { data: string } ) => ( res?.data ? JSON.parse( res.data ) : res ) )
+			.then( ( res: { data: string } ) => {
+				if ( res?.data ) {
+					return JSON.parse( res.data );
+				}
+				return res ? res : [];
+			} )
 			.catch( ( error: APIError ) => error )
 	);
 }
@@ -108,7 +113,7 @@ export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number 
 			reduxDispatch( {
 				type: PURCHASES_SITE_FETCH_COMPLETED,
 				siteId,
-				purchases: purchases,
+				purchases,
 			} );
 		}
 	}, [ purchases, isFetching, reduxDispatch, hasOtherErrors, siteId ] );

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -23,9 +23,8 @@ async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
 	return wpcom.req
 		.get( {
 			path: getApiPath( '/site/purchases', { siteId } ),
-			apiNamespace: getApiNamespace(),
+			apiNamespace: getApiNamespace( 'my-jetpack/v1' ),
 		} )
-		.then( ( res: { data: string } ) => JSON.parse( res.data ) )
 		.catch( ( error: APIError ) => error );
 }
 /**
@@ -63,26 +62,11 @@ export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number 
 		}
 
 		if ( isError( purchases ) || hasOtherErrors ) {
-			if ( ( purchases as APIError ).status !== 403 ) {
-				// Dispatch to the Purchases reducer for error status
-				reduxDispatch( {
-					type: PURCHASES_SITE_FETCH_FAILED,
-					error: 'purchase_fetch_failed',
-				} );
-			} else {
-				// TODO: Remove this after fixing the API permission issue from Jetpack.
-				reduxDispatch( {
-					type: PURCHASES_SITE_FETCH_COMPLETED,
-					siteId,
-					purchases: [
-						{
-							expiry_status: 'active',
-							product_slug: 'jetpack_stats_pwyw_yearly',
-							blog_id: siteId,
-						},
-					],
-				} );
-			}
+			// Dispatch to the Purchases reducer for error status
+			reduxDispatch( {
+				type: PURCHASES_SITE_FETCH_FAILED,
+				error: 'purchase_fetch_failed',
+			} );
 		} else {
 			// Dispatch to the Purchases reducer for consistent requesting status
 			reduxDispatch( {

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -28,12 +28,13 @@ async function queryOdysseyQuerySitePurchases(
 	const apiPath = shouldUseStatsBuiltInPurchasesApi
 		? `/sites/${ siteId }/purchases`
 		: '/site/purchases';
+	const apiNamespace = shouldUseStatsBuiltInPurchasesApi ? 'jetpack/v4/stats-app' : 'jetpack/v4';
 
 	return (
 		wpcom.req
 			.get( {
 				path: getApiPath( apiPath, { siteId } ),
-				apiNamespace: getApiNamespace(),
+				apiNamespace: getApiNamespace( apiNamespace ),
 			} )
 			// Endpoint `site/purchases` returns a stringified JSON object as data.
 			// Our own endpoint `/sites/${ siteId }/purchases` returns a JSON object.

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -19,13 +19,13 @@ import { getApiNamespace, getApiPath } from '../lib/get-api';
 
 async function queryOdysseyQuerySitePurchases(
 	siteId: number | null,
-	shouldUsePurchasesApiInJetpack: boolean
+	shouldUseStatsBuiltInPurchasesApi: boolean
 ) {
 	if ( ! siteId ) {
 		return;
 	}
 
-	const apiPath = shouldUsePurchasesApiInJetpack
+	const apiPath = shouldUseStatsBuiltInPurchasesApi
 		? `/sites/${ siteId }/purchases`
 		: '/site/purchases';
 
@@ -47,12 +47,12 @@ async function queryOdysseyQuerySitePurchases(
 
 const useOdysseyQuerySitePurchases = (
 	siteId: number | null,
-	shouldUsePurchasesApiInJetpack = false
+	shouldUseStatsBuiltInPurchasesApi = false
 ) => {
 	return useQuery( {
 		...getDefaultQueryParams(),
 		queryKey: [ 'odyssey-stats', 'site-purchases', siteId ],
-		queryFn: () => queryOdysseyQuerySitePurchases( siteId, shouldUsePurchasesApiInJetpack ),
+		queryFn: () => queryOdysseyQuerySitePurchases( siteId, shouldUseStatsBuiltInPurchasesApi ),
 		staleTime: 10 * 1000,
 		// If the module is not active, we don't want to retry the query.
 		retry: false,
@@ -60,14 +60,14 @@ const useOdysseyQuerySitePurchases = (
 };
 
 export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number | null } ) {
-	const { shouldUsePurchasesApiInJetpack } = useSelector( ( state ) =>
+	const { shouldUseStatsBuiltInPurchasesApi } = useSelector( ( state ) =>
 		getEnvStatsFeatureSupportChecks( state, siteId )
 	);
 	const {
 		data: purchases,
 		isFetching,
 		isError: hasOtherErrors,
-	} = useOdysseyQuerySitePurchases( siteId, shouldUsePurchasesApiInJetpack );
+	} = useOdysseyQuerySitePurchases( siteId, shouldUseStatsBuiltInPurchasesApi );
 	const reduxDispatch = useDispatch();
 
 	useEffect( () => {

--- a/apps/odyssey-stats/src/lib/get-api.ts
+++ b/apps/odyssey-stats/src/lib/get-api.ts
@@ -5,8 +5,8 @@ import config from '@automattic/calypso-config';
  * This is needed as WP.com Simple Classic is loading Odyssey Stats, which we will use the public-api.wordpress.com APIs.
  * @returns {string} The API namespace to use.
  */
-export const getApiNamespace = (): string => {
-	return config.isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack/v4' : 'rest/v1.1';
+export const getApiNamespace = ( namespace = 'jetpack/v4' ): string => {
+	return config.isEnabled( 'is_running_in_jetpack_site' ) ? namespace : 'rest/v1.1';
 };
 
 /**

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -54,7 +54,7 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.18.0-alpha',
 			isOdysseyStats
 		),
-		shouldUsePurchasesApiInJetpack: version_greater_than_or_equal(
+		shouldUseStatsBuiltInPurchasesApi: version_greater_than_or_equal(
 			statsAdminVersion,
 			'0.21.0-alpha',
 			isOdysseyStats

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -54,6 +54,11 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.18.0-alpha',
 			isOdysseyStats
 		),
+		shouldUsePurchasesApiInJetpack: version_greater_than_or_equal(
+			statsAdminVersion,
+			'0.21.0-alpha',
+			isOdysseyStats
+		),
 		isOldJetpack:
 			isSiteJetpackNotAtomic &&
 			! version_greater_than_or_equal( statsAdminVersion, '0.19.0-alpha', isOdysseyStats ),


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/58

## Proposed Changes

* Use newly added stats built-in API when possible. The stats built-in purchases endpoint allows non-admin user access, provided they have access to Stats.

## Why are these changes being made?

* My Jetpack is not available on Atomic yet, so we cannot use the purchases endpoint there.
* The Jetpack one (`jetpack/v4/site/purchases`) requires admin access and I'm not keen to change it.

## Testing Instructions
* Pull changes from https://github.com/Automattic/jetpack/pull/38150 for Jetpack
* Build Odyssey Stats and Jetpack locally
  * `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
  * `jetpack build plugins/jetpack`
* Purchase a commercial license for your local site not yet 
* Open /wp-admin/ and switch to a non-admin user with Stats access
  * Grant access for roles here: `/wp-admin/admin.php?page=jetpack#/traffic` 
* Switch to the user
* Open `/wp-admin/admin.php?page=stats`
* Ensure you are able to view the advance modules, including Devices, UTM, and Date Picker.
* Checkout trunk for Jetpack and build again
* Ensure it works well for admin users
* Ensure it works okay for non-admin users except they are not able to view advanced modules

**Note: Please install on sandbox and test on Simple sites too.**

- Install the build on sandbox `bin/install-plugin.sh odyssey-stats update/use-my-jetpack-purchases-api`
- Sandbox `widgets.wp.com`
- Enable Classic WP-Admin for a simple site
- Open `/wp-admin/admin.php?page=stats`
- Ensure Stats works as it was


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?