### PR TITLE
A4A: Improve vertical alignment of the unassigned license

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -202,7 +202,7 @@ export default function LicensePreview( {
 								</a>
 							) }
 							{ ! domain && licenseState === LicenseState.Detached && (
-								<span>
+								<span className="license-preview__unassigned">
 									<Badge type="warning">{ translate( 'Unassigned' ) }</Badge>
 									{ licenseType === LicenseType.Partner && (
 										<Button

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -167,6 +167,11 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 74px;
 	.license-preview__product-small {
 		font-size: 1rem;
 	}
+
+	.license-preview__unassigned {
+		display: flex;
+		align-items: center;
+	}
 }
 
 .license-preview__bundle {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/801

## Proposed Changes

* Fix the vertical placement of the `unassigned` license label.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, the label is incorrectly placed, negatively impacting the UI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a Live Branch or run this PR locally.
* Buy a license from the Marketplace.
* Visit `/purchases/licenses/unassigned`.
* Ensure the `unassigned` license label is correctly aligned.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="1634" alt="LabelUnassigned1" src="https://github.com/Automattic/wp-calypso/assets/3418513/ce40eb63-2806-478e-b86e-5d801fe83ece">
</td>
<td>
<img width="1634" alt="LabelUnassigned2" src="https://github.com/Automattic/wp-calypso/assets/3418513/174be4cc-fd0d-4b0f-bfa2-a24a6cc37f95">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
