### PR TITLE
Fix the padding for the first tag in the Reader

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -480,10 +480,6 @@
 	padding: 0 9px 2px;
 	background-color: var(--color-neutral-0);
 	align-self: center;
-
-	&:first-child {
-		padding-left: 0;
-	}
 }
 
 .reader-post-card__byline .reader-avatar {


### PR DESCRIPTION
## Proposed Changes

#91990 introduced a padding change for the first tag that looks inconsistent with the other tags as one of many styling changes 

## Why are these changes being made?

All tags look like buttons except the first one, this doesn't look good.

## Testing Instructions

1. On Desktop, go to the reader and select a tag or visit /tag/blog (or any other tag)
2. Check the right sidebar

Before the change:
<img width="1066" alt="Screenshot 2024-07-04 at 14 15 06" src="https://github.com/Automattic/wp-calypso/assets/82778/cc6206f6-0673-436f-abbb-dafb522aa679">

After the change:
<img width="1066" alt="Screenshot 2024-07-04 at 14 14 59" src="https://github.com/Automattic/wp-calypso/assets/82778/2033c979-e6d7-4503-b1f8-d2f481a279db">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
