### PR TITLE
Marketplace: avoids shuflling plugins in landing page.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
+++ b/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
@@ -1,6 +1,4 @@
-import { shuffle } from '@automattic/js-utils';
-import { ReactElement, useEffect, useRef } from 'react';
-import { Plugin } from 'calypso/my-sites/plugins/categories';
+import { ReactElement } from 'react';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import { useGetCategoryUrl } from 'calypso/my-sites/plugins/categories/use-get-category-url';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
@@ -9,7 +7,6 @@ import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { useServerEffect } from '../../utils';
 
 export default function CollectionListView( {
 	category,
@@ -28,15 +25,7 @@ export default function CollectionListView( {
 	const getCategoryUrl = useGetCategoryUrl();
 	const categories = useCategories( [ category ] );
 
-	const plugins = useRef< Array< Plugin > >();
-
-	const setPlugins = () => {
-		plugins.current = shuffle( categories[ category ].preview.slice( 0, 6 ) );
-	};
-	useEffect( setPlugins, [ categories, category ] );
-	useServerEffect( setPlugins ); // This is needed to ensure this runs on the server.
-
-	plugins.current = shuffle( categories[ category ].preview.slice( 0, 6 ) );
+	const plugins = categories[ category ].preview.slice( 0, 6 );
 
 	if ( isJetpackSelfHosted ) {
 		return null;
@@ -46,8 +35,8 @@ export default function CollectionListView( {
 		<PluginsBrowserList
 			listName={ 'collection-' + category }
 			listType="collection"
-			plugins={ plugins.current || [] }
-			size={ plugins.current?.length }
+			plugins={ plugins || [] }
+			size={ plugins?.length }
 			title={ categories[ category ].title }
 			subtitle={ categories[ category ].description }
 			site={ siteSlug }

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -44,7 +44,7 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites, noHea
 	const { localizePath } = useLocalizedPlugins();
 
 	const installedPlugins = useSelector( ( state ) =>
-		getPlugins( state, siteObjectsToSiteIds( sites ) )
+		siteId ? getPlugins( state, siteObjectsToSiteIds( sites ) ) : []
 	);
 
 	plugins = plugins

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -47,9 +47,10 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites, noHea
 		siteId ? getPlugins( state, siteObjectsToSiteIds( sites ) ) : []
 	);
 
-	plugins = plugins
-		.filter( isNotBlocked )
-		.filter( ( plugin ) => isNotInstalled( plugin, installedPlugins ) );
+	plugins = plugins.filter(
+		( plugin ) =>
+			isNotBlocked( plugin ) && ( ! siteId || isNotInstalled( plugin, installedPlugins ) )
+	);
 
 	let listLink = '/plugins/browse/' + category;
 	if ( domain ) {

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -44,13 +44,12 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites, noHea
 	const { localizePath } = useLocalizedPlugins();
 
 	const installedPlugins = useSelector( ( state ) =>
-		siteId ? getPlugins( state, siteObjectsToSiteIds( sites ) ) : []
+		getPlugins( state, siteObjectsToSiteIds( sites ) )
 	);
 
-	plugins = plugins.filter(
-		( plugin ) =>
-			isNotBlocked( plugin ) && ( ! siteId || isNotInstalled( plugin, installedPlugins ) )
-	);
+	plugins = plugins
+		.filter( isNotBlocked )
+		.filter( ( plugin ) => ! siteId || isNotInstalled( plugin, installedPlugins ) );
 
 	let listLink = '/plugins/browse/' + category;
 	if ( domain ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Avoid shuffling plugin lists
* Avoid removing installed plugins in all sites view

## Why are these changes being made?
Fixes https://github.com/Automattic/dotcom-forge/issues/8065

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins` logged out, nothing should have changed in comparison to production
* Go to `/plugins` logged in
* Observe that `Supercharging and monetizing your blog` plugins don't rotate at all
* Observe that all plugins in `Developer's Favorites` are shown
* Go to `/plugins` in a specific site, observe that installed plugins are not shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
