### PR TITLE
Hosting Dashboard: Fix preview pane width

### DIFF
--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -521,6 +521,7 @@
 			overflow-y: initial;
 			max-height: initial;
 			max-width: 1400px;
+			width: 100%;
 
 			main {
 				max-width: 100%;


### PR DESCRIPTION
## Proposed Changes

There seems to be a CSS regression in hosting dashboard panel width, but I cannot pinpoint how/where. Here's what this PR fixes:

|Before|After|
|-|-|
|<img width="1253" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/abb5a8eb-f57e-4cde-b958-37a5d25b3d97">|<img width="1252" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/280cdf6f-0aee-4745-92c6-7bc5fd5d8d0d">|
|<img width="1252" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/7a8590d9-4346-414f-9274-ec397e868213">|<img width="1252" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/3cc4d0c6-9ac1-45cb-85f3-1b0e979e1ba1">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes a regression.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /sites.
2. Click a site
3. Open Monitoring and Logs tabs
4. Verify they look good as screenshot above
5. Smoke-test other tabs, and various viewports as well, make sure no further regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
