### PR TITLE
Stepper: Update `link-in-bio-tld` flow to use the new login strategy

### DIFF
--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -1,6 +1,4 @@
-import { type UserSelect } from '@automattic/data-stores';
 import { LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
@@ -13,8 +11,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
-import { USER_STORE } from '../stores';
-import { useLoginUrl } from '../utils/path';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import CreateSite from './internals/steps-repository/create-site';
 import DesignCarousel from './internals/steps-repository/design-carousel';
@@ -32,7 +29,8 @@ const linkInBio: Flow = {
 	},
 	isSignupFlow: true,
 	useSteps() {
-		return [
+		//TODO: Use steps from steps.ts and in its async version.
+		return stepsWithRequiredLogin( [
 			{ slug: 'domains', component: DomainsStep },
 			{ slug: 'patterns', component: DesignCarousel },
 			{ slug: 'linkInBioSetup', component: LinkInBioSetup },
@@ -40,25 +38,14 @@ const linkInBio: Flow = {
 			{ slug: 'createSite', component: CreateSite },
 			{ slug: 'processing', component: Processing },
 			{ slug: 'launchpad', component: LaunchPad },
-		];
+		] );
 	},
 
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
-
 		triggerGuidesForStep( flowName, _currentStepSlug );
-
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: `/setup/${ flowName }/patterns`,
-			pageTitle: translate( 'Link in Bio' ),
-		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
@@ -67,11 +54,7 @@ const linkInBio: Flow = {
 				case 'domains':
 					clearSignupDestinationCookie();
 
-					if ( userIsLoggedIn ) {
-						return navigate( 'patterns' );
-					}
-
-					return window.location.assign( logInUrl );
+					return navigate( 'patterns' );
 
 				case 'patterns':
 					return navigate( 'linkInBioSetup' );


### PR DESCRIPTION
Part of #92291

## Proposed Changes
* Replace all code related to managing the login to use stepsWithRequiredLogin 

## Why are these changes being made?
As explained on #92291 we are updating all flows to use the new stepper login capabilities.
This flow is the first one we are migrating that requires custom parameters when we redirect the user to the login flow.

## Testing Instructions
Flow: `/setup/link-in-bio-tld`
Scenario 1: Redirect to the login page
- Open a new browser where you don't have a WordPress.com session
- Try to access the flow or any of the flow steps (E.g `setup/link-in-bio-tld/domains`)
- Please ensure you have been redirected to the login page.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
