### PR TITLE
Stats: Empty States: Update empty state for Search terms

### DIFF
--- a/client/my-sites/stats/features/modules/stats-search/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-search/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-search';

--- a/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
+++ b/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
@@ -1,6 +1,6 @@
 import { StatsCard } from '@automattic/components';
-import { mail } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { search } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -16,11 +16,10 @@ import { SUPPORT_URL } from '../../../const';
 import { useShouldGateStats } from '../../../hooks/use-should-gate-stats';
 import StatsModule from '../../../stats-module';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
-// import StatsEmptyActionSearch from '../shared/stats-empty-action-search';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
 const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
-	// period,
+	period,
 	query,
 	moduleStrings,
 	className,
@@ -54,29 +53,13 @@ const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
 			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
 				<StatsModule
 					path="searchterms"
-					// moduleStrings={ moduleStrings.search }
-					// period={ this.props.period }
+					moduleStrings={ moduleStrings }
+					period={ period }
 					query={ query }
-					statType="statsSearchTerms"
+					statType={ statType }
 					showSummaryLink
-					// className={ clsx(
-					// 	{
-					// 		// Show "Search terms" as 1/3 when it's not Jetpack ("Downloads" visible) + "Videos" is visible
-					// 		'stats__flexible-grid-item--one-third--two-spaces':
-					// 			// ! isJetpack && ! this.isModuleHidden( 'videos' ),
-					// 	},
-					// 	{
-					// 		'stats__flexible-grid-item--full--large':
-					// 			// isJetpack && this.isModuleHidden( 'videos' ),
-					// 	},
-					// 	{
-					// 		// 1/2 for all other cases to stack with Devices or empty space
-					// 		// 'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
-					// 		// Avoid 1/3 on smaller screen if Videos is visible
-					// 		// 'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
-					// 	},
-					// 	'stats__flexible-grid-item--full--medium'
-					// ) }
+					className={ className }
+					skipQuery
 				/>
 			) }
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
@@ -86,9 +69,9 @@ const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
 					isEmpty
 					emptyMessage={
 						<EmptyModuleCard
-							icon={ mail }
+							icon={ search }
 							description={ translate(
-								'Learn about your {{link}}latest search sent{{/link}} to better understand how they performed. Start sending!',
+								'Learn about {{link}}popular terms{{/link}} visitors use to find your site content on search engines.',
 								{
 									comment: '{{link}} links to support documentation.',
 									components: {
@@ -97,7 +80,6 @@ const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
 									context: 'Stats: Info box label when the Search module is empty',
 								}
 							) }
-							// cards={ <StatsEmptyActionSearch from="module_search" /> }
 						/>
 					}
 				/>

--- a/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
+++ b/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
@@ -1,0 +1,109 @@
+import { StatsCard } from '@automattic/components';
+import { mail } from '@automattic/components/src/icons';
+import { localizeUrl } from '@automattic/i18n-utils';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { useSelector } from 'calypso/state';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { SUPPORT_URL } from '../../../const';
+import { useShouldGateStats } from '../../../hooks/use-should-gate-stats';
+import StatsModule from '../../../stats-module';
+import StatsCardSkeleton from '../shared/stats-card-skeleton';
+// import StatsEmptyActionSearch from '../shared/stats-empty-action-search';
+import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
+
+const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
+	// period,
+	query,
+	moduleStrings,
+	className,
+}: StatsDefaultModuleProps ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsSearchTerms';
+
+	const shouldGateStatsModule = useShouldGateStats( statType );
+
+	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	return (
+		<>
+			{ ! shouldGateStatsModule && siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
+			{ isRequestingData && (
+				<StatsCardSkeleton
+					isLoading={ isRequestingData }
+					className={ className }
+					title={ moduleStrings.title }
+					type={ 2 }
+				/>
+			) }
+			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
+				<StatsModule
+					path="searchterms"
+					// moduleStrings={ moduleStrings.search }
+					// period={ this.props.period }
+					query={ query }
+					statType="statsSearchTerms"
+					showSummaryLink
+					// className={ clsx(
+					// 	{
+					// 		// Show "Search terms" as 1/3 when it's not Jetpack ("Downloads" visible) + "Videos" is visible
+					// 		'stats__flexible-grid-item--one-third--two-spaces':
+					// 			// ! isJetpack && ! this.isModuleHidden( 'videos' ),
+					// 	},
+					// 	{
+					// 		'stats__flexible-grid-item--full--large':
+					// 			// isJetpack && this.isModuleHidden( 'videos' ),
+					// 	},
+					// 	{
+					// 		// 1/2 for all other cases to stack with Devices or empty space
+					// 		// 'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
+					// 		// Avoid 1/3 on smaller screen if Videos is visible
+					// 		// 'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
+					// 	},
+					// 	'stats__flexible-grid-item--full--medium'
+					// ) }
+				/>
+			) }
+			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
+				<StatsCard
+					className={ clsx( 'stats-card--empty-variant', className ) }
+					title={ translate( 'Search' ) }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ mail }
+							description={ translate(
+								'Learn about your {{link}}latest search sent{{/link}} to better understand how they performed. Start sending!',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: <a href={ localizeUrl( `${ SUPPORT_URL }#search` ) } />,
+									},
+									context: 'Stats: Info box label when the Search module is empty',
+								}
+							) }
+							// cards={ <StatsEmptyActionSearch from="module_search" /> }
+						/>
+					}
+				/>
+			) }
+		</>
+	);
+};
+
+export default StatSearch;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -53,6 +53,7 @@ import StatsModuleDevices, {
 } from './features/modules/stats-devices';
 import StatsModuleEmails from './features/modules/stats-emails';
 import StatsModuleReferrers from './features/modules/stats-referrers';
