### PR TITLE
Remove string from calypso apps to leave only new string

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -33,9 +33,7 @@ import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
 let unlock;
 try {
 	unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		window.wpcomGutenberg?.pluginVersion?.startsWith( 'v18.7' )
-			? 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.'
-			: 'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/edit-site'
 	).unlock;
 } catch ( error ) {

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
@@ -17,10 +17,7 @@ export const getUnlock = () => {
 	let unlock: ( object: any ) => any | undefined;
 	try {
 		unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			( window as any ).wpcomGutenberg?.pluginVersion?.startsWith( 'v18.7' )
-				? 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.'
-				: 'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+			'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 			'@wordpress/edit-site'
 		).unlock;
 		return unlock;

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/site-editor-load.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/site-editor-load.tsx
@@ -13,10 +13,7 @@ import tracksRecordEvent from './track-record-event';
 let unlock: ( object: any ) => any | undefined;
 try {
 	unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		( window as any ).wpcomGutenberg?.pluginVersion?.startsWith( 'v18.7' )
-			? 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.'
-			: 'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 		'@wordpress/edit-site'
 	).unlock;
 } catch ( error ) {

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -16,10 +16,7 @@ import type { RenderedStyle } from '../types';
 import './block-renderer-container.scss';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	( window as any ).wpcomGutenberg?.pluginVersion?.startsWith( 'v18.7' )
-		? 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.'
-		: 'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/block-editor'
 );
 

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -12,10 +12,7 @@ import { isPlainObject } from 'is-plain-object';
 import type { GlobalStylesObject, GlobalStylesContextObject } from '../types';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	( window as any ).wpcomGutenberg?.pluginVersion?.startsWith( 'v18.7' )
-		? 'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.'
-		: 'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/block-editor'
 );
 

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -12,7 +12,7 @@ import { isPlainObject } from 'is-plain-object';
 import type { GlobalStylesObject, GlobalStylesContextObject } from '../types';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
 	'@wordpress/block-editor'
 );
 

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -12,7 +12,7 @@ import { isPlainObject } from 'is-plain-object';
 import type { GlobalStylesObject, GlobalStylesContextObject } from '../types';
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/block-editor'
 );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/8118

## Proposed Changes

* Once GB [`v18.7.0`](https://github.com/Automattic/wp-calypso/issues/92109) is deployed, let's clean previous unlock strings

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To clean the code base from a temporal check

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass


* Run `yarn dev --sync `
* Sandbox `widgets.wp.com`
* Access a the post editor from wp-admin in a simple site, for example: `https://20240701gutenbergrotation.wordpress.com/wp-admin/post.php?post=2&action=edit`
* Observe in the console that there are no errors related to unlock APIs `Error: Unable to get the unlock api. Reason: Error: You tried to opt-in to unstable APIs without confirming you know the consequences.`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
