### PR TITLE
A4A: Remove add site via URL option in the Site selector dropdown menu.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -1,5 +1,5 @@
 import { Popover, Gridicon, Button, WordPressLogo, JetpackLogo } from '@automattic/components';
-import { Icon, navigation } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
@@ -146,12 +146,6 @@ export default function SiteSelectorAndImporter( {
 									setMenuVisible( false );
 								},
 							},
-						} ) }
-						{ menuItem( {
-							icon: navigation,
-							iconClassName: 'site-selector-and-importer__popover-button-wp-icon',
-							heading: translate( 'Via URL' ),
-							description: translate( 'Type in the address of your site' ),
 						} ) }
 					</div>
 					<div className="site-selector-and-importer__popover-column">


### PR DESCRIPTION
Since we haven't decided yet to support this feature in A4A, this PR removes the menu item.

<img width="532" alt="Screenshot 2024-07-06 at 1 00 36 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0bd433c3-0571-42ac-b24e-14bca11c5ed0">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/775

## Proposed Changes

* Remove the 'Add site via URL' option.


## Testing Instructions

* Use the A4A live link and go to `/overview` page.
* Click the 'Add site' dropdown menu.
* Confirm the option is no longer visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
