### PR TITLE
A4A > Referrals: Fix the referral details UI

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
@@ -14,6 +14,7 @@
 
 .item-preview__pane.referral-details-items {
 	.item-preview__content {
+		display: block;
 		@media (max-width: $break-mobile) {
 			height: 75vh;
 			padding: 18px;


### PR DESCRIPTION
This bug was caused by https://github.com/Automattic/wp-calypso/pull/91620. 

## Proposed Changes

This PR fixes the referral details UI.

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals - Dashboard view > Open details of any client and verify the fix is applied as shown below


| Before | After |
|--------|--------|
| <img width="1002" alt="Screenshot 2024-07-10 at 1 37 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ee679b79-17b8-4499-ba39-40e1544326f4">| <img width="1002" alt="Screenshot 2024-07-10 at 1 37 03 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/bfd85f1b-c5ab-4151-9d69-d58a3c4bf80c">| 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
