### PR TITLE
Plans (State): Remove plansLoaded logic from JP app plans

### DIFF
--- a/client/jetpack-app/plans/main.tsx
+++ b/client/jetpack-app/plans/main.tsx
@@ -2,18 +2,15 @@ import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getPlanSlug } from 'calypso/state/plans/selectors';
 import type { Plan } from '@automattic/calypso-products';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { AppState } from 'calypso/types';
 
 import './style.scss';
 
@@ -64,11 +61,6 @@ const Header: React.FC< HeaderProps > = ( { paidDomainName } ) => {
 
 const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, originalUrl } ) => {
 	const dispatch = useDispatch();
-	const planSlug = useSelector( ( state: AppState ) =>
-		getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 )
-	) as string | null;
-	const plansLoaded = Boolean( planSlug );
-
 	const freeDomainSuggestionNameRef = useRef< string | undefined >( undefined );
 
 	const onUpgradeClick = ( cartItems?: MinimalRequestCartProduct[] | null | undefined ) => {
@@ -105,26 +97,18 @@ const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, or
 	return (
 		<Main className="jetpack-app__plans">
 			<QueryPlans />
-			{ plansLoaded ? (
-				<>
-					<Header paidDomainName={ paidDomainName } />
-					<PlansFeaturesMain
-						paidDomainName={ paidDomainName }
-						intent="plans-jetpack-app-site-creation"
-						isInSignup
-						intervalType="yearly"
-						onUpgradeClick={ onUpgradeClick }
-						plansWithScroll={ false }
-						hidePlanTypeSelector
-						hidePlansFeatureComparison
-						setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
-					/>
-				</>
-			) : (
-				<div className="jetpack-app__plans-loading">
-					<LoadingEllipsis />
-				</div>
-			) }
+			<Header paidDomainName={ paidDomainName } />
+			<PlansFeaturesMain
+				paidDomainName={ paidDomainName }
+				intent="plans-jetpack-app-site-creation"
+				isInSignup
+				intervalType="yearly"
+				onUpgradeClick={ onUpgradeClick }
+				plansWithScroll={ false }
+				hidePlanTypeSelector
+				hidePlansFeatureComparison
+				setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
+			/>
 		</Main>
 	);
 };

--- a/client/state/plans/selectors/plan.ts
+++ b/client/state/plans/selectors/plan.ts
@@ -41,7 +41,6 @@ export const getPlanBySlug = createSelector(
 );
 
 /**
- * @deprecated but still in use
  * Returns a plan product_slug. Useful for getting a cartItem for a plan.
  * @param  {Object}  state     global state
  * @param  {number}  productId the plan productId


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

Removes the logic for generating the `plansLoaded` variable in the jetpack-app plans.

**Caveats:**

This is primarily used for generating a loading ellipsis before rendering the `PlansFeaturesMain` component, which generates its own loading status and placeholder. However, we'd need to confirm if `<Header paidDomainName={ paidDomainName } />` is ok to render before the plans are populated in the data-store. Otherwise, one of the Query hooks (or pricing selector hook) can be used to re-establish the loading state where it was.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We only need one form of handling plan pricing in the code base, more so one framework. Anything else risks having alternative and differing views of the same data propagating across the code base.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On the JP app plans page:
    * Confirm nothing suspicious happens around the loading placeholders, like page sections/headers loading before the grid / different to production

See detailed instructions below on testing various cases with the JP app: https://github.com/Automattic/wp-calypso/pull/92485#issuecomment-2214047736 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
