### PR TITLE
Stats: Devices module - moving files to new directory

### DIFF
--- a/client/my-sites/stats/features/modules/stats-devices/index.ts
+++ b/client/my-sites/stats/features/modules/stats-devices/index.ts
@@ -1,0 +1,2 @@
+export { default } from './stats-module-devices-wrapper';
+export { default as StatsModuleUpgradeDevicesOverlay } from './stats-module-upgrade-overlay';

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-devices-wrapper.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-devices-wrapper.tsx
@@ -1,14 +1,14 @@
 import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import clsx from 'clsx';
-import StatsCardSkeleton from '../features/modules/shared/stats-card-skeleton';
-import { default as usePlanUsageQuery } from '../hooks/use-plan-usage-query';
-import useStatsPurchases from '../hooks/use-stats-purchases';
-import StatsModulePlaceholder from '../stats-module/placeholder';
-import statsStrings from '../stats-strings';
+import { default as usePlanUsageQuery } from '../../../hooks/use-plan-usage-query';
+import useStatsPurchases from '../../../hooks/use-stats-purchases';
+import StatsModulePlaceholder from '../../../stats-module/placeholder';
+import statsStrings from '../../../stats-strings';
+import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import StatsModuleDevices from './stats-module-devices';
 import StatsModuleUpgradeOverlay from './stats-module-upgrade-overlay';
-import type { StatsAdvancedModuleWrapperProps } from '../features/modules/types';
+import type { StatsAdvancedModuleWrapperProps } from '../types';
 
 const DEVICES_CLASS_NAME = 'stats-module-devices';
 

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.scss
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.scss
@@ -1,5 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
-@import "../modernized-mixins";
+@import "../../../modernized-mixins";
 
 .stats-module-devices {
 	@include segmented-controls;

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
@@ -10,15 +10,15 @@ import PieChart from 'calypso/components/pie-chart';
 import PieChartLegend from 'calypso/components/pie-chart/legend';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import EmptyModuleCard from '../components/empty-module-card/empty-module-card';
-import { JETPACK_SUPPORT_URL } from '../const';
-import StatsCardSkeleton from '../features/modules/shared/stats-card-skeleton';
-import useModuleDevicesQuery, { StatsDevicesData } from '../hooks/use-modeule-devices-query';
-import { QueryStatsParams } from '../hooks/utils';
-import StatsListCard from '../stats-list/stats-list-card';
-import StatsModulePlaceholder from '../stats-module/placeholder';
-import statsStrings from '../stats-strings';
-import type { StatsPeriodType } from '../features/modules/types';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { JETPACK_SUPPORT_URL } from '../../../const';
+import useModuleDevicesQuery, { StatsDevicesData } from '../../../hooks/use-modeule-devices-query';
+import { QueryStatsParams } from '../../../hooks/utils';
+import StatsListCard from '../../../stats-list/stats-list-card';
+import StatsModulePlaceholder from '../../../stats-module/placeholder';
+import statsStrings from '../../../stats-strings';
+import StatsCardSkeleton from '../shared/stats-card-skeleton';
+import type { StatsPeriodType } from '../types';
 
 import './stats-module-devices.scss';
 

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-upgrade-overlay.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-upgrade-overlay.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
-import { STATS_TYPE_DEVICE_STATS } from '../constants';
-import StatsCardUpsellJetpack from '../stats-card-upsell/stats-card-upsell-jetpack';
-import StatsListCard from '../stats-list/stats-list-card';
+import { STATS_TYPE_DEVICE_STATS } from '../../../constants';
+import StatsCardUpsellJetpack from '../../../stats-card-upsell/stats-card-upsell-jetpack';
+import StatsListCard from '../../../stats-list/stats-list-card';
 
 import './stats-module-devices.scss';
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -48,6 +48,9 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import StatsModuleAuthors from './features/modules/stats-authors';
 import StatsModuleClicks from './features/modules/stats-clicks';
 import StatsModuleCountries from './features/modules/stats-countries';
+import StatsModuleDevices, {
+	StatsModuleUpgradeDevicesOverlay,
+} from './features/modules/stats-module-devices';
 import StatsModuleReferrers from './features/modules/stats-referrers';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
 import StatsModuleUTM, { StatsModuleUTMOverlay } from './features/modules/stats-utm';
@@ -61,8 +64,6 @@ import ChartTabs from './stats-chart-tabs';
 import Countries from './stats-countries';
 import DatePicker from './stats-date-picker';
 import StatsModule from './stats-module';
-import StatsModuleDevices from './stats-module-devices';
-import StatsModuleUpgradeDevicesOverlay from './stats-module-devices/stats-module-upgrade-overlay';
 import StatsModuleEmails from './stats-module-emails';
 import StatsNotices from './stats-notices';
 import PageViewTracker from './stats-page-view-tracker';

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -50,7 +50,7 @@ import StatsModuleClicks from './features/modules/stats-clicks';
 import StatsModuleCountries from './features/modules/stats-countries';
 import StatsModuleDevices, {
 	StatsModuleUpgradeDevicesOverlay,
-} from './features/modules/stats-module-devices';
+} from './features/modules/stats-devices';
 import StatsModuleReferrers from './features/modules/stats-referrers';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
 import StatsModuleUTM, { StatsModuleUTMOverlay } from './features/modules/stats-utm';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/70

## Proposed Changes

* moving component files to a new directory, unifying it with other Stats modules

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* following review comment https://github.com/Automattic/wp-calypso/pull/92467#discussion_r1669417219

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply `stats/empty-module-traffic` feature flag
* verify that a page with an empty Devices component works with and without the feature flag
* repeat for blogs with data
* verify that the advanced feature overlay works properly
* verify that the new empty state only shows up after applying the feature flag

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?