### PR TITLE
Submit create site configuration modal.

### DIFF
--- a/client/a8c-for-agencies/data/sites/use-create-wpcom-site.ts
+++ b/client/a8c-for-agencies/data/sites/use-create-wpcom-site.ts
@@ -3,10 +3,16 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
-export interface APIError {}
+export interface APIError {
+	status: number;
+}
 
 export interface CreateSiteParams {
 	id: number;
+	site_name?: string;
+	php_version?: string;
+	primary_data_center?: string;
+	is_fully_managed_agency_site?: boolean;
 }
 
 interface APIResponse {

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -138,19 +138,24 @@ export default function NeedSetup( { licenseKey }: Props ) {
 				features.wpcom_atomic.state === 'provisioning' && !! features.wpcom_atomic.license_key
 		);
 
+	const onCreateSiteSuccess = useCallback(
+		( id: number ) => {
+			refetchPendingSites();
+			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
+		},
+		[ refetchPendingSites ]
+	);
+
 	const onCreateSite = useCallback(
 		( id: number ) => {
 			createWPCOMSite(
 				{ id },
 				{
-					onSuccess: () => {
-						refetchPendingSites();
-						page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
-					},
+					onSuccess: () => onCreateSiteSuccess( id ),
 				}
 			);
 		},
-		[ createWPCOMSite, refetchPendingSites ]
+		[ createWPCOMSite, onCreateSiteSuccess ]
 	);
 
 	const onMigrateSite = useCallback(
@@ -197,6 +202,7 @@ export default function NeedSetup( { licenseKey }: Props ) {
 						randomSiteName={ randomSiteName }
 						isRandomSiteNameLoading={ isRandomSiteNameLoading }
 						siteId={ currentSiteConfigurationId }
+						onCreateSiteSuccess={ onCreateSiteSuccess }
 					/>
 				) }
 				<NeedSetupTable

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -5,6 +5,7 @@ import { check, closeSmall } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
+import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
@@ -15,6 +16,7 @@ import './style.scss';
 
 type SiteConfigurationsModalProps = {
 	closeModal: () => void;
+	onCreateSiteSuccess: ( id: number ) => void;
 	randomSiteName: string;
 	isRandomSiteNameLoading: boolean;
 	siteId: number;
@@ -22,15 +24,18 @@ type SiteConfigurationsModalProps = {
 
 export default function SiteConfigurationsModal( {
 	closeModal,
+	onCreateSiteSuccess,
 	randomSiteName,
 	isRandomSiteNameLoading,
 	siteId,
 }: SiteConfigurationsModalProps ) {
 	const [ allowClientsToUseSiteHelpCenter, setAllowClientsToUseSiteHelpCenter ] = useState( true );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const translate = useTranslate();
 	const dataCenterOptions = useDataCenterOptions();
 	const { phpVersions } = usePhpVersions();
 	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading, siteId );
+	const { mutate: createWPCOMSite } = useCreateWPCOMSiteMutation();
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>
 		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );
@@ -63,23 +68,40 @@ export default function SiteConfigurationsModal( {
 
 	const onSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
+		setIsSubmitting( true );
 		const formData = new FormData( event.currentTarget );
 		const phpVersion = formData.get( 'php_version' ) as string;
 		const primaryDataCenter = ( formData.get( 'primary_data_center' ) as string ) || undefined;
 		const params = {
+			id: siteId,
 			site_name: siteName.siteName,
 			php_version: phpVersion,
 			primary_data_center: primaryDataCenter,
 			is_fully_managed_agency_site: allowClientsToUseSiteHelpCenter,
 		};
-		// eslint-disable-next-line no-console
-		console.log( params );
+		createWPCOMSite( params, {
+			onSuccess: () => {
+				onCreateSiteSuccess( siteId );
+			},
+			onError: async ( error ) => {
+				if ( error.status === 400 ) {
+					await siteName.revalidateCurrentSiteName();
+					setIsSubmitting( false );
+				}
+			},
+		} );
+	};
+
+	const onRequestCloseModal = () => {
+		if ( ! isSubmitting ) {
+			closeModal();
+		}
 	};
 
 	return (
 		<Modal
 			title={ translate( 'Configure your new site' ) }
-			onRequestClose={ closeModal }
+			onRequestClose={ onRequestCloseModal }
 			className="configure-your-site-modal-form"
 		>
 			<form onSubmit={ onSubmit }>
@@ -105,6 +127,7 @@ export default function SiteConfigurationsModal( {
 								suffix=".wpcomstaging.com"
 								noWrap
 								spellCheck="false"
+								disabled={ isSubmitting }
 							/>
 						) }
 						<div className="configure-your-site-modal-form__site-name-icon-wrapper">
@@ -156,12 +179,13 @@ export default function SiteConfigurationsModal( {
 						className="configure-your-site-modal-form__php-version-select"
 						name="php_version"
 						onChange={ () => {} }
+						disabled={ isSubmitting }
 					>
 						{ phpVersionsElements }
 					</FormSelect>
 				</FormField>
 				<FormField label={ translate( 'Primary data center' ) }>
-					<FormSelect name="primary_data_center" onChange={ () => {} }>
+					<FormSelect disabled={ isSubmitting } name="primary_data_center" onChange={ () => {} }>
 						<option value="">{ translate( 'No preference' ) }</option>
 						{ dataCenterOptionsElements }
 					</FormSelect>
@@ -173,6 +197,7 @@ export default function SiteConfigurationsModal( {
 							onChange={ toggleAllowClientsToUseSiteHelpCenter }
 							checked={ allowClientsToUseSiteHelpCenter }
 							name="is_fully_managed_agency_site"
+							disabled={ isSubmitting }
 						/>
 						<label htmlFor="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox">
 							{ translate(
@@ -204,7 +229,7 @@ export default function SiteConfigurationsModal( {
 					</div>
 				</FormField>
 				<div className="configure-your-site-modal-form__footer">
-					<Button primary type="submit">
+					<Button primary type="submit" busy={ isSubmitting }>
 						{ translate( 'Create site' ) }
 					</Button>
 				</div>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -229,7 +229,12 @@ export default function SiteConfigurationsModal( {
 					</div>
 				</FormField>
 				<div className="configure-your-site-modal-form__footer">
-					<Button primary type="submit" busy={ isSubmitting }>
+					<Button
+						primary
+						type="submit"
+						busy={ isSubmitting }
+						disabled={ ! siteName.isSiteNameReadyForUse }
+					>
 						{ translate( 'Create site' ) }
 					</Button>
 				</div>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -69,7 +69,15 @@ const useCheckSiteAvailability = (
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ agencyId, siteId, siteName, skipAvailability ] );
 
-	return availabilityState;
+	const revalidateCurrentSiteName = async () => {
+		setAvilabilityState( {
+			isSiteNameAvailiable: false,
+			isCheckingSiteAvailability: false,
+			siteNameSuggestion: await getRandomSiteBaseUrl( siteName ),
+		} );
+	};
+
+	return { ...availabilityState, revalidateCurrentSiteName };
 };
 
 export const useSiteName = (
@@ -117,8 +125,12 @@ export const useSiteName = (
 	const skipAvailability =
 		validationMessage || isDebouncingSiteName || debouncedSiteName === randomSiteName;
 
-	const { isCheckingSiteAvailability, isSiteNameAvailiable, siteNameSuggestion } =
-		useCheckSiteAvailability( siteId, debouncedSiteName, !! skipAvailability );
+	const {
+		isCheckingSiteAvailability,
+		isSiteNameAvailiable,
+		siteNameSuggestion,
+		revalidateCurrentSiteName,
+	} = useCheckSiteAvailability( siteId, debouncedSiteName, !! skipAvailability );
 
 	if ( ! isSiteNameAvailiable && ! isCheckingSiteAvailability && ! isDebouncingSiteName ) {
 		validationMessage = translate(
@@ -156,5 +168,6 @@ export const useSiteName = (
 		showValidationMessage,
 		isCheckingSiteAvailability,
 		isDebouncingSiteName,
+		revalidateCurrentSiteName,
 	};
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8046

## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/33497086/75177df0-67a7-47aa-a434-f2ca0e9daa3c)

Actually creates the site when submitting the configuration form on modal.

## Testing Instructions

This feature is under `a4a-site-creation-configurations` flag.
Before accessing the Create new site button, your account needs to have at least 1 hosting license, ready to be used.
If you are not sure how to get that, read PdDOJh-3ys-p2.

1 - Open this link: http://agencies.localhost:3000/sites/need-setup?flags=a4a-site-creation-configurations
2 - Click on Create new site link on the table.
3 - It should open the site configuration modal
4 - Pick a custom name, PHP version, data center and check or uncheck the `is_fully_managed_agency_site`.
5 - Click on Create site button on the bottom.

The site creation is async job, but should not take long. You should be redirect to the sites list with a yellow notification, confirming that your site is in progress. After a minute it should turn into green. Your new site should have been created with the custom name.

PHP version and data center can be checked on server setting page:
`https://wordpress.com/hosting-config/{{your-site}}`
![image](https://github.com/Automattic/wp-calypso/assets/33497086/3c4a67b0-7f45-440f-bc14-5b1ff43f50c1)

The `is_fully_managed_agency_site` option can be checked under a search on ATAT: Site Options Lookup.

![image](https://github.com/Automattic/wp-calypso/assets/33497086/feaec88d-53fe-4caf-8ec7-89fc200dcddb)


### Testing edge case scenario:
When a user inputs a site address, the application check if that is address is available.
But if the address is taken between the first check and the time the user clicks on Create site button, the server will return a 400 error. If that happens, the application should communicate that the address is taken and suggest a new one.
![image](https://github.com/Automattic/wp-calypso/assets/33497086/b1f19158-4c22-4e64-859e-29a89e8f72f6)

To simulate this, you will need to start filling the form, inputing a valid address. On another tab, create a site on wordpress.com to make this unavailable. It can be a free site. Return to the A4A tab and complete click on `Create site`. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
