### PR TITLE
Add a menu item link to Themes in the Global navigation

### DIFF
--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -1,4 +1,4 @@
-import { category, Icon } from '@wordpress/icons';
+import { category, Icon, brush } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 
 export const SidebarIconPlugins = () => (
@@ -38,6 +38,14 @@ export default function globalSidebarMenu() {
 			navigationLabel: translate( 'Manage all domains' ),
 			type: 'menu-item',
 			url: '/domains/manage',
+		},
+		{
+			icon: <Icon icon={ brush } size={ 24 } className="sidebar__menu-icon" />,
+			slug: 'themes',
+			title: translate( 'Themes' ),
+			navigationLabel: translate( 'Themes' ),
+			type: 'menu-item',
+			url: '/themes',
 		},
 		{
 			icon: <SidebarIconPlugins />,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8053

## Proposed Changes

* Add a new "Themes" navigation menu item in the Global Nav

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In the LOHP header and footer, we link users to wordpress.com/themes, but for Logged in users we don't do that

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link and notice the new menu option in /sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
