### PR TITLE
Stats: Empty States: Update empty state for Emails

### DIFF
--- a/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-empty-action-email.tsx
@@ -1,0 +1,37 @@
+import { mail } from '@automattic/components/src/icons';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import EmptyStateAction from '../../../components/empty-state-action';
+
+type StatsEmptyActionEmailProps = {
+	from: string;
+};
+
+// TODO: move to a shared file if this is the final URL
+const JETPACK_SUPPORT_NEWSLETTER_URL = 'https://jetpack.com/support/newsletter';
+
+const StatsEmptyActionEmail: React.FC< StatsEmptyActionEmailProps > = ( { from } ) => {
+	const translate = useTranslate();
+
+	return (
+		<EmptyStateAction
+			icon={ mail }
+			text={ translate( 'Send emails with Newsletter' ) }
+			analyticsDetails={ {
+				from: from,
+				feature: 'newsletter',
+			} }
+			onClick={ () => {
+				// analytics event tracting handled in EmptyStateAction component
+
+				setTimeout(
+					() => ( window.location.href = localizeUrl( JETPACK_SUPPORT_NEWSLETTER_URL ) ),
+					250
+				);
+			} }
+		/>
+	);
+};
+
+export default StatsEmptyActionEmail;

--- a/client/my-sites/stats/features/modules/stats-emails/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-emails';

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -15,7 +15,6 @@ import EmptyModuleCard from '../../../components/empty-module-card/empty-module-
 import { SUPPORT_URL } from '../../../const';
 import StatsModule from '../../../stats-module';
 import StatsModulePlaceholder from '../../../stats-module/placeholder';
-import statsStrings from '../../../stats-strings';
 import StatsEmptyActionEmail from '../shared/stats-empty-action-email';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
@@ -94,54 +93,4 @@ const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
 	);
 };
 
-// TODO: remove this and use exclusively class above (StatEmail) once stats/empty-module-traffic feature flag is removed.
-
-type StatEmailsOldProps = {
-	period: string;
-	query: string;
-	className?: string;
-};
-
-const StatEmailsOld = ( { period, query, className }: StatEmailsOldProps ) => {
-	const translate = useTranslate();
-	const moduleStrings = statsStrings();
-
-	return (
-		<StatsModule
-			additionalColumns={ {
-				header: (
-					<>
-						<span>{ translate( 'Opens' ) }</span>
-					</>
-				),
-				body: ( item: any ) => (
-					<>
-						<span>{ item.opens }</span>
-					</>
-				),
-			} }
-			path="emails"
-			moduleStrings={ moduleStrings.emails }
-			period={ period }
-			query={ query }
-			statType="statsEmailsSummary"
-			mainItemLabel={ translate( 'Latest Emails' ) }
-			metricLabel={ translate( 'Clicks' ) }
-			showSummaryLink
-			className={ className }
-			hasNoBackground
-		/>
-	);
-};
-
-// Feature flag control component. TODO: remove this along with JSX above once stats/empty-module-traffic feature flag is removed.
-const EmailStatsComponent: React.FC< any > = ( props ) => {
-	const isNewStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
-
-	if ( isNewStateEnabled ) {
-		return <StatEmails { ...props } />;
-	}
-	return <StatEmailsOld { ...props } />;
-};
-
-export default EmailStatsComponent;
+export default StatEmails;

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -87,6 +87,7 @@ const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
 					showSummaryLink
 					className={ className }
 					hasNoBackground
