### PR TITLE
A4A: Enhance connection modals triggering action with Enter

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/a4a-connection-modal/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/a4a-connection-modal/index.tsx
@@ -1,6 +1,6 @@
 import { Button, FormLabel } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, ChangeEvent, useMemo } from 'react';
+import { useState, ChangeEvent, useMemo, useRef } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useDispatch } from 'calypso/state';
@@ -23,6 +23,7 @@ export default function A4AConnectionModal( { onClose }: Props ) {
 	const dispatch = useDispatch();
 
 	const [ site, setSite ] = useState( '' );
+	const linkRef = useRef< HTMLAnchorElement >( null );
 
 	const onComplete = () => {
 		dispatch(
@@ -54,6 +55,15 @@ export default function A4AConnectionModal( { onClose }: Props ) {
 		}
 	}, [ site ] );
 
+	const handleKeyDown = ( event: React.KeyboardEvent< HTMLInputElement > ) => {
+		if ( ! isValidURL( site ) ) {
+			return;
+		}
+		if ( event.key === 'Enter' ) {
+			linkRef?.current?.click?.();
+		}
+	};
+
 	return (
 		<A4AThemedModal
 			className="a4a-connection-modal"
@@ -82,6 +92,7 @@ export default function A4AConnectionModal( { onClose }: Props ) {
 						placeholder={ translate( 'Site URL' ) }
 						value={ site }
 						onChange={ onSiteChange }
+						onKeyDown={ handleKeyDown }
 						onClick={ () =>
 							dispatch(
 								recordTracksEvent( 'calypso_a4a_add_site_via_a4a_connection_modal_site_url_click' )
@@ -92,6 +103,7 @@ export default function A4AConnectionModal( { onClose }: Props ) {
 
 				<Button
 					primary
+					ref={ linkRef }
 					onClick={ onComplete }
 					disabled={ ! isValidURL( site ) }
 					href={ buttonUrl }

--- a/client/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal/index.tsx
@@ -1,6 +1,6 @@
 import { Button, FormLabel } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useDispatch } from 'calypso/state';
@@ -23,6 +23,7 @@ export default function JetpackConnectionModal( { onClose }: Props ) {
 	const dispatch = useDispatch();
 
 	const [ site, setSite ] = useState( '' );
+	const linkRef = useRef< HTMLAnchorElement >( null );
 
 	const onInstallJetpack = () => {
 		dispatch(
@@ -38,6 +39,15 @@ export default function JetpackConnectionModal( { onClose }: Props ) {
 
 	const onSiteChange = ( event: ChangeEvent< HTMLInputElement > ) => {
 		setSite( event.currentTarget.value );
+	};
+
+	const handleKeyDown = ( event: React.KeyboardEvent< HTMLInputElement > ) => {
+		if ( ! isValidURL( site ) ) {
+			return;
+		}
+		if ( event.key === 'Enter' ) {
+			linkRef?.current?.click?.();
+		}
 	};
 
 	return (
@@ -66,6 +76,7 @@ export default function JetpackConnectionModal( { onClose }: Props ) {
 						placeholder={ translate( 'Site URL' ) }
 						value={ site }
 						onChange={ onSiteChange }
+						onKeyDown={ handleKeyDown }
 						onClick={ () =>
 							dispatch(
 								recordTracksEvent(
@@ -78,6 +89,7 @@ export default function JetpackConnectionModal( { onClose }: Props ) {
 
 				<Button
 					primary
+					ref={ linkRef }
 					onClick={ onInstallJetpack }
 					disabled={ ! isValidURL( site ) }
 					href={ ` https://wordpress.com/jetpack/connect?url=${ site }` }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

A small change in order to allow triggering action with Enter button.

<img width="797" alt="Screenshot 2024-07-05 at 12 21 13 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/ff86d00b-51f4-4225-aa44-0d9f619f8bd3">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/overview` and click `Add site` button in the top right corner
- Choosing `Via A4A plugin` and/or `Via Jetpack` enter the URL (you can use fresh JN site) and hit Enter.
- Check the behavior

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
