### PR TITLE
Jetpack Cloud: Fix access to cloud for sites with VaultPress Backup standalone plugin

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -91,10 +91,13 @@ export function requestSites() {
 			} )
 			.then( ( response ) => {
 				const jetpackCloudSites = response.sites.filter( ( site ) => {
+					const isJetpack =
+						site?.jetpack || Boolean( site?.options?.jetpack_connection_active_plugins?.length );
+
 					// Filter Jetpack Cloud sites to exclude P2 and Simple non-Classic sites by default.
 					const isP2 = site?.options?.is_wpforteams_site;
 					const isSimpleClassic =
-						! site?.jetpack &&
+						! isJetpack &&
 						! site?.is_wpcom_atomic &&
 						site?.options?.wpcom_admin_interface !== 'wp-admin';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/jetpack-backup-team/issues/566

## Proposed Changes

* Consider sites with Jetpack standalone plugins as Jetpack sites so they can access Jetpack Cloud

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Since https://github.com/Automattic/wp-calypso/pull/91532, Jetpack sites with only the VaultPress Backup standalone plugin installed can not access Jetpack Cloud. This is because the /sites/ endpoint is returning `jetpack` as `false` in those cases because that flag is intended to tell if the site has the Jetpack plugin installed (ref: p1720144484388509-slack-C05PV073SG3).

So, to fix this, we just need to consider the option `jetpack_connection_active_plugins` as well instead of fully relying on the `jetpack` option.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch
* Install the VaultPress Backup plugin on one of your self-hosted sites (you can use Jurassic Ninja as well), connect the site to Jetpack and purchase a plan.
* Ensure you don't have the Jetpack plugin installed.
* In your VaultPress Backup plugin, try clicking on `See your backups in the cloud`, it should navigate you to Jetpack Cloud.
* Ensure Jetpack Cloud is working, and you can see backups, navigate to the Activity Log and Settings page without any issue.

In addition, follow the tests instructions of this PR and ensure it is still working: https://github.com/Automattic/wp-calypso/pull/91532

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?