### PR TITLE
A4A > Site Selector & Importer: Implement WPCOM site table mobile view

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -24,7 +24,7 @@
 }
 
 .import-from-wpcom-modal__main {
-	padding: 40px;
+	padding: 20px;
 	gap: 8px;
 	display: flex;
 	flex-direction: column;
@@ -32,6 +32,7 @@
 
 	@include break-large {
 		width: 800px;
+		padding: 40px;
 	}
 }
 
@@ -110,5 +111,34 @@ p.import-from-wpcom-modal__instruction {
 	.wpcom-sites-table__icon {
 		width: 24px;
 		height: 24px;
+	}
+}
+
+.wpcom-sites-table__site-mobile {
+	display: inline-flex;
+	align-items: center;
+
+	.wpcom-sites-table__icon {
+		margin-inline-end: 8px;
+	}
+
+	span {
+		@include a4a-font-body-sm;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 215px;
+
+		@include break-mobile {
+			max-width: 370px;
+		}
+
+		@include break-small {
+			max-width: 400px;
+		}
+
+		@include break-large {
+			max-width: unset;
+		}
 	}
 }

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -105,57 +105,94 @@ export default function WPCOMSitesTable( {
 	);
 
 	const fields = useMemo(
-		() => [
-			{
-				id: 'site',
-				header: (
-					<div>
-						<CheckboxControl
-							label={ translate( 'Site' ).toUpperCase() }
-							checked={ selectedSites.length === items.length }
-							onChange={ onSelectAllSites }
-							disabled={ false }
-						/>
-					</div>
-				),
-				getValue: () => '-' as string,
-				render: ( { item }: { item: SiteItem } ) => (
-					<CheckboxControl
-						className="view-details-button"
-						data-site-id={ item.id }
-						label={ item.site }
-						checked={ selectedSites.includes( item.id ) }
-						onChange={ ( checked ) => onSelectSite( checked, item ) }
-						disabled={ false }
-					/>
-				),
-				width: '100%',
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
-				id: 'date',
-				header: translate( 'Date' ).toUpperCase(),
-				getValue: () => '-',
-				render: ( { item }: { item: SiteItem } ) => new Date( item.date ).toLocaleDateString(),
-				width: '100%',
-				enableHiding: false,
-				enableSorting: false,
-			},
-			{
-				id: 'type',
-				header: translate( 'Type' ).toUpperCase(),
-				getValue: () => '-',
-				render: ( { item }: { item: SiteItem } ) => <TypeIcon siteId={ item.id } />,
-				width: '100%',
-				enableHiding: false,
-				enableSorting: false,
-			},
-		],
-		[ items.length, onSelectAllSites, onSelectSite, selectedSites, translate ]
+		() =>
+			! isDesktop
+				? [
+						{
+							id: 'site',
+							header: (
+								<div>
+									<CheckboxControl
+										label={ translate( 'Site' ).toUpperCase() }
+										checked={ selectedSites.length === items.length }
+										onChange={ onSelectAllSites }
+										disabled={ false }
+									/>
+								</div>
+							),
+							getValue: () => '-' as string,
+							render: ( { item }: { item: SiteItem } ) => (
+								<div className="wpcom-sites-table__site-mobile">
+									<CheckboxControl
+										className="view-details-button"
+										data-site-id={ item.id }
+										// We don't want to show the label here since we show the logo and site name separately
+										label={ undefined }
+										checked={ selectedSites.includes( item.id ) }
+										onChange={ ( checked ) => onSelectSite( checked, item ) }
+										disabled={ false }
+									/>
+									<TypeIcon siteId={ item.id } />
+									<span>{ item.site }</span>
+								</div>
+							),
+							width: '100%',
+							enableHiding: false,
+							enableSorting: false,
+						},
+				  ]
+				: [
+						{
+							id: 'site',
+							header: (
+								<div>
+									<CheckboxControl
+										label={ translate( 'Site' ).toUpperCase() }
+										checked={ selectedSites.length === items.length }
+										onChange={ onSelectAllSites }
+										disabled={ false }
+									/>
+								</div>
+							),
+							getValue: () => '-' as string,
+							render: ( { item }: { item: SiteItem } ) => (
+								<CheckboxControl
+									className="view-details-button"
+									data-site-id={ item.id }
+									label={ item.site }
+									checked={ selectedSites.includes( item.id ) }
+									onChange={ ( checked ) => onSelectSite( checked, item ) }
+									disabled={ false }
+								/>
+							),
+							width: '100%',
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'date',
+							header: translate( 'Date' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: SiteItem } ) =>
+								new Date( item.date ).toLocaleDateString(),
+							width: '100%',
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'type',
+							header: translate( 'Type' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: SiteItem } ) => <TypeIcon siteId={ item.id } />,
+							width: '100%',
+							enableHiding: false,
+							enableSorting: false,
+						},
+				  ],
+		[ isDesktop, items.length, onSelectAllSites, onSelectSite, selectedSites, translate ]
 	);
 
-	return isDesktop ? (
+	return (
 		<div className="wpcom-sites-table redesigned-a8c-table">
 			{ isFetching ? (
 				<>
@@ -172,5 +209,5 @@ export default function WPCOMSitesTable( {
 				<WPCOMSitesTableContent items={ items } fields={ fields } />
 			) }
 		</div>
-	) : null;
+	);
 }


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/92372

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/749

## Proposed Changes

This PR implements the WPCOM site table mobile view for the site selector

Note: 

- The `Add X sites` button does nothing
- The mobile view design is required and will be implemented in another PR.
- The list of sites might have to be updated and will be done in another PR.
- The sorting needs to be figured out and will be implemented in another PR.

## Testing Instructions

1. Open the A4A live link.
2. Click the `Add sites` button > Click the Via WordPress.com menu item
3. Switch to mobile view & verify it looks as displayed below:

<img width="370" alt="Screenshot 2024-07-04 at 5 14 27 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ec2cbdb0-43d2-4991-84fa-f1cc5342b36c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
