### PR TITLE
A4A: Enable Site selector and importer feature in staging.

### DIFF
--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -36,7 +36,8 @@
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
 		"a4a-logged-out-signup": true,
-		"a4a-automated-referrals": true
+		"a4a-automated-referrals": true,
+		"a4a-site-selector-and-importer": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/684

## Proposed Changes

* 'Enable' the Site selector and importer feature in staging.

## Why are these changes being made?


*

## Testing Instructions

* 

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
