### PR TITLE
Stats: Add some missing keys

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -136,8 +136,8 @@ const DoYouLoveJetpackStatsNotice = ( {
 				title={ hasFreeStats ? freeTitle : noPurchaseTitle }
 				onClose={ dismissNotice }
 			>
-				<p>{ description }</p>
-				<p>
+				<p key="desc">{ description }</p>
+				<p key="cta">
 					<button type="button" className="notice-banner__action-button" onClick={ handleCTAClick }>
 						{ CTAText }
 					</button>

--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -77,12 +77,13 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 	return (
 		<div className="plan-usage">
 			<h3 className="plan-usage-heading">{ translate( 'Your Stats plan usage' ) }</h3>
-			<div className={ progressClassNames }>
+			<div className={ progressClassNames } key="progress">
 				<div
 					className="plan-usage-progress-bar"
 					style={ { width: `${ progressWidthInPercentage }%` } }
+					key="bar"
 				></div>
-				<div>
+				<div key="usage">
 					{ translate( '%(numberOfUsage)s / %(numberOfLimit)s views', {
 						args: {
 							numberOfUsage: formattedNumber( usage ),
@@ -90,7 +91,7 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 						},
 					} ) }
 				</div>
-				<div>
+				<div key="message">
 					{ translate( 'Restarts in %(numberOfDays)d day', 'Restarts in %(numberOfDays)d days', {
 						count: daysToReset,
 						args: {
@@ -99,7 +100,7 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 					} ) }
 				</div>
 			</div>
-			<div className="plan-usage-note">
+			<div className="plan-usage-note" key="upgrade">
 				<span>
 					{ overLimitMonthsText } { upgradeNote }
 				</span>

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -63,7 +63,7 @@ const StatsCard = ( {
 			</div>
 			{ ! isEmpty && (
 				<div className={ `${ BASE_CLASS_NAME }--column-header` }>
-					<div className={ `${ BASE_CLASS_NAME }--column-header__left` }>
+					<div className={ `${ BASE_CLASS_NAME }--column-header__left` } key="left">
 						{ splitHeader && mainItemLabel }
 						{ additionalHeaderColumns && (
 							<div className={ `${ BASE_CLASS_NAME }-header__additional` }>
@@ -72,7 +72,7 @@ const StatsCard = ( {
 						) }
 					</div>
 					{ ! isEmpty && (
-						<div className={ `${ BASE_CLASS_NAME }--column-header__right` }>
+						<div className={ `${ BASE_CLASS_NAME }--column-header__right` } key="right">
 							{ metricLabel ?? translate( 'Views' ) }
 						</div>
 					) }


### PR DESCRIPTION

## Proposed Changes

* Add some missing keys

## Why are these changes being made?


* Removing warnings

## Testing Instructions

* Ensure it builds well
* Build and test Odyssey locally 
* Ensure no warnings thrown for Traffic and Insights page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?