### PR TITLE
Backup: Do not show in the date picker a backup that is not rewindable

### DIFF
--- a/client/my-sites/backup/status/hooks.js
+++ b/client/my-sites/backup/status/hooks.js
@@ -87,7 +87,7 @@ export const useDatesWithNoSuccessfulBackups = ( siteId, startDate, endDate ) =>
 				// Remove dates from the dates array that have backups
 				// This should leave only dates that have no backups in the array
 				const backupDate = adjustDate( item.activityDate ).format( 'MM-DD-YYYY' );
-				if ( dates.indexOf( backupDate ) > -1 ) {
+				if ( dates.indexOf( backupDate ) > -1 && item.activityIsRewindable ) {
 					dates.splice( dates.indexOf( backupDate ), 1 );
 				}
 			} );

--- a/client/my-sites/backup/status/test/hooks.jsx
+++ b/client/my-sites/backup/status/test/hooks.jsx
@@ -35,7 +35,11 @@ describe( 'useDatesWithNoSuccessfulBackups', () => {
 		useMatchingBackupAttemptsInRange.mockImplementation( () => {
 			return {
 				isLoading: false,
-				backups: [ { activityDate: '2021-12-01' }, { activityDate: '2021-12-04' } ],
+				backups: [
+					{ activityDate: '2021-12-01', activityIsRewindable: true },
+					{ activityDate: '2021-12-04', activityIsRewindable: true },
+					{ activityDate: '2021-12-05', activityIsRewindable: false },
+				],
 			};
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-backup-team/issues/552

## Proposed Changes

* Use `activityIsRewindable` to identify when a backup is usable. Otherwise, the date for a not rewindable backup will be shown as without backups
* 
Example: June 29 doesn't have a rewindable backup

**Before:**
<img width="500" alt="Screenshot 2024-07-04 at 12 42 39" src="https://github.com/Automattic/wp-calypso/assets/2747834/c1f537cf-a89a-4198-abd4-92c18194afa2">

**After:**
<img width="500" alt="Screenshot 2024-07-04 at 12 42 30" src="https://github.com/Automattic/wp-calypso/assets/2747834/4d3d1cda-675d-4716-aa7c-3b773d25ea61">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When a backup was successful in the past but now it was discarded by the "Days of backups saved" configuration, the day in the calendar was still with a dot as a valid backup, making it harder to find valid backups.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Jetpack Cloud link for this PR to verify the dates where there is no a rewindable backup in your sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
