### PR TITLE
A4A: add banner on referral page if no payment method set up

### DIFF
--- a/client/a8c-for-agencies/components/a4a-popover/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-popover/index.tsx
@@ -1,4 +1,5 @@
 import { Popover } from '@wordpress/components';
+import clsx from 'clsx';
 
 import './style.scss';
 
@@ -8,6 +9,7 @@ interface Props {
 	position?: React.ComponentProps< typeof Popover >[ 'position' ];
 	wrapperRef: React.MutableRefObject< HTMLElement | null >;
 	title: string;
+	className?: string;
 	onFocusOutside: ( event: React.SyntheticEvent ) => void;
 	children: React.ReactNode;
 }
@@ -18,6 +20,7 @@ export default function A4APopover( {
 	position = 'bottom',
 	wrapperRef,
 	title,
+	className,
 	onFocusOutside,
 	children,
 }: Props ) {
@@ -26,7 +29,7 @@ export default function A4APopover( {
 			isVisible
 			noArrow={ noArrow }
 			offset={ offset }
-			className="a4a-popover"
+			className={ clsx( 'a4a-popover', className ) }
 			context={ wrapperRef.current }
 			position={ position }
 			onFocusOutside={ onFocusOutside }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -29,6 +29,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useFetchReferrals from '../../hooks/use-fetch-referrals';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
+import { getAccountStatus } from '../../lib/get-account-status';
 import ReferralDetails from '../../referral-details';
 import ReferralsFooter from '../footer';
 import AutomatedReferralComingSoonBanner from './automated-referral-coming-soon-banner';
@@ -61,7 +62,9 @@ export default function ReferralsOverview( {
 			: translate( 'Referrals' );
 
 	const { data: tipaltiData, isFetching } = useGetTipaltiPayee();
-	const referralsAvailable = tipaltiData.statusType === 'success';
+	const accountStatus = getAccountStatus( tipaltiData, translate );
+	const referralsAvailable = accountStatus?.statusType === 'success';
+	const actionRequiredNotice = ! isFetching && accountStatus?.statusType === 'warning';
 
 	const { data: referrals, isFetching: isFetchingReferrals } =
 		useFetchReferrals( isAutomatedReferral );
@@ -95,7 +98,7 @@ export default function ReferralsOverview( {
 							onClose={ () => setReferralEmail( '' ) }
 						/>
 					) }
-					{ ! referralsAvailable && (
+					{ actionRequiredNotice && (
 						<div className="referrals-overview__notice">
 							<NoticeBanner
 								level="warning"

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -47,6 +47,7 @@ export default function ReferralsOverview( {
 	const dispatch = useDispatch();
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( initialDataViewsState );
+	const [ requiredNoticeClose, setRequiredNoticeClosed ] = useState( false );
 
 	const { value: referralEmail, setValue: setReferralEmail } = useUrlQueryParam(
 		REFERRAL_EMAIL_QUERY_PARAM_KEY
@@ -71,7 +72,8 @@ export default function ReferralsOverview( {
 
 	const hasReferrals = !! referrals?.length;
 
-	const actionRequiredNotice = ! isFetching && ! isPayable && ! isFetchingReferrals && hasReferrals;
+	const actionRequiredNotice =
+		! isFetching && ! isPayable && ! isFetchingReferrals && hasReferrals && ! requiredNoticeClose;
 
 	const makeAReferral = useCallback( () => {
 		sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, MARKETPLACE_TYPE_REFERRAL );
@@ -105,7 +107,7 @@ export default function ReferralsOverview( {
 							<LayoutBanner
 								level="warning"
 								title={ translate( 'Your payment settings require action' ) }
-								preferenceName="a4a-automated-referral-payment-settings-action-required"
+								onClose={ () => setRequiredNoticeClosed( true ) }
 							>
 								<div>
 									{ translate(

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -145,14 +145,14 @@ export default function ReferralsOverview( {
 									</Button>
 									{ showPopover && (
 										<A4APopover
-											// className="referral-toggle__notice"
+											className="referrals-overview__button-popover"
 											title={ translate( 'Your payment settings require action' ) }
 											offset={ 12 }
 											position="bottom left"
 											wrapperRef={ wrapperRef }
 											onFocusOutside={ () => setShowPopover( false ) }
 										>
-											<div className="referral-toggle__notice-description">
+											<div className="referrals-overview__button-popover-description">
 												{ translate(
 													'Please confirm your details before referring products to your clients.'
 												) }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -60,6 +61,8 @@ export default function ReferralsOverview( {
 			: translate( 'Referrals' );
 
 	const { data: tipaltiData, isFetching } = useGetTipaltiPayee();
+	const referralsAvailable = tipaltiData.statusType === 'success';
+
 	const { data: referrals, isFetching: isFetchingReferrals } =
 		useFetchReferrals( isAutomatedReferral );
 
@@ -92,6 +95,26 @@ export default function ReferralsOverview( {
 							onClose={ () => setReferralEmail( '' ) }
 						/>
 					) }
+					{ ! referralsAvailable && (
+						<div className="referrals-overview__notice">
+							<NoticeBanner
+								level="warning"
+								title={ translate( 'Your payment settings require action' ) }
+							>
+								<div>
+									{ translate(
+										'Please confirm your details before referring products to your clients.'
+									) }
+								</div>
+								<Button
+									className="referrals-overview__notice-button"
+									href="/referrals/payment-settings"
+								>
+									{ translate( 'Go to payment settings' ) }
+								</Button>
+							</NoticeBanner>
+						</div>
+					) }
 
 					{ ! isAutomatedReferral && <AutomatedReferralComingSoonBanner /> }
 
@@ -100,7 +123,12 @@ export default function ReferralsOverview( {
 						{ isAutomatedReferral && (
 							<Actions>
 								<MobileSidebarNavigation />
-								<Button primary href={ A4A_MARKETPLACE_PRODUCTS_LINK } onClick={ makeAReferral }>
+								<Button
+									primary
+									href={ A4A_MARKETPLACE_PRODUCTS_LINK }
+									onClick={ makeAReferral }
+									disabled={ ! referralsAvailable }
+								>
 									{ hasReferrals ? translate( 'New referral' ) : translate( 'Make a referral' ) }
 								</Button>
 							</Actions>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -47,6 +47,7 @@ export default function ReferralsOverview( {
 	const dispatch = useDispatch();
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( initialDataViewsState );
+	const [ requiredNoticeClose, setRequiredNoticeClosed ] = useState( false );
 
 	const { value: referralEmail, setValue: setReferralEmail } = useUrlQueryParam(
 		REFERRAL_EMAIL_QUERY_PARAM_KEY
@@ -64,7 +65,8 @@ export default function ReferralsOverview( {
 	const { data: tipaltiData, isFetching } = useGetTipaltiPayee();
 	const accountStatus = getAccountStatus( tipaltiData, translate );
 	const referralsAvailable = accountStatus?.statusType === 'success';
-	const actionRequiredNotice = ! isFetching && accountStatus?.statusType === 'warning';
+	const actionRequiredNotice =
+		! requiredNoticeClose && ! isFetching && accountStatus?.statusType === 'warning';
 
 	const { data: referrals, isFetching: isFetchingReferrals } =
 		useFetchReferrals( isAutomatedReferral );
@@ -103,6 +105,7 @@ export default function ReferralsOverview( {
 							<NoticeBanner
 								level="warning"
 								title={ translate( 'Your payment settings require action' ) }
+								onClose={ () => setRequiredNoticeClosed( true ) }
 							>
 								<div>
 									{ translate(

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -67,6 +67,7 @@ export default function LayoutBodyContent( {
 	}, [ dispatch ] );
 
 	const accountStatus = getAccountStatus( tipaltiData, translate );
+	const isPayable = !! tipaltiData?.IsPayable;
 
 	const hasPayeeAccount = !! accountStatus?.status;
 	let bankAccountCTAText = hasPayeeAccount
@@ -261,6 +262,7 @@ export default function LayoutBodyContent( {
 										children: translate( 'Get started' ),
 										compact: true,
 										primary: hasPayeeAccount,
+										disabled: ! isPayable,
 										href: A4A_MARKETPLACE_PRODUCTS_LINK,
 										onClick: onGetStartedClick,
 									} }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -26,9 +26,15 @@ $data-view-border-color: #f1f1f1;
 			@include a4a-font-body-md;
 		}
 
+
 		.button {
 			background-color: var(--color-accent-100);
 			color: var(--color-surface);
+
+			&:hover,
+			&:focus-visible {
+				background-color: var(--color-accent-100);
+			}
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -7,10 +7,13 @@ $data-view-border-color: #f1f1f1;
 	margin-block-end: 48px;
 }
 
-.referrals-overview__notice-button {
-	margin-block-start: 1rem;
-	background-color: var(--color-accent-100) !important;
-	color: var(--color-surface) !important;
+.theme-a8c-for-agencies {
+	.button.referrals-overview__notice-button {
+		margin-block-start: 1rem;
+		background-color: var(--color-accent-100);
+		color: var(--color-surface);
+	}
+
 }
 
 .referrals-overview__section-heading {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -13,7 +13,24 @@ $data-view-border-color: #f1f1f1;
 		background-color: var(--color-accent-100);
 		color: var(--color-surface);
 	}
+}
 
+.referrals-overview__button-popover {
+	.a4a-popover__content {
+		.a4a-popover__title {
+			@include a4a-font-heading-md;
+			color: var(--studio-gray-80);
+		}
+
+		.referrals-overview__button-popover-description {
+			@include a4a-font-body-md;
+		}
+
+		.button {
+			background-color: var(--color-accent-100);
+			color: var(--color-surface);
+		}
+	}
 }
 
 .referrals-overview__section-heading {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -7,6 +7,12 @@ $data-view-border-color: #f1f1f1;
 	margin-block-end: 48px;
 }
 
+.referrals-overview__notice-button {
+	margin-block-start: 1rem;
+	background-color: var(--color-accent-100) !important;
+	color: var(--color-surface) !important;
+}
+
 .referrals-overview__section-heading {
 	margin-block-start: 24px;
 	font-size: rem(24px);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/796

Related to https://github.com/Automattic/jetpack-genesis/issues/421

## Proposed Changes

On referrals overview page add banner in case of payment method not fully set up.

<img width="1376" alt="Screenshot 2024-07-10 at 3 07 26 PM" src="https://github.com/Automattic/wp-calypso/assets/60262784/03ec94cf-8c12-4a55-936d-1674a0cc523a">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check `/referrals/dashboard` page in these scenarios: no tipalti account (no banner, disabled button), tipalti account without full data (banner, disabled button), fully submitted tipalti account (no banner, enabled button)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
