### PR TITLE
Site Migration: Hide skip link on hosted site migration flow site picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -1,4 +1,8 @@
-import { IMPORT_HOSTED_SITE_FLOW, StepContainer } from '@automattic/onboarding';
+import {
+	IMPORT_HOSTED_SITE_FLOW,
+	SITE_MIGRATION_FLOW,
+	StepContainer,
+} from '@automattic/onboarding';
 import {
 	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
 	GroupableSiteLaunchStatuses,
@@ -91,7 +95,7 @@ const SitePickerStep: Step = function SitePickerStep( { navigation, flow } ) {
 				stepName="site-picker"
 				hideBack={ IMPORT_HOSTED_SITE_FLOW !== flow }
 				goBack={ navigation.goBack }
-				hideSkip={ false }
+				hideSkip={ SITE_MIGRATION_FLOW === flow }
 				skipLabelText={ __( 'Skip and create a new site' ) }
 				goNext={ createNewSite }
 				stepContent={


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

pcmemI-3dx-p2#comment-2386

## Proposed Changes

* Hide the skip link in the upper right when viewing the site migration flow site picker step.
* We already have a link in the header area to do the same thing that gets better performance.

**Before**

<img width="1510" alt="Screenshot 2024-07-10 at 2 56 40 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/61616649-96d9-48bc-aab9-bc3dda6a34c8">

**After**

<img width="1512" alt="Screenshot 2024-07-10 at 2 56 26 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/b199da9a-b610-431d-9c8c-d452b3a9f254">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pcmemI-3dx-p2#comment-2386 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR or use calypso.live
* Go to `/setup/hosted-site-migration`
* Enter your site URL
* You should be brought to the site picker step
* There should be no skip link in the upper right corner

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?