### PR TITLE
Remove Caribou team from the codeowners list for migration flows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -131,8 +131,6 @@
 /client/my-sites/importer @Automattic/caribou
 /client/blocks/import @Automattic/caribou
 /client/blocks/import-light @Automattic/caribou
-/client/blocks/importer @Automattic/caribou
-/client/my-sites/migrate @Automattic/caribou
 /client/landing/stepper/declarative-flow/import-flow.ts @Automattic/caribou
 /client/landing/stepper/declarative-flow/internals/steps-repository/import @Automattic/caribou
 /client/landing/stepper/declarative-flow/internals/steps-repository/import-list @Automattic/caribou


### PR DESCRIPTION
## Proposed Changes

* Remove the Caribou team from the code owners list for migration flows

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Doesn't need testing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
