### PR TITLE
A4A Address last feedback before shipping site configuration

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -141,7 +141,7 @@ export default function SiteConfigurationsModal( {
 							{ siteName.showValidationMessage && (
 								<Icon
 									icon={ info }
-									size={ 28 }
+									size={ 24 }
 									color="red"
 									className="configure-your-site-modal-form__site-name-fail"
 								/>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { CheckboxControl, Icon, Modal, Spinner } from '@wordpress/components';
-import { check, closeSmall } from '@wordpress/icons';
+import { check, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
@@ -140,7 +140,7 @@ export default function SiteConfigurationsModal( {
 							) }
 							{ siteName.showValidationMessage && (
 								<Icon
-									icon={ closeSmall }
+									icon={ info }
 									size={ 28 }
 									color="red"
 									className="configure-your-site-modal-form__site-name-fail"

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
@@ -2,17 +2,19 @@ import { useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 
 export const getRandomSiteBaseUrl = async ( title: string ) => {
-	let siteName: string;
+	const siteName = '';
 	try {
 		const { body: urlSuggestions } = await wpcom.req.get( {
 			apiNamespace: 'rest/v1.1',
-			path: `/domains/suggestions?http_envelope=1&query=${ title }&quantity=10&include_wordpressdotcom=true&include_dotblogsubdomain=false&only_wordpressdotcom=true&vendor=dot&managed_subdomain_quantity=0`,
+			path: `/domains/suggestions?http_envelope=1&query=${ title }&quantity=10&include_wordpressdotcom=true&include_dotblogsubdomain=false&vendor=dot`,
 		} );
-		const firstUrl = urlSuggestions[ 0 ].domain_name.split( '.' )[ 0 ];
-		siteName = firstUrl.split( '.' )[ 0 ];
-	} catch ( error ) {
-		return '';
-	}
+		const validUrlWpComUrl = urlSuggestions.find( ( suggestion: { domain_name: string } ) =>
+			suggestion.domain_name.includes( 'wordpress.com' )
+		);
+		if ( validUrlWpComUrl ) {
+			return validUrlWpComUrl.domain_name.split( '.' )[ 0 ];
+		}
+	} catch ( error ) {}
 	return siteName;
 };
 

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
@@ -51,6 +51,3 @@ export const useRandomSiteName = () => {
 
 	return { randomSiteName, isRandomSiteNameLoading };
 };
-
-// https://public-api.wordpress.com/rest/v1.1/domains/suggestions?http_envelope=1&query=test&quantity=1&include_wordpressdotcom=true&include_dotblogsubdomain=false&vendor=dot
-// https://public-api.wordpress.com/rest/v1.1domains/suggestions?http_envelope=1&query=test&quantity=1&include_wordpressdotcom=true&include_dotblogsubdomain=false&vendor=dot

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
@@ -6,7 +6,7 @@ export const getRandomSiteBaseUrl = async ( title: string ) => {
 	try {
 		const { body: urlSuggestions } = await wpcom.req.get( {
 			apiNamespace: 'rest/v1.1',
-			path: `/domains/suggestions?http_envelope=1&query=${ title }&quantity=10&include_wordpressdotcom=true&include_dotblogsubdomain=false&vendor=dot`,
+			path: `/domains/suggestions?http_envelope=1&query=${ title }&quantity=1&include_wordpressdotcom=true&include_dotblogsubdomain=false&vendor=dot`,
 		} );
 		const validUrlWpComUrl = urlSuggestions.find( ( suggestion: { domain_name: string } ) =>
 			suggestion.domain_name.includes( 'wordpress.com' )
@@ -51,3 +51,6 @@ export const useRandomSiteName = () => {
 
 	return { randomSiteName, isRandomSiteNameLoading };
 };
+
+// https://public-api.wordpress.com/rest/v1.1/domains/suggestions?http_envelope=1&query=test&quantity=1&include_wordpressdotcom=true&include_dotblogsubdomain=false&vendor=dot
+// https://public-api.wordpress.com/rest/v1.1domains/suggestions?http_envelope=1&query=test&quantity=1&include_wordpressdotcom=true&include_dotblogsubdomain=false&vendor=dot

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import wpcom from 'calypso/lib/wp';
@@ -35,11 +35,14 @@ const useCheckSiteAvailability = (
 	skipAvailability: boolean
 ) => {
 	const agencyId = useSelector( getActiveAgencyId );
+	const siteNameRef = useRef( '' );
 	const [ availabilityState, setAvilabilityState ] = useState( {
 		isSiteNameAvailiable: true,
 		isCheckingSiteAvailability: false,
 		siteNameSuggestion: '',
 	} );
+
+	siteNameRef.current = siteName;
 
 	useEffect( () => {
 		if ( skipAvailability || availabilityState.siteNameSuggestion === siteName ) {
@@ -60,11 +63,13 @@ const useCheckSiteAvailability = (
 		} );
 
 		checkSiteAvailability( agencyId, siteId, siteName ).then( ( result ) => {
-			setAvilabilityState( {
-				isSiteNameAvailiable: result.valid,
-				isCheckingSiteAvailability: false,
-				siteNameSuggestion: result.siteNameSuggestion,
-			} );
+			if ( siteName === siteNameRef.current ) {
+				setAvilabilityState( {
+					isSiteNameAvailiable: result.valid,
+					isCheckingSiteAvailability: false,
+					siteNameSuggestion: result.siteNameSuggestion,
+				} );
+			}
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ agencyId, siteId, siteName, skipAvailability ] );

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -36,7 +36,7 @@ const useCheckSiteAvailability = (
 ) => {
 	const agencyId = useSelector( getActiveAgencyId );
 	const siteNameRef = useRef( '' );
-	const [ availabilityState, setAvilabilityState ] = useState( {
+	const [ availabilityState, setAvailabilityState ] = useState( {
 		isSiteNameAvailiable: true,
 		isCheckingSiteAvailability: false,
 		siteNameSuggestion: '',
@@ -46,7 +46,7 @@ const useCheckSiteAvailability = (
 
 	useEffect( () => {
 		if ( skipAvailability || availabilityState.siteNameSuggestion === siteName ) {
-			setAvilabilityState( {
+			setAvailabilityState( {
 				isSiteNameAvailiable: true,
 				isCheckingSiteAvailability: false,
 				siteNameSuggestion: availabilityState.siteNameSuggestion,
@@ -56,7 +56,7 @@ const useCheckSiteAvailability = (
 		if ( ! agencyId ) {
 			return;
 		}
-		setAvilabilityState( {
+		setAvailabilityState( {
 			isSiteNameAvailiable: false,
 			isCheckingSiteAvailability: true,
 			siteNameSuggestion: '',
@@ -64,7 +64,7 @@ const useCheckSiteAvailability = (
 
 		checkSiteAvailability( agencyId, siteId, siteName ).then( ( result ) => {
 			if ( siteName === siteNameRef.current ) {
-				setAvilabilityState( {
+				setAvailabilityState( {
 					isSiteNameAvailiable: result.valid,
 					isCheckingSiteAvailability: false,
 					siteNameSuggestion: result.siteNameSuggestion,
@@ -75,7 +75,7 @@ const useCheckSiteAvailability = (
 	}, [ agencyId, siteId, siteName, skipAvailability ] );
 
 	const revalidateCurrentSiteName = async () => {
-		setAvilabilityState( {
+		setAvailabilityState( {
 			isSiteNameAvailiable: false,
 			isCheckingSiteAvailability: false,
 			siteNameSuggestion: await getRandomSiteBaseUrl( siteName ),


### PR DESCRIPTION
## Proposed Changes

This PR fix 3 last feedbacks we want to address before shipping:


### 1 Racing condition when editing the site name
If the site validation starts, but the user erases the whole input before the validation request is complete, the wrong error will be displayed when the request is complete. Gif slowed down to 0.5x speed. The `apex` name was pasted with command+V.
![Screen Recording 2024-07-10 at 15 31 41](https://github.com/Automattic/wp-calypso/assets/33497086/57020918-4b46-4592-9d55-47d7cd185062)

### 2 Update the red icon on site validation error
The previews one looked to much with the closing X above.
![image](https://github.com/Automattic/wp-calypso/assets/33497086/795a715b-7ece-462b-872d-8df08c744ecc)

### 3 Improve site suggestions
![image](https://github.com/Automattic/wp-calypso/assets/33497086/ae4fd6d5-dc1b-44a2-b2a6-3c08d162cef1)

The `only_wordpressdotcom` query parameter on the suggestions request is actually causing more troubles than fixing it. We decided to filter for `wordpress.com` sites on client side. There is a slack discussion with more details:
p1720633528661679/1718901226.583079-slack-C0BNMNMNG

Terms like `test` should return a valid suggestion now. And `home` should return home append with random number, not `landlord0` or some strange synonymous. 

## Testing Instructions

This feature is under a4a-site-creation-configurations flag.
Before accessing the Create new site button, your account needs to have at least 1 hosting license, ready to be used.

Open this link: http://agencies.localhost:3000/sites/need-setup?flags=a4a-site-creation-configurations

Test if all issues described were fixed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?