### PR TITLE
A4A > Partner Directory: Update BU Directory URL links

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -252,7 +252,7 @@ const PartnerDirectoryDashboard = () => {
 				</div>
 				{ directoryApplicationStatuses.length > 0 &&
 					directoryApplicationStatuses.map( ( { brand, status, type, key } ) => {
-						const brandMeta = getBrandMeta( brand );
+						const brandMeta = getBrandMeta( brand, agency );
 						const showPopoverOnLoad =
 							directoryApplicationStatuses.filter( ( { key } ) => key === 'rejected' ).length === 1;
 						return (
@@ -264,28 +264,33 @@ const PartnerDirectoryDashboard = () => {
 								heading={ brand }
 								description={
 									key === 'approved' ? (
-										<>
-											<Button
-												className="a8c-blue-link"
-												borderless
-												href={ brandMeta.url }
-												target="_blank"
-											>
-												{ translate( '%(brand)s Partner Directory', {
-													args: { brand },
-												} ) }
-												<Icon icon={ external } size={ 18 } />
-											</Button>
-											<br />
-											<Button
-												className="a8c-blue-link"
-												onClick={ onAgencyProfileClick }
-												href={ `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }` }
-												borderless
-											>
-												{ translate( `Your agency's profile` ) }
-											</Button>
-										</>
+										brandMeta.isPublic ? (
+											<>
+												<Button
+													className="a8c-blue-link"
+													borderless
+													href={ brandMeta.url }
+													target="_blank"
+												>
+													{ translate( '%(brand)s Partner Directory', {
+														args: { brand },
+													} ) }
+													<Icon icon={ external } size={ 18 } />
+												</Button>
+												<br />
+												<Button
+													className="a8c-blue-link"
+													onClick={ onAgencyProfileClick }
+													href={ brandMeta.urlProfile }
+													borderless
+												>
+													{ translate( `Your agency's profile` ) }
+													<Icon icon={ external } size={ 18 } />
+												</Button>
+											</>
+										) : (
+											<div>Comming soon message...</div>
+										)
 									) : (
 										<DashboardStatusBadge
 											statusProps={ {

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -149,10 +149,6 @@ const PartnerDirectoryDashboard = () => {
 		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_edit_profile_click' ) );
 	}, [ dispatch ] );
 
-	const onAgencyProfileClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_partner_directory_dashboard_agency_profile_click' ) );
-	}, [ dispatch ] );
-
 	// We want to scroll to the top of the page when the component is rendered
 	useEffect( () => {
 		document.querySelector( '.partner-directory__body' )?.scrollTo( 0, 0 );
@@ -176,7 +172,7 @@ const PartnerDirectoryDashboard = () => {
 
 	const { availableDirectories } = useFormSelectors();
 
-	const directoryApplicationStatuses =
+	const directoryApplicationStatuses: DirectoryApplicationStatus[] =
 		applicationData?.directories?.reduce( ( statuses: DirectoryApplicationStatus[], directory ) => {
 			statuses.push( {
 				brand: availableDirectories[ directory.directory ],
@@ -264,33 +260,29 @@ const PartnerDirectoryDashboard = () => {
 								heading={ brand }
 								description={
 									key === 'approved' ? (
-										brandMeta.isPublic ? (
-											<>
-												<Button
-													className="a8c-blue-link"
-													borderless
-													href={ brandMeta.url }
-													target="_blank"
-												>
-													{ translate( '%(brand)s Partner Directory', {
-														args: { brand },
-													} ) }
-													<Icon icon={ external } size={ 18 } />
-												</Button>
-												<br />
-												<Button
-													className="a8c-blue-link"
-													onClick={ onAgencyProfileClick }
-													href={ brandMeta.urlProfile }
-													borderless
-												>
-													{ translate( `Your agency's profile` ) }
-													<Icon icon={ external } size={ 18 } />
-												</Button>
-											</>
-										) : (
-											<div>Comming soon message...</div>
-										)
+										<>
+											<Button
+												className="a8c-blue-link"
+												borderless
+												href={ brandMeta.url }
+												target="_blank"
+											>
+												{ translate( '%(brand)s Partner Directory', {
+													args: { brand },
+												} ) }
+												<Icon icon={ external } size={ 18 } />
+											</Button>
+											<br />
+											<Button
+												className="a8c-blue-link"
+												borderless
+												href={ brandMeta.urlProfile }
+												target="_blank"
+											>
+												{ translate( `Your agency's profile` ) }
+												<Icon icon={ external } size={ 18 } />
+											</Button>
+										</>
 									) : (
 										<DashboardStatusBadge
 											statusProps={ {

--- a/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
@@ -1,33 +1,53 @@
 import { WooLogo, WordPressLogo, JetpackLogo } from '@automattic/components';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import { Agency } from 'calypso/state/a8c-for-agencies/types';
 
-export const getBrandMeta = ( brand: string ) => {
-	let className = '';
-	let icon = undefined;
-	let url = '';
+export const getBrandMeta = ( brand: string, agency?: Agency | null ) => {
+	const agencySlug =
+		agency?.name
+			.toLowerCase()
+			.replace( /[^a-z0-9\s]/g, '' )
+			.replace( /\s+/g, '-' )
+			.replace( /^-+|-+$/g, '' ) ?? '-';
+	const agencyId = agency?.id ?? '';
 
 	switch ( brand ) {
 		case 'WordPress.com':
-		case 'WordPress VIP':
-			icon = <WordPressLogo />;
-			url = 'https://wordpress.com/';
-			break;
+			return {
+				icon: <WordPressLogo />,
+				url: 'https://wordpress.com/development-services/',
+				urlProfile: `https://wordpress.com/development-services/${ agencySlug }/${ agencyId }`,
+				isPublic: true,
+			};
+
 		case 'WooCommerce.com':
-			icon = <WooLogo />;
-			className = 'partner-directory-dashboard__woo-icon';
-			url = 'https://woocommerce.com/';
-			break;
+			return {
+				icon: <WooLogo />,
+				className: 'partner-directory-dashboard__woo-icon',
+				url: 'https://woocommerce.com/development-services/',
+				urlProfile: `https://woocommerce.com/development-services/${ agencySlug }/${ agencyId }`,
+				isPublic: false,
+			};
 		case 'Pressable.com':
-			icon = <img src={ pressableIcon } alt="" />;
-			url = 'https://pressable.com/';
-			break;
+			return {
+				icon: <img src={ pressableIcon } alt="" />,
+				url: 'https://pressable.com/development-services/',
+				urlProfile: `https://pressable.com/development-services/${ agencySlug }/${ agencyId }`,
+				isPublic: false,
+			};
 		case 'Jetpack.com':
-			icon = <JetpackLogo />;
-			url = 'https://jetpack.com/';
-			break;
+			return {
+				icon: <JetpackLogo />,
+				url: 'https://jetpack.com/development-services/',
+				urlProfile: `https://jetpack.com/development-services/${ agencySlug }/${ agencyId }`,
+				isPublic: true,
+			};
 		default:
-			icon = undefined;
-			break;
+			return {
+				icon: undefined,
+				url: '',
+				urlProfile: '',
+				isPublic: false,
+			};
 	}
-	return { className, icon, url };
 };


### PR DESCRIPTION
Resolve: https://github.com/Automattic/automattic-for-agencies-dev/issues/740

## Proposed Changes

<img width="749" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/79c07fd5-b7af-4f75-9fcf-48e3dd2df688">


These PRs update the directory links for each BU page. Also, it introduces the `isPublic` parameter to be able to indicate when a BU directory is already public. We will activate each one on different dates. In a follow up PR we will add a coming soon message instead of displaying the links.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Check the links (WooComerce and Pressable ones don't work, they are on different staging sites. WordPress.com and Jetpack.com work A8c proxied).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
