### PR TITLE
Rotate unlock string for GB v18.7.0 in the rest of calypso app 

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -33,7 +33,9 @@ import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
 let unlock;
 try {
 	unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		window.wpcomGutenberg?.pluginVersion?.startsWith( 'v18.7' )
+			? 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.'
+			: 'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 		'@wordpress/edit-site'
 	).unlock;
 } catch ( error ) {

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -16,7 +16,10 @@ import type { RenderedStyle } from '../types';
 import './block-renderer-container.scss';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	( window as any ).wpcomGutenberg?.pluginVersion?.startsWith( 'v18.7' )
+		? 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.'
+		: 'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 	'@wordpress/block-editor'
 );
 

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -12,7 +12,10 @@ import { isPlainObject } from 'is-plain-object';
 import type { GlobalStylesObject, GlobalStylesContextObject } from '../types';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	( window as any ).wpcomGutenberg?.pluginVersion?.startsWith( 'v18.7' )
+		? 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.'
+		: 'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 	'@wordpress/block-editor'
 );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/8094
- Follow up https://github.com/Automattic/wp-calypso/pull/92384

## Proposed Changes

* Update  unlock strings GB APIs to match what's required on [v18.7.0](https://github.com/Automattic/wp-calypso/issues/92109) keeping the fallback if `wpcomGutenberg` version doesn't start with the new version.

- Previous String: `I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.`
- New String: `I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.`

- My Plan is to remove the condition and old string once I deployed the new GB version. https://github.com/Automattic/dotcom-forge/issues/8118

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/WordPress/gutenberg/pull/62635

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
