### PR TITLE
Stepper: Update `hundred-year-plan`  flow to use the new login strategy 

### DIFF
--- a/client/landing/stepper/declarative-flow/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-plan.ts
@@ -2,7 +2,6 @@ import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
 import { UserSelect } from '@automattic/data-stores';
 import { HUNDRED_YEAR_PLAN_FLOW, addProductsToCart } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import {
 	clearSignupDestinationCookie,
@@ -11,15 +10,16 @@ import {
 } from 'calypso/signup/storageUtils';
 import { SiteId, SiteSlug } from 'calypso/types';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
-import { useLoginUrl } from '../utils/path';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { ProvidedDependencies, Flow } from './internals/types';
 
 const HundredYearPlanFlow: Flow = {
 	name: HUNDRED_YEAR_PLAN_FLOW,
 	get title() {
-		return translate( '100-year Plan' );
+		return ( getPlan( PLAN_100_YEARS )?.getTitle() || '' ) as string;
 	},
+
 	isSignupFlow: true,
 	useSteps() {
 		const currentUser = useSelect(
@@ -28,7 +28,7 @@ const HundredYearPlanFlow: Flow = {
 		);
 
 		if ( currentUser?.site_count ) {
-			return [
+			return stepsWithRequiredLogin( [
 				{
 					slug: 'new-or-existing-site',
 					asyncComponent: () => import( './internals/steps-repository/new-or-existing-site' ),
@@ -55,10 +55,10 @@ const HundredYearPlanFlow: Flow = {
 					slug: 'createSite',
 					asyncComponent: () => import( './internals/steps-repository/create-site' ),
 				},
-			];
+			] );
 		}
 
-		return [
+		return stepsWithRequiredLogin( [
 			{
 				slug: 'setup',
 				asyncComponent: () => import( './internals/steps-repository/hundred-year-plan-setup' ),
@@ -76,7 +76,7 @@ const HundredYearPlanFlow: Flow = {
 				slug: 'createSite',
 				asyncComponent: () => import( './internals/steps-repository/create-site' ),
 			},
-		];
+		] );
 	},
 	useSideEffect() {
 		useEffect( () => {
@@ -85,22 +85,7 @@ const HundredYearPlanFlow: Flow = {
 	},
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
 		const { setPlanCartItem, setPendingAction } = useDispatch( ONBOARD_STORE );
-
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: `/setup/${ flowName }/setup`,
-			pageTitle: ( getPlan( PLAN_100_YEARS )?.getTitle() || '' ) as string,
-		} );
-
-		// Send non-logged-in users to account screen.
-		if ( ! userIsLoggedIn ) {
-			window.location.assign( logInUrl );
-		}
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );


### PR DESCRIPTION
Part of #92291

## Proposed Changes
* Replace all code related to managing the login to use stepsWithRequiredLogin 

## Why are these changes being made?
As explained on #92291 we are updating all flows to use the new stepper login capabilities.
This flow is the first one we are migrating that requires custom parameters when we redirect the user to the login flow.

## Testing Instructions
Flow: `/setup/hundred-year-plan/`
Scenario 1: Redirect to the login page
- Open a new browser where you don't have a WordPress.com session
- Try to access the flow or any of the flow steps (E.g `setup/hundred-year-plan/setup`)
- Please ensure you have been redirected to the login page.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
