### PR TITLE
A4A: Minor UI improvement on the 'Add site' dropdown menu.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -1,7 +1,7 @@
 import { Popover, Gridicon, Button, WordPressLogo, JetpackLogo } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
@@ -61,7 +61,7 @@ export default function SiteSelectorAndImporter( { showMainButtonLabel, onWPCOMI
 		icon: JSX.Element;
 		iconClassName?: string;
 		heading: string;
-		description: string;
+		description: string | TranslateResult;
 		buttonProps?: React.ComponentProps< typeof Button >;
 		extraContent?: JSX.Element;
 	} ) => {
@@ -121,7 +121,10 @@ export default function SiteSelectorAndImporter( { showMainButtonLabel, onWPCOMI
 						{ menuItem( {
 							icon: <WordPressLogo />,
 							heading: translate( 'Via WordPress.com' ),
-							description: translate( 'Import sites bought on WordPress.com' ),
+							description: translate( 'Import sites bought on{{nbsp/}}WordPress.com', {
+								components: { nbsp: <>&nbsp;</> },
+								comment: 'nbsp is a non-breaking space character',
+							} ),
 							buttonProps: {
 								onClick: handleImportFromWPCOM,
 							},
@@ -129,7 +132,10 @@ export default function SiteSelectorAndImporter( { showMainButtonLabel, onWPCOMI
 						{ menuItem( {
 							icon: <A4ALogo />,
 							heading: translate( 'Via the Automattic plugin' ),
-							description: translate( 'Connect with the Automattic for Agencies plugin' ),
+							description: translate( 'Connect with the Automattic for Agencies{{nbsp/}}plugin', {
+								components: { nbsp: <>&nbsp;</> },
+								comment: 'nbsp is a non-breaking space character',
+							} ),
 							buttonProps: {
 								onClick: () => {
 									setShowA4AConnectionModal( true );

--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -108,10 +108,11 @@ export default function SiteSelectorAndImporter( { showMainButtonLabel, onWPCOMI
 			<Popover
 				className="site-selector-and-importer__popover"
 				context={ popoverMenuContext?.current }
-				position="bottom right"
 				isVisible={ isMenuVisible }
 				closeOnEsc
 				onClose={ toggleMenu }
+				autoPosition={ false }
+				position="bottom left"
 			>
 				<div className="site-selector-and-importer__popover-content">
 					<div className="site-selector-and-importer__popover-column">

--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -81,8 +81,6 @@ export default function SiteSelectorAndImporter( { showMainButtonLabel, onWPCOMI
 		);
 	};
 
-	const chevronIcon = isMenuVisible ? 'chevron-up' : 'chevron-down';
-
 	const pressableOwnership = usePressableOwnershipType();
 
 	const { data: pendingSites } = useFetchPendingSites();
@@ -103,7 +101,10 @@ export default function SiteSelectorAndImporter( { showMainButtonLabel, onWPCOMI
 				onClick={ toggleMenu }
 			>
 				{ showMainButtonLabel ? translate( 'Add sites' ) : null }
-				<Gridicon icon={ showMainButtonLabel ? chevronIcon : 'plus' } />
+				<Gridicon
+					className={ clsx( { reverse: showMainButtonLabel && isMenuVisible } ) }
+					icon={ showMainButtonLabel ? 'chevron-down' : 'plus' }
+				/>
 			</Button>
 			<Popover
 				className="site-selector-and-importer__popover"

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -8,6 +8,8 @@
 	}
 }
 .site-selector-and-importer__popover {
+	margin-inline-start: 32px;
+
 	.popover__inner {
 		width: 280px;
 		text-align: unset;

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -5,9 +5,15 @@
 	.gridicon {
 		margin-left: 6px;
 		top: 2px;
+		transition: transform 100ms ease-in-out;
+
+		&.reverse {
+			transform: rotate(180deg);
+		}
 	}
 }
-.site-selector-and-importer__popover {
+.popover.site-selector-and-importer__popover {
+	animation: fadeIn 0.2s ease-out;
 	margin-inline-start: 32px;
 
 	.popover__inner {


### PR DESCRIPTION
This pull request includes several enhancements to the 'Add site' dropdown menu.

| Improvement | Before | After |
|--------|--------|--------|
| Remove runts | <img width="389" alt="Screenshot 2024-07-09 at 6 58 24 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0e30bf98-9798-459b-af71-ede27d763ea8"> | <img width="381" alt="Screenshot 2024-07-09 at 6 57 22 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/adf062de-9400-4c2f-949a-ac634cc3492c"> |
| Align the Dropdown menu to the button | <img width="734" alt="Screenshot 2024-07-09 at 6 58 28 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/5ff47ab0-fc19-45b6-9098-eb515091ed94"> | <img width="729" alt="Screenshot 2024-07-09 at 6 57 11 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/1982c7dc-c633-4ae6-86f7-87a520d34a91"> | 


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/785
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/786



## Proposed Changes

* Issue 1: Add &nbsp on the last two words to insert non-breaking space.
* Issue 2: Align the dropdown menu on the 'Add site' button.

## Testing Instructions

* Use the A4A live link below and go to the `/overview` page.
* Test the 'Add site' menu if the enhancement has taken effect.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
