### PR TITLE
A4A > Site Selector & Importer: Fix the WPCOM add site modal in small screens

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -18,7 +18,7 @@
 		}
 	}
 
-	@include break-medium {
+	@include break-small {
 		margin: auto;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

This PR fixes the WPCOM add site modal in small screens

## Testing Instructions

1. Open the A4A live link.
2. Click the `Add sites` button > Click the Via WordPress.com menu item
3. Switch to mobile view at 600px & verify it looks as mentioned below:


| Before | After |
|--------|--------|
| <img width="599" alt="Screenshot 2024-07-08 at 12 36 26 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e852763f-a2fd-422f-9497-a63b3f1c6253"> | <img width="595" alt="Screenshot 2024-07-08 at 12 30 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/27896f66-4a42-41f6-9690-2ae76e0e4042">| 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
