### PR TITLE
Help Center: Simplify passing information to Zendesk Messaging chat

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -184,20 +184,10 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 				section: sectionName,
 			} );
 
-			let message = '';
 			const escapedWapuuChatId = encodeURIComponent( wapuuChatId || '' );
-
-			if ( wapuuChatId ) {
-				message += `Support request started with <strong>Wapuu</strong><br />Wapuu Chat: <a href="https://mc.a8c.com/odie/odie-chat.php?chat_id=${ escapedWapuuChatId }">${ escapedWapuuChatId }</a><br />`;
-			}
-
-			if ( site?.URL ) {
-				message += `Site: ${ encodeURIComponent( site?.URL || '' ) }<br />`;
-			}
 
 			openChatWidget( {
 				aiChatId: escapedWapuuChatId,
-				message: message,
 				siteUrl: site?.URL,
 				onError: () => setHasSubmittingError( true ),
 				// Reset Odie chat after passing to support

--- a/packages/help-center/src/hooks/use-chat-widget.ts
+++ b/packages/help-center/src/hooks/use-chat-widget.ts
@@ -34,7 +34,7 @@ export default function useChatWidget(
 
 	const openChatWidget = ( {
 		aiChatId,
-		message = 'No message from user',
+		message = '',
 		siteUrl = 'No site selected',
 		onError,
 		onSuccess,


### PR DESCRIPTION
Since we no longer have an actual initial message from the user, let's simplify this logic and move it to the backend. It seems like a more proper and safe place to add details, including internal ones.

Related P2 discussion: pdm0RZ-VG-p2#comment-1845

Related PR: #91207.

## Proposed Changes

* Don't add internal references to the initial message - that will be done on the backend. See D154519-code.

## Testing Instructions

* Help Center -> Still need help? -> trigger escalation to human
* Verify in Network tab in dev tools that the `https://public-api.wordpress.com/wpcom/v2/help/zendesk/update-user-fields` request has an empty `messaging_initial_message` (unless it makes sense from the flow you triggered it from, like the pre-cancelation one).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
