### PR TITLE
Social: Redirect to admin page if Jetpack is not active

### DIFF
--- a/client/state/sites/selectors/get-jetpack-checkout-redirect-url.js
+++ b/client/state/sites/selectors/get-jetpack-checkout-redirect-url.js
@@ -16,12 +16,14 @@ export default function getJetpackCheckoutRedirectUrl( state, siteId ) {
 	const redirectMap = {
 		jetpack: 'admin.php?page=jetpack#/recommendations',
 		'jetpack-backup': 'admin.php?page=jetpack-backup',
+		'jetpack-social': 'admin.php?page=jetpack-social',
 	};
 
 	// Higher values are prioritized
 	const priority = {
 		jetpack: 1,
 		'jetpack-backup': 0,
+		'jetpack-social': 0,
 	};
 
 	let bestMatchingPlugin = null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-reach/issues/446

## Proposed Changes

* Added a custom redirect for Social the same way Backup has.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the blank page appearing after buying a Social plan with Jetpack being inactive

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new JN site with Jetpack and Social
* Turn Jetpack off
* Go to My-Jetpack, connect your account and add Social to your cart
* Before competing the checkout, change the checkout URL hostname to be the Calypso instance with this change
* Complete the checkout, it should direct you to the admin page.
* Do the same without disabling Jetpack. It should direct you to the recommendations page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