+					skipQuery
 				/>
 			) }
 		</>

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -1,0 +1,147 @@
+import { StatsCard } from '@automattic/components';
+import { mail } from '@automattic/components/src/icons';
+import { localizeUrl } from '@automattic/i18n-utils';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { useSelector } from 'calypso/state';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { SUPPORT_URL } from '../../../const';
+import StatsModule from '../../../stats-module';
+import StatsModulePlaceholder from '../../../stats-module/placeholder';
+import statsStrings from '../../../stats-strings';
+import StatsEmptyActionEmail from '../shared/stats-empty-action-email';
+import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
+
+const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
+	period,
+	query,
+	moduleStrings,
+	className,
+}: StatsDefaultModuleProps ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsEmailsSummary';
+
+	const requesting = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	return (
+		<>
+			{ siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
+			{ requesting && <StatsModulePlaceholder isLoading={ requesting } /> }
+			{ ! data?.length ? (
+				<StatsCard
+					className={ clsx( 'stats-card--empty-variant', className ) }
+					title={ translate( 'Emails' ) }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ mail }
+							description={ translate(
+								'Learn about your {{link}}latest emails sent{{/link}} to better understand how they performed. Start sending!',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: <a href={ localizeUrl( `${ SUPPORT_URL }#emails` ) } />,
+									},
+									context: 'Stats: Info box label when the Emails module is empty',
+								}
+							) }
+							cards={ <StatsEmptyActionEmail from="module_emails" /> }
+						/>
+					}
+				/>
+			) : (
+				<StatsModule
+					additionalColumns={ {
+						header: (
+							<>
+								<span>{ translate( 'Opens' ) }</span>
+							</>
+						),
+						body: ( item: { opens: number } ) => (
+							<>
+								<span>{ item.opens }</span>
+							</>
+						),
+					} }
+					path="emails"
+					moduleStrings={ moduleStrings }
+					period={ period }
+					query={ query }
+					statType="statsEmailsSummary"
+					mainItemLabel={ translate( 'Latest Emails' ) }
+					metricLabel={ translate( 'Clicks' ) }
+					showSummaryLink
+					className={ className }
+					hasNoBackground
+				/>
+			) }
+		</>
+	);
+};
+
+// TODO: remove this and use exclusively class above (StatEmail) once stats/empty-module-traffic feature flag is removed.
+
+type StatEmailsOldProps = {
+	period: string;
+	query: string;
+	className?: string;
+};
+
+const StatEmailsOld = ( { period, query, className }: StatEmailsOldProps ) => {
+	const translate = useTranslate();
+	const moduleStrings = statsStrings();
+
+	return (
+		<StatsModule
+			additionalColumns={ {
+				header: (
+					<>
+						<span>{ translate( 'Opens' ) }</span>
+					</>
+				),
+				body: ( item: any ) => (
+					<>
+						<span>{ item.opens }</span>
+					</>
+				),
+			} }
+			path="emails"
+			moduleStrings={ moduleStrings.emails }
+			period={ period }
+			query={ query }
+			statType="statsEmailsSummary"
+			mainItemLabel={ translate( 'Latest Emails' ) }
+			metricLabel={ translate( 'Clicks' ) }
+			showSummaryLink
+			className={ className }
+			hasNoBackground
+		/>
+	);
+};
+
+// Feature flag control component. TODO: remove this along with JSX above once stats/empty-module-traffic feature flag is removed.
+const EmailStatsComponent: React.FC< any > = ( props ) => {
+	const isNewStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
+
+	if ( isNewStateEnabled ) {
+		return <StatEmails { ...props } />;
+	}
+	return <StatEmailsOld { ...props } />;
+};
+
+export default EmailStatsComponent;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -51,6 +51,7 @@ import StatsModuleCountries from './features/modules/stats-countries';
 import StatsModuleDevices, {
 	StatsModuleUpgradeDevicesOverlay,
 } from './features/modules/stats-devices';
+import StatsModuleEmails from './features/modules/stats-emails';
 import StatsModuleReferrers from './features/modules/stats-referrers';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
 import StatsModuleUTM, { StatsModuleUTMOverlay } from './features/modules/stats-utm';
@@ -64,7 +65,7 @@ import ChartTabs from './stats-chart-tabs';
 import Countries from './stats-countries';
 import DatePicker from './stats-date-picker';
 import StatsModule from './stats-module';
-import StatsModuleEmails from './stats-module-emails';
+import StatsModuleEmailsOld from './stats-module-emails';
 import StatsNotices from './stats-notices';
 import PageViewTracker from './stats-page-view-tracker';
 import StatsPeriodHeader from './stats-period-header';
@@ -596,7 +597,29 @@ class StatsSite extends Component {
 						) }
 
 						{ /* Either stacks with "Authors" or takes full width, depending on UTM and Authors visibility */ }
-						{ supportsEmailStats && (
+						{ supportsEmailStats && ! isNewStateEnabled && (
+							<StatsModuleEmailsOld // This is the old component & location. Remove and consolidate once stats/empty-module-traffic flag is removed
+								period={ this.props.period }
+								query={ query }
+								className={ clsx(
+									{
+										// half if odd number of modules after countries - UTM + Clicks + Authors or Clicks
+										'stats__flexible-grid-item--half':
+											( supportsUTMStats && ! this.isModuleHidden( 'authors' ) ) ||
+											( ! supportsUTMStats && this.isModuleHidden( 'authors' ) ),
+										// full if even number of modules after countries - UTM + Clicks or Authors + Clicks
+										'stats__flexible-grid-item--full':
+											( supportsUTMStats && this.isModuleHidden( 'authors' ) ) ||
+											( ! supportsUTMStats && ! this.isModuleHidden( 'authors' ) ),
+									},
+									'stats__flexible-grid-item--full--large',
+									'stats__flexible-grid-item--full--medium'
+								) }
+							/>
+						) }
+
+						{ /* Either stacks with "Authors" or takes full width, depending on UTM and Authors visibility */ }
+						{ supportsEmailStats && isNewStateEnabled && (
 							<StatsModuleEmails
 								period={ this.props.period }
 								query={ query }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -622,6 +622,7 @@ class StatsSite extends Component {
 						{ supportsEmailStats && isNewStateEnabled && (
 							<StatsModuleEmails
 								period={ this.props.period }
+								moduleStrings={ moduleStrings.emails }
 								query={ query }
 								className={ clsx(
 									{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#66](https://github.com/Automattic/red-team/issues/66)

## Proposed Changes

* adds a new empty state for Emails
* moves the existing JSX component into the new TSX one, and uses a feature flag to determine which to call

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply `stats/empty-module-traffic` feature flag
* verify that a page with empty Email views component works with and without the feature flag
* check the link and the actions
* repeat for blogs with data

![image](https://github.com/Automattic/wp-calypso/assets/30754158/4fd5ac45-c68d-4525-99cc-7e7b91a020cb)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?