### PR TITLE
Jetpack Google Analytics: fix settings change tracking

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -65,6 +65,7 @@ const GoogleAnalyticsJetpackForm = ( {
 	const wooCommercePlugin = find( sitePlugins, { slug: 'woocommerce' } );
 	const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.sites[ siteId ].active : false;
 	const dispatch = useDispatch();
+	const trackTracksEvent = ( name, props ) => dispatch( recordTracksEvent( name, props ) );
 
 	useEffect( () => {
 		// Show the form if GA module is active, or it's been removed but GA is activated via the Legacy Plugin.
@@ -83,7 +84,7 @@ const GoogleAnalyticsJetpackForm = ( {
 
 	const handleToggleChange = ( key ) => {
 		const value = fields.wga ? ! fields.wga[ key ] : false;
-		recordTracksEvent( 'calypso_google_analytics_setting_changed', { key, path } );
+		trackTracksEvent( 'calypso_google_analytics_setting_changed', { key, path } );
 		handleFieldChange( key, value );
 	};
 
@@ -100,8 +101,12 @@ const GoogleAnalyticsJetpackForm = ( {
 		handleSubmitForm();
 	};
 
+	const trackActiveToggle = () => {
+		trackTracksEvent( 'calypso_google_analytics_setting_changed', { key: 'is_active', path } );
+	};
+
 	const handleSettingsToggleChange = ( value ) => {
-		recordTracksEvent( 'calypso_google_analytics_setting_changed', { key: 'is_active', path } );
+		trackActiveToggle();
 		handleFieldChange( 'is_active', value, handleSubmitForm );
 	};
 
@@ -272,6 +277,7 @@ const GoogleAnalyticsJetpackForm = ( {
 										moduleSlug="google-analytics"
 										label={ translate( 'Add Google' ) }
 										disabled={ isRequestingSettings || isSavingSettings }
+										onChange={ trackActiveToggle }
 									/>
 								) : (
 									renderSettingsToggle()


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/91913#pullrequestreview-2132858522

## Proposed Changes

* Fix/improve event tracking for recent Google Analytics settings changes.

## Why are these changes being made?

pfwV0U-4g-p2

## Testing Instructions

1. Connect Jetpack.
2. Go to "Jetpack -> Settings -> Traffic", find the "Google Analytics" card and purchase a plan.
3. Go to "Jetpack -> Settings -> Traffic" again, and click on "Configure your Google Analytics settings".
4. Replace the `https://wordpress.com` with the Calypso Live URL from this PR.
5. Run `localStorage.debug = 'calypso:analytics'` in the browser console to see the debug entries for event tracking. Reload the page for it to take effect.
6. Activate "Add Google", confirm you see `calypso:analytics Record event "calypso_google_analytics_setting_changed" called...` in the browser console.
7. Deactivate, confirm the event is there again.
8. Checkout the Jetpack branch `delete/jetpack-module-google-analytics` ([PR #37960](https://github.com/Automattic/jetpack/pull/37960)).
9. Reload the Calypso page. Repeat steps 6-7, confirm the event is still tracked.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
