### PR TITLE
ActivityLog: Reset dates in activity-log date picker after date filter is removed

### DIFF
--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -34,18 +34,13 @@ export class DateRangeSelector extends Component {
 		selectDateRange( this.props.siteId, formattedStartDate, formattedEndDate ); // enough?
 	};
 
-	handleResetSelection = ( clearDateRangePickerDates ) => {
+	handleResetSelection = () => {
 		const { siteId, selectDateRange } = this.props;
 		this.setState( {
 			fromDate: null,
 			toDate: null,
 		} );
 		selectDateRange( siteId, null, null );
-
-		if ( clearDateRangePickerDates ) {
-			// Call function to clear dates in DateRangePicker
-			clearDateRangePickerDates();
-		}
 	};
 
 	getFormattedFromDate = ( from, to ) => {
@@ -167,7 +162,10 @@ export class DateRangeSelector extends Component {
 								className="filterbar__selection-close"
 								compact
 								borderless
-								onClick={ () => this.handleResetSelection( props.onClearClick ) }
+								onClick={ () => {
+									this.handleResetSelection();
+									props.onClearClick();
+								} }
 							>
 								<Gridicon icon="cross-small" />
 							</Button>

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -34,13 +34,18 @@ export class DateRangeSelector extends Component {
 		selectDateRange( this.props.siteId, formattedStartDate, formattedEndDate ); // enough?
 	};
 
-	handleResetSelection = () => {
+	handleResetSelection = ( clearDateRangePickerDates ) => {
 		const { siteId, selectDateRange } = this.props;
 		this.setState( {
 			fromDate: null,
 			toDate: null,
 		} );
 		selectDateRange( siteId, null, null );
+
+		if ( clearDateRangePickerDates ) {
+			// Call function to clear dates in DateRangePicker
+			clearDateRangePickerDates();
+		}
 	};
 
 	getFormattedFromDate = ( from, to ) => {
@@ -162,7 +167,7 @@ export class DateRangeSelector extends Component {
 								className="filterbar__selection-close"
 								compact
 								borderless
-								onClick={ this.handleResetSelection }
+								onClick={ () => this.handleResetSelection( props.onClearClick ) }
 							>
 								<Gridicon icon="cross-small" />
 							</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-backup-team/issues/262

## Proposed Changes

* Call `onClearClick` from `date-range` then the selected dates are removed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Removing the dates in the ActivityLog Date Range filter is not removing the selected dates from the calendar when the Date Range is removed from the toolbar.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the ActivityLog in the a Jetpack Cloud live branch
* Filter by Date Range
* Remove the Date Filter by clicking the X
<img width="279" alt="Screenshot 2024-07-08 at 13 46 00" src="https://github.com/Automattic/wp-calypso/assets/2747834/6411eb3b-1087-4b95-9bc0-4e7b2c150289">

* Open again the Date Range and verify there is no date range selected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
