### PR TITLE
A4A > Site Selector & Importer: Make the whole row clickable on the WPCOM site table

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -89,6 +89,10 @@ p.import-from-wpcom-modal__instruction {
 			opacity: 1;
 		}
 
+		.components-checkbox-control__label {
+			cursor: pointer;
+		}
+
 		td {
 			border-bottom: none;
 			padding-block: 8px;

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/table-content.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/table-content.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react';
+import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
+import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { SiteItem } from './wpcom-sites-table';
+import type { DataViewsColumn } from '../../items-dashboard/items-dataviews/interfaces';
+
+interface Props {
+	items: SiteItem[];
+	fields: DataViewsColumn[];
+}
+
+export default function WPCOMSitesTableContent( { items, fields }: Props ) {
+	const [ dataViewsState, setDataViewsState ] = useState( initialDataViewsState );
+
+	useEffect( () => {
+		if ( items.length ) {
+			const handleRowClick = ( event: Event ) => {
+				const target = event.target as HTMLElement;
+
+				const row = target.closest(
+					'.dataviews-view-table__row, li:has(.dataviews-view-list__item)'
+				);
+
+				if (
+					target.tagName.toLowerCase() === 'input' ||
+					target.tagName.toLowerCase() === 'label'
+				) {
+					return;
+				}
+				if ( row ) {
+					const isButtonOrLink = target.closest( 'button, a' );
+					if ( ! isButtonOrLink ) {
+						const button = row.querySelector( '.view-details-button' ) as HTMLButtonElement;
+						const checkbox = button?.getElementsByTagName( 'input' )[ 0 ];
+						if ( checkbox ) {
+							checkbox.click();
+						}
+					}
+				}
+			};
+
+			const rowsContainer = document.querySelector( '.dataviews-view-table, .dataviews-view-list' );
+
+			if ( rowsContainer ) {
+				rowsContainer.addEventListener( 'click', handleRowClick as EventListener );
+			}
+
+			return () => {
+				if ( rowsContainer ) {
+					rowsContainer.removeEventListener( 'click', handleRowClick as EventListener );
+				}
+			};
+		}
+	}, [ dataViewsState, items ] );
+
+	return (
+		<ItemsDataViews
+			data={ {
+				items,
+				fields,
+				getItemId: ( item ) => `${ item.id }`,
+				pagination: {
+					totalItems: 1,
+					totalPages: 1,
+				},
+				enableSearch: false,
+				actions: [],
+				dataViewsState: dataViewsState,
+				setDataViewsState: setDataViewsState,
+			} }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -3,9 +3,7 @@ import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { CheckboxControl } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useMemo, useCallback } from 'react';
-import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
-import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
+import { useMemo, useCallback } from 'react';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
@@ -14,9 +12,10 @@ import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selecto
 import getSites from 'calypso/state/selectors/get-sites';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import WPCOMSitesTableContent from './table-content';
 import type { Site } from 'calypso/a8c-for-agencies/sections/sites/types';
 
-type SiteItem = {
+export type SiteItem = {
 	id: number;
 	site: string;
 	date: string;
@@ -66,9 +65,8 @@ export default function WPCOMSitesTable( {
 
 	const isDesktop = useDesktopBreakpoint();
 
-	const [ dataViewsState, setDataViewsState ] = useState( initialDataViewsState );
-
 	// FIXME: This is a temporary solution to filter out sites that are already connected
+	// Maybe we should finalize on the list if sites to be displayed
 	const items = useMemo( () => {
 		return sites
 			.filter(
@@ -123,6 +121,8 @@ export default function WPCOMSitesTable( {
 				getValue: () => '-' as string,
 				render: ( { item }: { item: SiteItem } ) => (
 					<CheckboxControl
+						className="view-details-button"
+						data-site-id={ item.id }
 						label={ item.site }
 						checked={ selectedSites.includes( item.id ) }
 						onChange={ ( checked ) => onSelectSite( checked, item ) }
@@ -169,21 +169,7 @@ export default function WPCOMSitesTable( {
 					<TextPlaceholder />
 				</>
 			) : (
-				<ItemsDataViews
-					data={ {
-						items,
-						fields,
-						getItemId: ( item ) => `${ item.id }`,
-						pagination: {
-							totalItems: 1,
-							totalPages: 1,
-						},
-						enableSearch: false,
-						actions: [],
-						dataViewsState: dataViewsState,
-						setDataViewsState: setDataViewsState,
-					} }
-				/>
+				<WPCOMSitesTableContent items={ items } fields={ fields } />
 			) }
 		</div>
 	) : null;


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/92313

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/752

## Proposed Changes

This PR makes the whole row clickable on the WPCOM site table. 

Note: 

- The `Add X sites` button does nothing
- The mobile view design is required and will be implemented in another PR.
- The list of sites might have to be updated and will be done in another PR.
- The sorting needs to be figured out and will be implemented in another PR.

## Testing Instructions

1. Open the A4A live link.
2. Click the `Add sites` button > Click the Via WordPress.com menu item
3. Verify that the whole row is clickable & select/unselect the item

<img width="815" alt="Screenshot 2024-07-03 at 3 31 32 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/41cd1ff0-b628-4b92-90eb-31b229cbb63a">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
