### PR TITLE
A4A > Referrals: Update client subscriptions price text

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -20,8 +20,8 @@ export function SubscriptionPrice( { isFetching, amount }: Props & { amount?: st
 	return isFetching ? (
 		<TextPlaceholder />
 	) : (
-		translate( '%(price)s per month', {
-			args: { price: formatCurrency( Number( amount ?? 0 ), 'USD' ) },
+		translate( '%(total)s/mo', {
+			args: { total: formatCurrency( Number( amount ?? 0 ), 'USD' ) },
 		} )
 	);
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/758

## Proposed Changes

This PR changes `per month` to "/mo" abbreviation for the pricing text to be consistent. 

## Testing Instructions

- Login as a client and visit `/client/subscriptions`
- Verify that the `PRICE` column on the purchases table shows the price as shown below:


| Before | After |
|--------|--------|
| <img width="909" alt="Screenshot 2024-07-04 at 12 20 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/59e58006-0b88-4490-a338-893ff4f64a48"> | <img width="909" alt="Screenshot 2024-07-04 at 12 20 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/24bd7c32-f9bd-45bb-8d3f-15cd6ca537a1">| 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
