### PR TITLE
Stats: Refactor Insights highlight cards

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -156,9 +156,8 @@ export default function AllTimeHighlightsSection( {
 			<h3 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h3>
 			<DotPager>
 				<AllTimeStatsCard infoItems={ infoItems } />
-				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
-					return <MostPopularDayTimeCard key={ card.id } cardInfo={ card } />;
-				} ) }
+				<MostPopularDayTimeCard cardInfo={ mostPopularTimeItems } />
+				<MostPopularDayTimeCard cardInfo={ bestViewsEverItems } />
 			</DotPager>
 
 			<PostCardsGroup siteId={ siteId } siteSlug={ siteSlug } />
@@ -171,9 +170,8 @@ export default function AllTimeHighlightsSection( {
 
 			<div className="highlight-cards-list">
 				<AllTimeStatsCard infoItems={ infoItems } />
-				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
-					return <MostPopularDayTimeCard key={ card.id } cardInfo={ card } />;
-				} ) }
+				<MostPopularDayTimeCard cardInfo={ mostPopularTimeItems } />
+				<MostPopularDayTimeCard cardInfo={ bestViewsEverItems } />
 			</div>
 
 			<PostCardsGroup siteId={ siteId } siteSlug={ siteSlug } />

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -157,24 +157,7 @@ export default function AllTimeHighlightsSection( {
 			<DotPager>
 				<AllTimeStatsCard infoItems={ infoItems } />
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
-					return (
-						<Card key={ card.id } className="highlight-card">
-							<h4 className="highlight-card-heading">{ card.heading }</h4>
-							<div className="highlight-card-detail-item-list">
-								{ card.items.map( ( item ) => {
-									return (
-										<div key={ item.id } className="highlight-card-detail-item">
-											<div className="highlight-card-detail-item-header">{ item.header }</div>
-
-											<div className="highlight-card-detail-item-content">{ item.content }</div>
-
-											<div className="highlight-card-detail-item-footer">{ item.footer }</div>
-										</div>
-									);
-								} ) }
-							</div>
-						</Card>
-					);
+					return <MostPopularDayTimeCard key={ card.id } card={ card } />;
 				} ) }
 			</DotPager>
 
@@ -189,24 +172,7 @@ export default function AllTimeHighlightsSection( {
 			<div className="highlight-cards-list">
 				<AllTimeStatsCard infoItems={ infoItems } />
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
-					return (
-						<Card key={ card.id } className="highlight-card">
-							<h4 className="highlight-card-heading">{ card.heading }</h4>
-							<div className="highlight-card-detail-item-list">
-								{ card.items.map( ( item ) => {
-									return (
-										<div key={ item.id } className="highlight-card-detail-item">
-											<div className="highlight-card-detail-item-header">{ item.header }</div>
-
-											<div className="highlight-card-detail-item-content">{ item.content }</div>
-
-											<div className="highlight-card-detail-item-footer">{ item.footer }</div>
-										</div>
-									);
-								} ) }
-							</div>
-						</Card>
-					);
+					return <MostPopularDayTimeCard key={ card.id } card={ card } />;
 				} ) }
 			</div>
 
@@ -272,6 +238,25 @@ function AllTimeStatsCard( { infoItems }: AllTimeStatsCardProps ) {
 							</div>
 						);
 					} ) }
