### PR TITLE
Related Plugins: Fetch the Product List

### DIFF
--- a/client/my-sites/plugins/related-plugins-page/index.tsx
+++ b/client/my-sites/plugins/related-plugins-page/index.tsx
@@ -3,6 +3,7 @@ import { UseQueryResult } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { RelatedPlugin } from 'calypso/data/marketplace/types';
@@ -44,6 +45,7 @@ export function RelatedPluginsPage( {
 
 	return (
 		<MainComponent wideLayout className="related-plugins-page">
+			<QueryProductsList />
 			<NavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs } />
 			<PluginsBrowserList
 				title={ translate( 'Related Plugins' ) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/88479


## Proposed Changes

Fetch the product list (with prices) on the Related Products page.

## Why are these changes being made?

To fix this behavior at https://github.com/Automattic/wp-calypso/issues/88479


## Testing Instructions
* Go to `/plugins/:plugin_id/related`. Ex: `/plugins/woocommerce-subscriptions/related`
* Clear the cache of this page on the Developer tools
* Reload the page
* Check if the prices of paid products are being displayed

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-07-08 at 10 36 10](https://github.com/Automattic/wp-calypso/assets/5039531/24eb83fa-f3b6-43ef-bb52-047a9b9f4072)|![CleanShot 2024-07-08 at 10 37 45](https://github.com/Automattic/wp-calypso/assets/5039531/88f89703-aa71-4a93-8c0b-3671472b693f)|


