### PR TITLE
Stats: fix issues that depend on `from` param

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -88,20 +88,17 @@ const getCheckoutBackUrl = ( {
 };
 
 const getRedirectUrl = ( {
-	from,
 	type,
 	adminUrl,
 	redirectUri,
 	siteSlug,
 }: {
-	from: string;
 	type: string;
 	adminUrl?: string;
 	redirectUri?: string;
 	siteSlug: string;
 } ) => {
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const isStartedFromJetpackSite = from.startsWith( 'jetpack' ) || isOdysseyStats;
+	const isFromWPAdmin = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsPurchaseSuccess = type === 'free' ? 'free' : 'paid';
 
 	// If it's a siteless checkout, let it redirect to the thank you page,
@@ -110,7 +107,7 @@ const getRedirectUrl = ( {
 		return '';
 	}
 
-	if ( ! isStartedFromJetpackSite ) {
+	if ( ! isFromWPAdmin ) {
 		redirectUri = addPurchaseTypeToUri(
 			redirectUri || `/stats/day/${ siteSlug }`,
 			statsPurchaseSuccess

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -38,7 +38,7 @@ const getStatsCheckoutURL = (
 	setUrlParam( checkoutProductUrl, 'checkoutBackUrl', checkoutBackUrl );
 
 	// Add more required params for siteless checkout.
-	if ( checkoutType === 'jetpack' ) {
+	if ( checkoutType === 'jetpack' && siteSlug ) {
 		setUrlParam( checkoutProductUrl, 'connect_after_checkout', 'true' );
 		setUrlParam( checkoutProductUrl, 'admin_url', adminUrl );
 		setUrlParam( checkoutProductUrl, 'from_site_slug', siteSlug );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -175,7 +175,7 @@ const gotoCheckoutPage = ( {
 		quantity,
 	} );
 
-	const redirectUrl = getRedirectUrl( { from, type, adminUrl, redirectUri, siteSlug } );
+	const redirectUrl = getRedirectUrl( { type, adminUrl, redirectUri, siteSlug } );
 	const checkoutBackUrl = getCheckoutBackUrl( { from, adminUrl, siteSlug } );
 
 	// Allow some time for the event to be recorded before redirecting.

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -67,14 +67,12 @@ const getCheckoutBackUrl = ( {
 	siteSlug: string;
 	adminUrl?: string;
 } ) => {
-	// TODO: Enumerate all possible values of `from` parameter.
-	const isFromWPAdmin = from.startsWith( 'jetpack' );
+	const isFromWPAdmin = config.isEnabled( 'is_running_in_jetpack_site' );
 	const isFromMyJetpack = from === 'jetpack-my-jetpack';
 	const isFromPlansPage = from === 'calypso-plans';
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	// Use full URL even though redirecting on Calypso.
-	if ( ! isFromWPAdmin && ! isOdysseyStats ) {
+	if ( ! isFromWPAdmin ) {
 		if ( ! siteSlug ) {
 			return 'https://cloud.jetpack.com/pricing/';
 		}

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -24,9 +24,10 @@ const getStatsCheckoutURL = (
 	adminUrl?: string,
 	isUpgrade?: boolean
 ) => {
-	const isFromJetpack = from?.startsWith( 'jetpack' );
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	// Get the checkout URL for the product, or the siteless checkout URL if from Jetpack or no siteSlug is provided
-	const checkoutType = ( isFromJetpack && ! isUpgrade ) || ! siteSlug ? 'jetpack' : siteSlug;
+	// TODO: We don't have Jetpack Stats purchase enabled for Simple sites, but if we do, we will want Simple sites to use normal checkout flow as users are always logged in.
+	const checkoutType = ( isOdysseyStats && ! isUpgrade ) || ! siteSlug ? 'jetpack' : siteSlug;
 	const checkoutProductUrl = new URL(
 		`/checkout/${ checkoutType }/${ product }`,
 		'https://wordpress.com'
@@ -36,7 +37,8 @@ const getStatsCheckoutURL = (
 	setUrlParam( checkoutProductUrl, 'redirect_to', redirectUrl );
 	setUrlParam( checkoutProductUrl, 'checkoutBackUrl', checkoutBackUrl );
 
-	if ( isFromJetpack && siteSlug ) {
+	// Add more required params for siteless checkout.
+	if ( checkoutType === 'jetpack' ) {
 		setUrlParam( checkoutProductUrl, 'connect_after_checkout', 'true' );
 		setUrlParam( checkoutProductUrl, 'admin_url', adminUrl );
 		setUrlParam( checkoutProductUrl, 'from_site_slug', siteSlug );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -257,10 +257,9 @@ const StatsPersonalPurchase = ( {
 		e.preventDefault();
 		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		const queryFrom = isOdysseyStats ? '&from=jetpack-my-jetpack' : '';
 		recordTracksEvent( `${ event_from }_stats_plan_switched_from_personal_to_commercial` );
 
-		page( `/stats/purchase/${ siteSlug }?productType=commercial${ queryFrom }` );
+		page( `/stats/purchase/${ siteSlug }?productType=commercial&from=switch-from-personal` );
 	};
 
 	return (
@@ -408,7 +407,11 @@ function StatsCommercialFlowOptOutForm( {
 	const handleSwitchToPersonalClick = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_purchase_commercial_switch_to_personal_clicked` );
-		setTimeout( () => page( `/stats/purchase/${ siteSlug }?productType=personal` ), 250 );
+		setTimeout(
+			() =>
+				page( `/stats/purchase/${ siteSlug }?productType=personal&from=switch-from-commercial` ),
+			250
+		);
 	};
 
 	const handleRequestUpdateClick = () => {


### PR DESCRIPTION
Related to https://github.com/Automattic/red-team/issues/56

## Proposed Changes

If it is Odyssey Stats then it is in WP Admin as the code is used to determine the checkout URL etc from the purchase page, and has not yet reach wp.com checkout.

## Why are these changes being made?

* `from` cannot be relied on to tell whether the purchase is happening in WP Admin or not, as there are `from` starting with `stats` and a few other ones. @a8ck3n shared https://github.com/Automattic/red-team/issues/56#issuecomment-2191368893.

## Testing Instructions
* Remove all Stats related subscription from the site
* Click upgrade from the upgrade link in the usage section
* Ensure you are able to purchase a stats product from site-only flow (license automatically assigned in the last step) and redirect back to WP Admin
* Open purchase page again - you might need to add `force_refresh` to the URL as the cache wouldn't be cleared with the site only flow
* Choose a higher tier
* Ensure you can upgrade successfully and returned to WP Admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?