### PR TITLE
Frictionless Email Subscriptions: Accept wordpress subdomains as valid redirect urls

### DIFF
--- a/client/lib/url/is-redirect-allowed.ts
+++ b/client/lib/url/is-redirect-allowed.ts
@@ -31,8 +31,11 @@ export function isRedirectAllowed( url: string ): boolean {
 			return false;
 		}
 
-		// Return true for *.calypso.live urls.
-		if ( /^([a-zA-Z0-9-]+\.)?calypso\.live$/.test( hostname ) ) {
+		// Return true for *.calypso.live or *.wordpress.com urls
+		if (
+			/^([a-zA-Z0-9-]+\.)?calypso\.live$/.test( hostname ) ||
+			/^([a-zA-Z0-9-]+\.)?wordpress\.com$/.test( hostname )
+		) {
 			return true;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3098

## Proposed Changes

* Accept WordPress.com subdomains as valid redirect urls

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Setting a `redirect_to` query param for a valid domain with any subdomain would force redirects to `wordpress.com`
* We want to allow subdomains for wordpress.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to https://wordpress.com/start/email-subscription/subscribe?user_email=aobyrne%40gmail.com&mailing_list=learn&from=%2Ftest-email-subscription%2F&redirect_to=https%3A%2F%2Fh4tests.wordpress.com%2Ftest-email-subscription%2F&first_name=zzz&last_name=zz
* Complete email subscription and verify that the user is redirected to `h4tests.wordpress.com/test-email-subscription`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
