### PR TITLE
A4A: Fix the shopping cart bug unable to checkout same products  on different bundles.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-shopping-cart.ts
@@ -64,20 +64,21 @@ export default function useShoppingCart() {
 		if ( data && !! selectedItemsCache.length ) {
 			const loadedItems: ShoppingCartItem[] = [];
 
-			data.forEach( ( product ) => {
-				const match = selectedItemsCache.find( ( { slug, quantity } ) => {
-					return (
-						product.slug === slug &&
-						( quantity === 1 ||
-							product.supported_bundles.map( ( bundle ) => bundle.quantity ).includes( quantity ) ||
-							product.family_slug === 'wpcom-hosting' )
-					);
-				} );
+			selectedItemsCache.forEach( ( { slug, quantity } ) => {
+				const match =
+					quantity === 1 || slug.startsWith( 'wpcom-hosting' )
+						? data.find( ( product ) => product.slug === slug )
+						: data.find(
+								( product ) =>
+									product.slug === slug &&
+									product.supported_bundles.some( ( bundle ) => bundle.quantity === quantity )
+						  );
 
 				if ( match ) {
-					loadedItems.push( { ...product, quantity: match.quantity } );
+					loadedItems.push( { ...match, quantity } );
 				}
 			} );
+
 			setSelectedCartItems( loadedItems );
 		} else if ( ! selectedItemsCache.length ) {
 			setSelectedCartItems( [] );


### PR DESCRIPTION
There is a bug in the Marketplace Products section where adding the same products on different bundle sizes will remove some of the bundle when proceeding to checkout. This PR resolves this issue.

## Proposed Changes

* Fix the bug on how we load the Shopping cart cache data (session storage).

## Why are these changes being made?


* Customers cannot buy the same products in different bundle sizes in a single checkout.

## Testing Instructions


* Use the A4A live link and go to the `/marketplace/products` page.
* Add the **'WooCommerce extension - Advance Notification' to the cart.**
* Add the **'WooCommerce extension - Advance Notification (bundle of 5)' to the cart.**
* Then proceed to checkout.
* Confirm that the same items are loaded in the checkout summary page with the correct total amount.
* Also test that the Pressable and WPCOM plans are working as expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
