### PR TITLE
Scheduled Updates: Optimistically update schedules list on add/delete action

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-form.tsx
@@ -143,7 +143,7 @@ export const ScheduleForm = ( { onNavBack, scheduleForEdit, onRecordSuccessEvent
 	const siteSlugsToUpdate = siteIdsToSlugs( sitesInInitialData );
 
 	const { mutateAsync: createUpdateScheduleAsync, isPending: createUpdateSchedulePending } =
-		useBatchCreateUpdateScheduleMutation( siteSlugsToCreate );
+		useBatchCreateUpdateScheduleMutation( siteSlugsToCreate, sitesNotInInitialData );
 
 	const { mutateAsync: editUpdateScheduleAsync, isPending: editUpdateSchedulePending } =
 		useBatchEditUpdateScheduleMutation( siteSlugsToUpdate );

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -53,9 +53,13 @@ export const ScheduleList = ( props: Props ) => {
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< string | undefined >(
 		initSelectedScheduleId
 	);
+	const selectedSchedule = schedules?.find( ( s ) => s.schedule_id === selectedScheduleId );
 	const [ selectedSiteSlug, setSelectedSiteSlug ] = useState< string | undefined >();
 	const [ selectedSiteSlugs, setSelectedSiteSlugs ] = useState< string[] >( [] );
 	const selectedSiteSlugsForMutate = selectedSiteSlug ? [ selectedSiteSlug ] : selectedSiteSlugs;
+	const selectedSiteIdsForMutate = selectedSiteSlugsForMutate
+		.map( ( slug ) => selectedSchedule?.sites.find( ( site ) => site.slug === slug )?.ID )
+		.filter( ( id ) => !! id ) as number[];
 
 	useEffect( () => {
 		const schedule = schedules?.find( ( schedule ) => schedule.schedule_id === selectedScheduleId );
@@ -63,14 +67,18 @@ export const ScheduleList = ( props: Props ) => {
 	}, [ selectedScheduleId ] );
 	useEffect( () => setSelectedScheduleId( initSelectedScheduleId ), [ initSelectedScheduleId ] );
 
-	const deleteUpdateSchedules = useBatchDeleteUpdateScheduleMutation( selectedSiteSlugsForMutate, {
-		onSuccess: () => {
-			// Refetch again after 5 seconds
-			setTimeout( () => {
-				refetch();
-			}, 5000 );
-		},
-	} );
+	const deleteUpdateSchedules = useBatchDeleteUpdateScheduleMutation(
+		[ ...selectedSiteSlugsForMutate ],
+		[ ...selectedSiteIdsForMutate ],
+		{
+			onSuccess: () => {
+				// Re-fetch again after 5 seconds
+				setTimeout( () => {
+					refetch();
+				}, 5000 );
+			},
+		}
+	);
 
 	const openRemoveDialog = ( id: string, siteSlug?: SiteSlug ) => {
 		setRemoveDialogOpen( true );

--- a/client/data/plugins/use-update-schedules-mutation.ts
+++ b/client/data/plugins/use-update-schedules-mutation.ts
@@ -1,7 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
-import { MultisiteSchedulesUpdatesResponse, ScheduleUpdates } from './use-update-schedules-query';
+import type {
+	MultisiteSchedulesUpdatesResponse,
+	ScheduleUpdates,
+} from './use-update-schedules-query';
 import type { SiteId, SiteSlug } from 'calypso/types';
 
 export type CreateRequestParams = {

--- a/client/data/plugins/use-update-schedules-mutation.ts
+++ b/client/data/plugins/use-update-schedules-mutation.ts
@@ -304,11 +304,6 @@ export function useBatchDeleteUpdateScheduleMutation(
 			// Set previous value on error
 			queryClient.setQueryData( [ 'multisite-schedules-update' ], context?.prevSiteSchedules );
 		},
-		onSettled: () => {
-			siteSlugs.forEach( ( siteSlug ) => {
-				queryClient.removeQueries( { queryKey: [ 'schedule-updates', siteSlug ] } );
-			} );
-		},
 		...queryOptions,
 	} );
 

--- a/client/data/plugins/use-update-schedules-mutation.ts
+++ b/client/data/plugins/use-update-schedules-mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
-import { MultisiteSchedulesUpdates, ScheduleUpdates } from './use-update-schedules-query';
+import { MultisiteSchedulesUpdatesResponse, ScheduleUpdates } from './use-update-schedules-query';
 import type { SiteId, SiteSlug } from 'calypso/types';
 
 export type CreateRequestParams = {
@@ -261,13 +261,13 @@ export function useBatchDeleteUpdateScheduleMutation(
 
 			return results;
 		},
-		onMutate: () => {
+		onMutate: ( id: string ) => {
 			// Optimistically update the cache
 			const prevSiteSchedules = queryClient.getQueryData( [
 				'multisite-schedules-update',
-			] ) as MultisiteSchedulesUpdates;
+			] ) as MultisiteSchedulesUpdatesResponse;
 			const sites = { ...prevSiteSchedules?.sites };
-			siteIds.forEach( ( siteId ) => delete sites[ siteId ] );
+			siteIds.forEach( ( siteId ) => sites[ siteId ] && delete sites[ siteId ][ id ] );
 
 			const newSiteSchedules = { sites: sites };
 

--- a/client/data/plugins/use-update-schedules-mutation.ts
+++ b/client/data/plugins/use-update-schedules-mutation.ts
@@ -266,13 +266,17 @@ export function useBatchDeleteUpdateScheduleMutation(
 			const prevSiteSchedules = queryClient.getQueryData( [
 				'multisite-schedules-update',
 			] ) as MultisiteSchedulesUpdatesResponse;
-			const sites = { ...prevSiteSchedules?.sites };
+			const sites = JSON.parse( JSON.stringify( prevSiteSchedules.sites ) );
 			siteIds.forEach( ( siteId ) => sites[ siteId ] && delete sites[ siteId ][ id ] );
 
-			const newSiteSchedules = { sites: sites };
+			const newSiteSchedules = { sites };
 
 			queryClient.setQueryData( [ 'multisite-schedules-update' ], newSiteSchedules );
-			return newSiteSchedules;
+			return { prevSiteSchedules };
+		},
+		onError: ( err, id, context ) => {
+			// Set previous value on error
+			queryClient.setQueryData( [ 'multisite-schedules-update' ], context?.prevSiteSchedules );
 		},
 		onSettled: () => {
 			siteSlugs.forEach( ( siteSlug ) => {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/92263

## Proposed Changes

* Optimistically update schedules in the multisite context on add/remove actions

## Testing Instructions

* Go to `/plugins/scheduled-updates`
* Click the "New schedule" button
* Select the proper site and plugins
* Check if it optimistically updates the list of schedules
* Then, try to delete an item
* Check if it optimistically updates the list of schedules

For more details, see the video on link: https://github.com/Automattic/wp-calypso/issues/92263#issue-2384972576

NOTE: If the async job throws any error, the schedules will be reverted on the previous state

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
