### PR TITLE
Midnight Color Scheme: Update to match wp-admin

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -224,15 +224,19 @@ $font-size: rem(14px);
 
 				&:hover,
 				&:focus {
-					background-color: var(--color-sidebar-menu-hover-background);
-					color: var(--color-sidebar-menu-hover-text);
+					background-color: var(--color-sidebar-submenu-hover-background);
+					color: var(--color-sidebar-submenu-hover-text);
 				}
 			}
 
 			.selected .sidebar__menu-link {
-				background-color: var(--color-sidebar-menu-selected-background);
-				color: var(--color-sidebar-menu-selected-text);
+				background-color: var(--color-sidebar-submenu-selected-background);
+				color: var(--color-sidebar-submenu-selected-text);
 				font-weight: 600;
+
+				&:hover {
+					color: var(--color-sidebar-submenu-hover-text);
+				}
 			}
 
 			.sidebar__menu-link-text {
@@ -315,6 +319,7 @@ $font-size: rem(14px);
 		.sidebar__menu.sidebar__menu--selected {
 			.sidebar__heading {
 				background: var(--color-sidebar-menu-hover-background);
+				color: var(--color-sidebar-menu-selected-text);
 
 				&::after {
 					display: block;
@@ -866,12 +871,18 @@ $font-size: rem(14px);
 	.collapse-sidebar__toggle {
 		.sidebar__menu-link {
 			cursor: pointer;
-			color: var(--color-sidebar-text-alternative);
+			color: var(--color-sidebar-text);
 			font-size: rem(13px);
 
 			&:hover,
 			&:focus {
+				color: var(--color-sidebar-submenu-hover-text);
 				background-color: transparent;
+				box-shadow: none;
+
+				.sidebar__menu-icon {
+					color: var(--color-sidebar-submenu-hover-text);
+				}
 			}
 		}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -318,7 +318,7 @@ $font-size: rem(14px);
 		// Is toggled open
 		.sidebar__menu.sidebar__menu--selected {
 			.sidebar__heading {
-				background: var(--color-sidebar-menu-hover-background);
+				background: var(--color-sidebar-menu-selected-background);
 				color: var(--color-sidebar-menu-selected-text);
 
 				&::after {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -871,7 +871,7 @@ $font-size: rem(14px);
 	.collapse-sidebar__toggle {
 		.sidebar__menu-link {
 			cursor: pointer;
-			color: var(--color-sidebar-text);
+			color: var(--color-collapse-menu-text);
 			font-size: rem(13px);
 
 			&:hover,

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -235,7 +235,7 @@ $font-size: rem(14px);
 				font-weight: 600;
 
 				&:hover {
-					color: var(--color-sidebar-submenu-hover-text);
+					color: var(--color-sidebar-submenu-selected-hover-text);
 				}
 			}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -638,6 +638,11 @@ $font-size: rem(14px);
 				background-color: revert;
 				color: var(--color-navredesign-sidebar-submenu-selected-text);
 				font-weight: 600;
+
+				&:hover,
+				&:focus {
+					color: var(--color-navredesign-sidebar-submenu-selected-hover-text);
+				}
 			}
 			.sidebar__menu-link {
 				color: var(--color-navredesign-sidebar-submenu-text);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -127,8 +127,6 @@ $notification-color: #69a8bb;
 	--color-sidebar-menu-hover-background-rgb: var(--theme-highlight-color-rgb);
 	--color-sidebar-menu-hover-text: var(--theme-text-color);
 
-	/* Sidebar Hover - Nav unification */
-
 	/* Sidebar Submenu - Nav Unification */
 	--color-sidebar-submenu-background: var(--theme-submenu-background-color);
 	--color-sidebar-submenu-text: var(--theme-submenu-text-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_midnight.scss
@@ -134,12 +134,14 @@ $notification-color: #69a8bb;
 	--color-sidebar-submenu-text: var(--theme-submenu-text-color);
 	--color-sidebar-submenu-hover-background: transparent;
 	--color-sidebar-submenu-hover-text: var(--theme-highlight-color);
+	--color-sidebar-submenu-selected-hover-text: var(--color-accent);
 
 	/* Sidebar Submenu - Nav Redesign */
 	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
 	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
 	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
 	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color);
+	--color-navredesign-sidebar-submenu-selected-hover-text: var(--theme-highlight-color);
 
 	/* Command Palette Items */
 	--wp-admin-theme-color: var(--theme-highlight-color);

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -165,8 +165,6 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	--color-sidebar-menu-hover-background-rgb: var(--theme-highlight-color-rgb);
 	--color-sidebar-menu-hover-text: var(--theme-text-color);
 
-	/* Sidebar Hover - Nav unification */
-
 	/* Sidebar Submenu - Nav Unification */
 	--color-sidebar-submenu-background: var(--theme-submenu-background-color);
 	--color-sidebar-submenu-text: var(--theme-submenu-text-color);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of 7884-gh-Automattic/dotcom-forge

## Proposed Changes

Updates the Midnight color scheme to address discrepancies from wp-admin, for a more consistent user experience.

## Why are these changes being made?

An [issue](https://github.com/Automattic/wp-calypso/pull/92005) recently highlighted some disconnects that have developed between our unified/redesigned sidebars and the wp-admin styles for various color schemes. This PR is addresses those for the Midnight color scheme.

## Note

Because the schemes depend on the variables provided by `client/my-sites/sidebar/style.scss`, this PR is branched off of https://github.com/Automattic/wp-calypso/pull/92397.

If any changes are recommended for `client/my-sites/sidebar/style.scss`, please leave a note on that PR instead of this one, so I can make changes there, and then rebase the individual scheme PRs.

## Testing Instructions

**Important** Some items have received changes to their code that won't be reflected visually, because the only change was renaming a variable. That means comparing to production/trunk can be misleading, because a changed sidebar might look just like production, but the change is still needed for the new variables in the sidebar styles to work.

Instead of direct production/trunk comparisons of a link like (for example) **My Sites** under **Hosting**, focus on comparing the behavior of the types of links you're looking at. When **My Sites** on the Hosting sidebar is the currently selected menu item, it should behave the same way and have the same color/hover effect as, for example **All Posts** under **Posts**, when it's selected... basically, when testing this one, avoid asking:

> Does this sidebar on local calypso look different than it does on production?

Instead, ask:

> Does this currently selected sidebar item on local calypso match currently selected submenu items in `wp-admin`?

There are three views we care about:
- Calypso sidebar
- My Home/Hosting sidebar
- wp-admin (the control that we're updating schemes to match again)

1. Select a simple site and make sure you have the "default" view (i.e. Calypso) selected
2. In a separate tab, select an Atomic site. If you haven't already done so previously, select **Tools > Hosting** for your Atomic site and activate hosting settings. If this site was already atomic, you should already see the **Hosting** sidebar item. This should open `/home/[site-url]`, where you'll find a Calypso interface with the **Hosting** section open to the **My Home** submenu item
3. Under **Settings > General**, choose the wp-admin/classic interface for your Atomic site
4. In a third tab, select the same Atomic site. Open any wp-admin page. **This tab isn't changing, but we'll want it open to visually compare the other two tabs to so we can make sure they match.**
5. Activate the Modern color scheme for your site
6. In your Calypso sidebar tab (from step 1) and your My Home/Hosting sidebar tab (from step 2), confirm that the following items match your wp-admin tab (from step 3):
	6.1. Unfocused text and background colors for menu items and submenu items
	6.2. Unfocused text and background colors in the flyout when hovering over an expandable item like "Posts"
	6.3. Unfocused text and background colors in the in-sidebar submenu when an expandable item is selected
	6.4. Unfocused text and background colors for the currently selected items (e.g. **Posts**) and submenu items (e.g. **All Posts**)
	6.5. Hover text and background colors for menu items and submenu items
	6.6. Hover text and background colors in the flyout when hovering over an expandable item like "Posts"
	6.7. Hover text and background colors in the in-sidebar submenu when an expandable item is selected
	6.8. Hover text and background colors for the currently selected items (e.g. **Posts**) and submenu items (e.g. **All Posts**)
	6.9. The "Collapse Menu" link, both unfocused and hovered

The hover states of a currently selected submenu item like "All Posts" and the "Collapse Menu" link were where I found the most nuance/variation from one scheme to the next.