### PR TITLE
A4A: Address design feedback on site creation configuration.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -1,10 +1,10 @@
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { CheckboxControl, Modal } from '@wordpress/components';
+import { CheckboxControl, Icon, Modal } from '@wordpress/components';
+import { check, closeSmall } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
@@ -49,21 +49,42 @@ export default function SiteConfigurationsModal( {
 		Object.keys( dataCenterOptions ) as Array< keyof typeof dataCenterOptions >
 	 ).map( ( key ) => (
 		<option key={ key } value={ key }>
-			{ dataCenterOptions[ key ] }
+			{ dataCenterOptions[ key as keyof typeof dataCenterOptions ] }
 		</option>
 	) );
 
+	const onSiteNameKeyDown = ( event: React.KeyboardEvent ) => {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+		}
+	};
+
+	const onSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		const formData = new FormData( event.currentTarget );
+		const phpVersion = formData.get( 'php_version' ) as string;
+		const primaryDataCenter = ( formData.get( 'primary_data_center' ) as string ) || undefined;
+		const params = {
+			site_name: siteName.siteName,
+			php_version: phpVersion,
+			primary_data_center: primaryDataCenter,
+			is_fully_managed_agency_site: allowClientsToUseSiteHelpCenter,
+		};
+		// eslint-disable-next-line no-console
+		console.log( params );
+	};
+
 	return (
 		<Modal
-			title={ translate( 'Configure your site' ) }
+			title={ translate( 'Configure your new site' ) }
 			onRequestClose={ toggleModal }
 			className="configure-your-site-modal-form"
 		>
-			<FormFieldset className="configure-your-site-modal-form__main">
+			<form onSubmit={ onSubmit }>
 				<FormField
 					label={ translate( 'Site address' ) }
 					description={ translate(
-						'Once the site is created, you can connect a custom domain to your site and make that your site address instead.'
+						'After creating your site, you can connect a custom domain for the address.'
 					) }
 				>
 					<div className="configure-your-site-modal-form__site-name-wrapper">
@@ -71,28 +92,31 @@ export default function SiteConfigurationsModal( {
 							<div className="configure-your-site-modal-form__site-name-placeholder" />
 						) : (
 							<FormTextInputWithAffixes
+								name="site_name"
 								isError={ siteName.showValidationMessage }
 								value={ siteName.siteName }
 								onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 									siteName.setSiteName( event.target.value )
 								}
+								onKeyDown={ onSiteNameKeyDown }
 								suffix=".wpcomstaging.com"
 								noWrap
-								spellcheck="false"
+								spellCheck="false"
 							/>
 						) }
 						<div className="configure-your-site-modal-form__site-name-icon-wrapper">
 							{ ! siteName.showValidationMessage && ! isRandomSiteNameLoading && (
-								<Gridicon
-									icon="checkmark-circle"
-									size={ 24 }
+								<Icon
+									icon={ check }
+									size={ 28 }
 									className="configure-your-site-modal-form__site-name-success"
 								/>
 							) }
 							{ siteName.showValidationMessage && (
-								<Gridicon
-									icon="cross-circle"
-									size={ 24 }
+								<Icon
+									icon={ closeSmall }
+									size={ 28 }
+									color="red"
 									className="configure-your-site-modal-form__site-name-fail"
 								/>
 							) }
@@ -106,13 +130,17 @@ export default function SiteConfigurationsModal( {
 					) }
 				</FormField>
 				<FormField
