### PR TITLE
Plans Grid: remove unused planUpgradeCreditsApplicable prop

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -75,7 +75,6 @@ import useGenerateActionHook from './hooks/use-generate-action-hook';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
-import { usePlanUpgradeCreditsApplicable } from './hooks/use-plan-upgrade-credits-applicable';
 import useGetFreeSubdomainSuggestion from './hooks/use-suggested-free-domain-from-paid-domain';
 import type {
 	PlansIntent,
@@ -630,10 +629,6 @@ const PlansFeaturesMain = ( {
 	const comparisonGridStickyRowOffset = enablePlanTypeSelectorStickyBehavior
 		? stickyPlanTypeSelectorHeight + masterbarHeight
 		: masterbarHeight;
-	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable(
-		siteId,
-		gridPlansForFeaturesGrid?.map( ( gridPlan ) => gridPlan.planSlug )
-	);
 
 	const {
 		primary: { callback: onFreePlanCTAClick },
@@ -766,7 +761,6 @@ const PlansFeaturesMain = ( {
 										isInSignup={ isInSignup }
 										onStorageAddOnClick={ handleStorageAddOnClick }
 										paidDomainName={ paidDomainName }
-										planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 										recordTracksEvent={ recordTracksEvent }
 										selectedFeature={ selectedFeature }
 										showLegacyStorageFeature={ showLegacyStorageFeature }
@@ -836,7 +830,6 @@ const PlansFeaturesMain = ( {
 															? { ...planTypeSelectorProps, plans: gridPlansForPlanTypeSelector }
 															: undefined
 													}
-													planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 													recordTracksEvent={ recordTracksEvent }
 													selectedFeature={ selectedFeature }
 													selectedPlan={ selectedPlan }

--- a/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.stories.tsx
@@ -50,7 +50,6 @@ const defaultProps = {
 	isInSignup: true,
 	onStorageAddOnClick: () => {},
 	planActionOverrides: undefined,
-	planUpgradeCreditsApplicable: undefined,
 	recordTracksEvent: () => {},
 	showRefundPeriod: false,
 	showUpgradeableStorage: true,

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -330,7 +330,6 @@ type ComparisonGridHeaderProps = {
 	isStuck: boolean;
 	isHiddenInMobile?: boolean;
 	planTypeSelectorProps?: PlanTypeSelectorProps;
-	planUpgradeCreditsApplicable?: number | null;
 };
 
 type ComparisonGridHeaderCellProps = Omit< ComparisonGridHeaderProps, 'planTypeSelectorProps' > & {
@@ -355,7 +354,6 @@ const ComparisonGridHeaderCell = ( {
 	displayedGridPlans,
 	currentSitePlanSlug,
 	planActionOverrides,
-	planUpgradeCreditsApplicable,
 	showRefundPeriod,
 	isStuck,
 }: ComparisonGridHeaderCellProps ) => {
@@ -431,7 +429,6 @@ const ComparisonGridHeaderCell = ( {
 			</PlanSelector>
 			<PlanFeatures2023GridHeaderPrice
 				planSlug={ planSlug }
-				planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 				currentSitePlanSlug={ currentSitePlanSlug }
 				visibleGridPlans={ visibleGridPlans }
 			/>
@@ -474,7 +471,6 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 			showRefundPeriod,
 			isStuck,
 			planTypeSelectorProps,
-			planUpgradeCreditsApplicable,
 		},
 		ref
 	) => {
@@ -503,7 +499,6 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 				{ visibleGridPlans.map( ( { planSlug }, index ) => (
 					<ComparisonGridHeaderCell
 						planSlug={ planSlug }
-						planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 						key={ planSlug }
 						isLastInRow={ index === visibleGridPlans.length - 1 }
 						isFooter={ isFooter }
@@ -927,7 +922,6 @@ const ComparisonGrid = ( {
 	onStorageAddOnClick,
 	showRefundPeriod,
 	planTypeSelectorProps,
-	planUpgradeCreditsApplicable,
 	gridSize,
 }: ComparisonGridProps ) => {
 	const { gridPlans, gridPlansIndex, featureGroupMap } = usePlansGridContext();
@@ -1073,7 +1067,6 @@ const ComparisonGrid = ( {
 							showRefundPeriod={ showRefundPeriod }
 							isStuck={ isStuck }
 							planTypeSelectorProps={ planTypeSelectorProps }
-							planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 						/>
 					) }
 				</StickyContainer>
@@ -1106,7 +1099,6 @@ const ComparisonGrid = ( {
 					isHiddenInMobile
 					ref={ bottomHeaderRef }
 					planTypeSelectorProps={ planTypeSelectorProps }
-					planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 				/>
 			</Grid>
 

--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -69,7 +69,6 @@ const defaultProps = {
 	isInSignup: true,
 	onStorageAddOnClick: () => {},
 	planActionOverrides: undefined,
-	planUpgradeCreditsApplicable: undefined,
 	recordTracksEvent: () => {},
 	showLegacyStorageFeature: false,
 	showRefundPeriod: false,

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -37,7 +37,6 @@ type MobileViewProps = {
 	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	paidDomainName?: string;
 	planActionOverrides?: PlanActionOverrides;
-	planUpgradeCreditsApplicable?: number | null;
 	renderedGridPlans: GridPlan[];
 	selectedFeature?: string;
 	showUpgradeableStorage: boolean;
@@ -68,7 +67,6 @@ const MobileView = ( {
 	onStorageAddOnClick,
 	paidDomainName,
 	planActionOverrides,
-	planUpgradeCreditsApplicable,
 	selectedFeature,
 	showUpgradeableStorage,
 }: MobileViewProps ) => {
@@ -107,7 +105,6 @@ const MobileView = ( {
 					{ isNotFreePlan && (
 						<PlanPrice
 							renderedGridPlans={ [ gridPlan ] }
-							planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 							currentSitePlanSlug={ currentSitePlanSlug }
 						/>
 					) }
@@ -188,7 +185,6 @@ type TabletViewProps = {
 	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	paidDomainName?: string;
 	planActionOverrides?: PlanActionOverrides;
-	planUpgradeCreditsApplicable?: number | null;
 	renderedGridPlans: GridPlan[];
 	selectedFeature?: string;
 	showRefundPeriod?: boolean;
@@ -206,7 +202,6 @@ const TabletView = ( {
 	onStorageAddOnClick,
 	paidDomainName,
 	planActionOverrides,
-	planUpgradeCreditsApplicable,
 	renderedGridPlans,
 	selectedFeature,
 	showRefundPeriod,
@@ -229,7 +224,6 @@ const TabletView = ( {
 		onStorageAddOnClick,
 		paidDomainName,
 		planActionOverrides,
-		planUpgradeCreditsApplicable,
 		selectedFeature,
 		showRefundPeriod,
 		showUpgradeableStorage,
@@ -262,7 +256,6 @@ const FeaturesGrid = ( {
 	onStorageAddOnClick,
 	paidDomainName,
 	planActionOverrides,
-	planUpgradeCreditsApplicable,
 	selectedFeature,
 	showRefundPeriod,
 	showUpgradeableStorage,
@@ -274,7 +267,6 @@ const FeaturesGrid = ( {
 		isInSignup,
 		onStorageAddOnClick,
 		planActionOverrides,
-		planUpgradeCreditsApplicable,
 		selectedFeature,
 		showUpgradeableStorage,
 	};

--- a/packages/plans-grid-next/src/components/features-grid/plan-price.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-price.tsx
@@ -4,19 +4,13 @@ import PlanDivOrTdContainer from '../plan-div-td-container';
 
 type PlanPriceProps = {
 	currentSitePlanSlug?: string | null;
-	planUpgradeCreditsApplicable?: number | null;
 	renderedGridPlans: GridPlan[];
 	options?: {
 		isTableCell?: boolean;
 	};
 };
 
-const PlanPrice = ( {
-	currentSitePlanSlug,
-	options,
-	planUpgradeCreditsApplicable,
-	renderedGridPlans,
-}: PlanPriceProps ) => {
+const PlanPrice = ( { currentSitePlanSlug, options, renderedGridPlans }: PlanPriceProps ) => {
 	return renderedGridPlans.map( ( { planSlug } ) => {
 		return (
 			<PlanDivOrTdContainer
@@ -27,7 +21,6 @@ const PlanPrice = ( {
 			>
 				<PlanFeatures2023GridHeaderPrice
 					planSlug={ planSlug }
-					planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 					currentSitePlanSlug={ currentSitePlanSlug }
 					visibleGridPlans={ renderedGridPlans }
 				/>

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -16,7 +16,6 @@ type SpotlightPlanProps = {
 	isInSignup: boolean;
 	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	planActionOverrides?: PlanActionOverrides;
-	planUpgradeCreditsApplicable?: number | null;
 	showUpgradeableStorage: boolean;
 	options?: {
 		isTableCell?: boolean;
@@ -29,7 +28,6 @@ const SpotlightPlan = ( {
 	isInSignup,
 	onStorageAddOnClick,
 	planActionOverrides,
-	planUpgradeCreditsApplicable,
 	showUpgradeableStorage,
 }: SpotlightPlanProps ) => {
 	if ( ! gridPlanForSpotlight ) {
@@ -51,7 +49,6 @@ const SpotlightPlan = ( {
 			{ isNotFreePlan && (
 				<PlanPrice
 					renderedGridPlans={ [ gridPlanForSpotlight ] }
-					planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 					currentSitePlanSlug={ currentSitePlanSlug }
 				/>
 			) }

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -26,7 +26,6 @@ type TableProps = {
 	onStorageAddOnClick?: ( addOnSlug: AddOns.StorageAddOnSlug ) => void;
 	paidDomainName?: string;
 	planActionOverrides?: PlanActionOverrides;
-	planUpgradeCreditsApplicable?: number | null;
 	renderedGridPlans: GridPlan[];
 	selectedFeature?: string;
 	showRefundPeriod?: boolean;
@@ -47,7 +46,6 @@ const Table = ( {
 	onStorageAddOnClick,
 	paidDomainName,
 	planActionOverrides,
-	planUpgradeCreditsApplicable,
 	renderedGridPlans,
 	selectedFeature,
 	showRefundPeriod,
@@ -111,7 +109,6 @@ const Table = ( {
 					<PlanPrice
 						renderedGridPlans={ gridPlansWithoutSpotlight }
 						options={ { isTableCell: true } }
-						planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 						currentSitePlanSlug={ currentSitePlanSlug }
 					/>
 				</tr>

--- a/packages/plans-grid-next/src/components/header-price.tsx
+++ b/packages/plans-grid-next/src/components/header-price.tsx
@@ -9,7 +9,6 @@ import type { GridPlan } from '../types';
 
 interface PlanFeatures2023GridHeaderPriceProps {
 	planSlug: PlanSlug;
-	planUpgradeCreditsApplicable?: number | null;
 	currentSitePlanSlug?: string | null;
 	visibleGridPlans: GridPlan[];
 }

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -24,7 +24,6 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 	const defaultProps = {
 		isLargeCurrency: false,
 		planSlug: PLAN_PERSONAL as PlanSlug,
-		planUpgradeCreditsApplicable: null,
 		visibleGridPlans: [],
 	};
 

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -115,7 +115,6 @@ export interface CommonGridProps {
 	showRefundPeriod?: boolean;
 	// only used for comparison grid
 	planTypeSelectorProps?: PlanTypeSelectorProps;
-	planUpgradeCreditsApplicable?: number | null;
 	gridContainerRef?: React.MutableRefObject< HTMLDivElement | null >;
 	gridSize?: string;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* In https://github.com/Automattic/wp-calypso/pull/92311, we [removed](https://github.com/Automattic/wp-calypso/pull/92311/files#diff-1004c0101417e9ed70407f86de757be09fe0c70abfb02e16a541c8af0decf9df) the only usage of the `planUpgradeCreditsApplicable` prop. This PR removes this prop from plans-grid-next types and passed props.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Cleanup after https://github.com/Automattic/wp-calypso/pull/92311.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There should be no functional changes.
* Smoke test a few flows - `/start/plans` and `/plans/<site slug>` to confirm that they work correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
