### PR TITLE
Stats: Empty States add Restricted Dash Check for Email Module

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -26,7 +26,10 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import memoizeLast from 'calypso/lib/memoize-last';
-import { STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS } from 'calypso/my-sites/stats/constants';
+import {
+	STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS,
+	STAT_TYPE_EMAILS_SUMMARY,
+} from 'calypso/my-sites/stats/constants';
 import {
 	recordGoogleEvent,
 	recordTracksEvent,
@@ -225,6 +228,7 @@ class StatsSite extends Component {
 			supportsDevicesStatsFeature,
 			isOldJetpack,
 			shouldForceDefaultDateRange,
+			gateEmails,
 		} = this.props;
 		const isNewStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -619,7 +623,7 @@ class StatsSite extends Component {
 						) }
 
 						{ /* Either stacks with "Authors" or takes full width, depending on UTM and Authors visibility */ }
-						{ supportsEmailStats && isNewStateEnabled && (
+						{ supportsEmailStats && isNewStateEnabled && ! gateEmails && (
 							<StatsModuleEmails
 								period={ this.props.period }
 								moduleStrings={ moduleStrings.emails }
@@ -903,6 +907,9 @@ export default connect(
 			STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS
 		);
 
+		// Determine if the STAT_TYPE_SEARCH_TERMS stat should be gated for the current site.
+		const gateEmails = shouldGateStats( STAT_TYPE_EMAILS_SUMMARY );
+
 		return {
 			canUserViewStats,
 			isAtomic: isAtomicSite( state, siteId ),
@@ -923,6 +930,7 @@ export default connect(
 			supportsDevicesStatsFeature: supportsDevicesStats,
 			isOldJetpack,
 			shouldForceDefaultDateRange,
+			gateEmails,
 		};
 	},
 	{

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -602,8 +602,8 @@ class StatsSite extends Component {
 						) }
 
 						{ /* Either stacks with "Authors" or takes full width, depending on UTM and Authors visibility */ }
-						{ supportsEmailStats && ! isNewStateEnabled && (
-							<StatsModuleEmailsOld // This is the old component & location. Remove and consolidate once stats/empty-module-traffic flag is removed
+						{ supportsEmailStats && ( ! isNewStateEnabled || gateModuleEmails ) && (
+							<StatsModuleEmailsOld // This is the old component & location. we will display it if gateModuleEmails is true because it supports the overlay
 								period={ this.props.period }
 								query={ query }
 								className={ clsx(

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -228,7 +228,7 @@ class StatsSite extends Component {
 			supportsDevicesStatsFeature,
 			isOldJetpack,
 			shouldForceDefaultDateRange,
-			gateEmails,
+			gateModuleEmails,
 		} = this.props;
 		const isNewStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 		let defaultPeriod = PAST_SEVEN_DAYS;
@@ -623,7 +623,7 @@ class StatsSite extends Component {
 						) }
 
 						{ /* Either stacks with "Authors" or takes full width, depending on UTM and Authors visibility */ }
-						{ supportsEmailStats && isNewStateEnabled && ! gateEmails && (
+						{ supportsEmailStats && isNewStateEnabled && ! gateModuleEmails && (
 							<StatsModuleEmails
 								period={ this.props.period }
 								moduleStrings={ moduleStrings.emails }
@@ -908,7 +908,7 @@ export default connect(
 		);
 
 		// Determine if the STAT_TYPE_SEARCH_TERMS stat should be gated for the current site.
-		const gateEmails = shouldGateStats( STAT_TYPE_EMAILS_SUMMARY );
+		const gateModuleEmails = shouldGateStats( STAT_TYPE_EMAILS_SUMMARY );
 
 		return {
 			canUserViewStats,
@@ -930,7 +930,7 @@ export default connect(
 			supportsDevicesStatsFeature: supportsDevicesStats,
 			isOldJetpack,
 			shouldForceDefaultDateRange,
-			gateEmails,
+			gateModuleEmails,
 		};
 	},
 	{

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -230,6 +230,7 @@ class StatsSite extends Component {
 			shouldForceDefaultDateRange,
 			gateModuleEmails,
 		} = this.props;
+
 		const isNewStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 		let defaultPeriod = PAST_SEVEN_DAYS;
 
@@ -907,8 +908,8 @@ export default connect(
 			STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS
 		);
 
-		// Determine if the STAT_TYPE_SEARCH_TERMS stat should be gated for the current site.
-		const gateModuleEmails = shouldGateStats( STAT_TYPE_EMAILS_SUMMARY );
+		// Determine if the emails module should be gated for the current site.
+		const gateModuleEmails = shouldGateStats( state, siteId, STAT_TYPE_EMAILS_SUMMARY );
 
 		return {
 			canUserViewStats,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This checks if a module should be restricted on the dashboard, and if it is, falls back to the old modules which support the overlay being displayed. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
