### PR TITLE
Newsletter: Add reply by comment option for reply-to setting

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
@@ -1,15 +1,8 @@
 import { FormLabel } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import versionCompare from 'calypso/lib/version-compare';
-import {
-	isJetpackSite as isJetpackSiteSelector,
-	getSiteOption,
-} from 'calypso/state/sites/selectors';
-import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 
 type ReplyToSettingProps = {
 	value?: string;
@@ -23,15 +16,6 @@ export const ReplyToSetting = ( {
 	updateFields,
 }: ReplyToSettingProps ) => {
 	const translate = useTranslate();
-	const selectedSite = useSelector( getSelectedSite );
-	const siteId = selectedSite?.ID;
-	const isSupportedSite = useSelector( ( state ) => {
-		if ( ! isJetpackSiteSelector( state, siteId ) ) {
-			return true;
-		}
-		const jetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
-		return jetpackVersion && versionCompare( jetpackVersion, '13.5', '>=' );
-	} );
 
 	return (
 		<FormFieldset>
@@ -47,19 +31,15 @@ export const ReplyToSetting = ( {
 					label={ translate( 'Replies are not allowed' ) }
 				/>
 			</FormLabel>
-			{ isSupportedSite && (
-				<>
-					<FormLabel>
-						<FormRadio
-							checked={ value === 'comment' }
-							value="comment"
-							onChange={ () => updateFields( { jetpack_subscriptions_reply_to: 'comment' } ) }
-							disabled={ disabled }
-							label={ translate( 'Replies will be a public comment on the post' ) }
-						/>
-					</FormLabel>
-				</>
-			) }
+			<FormLabel>
+				<FormRadio
+					checked={ value === 'comment' }
+					value="comment"
+					onChange={ () => updateFields( { jetpack_subscriptions_reply_to: 'comment' } ) }
+					disabled={ disabled }
+					label={ translate( 'Replies will be a public comment on the post' ) }
+				/>
+			</FormLabel>
 			<FormLabel>
 				<FormRadio
 					checked={ value === 'author' }

--- a/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx
@@ -4,7 +4,11 @@ import { useSelector } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import { isJetpackSite as isJetpackSiteSelector } from 'calypso/state/sites/selectors';
+import versionCompare from 'calypso/lib/version-compare';
+import {
+	isJetpackSite as isJetpackSiteSelector,
+	getSiteOption,
+} from 'calypso/state/sites/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 
 type ReplyToSettingProps = {
@@ -21,8 +25,12 @@ export const ReplyToSetting = ( {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = selectedSite?.ID;
-	const isWPcomSite = useSelector( ( state ) => {
-		return ! isJetpackSiteSelector( state, siteId );
+	const isSupportedSite = useSelector( ( state ) => {
+		if ( ! isJetpackSiteSelector( state, siteId ) ) {
+			return true;
+		}
+		const jetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
+		return jetpackVersion && versionCompare( jetpackVersion, '13.5', '>=' );
 	} );
 
 	return (
@@ -39,7 +47,7 @@ export const ReplyToSetting = ( {
 					label={ translate( 'Replies are not allowed' ) }
 				/>
 			</FormLabel>
-			{ isWPcomSite && (
+			{ isSupportedSite && (
 				<>
 					<FormLabel>
 						<FormRadio


### PR DESCRIPTION
This PR adds the reply by comment to the calypso newsletter settings. 

The settings is available already in Jetpack since version 13.6 since the work was mostly on the .com side and we manged to ship the endpoint changes in 13.5 Jetpack sites running 13.5 should also be supported. See https://github.com/Automattic/jetpack/pull/37357 

## Proposed Changes

* Allows for jetpack sites (atomic) to enable the reply via comment option. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

On an atomic site. Enable the reply by comment. 
Notice that now you your users can reply by comment when a new newsletter goes out. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
