### PR TITLE
Assembler: Remove survey banner

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -91,11 +91,7 @@ const ScreenConfirmation = ( {
 					) ) }
 				</VStack>
 				{ ! surveyDismissed && isEnglishLocale && (
-					<Survey
-						eventName="assembler-january-2024"
-						eventUrl="https://automattic.survey.fm/assembler-simple-survey"
-						setSurveyDismissed={ setSurveyDismissed }
-					/>
+					<Survey setSurveyDismissed={ setSurveyDismissed } />
 				) }
 			</div>
 			<div className="screen-container__footer">


### PR DESCRIPTION
## Proposed Changes

This PR removes the survey banner as discussed in p1720620934370169-slack-C048CUFRGFQ.

| Before | After |
| --- | --- |
| ![Screenshot 2024-07-11 at 1 31 55 PM](https://github.com/Automattic/wp-calypso/assets/797888/1f3cc769-5777-48be-a770-e2260c4adddb) | ![Screenshot 2024-07-11 at 1 32 14 PM](https://github.com/Automattic/wp-calypso/assets/797888/00fc696b-e3de-4a0f-8fd6-8abcf07f65c7) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

No need to gather user feedback at the moment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Continue the Assembler until you reach the confirmation screen.
* Ensure that the survey is no longer available.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?