### PR TITLE
Introduce Whats New App

### DIFF
--- a/apps/whats-new/.eslintrc.js
+++ b/apps/whats-new/.eslintrc.js
@@ -1,0 +1,10 @@
+const { nodeConfig } = require( '@automattic/calypso-eslint-overrides' );
+
+module.exports = {
+	overrides: [
+		{
+			files: [ './bin/**/*', './webpack.config.js' ],
+			...nodeConfig,
+		},
+	],
+};

--- a/apps/whats-new/README.md
+++ b/apps/whats-new/README.md
@@ -4,5 +4,5 @@ This app provides a regular global JS function that renders the whats new from `
 
 ## External dependencies
 
-Dependencies that are globally available on all WP sites (e.g. `@wordpress/components`, `@wordpress/url`, etc.) are not included in the bundled build to optimize its size. We need to declare these dependencies though when enqueueing the build in the `jetpack-mu-wpcom` package, so remember to keep [this list](TBD) updated if you ever need to change the dependencies.
+Dependencies that are globally available on all WP sites (e.g. `@wordpress/components`, `@wordpress/url`, etc.) are not included in the bundled build to optimize its size. We need to declare these dependencies though when enqueueing the build in the `jetpack-mu-wpcom` package, so remember to keep [this list](https://github.com/Automattic/jetpack/blob/4d09351e8c36cb4be84b0a98870a3022fd21d080/projects/packages/jetpack-mu-wpcom/src/features/wpcom-whats-new/wpcom-whats-new.php#L50-L62) updated if you ever need to change the dependencies.
 gi

--- a/apps/whats-new/README.md
+++ b/apps/whats-new/README.md
@@ -1,0 +1,8 @@
+# Whats New App
+
+This app provides a regular global JS function that renders the whats new from `@automattic/whats-new` in a given node. This way, we can load the whats new app on different context.
+
+## External dependencies
+
+Dependencies that are globally available on all WP sites (e.g. `@wordpress/components`, `@wordpress/url`, etc.) are not included in the bundled build to optimize its size. We need to declare these dependencies though when enqueueing the build in the `jetpack-mu-wpcom` package, so remember to keep [this list](TBD) updated if you ever need to change the dependencies.
+gi

--- a/apps/whats-new/package.json
+++ b/apps/whats-new/package.json
@@ -1,0 +1,59 @@
+{
+	"name": "@automattic/whats-new-app",
+	"version": "1.0.0",
+	"description": "Provides utils to load the whats new in different environments",
+	"main": "dist/build.min.js",
+	"sideEffects": true,
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/Automattic/wp-calypso.git",
+		"directory": "apps/whats-new-app"
+	},
+	"private": true,
+	"author": "Automattic Inc.",
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"scripts": {
+		"clean": "npx rimraf dist",
+		"build": "NODE_ENV=production yarn dev",
+		"build:whats-new": "calypso-build",
+		"teamcity:build-app": "yarn run build && yarn run translate",
+		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/whats-new",
+		"translate": "rm -rf dist/strings && mkdirp dist && wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir './dist/strings' --output './dist/whats-new-strings.pot' && build-app-languages --stringsFilePath='./dist/whats-new-strings.pot'"
+	},
+	"dependencies": {
+		"@automattic/calypso-analytics": "workspace:^",
+		"@automattic/sites": "workspace:^",
+		"@automattic/whats-new": "workspace:^",
+		"@tanstack/react-query": "^5.15.5",
+		"@wordpress/components": "^28.0.0",
+		"@wordpress/data": "^10.0.0",
+		"@wordpress/element": "^6.0.0",
+		"@wordpress/i18n": "^5.0.0",
+		"@wordpress/plugins": "^7.0.0",
+		"calypso": "workspace:^",
+		"i18n-calypso": "workspace:^",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"redux": "^4.2.1"
+	},
+	"devDependencies": {
+		"@automattic/calypso-apps-builder": "workspace:^",
+		"@automattic/calypso-build": "workspace:^",
+		"@automattic/calypso-eslint-overrides": "workspace:^",
+		"@automattic/languages": "workspace:^",
+		"@automattic/wp-babel-makepot": "workspace:^",
+		"@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
+		"gettext-parser": "^6.0.0",
+		"lodash": "^4.17.21",
+		"mkdirp": "^1.0.4",
+		"node-fetch": "^2.6.6",
+		"npm-run-all": "^4.1.5",
+		"postcss": "^8.4.5",
+		"webpack": "^5.91.0",
+		"webpack-bundle-analyzer": "^4.10.2"
+	}
+}

--- a/apps/whats-new/src/index.js
+++ b/apps/whats-new/src/index.js
@@ -1,0 +1,51 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import WhatsNewGuide from '@automattic/whats-new';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Fill, MenuItem } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { useState } from 'react';
+
+function WhatsNewApp( { siteId } ) {
+	const [ showGuide, setShowGuide ] = useState( false );
+	const { setHasSeenWhatsNewModal } = useDispatch( 'automattic/help-center' );
+
+	const openWhatsNew = () => {
+		setHasSeenWhatsNewModal( true ).finally( () => setShowGuide( true ) );
+	};
+
+	const closeWhatsNew = () => setShowGuide( false );
+
+	// Record Tracks event if user opens What's New
+	useEffect( () => {
+		if ( showGuide ) {
+			recordTracksEvent( 'calypso_block_editor_whats_new_open' );
+		}
+	}, [ showGuide ] );
+
+	return (
+		<>
+			<Fill name="ToolsMoreMenuGroup">
+				<MenuItem onClick={ openWhatsNew }>{ __( "What's new", 'full-site-editing' ) }</MenuItem>
+			</Fill>
+			{ showGuide && <WhatsNewGuide onClose={ closeWhatsNew } siteId={ siteId } /> }
+		</>
+	);
+}
+
+registerPlugin( 'whats-new', {
+	render: () => {
+		if ( ! window.whatsNewAppConfig ) {
+			// Can't load the whats new app without a config.
+			return null;
+		}
+
+		return (
+			<QueryClientProvider client={ new QueryClient() }>
+				<WhatsNewApp { ...( window.whatsNewAppConfig || {} ) } />
+			</QueryClientProvider>
+		);
+	},
+} );

--- a/apps/whats-new/webpack.config.js
+++ b/apps/whats-new/webpack.config.js
@@ -1,0 +1,52 @@
+/**
+ *WARNING: No ES6 modules here. Not transpiled! ****
+ */
+
+const path = require( 'path' );
+const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const webpack = require( 'webpack' );
+const GenerateChunksMapPlugin = require( '../../build-tools/webpack/generate-chunks-map-plugin' );
+
+function getWebpackConfig( env, argv ) {
+	const webpackConfig = getBaseWebpackConfig( { ...env, WP: true }, argv );
+
+	return {
+		...webpackConfig,
+		entry: {
+			build: path.join( __dirname, 'src', 'index' ),
+		},
+		output: {
+			...webpackConfig.output,
+			filename: '[name].min.js',
+		},
+		plugins: [
+			...webpackConfig.plugins.filter(
+				( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
+			),
+			new GenerateChunksMapPlugin( {
+				output: path.resolve( __dirname, 'dist/chunks-map.json' ),
+			} ),
+			new webpack.DefinePlugin( {
+				__i18n_text_domain__: JSON.stringify( 'command-palette' ),
+			} ),
+			new DependencyExtractionWebpackPlugin( {
+				injectPolyfill: true,
+				outputFilename: '[name].asset.php',
+				requestToExternal( request ) {
+					// The extraction logic will only extract a dependency if requestToExternal
+					// explicitly returns undefined for the given request. Null shortcuts the
+					// logic such that @wordpress/commands styles and @wordpress/react-i18n are bundled.
+					if (
+						request === '@wordpress/commands/build-style/style.css' ||
+						request === '@wordpress/react-i18n'
+					) {
+						return null;
+					}
+				},
+			} ),
+		],
+	};
+}
+
+module.exports = getWebpackConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,6 +2039,41 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/whats-new-app@workspace:apps/whats-new":
+  version: 0.0.0-use.local
+  resolution: "@automattic/whats-new-app@workspace:apps/whats-new"
+  dependencies:
+    "@automattic/calypso-analytics": "workspace:^"
+    "@automattic/calypso-apps-builder": "workspace:^"
+    "@automattic/calypso-build": "workspace:^"
+    "@automattic/calypso-eslint-overrides": "workspace:^"
+    "@automattic/languages": "workspace:^"
+    "@automattic/sites": "workspace:^"
+    "@automattic/whats-new": "workspace:^"
+    "@automattic/wp-babel-makepot": "workspace:^"
+    "@tanstack/react-query": "npm:^5.15.5"
+    "@wordpress/components": "npm:^28.0.0"
+    "@wordpress/data": "npm:^10.0.0"
+    "@wordpress/dependency-extraction-webpack-plugin": "npm:^5.9.0"
+    "@wordpress/element": "npm:^6.0.0"
+    "@wordpress/i18n": "npm:^5.0.0"
+    "@wordpress/plugins": "npm:^7.0.0"
+    calypso: "workspace:^"
+    gettext-parser: "npm:^6.0.0"
+    i18n-calypso: "workspace:^"
+    lodash: "npm:^4.17.21"
+    mkdirp: "npm:^1.0.4"
+    node-fetch: "npm:^2.6.6"
+    npm-run-all: "npm:^4.1.5"
+    postcss: "npm:^8.4.5"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    redux: "npm:^4.2.1"
+    webpack: "npm:^5.91.0"
+    webpack-bundle-analyzer: "npm:^4.10.2"
+  languageName: unknown
+  linkType: soft
+
 "@automattic/whats-new@workspace:^, @automattic/whats-new@workspace:packages/whats-new":
   version: 0.0.0-use.local
   resolution: "@automattic/whats-new@workspace:packages/whats-new"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8032, https://github.com/Automattic/dotcom-forge/issues/8035

## Proposed Changes

* Build the `whats-new` app so that we can share the `@automattic/whats-new` package across different environments.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* ETK Migration

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See https://github.com/Automattic/jetpack/pull/38229

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
