### PR TITLE
A4A: Fix the limitation on the calculation of unmanaged sites. 

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
@@ -7,7 +7,7 @@ type Props = {
 	size?: number;
 };
 
-export default function useManagedSitsMap( { size = 100 }: Props ) {
+export default function useManagedSitesMap( { size = 100 }: Props ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	const { data, isPending } = useFetchDashboardSites( {

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+type Props = {
+	size?: number;
+};
+
+export default function useManagedSitsMap( { size = 100 }: Props ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const { data, isPending } = useFetchDashboardSites( {
+		isPartnerOAuthTokenLoaded: false,
+		searchQuery: '',
+		currentPage: 1,
+		sort: {
+			field: '',
+			direction: '',
+		},
+		perPage: size,
+		agencyId,
+		filter: {
+			issueTypes: [],
+			showOnlyFavorites: false,
+		},
+	} );
+
+	return useMemo( () => {
+		return {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			map: data?.sites.reduce( ( map: Record< number, boolean >, site: any ) => {
+				map[ site.blog_id ] = true;
+				return map;
+			}, {} ),
+			isPending,
+		};
+	}, [ data, isPending ] );
+}

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -83,7 +83,35 @@ p.import-from-wpcom-modal__instruction {
 }
 
 .wpcom-sites-table.redesigned-a8c-table {
+	overflow-y: auto;
 	margin-block-start: 24px;
+
+	&::-webkit-scrollbar {
+		width: 4px;
+	}
+
+	&::-webkit-scrollbar-track {
+		background: transparent;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		background-color: rgba(155, 155, 155, 0.5);
+		border-radius: 4px;
+		border: transparent;
+	}
+
+
+	&::after {
+		content: "";
+		position: absolute;
+		left: 0;
+		bottom: 85px;
+		width: 100%;
+		height: 5%;
+		display: inline-block;
+		background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(255, 255, 255, 1) 100%);
+		transition: opacity 0.3s ease-out;
+	}
 
 	.dataviews-wrapper tr.dataviews-view-table__row {
 		.components-checkbox-control__input {
@@ -101,7 +129,14 @@ p.import-from-wpcom-modal__instruction {
 	}
 
 	.dataviews-view-table {
-		padding-block-end: 60px;
+		padding-block-end: 80px;
+		margin: 0;
+	}
+
+	.dataviews-view-table thead {
+		position: sticky;
+		top: 0;
+		z-index: 2;
 	}
 
 	.a4a-text-placeholder {

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -12,8 +12,8 @@ import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selecto
 import getSites from 'calypso/state/selectors/get-sites';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import useManagedSitsMap from './hooks/use-managed-sites-map';
 import WPCOMSitesTableContent from './table-content';
-import type { Site } from 'calypso/a8c-for-agencies/sections/sites/types';
 
 export type SiteItem = {
 	id: number;
@@ -45,7 +45,7 @@ export default function WPCOMSitesTable( {
 	const translate = useTranslate();
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const { data, isFetching } = useFetchDashboardSites( {
+	const { data } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded: false,
 		searchQuery: '',
 		currentPage: 1,
@@ -53,13 +53,15 @@ export default function WPCOMSitesTable( {
 			field: '',
 			direction: '',
 		},
-		perPage: 100,
+		perPage: 1,
 		agencyId,
 		filter: {
 			issueTypes: [],
 			showOnlyFavorites: false,
 		},
 	} );
+
+	const { map: managedSitesMap, isPending } = useManagedSitsMap( { size: data?.total } );
 
 	const sites = useSelector( getSites );
 
@@ -69,12 +71,7 @@ export default function WPCOMSitesTable( {
 	// Maybe we should finalize on the list if sites to be displayed
 	const items = useMemo( () => {
 		return sites
-			.filter(
-				( site ) =>
-					site?.visible &&
-					! site.is_private &&
-					data?.sites.every( ( s: Site ) => s.blog_id !== site.ID )
-			)
+			.filter( ( site ) => site && ! managedSitesMap?.[ site.ID as number ] )
 			.map( ( site ) =>
 				site
 					? {
@@ -85,7 +82,7 @@ export default function WPCOMSitesTable( {
 					: undefined
 			)
 			.filter( Boolean ) as SiteItem[];
-	}, [ data?.sites, sites ] );
+	}, [ managedSitesMap, sites ] );
 
 	const onSelectAllSites = useCallback( () => {
 		setSelectedSites(
@@ -194,7 +191,7 @@ export default function WPCOMSitesTable( {
 
 	return (
 		<div className="wpcom-sites-table redesigned-a8c-table">
-			{ isFetching ? (
+			{ isPending ? (
 				<>
 					<TextPlaceholder />
 					<TextPlaceholder />

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -12,7 +12,7 @@ import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selecto
 import getSites from 'calypso/state/selectors/get-sites';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import useManagedSitsMap from './hooks/use-managed-sites-map';
+import useManagedSitesMap from './hooks/use-managed-sites-map';
 import WPCOMSitesTableContent from './table-content';
 
 export type SiteItem = {
@@ -61,7 +61,7 @@ export default function WPCOMSitesTable( {
 		},
 	} );
 
-	const { map: managedSitesMap, isPending } = useManagedSitsMap( { size: data?.total } );
+	const { map: managedSitesMap, isPending } = useManagedSitesMap( { size: data?.total } );
 
 	const sites = useSelector( getSites );
 

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -71,7 +71,10 @@ export default function WPCOMSitesTable( {
 	// Maybe we should finalize on the list if sites to be displayed
 	const items = useMemo( () => {
 		return sites
-			.filter( ( site ) => site && ! managedSitesMap?.[ site.ID as number ] )
+			.filter(
+				( site ) =>
+					site && site.visible && ! site.is_private && ! managedSitesMap?.[ site.ID as number ]
+			)
 			.map( ( site ) =>
 				site
 					? {


### PR DESCRIPTION
Currently, the Unmanaged sites on the Site selector are calculated based only on the first 100 managed sites. This PR fixes this issue by ensuring that all managed sites are queried before calculating unmanaged sites. Otherwise, we will see some managed sites appearing on the Site selector.

Additionally, this PR improves the scroll behavior of the site table to match the design closer.

https://github.com/Automattic/wp-calypso/assets/56598660/c3866488-e82c-49ac-8828-5a9b9ad87f6a


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/762

## Proposed Changes

* Update the `WPCOMSitesTable` component to calculate unmanaged sites correctly based on the full managed sites list and not only the first 100 sites. The calculation is also improved by using a map instead of the array when filtering unmanaged sites. This data structure improves time complexity to `o(n)` from `o(n^2)`.
* Fix the modal scroll behavior by setting the main table to overflow instead of the entire modal. An overflow overlay is also added as an additional visual cue.

## Why are these changes being made?

* The site selector is not currently calculating all unmanaged sites correctly, which could lead to user confusion.

## Testing Instructions

* Use the A4A live link and go to `/overview` page.
* Click the 'Add site' dropdown menu.
* Click the 'Via WordPress.com` option.
* Confirm that the Site selector lists the correct unmanaged sites.
* Also confirm that the scroll behavior of the table is working correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
