### PR TITLE
Stats: Optimize moment.js timezone dependency

### DIFF
--- a/apps/odyssey-stats/src/lib/set-locale.ts
+++ b/apps/odyssey-stats/src/lib/set-locale.ts
@@ -1,7 +1,6 @@
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
 import moment, { LongDateFormatKey } from 'moment';
-import { phpToMomentMapping } from 'calypso/my-sites/site-settings/date-time-format/utils';
 const debug = debugFactory( 'apps:odyssey' );
 
 const DEFAULT_LANGUAGE = 'en';
@@ -9,6 +8,57 @@ const DEFAULT_MOMENT_LOCALE = 'en';
 // Only Simple Site has the default locale as 'en'. For atomic/jetpack sites the default locale is 'en-us'.
 const SIMPLE_SITE_DEFAULT_LOCALE = 'en';
 const ALWAYS_LOAD_WITH_LOCALE = [ 'pt', 'zh' ];
+/**
+ * inlined from 'calypso/my-sites/site-settings/date-time-format/utils' as the moduel import the whole moment-timezone library, which is 755k before gzip.
+ */
+export const phpToMomentMapping = {
+	d: 'DD',
+	D: 'ddd',
+	j: 'D',
+	l: 'dddd',
+	N: 'E',
+	// "S" is andled via custom check
+	//S: '',
+	w: 'd',
+	// Moment.js equivalent of "z" (0 based) is "DDD" (1 based), so it must be adjusted
+	//z: 'DDD',
+	W: 'W',
+	F: 'MMMM',
+	m: 'MM',
+	M: 'MMM',
+	n: 'M',
+	// Moment.js has no "t" token equivalent, but a `moment().daysInMonth()` function
+	//t: '',
+	// Moment.js has no "L" token equivalent, but a `moment().isLeapYear()` function
+	//L: '',
+	o: 'Y',
+	Y: 'YYYY',
+	y: 'YY',
+	a: 'a',
+	A: 'A',
+	// Moment.js has no "B" token equivalent, but can be generated nonetheless
+	//B: '',
+	g: 'h',
+	G: 'H',
+	h: 'hh',
+	H: 'HH',
+	i: 'mm',
+	s: 'ss',
+	u: 'SSSSSS',
+	v: 'SSS',
+	e: 'z',
+	// Moment.js has no "I" token, but a `moment().isDST()` function
+	//I: '',
+	O: 'ZZ',
+	P: 'Z',
+	// Moment.js has no "T" token equivalent, but is similar enough to "z"
+	T: 'z',
+	// Moment.js has no "Z" token equivalent, but can be generated nonetheless
+	//Z: '',
+	c: 'YYYY-MM-DDTHH:mm-ssZ',
+	r: 'ddd, DD MMM YYYY HH:mm:ss ZZ',
+	U: 'X',
+};
 
 const getLanguageCodeFromLocale = ( localeSlug: string ) => {
 	debug( localeSlug );

--- a/apps/odyssey-stats/src/lib/set-locale.ts
+++ b/apps/odyssey-stats/src/lib/set-locale.ts
@@ -9,7 +9,7 @@ const DEFAULT_MOMENT_LOCALE = 'en';
 const SIMPLE_SITE_DEFAULT_LOCALE = 'en';
 const ALWAYS_LOAD_WITH_LOCALE = [ 'pt', 'zh' ];
 /**
- * inlined from 'calypso/my-sites/site-settings/date-time-format/utils' as the moduel import the whole moment-timezone library, which is 755k before gzip.
+ * inlined from 'calypso/my-sites/site-settings/date-time-format/utils' as the module import the whole moment-timezone library, which is 755k before gzip.
  */
 export const phpToMomentMapping = {
 	d: 'DD',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

The PR proposes to inline `phpToMomentMapping` object rather than referencing the module `calypso/my-sites/site-settings/date-time-format/utils`, which imports the whole package of `moment-timezone` sized 775k before gzip.

## Why are these changes being made?

This line imported the whole moment locales json, which accounts for 1/3 of the Odyssey bundle size.


https://github.com/Automattic/wp-calypso/blob/9ae25d0dc62807ec92aec0f5b98c79706baae1aa/apps/odyssey-stats/src/lib/set-locale.ts#L4


![image](https://github.com/Automattic/wp-calypso/assets/1425433/c3feb944-874e-4d2a-b23b-91b0d538da57)


## Testing Instructions

* Pull the branch to local
* `cd apps/odyssey-stats && yarn show-stats`
* Ensure you see something like the following, but not what's shared in the PR above

<img width="1284" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/d0785037-3f02-4391-a308-b23ab286f8b5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?