### PR TITLE
Support: Fix opening help links in Help Center

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -109,7 +109,7 @@ function HelpSearchResults( {
 	const { setShowSupportDoc } = useDataStoreDispatch( 'automattic/help-center' );
 
 	const onLinkClickHandler = ( event, result, type ) => {
-		const { link, post_id: postId } = result;
+		const { link, post_id: postId, blog_id: blogId } = result;
 		if ( ! link ) {
 			onSelect( event, result );
 			return;
@@ -119,7 +119,7 @@ function HelpSearchResults( {
 			if ( type === SUPPORT_TYPE_API_HELP ) {
 				event.preventDefault();
 
-				setShowSupportDoc( link, postId );
+				setShowSupportDoc( link, postId, blogId );
 			}
 			onSelect( event, result );
 			return;


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/92279#issuecomment-2214640483

Related to #92279

## Proposed Changes

* Pass the correct blog ID, so the results are loaded from the correct site.

## Why are these changes being made?
Non-English results have different blog ID (since each supported locale is a different page). So we need to make sure to pass the correct blog ID from results.

## Testing Instructions

See #92279, but test with non-English locales.
For a locale that we have a dedicated support site (like Spanish), the docs should be shown in that language (and loaded from that support site, of course). For example, for Spanish it's from blog ID `110643074`.

For a locale that does *not* have a dedicated support site (like Polish), the results should be loaded from the default, English support site (blog ID `9619154`).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
