### PR TITLE
Migration: Redirect to /setup/migration-signup

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -249,9 +249,8 @@ export function generateFlows( {
 		},
 		{
 			name: 'import',
-			steps: [ userSocialStep, 'domains', 'plans-import' ],
-			destination: ( dependencies ) =>
-				`/setup/import-focused/import?siteSlug=${ dependencies.siteSlug }`,
+			steps: [ userSocialStep ],
+			destination: () => `/setup/migration-signup`,
 			description: 'Beginning of the flow to import content',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Make `/start/import` redirect to `/setup/migration-signup`. In this PR I leave only one step in the signup flow and that is the user social login step. While this is not ideal, it's a good compromise since this endpoint receives basically no traffic (see Slack link below). If I removed all the steps it failed and it isn't worth it to try to fix the old signup Framework.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It was brought up in this Slack thread: p1719998717675159-slack-C0347E545HR that following `/start/import` led you to the old migration flow. Since we are moving away from it, I've created this PR to point it to `/setup/migration-signup`.

We shouldn't turn off this endpoint since it's still referenced from our support docs: https://github.com/Automattic/en.support-docs-content/issues/2756.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or navigate to the calypso.live link in the comments
* Go to `/start/import`
* You should see the social login step
* Click the CTA
* Verify you end up in `/setup/migration-signup`
* Enter a site URL and see that the next step is the plan step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?