### PR TITLE
Allow translators to localize the date format

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
@@ -104,8 +104,12 @@ export default function BillingSummary() {
 				<span className="billing-summary__label">
 					{ billing.isSuccess && <CostTooltip /> }
 					{ billing.isSuccess &&
-						translate( 'Cost for %(date)s', {
-							args: { date: moment( billing.data.date ).format( 'MMMM, YYYY' ) },
+						/* translators: fullMonth (e.g. "January") and fullYear (e.g. "2024") */
+						translate( 'Cost for %(fullMonth)s, %(fullYear)s', {
+							args: {
+								fullMonth: moment( billing.data.date ).format( 'MMMM' ),
+								fullYear: moment( billing.data.date ).format( 'YYYY' ),
+							},
 						} ) }
 
 					{ ! billing.isSuccess && <br /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#835


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In this PR, I've added the capability for translators to localize date formats.

Previously, I explored browser-based solutions such as [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) and [Date.toLocaleDateString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString).

However, these methods proved inadequate for our needs because their dateStyle options do not support the `MMMM YYYY` format. Both dateStyle: 'medium' and dateStyle: 'long' include the day in the format (e.g., July **3**, 2024), which is not desirable for our use case.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
