### PR TITLE
Disable refs to jetpackedgephp74 and jetpackedge82 pending rename

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -359,7 +359,8 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 }
 
 fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String ): BuildType {
-	val atomicVariations = listOf("default", "php-old", "php-new", "wp-beta", "wp-previous", "private", "ecomm-plan")
+	// Temporarily removed php-old and php-new from this list pending rename of the blogs. See p1720019588866209-slack-C05Q5HSS013.
+	val atomicVariations = listOf("default", "wp-beta", "wp-previous", "private", "ecomm-plan")
 
 	return BuildType({
 		id("WPComTests_jetpack_atomic_deployment_e2e_$targetDevice")

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -240,8 +240,9 @@ class EnvVariables implements SupportedEnvVariables {
 function getAtomicVariationInMixedRun() {
 	const allVariations: AtomicVariation[] = [
 		'default',
-		'php-old',
-		'php-new',
+		// Disable pending rename of the blogs. p1720019588866209-slack-C05Q5HSS013
+		//'php-old',
+		//'php-new',
 		'wp-beta',
 		'wp-previous',
 		'private',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Disable references to places where jetpackedgephp74 and jetpackedgephp82 sites are used in CI.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're planning to rename these sites to jetpackedgephpold and jetpackedgephpnew to better reflect their purpose. To avoid potential disruption, though, we have to comment out the references to the old names while we're doing that.

Here we don't bother to remove the refs from parameter validation and configurations, just the places where it's actually used by CI.

See p1720019588866209-slack-C05Q5HSS013 for details.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Merge and observe

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
