### PR TITLE
Added badge option to `FlowCard` component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/index.tsx
@@ -1,5 +1,7 @@
+import { Badge } from '@automattic/components';
 import { Flex, FlexBlock, FlexItem, Card, CardBody, Icon } from '@wordpress/components';
 import { chevronRight } from '@wordpress/icons';
+import type { BadgeType } from '@automattic/components';
 import './style.scss';
 
 interface FlowCardProps {
@@ -8,9 +10,13 @@ interface FlowCardProps {
 	text: string;
 	title: string;
 	disabled?: boolean;
+	badge?: {
+		type: BadgeType;
+		text: string;
+	};
 }
 
-const FlowCard = ( { icon, onClick, text, title, disabled = false }: FlowCardProps ) => {
+const FlowCard = ( { icon, onClick, text, title, disabled = false, badge }: FlowCardProps ) => {
 	return (
 		<Card
 			className="flow-question"
@@ -27,7 +33,10 @@ const FlowCard = ( { icon, onClick, text, title, disabled = false }: FlowCardPro
 						</FlexItem>
 					) }
 					<FlexBlock>
-						<h3 className="flow-question__heading">{ title }</h3>
+						<div className="flow-question__title-wrapper">
+							<h3 className="flow-question__heading">{ title }</h3>
+							{ badge && <Badge type={ badge.type }>{ badge.text }</Badge> }
+						</div>
 						<p className="flow-question__description">{ text }</p>
 					</FlexBlock>
 					<FlexItem>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/index.tsx
@@ -33,10 +33,10 @@ const FlowCard = ( { icon, onClick, text, title, disabled = false, badge }: Flow
 						</FlexItem>
 					) }
 					<FlexBlock>
-						<div className="flow-question__title-wrapper">
-							<h3 className="flow-question__heading">{ title }</h3>
+						<h3 className="flow-question__heading">
+							{ title }
 							{ badge && <Badge type={ badge.type }>{ badge.text }</Badge> }
-						</div>
+						</h3>
 						<p className="flow-question__description">{ text }</p>
 					</FlexBlock>
 					<FlexItem>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
@@ -34,9 +34,14 @@ $blueberry-color: #3858e9;
 		padding: 2px 1px 0 0;
 	}
 
+	.flow-question__title-wrapper {
+		display: flex;
+	}
+
 	.flow-question__heading {
 		font-weight: 500;
 		font-size: $font-body-large;
+		margin-right: 8px;
 	}
 
 	.flow-question__description {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
@@ -34,10 +34,6 @@ $blueberry-color: #3858e9;
 		padding: 2px 1px 0 0;
 	}
 
-	.flow-question__title-wrapper {
-		display: flex;
-	}
-
 	.flow-question__heading {
 		font-weight: 500;
 		font-size: $font-body-large;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/flow-card/style.scss
@@ -37,7 +37,9 @@ $blueberry-color: #3858e9;
 	.flow-question__heading {
 		font-weight: 500;
 		font-size: $font-body-large;
-		margin-right: 8px;
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
 	}
 
 	.flow-question__description {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/92349

## Proposed Changes

* Added a `badge` prop to the `FlowCard` component, allowing us to show a badge next to the title

Ex: `badge` prop:
```
{
   type: 'info-blue',
   text: 'My badge',
}
```
 
![Captura de Tela 2024-07-04 às 11 07 42](https://github.com/Automattic/wp-calypso/assets/1234758/139efc2c-3dfd-440d-9793-573228dd28a9)

If you don't pass a `badge` prop, the card should still render as it currently does:

![image](https://github.com/Automattic/wp-calypso/assets/3801502/f7a505a1-8202-4f12-860d-05e4cb992f15)


## Testing Instructions

* Code inspection
* Currently, the `FlowCard` is used in the newsletter Stepper flow, in the `newsletterGoals` step.
   * Access `/setup/newsletter/newsletterGoals` and check it still works correctly.
* It's being used in a related PR, so it can be seen there: https://github.com/Automattic/wp-calypso/pull/92349
* You can also add a badge to it in your local environment. For example, below is the code I used on the `client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-goals/index.tsx` file:
```
<FlowCard
	icon={ IconFree }
	title={ translate( 'Free newsletter' ) }
	badge={ { type: 'info-blue', text: translate( 'Recommended' ) } }
	text={ translate(
		'Start a newsletter with free content and grow your audience. You can always monetize it later.'
	) }
	onClick={ () => handleSubmit( null ) }
/>
```

