### PR TITLE
A4A > Referrals: Disable referral toggle when no Tipalti account

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
@@ -4,6 +4,7 @@ import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect } from 'react';
 import useReferralsGuide from 'calypso/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide';
+import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
 import { useDispatch, useSelector } from 'calypso/state';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
@@ -15,6 +16,9 @@ const PREFERENCE_NAME = 'a4a-marketplace-referral-guide-seen';
 
 const ReferralToggle = () => {
 	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
+	const { data: tipaltiData } = useGetTipaltiPayee();
+	const hasActivePayeeAcount = tipaltiData?.Status === 'Active';
+
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { marketplaceType, toggleMarketplaceType } = useContext( MarketplaceTypeContext );
@@ -28,7 +32,7 @@ const ReferralToggle = () => {
 		}
 	}, [ dispatch, guideModalSeen, marketplaceType, openGuide ] );
 
-	if ( ! isAutomatedReferrals ) {
+	if ( ! isAutomatedReferrals || ! hasActivePayeeAcount ) {
 		return null;
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
@@ -16,8 +16,8 @@ const PREFERENCE_NAME = 'a4a-marketplace-referral-guide-seen';
 
 const ReferralToggle = () => {
 	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
-	const { data: tipaltiData } = useGetTipaltiPayee();
-	const hasActivePayeeAcount = tipaltiData?.Status === 'Active';
+	const { data: tipaltiData } = useGetTipaltiPayee( true );
+	const isPayable = tipaltiData?.IsPayable;
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -32,7 +32,7 @@ const ReferralToggle = () => {
 		}
 	}, [ dispatch, guideModalSeen, marketplaceType, openGuide ] );
 
-	if ( ! isAutomatedReferrals || ! hasActivePayeeAcount ) {
+	if ( ! isAutomatedReferrals || ! isPayable ) {
 		return null;
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/style.scss
@@ -27,5 +27,10 @@
 	.button {
 		background-color: var(--color-accent-100);
 		color: var(--color-surface);
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--color-accent-100);
+		}
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/style.scss
@@ -13,3 +13,19 @@
 		cursor: pointer;
 	}
 }
