### PR TITLE
Remove forced sites fallback

### DIFF
--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -19,7 +19,6 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 			className={ clsx( 'sidebar--plugins', { 'is-collapsed': isCollapsed } ) }
 			siteTitle={ ! isCollapsed && translate( 'Plugins' ) }
 			requireBackLink
-			backLinkHref="/sites"
 			subHeading={
 				! isCollapsed &&
 				translate(

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -296,7 +296,7 @@ export class ReaderSidebar extends Component {
 			onClick: this.handleClick,
 			requireBackLink: true,
 			siteTitle: i18n.translate( 'Reader' ),
-			backLinkHref: this.props.returnPath || '/sites',
+			backLinkHref: this.props.returnPath,
 			onClose: this.props.onClose && ( () => this.props.onClose() ),
 		};
 		return (


### PR DESCRIPTION
Related to # https://github.com/Automattic/dotcom-forge/issues/8070

## Proposed Changes

* Removes forced /sites fallback from sidebar links allowing the global sidebar to determine the back link location

## Testing Instructions

* Click around global nav ensure back links make sense

