### PR TITLE
Migration Instructions: Add the provisioning component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -2,9 +2,12 @@ import { LaunchpadContainer } from '@automattic/launchpad';
 import { StepContainer } from '@automattic/onboarding';
 import React from 'react';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
+import { usePrepareSiteForMigration } from 'calypso/landing/stepper/hooks/use-prepare-site-for-migration';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { HostingBadge } from './hosting-badge';
+import { Provisioning } from './provisioning';
 import { Questions } from './questions';
 import { Sidebar } from './sidebar';
 import { SitePreview } from './site-preview';
@@ -17,7 +20,21 @@ const SiteMigrationInstructions: Step = function () {
 	const { data: hostingDetails } = useHostingProviderUrlDetails( importSiteQueryParam );
 	const showHostingBadge = ! hostingDetails.is_unknown && ! hostingDetails.is_a8c;
 
-	const sidebar = <Sidebar />;
+	const site = useSite();
+	const siteId = site?.ID;
+	const {
+		detailedStatus,
+		// migrationKey,
+		// completed: isSetupCompleted,
+		// error: setupError,
+	} = usePrepareSiteForMigration( siteId );
+
+	const sidebar = (
+		<Sidebar>
+			<Provisioning status={ detailedStatus } />
+		</Sidebar>
+	);
+
 	const stepContent = (
 		<LaunchpadContainer sidebar={ sidebar }>
 			{ showHostingBadge && <HostingBadge hostingName={ hostingDetails.name } /> }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -22,12 +22,7 @@ const SiteMigrationInstructions: Step = function () {
 
 	const site = useSite();
 	const siteId = site?.ID;
-	const {
-		detailedStatus,
-		// migrationKey,
-		// completed: isSetupCompleted,
-		// error: setupError,
-	} = usePrepareSiteForMigration( siteId );
+	const { detailedStatus } = usePrepareSiteForMigration( siteId );
 
 	const sidebar = (
 		<Sidebar>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/index.tsx
@@ -1,0 +1,56 @@
+import { Spinner } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+import { FC } from 'react';
+import './style.scss';
+
+type Status = 'idle' | 'pending' | 'success' | 'error';
+
+interface ProvisioningProps {
+	status: {
+		siteTransfer: Status;
+		pluginInstallation: Status;
+		migrationKey: Status;
+	};
+}
+
+export const Provisioning: FC< ProvisioningProps > = ( { status } ) => {
+	const {
+		siteTransfer: siteTransferStatus,
+		pluginInstallation: pluginInstallationStatus,
+		migrationKey: migrationKeyStatus,
+	} = status;
+
+	const actions = [
+		{ status: siteTransferStatus, text: translate( 'Provisioning your new site' ) },
+		{ status: pluginInstallationStatus, text: translate( 'Installing the required plugins' ) },
+		{ status: migrationKeyStatus, text: translate( 'Getting the migration key' ) },
+	];
+
+	const currentActionIndex = actions.findIndex( ( action ) => action.status !== 'success' );
+	const currentAction = actions[ currentActionIndex ];
+	if ( ! currentAction || currentAction.status === 'error' ) {
+		return;
+	}
+
+	return (
+		<div className="migration-instructions-provisioning">
+			<p className="migration-instructions-provisioning__message">
+				{ translate( "Meanwhile, we're preparing everything to ensure your site is ready." ) }
+			</p>
+
+			<div className="migration-instructions-provisioning__action">
+				<div className="migration-instructions-provisioning__action-icon">
+					<Spinner />
+				</div>
+
+				<div className="migration-instructions-provisioning__action-text">
+					{ currentAction.text }
+				</div>
+
+				<div className="migration-instructions-provisioning__action-progress">
+					{ currentActionIndex + 1 }/{ actions.length }
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/style.scss
@@ -1,0 +1,46 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.migration-instructions-provisioning {
+	background: #e8ecfb;
+	border-radius: 4px;
+	bottom: 80px;
+	font-size: 0.875rem;
+	margin: auto 16px 0 0;
+	padding: 12px;
+	position: fixed;
+
+	@include break-large {
+		bottom: 40px;
+		margin-right: 0;
+		position: sticky;
+	}
+}
+
+.migration-instructions-provisioning__message {
+	margin-bottom: 12px;
+}
+
+.migration-instructions-provisioning__action {
+	align-items: center;
+	display: flex;
+	gap: 8px;
+}
+
+.migration-instructions-provisioning__action-icon {
+	align-items: center;
+	display: flex;
+
+	.components-spinner {
+		margin: 0;
+	}
+}
+
+.migration-instructions-provisioning__action-text {
+	font-size: 1rem;
+	font-weight: 500;
+}
+
+.migration-instructions-provisioning__action-progress {
+	margin-left: auto;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/test/index.tsx
@@ -45,7 +45,7 @@ describe( 'Provisioning', () => {
 		expect( provisioningElement.length ).toBe( 0 );
 	} );
 
-	it( "shouldn't render when all actins are done", () => {
+	it( "shouldn't render when all actions are done", () => {
 		const status = {
 			siteTransfer: 'success',
 			pluginInstallation: 'success',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provisioning/test/index.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { Provisioning } from '..';
+
+describe( 'Provisioning', () => {
+	it( 'should render the first non-successful action', () => {
+		const status = {
+			siteTransfer: 'success',
+			pluginInstallation: 'pending',
+			migrationKey: 'error',
+		};
+
+		render( <Provisioning status={ status } /> );
+
+		expect( screen.getByText( 'Installing the required plugins' ) ).toBeVisible();
+	} );
+
+	it( 'should render the correct action progress number', () => {
+		const status = {
+			siteTransfer: 'success',
+			pluginInstallation: 'pending',
+			migrationKey: 'error',
+		};
+
+		render( <Provisioning status={ status } /> );
+
+		expect( screen.getByText( '2/3' ) ).toBeVisible();
+	} );
+
+	it( "shouldn't render when an action failed", () => {
+		const status = {
+			siteTransfer: 'success',
+			pluginInstallation: 'success',
+			migrationKey: 'error',
+		};
+
+		const { container } = render( <Provisioning status={ status } /> );
+		const provisioningElement = container.getElementsByClassName(
+			'migration-instructions-provisioning'
+		);
+
+		expect( provisioningElement.length ).toBe( 0 );
+	} );
+
+	it( "shouldn't render when all actins are done", () => {
+		const status = {
+			siteTransfer: 'success',
+			pluginInstallation: 'success',
+			migrationKey: 'success',
+		};
+
+		const { container } = render( <Provisioning status={ status } /> );
+		const provisioningElement = container.getElementsByClassName(
+			'migration-instructions-provisioning'
+		);
+
+		expect( provisioningElement.length ).toBe( 0 );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/sidebar/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/sidebar/index.tsx
@@ -1,8 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import './style.scss';
 
-export const Sidebar: FC = () => {
+export const Sidebar: FC< { children: ReactNode } > = ( { children } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -14,6 +14,7 @@ export const Sidebar: FC = () => {
 				{ translate( 'Follow these steps to get started.' ) }
 			</p>
 			[CHECKLIST HERE]
+			{ children }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/sidebar/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/sidebar/style.scss
@@ -1,5 +1,11 @@
 @import "@automattic/typography/styles/fonts";
 
+.migration-instructions-sidebar {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+}
+
 .migration-instructions-sidebar__title {
 	font-family: $brand-serif;
 	font-size: 2rem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #91779

## Proposed Changes

* This PR adds the component for provisioning the site and plugin installation following the logic from the [previous implementation](https://github.com/Automattic/wp-calypso/blob/c898e9ccbc435a346d39d48951f3912af2fdee31/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx).
* The component is sticky on desktop and fixed on mobile.
* Error handling is not part of this PR. We should discuss further how errors should be handled/displayed.
  * One option is to display an error message in the same component and change the loading icon to a red X icon.
  * We could also show the error message in the parent component.
* On some sites, the migration key step (step 3) is failing. Looking at the code of the [previous implementation](https://github.com/Automattic/wp-calypso/blob/c898e9ccbc435a346d39d48951f3912af2fdee31/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions-i2/index.tsx#L64), this seems expected and should be handled in the parent component.

Desktop:
![image](https://github.com/Automattic/wp-calypso/assets/1612178/0d162aef-e139-4727-a426-5eca2656df07)
(_Note that Wikipedia is not hosted on WP._ 😄 )

Mobile:
![image](https://github.com/Automattic/wp-calypso/assets/1612178/95b07bed-47c1-443e-bcda-6693e1caf7a4)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `migration-flow/new-migration-instructions-step` feature flag.
* Go to http://calypso.localhost:3000/setup/hosted-site-migration/site-migration-identify
* Enter a WP site URL (jurassic.ninja works), choose a destination site on atomic, and choose "I'll do it myself".
* You should see the provisioning component.
* Check that the provisioning is working by making sure the Migration Guru plugin is installed on your destination site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?