### PR TITLE
Frictionless Email Subscriptions: Add new query params to subscribe email flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -49,7 +49,14 @@ const getEmailSubscriptionFlow = () => {
 						'Signup flow that subscripes user to guides appointments for email campaigns',
 					lastModified: '2024-06-17',
 					showRecaptcha: true,
-					providesDependenciesInQuery: [ 'user_email', 'redirect_to', 'mailing_list', 'from' ],
+					providesDependenciesInQuery: [
+						'user_email',
+						'redirect_to',
+						'mailing_list',
+						'from',
+						'first_name',
+						'last_name',
+					],
 					hideProgressIndicator: true,
 				},
 		  ]

--- a/client/signup/hooks/use-subscribe-to-mailing-list.ts
+++ b/client/signup/hooks/use-subscribe-to-mailing-list.ts
@@ -8,6 +8,9 @@ interface APIResponse {
 
 interface SubscribeToMailingListParams {
 	email_address: string;
+	first_name: string;
+	from: string;
+	last_name: string;
 	mailing_list_category: string;
 }
 

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -66,7 +66,7 @@ function SubscribeEmailStep( props ) {
 		} );
 
 	const handleSubscribeToMailingList = useCallback(
-		( { email_address = email } ) => {
+		( { email_address } = { email_address: email } ) => {
 			subscribeToMailingList( {
 				email_address,
 				mailing_list_category: queryArguments.mailing_list,

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useEffect } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import DOMPurify from 'dompurify';
 import emailValidator from 'email-validator';
@@ -27,7 +27,7 @@ function sanitizeEmail( email ) {
 	return DOMPurify.sanitize( email ).trim();
 }
 
-function sanitizeRedirectUrl( redirect ) {
+function getRedirectUrl( redirect ) {
 	const isHttpOrHttps =
 		!! redirect && ( redirect.startsWith( 'https://' ) || redirect.startsWith( 'http://' ) );
 	const redirectUrl = isHttpOrHttps
@@ -48,7 +48,7 @@ function SubscribeEmailStep( props ) {
 
 	const email = sanitizeEmail( queryArguments.user_email );
 
-	const redirectUrl = sanitizeRedirectUrl( queryArguments.redirect_to );
+	const redirectUrl = getRedirectUrl( queryArguments.redirect_to );
 
 	const redirectToAfterLoginUrl = currentUser
 		? addQueryArgs( window.location.href, { user_email: currentUser?.email } )
@@ -65,44 +65,60 @@ function SubscribeEmailStep( props ) {
 			},
 		} );
 
+	const handleSubscribeToMailingList = useCallback(
+		( { email_address = email } ) => {
+			subscribeToMailingList( {
+				email_address,
+				mailing_list_category: queryArguments.mailing_list,
+				from: queryArguments.from,
+				first_name: queryArguments.first_name,
+				last_name: queryArguments.last_name,
+			} );
+		},
+		[
+			email,
+			queryArguments.first_name,
+			queryArguments.from,
+			queryArguments.last_name,
+			queryArguments.mailing_list,
+			subscribeToMailingList,
+		]
+	);
+
+	const handlerecordRegistration = useCallback(
+		( userData ) => {
+			recordRegistration( {
+				userData,
+				flow: flowName,
+				type: 'passwordless',
+			} );
+		},
+		[ flowName ]
+	);
+
 	const { mutate: createNewAccount, isPending: isCreateNewAccountPending } =
 		useCreateNewAccountMutation( {
 			onSuccess: ( response ) => {
-				const username =
-					( response && response.signup_sandbox_username ) || ( response && response.username );
+				const userData = {
+					ID: ( response && response.signup_sandbox_user_id ) || ( response && response.user_id ),
+					username:
+						( response && response.signup_sandbox_username ) || ( response && response.username ),
+					email,
+				};
 
-				const userId =
-					( response && response.signup_sandbox_user_id ) || ( response && response.user_id );
-
-				recordRegistration( {
-					userData: {
-						ID: userId,
-						username: username,
-						email,
-					},
-					flow: flowName,
-					type: 'passwordless',
-				} );
-
-				subscribeToMailingList( {
-					email_address: email,
-					mailing_list_category: queryArguments.mailing_list,
-					from: queryArguments.from,
-				} );
+				handlerecordRegistration( userData );
+				handleSubscribeToMailingList();
 			},
 			onError: ( error ) => {
 				if ( isExistingAccountError( error.error ) ) {
-					subscribeToMailingList( {
-						email_address: email,
-						mailing_list_category: queryArguments.mailing_list,
-						from: queryArguments.from,
-					} );
+					handleSubscribeToMailingList();
 				}
 			},
 		} );
 
 	useEffect( () => {
-		if ( emailValidator.validate( email ) && ! currentUser ) {
+		// 1. User is not logged in and the email submitted to the flow is valid
+		if ( ! currentUser && emailValidator.validate( email ) ) {
 			createNewAccount( {
 				userData: {
 					email,
@@ -112,22 +128,11 @@ function SubscribeEmailStep( props ) {
 			} );
 		}
 
+		// 2. User is logged in and their email matches the email submitted to the flow
 		if ( currentUser?.email === email ) {
-			subscribeToMailingList( {
-				email_address: email,
-				mailing_list_category: queryArguments.mailing_list,
-				from: queryArguments.from,
-			} );
+			handleSubscribeToMailingList();
 		}
-	}, [
-		createNewAccount,
-		currentUser,
-		email,
-		flowName,
-		queryArguments.from,
-		queryArguments.mailing_list,
-		subscribeToMailingList,
-	] );
+	}, [ createNewAccount, currentUser, email, flowName, handleSubscribeToMailingList ] );
 
 	return (
 		<div className="subscribe-email">
@@ -148,25 +153,12 @@ function SubscribeEmailStep( props ) {
 						subscribeToMailingList={ subscribeToMailingList }
 						handleCreateAccountError={ ( error, submittedEmail ) => {
 							if ( isExistingAccountError( error.error ) ) {
-								subscribeToMailingList( {
-									email_address: submittedEmail,
-									mailing_list_category: queryArguments.mailing_list,
-									from: queryArguments.from,
-								} );
+								handleSubscribeToMailingList( { email_address: submittedEmail } );
 							}
 						} }
 						handleCreateAccountSuccess={ ( userData ) => {
-							recordRegistration( {
-								userData,
-								flow: flowName,
-								type: 'passwordless',
-							} );
-
-							subscribeToMailingList( {
-								email_address: userData.email,
-								mailing_list_category: queryArguments.mailing_list,
-								from: queryArguments.from,
-							} );
+							handlerecordRegistration( userData );
+							handleSubscribeToMailingList( { email_address: userData.email } );
 						} }
 					/>
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3126

## Proposed Changes

* Adds `first_name` and `last_name` query params to the subscribe email flow
* Some function renaming ( Ex. `sanitizeRedirectUrl` wasn't actually sanitizing, so we changed the game to `getRedirectUrl` )

<img width="638" alt="Screenshot 2024-07-03 at 11 25 56 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/77e7da55-0d83-4619-881d-dafa21486a6f">

<img width="635" alt="Screenshot 2024-07-03 at 11 26 01 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/12d9bcee-d632-4b95-b149-6a785b008484">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to tailor outbound communication to our users to improve success of our marketing campaigns
* Because of this, we will capture several more key pieces of information about a user when they sign up for an email list

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log into wordpress.com
* With these PR changes, navigate to `/start/email-subscription/subscribe?user_email=test1016@gmail.com&redirect_to=wordpress.com%2Flearn&mailing_list=learn&from=/learn&first_name=Edna&last_name=Mode` in the WordPress staging environment
* Verify that you see the continue as user page
* Verify that clicking continue subscribes the current user to the email subscription ( instead of whatever was originally in the user_email query param ). Also confirm that first_name and last_name params are included in the pigeon request. You can confirm this through the dev network console searching for `/pigeon`
* Verify that clicking on "another account" logs out the current user and subscribes the original user_email query param to `/pigeon`. Also confirm that the first_name and last_name params are included in the pigeon request.
* As a logged out user revisit the email-subscription flow by submitting both an existing email and a non-existant email in the `user_email` url query params. Confirm that the `/pigeon` request is made with the `first_name` and `last_name` params and that the user is redirected to the `redirect_to` url query param.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
