### PR TITLE
Add tracking for a4a site creation config feature

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { addQueryArgs } from '@wordpress/url';
@@ -158,6 +159,14 @@ export default function NeedSetup( { licenseKey }: Props ) {
 		[ createWPCOMSite, onCreateSiteSuccess ]
 	);
 
+	const onCreateSiteWithConfig = useCallback(
+		( id: number ) => {
+			recordTracksEvent( 'calypso_a4a_create_site_config' );
+			setCurrentSiteConfigurationId( id );
+		},
+		[ setCurrentSiteConfigurationId ]
+	);
+
 	const onMigrateSite = useCallback(
 		( id: number ) => {
 			createWPCOMSite(
@@ -210,7 +219,7 @@ export default function NeedSetup( { licenseKey }: Props ) {
 					isLoading={ isFetching }
 					provisioning={ isProvisioning }
 					onCreateSite={
-						isA4aSiteCreationConfigurationsEnabled ? setCurrentSiteConfigurationId : onCreateSite
+						isA4aSiteCreationConfigurationsEnabled ? onCreateSiteWithConfig : onCreateSite
 					}
 					onMigrateSite={ onMigrateSite }
 				/>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { CheckboxControl, Icon, Modal, Spinner } from '@wordpress/components';
@@ -72,13 +73,19 @@ export default function SiteConfigurationsModal( {
 		const formData = new FormData( event.currentTarget );
 		const phpVersion = formData.get( 'php_version' ) as string;
 		const primaryDataCenter = ( formData.get( 'primary_data_center' ) as string ) || undefined;
-		const params = {
-			id: siteId,
-			site_name: siteName.siteName,
+		const trackingParams = {
 			php_version: phpVersion,
 			primary_data_center: primaryDataCenter,
 			is_fully_managed_agency_site: ! allowClientsToUseSiteHelpCenter,
 		};
+		const params = {
+			...trackingParams,
+			id: siteId,
+			site_name: siteName.siteName,
+		};
+
+		recordTracksEvent( 'calypso_a4a_create_site_config_submit', trackingParams );
+
 		createWPCOMSite( params, {
 			onSuccess: () => {
 				onCreateSiteSuccess( siteId );
@@ -94,6 +101,7 @@ export default function SiteConfigurationsModal( {
 
 	const onRequestCloseModal = () => {
 		if ( ! isSubmitting ) {
+			recordTracksEvent( 'calypso_a4a_create_site_config_close' );
 			closeModal();
 		}
 	};

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useDebounce } from 'use-debounce';
@@ -147,7 +148,10 @@ export const useSiteName = (
 						nbsp: <>&nbsp;</>,
 						button: (
 							<button
-								onClick={ () => setSiteName( siteNameSuggestion ) }
+								onClick={ () => {
+									recordTracksEvent( 'calypso_a4a_create_site_config_suggested_name' );
+									setSiteName( siteNameSuggestion );
+								} }
 								className="configure-your-site-modal-form__site-name-suggestion"
 							/>
 						),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8207

## Proposed Changes

Introduce the following Tracks event to track usage of the A4A site creation configuration feature:
* `calypso_a4a_create_site_config` - When user clicks on "Create new site" to bring up the site creation configuration modal.
* `calypso_a4a_create_site_config_close` - When user closes the modal.
* `calypso_a4a_create_site_config_suggested_name` - When user clicks on the suggested site name.
* `calypso_a4a_create_site_config_submit` - When user submits the form. The respective configurations will be sent as event properties:
    * `php_version`
    * `is_fully_managed_agency_site`
    * `primary_data_center` (if one is selected)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

By introducing Tracks event to track feature usage, we'll gain understanding in:
* Common configurations agencies create sites with.
* Usability of the feature (e.g. If many users end up closing the modal, then something isn't right with our UX).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and run it locally.
* Purchase a WordPress.coms hosting license if you don't already have one.
* Go to `/sites/need-setup?flags=a4a-site-creation-configurations`
* Click "Create new site". Assert that the `calypso_a4a_create_site_config` event is fired.

<kbd>
<img width="449" alt="Screen Shot 2024-07-10 at 10 01 26 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/9efc42ad-4b08-4ade-840a-c734b03fc864" ></kbd>

* Close the modal. Assert that the `calypso_a4a_create_site_config_close` event is fired.

<kbd><img width="429" alt="Screen Shot 2024-07-10 at 10 02 47 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/5ad808df-882d-403c-83e4-3b86ad1917ba"></kbd>

* Open the modal again. Enter a site name that isn't available, click on the suggested name. Assert that the `calypso_a4a_create_site_config_suggested_name` event is fired.

<kbd><img width="421" alt="Screen Shot 2024-07-10 at 10 01 46 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/752d90ab-21ae-4769-b5d6-545cfec5c3a8"></kbd>

* Click "Create site". Assert that the `calypso_a4a_create_site_config_submit` event is fired sending the appropriate configurations as event properties.

<kbd><img width="471" alt="Screen Shot 2024-07-10 at 10 02 06 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/afa755a0-066b-4a84-97aa-b41db3fd545f"></kbd>

* Finally, we have to ensure the site is successfully created with the correct settings.
