### PR TITLE
Fix migration card layouts

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,8 +1,8 @@
-import { Card } from '@automattic/components';
-import { StepContainer, SubTitle, Title } from '@automattic/onboarding';
+import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
@@ -11,6 +11,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
+import FlowCard from '../components/flow-card';
 import type { Step } from '../../types';
 
 import './style.scss';
@@ -74,33 +75,14 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 
 	const stepContent = (
 		<>
-			<Title>{ translate( 'How do you want to migrate?' ) }</Title>
-
-			{ shouldDisplayHostIdentificationMessage && (
-				<SubTitle>
-					{
-						// translators: %(hostingProviderName)s is the name of a hosting provider (e.g. WP Engine).
-						translate( 'Your WordPress site is hosted with %(hostingProviderName)s.', {
-							args: { hostingProviderName },
-						} )
-					}
-				</SubTitle>
-			) }
-
 			<div className="how-to-migrate__list">
 				{ options.map( ( option, i ) => (
-					<Card
-						tagName="button"
-						displayAsLink
+					<FlowCard
 						key={ i }
+						title={ option.label }
+						text={ option.description }
 						onClick={ () => handleClick( option.value ) }
-					>
-						<div className="how-to-migrate__header">
-							<h2 className="how-to-migrate__name">{ option.label }</h2>
-						</div>
-
-						<p className="how-to-migrate__description">{ option.description }</p>
-					</Card>
+					/>
 				) ) }
 			</div>
 		</>
@@ -114,6 +96,21 @@ const SiteMigrationHowToMigrate: Step = function ( { navigation } ) {
 				className="how-to-migrate"
 				shouldHideNavButtons={ false }
 				hideSkip
+				formattedHeader={
+					<FormattedHeader
+						id="how-to-migrate-header"
+						headerText={ translate( 'How do you want to migrate?' ) }
+						className="how-to-migrate__formatted-header"
+						subHeaderText={
+							shouldDisplayHostIdentificationMessage
+								? translate( 'Your WordPress site is hosted with %(hostingProviderName)s.', {
+										args: { hostingProviderName },
+								  } )
+								: ''
+						}
+						align="center"
+					/>
+				}
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
 				goBack={ navigation.goBack }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
@@ -5,6 +5,12 @@
 	max-width: 602px;
 	padding: 0 12px;
 
+	@include break-large {
+		.step-container__header .how-to-migrate__formatted-header {
+			margin: 0 -24px;
+		}
+	}
+
 	.onboarding-title {
 		font-size: 2.75rem;
 		text-align: center;
@@ -19,18 +25,16 @@
 	}
 
 	.how-to-migrate__list {
-		margin-top: 50px;
 		padding-bottom: 108px;
+		display: flex;
+		flex-direction: column;
 
 		@include break-mobile {
-			margin-top: 80px;
 			padding-bottom: revert;
 		}
 
-		.card {
-			svg {
-				fill: #1e1e1e;
-			}
+		.flow-question {
+			max-width: none;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

Updates "How do you want to migrate?" step in the migration flow to use the `StepContainer` and `FlowCard` components like the previous step for better consistancy. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I initially noticed that the cards on the two steps didn't have the same hover effects, then I noticed the layout was not constant. 

**Before**
![Jul-10-2024 21-55-32](https://github.com/Automattic/wp-calypso/assets/6981253/2713f0de-2cb6-4662-b15b-0983a379e078)

**After**
![Jul-10-2024 21-55-37](https://github.com/Automattic/wp-calypso/assets/6981253/cde4350f-fe49-42b1-85db-c22f0df2c6f6)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start`
* Pick "Import existing content or website" on the Goals step
* Enter a URL or click "pick your current platform from a list" and pick WordPress
* Notice the spacing and roll over effect on the "What do you want to do?"
* Select Migrate Site
* The spacing and roll over effects should now be the same on the "How do you want to migrate?" step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
