### PR TITLE
A4A: add isGlobal field to Partner Directory agency details form

### DIFF
--- a/client/a8c-for-agencies/data/partner-directory/use-submit-agency-details.ts
+++ b/client/a8c-for-agencies/data/partner-directory/use-submit-agency-details.ts
@@ -41,6 +41,7 @@ function mutationSubmitAgencyDetails(
 			profile_company_logo_url: agencyDetails.logoUrl,
 			profile_company_landing_page_url: agencyDetails.landingPageUrl,
 			profile_company_country: agencyDetails.country,
+			profile_listing_is_global: agencyDetails.isGlobal,
 			profile_listing_is_available: agencyDetails.isAvailable,
 			profile_listing_industries: agencyDetails.industries,
 			profile_listing_languages_spoken: languages,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-details-form.ts
@@ -17,6 +17,7 @@ export default function useDetailsForm( { initialFormData }: Props ) {
 			logoUrl: '',
 			landingPageUrl: '',
 			country: '',
+			isGlobal: false,
 			isAvailable: true,
 			industries: [],
 			languagesSpoken: [],

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -211,13 +211,14 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			>
 				<FormField label={ translate( 'Availability' ) }>
 					<ToggleControl
+						onChange={ ( isChecked ) => setFormFields( { isGlobal: isChecked } ) }
+						checked={ formData.isGlobal }
+						label={ translate( 'Accepting remote work from any location' ) }
+					/>
+					<ToggleControl
 						onChange={ ( isChecked ) => setFormFields( { isAvailable: isChecked } ) }
 						checked={ formData.isAvailable }
-						label={
-							formData.isAvailable
-								? translate( "I'm accepting new clients" )
-								: translate( "I'm not accepting new clients" )
-						}
+						label={ translate( 'Accepting new clients' ) }
 					/>
 				</FormField>
 				<FormField

--- a/client/a8c-for-agencies/sections/partner-directory/types.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/types.ts
@@ -27,6 +27,7 @@ export interface AgencyDetails {
 	logoUrl: string;
 	landingPageUrl: string;
 	country: string;
+	isGlobal: boolean;
 	isAvailable: boolean;
 	industries: string[];
 	services: string[];

--- a/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/utils/map-application-form-data.ts
@@ -51,6 +51,7 @@ export function mapAgencyDetailsFormData( agency: Agency | null ): AgencyDetails
 		landingPageUrl: agency.profile.company_details.landing_page_url,
 		country: agency.profile.company_details.country,
 		isAvailable: agency.profile.listing_details.is_available,
+		isGlobal: agency.profile.listing_details.is_global,
 		industries: agency.profile.listing_details.industries,
 		services: agency.profile.listing_details.services,
 		products: agency.profile.listing_details.products,

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -36,6 +36,7 @@ export interface Agency {
 		};
 		listing_details: {
 			is_available: boolean;
+			is_global: boolean;
 			industries: string[];
 			services: string[];
 			products: string[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/739

## Proposed Changes

Add isGlobal switch to Agency details form.

<img width="566" alt="Screenshot 2024-07-08 at 9 50 05 AM" src="https://github.com/Automattic/wp-calypso/assets/60262784/b64fbee8-3d82-44b4-b8d9-a61807c863d1">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- This PR should be checked with D154628-code 
- Navigate to `/partner-directory/agency-details` and check behavior of new switch

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?