### PR TITLE
Simplify the Design object

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -3,7 +3,6 @@ import type { Design } from '@automattic/design-picker';
 export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
 	slug: 'hey',
 	title: 'Hey',
-	is_premium: false,
 	categories: [],
 	theme: 'hey',
 	design_tier: null,

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -6,6 +6,7 @@ import {
 } from '@automattic/design-picker';
 import { getVariationTitle, getVariationType } from '@automattic/global-styles';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
+import { THEME_TIER_PREMIUM } from 'calypso/components/theme-tier/constants';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
@@ -113,7 +114,7 @@ export function getDesignEventProps( {
 		theme_style: design.recipe?.stylesheet + variationSlugSuffix,
 		design_type: design.design_type,
 		...( design?.design_tier && { design_tier: design.design_tier } ),
-		is_premium: design.is_premium,
+		is_premium: design?.design_tier === THEME_TIER_PREMIUM,
 		is_externally_managed: design?.is_externally_managed,
 		is_bundled_with_woo: design?.is_bundled_with_woo,
 		has_style_variations: ( design.style_variations || [] ).length > 0,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -37,7 +37,11 @@ import { useQueryTheme } from 'calypso/components/data/query-theme';
 import { useQueryThemes } from 'calypso/components/data/query-themes';
 import FormattedHeader from 'calypso/components/formatted-header';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
-import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
+import {
+	THEME_TIERS,
+	THEME_TIER_PARTNER,
+	THEME_TIER_PREMIUM,
+} from 'calypso/components/theme-tier/constants';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
 import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
@@ -173,8 +177,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				.filter(
 					( design ) =>
 						! (
-							design.is_premium ||
-							design.is_externally_managed ||
+							design?.design_tier === THEME_TIER_PREMIUM ||
+							design?.design_tier === THEME_TIER_PARTNER ||
 							( design.software_sets && design.software_sets.length > 0 )
 						)
 				)
@@ -422,7 +426,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const isLockedTheme =
 		! canSiteActivateTheme ||
-		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||
+		( selectedDesign?.design_tier === THEME_TIER_PREMIUM &&
+			! isPremiumThemeAvailable &&
+			! didPurchaseSelectedTheme ) ||
 		( selectedDesign?.is_externally_managed &&
 			( ! isMarketplaceThemeSubscribed || ! isExternallyManagedThemeAvailable ) ) ||
 		( ! isPluginBundleEligible && isBundled );
@@ -833,7 +839,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					placeholder={ null }
 					previewUrl={ previewUrl }
 					splitDefaultVariation={
-						! selectedDesign.is_premium &&
+						! ( selectedDesign?.design_tier === THEME_TIER_PREMIUM ) &&
 						! isBundled &&
 						! isPremiumThemeAvailable &&
 						! didPurchaseSelectedTheme &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -38,7 +38,6 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 		setSelectedDesign( {
 			slug: 'videomaker',
 			theme: slug,
-			is_premium: ! config.isEnabled( 'videomaker-trial' ),
 			title: 'Videomaker',
 			categories: [],
 		} );

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -56,7 +56,7 @@ export const hasPaidDesign = ( state: State ): boolean => {
 	if ( ! state.selectedDesign ) {
 		return false;
 	}
-	return state.selectedDesign.is_premium;
+	return state.selectedDesign?.design_tier !== 'free';
 };
 export const hasPaidDomain = ( state: State ): boolean => {
 	if ( ! state.domain ) {

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -433,7 +433,6 @@ describe( 'Site Actions', () => {
 			template: 'zoologist',
 			theme: 'zoologist',
 			categories: [ { slug: 'featured', name: 'Featured' } ],
-			is_premium: false,
 			features: [],
 			recipe: mockedRecipe,
 		};

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -114,7 +114,7 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		is_bundled_with_woo,
 		price,
 		software_sets,
-		design_type: design_type ?? ( theme_tier?.slug === 'premium' ? 'premium' : 'standard' ),
+		design_type: design_type ?? ( theme_tier?.slug === 'free' ? 'standard' : 'premium' ),
 		style_variations,
 		is_virtual: design.is_virtual && !! design.recipe?.pattern_ids?.length,
 		...( preview_data && { preview_data } ),

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -98,8 +98,6 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		screenshot,
 		theme_tier,
 	} = design;
-	const is_premium =
-		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
 
 	const is_externally_managed = design.theme_type === 'managed-external';
 	const is_bundled_with_woo = ( design.software_sets || [] ).some(
@@ -112,12 +110,11 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		description,
 		recipe,
 		categories,
-		is_premium,
 		is_externally_managed,
 		is_bundled_with_woo,
 		price,
 		software_sets,
-		design_type: design_type ?? ( is_premium ? 'premium' : 'standard' ),
+		design_type: design_type ?? ( theme_tier?.slug === 'premium' ? 'premium' : 'standard' ),
 		style_variations,
 		is_virtual: design.is_virtual && !! design.recipe?.pattern_ids?.length,
 		...( preview_data && { preview_data } ),

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -91,13 +91,15 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const blankCanvasTitle = __( 'Blank Canvas', __i18n_text_domain__ );
 	const designTitle = isBlankCanvas ? blankCanvasTitle : defaultTitle;
 
-	const badgeType = design.is_premium ? 'premium' : 'none';
+	const isPremiumDesign = design?.design_tier === 'premium';
+
+	const badgeType = isPremiumDesign ? 'premium' : 'none';
 
 	const badgeContainer = (
 		<BadgeContainer badgeType={ badgeType } isPremiumThemeAvailable={ isPremiumThemeAvailable } />
 	);
 
-	const shouldUpgrade = design.is_premium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
+	const shouldUpgrade = isPremiumDesign && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 
 	function getPricingDescription() {
 		if ( hideDescription ) {
@@ -106,7 +108,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 
 		let text: React.ReactNode = null;
 
-		if ( design.is_premium && shouldUpgrade ) {
+		if ( isPremiumDesign && shouldUpgrade ) {
 			text = (
 				<Button
 					variant="link"
@@ -121,11 +123,11 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						: __( 'Upgrade to Premium' ) }
 				</Button>
 			);
-		} else if ( design.is_premium && ! shouldUpgrade && hasPurchasedTheme ) {
+		} else if ( isPremiumDesign && ! shouldUpgrade && hasPurchasedTheme ) {
 			text = __( 'Purchased on an annual subscription' );
-		} else if ( design.is_premium && ! shouldUpgrade && ! hasPurchasedTheme ) {
+		} else if ( isPremiumDesign && ! shouldUpgrade && ! hasPurchasedTheme ) {
 			text = __( 'Included in your plan' );
-		} else if ( ! design.is_premium ) {
+		} else if ( ! isPremiumDesign ) {
 			text = __( 'Free' );
 		}
 
@@ -136,7 +138,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 		<button
 			className="design-picker__design-option"
 			disabled={ disabled }
-			data-e2e-button={ design.is_premium ? 'paidOption' : 'freeOption' }
+			data-e2e-button={ isPremiumDesign ? 'paidOption' : 'freeOption' }
 			onClick={ () => onSelect( design ) }
 		>
 			{ hasDesignOptionHeader && (
@@ -200,7 +202,7 @@ const DesignButtonCover: React.FC< DesignButtonCoverProps > = ( {
 	onUpgrade,
 } ) => {
 	const { __ } = useI18n();
-	const shouldUpgrade = design.is_premium && ! isPremiumThemeAvailable;
+	const shouldUpgrade = design?.design_tier === 'premium' && ! isPremiumThemeAvailable;
 
 	return (
 		<div className="design-button-cover">

--- a/packages/design-picker/src/components/index.tsx
+++ b/packages/design-picker/src/components/index.tsx
@@ -91,7 +91,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const blankCanvasTitle = __( 'Blank Canvas', __i18n_text_domain__ );
 	const designTitle = isBlankCanvas ? blankCanvasTitle : defaultTitle;
 
-	const isPremiumDesign = design?.design_tier === 'premium';
+	const isPremiumDesign = design?.design_tier !== 'free';
 
 	const badgeType = isPremiumDesign ? 'premium' : 'none';
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -196,7 +196,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	const isDefaultVariation = isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug );
 
 	const isLocked = isLockedStyleVariation( {
-		isPremiumTheme: design.is_premium,
+		isPremiumTheme: design?.design_tier === 'premium',
 		styleVariationSlug: selectedStyleVariation?.slug,
 		shouldLimitGlobalStyles,
 	} );

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -53,20 +53,17 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet, price, theme_tier
 		( { slug }: any ) => slug === 'featured'
 	);
 
-	const is_premium = stylesheet && stylesheet.startsWith( 'premium/' );
-
 	return {
 		slug: id,
 		title: name,
 		recipe: {
 			stylesheet,
 		},
-		is_premium,
 		categories: taxonomies?.theme_subject ?? [],
 		is_featured_picks: isFeaturedPicks,
 		showFirst: isFeaturedPicks,
 		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
-		design_type: is_premium ? 'premium' : 'standard',
+		design_type: theme_tier?.slug === 'premium' ? 'premium' : 'standard',
 		design_tier: theme_tier?.slug,
 		price,
 

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -63,7 +63,7 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet, price, theme_tier
 		is_featured_picks: isFeaturedPicks,
 		showFirst: isFeaturedPicks,
 		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
-		design_type: theme_tier?.slug === 'premium' ? 'premium' : 'standard',
+		design_type: theme_tier?.slug === 'free' ? 'standard' : 'premium',
 		design_tier: theme_tier?.slug,
 		price,
 

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -86,7 +86,6 @@ export interface Design {
 	title: string;
 	description?: string;
 	recipe?: DesignRecipe;
-	is_premium: boolean;
 	is_externally_managed?: boolean;
 	is_bundled_with_woo?: boolean;
 	categories: Category[];

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -69,7 +69,7 @@ export interface SoftwareSet {
  */
 export type DesignType =
 	| 'vertical'
-	| 'premium'
+	| 'premium' // The design is non-free, Design.design_tier will have more nuance.
 	| 'standard' // The design is free.
 	| 'default' // The default design and it means user skipped the step and didn't select any design.
 	| 'anchor-fm'

--- a/packages/design-picker/src/utils/__tests__/index.test.ts
+++ b/packages/design-picker/src/utils/__tests__/index.test.ts
@@ -15,7 +15,6 @@ const testDesign: Design = {
 		base: 'Cabin',
 	},
 	categories: [ { slug: 'featured', name: 'Featured' } ],
-	is_premium: false,
 	features: [],
 };
 

--- a/packages/design-picker/src/utils/__tests__/is-blank-canvas-design.ts
+++ b/packages/design-picker/src/utils/__tests__/is-blank-canvas-design.ts
@@ -13,7 +13,6 @@ describe( 'Design Picker blank canvas utils', () => {
 				template: 'mock-blank-canvas-design-template',
 				theme: 'mock-blank-canvas-design-theme',
 				categories: [ { slug: 'featured', name: 'Featured' } ],
-				is_premium: false,
 				features: [],
 			};
 			expect( isBlankCanvasDesign( mockDesign ) ).toBeTruthy();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6349

## Proposed Changes

Remove the `is_premium` prop from the Design (and related) types. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It's unnecessary as it can be calculated from the theme's `design_type` property, and using that will force people to be more intentional about whether they mean free, paid, premium tier etc.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Standard onboarding flow

Go through the standard onboarding flow, pay careful attention to where you see differences between free and premium themes, for example whether global styles are displayed 'split' or together.

It should work the same as in production

### DIFM flow

This should work the same as in production.

1. Go to /start
2. Once you reach the goals screen use "let us build your site in four days"
3. Continue until the design picker screen, and test that it works the same as in production.

### Videomaker

Go through the [videomaker flow](https://wordpress.com/setup/videopress/intro?from=vpcom), ensure that it works identically to production. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
