### PR TITLE
Fix Help Center watching script

### DIFF
--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -23,8 +23,8 @@
 	"scripts": {
 		"clean": "rm -rf dist",
 		"teamcity:build-app": "yarn run build",
-		"build": "NODE_ENV=production yarn dev",
-		"build:app": "calypso-build && yarn run translate",
+		"build": "NODE_ENV=production yarn dev && yarn run translate",
+		"build:app": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/help-center",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",

--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -6,6 +6,8 @@ const CopyPlugin = require( 'copy-webpack-plugin' );
 const webpack = require( 'webpack' );
 const GenerateChunksMapPlugin = require( '../../build-tools/webpack/generate-chunks-map-plugin' );
 
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
 /* Arguments to this function replicate webpack's so this config can be used on the command line,
  * with individual options overridden by command line args.
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
@@ -24,7 +26,7 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 
 	return {
 		...webpackConfig,
-		mode: 'production',
+		mode: isDevelopment ? 'development' : 'production',
 		entry: {
 			'help-center-gutenberg': path.join( __dirname, 'help-center-gutenberg.js' ),
 			'help-center-wp-admin': path.join( __dirname, 'help-center-wp-admin.js' ),


### PR DESCRIPTION
This fixes running `yarn dev --sync` in `apps/help-center`. It now actually watches.