### PR TITLE
Fix migration page spacing

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
@@ -4,6 +4,14 @@
 .import-hosted-site,
 .site-migration :not(.site-migration-instructions--launchpad),
 .import-focused.migrate-message {
+
+	.step-container__header {
+		margin: auto;
+		max-width: 720px;
+		padding: 24px;
+		width: auto;
+	}
+
 	.step-container__content {
 		margin: auto;
 		max-width: 720px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
@@ -58,6 +58,11 @@
 	.migration-message__actions {
 		display: flex;
 		justify-content: center;
-		margin: 0 -10px;
+		margin: 32px -10px 0;
+		flex-direction: column;
+
+		@include break-small {
+			flex-direction: row;
+		}
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/92260

## Proposed Changes
This PR fixes makes the following updates to the post migration screen:

- Fixes the button spacing
- Optimizes the layout for mobile
- Updates the support link to Getting started with WordPress.com

## Why are these changes being made?

- The next step buttons appear too close to the `What to expect` section,
- the layout isn't optimized for mobile,
- The generic support link is overwhelming.

## Screenshots

**Before**
<img width="1840" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6981253/9b10cb5f-0dba-4172-b76a-a7f2a99daced">

<img width="1840" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6981253/6b510042-3d51-4ce9-8a84-e10bfab3414c">

<img width="1840" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6981253/fa8225cd-b72c-4905-94b4-e1a99f0d055c">


**After**
<img width="1724" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6981253/1e14e5c2-17af-459e-a7a1-f1cb10122bee">

<img width="1840" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6981253/1cfb3ce6-b5f8-481f-9b3b-93fbb98915f7">


<img width="1840" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6981253/aaffcac0-9510-4342-945e-97c8e3719f93">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this PR to your local environment or use the Calypso Live link below
- Navigate to /start and go through the migration flow until you reach the "What do you want to do?" step.
- Select "Migrate site"
- On the "How to migrate" step, select the "Do it for me" option
- Go through the checkout in case you are testing on a free site
- You should land on the assisted migration instruction step
- You should now see two cards on the bottom. Click on both of them and check that you are being redirected to the Customer Home page and the Getting started with WordPress.com support page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
