### PR TITLE
Check if the Jetpack AI and Stats have tiers before showing tiered text

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -256,8 +256,7 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 	if (
 		isJetpackAISlug( purchase.productSlug ) &&
 		purchase.purchaseRenewalQuantity &&
-		purchase.priceTierList &&
-		purchase.priceTierList.length > 0
+		! purchase.priceTierList?.length
 	) {
 		return i18n.translate( '%(productName)s (%(quantity)s requests per month)', {
 			args: {
@@ -267,7 +266,11 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 		} );
 	}
 
-	if ( isJetpackStatsPaidProductSlug( purchase.productSlug ) && purchase.purchaseRenewalQuantity ) {
+	if (
+		isJetpackStatsPaidProductSlug( purchase.productSlug ) &&
+		purchase.purchaseRenewalQuantity &&
+		! purchase.priceTierList?.length
+	) {
 		return i18n.translate( '%(productName)s (%(quantity)s views per month)', {
 			args: {
 				productName: jetpackProductsDisplayNames[ productSlug ],

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -253,7 +253,12 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 	const { productName, productSlug, purchaseRenewalQuantity } = purchase;
 	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames( 'full' );
 
-	if ( isJetpackAISlug( purchase.productSlug ) && purchase.purchaseRenewalQuantity ) {
+	if (
+		isJetpackAISlug( purchase.productSlug ) &&
+		purchase.purchaseRenewalQuantity &&
+		purchase.priceTierList &&
+		purchase.priceTierList.length > 0
+	) {
 		return i18n.translate( '%(productName)s (%(quantity)s requests per month)', {
 			args: {
 				productName: jetpackProductsDisplayNames[ productSlug ],

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -256,7 +256,7 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 	if (
 		isJetpackAISlug( purchase.productSlug ) &&
 		purchase.purchaseRenewalQuantity &&
-		! purchase.priceTierList?.length
+		purchase.priceTierList?.length
 	) {
 		return i18n.translate( '%(productName)s (%(quantity)s requests per month)', {
 			args: {
@@ -269,7 +269,7 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 	if (
 		isJetpackStatsPaidProductSlug( purchase.productSlug ) &&
 		purchase.purchaseRenewalQuantity &&
-		! purchase.priceTierList?.length
+		purchase.priceTierList?.length
 	) {
 		return i18n.translate( '%(productName)s (%(quantity)s views per month)', {
 			args: {


### PR DESCRIPTION
## Proposed Changes

Ensure that Jetpack AI and Stats plans support tiers before showing tiered text ("x requests per month") on /me/purchases

## Why are these changes being made?

* User can see "1 requests per month" information for Jetpack AI legacy plans on /me/purchases
![CleanShot 2024-07-09 at 15 53 08@2x](https://github.com/Automattic/wp-calypso/assets/8419292/2d79ae11-633c-4af7-94b0-c2b89588a032)


## Testing Instructions

* Add legacy Jetpack AI and Stats Commercial subscriptions to any of your sites via SA
* Go to /me/purchases (on Calypso Live link) and make sure that the subscription has name "Jetpack AI" - without mentioning any requests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
