### PR TITLE
ETK: Add flag to turn off the specific feature

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -54,9 +54,39 @@ function is_homepage_title_hidden() {
 		return false;
 	}
 
+	if ( defined( 'MU_WPCOM_HOMEPAGE_TITLE_HIDDEN' ) && MU_WPCOM_HOMEPAGE_TITLE_HIDDEN ) {
+		return
+	}
+
 	$hide_homepage_title = (bool) get_theme_mod( 'hide_front_page_title', false );
 	$is_homepage         = ( (int) get_option( 'page_on_front' ) === $post->ID );
 	return (bool) is_block_editor_screen() && $hide_homepage_title && $is_homepage;
+}
+
+/**
+ * Detects if the site is using Gutenberg 9.2 or above, which contains a bug in the
+ * interface package, causing some "slider" blocks (such as Jetpack's Slideshow) to
+ * incorrectly calculate their width as 33554400px when set at full width.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/26552
+ *
+ * @return bool True if the site needs a temporary fix for the incorrect slider width.
+ */
+function needs_slider_width_workaround() {
+	global $post;
+
+	if ( defined( 'MU_WPCOM_SLIDER_WIDTH' ) && MU_WPCOM_SLIDER_WIDTH ) {
+		return
+	}
+
+	if (
+		( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE ) ||
+		( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '9.2', '>=' ) )
+	) {
+		// Workaround only needed when in the editor.
+		return isset( $post );
+	}
+	return false;
 }
 
 /**
@@ -151,6 +181,10 @@ add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_script_and_style'
  * @see https://github.com/WordPress/gutenberg/pull/23904
  **/
 function wpcom_gutenberg_enable_custom_line_height() {
+	if ( defined( 'MU_WPCOM_CUSTOM_LINE_HEIGHT' ) && MU_WPCOM_CUSTOM_LINE_HEIGHT ) {
+		return
+	}
+
 	add_theme_support( 'custom-line-height' );
 }
 add_action( 'after_setup_theme', __NAMESPACE__ . '\wpcom_gutenberg_enable_custom_line_height' );
