### PR TITLE
A4A: Suggest an available site address to users based on their input

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -20,7 +20,7 @@ import ClientSite from './client-site';
 import { AvailablePlans } from './plan-field';
 import PurchaseConfirmationMessage from './purchase-confirmation-message';
 import SiteConfigurationsModal from './site-configurations-modal';
-import { useRandomSiteName } from './site-configurations-modal/use-site-name';
+import { useRandomSiteName } from './site-configurations-modal/use-random-site-name';
 import NeedSetupTable from './table';
 import type { ReferralAPIResponse } from '../../referrals/types';
 
@@ -46,9 +46,11 @@ const isA4aSiteCreationConfigurationsEnabled = config.isEnabled(
 export default function NeedSetup( { licenseKey }: Props ) {
 	const { randomSiteName, isRandomSiteNameLoading } = useRandomSiteName();
 	const translate = useTranslate();
-	const [ displaySiteConfigurationModal, setDisplaySiteConfigurationModal ] = useState( false );
+	const [ currentSiteConfigurationId, setCurrentSiteConfigurationId ] = useState< number | null >(
+		null
+	);
 
-	const toggleModal = () => setDisplaySiteConfigurationModal( ! displaySiteConfigurationModal );
+	const closeModal = () => setCurrentSiteConfigurationId( null );
 
 	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
 
@@ -189,18 +191,21 @@ export default function NeedSetup( { licenseKey }: Props ) {
 						</Actions>
 					</LayoutHeader>
 				</LayoutTop>
-				{ displaySiteConfigurationModal && (
+				{ currentSiteConfigurationId && (
 					<SiteConfigurationsModal
-						toggleModal={ toggleModal }
+						closeModal={ closeModal }
 						randomSiteName={ randomSiteName }
 						isRandomSiteNameLoading={ isRandomSiteNameLoading }
+						siteId={ currentSiteConfigurationId }
 					/>
 				) }
 				<NeedSetupTable
 					availablePlans={ availablePlans }
 					isLoading={ isFetching }
 					provisioning={ isProvisioning }
-					onCreateSite={ isA4aSiteCreationConfigurationsEnabled ? toggleModal : onCreateSite }
+					onCreateSite={
+						isA4aSiteCreationConfigurationsEnabled ? setCurrentSiteConfigurationId : onCreateSite
+					}
 					onMigrateSite={ onMigrateSite }
 				/>
 			</LayoutColumn>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { CheckboxControl, Icon, Modal } from '@wordpress/components';
+import { CheckboxControl, Icon, Modal, Spinner } from '@wordpress/components';
 import { check, closeSmall } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -14,21 +14,23 @@ import { useSiteName } from './use-site-name';
 import './style.scss';
 
 type SiteConfigurationsModalProps = {
-	toggleModal: () => void;
+	closeModal: () => void;
 	randomSiteName: string;
 	isRandomSiteNameLoading: boolean;
+	siteId: number;
 };
 
 export default function SiteConfigurationsModal( {
-	toggleModal,
+	closeModal,
 	randomSiteName,
 	isRandomSiteNameLoading,
+	siteId,
 }: SiteConfigurationsModalProps ) {
 	const [ allowClientsToUseSiteHelpCenter, setAllowClientsToUseSiteHelpCenter ] = useState( true );
 	const translate = useTranslate();
 	const dataCenterOptions = useDataCenterOptions();
 	const { phpVersions } = usePhpVersions();
-	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading );
+	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading, siteId );
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>
 		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );
@@ -77,7 +79,7 @@ export default function SiteConfigurationsModal( {
 	return (
 		<Modal
 			title={ translate( 'Configure your new site' ) }
-			onRequestClose={ toggleModal }
+			onRequestClose={ closeModal }
 			className="configure-your-site-modal-form"
 		>
 			<form onSubmit={ onSubmit }>
@@ -106,7 +108,7 @@ export default function SiteConfigurationsModal( {
 							/>
 						) }
 						<div className="configure-your-site-modal-form__site-name-icon-wrapper">
-							{ ! siteName.showValidationMessage && ! isRandomSiteNameLoading && (
+							{ siteName.isSiteNameReadyForUse && (
 								<Icon
 									icon={ check }
 									size={ 28 }
@@ -120,6 +122,9 @@ export default function SiteConfigurationsModal( {
 									color="red"
 									className="configure-your-site-modal-form__site-name-fail"
 								/>
+							) }
+							{ siteName.isCheckingSiteAvailability && (
+								<Spinner className="configure-your-site-modal-form__site-name-loading" />
 							) }
 						</div>
 					</div>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -192,7 +192,7 @@ export default function SiteConfigurationsModal( {
 											<a
 												target="_blank"
 												href={ localizeUrl(
-													'https://wordpress.com/support/hosting-configuration'
+													'https://developer.wordpress.com/docs/developer-tools/web-server-settings/'
 												) }
 												rel="noreferrer"
 											/>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/style.scss
@@ -50,16 +50,24 @@
 		.configure-your-site-modal-form__site-name-icon-wrapper {
 			display: flex;
 			justify-content: space-around;
-			margin-right: -5px;
 			margin-left: 5px;
+			width: 28px;
 		}
 
 		.configure-your-site-modal-form__site-name-success {
+			margin-right: -5px;
 			fill: var(--color-success);
 		}
 
 		.configure-your-site-modal-form__site-name-fail {
+			margin-right: -5px;
 			fill: var(--color-error);
+		}
+
+		.configure-your-site-modal-form__site-name-loading {
+			display: flex;
+			justify-content: space-around;
+			margin: 0;
 		}
 	}
 
@@ -70,6 +78,13 @@
 		line-height: 1.5;
 		color: var(--color-error);
 		margin-top: 4px;
+
+		.configure-your-site-modal-form__site-name-suggestion {
+			text-decoration: underline;
+			font-weight: bold;
+			color: var(--color-error);
+			cursor: pointer;
+		}
 
 		svg {
 			margin-right: 5px;

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+
+export const getRandomSiteBaseUrl = async ( title: string ) => {
+	const { body: urlSuggestions } = await wpcom.req.get( {
+		apiNamespace: 'rest/v1.1',
+		path: `/domains/suggestions?http_envelope=1&query=${ title }&quantity=10&include_wordpressdotcom=true&include_dotblogsubdomain=false&only_wordpressdotcom=true&vendor=dot&managed_subdomain_quantity=0`,
+	} );
+	const firstUrl = urlSuggestions[ 0 ].domain_name.split( '.' )[ 0 ];
+	const siteName = firstUrl.split( '.' )[ 0 ];
+	return siteName;
+};
+
+const getRandomSiteName = async () => {
+	try {
+		const { suggestions } = await wpcom.req.get( {
+			apiNamespace: 'wpcom/v2',
+			path: `/site-suggestions`,
+		} );
+		const { title } = suggestions[ 0 ];
+
+		const siteName = await getRandomSiteBaseUrl( title );
+
+		return siteName;
+	} catch ( error ) {
+		return '';
+	}
+};
+
+export const useRandomSiteName = () => {
+	const [ randomSiteName, setRandomSiteName ] = useState( '' );
+	const [ isRandomSiteNameLoading, setIsRandomSiteNameLoading ] = useState( true );
+	useEffect( () => {
+		getRandomSiteName()
+			.then( ( randomSiteName ) => {
+				setRandomSiteName( randomSiteName );
+				setIsRandomSiteNameLoading( false );
+			} )
+			.catch( () => {
+				setRandomSiteName( '' );
+				setIsRandomSiteNameLoading( false );
+			} );
+	}, [] );
+
+	return { randomSiteName, isRandomSiteNameLoading };
+};

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -42,11 +42,11 @@ const useCheckSiteAvailability = (
 	} );
 
 	useEffect( () => {
-		if ( skipAvailability ) {
+		if ( skipAvailability || availabilityState.siteNameSuggestion === siteName ) {
 			setAvilabilityState( {
 				isSiteNameAvailiable: true,
 				isCheckingSiteAvailability: false,
-				siteNameSuggestion: '',
+				siteNameSuggestion: availabilityState.siteNameSuggestion,
 			} );
 			return;
 		}
@@ -66,6 +66,7 @@ const useCheckSiteAvailability = (
 				siteNameSuggestion: result.siteNameSuggestion,
 			} );
 		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ agencyId, siteId, siteName, skipAvailability ] );
 
 	return availabilityState;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8046

## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/33497086/68a88227-7f94-4c81-a1c0-addd88b14dc1)

This PR improves the `Site address` field on site creation configuration modal on Automattic for Agencies client:
- It checks if the address inputed by the user is available on server side.
- If not, it also suggests a valid suggestion. This helps the user to not rely only on trial and error to finde a valid url.

## Testing Instructions
This feature is under `a4a-site-creation-configurations` flag.
Before accessing the Create new site button, your account needs to have at least 1 hosting license, ready to be used.
If you are not sure how to get that, read PdDOJh-3ys-p2.

1 - Open this link: http://agencies.localhost:3000/sites/need-setup?flags=a4a-site-creation-configurations
2 - Click on Create new site button.
3 - It should open the site configuration modal, with a random site address already pre-filled.
4 - Try different combinations, with addresses that you know that are free and taken on Wordpress.
5 - When the address is already taken, you should get the `Sorry, that address is taken. How about {new-suggested-address}?` feedback message.
6 - Click on the suggestion. The input field should be populated with the new suggested address.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
