### PR TITLE
Sites logs overview - fix layout

### DIFF
--- a/client/site-logs/controller.tsx
+++ b/client/site-logs/controller.tsx
@@ -5,7 +5,7 @@ import type { Context as PageJSContext } from '@automattic/calypso-router';
 
 export function phpErrorLogs( context: PageJSContext, next: () => void ) {
 	context.primary = (
-		<div className="site-logs-overview">
+		<div className="site-logs">
 			<PageViewTracker path="/site-logs/:site/php" title="PHP Error Logs" />
 			<LogsHeader logType="php" />
 			<LogsTab logType="php" />
@@ -17,7 +17,7 @@ export function phpErrorLogs( context: PageJSContext, next: () => void ) {
 
 export function httpRequestLogs( context: PageJSContext, next: () => void ) {
 	context.primary = (
-		<div className="site-logs-overview">
+		<div className="site-logs">
 			<PageViewTracker path="/site-logs/:site/web" title="Web Server Logs" />
 			<LogsHeader logType="web" />
 			<LogsTab logType="web" />

--- a/client/site-logs/controller.tsx
+++ b/client/site-logs/controller.tsx
@@ -5,11 +5,11 @@ import type { Context as PageJSContext } from '@automattic/calypso-router';
 
 export function phpErrorLogs( context: PageJSContext, next: () => void ) {
 	context.primary = (
-		<>
+		<div className="site-logs-overview">
 			<PageViewTracker path="/site-logs/:site/php" title="PHP Error Logs" />
 			<LogsHeader logType="php" />
 			<LogsTab logType="php" />
-		</>
+		</div>
 	);
 
 	next();
@@ -17,11 +17,11 @@ export function phpErrorLogs( context: PageJSContext, next: () => void ) {
 
 export function httpRequestLogs( context: PageJSContext, next: () => void ) {
 	context.primary = (
-		<>
+		<div className="site-logs-overview">
 			<PageViewTracker path="/site-logs/:site/web" title="Web Server Logs" />
 			<LogsHeader logType="web" />
 			<LogsTab logType="web" />
-		</>
+		</div>
 	);
 
 	next();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/92534

## Proposed Changes

* Adds a wrapper element to the sites logs section to fix the layout problem.
    * I am unsure why this broke. Simply adding a wrapper seems to fix the problem. I added a classname just for future ease of development.

BEFORE
<img width="1148" alt="Screenshot 2024-07-09 at 4 23 40 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/f4254e34-bdc6-49d3-a29e-99739bc01fe8">


AFTER
<img width="1146" alt="Screenshot 2024-07-09 at 4 23 55 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/01307771-1244-42c2-825a-e8029b1f8c69">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit the sites dashboard, select an atomic site, and view the site logs tab.
* verify the layout problem is resolved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
