### PR TITLE
A4A > Site Selector & Importer: Implement WPCOM site selector modal

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/index.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@automattic/components';
+import { Modal } from '@wordpress/components';
+import { Icon, close } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import WPCOMSitesTable from './wpcom-sites-table';
+
+import './style.scss';
+
+export default function ImportFromWPCOMModal( { onClose }: { onClose: () => void } ) {
+	const translate = useTranslate();
+
+	const [ selectedSites, setSelectedSites ] = useState< number[] | [] >( [] );
+
+	return (
+		<Modal onRequestClose={ onClose } className="import-from-wpcom-modal" __experimentalHideHeader>
+			<div className="import-from-wpcom-modal__main">
+				<Button
+					className="import-from-wpcom-modal__close-button"
+					plain
+					onClick={ onClose }
+					aria-label={ translate( 'Close' ) }
+				>
+					<Icon size={ 24 } icon={ close } />
+				</Button>
+
+				<h1 className="import-from-wpcom-modal__title">
+					{ translate( 'Add sites via WordPress.com connection' ) }
+				</h1>
+
+				<p className="import-from-wpcom-modal__instruction">
+					{ translate(
+						'Add one or more sites you previously created on WordPress.com or connected with Jetpack.'
+					) }
+				</p>
+				<WPCOMSitesTable setSelectedSites={ setSelectedSites } selectedSites={ selectedSites } />
+			</div>
+			<div className="import-from-wpcom-modal__footer">
+				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
+
+				<Button primary disabled={ selectedSites.length === 0 }>
+					{ selectedSites.length > 0
+						? translate( 'Add %(count)d site', 'Add %(count)d sites', {
+								args: {
+									count: selectedSites.length,
+								},
+								count: selectedSites.length,
+								comment: '%(count)s is the number of sites selected.',
+						  } )
+						: translate( 'Add sites' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -36,16 +36,13 @@
 }
 
 .import-from-wpcom-modal__title {
-	font-size: rem(20px);
-	font-weight: 600;
-	line-height: 1.2;
+	@include a4a-font-heading-lg;
 	margin: 0;
 	padding: 0;
 }
 
 p.import-from-wpcom-modal__instruction {
-	font-size: rem(12px);
-	line-height: 1.3;
+	@include a4a-font-body-sm;
 	margin: 0;
 	color: var(--color-accent-60);
 }

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -1,0 +1,113 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.import-from-wpcom-modal {
+	max-width: 827px;
+	max-height: 100%;
+	margin: 0;
+
+	.components-modal__content {
+		padding: 0;
+
+		> div {
+			display: flex;
+			flex-direction: column;
+			justify-content: space-between;
+			height: 100%;
+			position: relative;
+		}
+	}
+
+	@include break-medium {
+		margin: auto;
+	}
+}
+
+.import-from-wpcom-modal__main {
+	padding: 40px;
+	gap: 8px;
+	display: flex;
+	flex-direction: column;
+	height: 680px;
+
+	@include break-large {
+		width: 800px;
+	}
+}
+
+.import-from-wpcom-modal__title {
+	font-size: rem(20px);
+	font-weight: 600;
+	line-height: 1.2;
+	margin: 0;
+	padding: 0;
+}
+
+p.import-from-wpcom-modal__instruction {
+	font-size: rem(12px);
+	line-height: 1.3;
+	margin: 0;
+	color: var(--color-accent-60);
+}
+
+.import-from-wpcom-modal__footer {
+	padding: 24px 40px;
+	text-align: right;
+	border-radius: 4px;
+	position: fixed;
+	bottom: 0;
+	width: 100%;
+	background: var(--color-light-backdrop);
+
+	.button {
+		margin-inline-end: 8px;
+	}
+}
+
+.import-from-wpcom-modal__close-button {
+	position: absolute;
+	inset-inline-end: 1rem;
+	inset-block-start: 1rem;
+	cursor: pointer;
+	transition: scale 0.2s ease-in;
+	max-height: 24px;
+
+	&:hover {
+		scale: 1.2;
+	}
+
+	&:focus-visible {
+		border-color: var(--color-primary);
+		outline: none;
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+		border-radius: 4px;
+	}
+}
+
+.wpcom-sites-table.redesigned-a8c-table {
+	margin-block-start: 24px;
+
+	.dataviews-wrapper tr.dataviews-view-table__row {
+		.components-checkbox-control__input {
+			opacity: 1;
+		}
+
+		td {
+			border-bottom: none;
+			padding-block: 8px;
+		}
+	}
+
+	.dataviews-view-table {
+		padding-block-end: 60px;
+	}
+
+	.a4a-text-placeholder {
+		margin-block: 32px;
+	}
+
+	.wpcom-sites-table__icon {
+		width: 24px;
+		height: 24px;
+	}
+}

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -1,0 +1,190 @@
+import { WordPressLogo, JetpackLogo, Gridicon } from '@automattic/components';
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { CheckboxControl } from '@wordpress/components';
+import { Icon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useMemo, useCallback } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import getSites from 'calypso/state/selectors/get-sites';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import type { Site } from 'calypso/a8c-for-agencies/sections/sites/types';
+
+type SiteItem = {
+	id: number;
+	site: string;
+	date: string;
+	type: string;
+};
+
+const TypeIcon = ( { siteId }: { siteId: number } ) => {
+	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+
+	if ( isWPCOM ) {
+		return <Icon className="wpcom-sites-table__icon" icon={ <WordPressLogo /> } />;
+	}
+	if ( isJetpack ) {
+		return <Icon className="wpcom-sites-table__icon" icon={ <JetpackLogo /> } />;
+	}
+	return <Gridicon icon="minus" />;
+};
+
+export default function WPCOMSitesTable( {
+	selectedSites,
+	setSelectedSites,
+}: {
+	selectedSites: number[];
+	setSelectedSites: ( sites: number[] ) => void;
+} ) {
+	const translate = useTranslate();
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const { data, isFetching } = useFetchDashboardSites( {
+		isPartnerOAuthTokenLoaded: false,
+		searchQuery: '',
+		currentPage: 1,
+		sort: {
+			field: '',
+			direction: '',
+		},
+		perPage: 100,
+		agencyId,
+		filter: {
+			issueTypes: [],
+			showOnlyFavorites: false,
+		},
+	} );
+
+	const sites = useSelector( getSites );
+
+	const isDesktop = useDesktopBreakpoint();
+
+	const [ dataViewsState, setDataViewsState ] = useState( initialDataViewsState );
+
+	// FIXME: This is a temporary solution to filter out sites that are already connected
+	const items = useMemo( () => {
+		return sites
+			.filter(
+				( site ) =>
+					site?.visible &&
+					! site.is_private &&
+					data?.sites.every( ( s: Site ) => s.blog_id !== site.ID )
+			)
+			.map( ( site ) =>
+				site
+					? {
+							id: site.ID,
+							site: urlToSlug( site.URL ),
+							date: site.options?.created_at || '',
+					  }
+					: undefined
+			)
+			.filter( Boolean ) as SiteItem[];
+	}, [ data?.sites, sites ] );
+
+	const onSelectAllSites = useCallback( () => {
+		setSelectedSites(
+			selectedSites.length === items.length ? [] : items.map( ( item ) => item.id )
+		);
+	}, [ items, selectedSites.length, setSelectedSites ] );
+
+	const onSelectSite = useCallback(
+		( checked: boolean, item: SiteItem ) => {
+			if ( checked ) {
+				setSelectedSites( [ ...selectedSites, item.id ] );
+			} else {
+				setSelectedSites( selectedSites.filter( ( id ) => id !== item.id ) );
+			}
+		},
+		[ selectedSites, setSelectedSites ]
+	);
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'site',
+				header: (
+					<div>
+						<CheckboxControl
+							label={ translate( 'Site' ).toUpperCase() }
+							checked={ selectedSites.length === items.length }
+							onChange={ onSelectAllSites }
+							disabled={ false }
+						/>
+					</div>
+				),
+				getValue: () => '-' as string,
+				render: ( { item }: { item: SiteItem } ) => (
+					<CheckboxControl
+						label={ item.site }
+						checked={ selectedSites.includes( item.id ) }
+						onChange={ ( checked ) => onSelectSite( checked, item ) }
+						disabled={ false }
+					/>
+				),
+				width: '100%',
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'date',
+				header: translate( 'Date' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: SiteItem } ) => new Date( item.date ).toLocaleDateString(),
+				width: '100%',
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'type',
+				header: translate( 'Type' ).toUpperCase(),
+				getValue: () => '-',
+				render: ( { item }: { item: SiteItem } ) => <TypeIcon siteId={ item.id } />,
+				width: '100%',
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[ items.length, onSelectAllSites, onSelectSite, selectedSites, translate ]
+	);
+
+	return isDesktop ? (
+		<div className="wpcom-sites-table redesigned-a8c-table">
+			{ isFetching ? (
+				<>
+					<TextPlaceholder />
+					<TextPlaceholder />
+					<TextPlaceholder />
+					<TextPlaceholder />
+					<TextPlaceholder />
+					<TextPlaceholder />
+					<TextPlaceholder />
+					<TextPlaceholder />
+				</>
+			) : (
+				<ItemsDataViews
+					data={ {
+						items,
+						fields,
+						getItemId: ( item ) => `${ item.id }`,
+						pagination: {
+							totalItems: 1,
+							totalPages: 1,
+						},
+						enableSearch: false,
+						actions: [],
+						dataViewsState: dataViewsState,
+						setDataViewsState: setDataViewsState,
+					} }
+				/>
+			) }
+		</div>
+	) : null;
+}

--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -6,6 +6,8 @@ import { useRef, useState } from 'react';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import A4ALogo from '../a4a-logo';
 import {
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
@@ -13,6 +15,7 @@ import {
 	A4A_SITES_LINK_NEEDS_SETUP,
 } from '../sidebar-menu/lib/constants';
 import A4AConnectionModal from './a4a-connection-modal';
+import ImportFromWPCOMModal from './import-from-wpcom-modal';
 import JetpackConnectionModal from './jetpack-connection-modal';
 
 import './style.scss';
@@ -27,13 +30,21 @@ export default function SiteSelectorAndImporter( {
 	showMainButtonLabel: boolean;
 } ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const [ isMenuVisible, setMenuVisible ] = useState( false );
 	const [ showA4AConnectionModal, setShowA4AConnectionModal ] = useState( false );
 	const [ showJetpackConnectionModal, setShowJetpackConnectionModal ] = useState( false );
+	const [ showImportFromWPCOMModal, setShowImportFromWPCOMModal ] = useState( false );
 
 	const toggleMenu = () => {
 		setMenuVisible( ( isVisible ) => ! isVisible );
+	};
+
+	const handleImportFromWPCOM = () => {
+		dispatch( recordTracksEvent( 'calypso_a8c_agency_sites_import_wpcom_click' ) );
+		setShowImportFromWPCOMModal( true );
+		setMenuVisible( false );
 	};
 
 	const popoverMenuContext = useRef( null );
@@ -110,6 +121,9 @@ export default function SiteSelectorAndImporter( {
 							icon: <WordPressLogo />,
 							heading: translate( 'Via WordPress.com' ),
 							description: translate( 'Import sites bought on WordPress.com' ),
+							buttonProps: {
+								onClick: handleImportFromWPCOM,
+							},
 						} ) }
 						{ menuItem( {
 							icon: <A4ALogo />,
@@ -191,6 +205,10 @@ export default function SiteSelectorAndImporter( {
 
 			{ showJetpackConnectionModal && (
 				<JetpackConnectionModal onClose={ () => setShowJetpackConnectionModal( false ) } />
+			) }
+
+			{ showImportFromWPCOMModal && (
+				<ImportFromWPCOMModal onClose={ () => setShowImportFromWPCOMModal( false ) } />
 			) }
 		</>
 	);

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -45,7 +45,7 @@
 	margin-block-end: 8px;
 }
 
-.theme-a8c-for-agencies  .button.site-selector-and-importer__popover-button {
+.theme-a8c-for-agencies  .button.is-borderless.site-selector-and-importer__popover-button {
 	padding: 0 8px;
 	white-space: unset;
 	text-align: unset;


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/677

## Proposed Changes

This PR implements the WPCOM site selector modal.

Note: 

- The `Add X sites` button does nothing
- The mobile view design is required and will be implemented in another PR.
- The list of sites might have to be updated and will be done in another PR.
- The sorting needs to be figured out and will be implemented in another PR.
- Making the whole row clickable will be implemented in another PR.

## Testing Instructions

1. Open the A4A live link.
2. Click the `Add sites` button > Click the Via WordPress.com menu item
3. Verify that the UI is displayed as shown below & select/deselect works as expected.

<img width="815" alt="Screenshot 2024-07-03 at 3 31 32 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/41cd1ff0-b628-4b92-90eb-31b229cbb63a">

<img width="815" alt="Screenshot 2024-07-03 at 3 40 17 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0b72ca02-a2bd-4c17-ad90-eef6be277f0e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
