### PR TITLE
A4A: Fix a minor typo in the migration offer banner

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -22,7 +22,7 @@ const MigrationOfferHeader = ( { withIcon }: { withIcon?: boolean } ) => {
 const MigrationOfferBody = () => {
 	const translate = useTranslate();
 	const description = translate(
-		'Migrate your clients sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You’ll also receive an additional $100 for each migrated site—up to $3,000 until July 31, 2024.'
+		"Migrate your clients' sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You'll also receive an additional $100 for each migrated site—up to $3,000 until July 31, 2024."
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
@@ -61,7 +61,7 @@ export default function MigrationsOverview() {
 				</div>
 				<div className="migrations-overview__section-intro">
 					{ translate(
-						'Migrate your clients sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You’ll also receive an additional $100 for each migrated site—up to $3,000 until July 31, 2024.'
+						"Migrate your clients' sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You'll also receive an additional $100 for each migrated site—up to $3,000 until July 31, 2024."
 					) }
 				</div>
 				<div className="migrations-overview__section-subtitle">


### PR DESCRIPTION
## Proposed Changes

This PR fixes a minor typo (clients to clients') in the migration offer banner.

## Testing Instructions

1. Open the A4A live link.
2. Go to Marketplace - Hosting > Verify the typo in the banner now is fixed



| Before | After |
|--------|--------|
| <img width="1356" alt="Screenshot 2024-07-10 at 5 06 19 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0ad8231b-8c2f-449f-ae73-6e47eab31e62">| <img width="1356" alt="Screenshot 2024-07-10 at 5 06 17 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ae845c0d-82bb-41f8-af01-3a15635b064c">| 

3. Go to Overview - Hosting > Verify the typo in the banner now is fixed


| Before | After |
|--------|--------|
| <img width="919" alt="Screenshot 2024-07-10 at 5 07 17 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0d9ca893-506b-4149-82e5-044fb68a1b99">| <img width="919" alt="Screenshot 2024-07-10 at 5 07 10 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/87d3ed3d-f15c-4469-9c23-40400df5bc8e">| 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
