### PR TITLE
Help Center: fix overflow when minimized

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -125,6 +125,10 @@ $head-foot-height: 50px;
 				.help-center__container-header {
 					cursor: pointer;
 				}
+
+				.help-center__container-content {
+					display: none;
+				}
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Set the Help Center body content to display none when minimized.

## Why are these changes being made?

Wapuu assistant spills out the bottom of the help center when minimized.

## Testing Instructions

1. Open Calypso Live
2. Open Help Center
3. Test different minimized pages of the Help Center etc articles, contact form, and most importantly Wapuu

| Before | After |
| - | - |
| <img width="912" alt="Markup 2024-07-03 at 23 20 52" src="https://github.com/Automattic/wp-calypso/assets/33258733/5b0c3637-bd81-4176-adee-b3dafbdbb5df"> | <img width="970" alt="Markup 2024-07-03 at 23 20 33" src="https://github.com/Automattic/wp-calypso/assets/33258733/5ba2b5eb-036a-47ae-b056-c6253d4bcf4f"> |