### PR TITLE
Help page: Switch to link to youtube channel

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -139,7 +139,7 @@ class Help extends PureComponent {
 				{ this.getCoursesTeaser() }
 				<CompactCard
 					className="help__support-link"
-					href={ localizeUrl( 'https://www.youtube.com/@WordPressdotcom' ) }
+					href="https://www.youtube.com/@WordPressdotcom"
 					target="_blank"
 				>
 					<Gridicon icon="video" size={ 36 } />

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -139,7 +139,7 @@ class Help extends PureComponent {
 				{ this.getCoursesTeaser() }
 				<CompactCard
 					className="help__support-link"
-					href={ localizeUrl( 'https://wordpress.com/support/video-tutorials/' ) }
+					href={ localizeUrl( 'https://www.youtube.com/@WordPressdotcom' ) }
 					target="_blank"
 				>
 					<Gridicon icon="video" size={ 36 } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: p58i-hsX-p2#comment-63488

## Proposed Changes

Link the Video tutorials card to the youtube channel

<img width="277" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/21409834-2090-44a1-bfe6-091296c5b46c">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The old link, https://wordpress.com/support/video-tutorials/, is no longer actual.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live link
* Visit `/help`
* Click on the Video tutorials card
* You should land on YouTube
