### PR TITLE
A4A: Add a hover state on the Site selector menu items.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -46,12 +46,16 @@
 }
 
 .theme-a8c-for-agencies  .button.is-borderless.site-selector-and-importer__popover-button {
-	padding: 0 8px;
+	padding: 8px;
 	white-space: unset;
 	text-align: unset;
-	margin-block: 16px;
+	margin-block: 0;
 	width: 100%;
-	border-radius: 0;
+	border-radius: 4px;
+
+	&:hover {
+		background-color: var(--color-neutral-0);
+	}
 
 	@include break-large {
 		display: flex;


### PR DESCRIPTION
This pull request includes adding a hover state for the menu items in the Site selector.

<img width="697" alt="Screenshot 2024-07-06 at 1 20 54 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7280e327-4b97-4f2a-98b6-3680441788c7">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/776

## Proposed Changes

* Add CSS rules that will set a neutral background on the Site selector menu items when hovered. Fix a few paddings and border-radius to follow standard A4A styling.

## Testing Instructions


* Use the A4A live link and go to the `/overview` page.
* Click on the 'Add site' dropdown menu.
* Confirm that there is a hover state for the dropdown menu items.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
