### PR TITLE
A4A > Partner Directory: Add the "Global remote work" FormField title and move it after Availability

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -211,14 +211,16 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			>
 				<FormField label={ translate( 'Availability' ) }>
 					<ToggleControl
-						onChange={ ( isChecked ) => setFormFields( { isGlobal: isChecked } ) }
-						checked={ formData.isGlobal }
-						label={ translate( 'Accepting remote work from any location' ) }
-					/>
-					<ToggleControl
 						onChange={ ( isChecked ) => setFormFields( { isAvailable: isChecked } ) }
 						checked={ formData.isAvailable }
 						label={ translate( 'Accepting new clients' ) }
+					/>
+				</FormField>
+				<FormField label={ translate( 'Global remote work' ) }>
+					<ToggleControl
+						onChange={ ( isChecked ) => setFormFields( { isGlobal: isChecked } ) }
+						checked={ formData.isGlobal }
+						label={ translate( 'Accepting remote work from any location' ) }
 					/>
 				</FormField>
 				<FormField


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/782

## Proposed Changes

This PR adds the "Global remote work" title to the switcher field "Accepting remote work from any location" and moves its position after Availability.

<img width="732" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/3b231025-3821-46a5-a9ca-407fc04e16ec">

- Context 3: p1719842225100269-slack-C072ZPV99RS


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the title and the new position after the Availability switcher.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?