+			</div>
+		</Card>
+	);
+}
+
+function MostPopularDayTimeCard( { card }: any ) {
+	return (
+		<Card key={ card.id } className="highlight-card">
+			<h4 className="highlight-card-heading">{ card.heading }</h4>
+			<div className="highlight-card-detail-item-list">
+				{ card.items.map( ( item ) => {
+					return (
+						<div key={ item.id } className="highlight-card-detail-item">
+							<div className="highlight-card-detail-item-header">{ item.header }</div>
+							<div className="highlight-card-detail-item-content">{ item.content }</div>
+							<div className="highlight-card-detail-item-footer">{ item.footer }</div>
+						</div>
+					);
+				} ) }
 			</div>
 		</Card>
 	);

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -155,30 +155,7 @@ export default function AllTimeHighlightsSection( {
 		<div className="highlight-cards-mobile">
 			<h3 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h3>
 			<DotPager>
-				<Card className="highlight-card">
-					<h4 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h4>
-					<div className="highlight-card-info-item-list">
-						{ infoItems
-							.filter( ( i ) => ! i.hidden )
-							.map( ( info ) => {
-								return (
-									<div key={ info.id } className="highlight-card-info-item">
-										<Icon icon={ info.icon } />
-
-										<span className="highlight-card-info-item-title">{ info.title }</span>
-
-										<span
-											className="highlight-card-info-item-count"
-											title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
-										>
-											{ formattedNumber( info.count ) }
-										</span>
-									</div>
-								);
-							} ) }
-					</div>
-				</Card>
-
+				<AllTimeStatsCard infoItems={ infoItems } />
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
 					return (
 						<Card key={ card.id } className="highlight-card">
@@ -210,30 +187,7 @@ export default function AllTimeHighlightsSection( {
 			<h3 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h3>
 
 			<div className="highlight-cards-list">
-				<Card className="highlight-card">
-					<h4 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h4>
-					<div className="highlight-card-info-item-list">
-						{ infoItems
-							.filter( ( i ) => ! i.hidden )
-							.map( ( info ) => {
-								return (
-									<div key={ info.id } className="highlight-card-info-item">
-										<Icon icon={ info.icon } />
-
-										<span className="highlight-card-info-item-title">{ info.title }</span>
-
-										<span
-											className="highlight-card-info-item-count"
-											title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
-										>
-											{ formattedNumber( info.count ) }
-										</span>
-									</div>
-								);
-							} ) }
-					</div>
-				</Card>
-
+				<AllTimeStatsCard infoItems={ infoItems } />
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
 					return (
 						<Card key={ card.id } className="highlight-card">
@@ -281,5 +235,32 @@ export default function AllTimeHighlightsSection( {
 				breakpointInactiveComponent={ highlightCards }
 			/>
 		</div>
+	);
+}
+
+function AllTimeStatsCard( props: any ) {
+	const translate = useTranslate();
+	return (
+		<Card className="highlight-card">
+			<h4 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h4>
+			<div className="highlight-card-info-item-list">
+				{ props.infoItems
+					.filter( ( i ) => ! i.hidden )
+					.map( ( info ) => {
+						return (
+							<div key={ info.id } className="highlight-card-info-item">
+								<Icon icon={ info.icon } />
+								<span className="highlight-card-info-item-title">{ info.title }</span>
+								<span
+									className="highlight-card-info-item-count"
+									title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
+								>
+									{ formattedNumber( info.count ) }
+								</span>
+							</div>
+						);
+					} ) }
+			</div>
+		</Card>
 	);
 }

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -9,7 +9,7 @@ import {
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { useSelector } from 'calypso/state';
@@ -157,7 +157,7 @@ export default function AllTimeHighlightsSection( {
 			<DotPager>
 				<AllTimeStatsCard infoItems={ infoItems } />
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
-					return <MostPopularDayTimeCard key={ card.id } card={ card } />;
+					return <MostPopularDayTimeCard key={ card.id } cardInfo={ card } />;
 				} ) }
 			</DotPager>
 
@@ -172,7 +172,7 @@ export default function AllTimeHighlightsSection( {
 			<div className="highlight-cards-list">
 				<AllTimeStatsCard infoItems={ infoItems } />
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
-					return <MostPopularDayTimeCard key={ card.id } card={ card } />;
+					return <MostPopularDayTimeCard key={ card.id } cardInfo={ card } />;
 				} ) }
 			</div>
 
@@ -243,12 +243,28 @@ function AllTimeStatsCard( { infoItems }: AllTimeStatsCardProps ) {
 	);
 }
 
-function MostPopularDayTimeCard( { card }: any ) {
+type CardInfoItem = {
+	id: string;
+	header: string;
+	content: string | JSX.Element;
+	footer: string | React.ReactNode;
+};
+
+type MostPopularDayTimeCardProps = {
+	cardInfo: {
+		id: string;
+		loading?: boolean;
+		heading: string;
+		items: CardInfoItem[];
+	};
+};
+
+function MostPopularDayTimeCard( { cardInfo }: MostPopularDayTimeCardProps ) {
 	return (
-		<Card key={ card.id } className="highlight-card">
-			<h4 className="highlight-card-heading">{ card.heading }</h4>
+		<Card key={ cardInfo.id } className="highlight-card">
+			<h4 className="highlight-card-heading">{ cardInfo.heading }</h4>
 			<div className="highlight-card-detail-item-list">
-				{ card.items.map( ( item ) => {
+				{ cardInfo.items.map( ( item ) => {
 					return (
 						<div key={ item.id } className="highlight-card-detail-item">
 							<div className="highlight-card-detail-item-header">{ item.header }</div>

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -238,13 +238,25 @@ export default function AllTimeHighlightsSection( {
 	);
 }
 
-function AllTimeStatsCard( props: any ) {
+type InfoItem = {
+	id: string;
+	icon: JSX.Element;
+	title: string;
+	count: number;
+	hidden?: boolean;
+};
+
+type AllTimeStatsCardProps = {
+	infoItems: InfoItem[];
+};
+
+function AllTimeStatsCard( { infoItems }: AllTimeStatsCardProps ) {
 	const translate = useTranslate();
 	return (
 		<Card className="highlight-card">
 			<h4 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h4>
 			<div className="highlight-card-info-item-list">
-				{ props.infoItems
+				{ infoItems
 					.filter( ( i ) => ! i.hidden )
 					.map( ( info ) => {
 						return (

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -151,7 +151,7 @@ export default function AllTimeHighlightsSection( {
 		};
 	}, [ isStatsLoading, translate, views, viewsBestDay, viewsBestDayTotal, userLocale ] );
 
-	const mobileCards = (
+	const highlightCardsMobile = (
 		<div className="highlight-cards-mobile">
 			<h3 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h3>
 			<DotPager>
@@ -159,12 +159,11 @@ export default function AllTimeHighlightsSection( {
 				<MostPopularDayTimeCard cardInfo={ mostPopularTimeItems } />
 				<MostPopularDayTimeCard cardInfo={ bestViewsEverItems } />
 			</DotPager>
-
 			<PostCardsGroup siteId={ siteId } siteSlug={ siteSlug } />
 		</div>
 	);
 
-	const highlightCards = (
+	const highlightCardsStandard = (
 		<div className="highlight-cards">
 			<h3 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h3>
 			<div className="highlight-cards-list">
@@ -193,8 +192,8 @@ export default function AllTimeHighlightsSection( {
 			<ComponentSwapper
 				className="all-time-highlights-section__highlight-cards-swapper"
 				breakpoint="<660px"
-				breakpointActiveComponent={ mobileCards }
-				breakpointInactiveComponent={ highlightCards }
+				breakpointActiveComponent={ highlightCardsMobile }
+				breakpointInactiveComponent={ highlightCardsStandard }
 			/>
 		</div>
 	);

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -167,13 +167,11 @@ export default function AllTimeHighlightsSection( {
 	const highlightCards = (
 		<div className="highlight-cards">
 			<h3 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h3>
-
 			<div className="highlight-cards-list">
 				<AllTimeStatsCard infoItems={ infoItems } />
 				<MostPopularDayTimeCard cardInfo={ mostPopularTimeItems } />
 				<MostPopularDayTimeCard cardInfo={ bestViewsEverItems } />
 			</div>
-
 			<PostCardsGroup siteId={ siteId } siteSlug={ siteSlug } />
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

https://github.com/Automattic/red-team/issues/87

## Proposed Changes

Small refactoring of "All-time highlights" cards on the Insights page to eliminate some code duplication. Will make adding the card locking behaviour a bit cleaner.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of the Restricted Dashboard project.

pejTkB-1t3-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No visible UX changes. Should behave as before.

* Launch the Calypso Live link.
* Visit the Stats → Insights dashboard.
* Disable the paywall with `?flags=stats/restricted-dashboard` if necessary.
* Confirm the "All-time highlights" cards load as expected (not locked yet).
* Test mobile screen size and confirm the DotPager UI still works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?