### PR TITLE
Nav Redesign: Show masterbar on global pages

### DIFF
--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -689,7 +689,7 @@
 		padding-top: var(--masterbar-height);
 
 		@include break-small {
-			padding-top: calc(var(--masterbar-height) + 24px);
+			padding-top: calc(var(--masterbar-height) + 12px);
 		}
 
 		.main.a4a-layout.sites-dashboard.sites-dashboard__layout {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -524,17 +524,6 @@ $brand-text: "SF Pro Text", $sans;
 	}
 }
 
-body.has-global-sidebar .help-center .components-card.help-center__container.is-desktop {
-	top: auto;
-	right: auto;
-	bottom: 34px;
-	left: 116px;
-}
-
-body.has-global-sidebar.has-global-sidebar-collapsed .help-center .components-card.help-center__container.is-desktop {
-	left: 82px;
-}
-
 body.has-global-sidebar .is-global-sidebar-visible.is-support-session {
 	&::before {
 		border: 2px solid var(--studio-orange);

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -246,7 +246,6 @@ class Layout extends Component {
 		} );
 
 		this.refreshColorScheme( undefined, this.props.colorScheme );
-		this.addSidebarClassToBody();
 	}
 
 	/**
@@ -265,31 +264,6 @@ class Layout extends Component {
 				this.props.colorScheme !== 'modern' )
 		) {
 			this.refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
-		}
-
-		if (
-			prevProps.isGlobalSidebarVisible !== this.props.isGlobalSidebarVisible ||
-			prevProps.isGlobalSidebarCollapsed !== this.props.isGlobalSidebarCollapsed
-		) {
-			this.addSidebarClassToBody();
-		}
-	}
-
-	addSidebarClassToBody() {
-		if ( typeof document === 'undefined' ) {
-			return;
-		}
-
-		if ( this.props.isGlobalSidebarVisible ) {
-			document.querySelector( 'body' ).classList.add( 'has-global-sidebar' );
-		} else {
-			document.querySelector( 'body' ).classList.remove( 'has-global-sidebar' );
-		}
-
-		if ( this.props.isGlobalSidebarCollapsed ) {
-			document.querySelector( 'body' ).classList.add( 'has-global-sidebar-collapsed' );
-		} else {
-			document.querySelector( 'body' ).classList.remove( 'has-global-sidebar-collapsed' );
 		}
 	}
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -327,8 +327,7 @@ class Layout extends Component {
 	}
 
 	renderMasterbar( loadHelpCenterIcon ) {
-		const globalSidebarDesktop = this.state.isDesktop && this.props.isGlobalSidebarVisible;
-		if ( this.props.masterbarIsHidden || globalSidebarDesktop ) {
+		if ( this.props.masterbarIsHidden ) {
 			return <EmptyMasterbar />;
 		}
 		if ( this.props.isWooCoreProfilerFlow ) {
@@ -360,13 +359,12 @@ class Layout extends Component {
 	}
 
 	render() {
-		const globalSidebarDesktop = this.state.isDesktop && this.props.isGlobalSidebarVisible;
 		const sectionClass = clsx( 'layout', `focus-${ this.props.currentLayoutFocus }`, {
 			[ 'is-group-' + this.props.sectionGroup ]: this.props.sectionGroup,
 			[ 'is-section-' + this.props.sectionName ]: this.props.sectionName,
 			'is-support-session': this.props.isSupportSession,
 			'has-no-sidebar': this.props.sidebarIsHidden,
-			'has-no-masterbar': this.props.masterbarIsHidden || globalSidebarDesktop,
+			'has-no-masterbar': this.props.masterbarIsHidden,
 			'is-logged-in': this.props.isLoggedIn,
 			'is-jetpack-login': this.props.isJetpackLogin,
 			'is-jetpack-site': this.props.isJetpack,

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -3,7 +3,7 @@ body.is-section-me {
 	background: var(--studio-gray-0);
 
 	&.rtl .layout__content {
-		padding: 16px calc(var(--sidebar-width-max)) 16px 16px;
+		padding: calc(var(--masterbar-height) + 12px) calc(var(--sidebar-width-max)) 16px 16px;
 	}
 
 	.layout__content {
@@ -12,7 +12,7 @@ body.is-section-me {
 		min-height: 100vh;
 		padding-bottom: 0;
 		@media only screen and (min-width: 782px) {
-			padding: 16px 16px 16px calc(var(--sidebar-width-max)) !important;
+			padding: calc(var(--masterbar-height) + 12px) 16px 16px calc(var(--sidebar-width-max)) !important;
 		}
 		@media only screen and (max-width: 600px) {
 			background: var(--studio-white);
@@ -32,13 +32,7 @@ body.is-section-me {
 
 	div.layout.is-global-sidebar-visible {
 		.main {
-			@media only screen and (min-width: 600px) and (max-width: 960px) {
-				padding: 24px;
-			}
-			@media only screen and (max-width: 600px) {
-				padding-top: 0;
-				padding-bottom: 0;
-			}
+			padding: 24px;
 			border-block-end: 1px solid var(--studio-gray-0);
 		}
 		.layout__primary {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -66,7 +66,7 @@ body.is-section-reader {
 	background: var(--studio-gray-0);
 
 	&.rtl .layout__content {
-		padding: 16px calc(var(--sidebar-width-max)) 16px 16px;
+		padding: calc(var(--masterbar-height) + 12px) calc(var(--sidebar-width-max)) 16px 16px;
 	}
 
 	.layout__content {
@@ -74,7 +74,7 @@ body.is-section-reader {
 		overflow: hidden;
 		min-height: 100vh;
 		@media only screen and (min-width: 782px) {
-			padding: 16px 16px 16px calc(var(--sidebar-width-max)) !important;
+			padding: calc(var(--masterbar-height) + 12px) 16px 16px calc(var(--sidebar-width-max)) !important;
 		}
 		.layout_primary > div {
 			padding-bottom: 0;

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -3,13 +3,8 @@
 
 body.is-section-reader {
 	div.layout.is-global-sidebar-visible {
-		.main:not(.reader-full-post) {
-			@media only screen and (min-width: 600px) and (max-width: 960px) {
-				padding: 24px;
-			}
-			@media only screen and (max-width: 660px) {
-				padding-top: 0;
-			}
+		.main {
+			padding: 24px;
 			border-block-end: 1px solid var(--studio-gray-0);
 		}
 		.layout__primary > div {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8040

## Proposed Changes

* This updates the layout to render the masterbar on the global pages (All sites, Reader and Me/Profile)
* This also updates the styles to move the pages content to make room for the masterbar

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Based on feedback that UI has some logical flow issues

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go the All sites, Reader and Me/Profile pages in calypso live and confirm masterbar and pages look and behave ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
