### PR TITLE
Plugins: Remove Domain-Only Sites from Site List

### DIFF
--- a/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
+++ b/client/my-sites/plugins/manage-site-plugins-dialog/index.jsx
@@ -22,7 +22,9 @@ export const ManageSitePluginsDialog = ( { isVisible, onClose, plugin } ) => {
 
 	const sites = useSelector( getSelectedOrAllSites );
 	sites.sort( orderByAtomic );
-	const sitesWithoutPlugin = sites.filter(
+
+	const sitesToShow = sites.filter( ( item ) => item && ! item?.options?.is_domain_only );
+	const sitesWithoutPlugin = sitesToShow.filter(
 		( site ) => ! sitesWithPlugin.find( ( siteWithPlugin ) => siteWithPlugin.ID === site.ID )
 	);
 


### PR DESCRIPTION
## Proposed Changes

* Removes domain-only sites from Plugins site list. 

## Why are these changes being made?

The link for these sites are broken currently, and I don't think it makes sense to display those sites at all here. 

## Testing Instructions

1) Go to `/plugins` in global site view
2) Pick a plugin
3) Select "Manage Sites"
4) Confirm that domain-only sites are now filtered from the list 

<img width="933" alt="Screenshot 2024-07-03 at 12 26 48" src="https://github.com/Automattic/wp-calypso/assets/43215253/626204ff-b67d-4364-9592-b9c1cc9b70bd">

cc @WBerredo, @DustyReagan  