### PR TITLE
Avoid translating on build

### DIFF
--- a/packages/verbum-block-editor/README.md
+++ b/packages/verbum-block-editor/README.md
@@ -33,7 +33,7 @@ This package can be utilized in two primary ways:
 
 To deploy modifications to the package:
 1. Ensure your sandbox is in a clean git state.
-2. Run `yarn upload`. This will upload the production-built files to your sandbox.
+2. Run `yarn upload`. This will upload the production-built files as well as the translations to your sandbox.
 3. Create a patch.
 4. Deploy the patch.
 
@@ -41,4 +41,4 @@ To deploy modifications to the package:
 
 This project uses .org's GlotPress translations as a source. 
 
-To translate simply run `yarn build`. 
+To translate simply run `yarn translate`. 

--- a/packages/verbum-block-editor/package.json
+++ b/packages/verbum-block-editor/package.json
@@ -24,8 +24,8 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "NODE_ENV=production yarn dev && yarn translate",
-		"upload": "yarn build && rsync -ahz --delete --exclude='.*' dist/ wpcom-sandbox:/home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
+		"build": "NODE_ENV=production yarn dev",
+		"upload": "yarn build && yarn translate && rsync -ahz --delete --exclude='.*' dist/ wpcom-sandbox:/home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
 		"build:app": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
 		"watch": "tsc --build ./tsconfig.json --watch",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
We need to avoid creating translation files on build.
The process is long and excessive. This command should be run only while developing or deploying.

Related to #

## Proposed Changes

* Run `yarn translate` as part of `yarn upload` instead of `build`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* `yarn translate` will slow down the general build process after running `yarn clean`.
* Its better to explicitly run it when needed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* cd into `packages/verbum-block-editor`
* run `yarn build` and ensure that the languages are not built
* run `yarn upload` and ensure that the languages are built and correctly synced to your sandbox

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
