### PR TITLE
Show sites without title on plugins schedule updates

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form-sites.tsx
@@ -83,25 +83,28 @@ export const ScheduleFormSites = ( props: Props ) => {
 				<div className="checkbox-options-container checkbox-options-container__sites">
 					{ sites.map( ( site ) => (
 						<Fragment key={ site.ID }>
-							{ site?.name &&
-								( site.name.toLowerCase().includes( searchTerm.toLowerCase() ) ||
-									site.slug.toLowerCase().includes( searchTerm.toLowerCase() ) ) && (
-									<div>
-										<CheckboxControl
-											key={ site.ID }
-											onChange={ ( isChecked ) => {
-												onSiteSelectionChange( site, isChecked );
-												setFieldTouched( true );
-											} }
-											checked={ selectedSites.includes( site.ID ) }
-										/>
-										<label htmlFor={ `${ site.ID }` }>
-											{ site.name }
-											<br />
-											<span className="site-slug">{ site.slug }</span>
-										</label>
-									</div>
-								) }
+							{ ( ( site?.name && site.name.toLowerCase().includes( searchTerm.toLowerCase() ) ) ||
+								site.slug.toLowerCase().includes( searchTerm.toLowerCase() ) ) && (
+								<div>
+									<CheckboxControl
+										key={ site.ID }
+										onChange={ ( isChecked ) => {
+											onSiteSelectionChange( site, isChecked );
+											setFieldTouched( true );
+										} }
+										checked={ selectedSites.includes( site.ID ) }
+									/>
+									<label htmlFor={ `${ site.ID }` }>
+										{ site?.name && (
+											<>
+												{ site.name }
+												<br />
+											</>
+										) }
+										<span className="site-slug">{ site.slug }</span>
+									</label>
+								</div>
+							) }
 						</Fragment>
 					) ) }
 				</div>


### PR DESCRIPTION
Related to p1720034769031379/1720032258.941659-slack-C06DN6QQVAQ

## Proposed Changes

Sites without title was not showing on Global Plugins Schedule Updates.

| Before | After |
| --- | --- |
| No title: ![image](https://github.com/Automattic/wp-calypso/assets/402286/15439400-7c12-4f18-a904-53e796168cba) | No title: ![image](https://github.com/Automattic/wp-calypso/assets/402286/3ed73368-62b8-4633-b326-4d1322fca527) |
| Title: ![image](https://github.com/Automattic/wp-calypso/assets/402286/e35e9aa8-b62f-43b6-bcc3-89d888cf0c77) | Title: ![image](https://github.com/Automattic/wp-calypso/assets/402286/337c029d-6bf5-4339-a4b3-cd67c1302889) |




## Why are these changes being made?
Missing sites to schedule updates

## Testing Instructions

* Clean an Atomic site title
* Go to `/plugins/scheduled-updates/create`
* Check if the site without title is showing.
