### PR TITLE
Hide 'My Mailboxes' for P2 sites

### DIFF
--- a/client/my-sites/email/mailboxes/index.tsx
+++ b/client/my-sites/email/mailboxes/index.tsx
@@ -112,6 +112,9 @@ const MailboxesManagement = ( {
 	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state, selectedSiteId as number ) );
 
 	if ( isP2 ) {
+		// This path is no longer accessible via the sidebar, but we still need
+		// to handle the case where the the url is accessed directly.
+		// see https://github.com/Automattic/dotcom-forge/issues/8069
 		return <NotSupportedOnP2Card />;
 	}
 

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 import Site from 'calypso/blocks/site';
 import SidebarSeparator from 'calypso/layout/sidebar/separator';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSidebarIsCollapsed,
@@ -34,6 +35,8 @@ export const MySitesSidebarUnifiedBody = ( {
 	// since WP Admin is considered a separate area from Calypso on those sites.
 	const shouldOpenExternalLinksInCurrentTab = ! isJetpack || isSiteAtomic;
 
+	const isP2 = useSelector( ( state ) => !! isSiteWPForTeams( state, siteId ) );
+
 	return (
 		<>
 			{ menuItems &&
@@ -42,6 +45,12 @@ export const MySitesSidebarUnifiedBody = ( {
 						( item?.url && itemLinkMatches( item.url, path ) ) ||
 						// Keep the Sites icon selected when there is a selected site.
 						( item.slug === 'sites' && site );
+
+					// Email is not available for P2 sites, so we don't show the
+					// 'My Mailboxes' menu item.
+					if ( isP2 && 'My Mailboxes' === item.title ) {
+						return;
+					}
 
 					if ( 'current-site' === item?.type ) {
 						return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8069-gh-Automattic/dotcom-forge

## Proposed Changes

* Add logic to prevent the My Mailboxes menu item from being displayed for P2s

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Mailboxes aren't supported for P2, so we're basically showing a menu item that leads to a dead-end warning. Much better UX to simply not offer the unavailable item in the first place.

## Testing Instructions

1. Visit My Home (or any other Calypso page) for a P2. Example: https://wordpress.com/home/YOURFAVORITEP2.wordpress.com
2. Confirm that **My Mailboxes** is not present.
3. Visit `wp-admin` for the same site. We don't currently have navigation in place for this, so you'll want to manually append `wp-admin` to the end of your P2 url. example: https://YOURFAVORITEP2.wordpress.com/wp-admin
4. Again, confirm that **My Mailboxes** is not present.
5. Visit Calypso and wp-admin for any other non-P2 site you have access to, and confirm that **My Mailboxes** still appears for sites that support it.
6. Test visiting the old warning URL directly so we can be sure that's still in place if someone stumbles upon it that way. Remember the link should be for the P2 site you tested with. Example: https://wordpress.com/mailboxes/YOURFAVORITEP2.wordpress.com