### PR TITLE
e2e: Fix Jetpack Forms test

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -29,6 +29,7 @@ export class FormAiFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'Form';
+	blockTestName = 'Form (AI)';
 	blockEditorSelector = makeSelectorFromBlockName( 'Form' );
 
 	/**
@@ -46,12 +47,9 @@ export class FormAiFlow implements BlockFlow {
 			aiInputParentLocator = context.addedBlockLocator;
 		}
 
-		const aiInputReadyLocator = aiInputParentLocator.getByPlaceholder(
-			'Ask Jetpack AI to create your form'
-		);
-		const aiInputBusyLocator = aiInputParentLocator.getByRole( 'textbox', {
-			name: 'Creating your form. Please wait a few moments.',
-			disabled: true,
+		const aiInputReadyLocator = aiInputParentLocator.getByPlaceholder( 'Ask Jetpack AI to edit…' );
+		const aiInputBusyLocator = aiInputParentLocator.getByRole( 'button', {
+			name: 'Stop request',
 		} );
 		const sendButtonLocator = aiInputParentLocator.getByRole( 'button', {
 			name: 'Send request',

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -33,6 +33,7 @@ export class FormPatternsFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'Form';
+	blockTestName = 'Form (Patterns)';
 	blockEditorSelector = makeSelectorFromBlockName( 'Form' );
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
@@ -6,6 +6,7 @@ import { EditorPage } from '../../pages';
  */
 export interface BlockFlow {
 	blockSidebarName: string;
+	blockTestName?: string;
 	blockEditorSelector: string;
 	configure?( context: EditorContext ): Promise< void >;
 	validateAfterPublish?( context: PublishedPostContext ): Promise< void >;

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -53,8 +53,18 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 		} );
 
 		describe( 'Add and configure blocks in the editor', function () {
+			const used = new Set();
 			for ( const blockFlow of blockFlows ) {
-				it( `${ blockFlow.blockSidebarName }: Add the block from the sidebar`, async function () {
+				const prefix = blockFlow.blockTestName ?? blockFlow.blockSidebarName;
+
+				if ( used.has( prefix ) ) {
+					throw new Error(
+						`Test name prefix "${ prefix }" is used by multiple BlockFlows! Set \`blockTestName\` to disambiguate.`
+					);
+				}
+				used.add( prefix );
+
+				it( `${ prefix }: Add the block from the sidebar`, async function () {
 					const blockHandle = await editorPage.addBlockFromSidebar(
 						blockFlow.blockSidebarName,
 						blockFlow.blockEditorSelector,
@@ -70,13 +80,13 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 					};
 				} );
 
-				it( `${ blockFlow.blockSidebarName }: Configure the block`, async function () {
+				it( `${ prefix }: Configure the block`, async function () {
 					if ( blockFlow.configure ) {
 						await blockFlow.configure( editorContext );
 					}
 				} );
 
-				it( `${ blockFlow.blockSidebarName }: There are no block warnings or errors in the editor`, async function () {
+				it( `${ prefix }: There are no block warnings or errors in the editor`, async function () {
 					expect( await editorPage.editorHasBlockWarnings() ).toBe( false );
 				} );
 			}
@@ -94,7 +104,9 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 
 		describe( 'Validating blocks in published post.', function () {
 			for ( const blockFlow of blockFlows ) {
-				it( `${ blockFlow.blockSidebarName }: Expected content is in published post`, async function () {
+				const prefix = blockFlow.blockTestName ?? blockFlow.blockSidebarName;
+
+				it( `${ prefix }: Expected content is in published post`, async function () {
 					if ( blockFlow.validateAfterPublish ) {
 						await blockFlow.validateAfterPublish( publishedPostContext );
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix Jetpack Forms AI test.
* Allow for prefixing the test name directly when using the block's name isn't unique enough.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The test using AI to create the form seems to have been broken since Automattic/jetpack#37754 and Automattic/jetpack#38067, which switched the AI Assistant from a custom form extension to a generic one. This changed the placeholder the test was looking for, and also the "busy" behavior is different.

TeamCity didn't notice this test failing, though. It turns out that's because the test for creating a form using patterns and the test for creating a form using AI are both named like `Jetpack Forms (Atomic: default): Add and configure blocks in the editor: Form: Configure the block` so TeamCity decided that the two separate tests were really just one test being flaky, and that it passed as long as one of the 'copies' passed (probably because the same thing is used to handle automatic retries when a test really is being flaky).

To fix that, we add a new optional `blockTestName` field that can be used to explicitly name the tests instead of using the name of the block. They're now `Jetpack Forms (Atomic: default): Add and configure blocks in the editor: Form (Patterns): Configure the block` and `Jetpack Forms (Atomic: default): Add and configure blocks in the editor: Form (AI): Configure the block`.

And for good measure, add some code to try to detect if this happens again.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Form test fix:
* `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test specs/blocks/blocks__jetpack-forms.ts`

Making sure no other name collisions are detected:
* `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" yarn workspace wp-e2e-tests test specs/blocks/ --group=jetpack-wpcom-integration`
* `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" yarn workspace wp-e2e-tests test specs/blocks/ --group=gutenberg`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
