### PR TITLE
Track clicks to 'Compare all plans' button

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -250,6 +250,10 @@ const PlansFeaturesMain = ( {
 	} );
 
 	const toggleShowPlansComparisonGrid = () => {
+		if ( ! showPlansComparisonGrid ) {
+			recordTracksEvent( 'calypso_signup_onboarding_plans_compare_all' );
+		}
+
 		setShowPlansComparisonGrid( ! showPlansComparisonGrid );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8142

## Proposed Changes

This PR introduces a new event `calypso_signup_onboarding_plans_compare_all` to capture clicks to "Compare all plans" in the plan selection step during onboarding.

![image](https://github.com/Automattic/wp-calypso/assets/104910361/2e1edb5b-c5e6-41d5-97c5-16670ed027da)

## Why are these changes being made?

Currently, when users click on the "Compare all plans" button in the `/start/plans` page, the `calypso_plans_plan_type_selector_view` Tracks event is fired. The problem is, the same event is tracked when users land on the "Upgrades > Plans" page making it impossible to measure clicks to the "Compare all plans" button. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Proceed with onboarding until you reach the plans selection page.
* Click on "Compare all plans"
* Assert that the `calypso_plans_plan_type_selector_view` event is fired.
* Click on "Hide comparison"
* Assert that the `calypso_plans_plan_type_selector_view` event is NOT fired.
