### PR TITLE
A4A > Sites: Implement site connection error preview

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -43,6 +43,7 @@ export function OverviewPreviewPane( {
 	className,
 	isSmallScreen = false,
 	hasError = false,
+	onRefetchSite,
 }: PreviewPaneProps ) {
 	const translate = useTranslate();
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
@@ -79,10 +80,22 @@ export function OverviewPreviewPane( {
 				true,
 				selectedSiteFeature,
 				setSelectedSiteFeature,
-				<SiteErrorPreview site={ site } trackEvent={ trackEvent } />
+				<SiteErrorPreview
+					site={ site }
+					trackEvent={ trackEvent }
+					onRefetchSite={ onRefetchSite }
+					closeSitePreviewPane={ closeSitePreviewPane }
+				/>
 			),
 		],
-		[ selectedSiteFeature, setSelectedSiteFeature, site, trackEvent ]
+		[
+			closeSitePreviewPane,
+			onRefetchSite,
+			selectedSiteFeature,
+			setSelectedSiteFeature,
+			site,
+			trackEvent,
+		]
 	);
 
 	// Jetpack features: Boost, Backup, Monitor, Stats

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-column/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-column/index.tsx
@@ -1,0 +1,49 @@
+import { Button, Gridicon, Tooltip } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
+
+import './style.scss';
+
+export default function SiteErrorColumn( {
+	isA4APluginInstalled,
+	openSitePreviewPane,
+}: {
+	isA4APluginInstalled?: boolean;
+	openSitePreviewPane: () => void;
+} ) {
+	const translate = useTranslate();
+
+	const [ showPopover, setShowPopover ] = useState( false );
+
+	const wrapperRef = useRef< HTMLDivElement | null >( null );
+
+	const tooltip = isA4APluginInstalled
+		? translate( "Automattic for Agencies can't connect to this site." )
+		: translate( "Jetpack can't connect to this site." );
+
+	return (
+		<span className="site-error-column">
+			<div
+				className="sites-dataview__site-error"
+				onMouseEnter={ () => setShowPopover( true ) }
+				onMouseLeave={ () => setShowPopover( false ) }
+				onMouseDown={ () => setShowPopover( false ) }
+				role="button"
+				tabIndex={ 0 }
+				ref={ wrapperRef }
+			>
+				<Gridicon size={ 18 } icon="notice-outline" />
+				<span>
+					{ translate( 'Site connectivity issue: {{button}}Fix now{{/button}}', {
+						components: {
+							button: <Button borderless onClick={ openSitePreviewPane } />,
+						},
+					} ) }
+				</span>
+			</div>
+			<Tooltip context={ wrapperRef.current } isVisible={ showPopover } position="top">
+				{ tooltip }
+			</Tooltip>
+		</span>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-column/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-column/style.scss
@@ -1,0 +1,16 @@
+
+.site-error-column {
+	.sites-dataview__site-error {
+		font-size: 0.75rem;
+
+		.button {
+			text-decoration: underline;
+			font-size: 0.75rem;
+			padding: 0;
+			width: auto;
+			position: relative;
+			inset-block-start: 1px;
+		}
+	}
+}
+

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
@@ -1,0 +1,133 @@
+import { Button, CompactCard, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import type { Site } from '../../../types';
+
+import './style.scss';
+
+export const A4A_PLUGIN_SLUG = 'automattic-for-agencies-client';
+const JETPACK_PLUGIN_SLUG = 'jetpack';
+
+export default function SiteErrorPreview( {
+	site,
+	trackEvent,
+}: {
+	site: Site;
+	trackEvent: ( eventName: string ) => void;
+} ) {
+	const translate = useTranslate();
+
+	const isA4APluginInstalled = site.enabled_plugin_slugs?.includes( A4A_PLUGIN_SLUG );
+
+	const troubleshootingHref = isA4APluginInstalled
+		? localizeUrl( 'https://agencieshelp.automattic.com/knowledge-base/' )
+		: localizeUrl(
+				'https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/'
+		  );
+
+	const page = isA4APluginInstalled ? A4A_PLUGIN_SLUG : JETPACK_PLUGIN_SLUG;
+
+	const disconnectHref = `${ site.url_with_scheme }/wp-admin/options-general.php?page=${ page }`;
+
+	return (
+		<>
+			<div className="site-error-preview__title">
+				{ isA4APluginInstalled
+					? translate( "Automattic for Agencies can't connect to this site." )
+					: translate( "Jetpack can't connect to this site." ) }
+			</div>
+			<div className="site-error-preview__description">
+				{ translate( "Try the following steps to fix your site's connection:" ) }
+			</div>
+			<div className="site-error-preview__actions">
+				<CompactCard>
+					<FormattedHeader
+						isSecondary
+						align="left"
+						headerText={ translate( 'Confirm that your site loads' ) }
+						subHeaderText={
+							isA4APluginInstalled
+								? translate(
+										"Visit your site to make sure it loads properly. If there's an issue, fix your site before worrying about Automattic for Agencies! That may resolve this error."
+								  )
+								: translate(
+										"Visit your site to make sure it loads properly. If there's an issue, fix your site before worrying about Jetpack! That may resolve this error."
+								  )
+						}
+					>
+						<Button
+							href={ site.url_with_scheme }
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_confirm' ) }
+						>
+							{ translate( 'Confirm now' ) }
+							<Gridicon icon="external" />
+						</Button>
+					</FormattedHeader>
+				</CompactCard>
+				<CompactCard>
+					<FormattedHeader
+						isSecondary
+						align="left"
+						headerText={
+							isA4APluginInstalled
+								? translate( 'Troubleshoot Automattic for Agencies' )
+								: translate( 'Troubleshoot Jetpack' )
+						}
+						subHeaderText={
+							isA4APluginInstalled
+								? translate(
+										"If your site is loading but you're still seeing this error, this guide will help you troubleshoot the Automattic for Agencies connection."
+								  )
+								: translate(
+										"If your site is loading but you're still seeing this error, this guide will help you troubleshoot the Jetpack connection."
+								  )
+						}
+					>
+						<Button
+							href={ troubleshootingHref }
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_troubleshoot' ) }
+						>
+							{ translate( 'View guide' ) }
+							<Gridicon icon="external" />
+						</Button>
+					</FormattedHeader>
+				</CompactCard>
+				<CompactCard>
+					<FormattedHeader
+						isSecondary
+						align="left"
+						headerText={
+							isA4APluginInstalled
+								? translate( 'Disconnect Automattic for Agencies' )
+								: translate( 'Disconnect Jetpack' )
+						}
+						subHeaderText={
+							isA4APluginInstalled
+								? translate(
+										"If you're no longer using Automattic for Agencies and/or WordPress for your site, or you've taken your site down, it's time to disconnect Automattic for Agencies."
+								  )
+								: translate(
+										"If you're no longer using Jetpack and/or WordPress for your site, or you've taken your site down, it's time to disconnect Jetpack."
+								  )
+						}
+					>
+						<Button
+							href={ disconnectHref }
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_disconnect' ) }
+						>
+							{ translate( 'Disconnect' ) }
+							<Gridicon icon="external" />
+						</Button>
+					</FormattedHeader>
+				</CompactCard>
+			</div>
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
@@ -63,7 +63,9 @@ export default function SiteErrorPreview( {
 	const isA4APluginInstalled = site.enabled_plugin_slugs?.includes( A4A_PLUGIN_SLUG );
 
 	const troubleshootingHref = isA4APluginInstalled
-		? localizeUrl( 'https://agencieshelp.automattic.com/knowledge-base/' )
+		? localizeUrl(
+				'https://agencieshelp.automattic.com/knowledge-base/fix-automattic-for-agencies-plugin-issues/'
+		  )
 		: localizeUrl(
 				'https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/'
 		  );

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/index.tsx
@@ -1,5 +1,6 @@
-import { Button, CompactCard, Gridicon } from '@automattic/components';
+import { Button, CompactCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Icon, external, trash } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import useRemoveSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-remove-site';
@@ -109,7 +110,7 @@ export default function SiteErrorPreview( {
 							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_confirm' ) }
 						>
 							{ translate( 'Confirm now' ) }
-							<Gridicon icon="external" />
+							<Icon icon={ external } />
 						</Button>
 					</FormattedHeader>
 				</CompactCard>
@@ -139,7 +140,7 @@ export default function SiteErrorPreview( {
 							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_troubleshoot' ) }
 						>
 							{ translate( 'View guide' ) }
-							<Gridicon icon="external" />
+							<Icon icon={ external } />
 						</Button>
 					</FormattedHeader>
 				</CompactCard>
@@ -169,7 +170,7 @@ export default function SiteErrorPreview( {
 							onClick={ () => trackEvent( 'calypso_a4a_site_indicator_disconnect_disconnect' ) }
 						>
 							{ translate( 'Disconnect' ) }
-							<Gridicon icon="external" />
+							<Icon icon={ external } />
 						</Button>
 					</FormattedHeader>
 				</CompactCard>
@@ -182,7 +183,7 @@ export default function SiteErrorPreview( {
 					>
 						<Button onClick={ handleRemoveSite }>
 							{ translate( 'Remove' ) }
-							<Gridicon icon="trash" />
+							<Icon icon={ trash } />
 						</Button>
 					</FormattedHeader>
 				</CompactCard>

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
@@ -72,8 +72,9 @@
 		}
 	}
 
-	.button .gridicon {
+	.button svg {
+		position: relative;
 		inset-block-start: 1px;
-		inset-inline-start: 6px;
+		inset-inline-start: 4px;
 	}
 }

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
@@ -73,7 +73,7 @@
 	}
 
 	.button .gridicon {
-		inset-block-start: 6px;
-		inset-inline-start: 1px;
+		inset-block-start: 1px;
+		inset-inline-start: 6px;
 	}
 }

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
@@ -1,0 +1,75 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.main.a4a-layout.sites-dashboard .site-error-preview {
+	.preview-pane__navigation.is-hidden {
+		display: none;
+	}
+
+	.item-preview__content {
+		padding: 24px;
+		display: block;
+
+		@include break-large {
+			padding: 48px;
+		}
+	}
+}
+
+.site-error-preview__title {
+	@include a4a-font-heading-lg;
+	margin-block-end: 16px;
+}
+
+.site-error-preview__description {
+	@include a4a-font-body-md;
+	margin-block-end: 16px;
+}
+
+.site-error-preview__actions {
+
+	.card {
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+		margin-block-end: 16px;
+
+		.formatted-header {
+			margin: 0;
+
+			.button {
+				margin-block-start: 16px;
+			}
+
+			@include break-large {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 32px;
+
+				> div {
+					width: 70%;
+					flex: 1;
+				}
+
+				.button {
+					margin-block-start: 0;
+				}
+			}
+		}
+
+		.formatted-header__title {
+			@include a4a-font-heading-md;
+			margin-block-end: 4px;
+			color: var(--color-primary-100);
+		}
+
+		.formatted-header__subtitle {
+			@include a4a-font-body-md;
+			margin-block-end: 0;
+		}
+	}
+
+	.button .gridicon {
+		inset-block-start: 6px;
+		inset-inline-start: 1px;
+	}
+}

--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
@@ -14,6 +14,10 @@
 			padding: 48px;
 		}
 	}
+
+	.item-preview__header {
+		border: 1px solid var(--color-accent-5);
+	}
 }
 
 .site-error-preview__title {

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -26,6 +26,8 @@ import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
 import useFormattedSites from '../../hooks/use-formatted-sites';
 import { AllowedTypes, Site, SiteData } from '../../types';
+import SiteErrorColumn from '../a4a/site-error-column';
+import { A4A_PLUGIN_SLUG } from '../a4a/site-error-preview';
 import type { MouseEvent, KeyboardEvent } from 'react';
 
 export const JetpackSitesDataViews = ( {
@@ -76,15 +78,13 @@ export const JetpackSitesDataViews = ( {
 				return;
 			}
 
-			if ( site.is_connection_healthy ) {
-				setDataViewsState( ( prevState: DataViewsState ) => ( {
-					...prevState,
-					selectedItem: site,
-					type: DATAVIEWS_LIST,
-				} ) );
-			}
+			setDataViewsState( ( prevState: DataViewsState ) => ( {
+				...prevState,
+				selectedItem: site,
+				type: DATAVIEWS_LIST,
+			} ) );
 		},
-		[ setDataViewsState ]
+		[ isNotProduction, setDataViewsState ]
 	);
 
 	const renderField = useCallback(
@@ -175,12 +175,14 @@ export const JetpackSitesDataViews = ( {
 					}
 					const site = item.site.value;
 
+					const isA4APluginInstalled = site.enabled_plugin_slugs?.includes( A4A_PLUGIN_SLUG );
+
 					if ( item.site.type === 'error' ) {
 						return (
-							<div className="sites-dataview__site-error">
-								<Gridicon size={ 18 } icon="notice-outline" />
-								<span>{ translate( "Jetpack can't connect to this site." ) }</span>
-							</div>
+							<SiteErrorColumn
+								isA4APluginInstalled={ isA4APluginInstalled }
+								openSitePreviewPane={ () => openSitePreviewPane( item.site.value ) }
+							/>
 						);
 					}
 
@@ -382,21 +384,21 @@ export const JetpackSitesDataViews = ( {
 							{ item.site.error && <span className="sites-dataview__site-error-span"></span> }
 							{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
 							<div
-								className={ `sites-dataviews__actions ${
-									item.site.error ? 'sites-dataviews__actions-error' : ''
-								}` }
+								className="sites-dataviews__actions"
 								onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 								onKeyDown={ ( e: KeyboardEvent ) => e.stopPropagation() }
 							>
 								{ ( ! item.site.value.sticker?.includes( 'migration-in-progress' ) ||
 									isNotProduction ) && (
 									<>
-										<SiteActions
-											isLargeScreen={ isLargeScreen }
-											site={ item.site }
-											siteError={ item.site.error }
-											onRefetchSite={ onRefetchSite }
-										/>
+										{ ! item.site.error && (
+											<SiteActions
+												isLargeScreen={ isLargeScreen }
+												site={ item.site }
+												siteError={ item.site.error }
+												onRefetchSite={ onRefetchSite }
+											/>
+										) }
 										<Button
 											onClick={ () => openSitePreviewPane( item.site.value ) }
 											className="site-preview__open"
@@ -435,6 +437,7 @@ export const JetpackSitesDataViews = ( {
 			isLoading,
 			openSitePreviewPane,
 			renderField,
+			isNotProduction,
 			isLargeScreen,
 			onRefetchSite,
 		]

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/types.ts
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/types.ts
@@ -25,4 +25,5 @@ export interface PreviewPaneProps {
 	className?: string;
 	isSmallScreen?: boolean;
 	hasError?: boolean;
+	onRefetchSite?: () => Promise< unknown >;
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -285,6 +285,7 @@ export default function SitesDashboard() {
 						closeSitePreviewPane={ closeSitePreviewPane }
 						isSmallScreen={ ! isLargeScreen }
 						hasError={ isError }
+						onRefetchSite={ refetch }
 					/>
 				</LayoutColumn>
 			) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -118,7 +118,7 @@ export default function SiteActions( {
 
 			{ showRemoveSiteDialog && (
 				<SiteRemoveConfirmationDialog
-					site={ site }
+					siteName={ site.value?.url }
 					onClose={ () => setShowRemoveSiteDialog( false ) }
 					onConfirm={ onRemoveSite }
 					busy={ isPending || isPendingRefetch }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-remove-confirmation-dialog/index.tsx
@@ -1,17 +1,16 @@
 import { Button, Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { SiteNode } from '../types';
 
 import './style.scss';
 
 type Props = {
-	site: SiteNode;
+	siteName: string;
 	onClose: () => void;
 	onConfirm?: () => void;
 	busy?: boolean;
 };
 
-export function SiteRemoveConfirmationDialog( { site, onConfirm, onClose, busy }: Props ) {
+export function SiteRemoveConfirmationDialog( { siteName, onConfirm, onClose, busy }: Props ) {
 	const translate = useTranslate();
 
 	const title = translate( 'Remove site' );
@@ -44,7 +43,7 @@ export function SiteRemoveConfirmationDialog( { site, onConfirm, onClose, busy }
 			{ translate(
 				'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
 				{
-					args: { siteName: site.value?.url },
+					args: { siteName },
 					components: {
 						b: <b />,
 					},


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/622

## Proposed Changes

This PR implements a site error preview when a site has a connection error. 

## Testing Instructions

1. Open the A4A live link.
2. Go to Sites > Verify that the error message when there is a connection error is displayed, as shown below, with a `Fix now` button. Also, verify that the action icon(`...`) is hidden and only the `>` icon is shown.

<img width="1427" alt="Screenshot 2024-07-10 at 11 31 36 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d450a32b-ffc0-4683-bf81-110cf474afaf">

3. Hover over the message, and it shows the tooltip as mentioned below:

When the A4A plugin is installed

<img width="1427" alt="Screenshot 2024-07-10 at 11 35 36 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ac7e9628-699b-4ebb-86d3-1dc75a5e324d">

When the Jetpack plugin is installed


<img width="403" alt="Screenshot 2024-07-09 at 2 30 17 PM" src="https://github.com/user-attachments/assets/0b30c7cb-4b51-441f-872b-dc971d79acc5">


4. Click the `Fix now` button & the `>` icon & verify that the error preview is displayed as shown below:

<img width="1726" alt="Screenshot 2024-07-24 at 2 37 49 PM" src="https://github.com/user-attachments/assets/53214cad-5797-4256-b1a1-77a94abcc6f7">

Error preview when the A4A plugin is installed:

<img width="1726" alt="Screenshot 2024-07-24 at 2 38 03 PM" src="https://github.com/user-attachments/assets/20f8f2ec-53bf-4a64-9a3f-df7f172b109e">

5. Verify the error preview looks good on various screens:


<img width="586" alt="Screenshot 2024-07-24 at 2 39 06 PM" src="https://github.com/user-attachments/assets/f358308c-3ee7-4563-98f8-3ceb5a3b4b5f">

<img width="282" alt="Screenshot 2024-07-24 at 2 39 27 PM" src="https://github.com/user-attachments/assets/32c27fec-d214-43e0-9fc0-c8a7ca95802d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
