### PR TITLE
A4A: Ensure that staging sites are not included in the WPCOM site selector.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -74,6 +74,7 @@ export default function WPCOMSitesTable( {
 			.filter(
 				( site ) =>
 					site &&
+					! site.is_wpcom_staging_site &&
 					( site.is_wpcom_atomic || site.jetpack ) &&
 					! managedSitesMap?.[ site.ID as number ]
 			)


### PR DESCRIPTION
This pull request excludes Staging sites from the list of unmanaged sites in the Site Selector.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/783

## Proposed Changes

* Filter out sites with `is_wpcom_staging_site` prop set to true when calculating unmanaged sites.


## Testing Instructions

* Spin up a WPCOM site (Creator plan) and add a staging site. (see https://wordpress.com/support/how-to-create-a-staging-site/)
* Use the A4A live link and go to the `/overview` page.
* Click the 'Add site' -> 'Via WordPress.com' dropdown menu.
* Confirm that you do not see the staging site in the list. (Staging site are named with `staging-{random-characters}-{original-site}`)

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
