### PR TITLE
Whats New: Add the app to Team City build

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -44,6 +44,7 @@ object WPComPlugins : Project({
 					"happy-blocks-release-build",
 					"command-palette-wp-admin-release-build",
 					"help-center-release-build",
+					"whats-new-release-build",
 				)
 			}
 			dataToKeep = everything()
@@ -127,6 +128,7 @@ object CalypsoApps: BuildType({
 		apps/editing-toolkit/editing-toolkit-plugin => editing-toolkit.zip
 		apps/command-palette-wp-admin/dist => command-palette-wp-admin.zip
 		apps/help-center/dist => help-center.zip
+		apps/whats-new/dist => whats-new.zip
 	""".trimIndent()
 
 	steps {

--- a/apps/whats-new/package.json
+++ b/apps/whats-new/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@automattic/whats-new-app",
 	"version": "1.0.0",
-	"description": "Provides utils to load the whats new in different environments",
+	"description": "Provides utils to load the whats new in different environments.",
 	"main": "dist/build.min.js",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/92470

## Proposed Changes

* This PR adds the Whats New app to the Build Calypso Apps script in TC, so the built .zip is available as an artifact that will be downloaded by the install-plugin.sh script in wpcom.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* ETK Migration

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just to make sure the app is built

![image](https://github.com/Automattic/wp-calypso/assets/13596067/8efdbe73-4597-48f2-a03b-c90f267721a9)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
