### PR TITLE
Stats: Apply blurred content under the upsell overlay to Insights highlights

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@automattic/components';
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React, { useMemo } from 'react';
 import QueryPosts from 'calypso/components/data/query-posts';
@@ -239,31 +240,34 @@ type AllTimeStatsCardProps = {
 function AllTimeStatsCard( { infoItems, siteId, isLocked }: AllTimeStatsCardProps ) {
 	const translate = useTranslate();
 	const heading = translate( 'All-time stats' );
-	if ( isLocked ) {
-		return <UpsellCard heading={ heading } siteId={ siteId } />;
-	}
+	const wrapperClassName = clsx( 'highlight-card', {
+		'highlight-card--has-overlay': isLocked,
+	} );
 
 	return (
-		<Card className="highlight-card">
+		<Card className={ wrapperClassName }>
 			<h4 className="highlight-card-heading">{ heading }</h4>
-			<div className="highlight-card-info-item-list">
-				{ infoItems
-					.filter( ( i ) => ! i.hidden )
-					.map( ( info ) => {
-						return (
-							<div key={ info.id } className="highlight-card-info-item">
-								<Icon icon={ info.icon } />
-								<span className="highlight-card-info-item-title">{ info.title }</span>
-								<span
-									className="highlight-card-info-item-count"
-									title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
-								>
-									{ formattedNumber( info.count ) }
-								</span>
-							</div>
-						);
-					} ) }
+			<div className="highlight-card-content">
+				<div className="highlight-card-info-item-list">
+					{ infoItems
+						.filter( ( i ) => ! i.hidden )
+						.map( ( info ) => {
+							return (
+								<div key={ info.id } className="highlight-card-info-item">
+									<Icon icon={ info.icon } />
+									<span className="highlight-card-info-item-title">{ info.title }</span>
+									<span
+										className="highlight-card-info-item-count"
+										title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
+									>
+										{ formattedNumber( info.count ) }
+									</span>
+								</div>
+							);
+						} ) }
+				</div>
 			</div>
+			{ isLocked && <StatsCardUpsell statType={ STAT_TYPE_INSIGHTS } siteId={ siteId } /> }
 		</Card>
 	);
 }
@@ -287,42 +291,27 @@ type MostPopularDayTimeCardProps = {
 };
 
 function MostPopularDayTimeCard( { cardInfo, siteId, isLocked }: MostPopularDayTimeCardProps ) {
-	if ( isLocked ) {
-		return <UpsellCard heading={ cardInfo.heading } siteId={ siteId } />;
-	}
+	const wrapperClassName = clsx( 'highlight-card', {
+		'highlight-card--has-overlay': isLocked,
+	} );
 
 	return (
-		<Card key={ cardInfo.id } className="highlight-card">
+		<Card key={ cardInfo.id } className={ wrapperClassName }>
 			<h4 className="highlight-card-heading">{ cardInfo.heading }</h4>
-			<div className="highlight-card-detail-item-list">
-				{ cardInfo.items.map( ( item ) => {
-					return (
-						<div key={ item.id } className="highlight-card-detail-item">
-							<div className="highlight-card-detail-item-header">{ item.header }</div>
-							<div className="highlight-card-detail-item-content">{ item.content }</div>
-							<div className="highlight-card-detail-item-footer">{ item.footer }</div>
-						</div>
-					);
-				} ) }
+			<div className="highlight-card-content">
+				<div className="highlight-card-detail-item-list">
+					{ cardInfo.items.map( ( item ) => {
+						return (
+							<div key={ item.id } className="highlight-card-detail-item">
+								<div className="highlight-card-detail-item-header">{ item.header }</div>
+								<div className="highlight-card-detail-item-content">{ item.content }</div>
+								<div className="highlight-card-detail-item-footer">{ item.footer }</div>
+							</div>
+						);
+					} ) }
+				</div>
 			</div>
-		</Card>
-	);
-}
-
-type UpsellCardProps = {
-	heading: string;
-	siteId: number;
-};
-
-function UpsellCard( { heading, siteId }: UpsellCardProps ) {
-	return (
-		<Card className="highlight-card">
-			<h4 className="highlight-card-heading">{ heading }</h4>
-			<StatsCardUpsell
-				className="stats-module__upsell"
-				statType="insights-highlights"
-				siteId={ siteId }
-			/>
+			{ isLocked && <StatsCardUpsell statType={ STAT_TYPE_INSIGHTS } siteId={ siteId } /> }
 		</Card>
 	);
 }

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -15,6 +15,21 @@
 	.highlight-card {
 		padding: 24px;
 		min-width: 320px;
+
+		&.highlight-card--has-overlay {
+			.highlight-card-content {
+				filter: blur(10px);
+			}
+		}
+
+		.stats-card-upsell {
+			position: absolute;
+			left: 0;
+			top: 0;
+			width: 100%;
+			height: 100%;
+			z-index: 1;
+		}
 	}
 
 	.post-stats-card {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/87

## Proposed Changes

* Apply the `StatsCardUpsell` directly to Insights highlight cards with blurred card content.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This PR is the follow-up for https://github.com/Automattic/wp-calypso/pull/92360.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > `Insights` page for a new Jetpack site without Stats commercial purchase with a feature flag: `/stats/insights/{site-slug}?flags=stats/restricted-dashboard`.
* Ensure the `All-time highlights` section is paywalled with blurred card content.

![Image](https://github.com/Automattic/red-team/assets/6869813/2cec045f-c90e-428f-b1b8-1554bd3b9918)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
