### PR TITLE
Advertising A4A: Remove references to multi site management in Calypso admin

### DIFF
--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -1,5 +1,5 @@
 import { Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import {
 	type SiteExcerptData,
 	SitesSortKey,
@@ -103,6 +103,8 @@ const SitesDashboard = ( {
 		[],
 		( site ) => ! site.options?.is_domain_only
 	);
+
+	const hasEnTranslation = useHasEnTranslation();
 
 	useShowSiteCreationNotice( allSites, newSiteID );
 	useShowSiteTransferredNotice();
@@ -290,9 +292,17 @@ const SitesDashboard = ( {
 									},
 								} ) }
 								className="sites-a8c-for-agencies-banner"
-								description={ translate(
-									'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.'
-								) }
+								description={
+									hasEnTranslation(
+										"Earn up to 50% revenue share and get volume discounts on WordPress.com hosting when you migrate sites to our platform and promote Automattic's products to clients."
+									)
+										? translate(
+												"Earn up to 50% revenue share and get volume discounts on WordPress.com hosting when you migrate sites to our platform and promote Automattic's products to clients."
+										  )
+										: translate(
+												'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.'
+										  )
+								}
 								dismissPreferenceName="dismissible-card-a8c-for-agencies-sites"
 								event="learn-more"
 								horizontal
@@ -300,7 +310,15 @@ const SitesDashboard = ( {
 									'https://wordpress.com/for-agencies?ref=wpcom-sites-dashboard'
 								) }
 								target="_blank"
-								title={ translate( 'Managing multiple sites? Meet our agency hosting' ) }
+								title={
+									hasEnTranslation(
+										'Building sites for customers? Earn more with our agency program.'
+									)
+										? translate(
+												'Building sites for customers? Earn more with our agency program.'
+										  )
+										: translate( 'Managing multiple sites? Meet our agency hosting' )
+								}
 								tracksClickName="calypso_sites_dashboard_a4a_banner_click"
 							/>
 						</div>

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -1,9 +1,10 @@
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useHandleClickLink } from './use-handle-click-link';
 
 export const useFeaturesList = () => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const handleClickLink = useHandleClickLink();
 
 	return [
@@ -37,15 +38,28 @@ export const useFeaturesList = () => {
 		},
 		{
 			id: 'multi-site-management',
-			title: translate( 'Multiple site management', {
-				comment: 'Feature title',
-			} ),
-			description: translate(
-				'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.',
-				{
-					comment: 'Feature description',
-				}
-			),
+			title: hasEnTranslation( 'Agency Hosting' )
+				? translate( 'Agency Hosting', {
+						comment: 'Feature title',
+				  } )
+				: translate( 'Multiple site management', {
+						comment: 'Feature title',
+				  } ),
+			description: hasEnTranslation(
+				"Earn up to 50% revenue share and get volume discounts on WordPress.com hosting when you migrate sites to our platform and promote Automattic's products to clients."
+			)
+				? translate(
+						"Earn up to 50% revenue share and get volume discounts on WordPress.com hosting when you migrate sites to our platform and promote Automattic's products to clients.",
+						{
+							comment: 'Feature description',
+						}
+				  )
+				: translate(
+						'Manage multiple WordPress sites from one place, get volume discounts on hosting products, and earn up to 50% revenue share when you migrate sites to our platform and refer our products to clients.',
+						{
+							comment: 'Feature description',
+						}
+				  ),
 			linkLearnMore: localizeUrl( 'https://wordpress.com/for-agencies?ref=wpcom-dev-dashboard' ),
 		},
 		{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8059

## Proposed Changes

* Update advertising A4A touchpoint copy
* Title: Building sites for customers? Earn more with our agency program
* Body: Earn up to 50% revenue share and get volume discounts on WordPress.com hosting when you migrate sites to our platform and promote Automattic's products to clients.

<img width="1701" alt="Screenshot 2024-07-08 at 11 13 39 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/bba22ca6-8da8-4ef3-a973-99e06ef09050">

<img width="1699" alt="Screenshot 2024-07-08 at 11 13 59 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/5d5b24cb-6e63-4aa7-b019-64683c82145a">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/dotcom-forge/issues/8059. We should not use the A4A dashboard's multisite capabilities as a claim to attract agencies into the A4A program because eventually, we'd like for dotCom and Jetpack to offer similar multisite support. We do, however,  still want to advertise the Agency program. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* Navigate to /sites as a user with 5 or more sites
* Verify that the banner is rendered
* Verify that the banner can be dismissed permanently
* Visit `/me/developer`
* Verify that the new multi-site management card is shown
* Verify that the "Learn more" hyperlink leads to the A4A website

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
