### PR TITLE
A4A: update referral faq footer text

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
@@ -5,15 +5,15 @@ import './style.scss';
 export default function ReferralsFooter() {
 	const translate = useTranslate();
 
-	const tosLink = 'https://automattic.com/for-agencies/platform-agreement/';
+	const link = 'https://automattic.com/for-agencies/program-incentives/';
 
 	return (
 		<div className="referrals-footer">
 			{ translate(
-				"Every 60 days, we'll calculate and pay out your commissions based on your clients’ purchases. Read the {{a}}Terms of Service.{{/a}}",
+				"Every 60 days, we'll calculate and pay out your commissions based on your clients’ purchases. Learn more about {{a}}partner earnings.{{/a}}",
 				{
 					components: {
-						a: <a href={ tosLink } target="_blank" rel="noreferrer" />,
+						a: <a href={ link } target="_blank" rel="noreferrer" />,
 					},
 				}
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/761

## Proposed Changes

Update footer text as requested

<img width="693" alt="Screenshot 2024-07-03 at 2 51 48 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/ff9f140d-0857-48b1-978a-5b6ee949c4f8">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link navigate to `/referrals/faq` and check the footer text

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
