### PR TITLE
A4A > Purchases: Fix the Licenses' empty state

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -61,7 +61,7 @@ export default function LicensesOverview( {
 
 	const { data, isFetched } = useFetchLicenseCounts();
 
-	const showEmptyStateContent = isFetched && data?.[ LicenseFilter.NotRevoked ] === 0;
+	const showEmptyStateContent = isFetched && data?.all === 0;
 
 	return (
 		<Layout className="licenses-overview" title={ title } wide withBorder>


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/509

## Proposed Changes

This PR fixes the Licenses' empty state

## Testing Instructions

1. Open the A4A live link.
2. Go to Purchases - Licenses view > Revoke all the active licenses or login to a new account where there are not licenses > Verify that we show the tabs only when the all licenses count is 0, not when the active licenses count is 0


| Before | After |
|--------|--------|
| <img width="1581" alt="Screenshot 2024-07-09 at 8 15 11 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/747bab6b-8130-43b4-b17b-d551be9613f4">| <img width="1581" alt="Screenshot 2024-07-09 at 8 15 07 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/589cd96c-c857-4c48-9001-dd49e4cd9eb3">| 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
