### PR TITLE
GF Signup: Remove Modal experiment to offer higher tier options 

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -1,12 +1,6 @@
-import {
-	type PlanSlug,
-	PLAN_BUSINESS,
-	PLAN_PERSONAL,
-	PLAN_PREMIUM,
-} from '@automattic/calypso-products';
+import { type PlanSlug, PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useExperiment } from 'calypso/lib/explat';
 import PlanUpsellButton from './plan-upsell-button';
 import { DomainName } from '.';
 
@@ -18,101 +12,6 @@ const FreeDomainText = styled.div`
 	margin-top: 4px;
 `;
 
-function SuggestedPlanExplorerCreator( {
-	paidDomainName,
-	onPlanSelected,
-	isBusy,
-}: {
-	paidDomainName?: string;
-	onPlanSelected: ( planSlug: PlanSlug ) => void;
-	isBusy: boolean;
-} ) {
-	const translate = useTranslate();
-	return (
-		<>
-			{ paidDomainName && (
-				<DomainName>
-					<div>{ paidDomainName }</div>
-					<FreeDomainText>
-						{ translate( 'Free domain and premium themes included.' ) }
-					</FreeDomainText>
-				</DomainName>
-			) }
-			<PlanUpsellButton
-				planSlug={ PLAN_PREMIUM }
-				onPlanSelected={ onPlanSelected }
-				isBusy={ isBusy }
-			/>
-			{ paidDomainName && (
-				<DomainName>
-					<div>{ paidDomainName }</div>
-					<FreeDomainText>
-						{ translate( 'Best for developers. Free domain and plugins.' ) }
-					</FreeDomainText>
-				</DomainName>
-			) }
-			<PlanUpsellButton
-				planSlug={ PLAN_BUSINESS }
-				onPlanSelected={ onPlanSelected }
-				isBusy={ isBusy }
-			/>
-		</>
-	);
-}
-
-function SuggestedPlanStarterExplorerCreator( {
-	paidDomainName,
-	onPlanSelected,
-	isBusy,
-}: {
-	paidDomainName?: string;
-	onPlanSelected: ( planSlug: PlanSlug ) => void;
-	isBusy: boolean;
-} ) {
-	const translate = useTranslate();
-	return (
-		<>
-			{ paidDomainName && (
-				<DomainName>
-					<div>{ paidDomainName }</div>
-					<FreeDomainText>{ translate( 'Free domain for one year included.' ) }</FreeDomainText>
-				</DomainName>
-			) }
-			<PlanUpsellButton
-				planSlug={ PLAN_PERSONAL }
-				onPlanSelected={ onPlanSelected }
-				isBusy={ isBusy }
-			/>
-			{ paidDomainName && (
-				<DomainName>
-					<div>{ paidDomainName }</div>
-					<FreeDomainText>
-						{ translate( 'Free domain and premium themes included.' ) }
-					</FreeDomainText>
-				</DomainName>
-			) }
-			<PlanUpsellButton
-				planSlug={ PLAN_PREMIUM }
-				onPlanSelected={ onPlanSelected }
-				isBusy={ isBusy }
-			/>
-			{ paidDomainName && (
-				<DomainName>
-					<div>{ paidDomainName }</div>
-					<FreeDomainText>
-						{ translate( 'Best for developers. Free domain and plugins.' ) }
-					</FreeDomainText>
-				</DomainName>
-			) }
-			<PlanUpsellButton
-				planSlug={ PLAN_BUSINESS }
-				onPlanSelected={ onPlanSelected }
-				isBusy={ isBusy }
-			/>
-		</>
-	);
-}
-
 export default function SuggestedPlanSection( props: {
 	paidDomainName?: string;
 	onPlanSelected: ( planSlug: PlanSlug ) => void;
@@ -120,19 +19,6 @@ export default function SuggestedPlanSection( props: {
 } ) {
 	const translate = useTranslate();
 	const { paidDomainName, onPlanSelected, isBusy } = props;
-	const [ isExperimentLoading, assignment ] = useExperiment(
-		'calypso_signup_onboarding_plans_paid_domain_free_plan_modal_optimization'
-	);
-
-	if ( isExperimentLoading ) {
-		return null;
-	}
-
-	if ( assignment?.variationName === 'creator_for_starter' ) {
-		return <SuggestedPlanExplorerCreator { ...props } />;
-	} else if ( assignment?.variationName === 'creator_and_free_link' ) {
-		return <SuggestedPlanStarterExplorerCreator { ...props } />;
-	}
 
 	return (
 		<>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -52,7 +52,6 @@ import QuerySites from 'calypso/components/data/query-sites';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
-import { useExperiment } from 'calypso/lib/explat';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import { shouldForceDefaultPlansBasedOnIntent } from 'calypso/my-sites/plans-features-main/components/utils/utils';
@@ -616,11 +615,9 @@ const PlansFeaturesMain = ( {
 	const comparisonGridContainerClasses = clsx( 'plans-features-main__comparison-grid-container', {
 		'is-hidden': ! showPlansComparisonGrid,
 	} );
-	const [ isExperimentLoading ] = useExperiment(
-		'calypso_signup_onboarding_plans_paid_domain_free_plan_modal_optimization'
-	);
+
 	const isLoadingGridPlans = Boolean(
-		! intent || ! gridPlansForFeaturesGrid || ! gridPlansForComparisonGrid || isExperimentLoading
+		! intent || ! gridPlansForFeaturesGrid || ! gridPlansForComparisonGrid
 	);
 	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
 

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -45,9 +45,6 @@ jest.mock( '@automattic/data-stores', () => ( {
 
 jest.mock( 'calypso/components/data/query-active-promotions', () => jest.fn() );
 jest.mock( 'calypso/components/data/query-products-list', () => jest.fn() );
-jest.mock( 'calypso/lib/explat', () => ( {
-	useExperiment: () => [ false, { experimentName: 'control' } ],
-} ) );
 
 import {
 	PLAN_FREE,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2793 and https://github.com/Automattic/wp-calypso/pull/89559

## Proposed Changes

* Removes an experiment to show multiple buttons on the paid plan required modal

### Keeping

- Control
<img width="600" alt="Screenshot 2024-04-18 at 6 27 57 PM" src="https://github.com/Automattic/wp-calypso/assets/3422709/8d324a25-31a8-458d-a953-1f232cd6ea9f">

### Removing

- Variant creator_for_starter
<img width="600" alt="Screenshot 2024-04-18 at 6 27 36 PM" src="https://github.com/Automattic/wp-calypso/assets/3422709/f1a7831d-709e-443d-8378-849b0e34ac3c">

- Variant creator_and_free_link
<img width="600" alt="Screenshot 2024-04-18 at 6 27 15 PM" src="https://github.com/Automattic/wp-calypso/assets/3422709/fc3c5933-3231-4466-840e-8913a9b155cc">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

> It seems there is no meaningful/directional increase for both variants. The variant with 3 plans is more clearly directional toward control than the other (not that the other is improving, but it is clearer for the 3-plan one), which is some insight here regarding the modal pattern and having too many plans. One plausible explanation can be ‘we cannot clearly differentiate plans on the modal and having 3 plans creates extra cognitive load’.
> For the two-plan variant, the plausible explanation could be that the price jump between the two plans is too high for this to appeal to a broader audience.
> Since we p5uIfZ-f5p-p2 which was the target of this new modal as well.
> The recommendation would be to keep the modal as is for now and focus on new initiatives that can create a larger impact.

pbxNRc-3Eu-p2#comment-5575

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` 
* Select a paid domain 
* Click on the free plan
* Make sure only the control modal is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?