### PR TITLE
Calypso Application Builder: translate during build

### DIFF
--- a/apps/blaze-dashboard/package.json
+++ b/apps/blaze-dashboard/package.json
@@ -20,7 +20,7 @@
 		"clean": "npx rimraf dist",
 		"build": "NODE_ENV=production yarn dev",
 		"build:stats": "calypso-build",
-		"teamcity:build-app": "yarn run build && yarn run translate",
+		"teamcity:build-app": "yarn run build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/blaze-dashboard/v1",
 		"show-stats": "NODE_ENV=production EMIT_STATS=true yarn build",
 		"translate": "rm -rf dist/strings && mkdirp dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --output './dist/blaze-dashboard-strings.pot' && build-app-languages --stringsFilePath='./dist/blaze-dashboard-strings.pot'"

--- a/apps/command-palette-wp-admin/package.json
+++ b/apps/command-palette-wp-admin/package.json
@@ -20,7 +20,7 @@
 		"clean": "npx rimraf dist",
 		"build": "NODE_ENV=production yarn dev",
 		"build:command-palette-wp-admin": "calypso-build",
-		"teamcity:build-app": "yarn run build && yarn run translate",
+		"teamcity:build-app": "yarn run build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/command-palette",
 		"translate": "rm -rf dist/strings && mkdirp dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --output './dist/command-palette-strings.pot' && build-app-languages --stringsFilePath='./dist/command-palette-strings.pot'"
 	},

--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -23,7 +23,7 @@
 	"scripts": {
 		"clean": "rm -rf dist",
 		"teamcity:build-app": "yarn run build",
-		"build": "NODE_ENV=production yarn dev && yarn run translate",
+		"build": "NODE_ENV=production yarn dev",
 		"build:app": "calypso-build",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/help-center",
 		"prepack": "yarn run clean && yarn run build",

--- a/packages/calypso-apps-builder/index.js
+++ b/packages/calypso-apps-builder/index.js
@@ -74,10 +74,13 @@ async function runBuilder( args ) {
 	await Promise.all( [
 		runAll( [ `build:*${ watch ? ' --watch' : '' }` ], runOpts ).then( () => {
 			console.log( 'Build completed!' );
-			if ( ! watch && sync ) {
-				// In non-watch + sync mode, we sync only once after the build has finished.
-				setupRemoteSync( localPath, remotePath );
-			}
+			const translate = runAll( 'translate', runOpts ).catch( () => {} );
+			translate.then( () => {
+				if ( ! watch && sync ) {
+					// In non-watch + sync mode, we sync only once after the build has finished.
+					setupRemoteSync( localPath, remotePath );
+				}
+			} );
 		} ),
 		// In watch + sync mode, we start watching to sync while the webpack build is happening.
 		watch && sync && setupRemoteSync( localPath, remotePath, true ),


### PR DESCRIPTION
## Proposed Changes

Currently, it's impossible to sync translations to sandbox using CAB. Here's what happens:

1. You run `yarn build`.
2. It runs `yarn dev && yarn translate`.
3. `yarn dev` runs CAB.
4. CAB builds and syncs with your sandbox.
5. It exits with code 0.
6. `yarn translate` runs.
7. It exits, but CAB has already exited and translations won't sync.

You can't translate then build because translations need built files. 

So unless you `rsync` manually, you can't upload translations.  

This PR makes CAB attempt to run the translation script before syncing when not in watch mode. If the script doesn't exist, nothing will happen and it will work as usual.

## Testing Instructions

1. cd into `apps/help-center`.
2. run `yarn build --sync`.
3. The translation script should run before syncing is done.
---
1. cd into `apps/blaze-dashboard`.
2. run `yarn build --sync`.
3. The translation script should run before syncing is done.
---
1. cd into `apps/command-palette-wp-admin`.
2. run `yarn build --sync`.
3. The translation script should run before syncing is done.

