### PR TITLE
Thank You Theme: Show the button as busy during installing

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -19,6 +19,7 @@ import {
 	hasActivatedTheme,
 	isThemeActive,
 	isActivatingTheme,
+	isInstallingTheme,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useIsValidThankYouTheme from './use-is-valid-thank-you-theme';
@@ -61,6 +62,7 @@ export const ThankYouThemeSection = ( {
 	const isFSEActive = activeThemeData?.[ 0 ]?.is_block_theme ?? false;
 	const hasActivated = useSelector( ( state ) => hasActivatedTheme( state, siteId ) );
 	const isActivating = useSelector( ( state ) => isActivatingTheme( state, siteId ) );
+	const isInstalling = useSelector( ( state ) => isInstallingTheme( state, theme.id, siteId ) );
 	const customizeUrl = useSelector( ( state ) =>
 		getCustomizeUrl( state, theme.id, siteId, isFSEActive )
 	);
@@ -119,7 +121,7 @@ export const ThankYouThemeSection = ( {
 					<>
 						<Button
 							primary
-							busy={ ( isActivating && ! hasActivated ) || isLoading }
+							busy={ ( ( isInstalling || isActivating ) && ! hasActivated ) || isLoading }
 							onClick={ handleActivateTheme }
 							href={ isActive ? customizeUrl : undefined }
 							disabled={ ! isValidThankyouSectionTheme }


### PR DESCRIPTION
Fixes [#8067](https://github.com/Automattic/dotcom-forge/issues/8067)

## Proposed Changes

Keep the `Activate this design` button as busy when installing a theme.s
Currently this button is only shown as busy during the activation step.


## Why are these changes being made?

To make the button not clickable when the user is already installing a theme, as described here [#8067](https://github.com/Automattic/dotcom-forge/issues/8067).

## Testing Instructions

* Go to `/theme/twentytwentyfour/:site`
* Click on `Activate this design`
* If a modal appears, you should click on the confirming button
* On the Thank You page, the button shouldn't be clickable when installing the theme

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-07-08 at 16 11 09](https://github.com/Automattic/wp-calypso/assets/5039531/d066dee1-fe0b-43d0-bd84-d74045bf2280)|![CleanShot 2024-07-08 at 16 10 02](https://github.com/Automattic/wp-calypso/assets/5039531/d26b20b8-9fef-4715-9ee6-4ae43767ee8f)|