+import StatsModuleSearch from './features/modules/stats-search';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
 import StatsModuleUTM, { StatsModuleUTMOverlay } from './features/modules/stats-utm';
 import HighlightsSection from './highlights-section';
@@ -636,6 +637,35 @@ class StatsSite extends Component {
 											( ! supportsUTMStats && ! this.isModuleHidden( 'authors' ) ),
 									},
 									'stats__flexible-grid-item--full--large',
+									'stats__flexible-grid-item--full--medium'
+								) }
+							/>
+						) }
+
+						{ isNewStateEnabled && (
+							<StatsModuleSearch
+								path="searchterms"
+								moduleStrings={ moduleStrings.search }
+								period={ this.props.period }
+								query={ query }
+								statType="statsSearchTerms"
+								showSummaryLink
+								className={ clsx(
+									{
+										// Show "Search terms" as 1/3 when it's not Jetpack ("Downloads" visible) + "Videos" is visible
+										'stats__flexible-grid-item--one-third--two-spaces':
+											! isJetpack && ! this.isModuleHidden( 'videos' ),
+									},
+									{
+										'stats__flexible-grid-item--full--large':
+											isJetpack && this.isModuleHidden( 'videos' ),
+									},
+									{
+										// 1/2 for all other cases to stack with Devices or empty space
+										'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
+										// Avoid 1/3 on smaller screen if Videos is visible
+										'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
+									},
 									'stats__flexible-grid-item--full--medium'
 								) }
 							/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -644,6 +644,33 @@ class StatsSite extends Component {
 
 						{ isNewStateEnabled && (
 							<StatsModuleSearch
+								moduleStrings={ moduleStrings.search }
+								period={ this.props.period }
+								query={ query }
+								statType="statsSearchTerms"
+								showSummaryLink
+								className={ clsx(
+									{
+										// Show "Search terms" as 1/3 when it's not Jetpack ("Downloads" visible) + "Videos" is visible
+										'stats__flexible-grid-item--one-third--two-spaces':
+											! isJetpack && ! this.isModuleHidden( 'videos' ),
+									},
+									{
+										'stats__flexible-grid-item--full--large':
+											isJetpack && this.isModuleHidden( 'videos' ),
+									},
+									{
+										// 1/2 for all other cases to stack with Devices or empty space
+										'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
+										// Avoid 1/3 on smaller screen if Videos is visible
+										'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
+									},
+									'stats__flexible-grid-item--full--medium'
+								) }
+							/>
+						) }
+						{ ! isNewStateEnabled && (
+							<StatsModule
 								path="searchterms"
 								moduleStrings={ moduleStrings.search }
 								period={ this.props.period }
@@ -670,33 +697,6 @@ class StatsSite extends Component {
 								) }
 							/>
 						) }
-
-						<StatsModule
-							path="searchterms"
-							moduleStrings={ moduleStrings.search }
-							period={ this.props.period }
-							query={ query }
-							statType="statsSearchTerms"
-							showSummaryLink
-							className={ clsx(
-								{
-									// Show "Search terms" as 1/3 when it's not Jetpack ("Downloads" visible) + "Videos" is visible
-									'stats__flexible-grid-item--one-third--two-spaces':
-										! isJetpack && ! this.isModuleHidden( 'videos' ),
-								},
-								{
-									'stats__flexible-grid-item--full--large':
-										isJetpack && this.isModuleHidden( 'videos' ),
-								},
-								{
-									// 1/2 for all other cases to stack with Devices or empty space
-									'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
-									// Avoid 1/3 on smaller screen if Videos is visible
-									'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
-								},
-								'stats__flexible-grid-item--full--medium'
-							) }
-						/>
 
 						{ ! this.isModuleHidden( 'videos' ) && (
 							<StatsModule

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -647,7 +647,6 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.search }
 								period={ this.props.period }
 								query={ query }
-								statType="statsSearchTerms"
 								showSummaryLink
 								className={ clsx(
 									{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/67

## Proposed Changes

* update the Email module with a new empty state and place it behind a feature flag
* refactor TS definitions
* add the new skeleton loader to the module
* add the new `useShouldGateStats` check

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* for the empty states project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply `stats/empty-module-traffic` feature flag
* verify that a page with an empty component works with and without the feature flag
* repeat for blogs with search data
* check that the advanced feature overlay works properly
* check that the new empty state only shows up after applying the feature flag

![image](https://github.com/Automattic/wp-calypso/assets/30754158/570718d1-8531-4def-af5a-2288c3c7d788)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?