### PR TITLE
Remove unnecessary listener on Revisions Post Actions menu item

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -113,49 +113,13 @@ function handlePostTrash( calypsoPort ) {
 }
 
 function overrideRevisions( calypsoPort ) {
-	// For Gutenberg <= 18.4
-	// For Gutenberg >= 18.5.1 (see: https://github.com/WordPress/gutenberg/pull/62323)
 	addEditorListener( '[href*="revision.php"]', ( e ) => {
 		e.preventDefault();
-		openRevisions();
-	} );
-
-	// For Gutenberg >= 18.5 (see: https://github.com/WordPress/gutenberg/pull/61867)
-	// Hacky solution to identify View Revisions menu item.
-	const viewRevisionsLabel =
-		/View revisions|Revisionen anzeigen|Visualizza revisioni|リビジョンを表示|수정본 보기|Bekijk revisies|Vezi reviziile|Visa versioner/gi;
-
-	// We target the menu item manually when the dropdown button is clicked.
-	// This is because we cannot rely on event.preventDefault() to prevent an event handler
-	// that was attached on core's side from executing.
-	addEditorListener( '.editor-all-actions-button', () => {
-		document.querySelectorAll( 'div[id^=portal] [role=menuitem]' ).forEach( ( menuItem ) => {
-			if ( ( menuItem.innerText || '' ).match( viewRevisionsLabel ) ) {
-				// Replace original menu item with a clone
-				const replacementMenuItem = menuItem.cloneNode( true );
-				menuItem.replaceWith( replacementMenuItem );
-				replacementMenuItem.addEventListener( 'click', openRevisions );
-
-				// Add a class to uniquely identify the cloned menu item
-				replacementMenuItem.className += ' view-revisions-modal-button';
-
-				// Replicate hovering effect
-				replacementMenuItem.addEventListener( 'mouseover', () => {
-					replacementMenuItem.setAttribute( 'data-active-item', '' );
-				} );
-				replacementMenuItem.addEventListener( 'mouseout', () => {
-					replacementMenuItem.removeAttribute( 'data-active-item' );
-				} );
-			}
-		} );
-	} );
-
-	function openRevisions() {
 		calypsoPort.postMessage( { action: 'openRevisions' } );
 
 		calypsoPort.addEventListener( 'message', onLoadRevision, false );
 		calypsoPort.start();
-	}
+	} );
 
 	function onLoadRevision( message ) {
 		const action = get( message, 'data.action', '' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/8039
- Reverts https://github.com/Automattic/wp-calypso/pull/91790
- E2E tests being removed on https://github.com/Automattic/wp-calypso/pull/92352

## Proposed Changes

* In Gutenberg v18.7.0 the revisions are removed from the Post Actions dropdown. This PR removes a specific listener was added to that menu item.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Clean code that won't be executed due to GB changes. 

This button doesn't exist on GB v18.7.0 anymore (https://github.com/WordPress/gutenberg/pull/62443):

<img width="422" alt="Screenshot 2024-07-03 at 13 42 11" src="https://github.com/Automattic/wp-calypso/assets/779993/19fb5a00-09f9-4411-bf90-e4a121314c20">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Execute `cd apps/wpcom-block-editor/ && yarn dev --sync`
* Sandbox your simple site and `widgets.wp.com`
* Access a the post editor from wp.com for example: `https://wordpress.com/post/20240701gutenbergrotation.wordpress.com/2`
* Confirm the revisions are still opening in a modal in Calypsofy 


https://github.com/Automattic/wp-calypso/assets/779993/d98d5c76-c074-4a41-a3ea-bfcd83cdea2d



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?