### PR TITLE
A4A > Referrals: Update pricing text for purchases

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
@@ -1,3 +1,6 @@
+import { Gridicon } from '@automattic/components';
+import { formatCurrency } from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { ReferralPurchase } from '../../types';
@@ -9,9 +12,21 @@ type Props = {
 };
 
 const TotalAmount = ( { purchase, data, isFetching }: Props ) => {
+	const translate = useTranslate();
+
 	const product = data?.find( ( product ) => product.product_id === purchase.product_id );
 
-	return isFetching ? <TextPlaceholder /> : `$${ product?.amount }`;
+	if ( isFetching ) {
+		return <TextPlaceholder />;
+	}
+
+	return product?.amount ? (
+		translate( '%(total)s/mo', {
+			args: { total: formatCurrency( parseInt( product.amount ), product.currency ?? 'USD' ) },
+		} )
+	) : (
+		<Gridicon icon="minus" />
+	);
 };
 
 export default TotalAmount;


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/759

## Proposed Changes

This PR adds "/mo" abbreviation for the pricing text and uses the `formatCurrency` method for consistency. 

## Testing Instructions

- Open A4A live link
- Visit the Referrals - Dashboard > Click on any referral client > Verify that the `TOTAL` column on the purchases table shows the price as shown below:

| Before | After |
|--------|--------|
| <img width="1245" alt="Screenshot 2024-07-04 at 10 44 39 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/01567fe5-ed5b-41c8-8c53-213a8b77859d"> | <img width="1245" alt="Screenshot 2024-07-04 at 10 38 42 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e6a1607d-08fb-4c8c-a36d-2984011f3b4a">| 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
