### PR TITLE
Fix social previews for social post UI changes

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -30,7 +30,6 @@ import {
 	getPostImage,
 	getExcerptForPost,
 	getSummaryForPost,
-	getPostCustomImage,
 	getSigImageUrl,
 	getPostCustomMedia,
 } from './utils';
@@ -101,7 +100,7 @@ class SharingPreviewPane extends PureComponent {
 		const articleContent = getExcerptForPost( post );
 		const articleSummary = getSummaryForPost( post, translate );
 		const siteDomain = get( site, 'domain', '' );
-		const imageUrl = getSigImageUrl( post ) || getPostCustomImage( post ) || getPostImage( post );
+		const imageUrl = getSigImageUrl( post ) || getPostImage( post );
 		const media = getPostCustomMedia( post );
 
 		const connection = find( connections, { service: selectedService } ) ?? {};

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -55,30 +55,16 @@ export const isSocialPost = ( post ) => {
 };
 
 export function getPostCustomMedia( post ) {
-	const media = [];
-
 	// Attach media only if "Share as a social post" option is enabled.
 	if ( isSocialPost( post ) ) {
-		const sigImageUrl = getSigImageUrl( post );
-
-		if ( sigImageUrl ) {
-			media.push( {
-				type: 'image/jpeg',
-				url: sigImageUrl,
-				alt: '',
-			} );
-		} else {
-			for ( const { id, url, type } of getPostAttachedMedia( post ) ) {
-				media.push( {
-					type: type || post.attachments?.[ id ]?.mime_type,
-					url,
-					alt: '',
-				} );
-			}
-		}
+		return getPostAttachedMedia( post ).map( ( { id, url, type } ) => ( {
+			type: type || post.attachments?.[ id ]?.mime_type,
+			url,
+			alt: '',
+		} ) );
 	}
 
-	return media;
+	return [];
 }
 
 export function getSigImageUrl( post ) {

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -40,21 +40,18 @@ export function getPostAttachedMedia( post ) {
 	return getPostAutoSharingOptions( post )?.attached_media || [];
 }
 
-export const getPostCustomImage = ( post ) => {
-	const [ firstMedia ] = getPostAttachedMedia( post );
-
-	if ( firstMedia?.url && firstMedia.type?.startsWith( 'image/' ) ) {
-		return firstMedia.url;
-	}
-	return null;
-};
-
 export function getPostImageGeneratorSettings( post ) {
 	return getPostAutoSharingOptions( post )?.image_generator_settings || {};
 }
 
 export const isSocialPost = ( post ) => {
-	return !! getPostAutoSharingOptions( post )?.should_upload_attached_media;
+	const socialPostOptions = getPostAutoSharingOptions( post );
+
+	if ( socialPostOptions?.version === 2 ) {
+		return getPostAttachedMedia( post ).length > 0;
+	}
+
+	return Boolean( socialPostOptions?.should_upload_attached_media );
 };
 
 export function getPostCustomMedia( post ) {


### PR DESCRIPTION
We improved the attached media UI for Jetpack Social via https://github.com/Automattic/jetpack/pull/37964 and D153127-code and thus we need to make the changes in Calypso to account for that logic change.

## Proposed Changes

* Update `isSocialPost` logic to account for version 2 of attached media logic
* Remove custom image being used as OG image

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to make the attached media UI consistent with how Jetpack Social handles it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On trunk, goto `/posts/:site` for a Jetpack site which has custom media attached to a post via Jetpack Social
* For that post, click on options (3 dots) and click on Share and then click on Preview
* You will notice that attached media is not shown as such, it's rather shown as OG image
* Now boot up this PR and confirm the logic to remain the same.
* Now sandbox D153127-code and try the above steps again
* Confirm that the attached image is now shown as attached media
* Confirm that the link preview does not show attached image as OG image
* Confirm that when there is no attached image, it works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

#### Your post

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">Without custom media (No difference)</th>
        </tr>
        <tr>
            <td>
<img width="679" alt="Screenshot 2024-07-03 at 11 04 48 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/d77015f8-8a8a-4b4d-89c5-bcfec16ca4d3">
</td>
            <td>
<img width="679" alt="Screenshot 2024-07-03 at 11 04 48 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/0aff6f23-51da-48d0-be5a-43d71de226b9">
</td>
        </tr>
        <tr>
            <th colspan="2">With custom media</th>
        </tr>
        <tr>
            <td>
<img width="688" alt="Screenshot 2024-07-03 at 11 07 52 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/cc1f95c8-b67f-433c-a1c9-018595d8290b">
</td>
            <td>
<img width="691" alt="Screenshot 2024-07-03 at 11 06 57 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/f54e9ce3-d4c5-46b9-a935-009f997680f2">
</td>
        </tr>
    </tbody>
</table>

#### Link preview

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">Without custom media (No difference)</th>
        </tr>
        <tr>
            <td>
<img width="674" alt="Screenshot 2024-07-03 at 11 04 57 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/a0f10952-99bc-4eb9-a196-24aa42a4fa8c">

</td>
            <td>
<img width="674" alt="Screenshot 2024-07-03 at 11 04 57 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/a0f10952-99bc-4eb9-a196-24aa42a4fa8c">
</td>
        </tr>
        <tr>
            <th colspan="2">With custom media</th>
        </tr>
        <tr>
            <td>
<img width="681" alt="Screenshot 2024-07-03 at 11 07 59 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/88bbb5e7-ad02-4276-b5d7-71867098f3f0">

</td>
            <td>

<img width="674" alt="Screenshot 2024-07-03 at 11 04 57 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/a0f10952-99bc-4eb9-a196-24aa42a4fa8c">
</td>
        </tr>
    </tbody>
</table>