-					label={ translate( 'PHP Version' ) }
+					label={ translate( 'PHP version' ) }
 					description={ translate(
 						'The PHP version can be changed after your site is created via {{a}}Web Server Settings{{/a}}.',
 						{
 							components: {
 								a: (
-									<a href="https://developer.wordpress.com/docs/developer-tools/web-server-settings/" />
+									<a
+										target="_blank"
+										href="https://developer.wordpress.com/docs/developer-tools/web-server-settings/"
+										rel="noreferrer"
+									/>
 								),
 							},
 						}
@@ -120,14 +148,15 @@ export default function SiteConfigurationsModal( {
 				>
 					<FormSelect
 						className="configure-your-site-modal-form__php-version-select"
-						name="product"
+						name="php_version"
 						onChange={ () => {} }
 					>
 						{ phpVersionsElements }
 					</FormSelect>
 				</FormField>
-				<FormField label={ translate( 'Primary Data Center' ) }>
-					<FormSelect name="product" id="product" onChange={ () => {} }>
+				<FormField label={ translate( 'Primary data center' ) }>
+					<FormSelect name="primary_data_center" onChange={ () => {} }>
+						<option value="">{ translate( 'No Preference' ) }</option>
 						{ dataCenterOptionsElements }
 					</FormSelect>
 				</FormField>
@@ -137,6 +166,7 @@ export default function SiteConfigurationsModal( {
 							id="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox"
 							onChange={ toggleAllowClientsToUseSiteHelpCenter }
 							checked={ allowClientsToUseSiteHelpCenter }
+							name="is_fully_managed_agency_site"
 						/>
 						<label htmlFor="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox">
 							{ translate(
@@ -145,16 +175,20 @@ export default function SiteConfigurationsModal( {
 									components: {
 										HcLink: (
 											<a
+												target="_blank"
 												href={ localizeUrl(
-													'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
+													'https://wordpress.com/support/help-support-options/#how-to-contact-us'
 												) }
+												rel="noreferrer"
 											/>
 										),
 										HfLink: (
 											<a
+												target="_blank"
 												href={ localizeUrl(
 													'https://wordpress.com/support/hosting-configuration'
 												) }
+												rel="noreferrer"
 											/>
 										),
 									},
@@ -163,12 +197,12 @@ export default function SiteConfigurationsModal( {
 						</label>
 					</div>
 				</FormField>
-			</FormFieldset>
-			<div className="configure-your-site-modal-form__footer">
-				<Button primary onClick={ () => {} }>
-					{ translate( 'Create site' ) }
-				</Button>
-			</div>
+				<div className="configure-your-site-modal-form__footer">
+					<Button primary type="submit">
+						{ translate( 'Create site' ) }
+					</Button>
+				</div>
+			</form>
 		</Modal>
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -156,7 +156,7 @@ export default function SiteConfigurationsModal( {
 				</FormField>
 				<FormField label={ translate( 'Primary data center' ) }>
 					<FormSelect name="primary_data_center" onChange={ () => {} }>
-						<option value="">{ translate( 'No Preference' ) }</option>
+						<option value="">{ translate( 'No preference' ) }</option>
 						{ dataCenterOptionsElements }
 					</FormSelect>
 				</FormField>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -92,6 +92,7 @@ export default function SiteConfigurationsModal( {
 							<div className="configure-your-site-modal-form__site-name-placeholder" />
 						) : (
 							<FormTextInputWithAffixes
+								className="configure-your-site-modal-form__input"
 								name="site_name"
 								isError={ siteName.showValidationMessage }
 								value={ siteName.siteName }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .configure-your-site-modal-form {
-	max-width: 600px;
+	max-width: 650px;
 
 	select {
 		width: fit-content;

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
@@ -6,12 +6,6 @@
 	select {
 		width: fit-content;
 	}
-	.components-modal__content {
-		padding: 0;
-	}
-	.configure-your-site-modal-form__main {
-		padding: 0 30px;
-	}
 
 	.configure-your-site-modal-form__php-version-select {
 		min-width: 200px;
@@ -26,10 +20,8 @@
 	}
 
 	.configure-your-site-modal-form__footer {
-		padding: 24px 40px;
+		margin-top: 42px;
 		text-align: right;
-		background-color: var(--color-neutral-0);
-		border-radius: 4px;
 	}
 
 	.configure-your-site-modal-form__site-name-placeholder {
@@ -45,7 +37,8 @@
 
 		.configure-your-site-modal-form__site-name-icon-wrapper {
 			display: flex;
-			width: 24px;
+			justify-content: space-around;
+			margin-right: -5px;
 			margin-left: 5px;
 		}
 
@@ -54,7 +47,7 @@
 		}
 
 		.configure-your-site-modal-form__site-name-fail {
-			color: var(--color-error);
+			fill: var(--color-error);
 		}
 	}
 
@@ -64,6 +57,7 @@
 		font-size: rem(14px);
 		line-height: 1.5;
 		color: var(--color-error);
+		margin-top: 4px;
 
 		svg {
 			margin-right: 5px;

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
@@ -35,6 +35,18 @@
 		display: flex;
 		align-items: center;
 
+		.form-text-input-with-affixes {
+			.configure-your-site-modal-form__input {
+				border-top-left-radius: 2px;
+				border-bottom-left-radius: 2px;
+			}
+
+			.form-text-input-with-affixes__suffix {
+				border-top-right-radius: 2px;
+				border-bottom-right-radius: 2px;
+			}
+		}
+
 		.configure-your-site-modal-form__site-name-icon-wrapper {
 			display: flex;
 			justify-content: space-around;


### PR DESCRIPTION
## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/33497086/d1a3c889-507d-43cd-a892-3ab6cb03846b)
We are addressing some feedback got after design reviewed the site configuration modal.

- Add the `No preference` option on data center picker.
- Links in blue should open on another tab.
- `WordPress.com Help Center` should point to https://wordpress.com/support/help-support-options/#how-to-contact-us.
- Update the form title to `Configure your new site`
- Update site address description to `After creating your site, you can connect a custom domain for the address.`
- Use the [newer icon](https://www.figma.com/design/e4tLacmlPuZV47l7901FEs/WordPress-Design-Library?node-id=33465-27876&t=dpay3x89tD3tbBmw-4) for the check and x.
- Add a 4px margin-top to the validation error text, on site address field.
- Change modal footer to white.
- Use ' Sentence case' on fields labels. Meaing only the first word gets a uppercase first letter: `PHP Version` -> `PHP version`
## Testing Instructions

This feature is under a4a-site-creation-configurations flag.
Before accessing the Create new site button, your account needs to have at least 1 hosting license, ready to be used.
If you are not sure how to get that, read [PdDOJh-3ys-p2](https://href.li/?https://wp.me/PdDOJh-3ys).

Open this link: http://agencies.localhost:3000/sites/need-setup?flags=a4a-site-creation-configurations
Check list if the feedbacks listed above are addressed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
