### PR TITLE
A4A: Clean up the 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' feature flag conditional flow.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { category, starEmpty, tool, warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -15,16 +14,13 @@ import { createItem } from '../lib/utils';
 const useSitesMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 	const noActiveSite = useNoActiveSite();
-	const isWPCOMPurchaseOptionEnabled = isEnabled(
-		'a8c-for-agencies/wpcom-creator-plan-purchase-flow'
-	);
 	const { data } = useFetchPendingSites();
 	const totalAvailableSites =
 		data?.filter(
 			( { features }: { features: { wpcom_atomic: { state: string; license_key: string } } } ) =>
 				features.wpcom_atomic.state === 'pending' && !! features.wpcom_atomic.license_key
 		).length || 0;
-	const shouldAddNeedsSetup = isWPCOMPurchaseOptionEnabled && totalAvailableSites > 0;
+	const shouldAddNeedsSetup = totalAvailableSites > 0;
 
 	return useMemo( () => {
 		if ( noActiveSite ) {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	Badge,
 	BloombergLogo,
@@ -250,14 +249,10 @@ export default function HostingCard( {
 				{ exploreButton }
 			</div>
 
-			{ isEnabled( 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' ) && (
-				<>
-					{ features.length > 0 && (
-						<div className="hosting-card__section hosting-card__feature-section">
-							<SimpleList items={ features } />
-						</div>
-					) }
-				</>
+			{ features.length > 0 && (
+				<div className="hosting-card__section hosting-card__feature-section">
+					<SimpleList items={ features } />
+				</div>
 			) }
 
 			<div className="hosting-card__footer">

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -46,8 +46,6 @@ export default function HostingList( { selectedSite }: Props ) {
 		selectedSite,
 	} );
 
-	const isWPCOMOptionEnabled = isEnabled( 'a8c-for-agencies/wpcom-creator-plan-purchase-flow' );
-
 	const cheapestPressablePlan = useMemo(
 		() => ( pressablePlans.length ? getCheapestPlan( pressablePlans ) : null ),
 		[ pressablePlans ]
@@ -55,7 +53,7 @@ export default function HostingList( { selectedSite }: Props ) {
 
 	const highestDiscountPressable = 70; // FIXME: compute this value based on the actual data
 
-	const creatorPlan = isWPCOMOptionEnabled ? getWPCOMCreatorPlan( wpcomPlans ) : null;
+	const creatorPlan = getWPCOMCreatorPlan( wpcomPlans );
 
 	const highestDiscountWPCOM = useMemo(
 		() =>
@@ -132,7 +130,7 @@ export default function HostingList( { selectedSite }: Props ) {
 					/>
 				) }
 
-				{ isWPCOMOptionEnabled && ! hideSection && (
+				{ ! hideSection && (
 					<HostingCard
 						plan={ vipPlan }
 						className="hosting-list__vip-card"
@@ -140,7 +138,7 @@ export default function HostingList( { selectedSite }: Props ) {
 					/>
 				) }
 			</ListingSection>
-			{ isWPCOMOptionEnabled && ! hideSection && (
+			{ ! hideSection && (
 				<Card className="hosting-list__features">
 					<h3 className="hosting-list__features-heading">
 						{ translate( 'Included with Standard & Premier hosting' ) }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -30,7 +30,6 @@
 	"features": {
 		"ad-tracking": false,
 		"a8c-for-agencies": true,
-		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,
 		"always_use_logout_url": true,
 		"cookie-banner": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -27,7 +27,6 @@
 	"features": {
 		"ad-tracking": false,
 		"a8c-for-agencies": true,
-		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"cookie-banner": false,
 		"oauth": false,
 		"a4a/site-details-pane": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -29,7 +29,6 @@
 	"features": {
 		"ad-tracking": true,
 		"a8c-for-agencies": true,
-		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"cookie-banner": true,
 		"oauth": true,
 		"a4a-logged-out-signup": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -29,7 +29,6 @@
 	"features": {
 		"ad-tracking": false,
 		"a8c-for-agencies": true,
-		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"a8c-for-agencies/import-site-from-wpcom": true,
 		"cookie-banner": false,
 		"oauth": true,


### PR DESCRIPTION
This PR cleans up conditional flow for the `a8c-for-agencies/wpcom-creator-plan-purchase-flow` feature flag.

## Proposed Changes

* Remove `a8c-for-agencies/wpcom-creator-plan-purchase-flow` feature flag and its conditional flows.


## Testing Instructions

* Use the A4A live link and test that the WPCOM plan purchase flow is working and has no regression.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
