### PR TITLE
A4A: Address minor issues on site configurations

### DIFF
--- a/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
+++ b/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
@@ -20,7 +20,7 @@ export default function useIsSiteReady( { siteId }: Props ) {
 
 	useEffect( () => {
 		const match = data?.find(
-			( site: Site ) => site.id === siteId && site.features.wpcom_atomic.state === 'active'
+			( site: Site ) => site.id === siteId && site.features.wpcom_atomic?.state === 'active'
 		);
 
 		if ( match ) {

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -121,7 +121,7 @@ export default function SiteConfigurationsModal( {
 								isError={ siteName.showValidationMessage }
 								value={ siteName.siteName }
 								onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
-									siteName.setSiteName( event.target.value )
+									siteName.setSiteName( event.target.value.toLocaleLowerCase() )
 								}
 								onKeyDown={ onSiteNameKeyDown }
 								suffix=".wpcomstaging.com"

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -77,7 +77,7 @@ export default function SiteConfigurationsModal( {
 			site_name: siteName.siteName,
 			php_version: phpVersion,
 			primary_data_center: primaryDataCenter,
-			is_fully_managed_agency_site: allowClientsToUseSiteHelpCenter,
+			is_fully_managed_agency_site: ! allowClientsToUseSiteHelpCenter,
 		};
 		createWPCOMSite( params, {
 			onSuccess: () => {

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
@@ -2,12 +2,17 @@ import { useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 
 export const getRandomSiteBaseUrl = async ( title: string ) => {
-	const { body: urlSuggestions } = await wpcom.req.get( {
-		apiNamespace: 'rest/v1.1',
-		path: `/domains/suggestions?http_envelope=1&query=${ title }&quantity=10&include_wordpressdotcom=true&include_dotblogsubdomain=false&only_wordpressdotcom=true&vendor=dot&managed_subdomain_quantity=0`,
-	} );
-	const firstUrl = urlSuggestions[ 0 ].domain_name.split( '.' )[ 0 ];
-	const siteName = firstUrl.split( '.' )[ 0 ];
+	let siteName: string;
+	try {
+		const { body: urlSuggestions } = await wpcom.req.get( {
+			apiNamespace: 'rest/v1.1',
+			path: `/domains/suggestions?http_envelope=1&query=${ title }&quantity=10&include_wordpressdotcom=true&include_dotblogsubdomain=false&only_wordpressdotcom=true&vendor=dot&managed_subdomain_quantity=0`,
+		} );
+		const firstUrl = urlSuggestions[ 0 ].domain_name.split( '.' )[ 0 ];
+		siteName = firstUrl.split( '.' )[ 0 ];
+	} catch ( error ) {
+		return '';
+	}
 	return siteName;
 };
 

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -133,21 +133,25 @@ export const useSiteName = (
 	} = useCheckSiteAvailability( siteId, debouncedSiteName, !! skipAvailability );
 
 	if ( ! isSiteNameAvailiable && ! isCheckingSiteAvailability && ! isDebouncingSiteName ) {
-		validationMessage = translate(
-			'Sorry, that address is taken. How about{{nbsp /}}{{button}}%s{{/button}}?',
-			{
-				args: [ siteNameSuggestion ],
-				components: {
-					nbsp: <>&nbsp;</>,
-					button: (
-						<button
-							onClick={ () => setSiteName( siteNameSuggestion ) }
-							className="configure-your-site-modal-form__site-name-suggestion"
-						/>
-					),
-				},
-			}
-		);
+		if ( siteNameSuggestion ) {
+			validationMessage = translate(
+				'Sorry, that address is taken. How about{{nbsp /}}{{button}}%s{{/button}}?',
+				{
+					args: [ siteNameSuggestion ],
+					components: {
+						nbsp: <>&nbsp;</>,
+						button: (
+							<button
+								onClick={ () => setSiteName( siteNameSuggestion ) }
+								className="configure-your-site-modal-form__site-name-suggestion"
+							/>
+						),
+					},
+				}
+			);
+		} else {
+			validationMessage = translate( 'Sorry, that address is taken.' );
+		}
 	}
 
 	const showValidationMessage =


### PR DESCRIPTION
## Proposed Changes

This PR address 3 quick fixes on A4A site configuration modal.



1 - When creating a new site on A4A we ask client on a checkbox field:
`Allow clients to use the WordPress.com Help Center and hosting features.`

If unchecked, the new created site will be a white label solution, fully managed by the agency.
So we save this field as `is_fully_managed_agency_site` on server side.

But `is_fully_managed_agency_site` means the opposite of `allowClientsToUseSiteHelpCenter`. So we are updating the code to reflect it.
![image](https://github.com/Automattic/wp-calypso/assets/33497086/888949b1-29d5-4be2-bbc8-579d0d0e9097)


2 - When typing the site address, for some specific terms like `test`, the server side does not suggest alternative urls.
In the current implementation that breaks into a infinite loading. We are addressing it by displaying the `Sorry, that address is taken.`.
![image](https://github.com/Automattic/wp-calypso/assets/33497086/1059236b-8278-4695-88e3-725032021c09)

3 - The validation endpoint is not handling well uppercase names. So we converting to lowercase any input from the user on the Site address input.

## Testing Instructions

For the `is_fully_managed_agency_site` field, just a code review is fine.
The other two should be very stright forward to test on client under the `a4a-site-creation-configurations` feature flag.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
