### PR TITLE
A4A: Fix minor issues with the new Site selector and importer.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
@@ -10,7 +10,7 @@ type Props = {
 export default function useManagedSitesMap( { size = 100 }: Props ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const { data, isPending, isFetching } = useFetchDashboardSites( {
+	const { data, isPending } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded: false,
 		searchQuery: '',
 		currentPage: 1,
@@ -33,7 +33,7 @@ export default function useManagedSitesMap( { size = 100 }: Props ) {
 				map[ site.blog_id ] = true;
 				return map;
 			}, {} ),
-			isPending: isPending || isFetching,
+			isPending,
 		};
-	}, [ data?.sites, isFetching, isPending ] );
+	}, [ data?.sites, isPending ] );
 }

--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -164,7 +164,7 @@ export default function SiteSelectorAndImporter( { showMainButtonLabel, onWPCOMI
 						{ menuItem( {
 							icon: <WordPressLogo />,
 							heading: translate( 'WordPress.com' ),
-							description: translate( 'Best for large-scale businesses and major eCommerce sites' ),
+							description: translate( 'Optimized and hassle-free hosting for business websites' ),
 							buttonProps: {
 								href: hasPendingWPCOMSites
 									? A4A_SITES_LINK_NEEDS_SETUP
@@ -189,7 +189,7 @@ export default function SiteSelectorAndImporter( { showMainButtonLabel, onWPCOMI
 						{ menuItem( {
 							icon: <img src={ pressableIcon } alt="" />,
 							heading: translate( 'Pressable' ),
-							description: translate( 'Optimized and hassle-free hosting for business websites' ),
+							description: translate( 'Best for large-scale businesses and major eCommerce sites' ),
 							buttonProps: {
 								href:
 									pressableOwnership === 'regular'


### PR DESCRIPTION
This PR addresses few feedback for the Site selector and importer feature.

### Issue 1
Every time the Site Selector component is displayed, the list is fetched, making the UI feel slower. We need to only show the fetch state once during initialization when we don't have any cache data to display.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/784

### Issue 2
We need to swap the description for the WordPress.com and Pressable menus as they accurately represent the product.

| Before | After |
|--------|--------|
| <img width="301" alt="Screenshot 2024-07-09 at 9 07 07 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e3f2e5f1-1363-4c22-9237-225792f08982"> | <img width="266" alt="Screenshot 2024-07-09 at 9 07 22 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/06820e83-60b2-4bd8-a4a9-52669d418158"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/789

## Proposed Changes

* Do not show the loading state when reopening the site selector list. 
* Swap WPCOM and Pressable menu descriptions.

## Testing Instructions

* Use the A4A live link below and go to the `/overview` page.
* Click the 'Add site' and confirm that the WordPress.com and Pressable option descriptions are now swapped.
* Click the 'Add site' > 'Via WordPress.com' option.
* Do the step multiple times and confirm that the Site selector does not show a prefetch state every time it opens.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
