### PR TITLE
Frictionless Email Subscriptions: Reference props for create account success callback

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -91,41 +91,42 @@ const resetAnalyticsData = () => {
 class SignupForm extends Component {
 	static propTypes = {
 		className: PropTypes.string,
-		disableEmailExplanation: PropTypes.string,
-		disableEmailInput: PropTypes.bool,
-		disableSubmitButton: PropTypes.bool,
 		disableBlurValidation: PropTypes.bool,
 		disableContinueAsUser: PropTypes.bool,
 		disabled: PropTypes.bool,
+		disableEmailExplanation: PropTypes.string,
+		disableEmailInput: PropTypes.bool,
+		disableSubmitButton: PropTypes.bool,
 		displayNameInput: PropTypes.bool,
 		displayUsernameInput: PropTypes.bool,
 		email: PropTypes.string,
 		flowName: PropTypes.string,
 		footerLink: PropTypes.node,
 		formHeader: PropTypes.node,
-		redirectToAfterLoginUrl: PropTypes.string,
 		goToNextStep: PropTypes.func,
+		handleCreateAccountError: PropTypes.func,
+		handleCreateAccountSuccess: PropTypes.func,
 		handleLogin: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
+		horizontal: PropTypes.bool,
 		isPasswordless: PropTypes.bool,
-		isSocialSignupEnabled: PropTypes.bool,
 		isSocialFirst: PropTypes.bool,
+		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
+		notYouText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 		positionInFlow: PropTypes.number,
+		redirectToAfterLoginUrl: PropTypes.string,
 		save: PropTypes.func,
+		shouldDisplayUserExistsError: PropTypes.bool,
 		signupDependencies: PropTypes.object,
 		step: PropTypes.object,
-		submitButtonText: PropTypes.string,
 		submitButtonLabel: PropTypes.string,
 		submitButtonLoadingLabel: PropTypes.string,
+		submitButtonText: PropTypes.string,
+		submitForm: PropTypes.func,
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
-		horizontal: PropTypes.bool,
-		shouldDisplayUserExistsError: PropTypes.bool,
-		submitForm: PropTypes.func,
-		handleCreateAccountError: PropTypes.func,
-		notYouText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -1354,7 +1355,7 @@ class SignupForm extends Component {
 						onInputBlur={ this.handleBlur }
 						onInputChange={ this.handleChangeEvent }
 						onCreateAccountError={ this.handleCreateAccountError }
-						onCreateAccountSuccess={ this.handleCreateAccountSuccess }
+						onCreateAccountSuccess={ this.props.handleCreateAccountSuccess }
 						{ ...formProps }
 					>
 						{ emailErrorMessage && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3098 and https://github.com/Automattic/wp-calypso/pull/92138#discussion_r1661932586

## Proposed Changes

* Fix reference to handle create account success callback

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We were incorrectly referencing the component instance with `this` instead of props with `this.props`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log into wordpress.com
* With these PR changes, navigate to `/start/email-subscription/subscribe?user_email=test1161@gmail.com&redirect_to=wordpress.com%2Flearn&mailing_list=learn` in the WordPress staging environment
* Switch the email value in the user_email query param again. It should be a brand new user and account to WordPress.com.
* Verify that clicking on "subscribe with {email}" logs out the current user and subscribes the new user_email query param to `/pigeon`
* Verify that user is redirected to the `redirect_url` query param

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
