### PR TITLE
Reader - fix update notice position

### DIFF
--- a/client/reader/update-notice/style.scss
+++ b/client/reader/update-notice/style.scss
@@ -23,7 +23,7 @@
 	}
 
 	@media (min-width: 782px) {
-		top: 32px;
+		top: calc(var(--masterbar-height) + 32px);
 		right: 32px;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1720637522361159-slack-C06DN6QQVAQ

## Proposed Changes

* Adds masterbar height to the update notice top height postition for wider viewports.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  This seems to have been in place for all other viewports, but once we get past 782px we were just using a flat pixel value. So when we added the masterbar back, the update notice position did not change with ith.


BEFORE
![image](https://github.com/Automattic/wp-calypso/assets/28742426/2d0b7c1b-8154-422c-8475-fc31055f6f45)



AFTER
![image](https://github.com/Automattic/wp-calypso/assets/28742426/9ac4c4cf-3560-48ee-8081-bda733311f3e)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader.
* scroll down a bit
* either wait for the update notice to appear, or [add true to this line of code](https://github.com/Automattic/wp-calypso/blob/d5fa87e930c4b71b0e0060940cecf01a9c08ba95/client/reader/update-notice/index.jsx#L30) locally to force it to appear.
* Verify its position is better.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?