### PR TITLE
A4A > Migrations: Fix the payment details link in the migrations overview page

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, Card, WordPressLogo } from '@automattic/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -10,7 +11,10 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { A4A_REFERRALS_BANK_DETAILS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_REFERRALS_BANK_DETAILS_LINK,
+	A4A_REFERRALS_PAYMENT_SETTINGS,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge';
 import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
 import { getAccountStatus } from 'calypso/a8c-for-agencies/sections/referrals/lib/get-account-status';
@@ -25,6 +29,8 @@ export default function MigrationsOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const title = translate( 'Migrations' );
+
+	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
 
 	const { data } = useGetTipaltiPayee();
 	const accountStatus = getAccountStatus( data, translate );
@@ -136,7 +142,11 @@ export default function MigrationsOverview() {
 							<Button
 								primary
 								compact
-								href={ A4A_REFERRALS_BANK_DETAILS_LINK }
+								href={
+									isAutomatedReferralsEnabled
+										? A4A_REFERRALS_PAYMENT_SETTINGS
+										: A4A_REFERRALS_BANK_DETAILS_LINK
+								}
 								onClick={ onAddBankDetailsClick }
 							>
 								{ translate( 'Enter bank details' ) }


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/754

## Proposed Changes

This PR fixes the payment details link in the migrations overview page.

## Testing Instructions

1. Open the A4A live link.
2. Go to Migrations > Click the Enter Bank Details button > Verify that you are directed to /referrals/payment settings and that the page loads as expected.

<img width="1727" alt="Screenshot 2024-07-04 at 9 10 17 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c07072a0-d461-433c-9906-3073f62d5277">

3. Disable the feature flag `?flags=-a4a-automated-referrals` and repeat the step > Verify that you redirected to /referrals/bank-details and verify the page loads as expected

<img width="1727" alt="Screenshot 2024-07-04 at 9 10 02 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/61d7f316-1aca-4f1d-90c4-0ef5776947fb">

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
