### PR TITLE
A4A > Referrals: FAQ section icon alignment changes

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -86,10 +86,12 @@ export default function CommissionOverview( {
 					<StepSection heading={ translate( 'How much can I earn?' ) }>
 						<FoldableCard
 							header={
-								<div className="commission-overview__heading">
-									<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
-									{ translate( 'WooPayments revenue share' ) }
-								</div>
+								<>
+									<div className="a4a-overview-hosting__logo-container">
+										<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
+									</div>
+									<div>{ translate( 'WooPayments revenue share' ) }</div>
+								</>
 							}
 							expanded
 							clickableHeader
@@ -103,15 +105,20 @@ export default function CommissionOverview( {
 
 						<FoldableCard
 							header={
-								<div className="commission-overview__heading">
-									<img src={ pressableIcon } alt="Pressable" />
-									<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
-									{ translate( 'Hosting revenue share (WordPress.com and{{nbsp/}}Pressable)', {
-										components: {
-											nbsp: <>&nbsp;</>,
-										},
-									} ) }
-								</div>
+								<>
+									<div className="a4a-overview-hosting__logo-container">
+										<img src={ pressableIcon } alt="Pressable" />
+										<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />
+									</div>
+
+									<div>
+										{ translate( 'Hosting revenue share (WordPress.com and{{nbsp/}}Pressable)', {
+											components: {
+												nbsp: <>&nbsp;</>,
+											},
+										} ) }
+									</div>
+								</>
 							}
 							expanded
 							clickableHeader
@@ -124,16 +131,21 @@ export default function CommissionOverview( {
 
 						<FoldableCard
 							header={
-								<div className="commission-overview__heading">
-									<JetpackLogo className="jetpack-logo" size={ 24 } />
-									<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
-									{ translate( 'Jetpack products and Woo{{8209/}}owned{{nbsp/}}extensions', {
-										components: {
-											nbsp: <>&nbsp;</>,
-											8209: <>&#8209;</>,
-										},
-									} ) }
-								</div>
+								<>
+									<div className="a4a-overview-hosting__logo-container">
+										<JetpackLogo className="jetpack-logo" size={ 24 } />
+										<WooCommerceLogo className="woocommerce-logo" size={ 40 } />
+									</div>
+
+									<div>
+										{ translate( 'Jetpack products and Woo{{8209/}}owned{{nbsp/}}extensions', {
+											components: {
+												nbsp: <>&nbsp;</>,
+												8209: <>&#8209;</>,
+											},
+										} ) }
+									</div>
+								</>
 							}
 							expanded
 							clickableHeader

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
@@ -7,13 +7,6 @@
 		margin-block: 32px 0;
 	}
 
-	.commission-overview__heading {
-		display: flex;
-		flex-direction: row;
-		gap: 8px;
-		align-items: center;
-	}
-
 	.jetpack-logo {
 		fill: var(--color-jetpack);
 	}
@@ -53,6 +46,16 @@
 		color: var(--color-neutral-50);
 		font-weight: 400;
 		padding: 0 24px 24px;
+	}
+
+	.foldable-card__main {
+		display: block;
+
+		.a4a-overview-hosting__logo-container {
+			display: flex;
+			gap: 8px;
+			margin-block-end: 4px;
+		}
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/760

## Proposed Changes

This PR changes the Referrals FAQ section icon alignment.

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals - FAQ (/referrals/faq)
3. Verify the icons are aligned as displayed below:




| Before | After |
|--------|--------|
| <img width="781" alt="Screenshot 2024-07-08 at 2 11 40 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/74b804aa-c2e1-4097-8e32-6ed64c05338a">| <img width="781" alt="Screenshot 2024-07-08 at 2 11 54 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/64cdce09-0fa9-4650-ae1a-ff169ff58c85">| 
|<img width="781" alt="Screenshot 2024-07-08 at 2 12 23 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3dc0a27c-f30a-456b-a831-f1e83865b0e2">| <img width="781" alt="Screenshot 2024-07-08 at 2 12 28 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/07a32492-09c7-40ab-bc93-e276ad9380ce">| 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
