### PR TITLE
A4A-Partner Directory: Step 1 is always check when it should display the initial state

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
@@ -42,7 +42,7 @@ export function useFormSelectors() {
 	};
 
 	const availableProducts: Record< string, string > = {
-		wordpress: 'WordPress.com',
+		wordpress_com: 'WordPress.com',
 		woocommerce: 'WooCommerce',
 		jetpack: 'Jetpack',
 		wordpress_vip: 'WordPress VIP',

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -59,7 +59,7 @@ const PartnerDirectoryDashboard = () => {
 		}
 	}, [ agency ] );
 
-	const applicationWasSubmitted = applicationData?.status !== 'completed';
+	const applicationWasSubmitted = applicationData ? applicationData.status !== 'completed' : false;
 
 	const agencyDetailsData = useMemo( () => mapAgencyDetailsFormData( agency ), [ agency ] );
 


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/750
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/741

## Proposed Changes

This PR fixes an issue with the initial Step in the application process. If you don't have an application, you have to see the initial state:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/00cf12ff-9baf-403c-a1b1-608816cc4e56)

Before, with a fresh application, an agency without an application, you saw Step 1 checked:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/39bcbf9d-8f44-4f31-93aa-7fadbd7d7500)

Also, this PR update the WordPress.com product slug to `wordpress_com`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- With an agency without an existing application, go to the `partner-directory/dashboard` and you will see the initial state.
**Note:** If you have an agency, you can reset your application executing this in your sandbox: `update_blog_option( your_agency_id, 'agency_profile_partner_directory_application', null );`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
