### PR TITLE
Stats: support legacy Professional (Business) plans

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -1,6 +1,8 @@
 import {
 	JETPACK_COMPLETE_PLANS,
 	JETPACK_VIDEOPRESS_PRODUCTS,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PRODUCT_JETPACK_STATS_BI_YEARLY,
 	PRODUCT_JETPACK_STATS_FREE,
 	PRODUCT_JETPACK_STATS_MONTHLY,
@@ -59,7 +61,9 @@ export const hasAnyPlan = ( state: object, siteId: number | null ) => {
 	const isPWYWOwned = isProductOwned( sitePurchases, PRODUCT_JETPACK_STATS_PWYW_YEARLY );
 	const supportCommercialUse =
 		isCommercialOwned ||
-		JETPACK_COMPLETE_PLANS.some( ( plan ) => isProductOwned( sitePurchases, plan ) );
+		[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY, ...JETPACK_COMPLETE_PLANS ].some(
+			( plan ) => isProductOwned( sitePurchases, plan )
+		);
 
 	return isFreeOwned || isCommercialOwned || isPWYWOwned || supportCommercialUse;
 };
@@ -91,7 +95,9 @@ export default function useStatsPurchases( siteId: number | null ) {
 	const supportCommercialUse = useMemo(
 		() =>
 			isCommercialOwned ||
-			JETPACK_COMPLETE_PLANS.some( ( plan ) => isProductOwned( sitePurchases, plan ) ),
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY, ...JETPACK_COMPLETE_PLANS ].some(
+				( plan ) => isProductOwned( sitePurchases, plan )
+			),
 		[ sitePurchases, isCommercialOwned ]
 	);
 


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/13

## Proposed Changes

* Treat legacy Professional (Business) plans as Complete for Stats


## Why are these changes being made?

Related P2:
* pejTkB-1in-p2
* pejTkB-1ut-p2

## Testing Instructions

* DM @kangzj for a account to test
* Switch to the user on `http://calypso.localhost:3000/stats/day/:siteSlug` <- you can do this from MC
* Ensure stats works, including advanced modules
* Open `/wp-admin/admin.php?page=stats`
* Ensure stats works, including advanced modules

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?