@@ -201,6 +235,10 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_disable_hei
  * blocking.
  */
 function enqueue_override_preview_button_url() {
+	if ( defined( 'MU_WPCOM_OVERRIDE_PREVIEW_BUTTON_URL' ) && MU_WPCOM_OVERRIDE_PREVIEW_BUTTON_URL ) {
+		return
+	}
+
 	if ( ! function_exists( 'is_blog_atomic' ) ) {
 		return;
 	};

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -55,7 +55,7 @@ function is_homepage_title_hidden() {
 	}
 
 	if ( defined( 'MU_WPCOM_HOMEPAGE_TITLE_HIDDEN' ) && MU_WPCOM_HOMEPAGE_TITLE_HIDDEN ) {
-		return
+		return;
 	}
 
 	$hide_homepage_title = (bool) get_theme_mod( 'hide_front_page_title', false );
@@ -76,7 +76,7 @@ function needs_slider_width_workaround() {
 	global $post;
 
 	if ( defined( 'MU_WPCOM_SLIDER_WIDTH' ) && MU_WPCOM_SLIDER_WIDTH ) {
-		return
+		return;
 	}
 
 	if (
@@ -182,7 +182,7 @@ add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_script_and_style'
  **/
 function wpcom_gutenberg_enable_custom_line_height() {
 	if ( defined( 'MU_WPCOM_CUSTOM_LINE_HEIGHT' ) && MU_WPCOM_CUSTOM_LINE_HEIGHT ) {
-		return
+		return;
 	}
 
 	add_theme_support( 'custom-line-height' );
@@ -236,7 +236,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_disable_hei
  */
 function enqueue_override_preview_button_url() {
 	if ( defined( 'MU_WPCOM_OVERRIDE_PREVIEW_BUTTON_URL' ) && MU_WPCOM_OVERRIDE_PREVIEW_BUTTON_URL ) {
-		return
+		return;
 	}
 
 	if ( ! function_exists( 'is_blog_atomic' ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -40,6 +40,10 @@ function is_full_site_editing_active() {
 		return false;
 	}
 
+	if ( defined( 'MU_WPCOM_FSE' ) && MU_WPCOM_FSE ) {
+		return false;
+	}
+
 	return is_site_eligible_for_full_site_editing() && is_theme_supported() && did_insert_template_parts();
 }
 
@@ -179,6 +183,10 @@ function did_insert_template_parts() {
  * if the theme is unsupported.
  */
 function populate_wp_template_data() {
+	if ( defined( 'MU_WPCOM_TEMPLATE_INSERTER' ) && MU_WPCOM_TEMPLATE_INSERTER ) {
+		return;
+	}
+
 	if ( ! is_theme_supported() ) {
 		return;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -69,6 +69,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
  * Load Posts List Block.
  */
 function load_posts_list_block() {
+	if ( defined( 'MU_WPCOM_POSTS_LIST_BLOCK' ) && MU_WPCOM_POSTS_LIST_BLOCK ) {
+		return;
+	}
+
 	if ( class_exists( 'Posts_List_Block' ) ) {
 		return;
 	}
@@ -95,6 +99,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_posts_list_block' );
  * Load Starter_Page_Templates.
  */
 function load_starter_page_templates() {
+	if ( defined( 'MU_WPCOM_STARTER_PAGE_TEMPLATES' ) && MU_WPCOM_STARTER_PAGE_TEMPLATES ) {
+		return;
+	}
+
 	// We don't want the user to choose a template when copying a post.
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['jetpack-copy'] ) ) {
@@ -122,6 +130,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_starter_page_templates' );
  * Load Global Styles plugin.
  */
 function load_global_styles() {
+	if ( defined( 'MU_WPCOM_JETPACK_GLOBAL_STYLES' ) && MU_WPCOM_JETPACK_GLOBAL_STYLES ) {
+		return;
+	}
+
 	require_once __DIR__ . '/global-styles/class-global-styles.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
@@ -130,6 +142,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
  * Load Event Countdown Block.
  */
 function load_countdown_block() {
+	if ( defined( 'MU_WPCOM_JETPACK_COUNTDOWN_BLOCK' ) && MU_WPCOM_JETPACK_COUNTDOWN_BLOCK ) {
+		return;
+	}
+
 	require_once __DIR__ . '/event-countdown-block/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_countdown_block' );
@@ -138,6 +154,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_countdown_block' );
  * Load Timeline Block.
  */
 function load_timeline_block() {
+	if ( defined( 'MU_WPCOM_JETPACK_TIMELINE_BLOCK' ) && MU_WPCOM_JETPACK_TIMELINE_BLOCK ) {
+		return;
+	}
+
 	require_once __DIR__ . '/jetpack-timeline/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_timeline_block' );
@@ -151,6 +171,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_timeline_block' );
  * not aware of content sections outside of post_content yet.
  */
 function enqueue_coblocks_gallery_scripts() {
+	if ( defined( 'MU_WPCOM_COBLOCKS_GALLERY' ) && MU_WPCOM_COBLOCKS_GALLERY ) {
+		return;
+	}
+
 	if ( ! function_exists( 'CoBlocks' ) || ! is_full_site_editing_active() ) {
 		return;
 	}
@@ -198,6 +222,10 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_coblocks_gallery_scr
  * Load Blog Posts block.
  */
 function load_blog_posts_block() {
+	if ( defined( 'MU_WPCOM_NEWSPACK_BLOCKS' ) && MU_WPCOM_NEWSPACK_BLOCKS ) {
+		return;
+	}
+
 	// Use regex instead of static slug in order to match plugin installation also from github, where slug may contain (HASH|branch-name).
 	$slug_regex    = '/newspack-blocks(-[A-Za-z0-9-]+)?\/newspack-blocks\.php/';
 	$disable_block = (
@@ -227,6 +255,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_blog_posts_block' );
  * Load WPCOM Block Editor NUX.
  */
 function load_wpcom_block_editor_nux() {
+	if ( defined( 'MU_WPCOM_BLOCK_EDITOR_NUX' ) && MU_WPCOM_BLOCK_EDITOR_NUX ) {
+		return;
+	}
+
 	require_once __DIR__ . '/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );
@@ -235,6 +267,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );
  * Load Block Inserter Modifications module.
  */
 function load_block_inserter_modifications() {
+	if ( defined( 'MU_WPCOM_BLOCK_INSERTER_MODIFICATIONS' ) && MU_WPCOM_BLOCK_INSERTER_MODIFICATIONS ) {
+		return;
+	}
+
 	require_once __DIR__ . '/block-inserter-modifications/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_inserter_modifications' );
@@ -243,6 +279,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_inserter_modification
  * Load Mailerlite module.
  */
 function load_mailerlite() {
+	if ( defined( 'MU_WPCOM_MAILERLITE_WIDGET' ) && MU_WPCOM_MAILERLITE_WIDGET ) {
+		return;
+	}
+
 	require_once __DIR__ . '/mailerlite/subscriber-popup.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_mailerlite' );
@@ -264,6 +304,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_sidebar'
  * What's New section of the Tools menu.
  */
 function load_whats_new() {
+	if ( defined( 'MU_WPCOM_WHATS_NEW' ) && MU_WPCOM_WHATS_NEW ) {
+		return;
+	}
+
 	require_once __DIR__ . '/whats-new/class-whats-new.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_whats_new' );
@@ -272,6 +316,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_whats_new' );
  * Tags Education
  */
 function load_tags_education() {
+	if ( defined( 'MU_WPCOM_TAGS_EDUCATION' ) && MU_WPCOM_TAGS_EDUCATION ) {
+		return;
+	}
+
 	require_once __DIR__ . '/tags-education/class-tags-education.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
@@ -317,6 +365,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_help_center', 100 );
  * Load paragraph block
  */
 function load_paragraph_block() {
+	if ( defined( 'MU_WPCOM_PARAGRAPH_BLOCK' ) && MU_WPCOM_PARAGRAPH_BLOCK ) {
+		return;
+	}
+
 	require_once __DIR__ . '/paragraph-block/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_paragraph_block' );
@@ -325,6 +377,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_paragraph_block' );
  * Override org documentation links.
  */
 function load_wpcom_documentation_links() {
+	if ( defined( 'MU_WPCOM_DOCUMENTATION_LINKS' ) && MU_WPCOM_DOCUMENTATION_LINKS ) {
+		return;
+	}
+
 	require_once __DIR__ . '/wpcom-documentation-links/class-wpcom-documentation-links.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_documentation_links' );
@@ -333,6 +389,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_documentation_links' 
  * Add support links to block description.
  */
 function load_block_description_links() {
+	if ( defined( 'MU_WPCOM_BLOCK_DESCRIPTION_LINKS' ) && MU_WPCOM_BLOCK_DESCRIPTION_LINKS ) {
+		return;
+	}
+
 	require_once __DIR__ . '/wpcom-block-description-links/class-wpcom-block-description-links.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_description_links' );
@@ -341,6 +401,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_description_links' );
  * Load WP.com Global Styles.
  */
 function load_wpcom_global_styles() {
+	if ( defined( 'MU_WPCOM_GLOBAL_STYLES' ) && MU_WPCOM_GLOBAL_STYLES ) {
+		return;
+	}
+
 	require_once __DIR__ . '/wpcom-global-styles/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_global_styles' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8032

## Proposed Changes

* Add the flag to turn off the specific feature of the ETK plugin so the feature on ETK plugin won't be loaded automatically when it's migrated to the jetpack-mu-wpcom
  * MU_WPCOM_HOMEPAGE_TITLE_HIDDEN
  * MU_WPCOM_CUSTOM_LINE_HEIGHT
  * MU_WPCOM_OVERRIDE_PREVIEW_BUTTON_URL
  * MU_WPCOM_FSE
  * MU_WPCOM_TEMPLATE_INSERTER
  * MU_WPCOM_POSTS_LIST_BLOCK
  * MU_WPCOM_STARTER_PAGE_TEMPLATES
  * MU_WPCOM_JETPACK_GLOBAL_STYLES
  * MU_WPCOM_JETPACK_COUNTDOWN_BLOCK
  * MU_WPCOM_JETPACK_TIMELINE_BLOCK
  * MU_WPCOM_COBLOCKS_GALLERY
  * MU_WPCOM_NEWSPACK_BLOCKS
  * MU_WPCOM_BLOCK_EDITOR_NUX
  * MU_WPCOM_MAILERLITE_WIDGET
  * MU_WPCOM_WHATS_NEW
  * MU_WPCOM_TAGS_EDUCATION
  * MU_WPCOM_PARAGRAPH_BLOCK
  * MU_WPCOM_DOCUMENTATION_LINKS
  * MU_WPCOM_BLOCK_DESCRIPTION_LINKS
  * MU_WPCOM_GLOBAL_STYLES

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For the ETK migration

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
