### PR TITLE
A4A: Provide source context when redirecting the user to the Jetpack connection flow.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal/index.tsx
@@ -80,7 +80,7 @@ export default function JetpackConnectionModal( { onClose }: Props ) {
 					primary
 					onClick={ onInstallJetpack }
 					disabled={ ! isValidURL( site ) }
-					href={ ` https://wordpress.com/jetpack/connect?url=${ site }` }
+					href={ ` https://wordpress.com/jetpack/connect?url=${ site }&source=a8c-for-agencies` }
 					target="_blank"
 					rel="noreferrer noopener"
 				>


### PR DESCRIPTION
When adding a site via Jetpack connection, the user is redirected to the Jetpack pricing page after establishing the connection instead of the A4A dashboard. This PR fixes this issue.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/774

## Proposed Changes

* Add the `source=a8c-for-agencies` query parameter when redirecting to the Jetpack connection flow.


## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* Click on the 'Add site' dropdown menu.
* Click on the 'Via Jetpack connection' option and provide a Jetpack site URL.
* Confirm that after successfully connecting site, you are redirected back to A4A dashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
