### PR TITLE
ETK Migration: Remove slide width hotfix

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -60,28 +60,6 @@ function is_homepage_title_hidden() {
 }
 
 /**
- * Detects if the site is using Gutenberg 9.2 or above, which contains a bug in the
- * interface package, causing some "slider" blocks (such as Jetpack's Slideshow) to
- * incorrectly calculate their width as 33554400px when set at full width.
- *
- * @see https://github.com/WordPress/gutenberg/pull/26552
- *
- * @return bool True if the site needs a temporary fix for the incorrect slider width.
- */
-function needs_slider_width_workaround() {
-	global $post;
-
-	if (
-		( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE ) ||
-		( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '9.2', '>=' ) )
-	) {
-		// Workaround only needed when in the editor.
-		return isset( $post );
-	}
-	return false;
-}
-
-/**
  * Determines whether the user should be included in trialing a new font-smoothing rule.
  *
  * @return bool True if antialiased font-smoothing rule should be applied.
@@ -106,7 +84,7 @@ function use_font_smooth_antialiased() {
  * @return bool True if the common module assets should be loaded.
  */
 function should_load_assets() {
-	return (bool) is_homepage_title_hidden() || needs_slider_width_workaround() || use_font_smooth_antialiased();
+	return (bool) is_homepage_title_hidden() || use_font_smooth_antialiased();
 }
 
 /**
@@ -118,10 +96,6 @@ function should_load_assets() {
 function admin_body_classes( $classes ) {
 	if ( is_homepage_title_hidden() ) {
 		$classes .= ' hide-homepage-title';
-	}
-
-	if ( needs_slider_width_workaround() ) {
-		$classes .= ' slider-width-workaround';
 	}
 
 	if ( use_font_smooth_antialiased() && ! is_network_admin() ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.scss
@@ -6,12 +6,6 @@ body.hide-homepage-title {
 	}
 }
 
-body.slider-width-workaround {
-	.interface-interface-skeleton__editor {
-		max-width: 100%;
-	}
-}
-
 /*
  * Override bottom padding on post-publish footer
  * to account for inline help FAB


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8034

## Proposed Changes

This PR removes the hotfix introduced in https://github.com/Automattic/wp-calypso/pull/46951/files since it's no longer needed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The hotfix is no longer needed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout branch, sandbox a test site, and run yarn dev --sync.
- Open the post editor.
- Insert the Slideshow block, and add a couple of images.
- Set the block to be full width.
- Ensure that the block doesn't break the editor width.
- You can also double-check the page code, by searching for the interface-interface-skeleton__editor element, and make sure it has max-width: 100%.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
