### PR TITLE
Update Social feature list

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1334,6 +1334,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	const socialNetworksForSharing = [
 		translate( 'Facebook' ),
 		translate( 'Instagram' ),
+		translate( 'Threads' ),
 		translate( 'LinkedIn' ),
 		translate( 'Mastodon' ),
 		translate( 'Tumblr' ),
@@ -1365,9 +1366,9 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 			args: { socialNetworksList },
 			comment: 'Comma separated list of social networks like "Facebook, Mastodon and Tumblr".',
 		} ),
-		translate( 'Engagement Optimizer' ),
+		translate( 'Attach custom images or videos' ),
 		translate( 'Recycle content' ),
-		translate( 'Image generator' ),
+		translate( 'Automatically generate images for posts' ),
 	];
 	const socialIncludesInfo = socialAdvancedIncludesInfo;
 	const statsCommercialIncludesInfo = [

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1366,7 +1366,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 			args: { socialNetworksList },
 			comment: 'Comma separated list of social networks like "Facebook, Mastodon and Tumblr".',
 		} ),
-		translate( 'Attach custom images or videos' ),
+		translate( 'Upload custom images or videos with your posts' ),
 		translate( 'Recycle content' ),
 		translate( 'Automatically generate images for posts' ),
 	];


### PR DESCRIPTION


## Proposed Changes

* Update Jetpack Social feature list to clarify the features
* Add Threads to the list of social networks mentioned in the features.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Some features in their current state are not very clear.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Jetpack Cloud live link below and goto `/pricing`
* Click on "More about Social"
* Confirm that you see the updated features list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>
<img width="571" alt="Screenshot 2024-07-10 at 11 43 25 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/c3176fcc-4b3b-41ff-a173-faf3e87a8b5e">
</td>
            <td>
<img width="573" alt="Screenshot 2024-07-10 at 11 44 38 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/c7849d13-7f75-4e56-a812-e08eb635ba81">
</td>
        </tr>
    </tbody>
</table>