### PR TITLE
E2E: Update Revisions editor tests and removing all actions menu item check

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -9,11 +9,6 @@ const selectors = {
 	section: ( name: string ) =>
 		`${ panel } .components-panel__body-title button:has-text("${ name }")`,
 
-	// Actions Button
-	allActionsButton: '.editor-all-actions-button',
-	viewRevisionsModalMenuItem: '.view-revisions-modal-button',
-	viewRevisionsMenuItem: '[role=menuitem]:has-text("View revisions")',
-
 	// Revisions (before 18.4.0)
 	showRevisionButton: '.editor-post-last-revision__panel', // Revision is a link, not a panel.
 
@@ -350,53 +345,15 @@ export class EditorSettingsSidebarComponent {
 		}
 	}
 
-	/* All Actions Dropdown */
-
 	/**
-	 * Opens the All Actions dropdown
+	 * Opens the Revisions modal
+	 * via summary button for Gutenberg 18.7.0
 	 */
-	async openAllActionsDropdown(): Promise< void > {
-		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.allActionsButton );
-		await locator.click();
-	}
-
-	/* Revisions */
-
-	/**
-	 * Clicks on the View Revisions menu itme on the All Actions dropdown
-	 */
-	async showRevisionsViaActionsDropdown(): Promise< void > {
-		// Open the all actions dropdown menu
-		await this.openAllActionsDropdown();
-
-		const menuItem = envVariables.TEST_ON_ATOMIC
-			? selectors.viewRevisionsMenuItem
-			: selectors.viewRevisionsModalMenuItem;
-
-		// Click on the revisions menu item
-		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( menuItem );
-		await locator.click();
-	}
-
-	/**
-	 * Clicks on the Revision button
-	 */
-	async showRevisionsViaButton(): Promise< void > {
+	async showRevisions(): Promise< void > {
 		const editorParent = await this.editor.parent();
 		const locator = editorParent.locator( selectors.showRevisionButton );
 
 		await locator.click();
-	}
-
-	/**
-	 * Opens the Revisions modal
-	 * via button for Gutenberg < 18.6.0
-	 * via actions dropdown for Gutenberg >= 18.6.0
-	 */
-	async showRevisions(): Promise< void > {
-		await Promise.race( [ this.showRevisionsViaActionsDropdown(), this.showRevisionsViaButton() ] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -9,8 +9,8 @@ const selectors = {
 	section: ( name: string ) =>
 		`${ panel } .components-panel__body-title button:has-text("${ name }")`,
 
-	// Revisions (before 18.4.0)
-	showRevisionButton: '.editor-post-last-revision__panel', // Revision is a link, not a panel.
+	// Revisions (after 18.7.0)
+	showRevisionButton: '.editor-private-post-last-revision__button',
 
 	// Status & Visibility
 	visibilityButton: '.edit-post-post-visibility__toggle',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/8039

## Proposed Changes

* On GB v18.7.0 the Revisions menu item was removed, let's update the e2e tests to reflect that
* Update the target class of Revisions link
* This PR undos the tests added on https://github.com/Automattic/wp-calypso/pull/91766

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The revisions menu item has been removed from the Post Actions  https://github.com/WordPress/gutenberg/pull/62443
This Button doesn't exist anymore in GB v18.7.0:

<img width="422" alt="Screenshot 2024-07-03 at 13 42 11" src="https://github.com/Automattic/wp-calypso/assets/779993/d19412c8-6123-4c2a-8073-58be22956f55">

From now on we'll track this button:

![image](https://github.com/Automattic/wp-calypso/assets/779993/4e90034f-b5cf-47b1-859c-6d5c3e35616e)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* E2E tests should pass on production and edge sites.
* Execute: `GUTENBERG_EDGE=true NODE_OPTIONS="--inspect" yarn workspace wp-e2e-tests debug -- specs/editor/editor__revisions.ts`
* Execute: `NODE_OPTIONS="--inspect" yarn workspace wp-e2e-tests debug -- specs/editor/editor__revisions.ts`
* Observe both tests pass locally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
