### PR TITLE
A4A: Site selector and importer UI/UX improvements.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-themed-modal/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-themed-modal/index.tsx
@@ -28,7 +28,9 @@ export default function A4AThemedModal( {
 			__experimentalHideHeader
 		>
 			<div className="a4a-themed-modal__wrapper">
-				<img className="a4a-themed-modal__sidebar-image" src={ modalImage } alt="" />
+				<div className="a4a-themed-modal__sidebar-image-container">
+					<img className="a4a-themed-modal__sidebar-image" src={ modalImage } alt="" />
+				</div>
 				<div className="a4a-themed-modal__content">
 					{ dismissable && (
 						<Button className="a4a-themed-modal__dismiss-button" onClick={ onClose } plain>

--- a/client/a8c-for-agencies/components/a4a-themed-modal/style.scss
+++ b/client/a8c-for-agencies/components/a4a-themed-modal/style.scss
@@ -34,14 +34,20 @@
 	border: none;
 }
 
-.a4a-themed-modal__sidebar-image {
+
+.a4a-themed-modal__sidebar-image-container {
 	min-width: 270px;
-	height: auto;
+
 	display: none;
 
 	@include break-small {
 		display: block;
 	}
+}
+
+.a4a-themed-modal__sidebar-image {
+	width: 270px;
+	height: auto;
 }
 
 .a4a-themed-modal__content {

--- a/client/a8c-for-agencies/components/a4a-themed-modal/style.scss
+++ b/client/a8c-for-agencies/components/a4a-themed-modal/style.scss
@@ -35,7 +35,7 @@
 }
 
 .a4a-themed-modal__sidebar-image {
-	width: 270px;
+	min-width: 270px;
 	height: auto;
 	display: none;
 

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
@@ -10,7 +10,7 @@ type Props = {
 export default function useManagedSitesMap( { size = 100 }: Props ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const { data, isPending } = useFetchDashboardSites( {
+	const { data, isPending, isFetching } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded: false,
 		searchQuery: '',
 		currentPage: 1,
@@ -33,7 +33,7 @@ export default function useManagedSitesMap( { size = 100 }: Props ) {
 				map[ site.blog_id ] = true;
 				return map;
 			}, {} ),
-			isPending,
+			isPending: isPending || isFetching,
 		};
-	}, [ data, isPending ] );
+	}, [ data?.sites, isFetching, isPending ] );
 }

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/index.tsx
@@ -4,6 +4,8 @@ import { Icon, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import useImportWPCOMSitesMutation from 'calypso/a8c-for-agencies/data/sites/use-import-wpcom-sites';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import WPCOMSitesTable from './wpcom-sites-table';
 
 import './style.scss';
@@ -15,6 +17,7 @@ type Props = {
 
 export default function ImportFromWPCOMModal( { onImport, onClose }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const [ selectedSites, setSelectedSites ] = useState< number[] | [] >( [] );
 
@@ -32,6 +35,18 @@ export default function ImportFromWPCOMModal( { onImport, onClose }: Props ) {
 						onImport?.( selectedSites );
 						onClose();
 						setIsPendingImport( false );
+						dispatch(
+							successNotice(
+								selectedSites.length === 1
+									? translate( 'The site has been successfully added.' )
+									: translate( '%(count)s sites have been successfully added.', {
+											args: {
+												count: selectedSites.length,
+											},
+											comment: '%(count)s is the number of sites added.',
+									  } )
+							)
+						);
 					}, 1000 );
 				},
 			} );

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -139,10 +139,6 @@ p.import-from-wpcom-modal__instruction {
 		z-index: 2;
 	}
 
-	.a4a-text-placeholder {
-		margin-block: 32px;
-	}
-
 	.wpcom-sites-table__icon {
 		width: 24px;
 		height: 24px;
@@ -175,5 +171,34 @@ p.import-from-wpcom-modal__instruction {
 		@include break-large {
 			max-width: unset;
 		}
+	}
+}
+
+.wpcom-sites-table-placeholder {
+	display: flex;
+	flex-direction: column;
+
+	.a4a-text-placeholder {
+		margin: 0;
+	}
+
+	.wpcom-sites-table-placeholder__header {
+		padding: 16px 0;
+	}
+
+	.wpcom-sites-table-placeholder__row {
+		display: flex;
+		flex-direction: row;
+		width: 100%;
+		gap: 8px;
+		margin-block-end: 16px;
+	}
+
+	.wpcom-sites-table-placeholder__row .a4a-text-placeholder:first-child {
+		width: 24px;
+	}
+
+	.wpcom-sites-table-placeholder__row .a4a-text-placeholder:last-child {
+		width: calc(100% - 24px);
 	}
 }

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/table-placeholder.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/table-placeholder.tsx
@@ -1,0 +1,21 @@
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+
+export default function WPCOMSitesTablePlaceholder() {
+	return (
+		<div className="wpcom-sites-table-placeholder">
+			<div className="wpcom-sites-table-placeholder__header">
+				<TextPlaceholder />
+			</div>
+
+			<div className="wpcom-sites-table-placeholder__row">
+				<TextPlaceholder />
+				<TextPlaceholder />
+			</div>
+
+			<div className="wpcom-sites-table-placeholder__row">
+				<TextPlaceholder />
+				<TextPlaceholder />
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -4,7 +4,6 @@ import { CheckboxControl } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback } from 'react';
-import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useSelector } from 'calypso/state';
@@ -14,6 +13,7 @@ import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import useManagedSitesMap from './hooks/use-managed-sites-map';
 import WPCOMSitesTableContent from './table-content';
+import WPCOMSitesTablePlaceholder from './table-placeholder';
 
 export type SiteItem = {
 	id: number;
@@ -197,16 +197,7 @@ export default function WPCOMSitesTable( {
 	return (
 		<div className="wpcom-sites-table redesigned-a8c-table">
 			{ isPending ? (
-				<>
-					<TextPlaceholder />
-					<TextPlaceholder />
-					<TextPlaceholder />
-					<TextPlaceholder />
-					<TextPlaceholder />
-					<TextPlaceholder />
-					<TextPlaceholder />
-					<TextPlaceholder />
-				</>
+				<WPCOMSitesTablePlaceholder />
 			) : (
 				<WPCOMSitesTableContent items={ items } fields={ fields } />
 			) }

--- a/client/a8c-for-agencies/components/text-placeholder/style.scss
+++ b/client/a8c-for-agencies/components/text-placeholder/style.scss
@@ -4,4 +4,5 @@
 	@include placeholder( --color-neutral-10 );
 
 	display: block;
+	border-radius: 4px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -1,9 +1,12 @@
 import { Gridicon, Button } from '@automattic/components';
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useCallback } from 'react';
 import useRemoveSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-remove-site';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import { SiteRemoveConfirmationDialog } from '../site-remove-confirmation-dialog';
 import useSiteActions from './use-site-actions';
 import type { AllowedActionTypes, SiteNode } from '../types';
@@ -23,6 +26,9 @@ export default function SiteActions( {
 	siteError,
 	onRefetchSite,
 }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ showRemoveSiteDialog, setShowRemoveSiteDialog ] = useState( false );
 	const [ isPendingRefetch, setIsPendingRefetch ] = useState( false );
@@ -64,13 +70,14 @@ export default function SiteActions( {
 							onRefetchSite?.()?.then( () => {
 								setIsPendingRefetch( false );
 								setShowRemoveSiteDialog( false );
+								dispatch( successNotice( translate( 'The site has been successfully removed.' ) ) );
 							} );
 						}, 1000 );
 					},
 				}
 			);
 		}
