### PR TITLE
Stats: Adding empty state component for Downloads module

### DIFF
--- a/client/my-sites/stats/components/empty-state-action/empty-state-action.tsx
+++ b/client/my-sites/stats/components/empty-state-action/empty-state-action.tsx
@@ -27,7 +27,11 @@ const EmptyStateAction: React.FC< EmptyStateActionProps > = ( {
 	};
 
 	return (
-		<Card className="stats-empty-action__cta" size="small" onClick={ handleClick }>
+		<Card
+			className="stats-empty-action__cta stats-empty-action__cta-parent"
+			size="small"
+			onClick={ handleClick }
+		>
 			<CardBody className="stats-empty-action__card-body">
 				<Icon className="stats-empty-action__cta-link-icon" icon={ icon } size={ 20 } />
 				<span className="stats-empty-action__cta-link-text">{ text }</span>

--- a/client/my-sites/stats/components/empty-state-action/styles.scss
+++ b/client/my-sites/stats/components/empty-state-action/styles.scss
@@ -4,21 +4,24 @@
 @import "@automattic/components/src/styles/typography";
 
 .stats-empty-action__cta {
-	height: 52px;
-	margin-bottom: 12px;
-	border: 1px solid $studio-gray-5;
-	border-radius: 4px;
-	box-shadow: none;
-	width: 100%;
-	cursor: pointer;
+	// this needs an extra class because it' sometimes overwritten by build CSS file order
+	&.stats-empty-action__cta-parent {
+		height: 52px;
+		margin-bottom: 12px;
+		border: 1px solid $studio-gray-5;
+		border-radius: 4px;
+		box-shadow: none;
+		width: 100%;
+		cursor: pointer;
 
-	&:hover {
-		background: $studio-gray-0;
-		border: 1px solid $studio-gray-80;
-	}
+		&:hover {
+			background: $studio-gray-0;
+			border: 1px solid $studio-gray-80;
+		}
 
-	&:last-child {
-		margin-bottom: 0;
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	.stats-empty-action__card-body {
@@ -32,11 +35,11 @@
 	}
 
 	.stats-empty-action__cta-link-text {
-		color: $studio-gray-80 !important;
+		color: $studio-gray-80;
 		flex-grow: 1;
 	}
 
 	.stats-empty-action__cta-link-icon {
-		color: $studio-gray-90 !important;
+		color: $studio-gray-90;
 	}
 }

--- a/client/my-sites/stats/features/modules/stats-downloads/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-downloads/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-downloads';

--- a/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
+++ b/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
@@ -1,0 +1,99 @@
+import { StatsCard } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { customLink } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import EmptyModuleCard from 'calypso/my-sites/stats/components/empty-module-card/empty-module-card';
+import { SUPPORT_URL } from 'calypso/my-sites/stats/const';
+import StatsCardSkeleton from 'calypso/my-sites/stats/features/modules/shared/stats-card-skeleton';
+import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
+import StatsModule from 'calypso/my-sites/stats/stats-module';
+import { useSelector } from 'calypso/state';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type {
+	StatsDefaultModuleProps,
+	StatsStateProps,
+} from 'calypso/my-sites/stats/features/modules/types';
+
+const StatsDownloads: React.FC< StatsDefaultModuleProps > = ( {
+	period,
+	query,
+	moduleStrings,
+	className,
+} ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsFileDownloads';
+
+	// Use StatsModule to display paywall upsell.
+	const shouldGateStatsModule = useShouldGateStats( statType );
+
+	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	return (
+		<>
+			{ ! shouldGateStatsModule && siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
+			{ isRequestingData && (
+				<StatsCardSkeleton
+					isLoading={ isRequestingData }
+					className={ className }
+					title={ moduleStrings.title }
+					type={ 3 }
+				/>
+			) }
+			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
+				// show data or an overlay
+				<StatsModule
+					metricLabel={ translate( 'Downloads' ) }
+					useShortLabel
+					path="filedownloads"
+					moduleStrings={ moduleStrings }
+					period={ period }
+					query={ query }
+					statType={ statType }
+					showSummaryLink
+					className={ className }
+					skipQuery
+				/>
+			) }
+			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
+				// show empty state
+				<StatsCard
+					className={ clsx( 'stats-card--empty-variant', className ) } // when removing stats/empty-module-traffic add this to the root of the card
+					title={ moduleStrings.title }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ customLink }
+							description={ translate(
+								'Your most {{link}}downloaded files{{/link}} will display here.',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: <a href={ localizeUrl( `${ SUPPORT_URL }#file-downloads` ) } />,
+									},
+									context: 'Stats: Info box label when the file downloads module is empty',
+								}
+							) }
+						/>
+					}
+				/>
+			) }
+		</>
+	);
+};
+
+export default StatsDownloads;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -51,6 +51,7 @@ import StatsModuleCountries from './features/modules/stats-countries';
 import StatsModuleDevices, {
 	StatsModuleUpgradeDevicesOverlay,
 } from './features/modules/stats-devices';
+import StatsModuleDownloads from './features/modules/stats-downloads';
 import StatsModuleEmails from './features/modules/stats-emails';
 import StatsModuleReferrers from './features/modules/stats-referrers';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
@@ -686,10 +687,36 @@ class StatsSite extends Component {
 								) }
 							/>
 						) }
+
 						{
-							// File downloads are not yet supported in Jetpack Stats
+							// File downloads are not yet supported in Jetpack environment
+							isNewStateEnabled && ! isJetpack && (
+								<StatsModuleDownloads
+									moduleStrings={ moduleStrings.filedownloads }
+									period={ this.props.period }
+									query={ query }
+									className={ clsx(
+										{
+											'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),
+										},
+										{
+											'stats__flexible-grid-item--one-third--two-spaces':
+												! this.isModuleHidden( 'videos' ),
+										},
+
+										{
+											// Avoid 1/3 on smaller screen if Videos is visible
+											'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),
+										},
+										'stats__flexible-grid-item--full--medium'
+									) }
+								/>
+							)
+						}
+						{
+							// File downloads are not yet supported in Jetpack environment
 							// TODO: Confirm the above statement.
-							! isJetpack && (
+							! isNewStateEnabled && ! isJetpack && (
 								<StatsModule
 									path="filedownloads"
 									metricLabel={ translate( 'Downloads' ) }

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -148,6 +148,7 @@
 		display: flex;
 		flex: 1 0 auto;
 		align-items: center;
+		justify-content: center;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/69

## Proposed Changes

* adding an empty state to the Downloads module
* fixing module alignment
* updating empty action card CSS and ensuring it is always applied

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* a part of the empty states project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply `stats/empty-module-traffic` feature flag
* verify that a page with an empty Downloads component works with and without the feature flag
* repeat for blogs with data

![SCR-20240711-magg](https://github.com/Automattic/wp-calypso/assets/112354940/82eba904-93fb-43ef-9bbe-002b25a37b4e)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?