### PR TITLE
Prevent white screen if the pageSlug does not exist in the current step definitions

### DIFF
--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -63,7 +63,12 @@ function ConnectDomainStep( {
 	const baseClassName = 'connect-domain-step';
 	if ( stepsDefinition[ pageSlug ] === undefined ) {
 		// eslint-disable-next-line no-console
-		console.error( 'Tried to set invalid pageSlug in ConnectDomainStep', pageSlug, firstStep );
+		console.error(
+			'Tried to set invalid pageSlug in ConnectDomainStep',
+			pageSlug,
+			firstStep,
+			domain
+		);
 	}
 	const currentStep = stepsDefinition[ pageSlug ] || stepsDefinition[ firstStep ];
 	const isStepStart = stepType.START === currentStep.step;

--- a/client/components/domains/connect-domain-step/index.jsx
+++ b/client/components/domains/connect-domain-step/index.jsx
@@ -61,11 +61,16 @@ function ConnectDomainStep( {
 	const [ loadingDomainSetupInfo, setLoadingDomainSetupInfo ] = useState( false );
 
 	const baseClassName = 'connect-domain-step';
-	const isStepStart = stepType.START === stepsDefinition[ pageSlug ].step;
-	const mode = stepsDefinition[ pageSlug ].mode;
-	const step = stepsDefinition[ pageSlug ].step;
-	const prevPageSlug = stepsDefinition[ pageSlug ].prev;
-	const isTwoColumnLayout = ! stepsDefinition[ pageSlug ].singleColumnLayout;
+	if ( stepsDefinition[ pageSlug ] === undefined ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Tried to set invalid pageSlug in ConnectDomainStep', pageSlug, firstStep );
+	}
+	const currentStep = stepsDefinition[ pageSlug ] || stepsDefinition[ firstStep ];
+	const isStepStart = stepType.START === currentStep.step;
+	const mode = currentStep.mode;
+	const step = currentStep.step;
+	const prevPageSlug = currentStep.prev;
+	const isTwoColumnLayout = ! currentStep.singleColumnLayout;
 
 	const statusRef = useRef( {} );
 


### PR DESCRIPTION
We got reports that the domain connection flow is showing a white screen in certain cases. It seems that we get an invalid `pageSlug` and that leads to a white screen being rendered. The error in the console is "Cannot read properties of undefined (reading 'step')" which should not happen. There were two reports and both were for com.au domains - that might have somehting to do with it as it seems that Calypso doesn't properly determine if a com.au domain is a domain or a subdomain.

Anyway - with this PR I hope that we won't show the white screen and we'll hopefully get more data when that error happens in the console as I'm logging the `pageSlug` too.

see: p1720368375072989-slack-C0761SX4K

## Proposed Changes

* prevent the js errors and fall back to the firststep of the flow if we get a invalid step as `pageSlug`
* call console.error so hopefully when this happens we'll have some information on what the invalid `pageSlug` value was when the error happened

## Why are these changes being made?

* We got a report that after mapping a domain the customer gets a white screen instead of the instructions to connect a domain

## Testing Instructions

* Map a domain or a subdomain to your WordPress.com site and make sure that you can see the setup screen with the insstructions to connect your domain to WordPress.com

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?