### PR TITLE
Stepper: Update `newsletter` flow to use the new login strategy

### DIFF
--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,6 +1,6 @@
-import { updateLaunchpadSettings, type UserSelect } from '@automattic/data-stores';
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { NEWSLETTER_FLOW } from '@automattic/onboarding';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -15,8 +15,8 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
-import { ONBOARD_STORE, USER_STORE } from '../stores';
-import { useLoginUrl } from '../utils/path';
+import { ONBOARD_STORE } from '../stores';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
@@ -31,13 +31,15 @@ const newsletter: Flow = {
 		const query = useQuery();
 		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
 
-		return [
-			// Load intro step component only when not coming from the marketing page
+		const publicSteps = [
 			...( ! isComingFromMarketingPage
 				? [
 						{ slug: 'intro', asyncComponent: () => import( './internals/steps-repository/intro' ) },
 				  ]
 				: [] ),
+		];
+
+		const privateSteps = stepsWithRequiredLogin( [
 			{
 				slug: 'newsletterSetup',
 				asyncComponent: () => import( './internals/steps-repository/newsletter-setup' ),
@@ -64,7 +66,9 @@ const newsletter: Flow = {
 				slug: 'launchpad',
 				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
 			},
-		];
+		] );
+
+		return [ ...publicSteps, ...privateSteps ];
 	},
 	useSideEffect() {
 		const { setHidePlansFeatureComparison } = useDispatch( ONBOARD_STORE );
@@ -75,22 +79,10 @@ const newsletter: Flow = {
 	},
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
 		const query = useQuery();
 		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
-		const isLoadingIntroScreen =
-			! isComingFromMarketingPage && ( 'intro' === _currentStep || undefined === _currentStep );
-
-		const logInUrl = useLoginUrl( {
-			variationName: flowName,
-			redirectTo: `/setup/${ flowName }/newsletterSetup`,
-			pageTitle: translate( 'Newsletter' ),
-		} );
 
 		const completeSubscribersTask = async () => {
 			if ( siteSlug ) {
@@ -100,11 +92,6 @@ const newsletter: Flow = {
 			}
 		};
 
-		// Unless showing intro step, send non-logged-in users to account screen.
-		if ( ! isLoadingIntroScreen && ! userIsLoggedIn ) {
-			window.location.assign( logInUrl );
-		}
-
 		triggerGuidesForStep( flowName, _currentStep );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
@@ -113,10 +100,7 @@ const newsletter: Flow = {
 
 			switch ( _currentStep ) {
 				case 'intro':
-					if ( userIsLoggedIn ) {
-						return navigate( 'newsletterSetup' );
-					}
-					return window.location.assign( logInUrl );
+					return navigate( 'newsletterSetup' );
 
 				case 'newsletterSetup':
 					return navigate( 'newsletterGoals' );


### PR DESCRIPTION
Part of #92291

## Proposed Changes
* Replace all code related to managing the login to use stepsWithRequiredLogin.

## Why are these changes being made?
As explained on #92291 we are updating all flows to use the new stepper login capabilities.
This flow is the first one we are migrating that requires custom parameters when we redirect the user to the login flow.

## Testing Instructions
Flow: `/setup/newsletter`
Scenario 1: Redirect to the login page
- Open a new browser where you don't have a WordPress.com session
- Try to access the flow 
- Check the intro step doesn't require login
- Click on `Launch my newsletter`
- Check the next step requires login.


The login step is public and only available if the `ref=newsletter-lp` is NOT set. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
