### PR TITLE
Plugin Details: Pass all sites to the notice component

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -373,7 +373,7 @@ function PluginDetails( props ) {
 			<NavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs } />
 			<PluginNotices
 				pluginId={ fullPlugin.id }
-				sites={ sitesWithPlugins }
+				sites={ selectedOrAllSites }
 				plugins={ [ fullPlugin ] }
 			/>
 			{ isSiteConnected === false && (


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8083


## Proposed Changes

Pass all sites to the `PluginNotices` component. Before this change, only sites with plugins were being passsed.

## Why are these changes being made?

To fix Fixes https://github.com/Automattic/dotcom-forge/issues/8083

## Testing Instructions

Preparation: You must have an atomic site without plugins installed

* Go to a plugin details page of a free plugin: `/plugins/booking`
* Click on `Manage sites`
* Click on the `install` button of the atomic site without plugins installed
* You must see the site name (or URL) on the notification

| Before  | After |
| ------------- | ------------- |
|![](https://private-user-images.githubusercontent.com/12430020/345737383-ffe09bb1-3d11-464a-a1e5-7f2a892ac3f6.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjAxMjA5ODUsIm5iZiI6MTcyMDEyMDY4NSwicGF0aCI6Ii8xMjQzMDAyMC8zNDU3MzczODMtZmZlMDliYjEtM2QxMS00NjRhLWExZTUtN2YyYTg5MmFjM2Y2LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MDQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzA0VDE5MTgwNVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTIxMzExOTYxY2UzOWRiY2Q4NTllODljMDcxOGJmY2U5NWM1MmMzYjc5N2FjMTAyOWY2MDRmOWE5ZDBmMzAyMjkmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.SueywOPoGnw9hiRaC6gni9smwHS6n8LbChuvH6pM2Sg)|![CleanShot 2024-07-04 at 16 35 44@2x](https://github.com/Automattic/wp-calypso/assets/5039531/829b1bf0-5298-4ffc-991c-20da7a411864)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
