### PR TITLE
 Stats: Empty States: Update Emails Module with Skeleton Loading and Restricted Dash Check

### DIFF
--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -14,7 +14,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { SUPPORT_URL } from '../../../const';
 import StatsModule from '../../../stats-module';
-import StatsModulePlaceholder from '../../../stats-module/placeholder';
+import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import StatsEmptyActionEmail from '../shared/stats-empty-action-email';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
@@ -28,7 +28,7 @@ const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsEmailsSummary';
 
-	const requesting = useSelector( ( state: StatsStateProps ) =>
+	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
 		isRequestingSiteStatsForQuery( state, siteId, statType, query )
 	);
 	const data = useSelector( ( state ) =>
@@ -40,7 +40,14 @@ const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
 			{ siteId && statType && (
 				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 			) }
-			{ requesting && <StatsModulePlaceholder isLoading={ requesting } /> }
+			{ isRequestingData && (
+				<StatsCardSkeleton
+					isLoading={ isRequestingData }
+					className={ className }
+					title={ moduleStrings.title }
+					type={ 2 }
+				/>
+			) }
 			{ ! data?.length ? (
 				<StatsCard
 					className={ clsx( 'stats-card--empty-variant', className ) }

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -13,6 +13,7 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { SUPPORT_URL } from '../../../const';
+import { useShouldGateStats } from '../../../hooks/use-should-gate-stats';
 import StatsModule from '../../../stats-module';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import StatsEmptyActionEmail from '../shared/stats-empty-action-email';
@@ -28,6 +29,8 @@ const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsEmailsSummary';
 
+	const shouldGateStatsModule = useShouldGateStats( statType );
+
 	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
 		isRequestingSiteStatsForQuery( state, siteId, statType, query )
 	);
@@ -37,7 +40,7 @@ const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
 
 	return (
 		<>
-			{ siteId && statType && (
+			{ ! shouldGateStatsModule && siteId && statType && (
 				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 			) }
 			{ isRequestingData && (
@@ -48,29 +51,7 @@ const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
 					type={ 2 }
 				/>
 			) }
-			{ ! data?.length ? (
-				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
-					title={ translate( 'Emails' ) }
-					isEmpty
-					emptyMessage={
-						<EmptyModuleCard
-							icon={ mail }
-							description={ translate(
-								'Learn about your {{link}}latest emails sent{{/link}} to better understand how they performed. Start sending!',
-								{
-									comment: '{{link}} links to support documentation.',
-									components: {
-										link: <a href={ localizeUrl( `${ SUPPORT_URL }#emails` ) } />,
-									},
-									context: 'Stats: Info box label when the Emails module is empty',
-								}
-							) }
-							cards={ <StatsEmptyActionEmail from="module_emails" /> }
-						/>
-					}
-				/>
-			) : (
+			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
 				<StatsModule
 					additionalColumns={ {
 						header: (
@@ -95,6 +76,29 @@ const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
 					className={ className }
 					hasNoBackground
 					skipQuery
+				/>
+			) }
+			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
+				<StatsCard
+					className={ clsx( 'stats-card--empty-variant', className ) }
+					title={ translate( 'Emails' ) }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ mail }
+							description={ translate(
+								'Learn about your {{link}}latest emails sent{{/link}} to better understand how they performed. Start sending!',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: <a href={ localizeUrl( `${ SUPPORT_URL }#emails` ) } />,
+									},
+									context: 'Stats: Info box label when the Emails module is empty',
+								}
+							) }
+							cards={ <StatsEmptyActionEmail from="module_emails" /> }
+						/>
+					}
 				/>
 			) }
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR updates the Emails Module with Skeleton Loading as well as a Restricted Dashboard check. 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply stats/empty-module-traffic feature flag
* navigate to several blogs and first verify that the email component loads properly.
* check sites with and without the ability to access the email module to ensure everything works as expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