-	}, [ onRefetchSite, removeSite, site.value?.a4a_site_id ] );
+	}, [ dispatch, onRefetchSite, removeSite, site.value?.a4a_site_id, translate ] );
 
 	return (
 		<>


### PR DESCRIPTION
### Issue # 1
When opening the Jetpack or A4A plugin connection flow modal, there is a tendency for the sidebar image to cause movement in the flow due to the image not being ready.

https://github.com/Automattic/wp-calypso/assets/56598660/8c297764-4612-4107-b95f-00c7245952d9

### Issue # 2
Sometimes, the site selector list does a prefetch while already displaying a list.

https://github.com/Automattic/wp-calypso/assets/56598660/475f6e36-2ef5-4ed6-ae14-b3e91e151fc9

### Issue # 3
We do not show any notice when the UI successfully removes or adds a site.

## Proposed Changes

* **Issue # 1:** Make sure the sidebar image has a minimum width of 270px to avoid flickering when the image is not yet loaded.

   https://github.com/Automattic/wp-calypso/assets/56598660/00141563-8c4b-4be5-8b53-aa78cd8dfa9e

* **Issue # 2:** Make sure we have a proper prefetch state on the Site selector modal to avoid confusion.


   https://github.com/Automattic/wp-calypso/assets/56598660/1ae9d7a5-ba0b-4e51-8302-af8702b4524d

* **Issue # 3:** Show some toast message when removing or adding a site.
<img width="381" alt="Screenshot 2024-07-08 at 4 00 39 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/fabf1e80-acdb-4abd-9e68-d15af213f14c">
<img width="405" alt="Screenshot 2024-07-08 at 4 00 21 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/33540766-b73d-497e-b2ff-7daa04cc7290">
<img width="384" alt="Screenshot 2024-07-08 at 4 00 55 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c0081b81-967a-4089-9e5a-1647a09aeb0d">



## Testing Instructions

* Use the A4A live link below and go to the `/overview` page.
* Open the Jetpack or A4A plugin modal and confirm no more shifting happens when image is loading.
* Next, open the WPCOM site selector and confirm the loading state is loaded with a placeholder structure closer to actual data.
* Add some sites and confirm that a toast message is displayed.
* Remove a site in the `/sites` page and confirm a toast message is displayed.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
