### PR TITLE
Try: Fix base docker image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -117,7 +117,7 @@ RUN apt-get update && \
 RUN wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && \
 	dpkg -i libffi6_3.2.1-8_amd64.deb && \
 	wget https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg && \
-	echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php-sury.list && \
+	echo "deb https://packages.sury.org/php/ bullseye main" > /etc/apt/sources.list.d/php-sury.list && \
 	apt-get update && \
  	apt-get upgrade -y && \
 	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose && \


### PR DESCRIPTION
## Proposed Changes

This updates the base docker image to use bullseye instead of buster PHP release.

## Why are these changes being made?

The base image is currently broken, this attempts to fix it. 

It appears that the buster releases have come to EOL and are no longer supported: https://www.debian.org/releases/buster/

## Testing Instructions

Verify base image is passing in TeamCity.