### PR TITLE
Add a page modal: Hide the public library homepage category

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -199,8 +199,8 @@ class Starter_Page_Templates {
 			}
 		}
 
-		// Hide non-user-facing categories (Pages & Virtual Theme) in modal
-		$hidden_categories = array( 'page', 'virtual-theme' );
+		// Hide non-user-facing categories (Pages, Virtual Theme, and wordpress.com/patterns homepage) in modal
+		$hidden_categories = array( 'page', 'virtual-theme', '_public_library_homepage' );
 		foreach ( $page_templates as &$page_template ) {
 			if ( ! isset( $page_template['categories'] ) ) {
 				continue;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Hide the public library homepage category from the modal

|BEFORE|AFTER|
|-|-|
|<img width="343" alt="Screenshot 2567-07-03 at 13 07 48" src="https://github.com/Automattic/wp-calypso/assets/1881481/05e6bbe6-e9f6-49e3-9bc6-8e413fe8c5e7">|<img width="346" alt="Screenshot 2567-07-03 at 13 07 11" src="https://github.com/Automattic/wp-calypso/assets/1881481/fdf2ef30-761d-4745-9873-dd0c1ace1867">|

>[!NOTE]
>Rather than hiding them on the client side. Let's consider making it on the API output and centralize the feature. I'll post about this later because we might also hide categories per client.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because that category is used in the public library.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/wp-admin/post-new.php?post_type=page`
* Verify the category is not there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
