### PR TITLE
Light Color Scheme: Update to match wp-admin

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -224,15 +224,19 @@ $font-size: rem(14px);
 
 				&:hover,
 				&:focus {
-					background-color: var(--color-sidebar-menu-hover-background);
-					color: var(--color-sidebar-menu-hover-text);
+					background-color: var(--color-sidebar-submenu-hover-background);
+					color: var(--color-sidebar-submenu-hover-text);
 				}
 			}
 
 			.selected .sidebar__menu-link {
-				background-color: var(--color-sidebar-menu-selected-background);
-				color: var(--color-sidebar-menu-selected-text);
+				background-color: var(--color-sidebar-submenu-selected-background);
+				color: var(--color-sidebar-submenu-selected-text);
 				font-weight: 600;
+
+				&:hover {
+					color: var(--color-sidebar-submenu-hover-text);
+				}
 			}
 
 			.sidebar__menu-link-text {
@@ -315,6 +319,7 @@ $font-size: rem(14px);
 		.sidebar__menu.sidebar__menu--selected {
 			.sidebar__heading {
 				background: var(--color-sidebar-menu-hover-background);
+				color: var(--color-sidebar-menu-selected-text);
 
 				&::after {
 					display: block;
@@ -866,12 +871,18 @@ $font-size: rem(14px);
 	.collapse-sidebar__toggle {
 		.sidebar__menu-link {
 			cursor: pointer;
-			color: var(--color-sidebar-text-alternative);
+			color: var(--color-sidebar-text);
 			font-size: rem(13px);
 
 			&:hover,
 			&:focus {
+				color: var(--color-sidebar-submenu-hover-text);
 				background-color: transparent;
+				box-shadow: none;
+
+				.sidebar__menu-icon {
+					color: var(--color-sidebar-submenu-hover-text);
+				}
 			}
 		}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -318,7 +318,7 @@ $font-size: rem(14px);
 		// Is toggled open
 		.sidebar__menu.sidebar__menu--selected {
 			.sidebar__heading {
-				background: var(--color-sidebar-menu-hover-background);
+				background: var(--color-sidebar-menu-selected-background);
 				color: var(--color-sidebar-menu-selected-text);
 
 				&::after {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -871,7 +871,7 @@ $font-size: rem(14px);
 	.collapse-sidebar__toggle {
 		.sidebar__menu-link {
 			cursor: pointer;
-			color: var(--color-sidebar-text);
+			color: var(--color-collapse-menu-text);
 			font-size: rem(13px);
 
 			&:hover,

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -235,7 +235,7 @@ $font-size: rem(14px);
 				font-weight: 600;
 
 				&:hover {
-					color: var(--color-sidebar-submenu-hover-text);
+					color: var(--color-sidebar-submenu-selected-hover-text);
 				}
 			}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -638,6 +638,11 @@ $font-size: rem(14px);
 				background-color: revert;
 				color: var(--color-navredesign-sidebar-submenu-selected-text);
 				font-weight: 600;
+
+				&:hover,
+				&:focus {
+					color: var(--color-navredesign-sidebar-submenu-selected-hover-text);
+				}
 			}
 			.sidebar__menu-link {
 				color: var(--color-navredesign-sidebar-submenu-text);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -168,15 +168,15 @@ Primary+Accent is studio blue.
 	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color);
 	--color-navredesign-sidebar-submenu-selected-hover-text: var(--theme-highlight-color);
 
+	/* Collapse Menu Button */
+	--color-collapse-menu-text: #777;
+
 	/* Fix for notification bell */
 	.masterbar__item-notifications {
 		.gridicon {
 			fill: #000;
 		}
 	}
-
-	/* Collapse Menu Button Fix */
-	--color-collapse-menu-text: #777;
 
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-highlight-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -160,11 +160,13 @@ Primary+Accent is studio blue.
 	--color-sidebar-submenu-hover-background: transparent;
 	--color-sidebar-submenu-hover-text: var(--theme-highlight-color);
 	--color-sidebar-submenu-selected-text: #333;
+	--color-sidebar-submenu-selected-hover-text: var(--theme-highlight-color);
 
 	/* Sidebar Submenu - Nav Redesign */
 	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
 	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
 	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color);
+	--color-navredesign-sidebar-submenu-selected-hover-text: var(--theme-highlight-color);
 
 	/* Fix for notification bell */
 	.masterbar__item-notifications {
@@ -172,6 +174,9 @@ Primary+Accent is studio blue.
 			fill: #000;
 		}
 	}
+
+	/* Collapse Menu Button Fix */
+	--color-collapse-menu-text: #777;
 
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-highlight-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -142,10 +142,10 @@ Primary+Accent is studio blue.
 	--color-sidebar-gridicon-fill: var(--theme-icon-color);
 
 	/* Sidebar Selected */
-	--color-sidebar-menu-selected-background: #888;
-	--color-sidebar-menu-selected-background-rgb: 136, 136, 136;
-	--color-sidebar-menu-selected-text: #fff;
-	--color-sidebar-menu-selected-text-rgb: 255, 255, 255;
+	--color-sidebar-menu-selected-background: #fff;
+	--color-sidebar-menu-selected-background-rgb: 255, 255, 255;
+	--color-sidebar-menu-selected-text: #333;
+	--color-sidebar-menu-selected-text-rgb: 51, 51, 51;
 
 	/* Sidebar Hover */
 	--color-sidebar-menu-hover-background: #888;
@@ -163,7 +163,6 @@ Primary+Accent is studio blue.
 
 	/* Sidebar Submenu - Nav Redesign */
 	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
-	--color-navredesign-sidebar-menu-selected-text: var(--theme-submenu-background-color);
 	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
 	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of 7884-gh-Automattic/dotcom-forge

## Proposed Changes

Updates the Light color scheme to address discrepancies from wp-admin, for a more consistent user experience.

## Why are these changes being made?

An [issue](https://github.com/Automattic/wp-calypso/pull/92005) recently highlighted some disconnects that have developed between our unified/redesigned sidebars and the wp-admin styles for various color schemes. This PR is addresses those for the Light color scheme.

## Note

Because the schemes depend on the variables provided by `client/my-sites/sidebar/style.scss`, this PR is branched off of https://github.com/Automattic/wp-calypso/pull/92397.

If any changes are recommended for `client/my-sites/sidebar/style.scss`, please leave a note on that PR instead of this one, so I can make changes there, and then rebase the individual scheme PRs.

## Testing Instructions

There are three views we care about:
- Calypso sidebar
- My Home/Hosting sidebar
- wp-admin (the control that we're updating schemes to match again)

1. Select a simple site and make sure you have the "default" view (i.e. Calypso) selected
2. In a separate tab, select an Atomic site. Under **Settings > General**, choose the wp-admin/classic interaface. Open any wp-admin page.
3. In a third tab, select **Tools > Hosting** for your Atomic site. This should open `/home/[site-url]`, where you'll find a Calypso interface with the **Hosting** section open to the **My Home** submenu item
4. Activate the Light color scheme for your site
5. In both of your Calypso-based tabs, confirm that the following match wp-admin(hopefully exactly, but at least visually close enough to provide a good UX):
	5.1. Unfocused text and background colors for menu items and submenu items
	5.2. Unfocused text and background colors in the flyout when hovering over an expandable item like "Posts"
	5.3. Unfocused text and background colors in the in-sidebar submenu when an expandable item is selected
	5.4. Unfocused text and background colors for the currently selected items (e.g. **Posts**) and submenu items (e.g. **All Posts**)
	5.5. Hover text and background colors for menu items and submenu items
	5.6. Hover text and background colors in the flyout when hovering over an expandable item like "Posts"
	5.7. Hover text and background colors in the in-sidebar submenu when an expandable item is selected
	5.8. Hover text and background colors for the currently selected items (e.g. **Posts**) and submenu items (e.g. **All Posts**)
	5.9. The "Collapse Menu" link, both unfocused and hovered

The hover states of a currently selected submenu item like "All Posts" and the "Collapse Menu" link were where I found the most nuance/variation from one scheme to the next.