### PR TITLE
A4A: Update 'Add site' onboarding copies to match new button.

### DIFF
--- a/client/a8c-for-agencies/data/guided-tours/tours/use-add-new-site-tour.tsx
+++ b/client/a8c-for-agencies/data/guided-tours/tours/use-add-new-site-tour.tsx
@@ -7,14 +7,11 @@ export default function useAddNewSiteTour() {
 		{
 			id: 'add-new-site',
 			popoverPosition: 'bottom left',
-			title: translate( 'Click the arrow button' ),
+			title: translate( 'Manage all your agency’s sites' ),
 			description: (
 				<>
-					{ translate( 'Click the arrow button and select "Connect a site to Jetpack".' ) }
-					<br />
-					<br />
 					{ translate(
-						'Sites with Jetpack installed will automatically appear in the site management view.'
+						'The Add sites menu is your hub. Add sites you manage or create new ones. All sites will show in this site management view.'
 					) }
 				</>
 			),

--- a/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
+++ b/client/a8c-for-agencies/hooks/use-onboarding-tours.ts
@@ -52,7 +52,7 @@ export default function useOnboardingTours() {
 				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
 			},
 			id: 'add_sites',
-			title: translate( 'Learn how to add new sites' ),
+			title: translate( 'Learn how to add sites' ),
 			useCalypsoPath: true,
 		};
 

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -61,7 +61,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
 			},
 			id: 'add_sites',
-			title: translate( 'Learn how to add new sites' ),
+			title: translate( 'Learn how to add sites' ),
 			useCalypsoPath: true,
 		},
 		{


### PR DESCRIPTION
This PR updates the onboarding copies to match the new flow for adding sites.

| Before | After |
|--------|--------|
| <img width="1066" alt="Screenshot 2024-07-09 at 7 27 16 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/86852268-29d4-4983-ab0d-b57aa0f2eff5"> | <img width="1112" alt="Screenshot 2024-07-09 at 7 26 44 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b1fb3ac8-69c3-4504-b9a2-a50b859c2fec"> |
| <img width="292" alt="Screenshot 2024-07-09 at 7 27 55 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/11a437c5-f723-45fc-82ca-8174e6cd7b53"> | <img width="289" alt="Screenshot 2024-07-09 at 7 26 08 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d3056b6d-760e-41d0-8330-8840e4a641bf"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/788

## Proposed Changes

* Update onboarding copies on the overview page and tour guide component.

## Why are these changes being made?

* The text does not match the new button, which can confuse users.

## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* In the Next Steps section, confirm the new 'Learn how to add sites' link is visible.
* Click the link so you get redirected to the site's page.
* Confirm the onboarding popover shows the correct copies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
