### PR TITLE
Nav redesign: hide global sidebar header & footer

### DIFF
--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -1,11 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Spinner } from '@automattic/components';
-import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useRtl, useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { GlobalSidebarHeader } from 'calypso/layout/global-sidebar/header';
 import useSiteMenuItems from 'calypso/my-sites/sidebar/use-site-menu-items';
 import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -26,7 +24,6 @@ const GlobalSidebar = ( {
 	const menuItems = useSiteMenuItems();
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 	const translate = useTranslate();
-	const isDesktop = useBreakpoint( '>=782px' );
 	const isRtl = useRtl();
 	const previousRoute = useSelector( getPreviousRoute );
 	const section = useSelector( getSection );
@@ -85,7 +82,6 @@ const GlobalSidebar = ( {
 
 	return (
 		<div className="global-sidebar" ref={ wrapperRef }>
-			{ isDesktop && <GlobalSidebarHeader /> }
 			<div className="sidebar__body" ref={ bodyRef }>
 				<Sidebar className={ className } { ...sidebarProps } onClick={ onClick }>
 					{ requireBackLink && (

--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -8,12 +8,10 @@ import { useSelector } from 'react-redux';
 import { GlobalSidebarHeader } from 'calypso/layout/global-sidebar/header';
 import useSiteMenuItems from 'calypso/my-sites/sidebar/use-site-menu-items';
 import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { getSection } from 'calypso/state/ui/selectors';
 import Sidebar from '../sidebar';
 import { GLOBAL_SIDEBAR_EVENTS } from './events';
-import { GlobalSidebarFooter } from './footer';
 import './style.scss';
 
 const GlobalSidebar = ( {
@@ -28,7 +26,6 @@ const GlobalSidebar = ( {
 	const menuItems = useSiteMenuItems();
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 	const translate = useTranslate();
-	const currentUser = useSelector( getCurrentUser );
 	const isDesktop = useBreakpoint( '>=782px' );
 	const isRtl = useRtl();
 	const previousRoute = useSelector( getPreviousRoute );
@@ -102,7 +99,6 @@ const GlobalSidebar = ( {
 					{ children }
 				</Sidebar>
 			</div>
-			<GlobalSidebarFooter user={ currentUser } translate={ translate } />
 		</div>
 	);
 };

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -122,7 +122,7 @@ $brand-text: "SF Pro Text", $sans;
 		.sidebar {
 			overflow: visible;
 			&:first-child {
-				margin-top: 4px;
+				margin-top: 16px;
 			}
 
 			.sidebar__menu.is-togglable .sidebar__heading,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8040

We are showing the masterbar on global pages with https://github.com/Automattic/wp-calypso/pull/92382 

## Proposed Changes

* This hides the global sidebar header & footer that should be no longer needed when we are showing the masterbar on all pages ( https://github.com/Automattic/wp-calypso/pull/92382 )

## Before
<img width="450" alt="Screenshot 2024-07-04 at 14 07 50" src="https://github.com/Automattic/wp-calypso/assets/5560595/d2e95849-f1ac-41ac-8d65-531050215869">

## After
<img width="458" alt="Screenshot 2024-07-08 at 12 57 31" src="https://github.com/Automattic/wp-calypso/assets/5560595/79aff26b-c7c6-4528-96ec-f246943193e1">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy up the UI to make logical flows better

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to global pages (All sites, Reader and Me/Profile) and confirm that global sidebar header & footer are not showing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
