### PR TITLE
Plugins: update install notice state to handle incomplete install status

### DIFF
--- a/client/my-sites/plugins/notices.jsx
+++ b/client/my-sites/plugins/notices.jsx
@@ -44,12 +44,20 @@ class PluginNotices extends Component {
 	}
 
 	getCurrentNotices = () => {
-		const { completedNotices, errorNotices, inProgressNotices, pluginId, siteId } = this.props;
+		const {
+			completedNotices,
+			incompletedNotices,
+			errorNotices,
+			inProgressNotices,
+			pluginId,
+			siteId,
+		} = this.props;
 
 		return {
 			errors: filterNotices( errorNotices, siteId, pluginId ),
 			inProgress: filterNotices( inProgressNotices, siteId, pluginId ),
 			completed: filterNotices( completedNotices, siteId, pluginId ),
+			incompleted: filterNotices( incompletedNotices, siteId, pluginId ),
 		};
 	};
 
@@ -112,6 +120,14 @@ class PluginNotices extends Component {
 				this.getMessage( currentNotices.errors, this.errorMessage, 'error' ),
 				{
 					onDismissClick: () => this.props.removePluginStatuses( 'error' ),
+					id: 'plugin-notice',
+				}
+			);
+		} else if ( currentNotices.incompleted.length > 0 ) {
+			this.props.errorNotice(
+				this.getMessage( currentNotices.incompleted, this.errorMessage, 'incompleted' ),
+				{
+					onDismissClick: () => this.props.removePluginStatuses( 'incompleted' ),
 					id: 'plugin-notice',
 				}
 			);
@@ -808,11 +824,15 @@ class PluginNotices extends Component {
 
 	singleErrorMessage = ( action, translateArg, sampleLog ) => {
 		const { translate } = this.props;
-		const additionalExplanation = this.additionalExplanation( sampleLog.error.error );
+
+		//Check that error code exists in the log, if not, use 'unknown_error'
+		const errorCode = sampleLog.error.error || 'unknown_error';
+
+		const additionalExplanation = this.additionalExplanation( errorCode );
 
 		switch ( action ) {
 			case INSTALL_PLUGIN:
-				switch ( sampleLog.error.error ) {
+				switch ( errorCode ) {
 					case 'unauthorized_full_access':
 						return translate(
 							'Error installing %(plugin)s on %(site)s, remote management is off.',
@@ -845,7 +865,7 @@ class PluginNotices extends Component {
 				}
 
 			case REMOVE_PLUGIN:
-				switch ( sampleLog.error.error ) {
+				switch ( errorCode ) {
 					case 'unauthorized_full_access':
 						return translate( 'Error removing %(plugin)s on %(site)s, remote management is off.', {
 							args: translateArg,
@@ -857,7 +877,7 @@ class PluginNotices extends Component {
 				}
 
 			case UPDATE_PLUGIN:
-				switch ( sampleLog.error.error ) {
+				switch ( errorCode ) {
 					case 'unauthorized_full_access':
 						return translate( 'Error updating %(plugin)s on %(site)s, remote management is off.', {
 							args: translateArg,
@@ -878,7 +898,7 @@ class PluginNotices extends Component {
 				}
 
 			case ACTIVATE_PLUGIN:
-				switch ( sampleLog.error.error ) {
+				switch ( errorCode ) {
 					case 'unauthorized_full_access':
 						return translate(
 							'Error activating %(plugin)s on %(site)s, remote management is off.',
@@ -893,7 +913,7 @@ class PluginNotices extends Component {
 				}
 
 			case DEACTIVATE_PLUGIN:
-				switch ( sampleLog.error.error ) {
+				switch ( errorCode ) {
 					case 'unauthorized_full_access':
 						return translate(
 							'Error deactivating %(plugin)s on %(site)s, remote management is off.',
@@ -908,7 +928,7 @@ class PluginNotices extends Component {
 				}
 
 			case ENABLE_AUTOUPDATE_PLUGIN:
-				switch ( sampleLog.error.error ) {
+				switch ( errorCode ) {
 					case 'unauthorized_full_access':
 						return translate(
 							'Error enabling autoupdates for %(plugin)s on %(site)s, remote management is off.',
@@ -926,7 +946,7 @@ class PluginNotices extends Component {
 				}
 
 			case DISABLE_AUTOUPDATE_PLUGIN:
-				switch ( sampleLog.error.error ) {
+				switch ( errorCode ) {
 					case 'unauthorized_full_access':
 						return translate(
 							'Error disabling autoupdates for %(plugin)s on %(site)s, remote management is off.',
@@ -958,6 +978,7 @@ class PluginNotices extends Component {
 export default connect(
 	( state ) => ( {
 		completedNotices: getPluginStatusesByType( state, 'completed' ),
+		incompletedNotices: getPluginStatusesByType( state, 'incompleted' ),
 		errorNotices: getPluginStatusesByType( state, 'error' ),
 		inProgressNotices: getPluginStatusesByType( state, 'inProgress' ),
 		siteId: getSelectedSiteId( state ),

--- a/client/my-sites/plugins/plugin-management-v2/plugin-action-status/messages/install.ts
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-action-status/messages/install.ts
@@ -2,6 +2,7 @@ import {
 	PLUGIN_INSTALLATION_COMPLETED as COMPLETED,
 	PLUGIN_INSTALLATION_ERROR as ERROR,
 	PLUGIN_INSTALLATION_IN_PROGRESS as IN_PROGRESS,
+	PLUGIN_INSTALLATION_INCOMPLETED as INCOMPLETED,
 } from 'calypso/state/plugins/installed/status/constants';
 import type { PluginActionMessagesByStatus } from './types';
 
@@ -9,6 +10,7 @@ const InstallMessages: PluginActionMessagesByStatus = {
 	[ IN_PROGRESS ]: () => ( translate ) => translate( 'Installing' ),
 	[ COMPLETED ]: () => ( translate ) => translate( 'Installed' ),
 	[ ERROR ]: () => ( translate ) => translate( 'Failed to install' ),
+	[ INCOMPLETED ]: () => ( translate ) => translate( 'Failed to complete install' ),
 };
 
 export default InstallMessages;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-action-status/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-action-status/style.scss
@@ -37,7 +37,8 @@
 	color: #00450c;
 }
 
-.plugin-action-status-error {
+.plugin-action-status-error,
+.plugin-action-status-incompleted {
 	background: #facfd2;
 	color: #691c1c;
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -48,6 +48,7 @@ export default function PluginRowFormatter( {
 	const dispatch = useDispatch();
 
 	const billingPeriod = useSelector( getBillingInterval );
+	const pluginId = item.id || item.slug; // Plugin ID only available on Site plugin item object
 
 	const PluginDetailsButton = (
 		props: PropsWithChildren< { className: string; onClick?: MouseEventHandler } >
@@ -88,7 +89,7 @@ export default function PluginRowFormatter( {
 
 	const installInProgress = useSelector(
 		( state ) =>
-			selectedSite && isPluginActionInProgress( state, selectedSite.ID, item.id, INSTALL_PLUGIN )
+			selectedSite && isPluginActionInProgress( state, selectedSite.ID, pluginId, INSTALL_PLUGIN )
 	);
 
 	if ( selectedSite ) {
@@ -106,7 +107,7 @@ export default function PluginRowFormatter( {
 	const allStatuses = getPluginActionStatuses( state );
 
 	let currentSiteStatuses = allStatuses.filter(
-		( status ) => status.pluginId === item.id && status.action !== UPDATE_PLUGIN
+		( status ) => status.pluginId === pluginId && status.action !== UPDATE_PLUGIN
 	);
 
 	if ( 'site-name' === columnKey ) {

--- a/client/my-sites/plugins/plugin-management-v2/types.ts
+++ b/client/my-sites/plugins/plugin-management-v2/types.ts
@@ -8,6 +8,7 @@ import {
 	INSTALL_PLUGIN,
 } from 'calypso/lib/plugins/constants';
 import {
+	PLUGIN_INSTALLATION_INCOMPLETED,
 	PLUGIN_INSTALLATION_COMPLETED,
 	PLUGIN_INSTALLATION_ERROR,
 	PLUGIN_INSTALLATION_IN_PROGRESS,
@@ -51,7 +52,8 @@ export type PluginActionTypes =
 export type PluginActionStatus =
 	| typeof PLUGIN_INSTALLATION_IN_PROGRESS
 	| typeof PLUGIN_INSTALLATION_COMPLETED
-	| typeof PLUGIN_INSTALLATION_ERROR;
+	| typeof PLUGIN_INSTALLATION_ERROR
+	| typeof PLUGIN_INSTALLATION_INCOMPLETED;
 
 export type CurrentSiteStatus = {
 	action: PluginActionTypes;

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-statuses.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-statuses.ts
@@ -7,8 +7,15 @@ import type { AppState } from 'calypso/types';
 export const getPluginActionStatuses = ( state: AppState ) => {
 	const inProgressStatuses = getPluginStatusesByType( state, 'inProgress' );
 	const completedStatuses = getPluginStatusesByType( state, 'completed' );
+	const incompletedStatuses = getPluginStatusesByType( state, 'incompleted' );
 	const errorStatuses = getPluginStatusesByType( state, 'error' );
 	const uptoDateStatuses = getPluginStatusesByType( state, 'up-to-date' );
 
-	return [ ...inProgressStatuses, ...completedStatuses, ...errorStatuses, ...uptoDateStatuses ];
+	return [
+		...inProgressStatuses,
+		...completedStatuses,
+		...errorStatuses,
+		...incompletedStatuses,
+		...uptoDateStatuses,
+	];
 };

--- a/client/state/plugins/installed/status/constants.ts
+++ b/client/state/plugins/installed/status/constants.ts
@@ -4,5 +4,6 @@
 
 export const PLUGIN_INSTALLATION_IN_PROGRESS = 'inProgress';
 export const PLUGIN_INSTALLATION_COMPLETED = 'completed';
+export const PLUGIN_INSTALLATION_INCOMPLETED = 'incompleted';
 export const PLUGIN_INSTALLATION_ERROR = 'error';
 export const PLUGIN_INSTALLATION_UP_TO_DATE = 'up-to-date';

--- a/client/state/plugins/installed/status/reducer.js
+++ b/client/state/plugins/installed/status/reducer.js
@@ -26,6 +26,7 @@ import {
 	PLUGIN_INSTALL_REQUEST_PARTIAL_SUCCESS,
 } from 'calypso/state/action-types';
 import {
+	PLUGIN_INSTALLATION_INCOMPLETED,
 	PLUGIN_INSTALLATION_COMPLETED,
 	PLUGIN_INSTALLATION_ERROR,
 	PLUGIN_INSTALLATION_IN_PROGRESS,
@@ -160,9 +161,14 @@ function statusForSitePlugin( state = {}, action ) {
 		case PLUGIN_AUTOUPDATE_DISABLE_REQUEST_FAILURE:
 		case PLUGIN_INSTALL_REQUEST_FAILURE:
 		case PLUGIN_REMOVE_REQUEST_FAILURE:
-		case PLUGIN_INSTALL_REQUEST_PARTIAL_SUCCESS:
 			return Object.assign( {}, state, {
 				status: PLUGIN_INSTALLATION_ERROR,
+				action: action.action,
+				error: action.error,
+			} );
+		case PLUGIN_INSTALL_REQUEST_PARTIAL_SUCCESS:
+			return Object.assign( {}, state, {
+				status: PLUGIN_INSTALLATION_INCOMPLETED,
 				action: action.action,
 				error: action.error,
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/92396

## Proposed Changes

* Adds `incompleted` status to handle installs that don't fully complete and fail on activation
* Fix bug in reporting the install status when the install button has been clicked
* Fix bug in not reporting status in the sites list after install

## More details

The `PluginRowFormatter` appears to support an `item` property. When the `PluginRowFormatter` is used in the plugins list the plugin does not contain an `id` property. I think this has something to do with being core vs site plugin.

Oddly, when the Manage sites modal loads with a Sites list, the `item` does have an `id` property and it does report the status.

This PR checks if the `item` has an `id` and falls back to using `slug` if known found.

```
const pluginId = item.id || item.slug; // Plugin ID only available on Site plugin item object
```

This appears to retrieve the status later in `isPluginActionInProgress( state, selectedSite.ID, pluginId, INSTALL_PLUGIN )`.

The other thing of note with this PR is adding an `Incompleted` status. This will be used when we get a `PLUGIN_INSTALL_REQUEST_PARTIAL_SUCCESS` - where the install was successful but the activation failed (and caused server errors).

This allows us to report a new `INSTALL_PLUGIN` status of `Failed to complete install`.

## Before

https://github.com/Automattic/wp-calypso/assets/5560595/e0cd4d5e-4678-452a-a17f-1f2af1c0ee6c

## After 

https://github.com/Automattic/wp-calypso/assets/5560595/afa61bdd-5951-41e6-84c6-af370c0be0ab

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Broken UI in certain circumstances

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1.  Go to global plugins view at https://wordpress.com/plugins/widont-part-deux
2. Install the plugin on a WoA site
3. Observe how plugin status is reported - similar to video above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
