### PR TITLE
Jetpack Stats: reorder Views/Visitors cards in weekly highlights

### DIFF
--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -159,20 +159,20 @@ function WeeklyHighlighCardsStandard( {
 	return (
 		<div className="highlight-cards-list">
 			<CountComparisonCard
-				heading={ translate( 'Visitors' ) }
-				icon={ <Icon icon={ people } /> }
-				count={ counts?.visitors ?? null }
-				previousCount={ previousCounts?.visitors ?? null }
-				showValueTooltip={ showValueTooltip }
-				onClick={ onClickVisitors }
-			/>
-			<CountComparisonCard
 				heading={ translate( 'Views' ) }
 				icon={ <Icon icon={ eye } /> }
 				count={ counts?.views ?? null }
 				previousCount={ previousCounts?.views ?? null }
 				showValueTooltip={ showValueTooltip }
 				onClick={ onClickViews }
+			/>
+			<CountComparisonCard
+				heading={ translate( 'Visitors' ) }
+				icon={ <Icon icon={ people } /> }
+				count={ counts?.visitors ?? null }
+				previousCount={ previousCounts?.visitors ?? null }
+				showValueTooltip={ showValueTooltip }
+				onClick={ onClickVisitors }
 			/>
 			<CountComparisonCard
 				heading={ translate( 'Likes' ) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/red-team/issues/78

## Proposed Changes

* Reorder Views and Visitors cards in weekly highlights.
* Places Views in first place to follow the same logic as the chart below, and module in My Jetpack.

## Why are these changes being made?

* To fix the inconsistency between all Stats modules.
* More details here: p1HpG7-tde-p2

## Testing Instructions

* Fire up this PR.
* Open the Stats page for any site with JP Stats.
* Ensure the “Views” block comes first in the highlights.

## Screenshots

Before | After
--|--
<img width="1194" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/bae4de1d-fd9a-4773-a81c-09ccc97c44e1"> | <img width="1188" alt="image" src="https://github.com/Automattic/wp-calypso/assets/390760/5771dd6d-a4e4-4f1f-af4d-3b97faae2b38">