### PR TITLE
fix: gap between masterbar and notifications

### DIFF
--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -686,11 +686,6 @@
 	&.focus-content .layout__content,
 	&.focus-sidebar .layout__content {
 		padding-bottom: 0;
-		padding-top: var(--masterbar-height);
-
-		@include break-small {
-			padding-top: calc(var(--masterbar-height) + 24px);
-		}
 
 		.main.a4a-layout.sites-dashboard.sites-dashboard__layout {
 			height: calc(100vh - var(--masterbar-height));

--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -680,8 +680,8 @@
 }
 
 // Override styles from my-sites/sidebar
-.wpcom-site div.is-section-hosting:not(.has-no-masterbar),
-.wpcom-site div.is-section-hosting-dashboard:not(.has-no-masterbar),
+.wpcom-site div.is-group-sites:not(.has-no-masterbar),
+.wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar),
 .wpcom-site div.is-section-plugins:not(.has-no-masterbar) {
 	&.focus-content .layout__content,
 	&.focus-sidebar .layout__content {

--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -680,8 +680,8 @@
 }
 
 // Override styles from my-sites/sidebar
-.wpcom-site div.is-group-sites:not(.has-no-masterbar),
-.wpcom-site div.is-group-sites-dashboard:not(.has-no-masterbar),
+.wpcom-site div.is-section-hosting:not(.has-no-masterbar),
+.wpcom-site div.is-section-hosting-dashboard:not(.has-no-masterbar),
 .wpcom-site div.is-section-plugins:not(.has-no-masterbar) {
 	&.focus-content .layout__content,
 	&.focus-sidebar .layout__content {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8062

## Why are these changes being made?
During this walkthrough (p58i-hxi-p2) at 4:20, one issue came up - the notification collided with masterbar. So with this PR we should fix it - there should be some gap between them.

## Proposed Changes
Initially, I was planning to go another way, since actually there is bigger issue, connected with CSS chanks loading - https://github.com/Automattic/dotcom-forge/issues/8062#issuecomment-2209223769
And I wonder - do we have some rule in Calypso, for example - chank that is necessary only for some specific page should be unloaded after abandoning this page. Or maybe we should not unload, but every chunk should be encapsulated with some parent class, to avoid styles leaking to other pages.

But after digging around more I realized that this issue can be fixed easier - by removing redundant padding-top introduced in [this PR](https://github.com/Automattic/wp-calypso/pull/90251/files#diff-44bf73f450bf5f50d9bbcaa35d2e899f2d8dc8a5e3a3911b19980a2d550f2ed1R387-R391). There is huge chance that I missed something, some exceptional case where this padding is really necessary, but I can't find it, so with this PR I decided to propose to fix it this way. @taipeicoder could you please take a look, maybe there is indeed some case which I missed.

## Testing Instructions
* Apply the 34fba-pb diff to your sandbox to force showing the notification
* Open `http://calypso.localhost:3000/sites`
* Assert that padding at the top of the page looks good<br /><img width="1455" alt="Screenshot 2024-07-04 at 22 36 29" src="https://github.com/Automattic/wp-calypso/assets/5598437/ddadb10e-e63f-4127-b129-f6f2ad1534fe">
* Decrease window size till masterbar appears
* Assert that gap between masterbar and content looks good <br /><img width="706" alt="Screenshot 2024-07-04 at 22 38 27" src="https://github.com/Automattic/wp-calypso/assets/5598437/ddb2ada7-2d44-4a97-b763-4b0ac9c5f86d">
* Click on the stats graph of your website<br/><img width="1212" alt="Screenshot 2024-07-04 at 22 41 20" src="https://github.com/Automattic/wp-calypso/assets/5598437/9390d0b1-8a1c-4105-ad76-9a7bccf81d23">
* Assert that gap looks good <br />it's exactly the case, where we had previously a bug<table>
<tr>
<td>BEFORE
<td><img width="1266" alt="Screenshot 2024-07-04 at 22 45 47" src="https://github.com/Automattic/wp-calypso/assets/5598437/d31155f4-b46f-4826-bce3-e2b81dccfd60">
</tr>
<tr>
<td>AFTER
<td><img width="1286" alt="Screenshot 2024-07-04 at 22 43 12" src="https://github.com/Automattic/wp-calypso/assets/5598437/f56463f9-ab03-45db-a883-1f042d0324ea">
</tr>
</table><br />

* Reload the page
* Assert that the gap still looks good, as on the previous step
* Decrease window size
* Assert that the gap looks good