### PR TITLE
Stepper: Add support to use custom login path

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -121,7 +121,13 @@ export type Flow = {
 	 * @returns An object describing the configuration.
 	 * For now only extraQueryParams is supported.
 	 */
-	useLoginParams?: () => { extraQueryParams: Record< string, string | number > };
+	useLoginParams?: () => {
+		/**
+		 * A custom login path to use instead of the default login path.
+		 */
+		customLoginPath?: string;
+		extraQueryParams: Record< string, string | number >;
+	};
 	useSteps: UseStepsHook;
 	useStepNavigation: UseStepNavigationHook< ReturnType< Flow[ 'useSteps' ] > >;
 	useAssertConditions?: UseAssertConditionsHook< ReturnType< Flow[ 'useSteps' ] > >;

--- a/client/landing/stepper/hooks/test/use-login-url-for-flow.tsx
+++ b/client/landing/stepper/hooks/test/use-login-url-for-flow.tsx
@@ -37,6 +37,31 @@ describe( 'useLoginUrlForFlow', () => {
 		);
 	} );
 
+	it( 'returns the login with custom login path', () => {
+		const flowWithCustomLoginPath = {
+			...flow,
+			useLoginParams: () => ( {
+				customLoginPath: '/custom-login-path',
+			} ),
+		} as Flow;
+
+		const { result } = renderHookWithProvider(
+			() => useLoginUrlForFlow( { flow: flowWithCustomLoginPath } ),
+			{
+				wrapper: Wrapper( 'setup' ),
+			}
+		);
+
+		expect( result.current ).toEqual(
+			addQueryArgs( '/custom-login-path', {
+				variationName: 'some-flow',
+				redirect_to: '/setup/site-migration-flow',
+				pageTitle: 'some-title',
+				toStepper: true,
+			} )
+		);
+	} );
+
 	it( 'returns the login with with extra params', () => {
 		const flowWithExtraParams = {
 			...flow,

--- a/client/landing/stepper/hooks/use-login-url-for-flow.ts
+++ b/client/landing/stepper/hooks/use-login-url-for-flow.ts
@@ -14,7 +14,7 @@ export function useLoginUrlForFlow( { flow }: UseLoginUrlForFlowProps ): string 
 	const location = useLocation();
 	const { siteId, siteSlug } = useSiteData();
 	const path = useHref( location.pathname );
-	const { extraQueryParams } = flow.useLoginParams?.() ?? {};
+	const { extraQueryParams, customLoginPath } = flow.useLoginParams?.() ?? {};
 
 	const redirectTo = addQueryArgs( path, {
 		...( locale && locale !== 'en' ? { locale } : {} ),
@@ -29,5 +29,6 @@ export function useLoginUrlForFlow( { flow }: UseLoginUrlForFlowProps ): string 
 		locale,
 		redirectTo,
 		extra: extraQueryParams,
+		customLoginPath,
 	} );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #92291
It unblocks the  #92393

## Proposed Changes
* Enable flows to set custom login/sign-up login paths. 

## Why are these changes being made?
As part of #92291  We are moving all redirect logic to the login pages to stepper and there is a flow (videopress) that uses a different login path. 

## Testing Instructions
Open the site-migration-flow.ts
Add this hook
```
	useLoginParams: () => ( {
		customLoginPath: '/start/videopress-account/user',
	} ),
```

Similar to this:

<img width="765" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/9e5b152b-f577-4309-a803-95a9d19fe0a4">


* Open a browser without a WP session.
* Try to access /setup/migration-signup
* Check you have been redirected to the custom path (video-press account sign).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