+
+.referral-toggle__notice {
+	.a4a-popover__title {
+		@include a4a-font-heading-md;
+		color: var(--studio-gray-80);
+	}
+
+	.referral-toggle__notice-description {
+		@include a4a-font-body-md;
+	}
+
+	.button {
+		background-color: var(--color-accent-100);
+		color: var(--color-surface);
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
-import React, { ComponentType, useState } from 'react';
+import { ComponentType, useState } from 'react';
+import useGetTipaltiPayee from '../../referrals/hooks/use-get-tipalti-payee';
 import { MarketplaceTypeContext } from '../context';
 import { MarketplaceType } from '../types';
 
@@ -16,12 +17,15 @@ function withMarketplaceType< T >(
 ): ComponentType< T & ContextProps > {
 	return ( props ) => {
 		const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
+		const { data: tipaltiData } = useGetTipaltiPayee();
+		const hasActivePayeeAcount = tipaltiData?.Status === 'Active';
 		const usedMarketplaceType =
 			props.defaultMarketplaceType ??
 			( sessionStorage.getItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY ) as MarketplaceType ) ??
 			MARKETPLACE_TYPE_REGULAR;
 
-		const defaultType = isAutomatedReferrals ? usedMarketplaceType : MARKETPLACE_TYPE_REGULAR;
+		const defaultType =
+			isAutomatedReferrals && hasActivePayeeAcount ? usedMarketplaceType : MARKETPLACE_TYPE_REGULAR;
 		const [ marketplaceType, setMarketplaceType ] = useState( defaultType );
 
 		const updateMarketplaceType = ( type: MarketplaceType ) => {
@@ -30,7 +34,7 @@ function withMarketplaceType< T >(
 		};
 
 		const toggleMarketplaceType = () => {
-			if ( ! isAutomatedReferrals ) {
+			if ( ! isAutomatedReferrals || ! hasActivePayeeAcount ) {
 				return;
 			}
 			const nextType =

--- a/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type.tsx
@@ -17,15 +17,16 @@ function withMarketplaceType< T >(
 ): ComponentType< T & ContextProps > {
 	return ( props ) => {
 		const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
-		const { data: tipaltiData } = useGetTipaltiPayee();
-		const hasActivePayeeAcount = tipaltiData?.Status === 'Active';
+		const { data: tipaltiData } = useGetTipaltiPayee( true );
+		const isPayable = tipaltiData?.IsPayable;
+
 		const usedMarketplaceType =
 			props.defaultMarketplaceType ??
 			( sessionStorage.getItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY ) as MarketplaceType ) ??
 			MARKETPLACE_TYPE_REGULAR;
 
 		const defaultType =
-			isAutomatedReferrals && hasActivePayeeAcount ? usedMarketplaceType : MARKETPLACE_TYPE_REGULAR;
+			isAutomatedReferrals && isPayable ? usedMarketplaceType : MARKETPLACE_TYPE_REGULAR;
 		const [ marketplaceType, setMarketplaceType ] = useState( defaultType );
 
 		const updateMarketplaceType = ( type: MarketplaceType ) => {
@@ -34,7 +35,7 @@ function withMarketplaceType< T >(
 		};
 
 		const toggleMarketplaceType = () => {
-			if ( ! isAutomatedReferrals || ! hasActivePayeeAcount ) {
+			if ( ! isAutomatedReferrals || ! isPayable ) {
 				return;
 			}
 			const nextType =

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
@@ -31,8 +31,8 @@ export default function MigrationsOverview() {
 	const title = translate( 'Migrations' );
 
 	const isAutomatedReferralsEnabled = config.isEnabled( 'a4a-automated-referrals' );
+	const { data } = useGetTipaltiPayee( true );
 
-	const { data } = useGetTipaltiPayee();
 	const accountStatus = getAccountStatus( data, translate );
 	const statusProps = {
 		children: accountStatus?.status,

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -7,10 +7,20 @@ export const getGetTipaltiPayeeQueryKey = ( agencyId?: number ) => {
 	return [ 'a4a-tipalti-payee', agencyId ];
 };
 
-export default function useGetTipaltiPayee() {
+export default function useGetTipaltiPayee( useStaleData = false ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const data = useQuery( {
+	const queryClient = useQueryClient();
+	const data = queryClient.getQueryData( getGetTipaltiPayeeQueryKey( agencyId ) );
+
+	let staleTime = 0;
+
+	// If we have data and we want to use stale data, set the stale time to Infinity to prevent refetching.
+	if ( useStaleData && data ) {
+		staleTime = Infinity;
+	}
+
+	return useQuery( {
 		queryKey: getGetTipaltiPayeeQueryKey( agencyId ),
 		queryFn: () =>
 			wpcom.req.get( {
@@ -19,8 +29,6 @@ export default function useGetTipaltiPayee() {
 			} ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
-		staleTime: 5 * 60 * 1000,
+		staleTime,
 	} );
-
-	return data;
 }

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee.tsx
@@ -19,6 +19,7 @@ export default function useGetTipaltiPayee() {
 			} ),
 		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
+		staleTime: 5 * 60 * 1000,
 	} );
 
 	return data;

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -70,7 +70,7 @@ export default function ReferralsOverview( {
 	const { data: referrals, isFetching: isFetchingReferrals } =
 		useFetchReferrals( isAutomatedReferral );
 
-	const hasActivePayeeAcount = tipaltiData?.Status === 'Active';
+	const isPayable = tipaltiData?.IsPayable;
 
 	const hasReferrals = !! referrals?.length;
 
@@ -130,7 +130,7 @@ export default function ReferralsOverview( {
 
 					<LayoutHeader>
 						<Title>{ title } </Title>
-						{ isAutomatedReferral && hasActivePayeeAcount && (
+						{ isAutomatedReferral && isPayable && (
 							<Actions>
 								<MobileSidebarNavigation />
 								<span

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -70,6 +70,8 @@ export default function ReferralsOverview( {
 	const { data: referrals, isFetching: isFetchingReferrals } =
 		useFetchReferrals( isAutomatedReferral );
 
+	const hasActivePayeeAcount = tipaltiData?.Status === 'Active';
+
 	const hasReferrals = !! referrals?.length;
 
 	const actionRequiredNotice =
@@ -128,7 +130,7 @@ export default function ReferralsOverview( {
 
 					<LayoutHeader>
 						<Title>{ title } </Title>
-						{ isAutomatedReferral && (
+						{ isAutomatedReferral && hasActivePayeeAcount && (
 							<Actions>
 								<MobileSidebarNavigation />
 								<span

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -70,8 +70,6 @@ export default function ReferralsOverview( {
 	const { data: referrals, isFetching: isFetchingReferrals } =
 		useFetchReferrals( isAutomatedReferral );
 
-	const isPayable = tipaltiData?.IsPayable;
-
 	const hasReferrals = !! referrals?.length;
 
 	const actionRequiredNotice =
@@ -130,7 +128,7 @@ export default function ReferralsOverview( {
 
 					<LayoutHeader>
 						<Title>{ title } </Title>
-						{ isAutomatedReferral && isPayable && (
+						{ isAutomatedReferral && (
 							<Actions>
 								<MobileSidebarNavigation />
 								<span


### PR DESCRIPTION
Adding changes [added](https://github.com/Automattic/wp-calypso/pull/92100) here as the revert of the revert doesn't work

<img width="1840" alt="Screenshot 2024-07-11 at 4 38 33 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2fdc3530-a16e-47f6-b2a3-fb4e51afab93">

NOTE: the tooltip/popover will close only when clicked outside because we want the user to interact with it.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/712

## Proposed Changes

Remove referrals mode when no Tipalti account is set.
Also adding stale-time parameter to tipalty query, as these are quite slow and we don't expect that data to update often.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using account without Tipalti account, navigate to `/marketplace` and check that you see referral toggle disabled and a tooltip is shown when hovered over.
- Navigate to `referrals` and check that you see `Make a referral` button disabled
- Setup Tipalti account and verify that toggle and button from above are present and you are able to make referrals

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
