### PR TITLE
Fix hosting dashboard style bleed, breaking my home layout, etc.

### DIFF
--- a/client/hosting/sites/components/style.scss
+++ b/client/hosting/sites/components/style.scss
@@ -1118,16 +1118,20 @@
 	}
 }
 
-/* See wp-calypso/client/layout/style.scss for the original style - this is removed on sites dashboard to enable pagination to display properly. */
-.layout__primary .preview-hidden {
-	@include breakpoint-deprecated( ">960px" ) {
-		padding-bottom: 0 !important;
+// Styles need to ensure they do not bleed into other areas of calypso once loaded.
+// If we only apply to layout__primary, we will have bleed going from the dashboard to site level calypso.
+.is-global-sidebar-visible {
+	/* See wp-calypso/client/layout/style.scss for the original style - this is removed on sites dashboard to enable pagination to display properly. */
+	.layout__primary .preview-hidden {
+		@include breakpoint-deprecated( ">960px" ) {
+			padding-bottom: 0 !important;
+		}
 	}
-}
 
-.layout__content {
-	@include breakpoint-deprecated( "<960px" ) {
-		padding: 70px 24px 24px calc(var(--sidebar-width-min) + 1px);
+	.layout__content {
+		@include breakpoint-deprecated( "<960px" ) {
+			padding: 70px 24px 24px calc(var(--sidebar-width-min) + 1px);
+		}
 	}
 }
 

--- a/client/hosting/sites/components/style.scss
+++ b/client/hosting/sites/components/style.scss
@@ -1119,8 +1119,9 @@
 }
 
 // Styles need to ensure they do not bleed into other areas of calypso once loaded.
-// If we only apply to layout__primary, we will have bleed going from the dashboard to site level calypso.
-.is-global-sidebar-visible {
+// If we only apply to layout__primary, etc., we will have bleed going from the dashboard to site level calypso.
+.is-global-sidebar-visible.is-group-sites-dashboard,
+.is-global-sidebar-visible.is-group-sites {
 	/* See wp-calypso/client/layout/style.scss for the original style - this is removed on sites dashboard to enable pagination to display properly. */
 	.layout__primary .preview-hidden {
 		@include breakpoint-deprecated( ">960px" ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* These last styles in the hosting dashboard css are too generic. once loaded, they effect undesired areas of calypso due to their lack of specificty.
* NOTE this modifies hosting/sites/componentes/style.scss instead of hosting/sites/components/dotcom-style.scss - While generally we want to make our dotcom changes in dotcom-style, this rule in style.scss is problematic and I think this makes more sense than adding ad-hoc specificity and extra rules to other calypso pages this is bleeding into...

BEFORE

![style-bleeds](https://github.com/Automattic/wp-calypso/assets/28742426/d16c278c-3904-4a8a-8ffe-94bc2db39f98)

First it looks good, then we visit /sites and go back, then the padding has changed.


AFTER

![style-bleed-after](https://github.com/Automattic/wp-calypso/assets/28742426/061f03cc-0280-4ac3-b8d9-b429a538aee0)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If you visit /sites and then load into my home, you will see the paddings are a bit messed up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Adjust screen width <960px
* visit my home for a site, verify the layout is good
* visit the sites dashboard, verify the layout is unchanged from before
* select the a site to visit my home, verify the layout is still good and has not changed after visitng the sites dashboard in the meantime.
* smoke test the sites dashboard both above and below 960px to verify there are no regressions.
* smoke test reader and me after visiting the dashboard, verify there are no regressions in layout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
