### PR TITLE
ContinueAsUser: disconnect from Redux, pass explicit props

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -1,14 +1,8 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { get } from 'lodash';
 import { useEffect, useState } from 'react';
-import { connect } from 'react-redux';
 import Gravatar from 'calypso/components/gravatar';
 import wpcom from 'calypso/lib/wp';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
-import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
-import getIsWooPasswordless from 'calypso/state/selectors/get-is-woo-passwordless';
 import SocialToS from '../authentication/social/social-tos';
 
 import './continue-as-user.scss';
@@ -38,23 +32,18 @@ function useValidatedURL( redirectUrl ) {
 	return { url, loading: isLoading && !! redirectUrl };
 }
 
-function ContinueAsUser( {
+export default function ContinueAsUser( {
 	currentUser,
-	redirectUrlFromQuery,
 	onChangeAccount,
 	redirectPath,
-	isWooOAuth2Client,
+	isWoo,
 	isWooPasswordless,
 	isBlazePro,
 	notYouText,
 } ) {
 	const translate = useTranslate();
-	const { url: validatedRedirectUrlFromQuery, loading: validatingQueryURL } =
-		useValidatedURL( redirectUrlFromQuery );
 
-	const { url: validatedRedirectPath, loading: validatingPath } = useValidatedURL( redirectPath );
-
-	const isLoading = validatingQueryURL || validatingPath;
+	const { url: validatedPath, loading: validatingPath } = useValidatedURL( redirectPath );
 
 	const userName = currentUser.display_name || currentUser.username;
 
@@ -94,7 +83,7 @@ function ContinueAsUser( {
 		</div>
 	);
 
-	if ( isWooOAuth2Client ) {
+	if ( isWoo ) {
 		if ( isWooPasswordless ) {
 			return (
 				<div className="continue-as-user">
@@ -113,9 +102,9 @@ function ContinueAsUser( {
 					</div>
 					<Button
 						primary
-						busy={ isLoading }
 						className="continue-as-user__continue-button"
-						href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
+						busy={ validatingPath }
+						href={ validatedPath || '/' }
 					>
 						{ `${ translate( 'Continue as', {
 							context: 'Continue as an existing WordPress.com user',
@@ -139,11 +128,7 @@ function ContinueAsUser( {
 							{ translate( 'Log in with a different WordPress.com account' ) }
 						</button>
 					</div>
-					<Button
-						busy={ isLoading }
-						primary
-						href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
-					>
+					<Button primary busy={ validatingPath } href={ validatedPath || '/' }>
 						{ `${ translate( 'Continue as', {
 							context: 'Continue as an existing WordPress.com user',
 						} ) } ${ userName }` }
@@ -171,9 +156,9 @@ function ContinueAsUser( {
 				</div>
 				<Button
 					primary
-					busy={ isLoading }
 					className="continue-as-user__continue-button"
-					href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
+					busy={ validatingPath }
+					href={ validatedPath || '/' }
 				>
 					{ `${ translate( 'Continue as', {
 						context: 'Continue as an existing WordPress.com user',
@@ -188,11 +173,7 @@ function ContinueAsUser( {
 		<div className="continue-as-user">
 			<div className="continue-as-user__user-info">
 				{ gravatarLink }
-				<Button
-					busy={ isLoading }
-					primary
-					href={ validatedRedirectPath || validatedRedirectUrlFromQuery || '/' }
-				>
+				<Button primary busy={ validatingPath } href={ validatedPath || '/' }>
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>
@@ -200,10 +181,3 @@ function ContinueAsUser( {
 		</div>
 	);
 }
-
-export default connect( ( state ) => ( {
-	currentUser: getCurrentUser( state ),
-	redirectUrlFromQuery: get( getCurrentQueryArguments( state ), 'redirect_to', null ),
-	isWooPasswordless: getIsWooPasswordless( state ),
-	isBlazePro: getIsBlazePro( state ),
-} ) )( ContinueAsUser );

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -177,7 +177,7 @@ class Login extends Component {
 				locale: this.props.locale,
 				twoFactorAuthType: 'link',
 				oauth2ClientId: this.props.currentQuery?.client_id,
-				redirectTo: this.props.currentQuery?.redirect_to,
+				redirectTo: this.props.redirectTo,
 				usernameOnly: true,
 			} );
 
@@ -825,6 +825,7 @@ class Login extends Component {
 			handleUsernameChange,
 			signupUrl,
 			isWoo,
+			isWooPasswordless,
 			isBlazePro,
 			translate,
 			isPartnerSignup,
@@ -836,6 +837,8 @@ class Login extends Component {
 			isSocialFirst,
 			isFromAutomatticForAgenciesPlugin,
 			loginButtons,
+			currentUser,
+			redirectTo,
 		} = this.props;
 
 		const signupLink = this.getSignupLinkComponent();
@@ -939,9 +942,11 @@ class Login extends Component {
 				return (
 					<div className="login__body login__body--continue-as-user">
 						<ContinueAsUser
+							currentUser={ currentUser }
 							onChangeAccount={ this.handleContinueAsAnotherUser }
-							isWooOAuth2Client={ isWoo }
-							isBlazePro={ isBlazePro }
+							redirectPath={ redirectTo }
+							isWoo={ isWoo }
+							isWooPasswordless={ isWooPasswordless }
 						/>
 						<LoginForm
 							disableAutoFocus={ disableAutoFocus }
@@ -966,7 +971,9 @@ class Login extends Component {
 				return (
 					<div className="login__body login__body--continue-as-user">
 						<ContinueAsUser
+							currentUser={ currentUser }
 							onChangeAccount={ this.handleContinueAsAnotherUser }
+							redirectPath={ redirectTo }
 							isBlazePro={ isBlazePro }
 						/>
 						<LoginForm
@@ -990,7 +997,13 @@ class Login extends Component {
 			}
 
 			// someone is already logged in, offer to proceed to the app without a new login
-			return <ContinueAsUser onChangeAccount={ this.handleContinueAsAnotherUser } />;
+			return (
+				<ContinueAsUser
+					currentUser={ currentUser }
+					onChangeAccount={ this.handleContinueAsAnotherUser }
+					redirectPath={ redirectTo }
+				/>
+			);
 		}
 
 		return (

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1182,8 +1182,12 @@ class SignupForm extends Component {
 		if ( this.props.currentUser && ! this.props.disableContinueAsUser ) {
 			return (
 				<ContinueAsUser
-					redirectPath={ this.props.redirectToAfterLoginUrl }
+					currentUser={ this.props.currentUser }
 					onChangeAccount={ this.handleOnChangeAccount }
+					redirectPath={ this.props.redirectToAfterLoginUrl }
+					isWoo={ this.props.isWoo }
+					isWooPasswordless={ this.props.isWooPasswordless }
+					isBlazePro={ this.props.isBlazePro }
 					notYouText={
 						this.props.notYouText ||
 						this.props.translate(


### PR DESCRIPTION
I wanted to migrate `ContinueAsUser` away from the `connect` HOC, but then I figured that the component doesn't need to be connected to Redux at all. All the data can be passed as props by the parent component, which always already knows all of them.

- `currentUser`: the login and signup component already know about the current user, and passing it as a prop enables future use where `currentUser` doesn't come from Redux `state.currentUser`, but can be for example constructed from data in `signupDependencies`, from the `/users/new` REST response.
- `isWoo`, `isBlazePro` etc.: there was the `isWooOAuth2Client` prop (I renamed it to `isWoo`) that had to always be passed from parent, so I'm converting to this behavior for all the "variant" props: the parent component needs to pass it down.
- `redirectUrlFromQuery`: now the parent component needs to pass `redirectPath`. It knows better what the redirect path should be, and the default fallback (`redirect_to` query argument) is already incorporated into `redirectPath` by all the parents.

**How to test:**
Verify that login and signup flows that display `ContinueAsUser` (in various product variations like Woo or Blaze Pro) continue to work.

@jeyip Please verify that the email subscriptions (after changes like #92222) continue to work.