### PR TITLE
Plans (State): Update stats-upsell-modal to utilise Plans data-store

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -4,15 +4,14 @@ import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Gridicon, PlanPrice } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
+import formatCurrency from '@automattic/format-currency';
 import { Button, Modal } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { useSelector } from 'calypso/state';
-import { getPlanBySlug } from 'calypso/state/plans/selectors';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getUpsellModalStatType } from 'calypso/state/stats/paid-stats-upsell/selectors';
@@ -23,20 +22,11 @@ import './style.scss';
 export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const plan = useSelector( ( state ) => getPlanBySlug( state, PLAN_PREMIUM ) );
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const planMonthly = Plans.usePricingMetaForGridPlans( {
-		planSlugs: [ PLAN_PREMIUM ],
-		siteId: selectedSiteId,
-		coupon: undefined,
-		useCheckPlanAvailabilityForPurchase,
-		storageAddOns: null,
-	} );
-
-	const pricing = planMonthly?.[ PLAN_PREMIUM ];
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const planName = plan?.product_name_short ?? '';
-	const isLoading = ! plan || ! planMonthly;
+	const plans = Plans.usePlans( { coupon: undefined } );
+	const plan = plans?.data?.[ PLAN_PREMIUM ];
+	const isLoading = plans.isLoading;
 	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
 	const eventPrefix = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 	const isSimpleClassic = useSelector( ( state ) =>
@@ -61,7 +51,7 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 			checkoutProductUrl.searchParams.set( 'redirect_to', window.location.href );
 			window.open( checkoutProductUrl, '_self' );
 		} else {
-			page( `/checkout/${ siteSlug }/${ plan?.path_slug ?? 'premium' }` );
+			page( `/checkout/${ siteSlug }/${ plan?.pathSlug ?? 'premium' }` );
 		}
 	};
 
@@ -94,21 +84,27 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 						onClick={ onClick }
 						disabled={ isLoading }
 					>
-						{ isLoading
+						{ ! plan?.productNameShort
 							? translate( 'Upgrade plan' )
-							: translate( 'Upgrade to %(planName)s', { args: { planName } } ) }
+							: translate( 'Upgrade to %(planName)s', {
+									args: { planName: plan.productNameShort },
+							  } ) }
 					</Button>
 				</div>
 				<div className="stats-upsell-modal__right">
 					<h2 className="stats-upsell-modal__plan">
-						{ isLoading ? '' : translate( '%(planName)s plan', { args: { planName } } ) }
+						{ ! plan?.productNameShort
+							? ''
+							: translate( '%(planName)s plan', { args: { planName: plan.productNameShort } } ) }
 					</h2>
