### PR TITLE
Stats: opt out all cross upgrades for site-only checkout flow

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -123,7 +123,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 		isLegacyCommercialLicense,
 		hasLoadedSitePurchases,
 		hasAnyPlan: isFreeOwned || isCommercialOwned || isPWYWOwned || supportCommercialUse,
-		hasAnyStatsPlan: isCommercialOwned || isPWYWOwned || isPWYWOwned,
+		hasAnyStatsPlan: isCommercialOwned || isPWYWOwned || isFreeOwned,
 		isLoading: ! hasLoadedSitePurchases || isRequestingSitePurchases,
 	};
 }

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -123,6 +123,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 		isLegacyCommercialLicense,
 		hasLoadedSitePurchases,
 		hasAnyPlan: isFreeOwned || isCommercialOwned || isPWYWOwned || supportCommercialUse,
+		hasAnyStatsPlan: isCommercialOwned || isPWYWOwned || isPWYWOwned,
 		isLoading: ! hasLoadedSitePurchases || isRequestingSitePurchases,
 	};
 }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -12,6 +12,7 @@ import React, { useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import useStatsPurchases from 'calypso/my-sites/stats/hooks/use-stats-purchases';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
@@ -61,6 +62,7 @@ const PersonalPurchase = ( {
 	} = sliderSettings;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
+	const { hasAnyStatsPlan } = useStatsPurchases( siteId );
 
 	const sliderLabel = ( ( props, state ) => {
 		let emoji;
@@ -122,6 +124,7 @@ const PersonalPurchase = ( {
 			adminUrl,
 			redirectUri,
 			price: subscriptionValue / MIN_STEP_SPLITS,
+			isUpgrade: hasAnyStatsPlan, // All cross grades are not possible for the site-only flow.
 		} );
 	};
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -147,7 +147,7 @@ const StatsCommercialPurchase = ( {
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
 	const tiers = useAvailableUpgradeTiers( siteId ) || [];
-	const { isCommercialOwned } = useStatsPurchases( siteId );
+	const { isCommercialOwned, hasAnyStatsPlan } = useStatsPurchases( siteId );
 
 	// The button of @automattic/components has built-in color scheme support for Calypso.
 	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
@@ -214,7 +214,7 @@ const StatsCommercialPurchase = ( {
 									redirectUri,
 									price: undefined,
 									quantity: purchaseTierQuantity,
-									isUpgrade: isCommercialOwned,
+									isUpgrade: hasAnyStatsPlan, // All cross grades are not possible for the site-only flow.
 								} )
 							}
 						>
@@ -241,6 +241,7 @@ const StatsPersonalPurchase = ( {
 	disableFreeProduct = false,
 }: StatsPersonalPurchaseProps ) => {
 	const translate = useTranslate();
+
 	const sliderStepPrice = pwywProduct.cost / MIN_STEP_SPLITS;
 
 	const steps = Math.floor( maxSliderPrice / sliderStepPrice );


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/56

## Proposed Changes

When site has any plan, including Free, PWYW or Commercial, we use the normal checkout for sites: `https://wordpress.com/checkout/:siteSlug/:productSlug` (A).

Only use site-only checkout, which doesn't require login for new purchases: `https://wordpress.com/checkout/jetpack/:productSlug?from_site_slug=:siteSlug` (B).

https://github.com/Automattic/wp-calypso/blob/578a5de802fe9aa7029e53b784b1690373b0b287/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx#L42

## Why are these changes being made?

* As of now, the site-only flow is not able to handle either tier upgrades for Commercial or cross upgrades, for example, Free to PWYW, PWYW to Commercial or Free to Commercial. Users end up with an error saying site already has a subscription.

## Testing Instructions

* Build Odyssey Stats and Jetpack locally
  * `jetpack build plugins/jetpack`
  * `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Purchase a Free Stats license for your site if not yet
* Open `/wp-admin/admin.php?page=stats#!/stats/purchase/:siteSlug`
* Choose Commercial plan with any tier
* Ensure you are redirected to checkout with checkout URL `A` mentioned in the description above
* Ensure you are able to purchase commercial for the site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?