### PR TITLE
A4A > Referrals: Show recent referrals on top of the referral table

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -12,13 +12,9 @@ const getConsolidatedData = ( referrals: Referral[] ) => {
 	};
 
 	referrals.forEach( ( referral ) => {
-		consolidatedData.allTimeCommissions += referral.commissions;
 		consolidatedData.pendingOrders += referral.statuses.filter(
 			( status ) => status === 'pending'
 		).length;
-		if ( referral.statuses.includes( 'pending' ) ) {
-			consolidatedData.pendingCommission += referral.commissions;
-		}
 	} );
 
 	return consolidatedData;

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -18,10 +18,9 @@ export interface ReferralClient {
 	email: string;
 }
 export interface Referral {
-	id: string;
+	id: number;
 	client: ReferralClient;
 	purchases: ReferralPurchase[];
-	commissions: number;
 	statuses: string[];
 }
 
@@ -29,6 +28,5 @@ export interface ReferralAPIResponse {
 	id: number;
 	client: ReferralClient;
 	products: ReferralPurchaseAPIResponse[];
-	commission: number;
 	status: string;
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/756

## Proposed Changes

This PR: 

- Updates the useFetchReferrals hook to show recent referrals on top of the referral table
- Removes `commissions` as they are not used.

## Testing Instructions

- Open A4A live link
- Visit the Referrals - Dashboard > Verify that the recent referrals are at the top of the referral table. Please refer to products with different client email addresses and test this. Compare the same with production.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
