### PR TITLE
A4A: Add Site remove functionality.

### DIFF
--- a/client/a8c-for-agencies/data/sites/use-remove-site.ts
+++ b/client/a8c-for-agencies/data/sites/use-remove-site.ts
@@ -1,0 +1,39 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export interface APIError {}
+
+interface APIResponse {
+	success: boolean;
+}
+
+interface Props {
+	siteId: number;
+	agencyId?: number;
+}
+
+function mutationRemoveSite( { siteId, agencyId }: Props ): Promise< APIResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to assign a license' );
+	}
+
+	return wpcom.req.post( {
+		method: 'DELETE',
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/sites/${ siteId }`,
+		body: { siteId, agency_id: agencyId },
+	} );
+}
+
+export default function useRemoveSiteMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIError, Error, Props, TContext >
+): UseMutationResult< APIError, Error, Props, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< APIError, Error, Props, TContext >( {
+		...options,
+		mutationFn: ( args ) => mutationRemoveSite( { ...args, agencyId } ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -36,6 +36,7 @@ export const JetpackSitesDataViews = ( {
 	dataViewsState,
 	forceTourExampleSite = false,
 	className,
+	onRefetchSite,
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
 
@@ -394,6 +395,7 @@ export const JetpackSitesDataViews = ( {
 											isLargeScreen={ isLargeScreen }
 											site={ item.site }
 											siteError={ item.site.error }
+											onRefetchSite={ onRefetchSite }
 										/>
 										<Button
 											onClick={ () => openSitePreviewPane( item.site.value ) }
@@ -433,7 +435,9 @@ export const JetpackSitesDataViews = ( {
 			isLoading,
 			openSitePreviewPane,
 			renderField,
+			isNotProduction,
 			isLargeScreen,
+			onRefetchSite,
 		]
 	);
 

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -435,7 +435,6 @@ export const JetpackSitesDataViews = ( {
 			isLoading,
 			openSitePreviewPane,
 			renderField,
-			isNotProduction,
 			isLargeScreen,
 			onRefetchSite,
 		]

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -272,6 +272,7 @@ export default function SitesDashboard() {
 							isLargeScreen={ isLargeScreen || false }
 							setDataViewsState={ setDataViewsState }
 							dataViewsState={ dataViewsState }
+							onRefetchSite={ refetch }
 						/>
 					</DashboardDataContext.Provider>
 				</LayoutColumn>

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
@@ -16,6 +16,7 @@ export interface SitesDataViewsProps {
 	isLoading: boolean;
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
 	dataViewsState: DataViewsState;
+	onRefetchSite?: () => void;
 }
 
 export interface SiteInfo extends SiteData {

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
@@ -16,7 +16,7 @@ export interface SitesDataViewsProps {
 	isLoading: boolean;
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
 	dataViewsState: DataViewsState;
-	onRefetchSite?: () => void;
+	onRefetchSite?: () => Promise< unknown >;
 }
 
 export interface SiteInfo extends SiteData {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/get-action-event-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/get-action-event-name.ts
@@ -38,6 +38,10 @@ const actionEventNames: ActionEventNames = {
 		large_screen: 'calypso_jetpack_agency_dashboard_hosting_configuration_large_screen',
 		small_screen: 'calypso_jetpack_agency_dashboard_hosting_configuration_small_screen',
 	},
+	remove_site: {
+		large_screen: 'calypso_jetpack_agency_dashboard_remove_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_remove_small_screen',
+	},
 };
 
 // Returns event name based on the action type

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -1,6 +1,7 @@
 import { Gridicon, Button } from '@automattic/components';
 import clsx from 'clsx';
 import { useState, useRef, useCallback } from 'react';
+import useRemoveSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-remove-site';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { SiteRemoveConfirmationDialog } from '../site-remove-confirmation-dialog';
@@ -13,9 +14,15 @@ interface Props {
 	isLargeScreen?: boolean;
 	site: SiteNode;
 	siteError: boolean | undefined;
+	onRefetchSite?: () => void;
 }
 
-export default function SiteActions( { isLargeScreen = false, site, siteError }: Props ) {
+export default function SiteActions( {
+	isLargeScreen = false,
+	site,
+	siteError,
+	onRefetchSite,
+}: Props ) {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ showRemoveSiteDialog, setShowRemoveSiteDialog ] = useState( false );
 
@@ -41,6 +48,22 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 		siteError,
 		onSelect: onSelectAction,
 	} );
+
+	const { mutate: removeSite, isPending } = useRemoveSiteMutation();
+
+	const onRemoveSite = useCallback( () => {
+		if ( site.value?.a4a_site_id ) {
+			removeSite(
+				{ siteId: site.value?.a4a_site_id },
+				{
+					onSuccess: () => {
+						setShowRemoveSiteDialog( false );
+						onRefetchSite?.();
+					},
+				}
+			);
+		}
+	}, [ onRefetchSite, removeSite, site.value?.a4a_site_id ] );
 
 	return (
 		<>
@@ -83,6 +106,8 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 				<SiteRemoveConfirmationDialog
 					site={ site }
 					onClose={ () => setShowRemoveSiteDialog( false ) }
+					onConfirm={ onRemoveSite }
+					busy={ isPending }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -1,10 +1,11 @@
 import { Gridicon, Button } from '@automattic/components';
 import clsx from 'clsx';
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { SiteRemoveConfirmationDialog } from '../site-remove-confirmation-dialog';
 import useSiteActions from './use-site-actions';
-import type { SiteNode } from '../types';
+import type { AllowedActionTypes, SiteNode } from '../types';
 
 import './style.scss';
 
@@ -16,18 +17,30 @@ interface Props {
 
 export default function SiteActions( { isLargeScreen = false, site, siteError }: Props ) {
 	const [ isOpen, setIsOpen ] = useState( false );
+	const [ showRemoveSiteDialog, setShowRemoveSiteDialog ] = useState( false );
 
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 
-	const showActions = () => {
+	const showActions = useCallback( () => {
 		setIsOpen( true );
-	};
+	}, [] );
 
-	const closeDropdown = () => {
+	const closeDropdown = useCallback( () => {
 		setIsOpen( false );
-	};
+	}, [] );
 
-	const siteActions = useSiteActions( site, isLargeScreen, siteError );
+	const onSelectAction = useCallback( ( action: AllowedActionTypes ) => {
+		if ( action === 'remove_site' ) {
+			setShowRemoveSiteDialog( true );
+		}
+	}, [] );
+
+	const siteActions = useSiteActions( {
+		site,
+		isLargeScreen,
+		siteError,
+		onSelect: onSelectAction,
+	} );
 
 	return (
 		<>
@@ -65,6 +78,13 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 						</PopoverMenuItem>
 					) ) }
 			</PopoverMenu>
+
+			{ showRemoveSiteDialog && (
+				<SiteRemoveConfirmationDialog
+					site={ site }
+					onClose={ () => setShowRemoveSiteDialog( false ) }
+				/>
+			) }
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -58,9 +58,10 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 							isExternalLink={ action.isExternalLink }
 							onClick={ action.onClick }
 							href={ action.href }
-							className="site-actions__menu-item"
+							className={ clsx( 'site-actions__menu-item', action.className ) }
 						>
 							{ action.name }
+							{ action.icon && <Gridicon icon={ action.icon } size={ 18 } /> }
 						</PopoverMenuItem>
 					) ) }
 			</PopoverMenu>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/style.scss
@@ -27,7 +27,7 @@
 	color: var(--studio-gray-40);
 	margin: 0 0.1em;
 }
-a.site-actions__menu-item {
+.site-actions__menu-item {
 	margin: 0 -1px;
 	border-style: solid;
 	border-color: var(--studio-gray-5);
@@ -40,13 +40,24 @@ a.site-actions__menu-item {
 	align-items: center;
 	padding: 0 16px;
 	min-width: 200px;
+
+	&.is-error {
+		color: var(--color-error);
+
+		svg.gridicon {
+			fill: var(--color-error);
+		}
+	}
+
 	&:last-child {
 		margin-bottom: 5px;
 		border-bottom-width: 0;
 	}
+
 	&:first-child {
 		margin-top: 5px;
 	}
+
 	&:hover,
 	&:focus {
 		border-style: solid;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/test/site-actions.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/test/site-actions.tsx
@@ -46,6 +46,9 @@ describe( '<SiteActions>', () => {
 					},
 				},
 			},
+			a8cForAgencies: {
+				agencies: {},
+			},
 		};
 		const store = mockStore( initialState );
 
@@ -96,6 +99,11 @@ describe( '<SiteActions>', () => {
 					current: {
 						can_issue_licenses: false,
 					},
+				},
+			},
+			a8cForAgencies: {
+				agencies: {
+					activeAgency: 1,
 				},
 			},
 		};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -10,11 +10,14 @@ import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selector
 import getActionEventName from './get-action-event-name';
 import type { SiteNode, AllowedActionTypes } from '../types';
 
-export default function useSiteActions(
-	site: SiteNode,
-	isLargeScreen: boolean,
-	siteError?: boolean
-) {
+type Props = {
+	site: SiteNode;
+	isLargeScreen: boolean;
+	siteError?: boolean;
+	onSelect?: ( action: AllowedActionTypes ) => void;
+};
+
+export default function useSiteActions( { site, isLargeScreen, siteError, onSelect }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const partner = useSelector( getCurrentPartner );
@@ -42,6 +45,7 @@ export default function useSiteActions(
 		const handleClickMenuItem = ( actionType: AllowedActionTypes ) => {
 			const eventName = getActionEventName( actionType, isLargeScreen );
 			dispatch( recordTracksEvent( eventName ) );
+			onSelect?.( actionType );
 		};
 
 		const isWPCOMAtomicSiteCreationEnabled =

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -124,6 +124,13 @@ export default function useSiteActions(
 				isExternalLink: true,
 				isEnabled: true && ! isUrlOnly,
 			},
+			{
+				name: translate( 'Remove site' ),
+				onClick: () => handleClickMenuItem( 'remove_site' ),
+				isEnabled: isA8CForAgencies() && isEnabled( 'a4a-site-selector-and-importer' ),
+				icon: 'trash',
+				className: 'is-error',
+			},
 		];
 	}, [
 		dispatch,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
@@ -94,6 +94,9 @@ describe( '<SiteCard>', () => {
 					[ blogId ]: siteObj,
 				},
 			},
+			a8cForAgencies: {
+				agencies: {},
+			},
 		};
 		const mockStore = configureStore();
 		const store = mockStore( initialState );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/index.tsx
@@ -41,13 +41,16 @@ export function SiteRemoveConfirmationDialog( { site, onConfirm, onClose, busy }
 		>
 			<h2 className="site-remove-confirmation-dialog__heading">{ title }</h2>
 
-			{ translate( 'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}}?', {
-				args: { siteName: site.value?.url },
-				components: {
-					b: <b />,
-				},
-				comment: '%(siteName)s is the site name',
-			} ) }
+			{ translate(
+				'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
+				{
+					args: { siteName: site.value?.url },
+					components: {
+						b: <b />,
+					},
+					comment: '%(siteName)s is the site name',
+				}
+			) }
 		</Dialog>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/index.tsx
@@ -7,12 +7,15 @@ import './style.scss';
 type Props = {
 	site: SiteNode;
 	onClose: () => void;
+	onConfirm?: () => void;
+	busy?: boolean;
 };
 
-export function SiteRemoveConfirmationDialog( { site, onClose }: Props ) {
+export function SiteRemoveConfirmationDialog( { site, onConfirm, onClose, busy }: Props ) {
 	const translate = useTranslate();
 
 	const title = translate( 'Remove site' );
+
 	return (
 		<Dialog
 			label={ title }
@@ -20,11 +23,18 @@ export function SiteRemoveConfirmationDialog( { site, onClose }: Props ) {
 			additionalClassNames="site-remove-confirmation-dialog"
 			onClose={ onClose }
 			buttons={ [
-				<Button key="cancel-button" onClick={ onClose }>
+				<Button key="cancel-button" onClick={ onClose } disabled={ busy }>
 					{ translate( 'Cancel' ) }
 				</Button>,
 
-				<Button key="remove-site-button" primary scary>
+				<Button
+					key="remove-site-button"
+					primary
+					scary
+					disabled={ busy }
+					busy={ busy }
+					onClick={ onConfirm }
+				>
 					{ translate( 'Remove site' ) }
 				</Button>,
 			] }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/index.tsx
@@ -1,0 +1,43 @@
+import { Button, Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { SiteNode } from '../types';
+
+import './style.scss';
+
+type Props = {
+	site: SiteNode;
+	onClose: () => void;
+};
+
+export function SiteRemoveConfirmationDialog( { site, onClose }: Props ) {
+	const translate = useTranslate();
+
+	const title = translate( 'Remove site' );
+	return (
+		<Dialog
+			label={ title }
+			isVisible
+			additionalClassNames="site-remove-confirmation-dialog"
+			onClose={ onClose }
+			buttons={ [
+				<Button key="cancel-button" onClick={ onClose }>
+					{ translate( 'Cancel' ) }
+				</Button>,
+
+				<Button key="remove-site-button" primary scary>
+					{ translate( 'Remove site' ) }
+				</Button>,
+			] }
+		>
+			<h2 className="site-remove-confirmation-dialog__heading">{ title }</h2>
+
+			{ translate( 'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}}?', {
+				args: { siteName: site.value?.url },
+				components: {
+					b: <b />,
+				},
+				comment: '%(siteName)s is the site name',
+			} ) }
+		</Dialog>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/style.scss
@@ -1,0 +1,9 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.site-remove-confirmation-dialog {
+	.site-remove-confirmation-dialog__heading {
+		padding-block-end: 16px;
+		@include a4a-font-heading-lg;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
@@ -129,6 +129,9 @@ describe( '<SiteTableRow>', () => {
 				[ blogId ]: siteObj,
 			},
 		},
+		a8cForAgencies: {
+			agencies: {},
+		},
 	};
 	const mockStore = configureStore();
 	const store = mockStore( initialState );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -117,6 +117,7 @@ export interface Site {
 	active_paid_subscription_slugs: Array< string >;
 	site_color?: string;
 	enabled_plugin_slugs?: Array< string >;
+	a4a_site_id?: number;
 }
 export interface SiteNode {
 	value: Site;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -221,7 +221,8 @@ export type AllowedActionTypes =
 	| 'site_settings'
 	| 'set_up_site'
 	| 'change_domain'
-	| 'hosting_configuration';
+	| 'hosting_configuration'
+	| 'remove_site';
 
 export type ActionEventNames = {
 	[ key in AllowedActionTypes ]: { small_screen: string; large_screen: string };


### PR DESCRIPTION
This pull request includes the 'Remove site' feature in the Site dashboard. Please note that this functionality will only be available when the 'a4a-site-selector-and-importer' feature flag is enabled.

<img width="499" alt="Screenshot 2024-07-03 at 7 49 10 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/456d68a7-7774-4201-b1e8-03daf75af001">
<img width="690" alt="Screenshot 2024-07-03 at 7 49 17 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7046a169-4043-495a-a8b9-08785c1ac665">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/745

## Proposed Changes

* Update the `SiteActions` component to include a new 'Remove site' option. This option will only be available when the A4A environment flag is enabled.
* Implement the remove site mutation hook integrated into the Sites endpoint.


## Testing Instructions


* Use the A4A live link and go to the `/sites` page.
* Select a site you want to remove and click the action menu. **(Make sure you are deleting a dummy site. Otherwise, there is no way to restore that site back to the dashboard. This functionality is still being worked on.)**
* Click the 'Remove Site' icon.
* Confirm that the functionality is working as expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
