### PR TITLE
Frictionless Email Subscriptions: Handle relative urls for redirect_to url query param

### DIFF
--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -28,13 +28,25 @@ function sanitizeEmail( email ) {
 }
 
 function getRedirectUrl( redirect ) {
-	const isHttpOrHttps =
-		!! redirect && ( redirect.startsWith( 'https://' ) || redirect.startsWith( 'http://' ) );
-	const redirectUrl = isHttpOrHttps
-		? addQueryArgs( redirect, { subscribed: true } )
-		: addQueryArgs( 'https://' + redirect, { subscribed: true } );
+	const baseUrl = 'https://wordpress.com/';
 
-	return isRedirectAllowed( redirectUrl ) ? redirectUrl : 'https://wordpress.com/';
+	if ( typeof redirect !== 'string' ) {
+		return baseUrl;
+	}
+
+	if ( redirect.startsWith( '/' ) ) {
+		redirect = 'https://wordpress.com' + redirect;
+	}
+
+	if (
+		! redirect.startsWith( 'https://' ) &&
+		! redirect.startsWith( 'http://' ) &&
+		! redirect.startsWith( '/' )
+	) {
+		redirect = 'https://' + redirect;
+	}
+
+	return isRedirectAllowed( redirect ) ? addQueryArgs( redirect, { subscribed: true } ) : baseUrl;
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3135

## Proposed Changes

* Handle relative paths for `redirect_to` query param of subscribe email flow ( assume wordpress.com is the intended base url )

![2024-07-03 13 22 53](https://github.com/Automattic/wp-calypso/assets/5414230/8edfbc65-f55c-484f-9a25-c34f17bd400d)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Currently, if a relative path is provided in the redirect_to query param for the subscribe email flow, the view will redirect to wordpress.com instead of to the relative path. We will assume that the user intends to have a base url of `wordpress.com`, so `redirect_to=/learn` should redirect to `wordpress.com/learn`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Log into wordpress.com
- With these PR changes, navigate to `/start/email-subscription/subscribe?user_email=test1016@gmail.com&redirect_to=/learn&mailing_list=learn&from=/learn&first_name=Edna&last_name=Mode` in the WordPress staging environment ( note the relative `redirect_to` path `/learn`
- Verify that you see the continue as user page
- Verify that clicking continue subscribes the current user to the email subscription. Also confirm that the user is redirected to wordpress.com/learn
- Verify that clicking on "another account" logs out the current user and subscribes the original user_email query param to /pigeon. Also confirm that the user is redirected to wordpress.com/learn
- As a logged out user revisit the email-subscription flow by submitting both an existing email and a non-existent email in the user_email url query params. Confirm that the user is redirected to wordpress.com/learn once user is subscribed to mailing list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
