### PR TITLE
Stepper: Update the `videopress` flow to use the new login strategy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -126,7 +126,7 @@ export type Flow = {
 		 * A custom login path to use instead of the default login path.
 		 */
 		customLoginPath?: string;
-		extraQueryParams: Record< string, string | number >;
+		extraQueryParams?: Record< string, string | number >;
 	};
 	useSteps: UseStepsHook;
 	useStepNavigation: UseStepNavigationHook< ReturnType< Flow[ 'useSteps' ] > >;

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -17,6 +17,7 @@ import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { PLANS_STORE, SITE_STORE, USER_STORE, ONBOARD_STORE } from '../stores';
 import './internals/videopress.scss';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 import ChooseADomain from './internals/steps-repository/choose-a-domain';
 import Launchpad from './internals/steps-repository/launchpad';
 import ProcessingStep from './internals/steps-repository/processing-step';
@@ -32,18 +33,32 @@ const videopress: Flow = {
 		return translate( 'Video' );
 	},
 	isSignupFlow: true,
+	useLoginParams() {
+		return {
+			customLoginPath: '/start/videopress-account/user',
+			extraQueryParams: {
+				pageTitle: translate( 'Video Portfolio' ),
+				flow: VIDEOPRESS_FLOW,
+			},
+		};
+	},
 	useSteps() {
-		return [
+		const publicSteps = [
 			{
 				slug: 'intro',
 				asyncComponent: () => import( './internals/steps-repository/intro' ),
 			},
 			{ slug: 'videomakerSetup', component: VideomakerSetup },
+		];
+
+		const privateSteps = stepsWithRequiredLogin( [
 			{ slug: 'options', component: SiteOptions },
 			{ slug: 'chooseADomain', component: ChooseADomain },
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'launchpad', component: Launchpad },
-		];
+		] );
+
+		return [ ...publicSteps, ...privateSteps ];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
@@ -65,7 +80,6 @@ const videopress: Flow = {
 			}
 		}
 
-		const name = this.name;
 		const { getSelectedStyleVariation } = useSelect(
 			( select ) => select( ONBOARD_STORE ) as OnboardSelect,
 			[]
@@ -74,10 +88,6 @@ const videopress: Flow = {
 			useDispatch( ONBOARD_STORE );
 		const siteId = useSiteIdParam();
 		const _siteSlug = useSiteSlug();
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
 		const _siteTitle = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
 			[]
@@ -118,19 +128,7 @@ const videopress: Flow = {
 
 		const siteSlug = useSiteSlug();
 
-		const stepValidateUserIsLoggedIn = () => {
-			if ( ! userIsLoggedIn ) {
-				navigate( 'intro' );
-				return false;
-			}
-			return true;
-		};
-
 		const stepValidateSiteTitle = () => {
-			if ( ! stepValidateUserIsLoggedIn() ) {
-				return false;
-			}
-
 			if ( ! _siteTitle.length ) {
 				navigate( 'options' );
 				return false;
@@ -304,9 +302,6 @@ const videopress: Flow = {
 				case 'intro':
 					clearOnboardingSiteOptions();
 					break;
-				case 'options':
-					stepValidateUserIsLoggedIn();
-					break;
 				case 'chooseADomain':
 					stepValidateSiteTitle();
 					break;
@@ -324,13 +319,7 @@ const videopress: Flow = {
 					return navigate( 'videomakerSetup' );
 
 				case 'videomakerSetup':
-					if ( userIsLoggedIn ) {
-						return navigate( 'options' );
-					}
-
-					return window.location.replace(
-						`/start/videopress-account/user/${ locale }?variationName=${ name }&flow=${ name }&pageTitle=Video%20Portfolio&redirect_to=/setup/videopress/options`
-					);
+					return navigate( 'options' );
 
 				case 'options': {
 					const { siteTitle, tagline } = providedDependencies;


### PR DESCRIPTION
Part of #92291


## Proposed Changes
* Replace all code related to managing the login to use stepsWithRequiredLogin 

## Why are these changes being made?
As explained on #92291 we are updating all flows to use the new stepper login capabilities.
This flow is the first one we are migrating that requires custom parameters when we redirect the user to the login flow.

## Testing Instructions
Flow: `/setup/videopress`
Scenario 1: Redirect to the login page
- Open a new browser where you don't have a WordPress.com session
- Access `/setup/videopress`
- Check the intro step doesn't require login
- Click on 'Start a free trial'
- Select any design on `videomakerSetup` on the 'Choose a design` page
- Check if you were redirected to the custom sign-up videopress `/videopress-account/user`



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
