### PR TITLE
Site Migration: Fix the site ID redirect to the migration flow from A4A

### DIFF
--- a/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
+++ b/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
@@ -11,6 +11,7 @@ type Site = {
 	features: {
 		wpcom_atomic: {
 			state: string;
+			blog_id: number;
 		};
 	};
 };

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -20,7 +20,7 @@ export default function ProvisioningSiteNotification( { siteId, migrationIntent 
 	const wpOverviewUrl = `https://wordpress.com/overview/${ siteSlug }`;
 	const wpMigrationUrl = addQueryArgs(
 		{
-			siteId: site?.id,
+			siteId: site?.features.wpcom_atomic.blog_id,
 			siteSlug,
 		},
 		'https://wordpress.com/setup/hosted-site-migration/site-migration-identify'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pfxNDN-Bq-p2

## Proposed Changes

* Fix the site ID when redirecting to WordPress.com to complete the site migration.
* This is part of the changes necessary to fix the white screen bug reported in the link above.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're using the Agency site ID record in the URL to redirect the users to the WordPress.com migration flow.  Without the real site ID, it would be difficult and not reliable to get the site information, which is the source of the problem.
* The white screen problem on the Upgrade step is caused by the fact that we can't find the atomic site with the simple site slug, and the site ID is being lost before getting to that step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local environment and use `yarn start-a8c-for-agencies` to start the A4A locally.
* Access the FG page and follow the steps under the `Testing A4A` section to set up your payment method: PCYsg-XAV-p2
* Navigate to `/marketplace/hosting/wpcom` and add the plan to your cart, and proceed to checkout.
* You should land on the `/sites/need-setup` page.
* Click on the "Migrate an existing site"
* On the next page, wait for the banner to complete the site creation and then click on the "Migrate to this site" button.
* Now verify that you were redirected to the Identification step with the appropriate WordPress.com site ID.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?