### PR TITLE
A4A:  Rephrase 'Import existing sites' to 'Add existing sites'.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/site-selector-and-importer.tsx
@@ -118,12 +118,12 @@ export default function SiteSelectorAndImporter( { showMainButtonLabel, onWPCOMI
 				<div className="site-selector-and-importer__popover-content">
 					<div className="site-selector-and-importer__popover-column">
 						<div className="site-selector-and-importer__popover-column-heading">
-							{ translate( 'Import existing sites' ).toUpperCase() }
+							{ translate( 'Add existing sites' ).toUpperCase() }
 						</div>
 						{ menuItem( {
 							icon: <WordPressLogo />,
 							heading: translate( 'Via WordPress.com' ),
-							description: translate( 'Import sites bought on{{nbsp/}}WordPress.com', {
+							description: translate( 'Add sites bought on{{nbsp/}}WordPress.com', {
 								components: { nbsp: <>&nbsp;</> },
 								comment: 'nbsp is a non-breaking space character',
 							} ),


### PR DESCRIPTION
It was brought to our attention that the term **Import sites** might be confusing to some agencies waiting for the migration tool for their existing WordPress.com plan to A4A. This pull request addresses this issue by rephrasing the text that uses the term. 

| Before | After |
|--------|--------|
| <img width="400" alt="Screenshot 2024-07-10 at 7 59 43 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d35e4aba-2727-4ca8-b1f6-6b6007ecb67a"> | <img width="405" alt="Screenshot 2024-07-10 at 7 58 22 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f0870919-5bc2-4434-909b-e97c6145cc6b"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/792


## Proposed Changes

* Update a few copies in the 'Add site' dropdown menu to replace the term 'Import' with 'Add'.

## Why are these changes being made?

* The text is confusing to some agency and needs to be updated.

## Testing Instructions


* Use the A4A live link below and go to the `/overview` page.
* Click the 'Add sites' dropdown menu.
* Confirm that the 'Import sites' texts are now replaced.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