-					{ ! isLoading && (
+					{ plan?.pricing && (
 						<div className="stats-upsell-modal__price-amount">
 							<PlanPrice
 								className="screen-upsell__plan-price"
-								currencyCode={ pricing?.currencyCode }
-								rawPrice={ pricing?.originalPrice?.monthly }
+								currencyCode={ plan.pricing.currencyCode }
+								rawPrice={
+									plan.pricing.discountedPrice.monthly ?? plan.pricing.originalPrice.monthly
+								}
 								displayPerMonthNotation={ false }
 								isLargeCurrency
 								isSmallestUnit
@@ -116,10 +112,19 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 						</div>
 					) }
 					<div className="stats-upsell-modal__price-per-month">
-						{ isLoading
+						{ ! plan?.pricing
 							? ''
 							: translate( 'per month, %(planPrice)s billed yearly', {
-									args: { planPrice: plan?.formatted_price ?? '' },
+									args: {
+										planPrice: formatCurrency(
+											plan.pricing.discountedPrice.full ?? plan.pricing.originalPrice.full ?? 0,
+											plan.pricing.currencyCode ?? '',
+											{
+												stripZeros: true,
+												isSmallestUnit: true,
+											}
+										),
+									},
 							  } ) }
 					</div>
 					<div className="stats-upsell-modal__features">
@@ -153,7 +158,7 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 							<Gridicon icon="checkmark" size={ 18 } />
 							<div className="stats-upsell-modal__feature-text">
 								{ translate( 'All %(planName)s plan features', {
-									args: { planName },
+									args: { planName: plan?.productNameShort ?? '' },
 								} ) }
 							</div>
 						</div>

--- a/client/state/plans/selectors/plan.ts
+++ b/client/state/plans/selectors/plan.ts
@@ -6,6 +6,7 @@ import type { AppState, PlanSlug } from 'calypso/types';
 import 'calypso/state/plans/init';
 
 /**
+ * @deprecated use Plan data-store instead
  * Return WordPress plans getting from state object
  */
 export const getPlans = ( state: AppState ): PricedAPIPlan[] | undefined => {
@@ -13,6 +14,7 @@ export const getPlans = ( state: AppState ): PricedAPIPlan[] | undefined => {
 };
 
 /**
+ * @deprecated use Plan data-store instead
  * Return requesting state
  */
 export const isRequestingPlans = ( state: AppState ): boolean => {
@@ -20,6 +22,7 @@ export const isRequestingPlans = ( state: AppState ): boolean => {
 };
 
 /**
+ * @deprecated use Plan data-store instead
  * Returns a plan
  */
 export const getPlan = createSelector(
@@ -29,7 +32,7 @@ export const getPlan = createSelector(
 );
 
 /**
- * @deprecated but still in use
+ * @deprecated use Plan data-store instead
  * Returns a plan searched by its slug
  * @param  {Object} state      global state
  * @param  {string} planSlug the plan slug
@@ -41,6 +44,7 @@ export const getPlanBySlug = createSelector(
 );
 
 /**
+ * @deprecated use Plan data-store instead
  * Returns a plan product_slug. Useful for getting a cartItem for a plan.
  * @param  {Object}  state     global state
  * @param  {number}  productId the plan productId
@@ -53,6 +57,7 @@ export function getPlanSlug( state: AppState, productId: string | number ): stri
 }
 
 /**
+ * @deprecated use Plan data-store instead
  * Returns a plan bill_period. Useful for comparing plan billing periods
  * @param {Object} state global state
  * @param {PlanSlug} planSlug the plan slug

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -48,6 +48,7 @@ function usePlans( {
 							planSlug: plan.product_slug,
 							productSlug: plan.product_slug,
 							productId: plan.product_id,
+							pathSlug: plan.path_slug,
 							productNameShort: plan.product_name_short,
 							pricing: {
 								billPeriod: plan.bill_period,

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -163,6 +163,7 @@ export interface PlanNext {
 	pricing: PlanPricing;
 	/* END: Same SitePlan/PlanNext props */
 	productNameShort: string;
+	pathSlug?: string;
 }
 
 export interface PricedAPIPlanIntroductoryOffer {
@@ -216,7 +217,7 @@ export interface PricedAPISitePlanPricing
 export interface PricedAPIPlan extends PricedAPIPlanPricing, PricedAPIPlanIntroductoryOffer {
 	product_id: number;
 	product_name: string;
-	path_slug?: PlanPath;
+	path_slug?: string;
 	product_slug: StorePlanSlug;
 	product_name_short: string;
 	product_type?: string;

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -51,7 +51,7 @@ export interface PlanProduct {
 	storeSlug: StorePlanSlug;
 	annualDiscount?: number;
 	periodAgnosticSlug: PlanSlug;
-	pathSlug?: PlanPath;
+	pathSlug?: string;
 	/**
 	 * Useful for two cases:
 	 * 1) to show how much we bill the users for annual plans ($8/mo billed $96)
@@ -271,7 +271,7 @@ export interface PricedAPIPlanFree extends PricedAPIPlan {
 	raw_price_integer: 0;
 }
 export interface PricedAPIPlanPaidAnnually extends PricedAPIPlan {
-	path_slug: PlanPath;
+	path_slug: string;
 	bill_period: 365;
 }
 export interface PricedAPIPlanPaidMonthly extends PricedAPIPlan {

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -7,7 +7,13 @@ import type { PlanSlug as PlanSlugFromProducts } from '@automattic/calypso-produ
 export type StorePlanSlug = ( typeof plansProductSlugs )[ number ];
 export type PlanSlug = ( typeof plansSlugs )[ number ];
 
-// at the moment possible plan paths are identical with plan slugs
+/**
+ * at the moment possible plan paths are identical with plan slugs
+ *
+ * Update 2024/07/10:
+ *   - it looks like the above is no longer the reality
+ *   - the type should either be removed (widened to string) or compiled to a list of all possible paths
+ */
 export type PlanPath = PlanSlug;
 
 export type PlanBillingPeriod = 'MONTHLY' | 'ANNUALLY';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

Update the stats plan upsell modal to utilise the Plans data-store for the various plan properties and pricing it currently derives from Calypso state. 

* Adds `pathSlug` as an optional property on the `PlansNext` type (this is the form returned from `usePlans` hook). Site-plans (returned from `useSitePlans` hook) do not bring back a value for this at all.
* ~Revert use of `usePricingMetaForGridPlans` and stick with `usePlans` (I guess this make for a valid case where `usePlans` may be preferred since we require additional plan properties - it makes calling both a bit redundant, although it may hurt consistency)~ (No, this is wrong and shouldn't be done. It's also leading to wrong results with currency discounts shown for paid plans. `usePricingMetaForGridPlans` ensures we are consistent at querying the right selectors - SitePlans or Plans - and will avoid ambiguous breakage. We stick with it)

### Media

<img width="500" alt="Screenshot 2024-07-09 at 2 00 39 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/298768ce-273f-4c9f-a78e-55c9364d9b31">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We only need one form of handling plan pricing in the code base, more so one framework. Anything else risks having alternative and differing views of the same data propagating across the code base.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/stats/day/[ site ]` on a recently created free site.
* Confirm pricing and plan info render correctly in the modal (click on "upgrade" from the banner)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
