### PR TITLE
Pricing Meta: use sitePlans if siteId is available

### DIFF
--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -68,3 +68,7 @@ export const PERIOD_LIST = [
 	PLAN_BIENNIAL_PERIOD,
 	PLAN_TRIENNIAL_PERIOD,
 ] as const;
+
+export const COST_OVERRIDE_REASONS = {
+	RECENT_PLAN_PRORATION: 'recent-plan-proration',
+};

--- a/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -76,6 +76,11 @@ describe( 'usePricingMetaForGridPlans', () => {
 							full: 250,
 							monthly: 250,
 						},
+						costOverrides: [
+							{
+								overrideCode: 'recent-plan-proration',
+							},
+						],
 					},
 				},
 			},
@@ -163,7 +168,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 		expect( pricingMeta ).toEqual( expectedPricingMeta );
 	} );
 
-	it( 'should return the original price and discounted price', () => {
+	it( 'should return the original price and discounted price when no site id is passed', () => {
 		Plans.useCurrentPlan.mockImplementation( () => ( {
 			productSlug: PLAN_PERSONAL,
 			planSlug: PLAN_PERSONAL,
@@ -179,7 +184,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PREMIUM ],
 			storageAddOns: null,
-			selectedSiteId: 100,
+			siteId: undefined,
 			coupon: undefined,
 			useCheckPlanAvailabilityForPurchase,
 		} );
@@ -193,6 +198,90 @@ describe( 'usePricingMetaForGridPlans', () => {
 				discountedPrice: {
 					full: 400,
 					monthly: 400,
+				},
+				billingPeriod: 365,
+				currencyCode: 'USD',
+				expiry: null,
+				introOffer: null,
+			},
+		};
+
+		expect( pricingMeta ).toEqual( expectedPricingMeta );
+	} );
+
+	it( 'should return the original price and discounted price when site id is passed and withProratedDiscounts is true', () => {
+		Plans.useCurrentPlan.mockImplementation( () => ( {
+			productSlug: PLAN_PERSONAL,
+			planSlug: PLAN_PERSONAL,
+		} ) );
+
+		const useCheckPlanAvailabilityForPurchase = () => {
+			return {
+				[ PLAN_PREMIUM ]: true,
+				[ PLAN_PERSONAL ]: true,
+			};
+		};
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_PREMIUM ],
+			storageAddOns: null,
+			siteId: 100,
+			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
+			withProratedDiscounts: true,
+		} );
+
+		const expectedPricingMeta = {
+			[ PLAN_PREMIUM ]: {
+				originalPrice: {
+					full: 500,
+					monthly: 500,
+				},
+				discountedPrice: {
+					full: 250,
+					monthly: 250,
+				},
+				billingPeriod: 365,
+				currencyCode: 'USD',
+				expiry: null,
+				introOffer: null,
+			},
+		};
+
+		expect( pricingMeta ).toEqual( expectedPricingMeta );
+	} );
+
+	it( 'should return the original price and discounted price when site id is passed and withProratedDiscounts is false', () => {
+		Plans.useCurrentPlan.mockImplementation( () => ( {
+			productSlug: PLAN_PERSONAL,
+			planSlug: PLAN_PERSONAL,
+		} ) );
+
+		const useCheckPlanAvailabilityForPurchase = () => {
+			return {
+				[ PLAN_PREMIUM ]: true,
+				[ PLAN_PERSONAL ]: true,
+			};
+		};
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_PREMIUM ],
+			storageAddOns: null,
+			siteId: 100,
+			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
+			withProratedDiscounts: false,
+		} );
+
+		const expectedPricingMeta = {
+			[ PLAN_PREMIUM ]: {
+				originalPrice: {
+					full: 500,
+					monthly: 500,
+				},
+				discountedPrice: {
+					full: null,
+					monthly: null,
 				},
 				billingPeriod: 365,
 				currencyCode: 'USD',

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -198,7 +198,7 @@ const usePricingMetaForGridPlans = ( {
 					// Do not return discounted prices if discount is due to plan proration
 					if (
 						! withProratedDiscounts &&
-						sitePlan?.pricing?.costOverrides?.[ 0 ].overrideCode ===
+						sitePlan?.pricing?.costOverrides?.[ 0 ]?.overrideCode ===
 							COST_OVERRIDE_REASONS.RECENT_PLAN_PRORATION
 					) {
 						return [

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -175,7 +175,52 @@ const usePricingMetaForGridPlans = ( {
 				}
 
 				/**
-				 * 2. Original and Discounted prices for plan available for purchase.
+				 * 2. Original and Discounted prices for site-specific plans available for purchase
+				 */
+				if ( siteId && planAvailabilityForPurchase[ planSlug ] ) {
+					const originalPrice = {
+						monthly: getTotalPrice(
+							sitePlan?.pricing.originalPrice.monthly,
+							storageAddOnPriceMonthly
+						),
+						full: getTotalPrice( sitePlan?.pricing.originalPrice.full, storageAddOnPriceYearly ),
+					};
+
+					// Do not return discounted prices if discount is due to plan proration
+					if ( sitePlan?.pricing.discountReasonCode === 'recent-plan-proration' ) {
+						return [
+							planSlug,
+							{
+								originalPrice,
+								discountedPrice: {
+									monthly: null,
+									full: null,
+								},
+								currencyCode: sitePlan?.pricing?.currencyCode,
+							},
+						];
+					}
+
+					const discountedPrice = {
+						monthly: getTotalPrice(
+							sitePlan?.pricing.discountedPrice.monthly,
+							storageAddOnPriceMonthly
+						),
+						full: getTotalPrice( sitePlan?.pricing.discountedPrice.full, storageAddOnPriceYearly ),
+					};
+
+					return [
+						planSlug,
+						{
+							originalPrice,
+							discountedPrice,
+							currencyCode: sitePlan?.pricing?.currencyCode,
+						},
+					];
+				}
+
+				/**
+				 * 3. Original and Discounted prices for plan available for purchase.
 				 */
 				if ( planAvailabilityForPurchase[ planSlug ] ) {
 					const originalPrice = {

--- a/packages/data-stores/src/plans/queries/lib/unpack-cost-overrides.ts
+++ b/packages/data-stores/src/plans/queries/lib/unpack-cost-overrides.ts
@@ -4,6 +4,9 @@ import { CostOverride, PricedAPISitePlan } from '../../types';
  * Unpacks cost overrides from an API plan to the respective `PlanCostOverride` structure for the store.
  */
 export default function unpackCostOverrides( plan: PricedAPISitePlan ): CostOverride[] | undefined {
+	if ( ! plan?.cost_overrides?.length ) {
+		return undefined;
+	}
 	return plan?.cost_overrides?.map( ( costOverride ) => ( {
 		doesOverrideOriginalCost: costOverride.does_override_original_cost,
 		firstUnitOnly: costOverride.first_unit_only,

--- a/packages/data-stores/src/plans/queries/lib/unpack-cost-overrides.ts
+++ b/packages/data-stores/src/plans/queries/lib/unpack-cost-overrides.ts
@@ -1,11 +1,9 @@
-import { PlanCostOverride, PricedAPISitePlan } from '../../types';
+import { CostOverride, PricedAPISitePlan } from '../../types';
 
 /**
  * Unpacks cost overrides from an API plan to the respective `PlanCostOverride` structure for the store.
  */
-export default function unpackCostOverrides(
-	plan: PricedAPISitePlan
-): PlanCostOverride[] | undefined {
+export default function unpackCostOverrides( plan: PricedAPISitePlan ): CostOverride[] | undefined {
 	return plan?.cost_overrides?.map( ( costOverride ) => ( {
 		doesOverrideOriginalCost: costOverride.does_override_original_cost,
 		firstUnitOnly: costOverride.first_unit_only,

--- a/packages/data-stores/src/plans/queries/lib/unpack-cost-overrides.ts
+++ b/packages/data-stores/src/plans/queries/lib/unpack-cost-overrides.ts
@@ -1,0 +1,17 @@
+import { PlanCostOverride, PricedAPISitePlan } from '../../types';
+
+/**
+ * Unpacks cost overrides from an API plan to the respective `PlanCostOverride` structure for the store.
+ */
+export default function unpackCostOverrides(
+	plan: PricedAPISitePlan
+): PlanCostOverride[] | undefined {
+	return plan?.cost_overrides?.map( ( costOverride ) => ( {
+		doesOverrideOriginalCost: costOverride.does_override_original_cost,
+		firstUnitOnly: costOverride.first_unit_only,
+		newPrice: costOverride.new_price,
+		oldPrice: costOverride.old_price,
+		overrideCode: costOverride.override_code,
+		percentage: costOverride.percentage,
+	} ) );
+}

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -53,6 +53,7 @@ function useSitePlans( { siteId }: Props ): UseQueryResult< SitePlansIndex > {
 							pricing: {
 								currencyCode: plan.currency_code,
 								introOffer: unpackIntroOffer( plan ),
+								discountReasonCode: plan.cost_overrides?.[ 0 ]?.override_code,
 								originalPrice: {
 									monthly:
 										typeof originalPriceFull === 'number'

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -1,6 +1,7 @@
 import { calculateMonthlyPriceForPlan } from '@automattic/calypso-products';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
+import unpackCostOverrides from './lib/unpack-cost-overrides';
 import unpackIntroOffer from './lib/unpack-intro-offer';
 import useQueryKeysFactory from './lib/use-query-keys-factory';
 import type { PricedAPISitePlan, SitePlan } from '../types';
@@ -53,7 +54,7 @@ function useSitePlans( { siteId }: Props ): UseQueryResult< SitePlansIndex > {
 							pricing: {
 								currencyCode: plan.currency_code,
 								introOffer: unpackIntroOffer( plan ),
-								discountReasonCode: plan.cost_overrides?.[ 0 ]?.override_code,
+								costOverrides: unpackCostOverrides( plan ),
 								originalPrice: {
 									monthly:
 										typeof originalPriceFull === 'number'

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -68,6 +68,15 @@ export interface PlanIntroductoryOffer {
 	isOfferComplete: boolean;
 }
 
+export interface PlanCostOverride {
+	doesOverrideOriginalCost: boolean;
+	firstUnitOnly: boolean;
+	newPrice: number;
+	oldPrice: number;
+	overrideCode: string;
+	percentage: number;
+}
+
 export interface PlanPricing {
 	billPeriod: -1 | ( typeof PERIOD_LIST )[ number ];
 	currencyCode: string;
@@ -91,11 +100,11 @@ export interface PlanPricing {
 		monthly: number | null;
 		full: number | null;
 	};
-
-	discountReasonCode?: string;
 }
 
-export interface SitePlanPricing extends Omit< PlanPricing, 'billPeriod' > {}
+export interface SitePlanPricing extends Omit< PlanPricing, 'billPeriod' > {
+	costOverrides?: PlanCostOverride[];
+}
 
 /**
  * `PricingMetaForGridPlan` should be adjusted to extend `PlanPricing`, or modify `PlanPricing` to have a single pricing interface.
@@ -164,7 +173,7 @@ export interface PricedAPIPlanIntroductoryOffer {
 	introductory_offer_end_date?: string;
 }
 
-export interface CostOverrides {
+export interface PricedAPIPlanCostOverrides {
 	does_override_original_cost: boolean;
 	first_unit_only: boolean;
 	new_price: number;
@@ -191,13 +200,13 @@ export interface PricedAPIPlanPricing {
 	orig_cost_integer: number;
 
 	currency_code: string;
-
-	cost_overrides?: CostOverrides[];
 }
 
 export interface PricedAPISitePlanPricing
 	extends Omit< PricedAPIPlanPricing, 'orig_cost_integer' | 'bill_period' > {
 	raw_discount_integer: number;
+
+	cost_overrides?: PricedAPIPlanCostOverrides[];
 }
 
 /**

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -91,6 +91,8 @@ export interface PlanPricing {
 		monthly: number | null;
 		full: number | null;
 	};
+
+	discountReasonCode?: string;
 }
 
 export interface SitePlanPricing extends Omit< PlanPricing, 'billPeriod' > {}
@@ -162,6 +164,15 @@ export interface PricedAPIPlanIntroductoryOffer {
 	introductory_offer_end_date?: string;
 }
 
+export interface CostOverrides {
+	does_override_original_cost: boolean;
+	first_unit_only: boolean;
+	new_price: number;
+	old_price: number;
+	override_code: string;
+	percentage: number;
+}
+
 export interface PricedAPIPlanPricing {
 	bill_period: -1 | ( typeof PERIOD_LIST )[ number ];
 	product_display_price: string;
@@ -180,6 +191,8 @@ export interface PricedAPIPlanPricing {
 	orig_cost_integer: number;
 
 	currency_code: string;
+
+	cost_overrides?: CostOverrides[];
 }
 
 export interface PricedAPISitePlanPricing

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -68,7 +68,7 @@ export interface PlanIntroductoryOffer {
 	isOfferComplete: boolean;
 }
 
-export interface PlanCostOverride {
+export interface CostOverride {
 	doesOverrideOriginalCost: boolean;
 	firstUnitOnly: boolean;
 	newPrice: number;
@@ -103,7 +103,7 @@ export interface PlanPricing {
 }
 
 export interface SitePlanPricing extends Omit< PlanPricing, 'billPeriod' > {
-	costOverrides?: PlanCostOverride[];
+	costOverrides?: CostOverride[];
 }
 
 /**
@@ -173,7 +173,7 @@ export interface PricedAPIPlanIntroductoryOffer {
 	introductory_offer_end_date?: string;
 }
 
-export interface PricedAPIPlanCostOverrides {
+export interface PricedAPISitePlanCostOverride {
 	does_override_original_cost: boolean;
 	first_unit_only: boolean;
 	new_price: number;
@@ -206,7 +206,7 @@ export interface PricedAPISitePlanPricing
 	extends Omit< PricedAPIPlanPricing, 'orig_cost_integer' | 'bill_period' > {
 	raw_discount_integer: number;
 
-	cost_overrides?: PricedAPIPlanCostOverrides[];
+	cost_overrides?: PricedAPISitePlanCostOverride[];
 }
 
 /**

--- a/packages/plans-grid-next/src/components/header-price.tsx
+++ b/packages/plans-grid-next/src/components/header-price.tsx
@@ -133,7 +133,6 @@ const HeaderPriceContainer = styled.div`
 
 const PlanFeatures2023GridHeaderPrice = ( {
 	planSlug,
-	planUpgradeCreditsApplicable,
 	visibleGridPlans,
 }: PlanFeatures2023GridHeaderPriceProps ) => {
 	const translate = useTranslate();
@@ -149,11 +148,10 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	 * then we do not show any discount messaging as per Automattic/martech#1927
 	 * We currently only support the `One time discount` in some currencies
 	 */
-	const isGridPlanOneTimeDiscounted =
-		Boolean( discountedPrice.monthly ) && ! planUpgradeCreditsApplicable;
-	const isAnyVisibleGridPlanOneTimeDiscounted =
-		visibleGridPlans.some( ( { pricing } ) => pricing.discountedPrice.monthly ) &&
-		! planUpgradeCreditsApplicable;
+	const isGridPlanOneTimeDiscounted = Boolean( discountedPrice.monthly );
+	const isAnyVisibleGridPlanOneTimeDiscounted = visibleGridPlans.some(
+		( { pricing } ) => pricing.discountedPrice.monthly
+	);
 
 	const isGridPlanOnIntroOffer = introOffer && ! introOffer.isOfferComplete;
 	const isAnyVisibleGridPlanOnIntroOffer = visibleGridPlans.some(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/3131

## Proposed Changes

* Supercedes #92205.
* Requires D154127-code
* If a `siteId` is passed to `usePricingMetaForGridPlans`, it will now return pricing data from `sitePlans`. This ensures that cases like first-term discounts, discounts due to plan proration, expired plans, etc., are handled correctly since we rely on the values returned by the endpoint.
* The above change solved the bug mentioned in [this PR](https://github.com/Automattic/wp-calypso/pull/92205). It also solved the issue mentioned [here](https://github.com/Automattic/wp-calypso/pull/92205#pullrequestreview-2154047944).
* However, now the plans grid started showing prices that are discounted by plan proration (Full price - upgrade credits). To handle this, I added a check so that discounts from plan proration are not returned by the hook. This change requires D154127-code as the reason for the discount was not returned by the API.
* Also added a TODO comment: https://github.com/Automattic/wp-calypso/pull/92311#discussion_r1663744120

_**Note**_: This PR is not complete and needs additional changes. Please review the general direction for now.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions in #92205.
* Go to `/start` and confirm that prices are shown correctly when currency-specific discounts are applicable and not applicable.
* Go to `/plans/<site slug>` and confirm that the prices shown on the spotlight plan and plans shown for upgrades is the same as production.
* Also test the above for expired plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
