### PR TITLE
A4A > Referrals: Fix the referral price rounding issue

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
@@ -22,7 +22,7 @@ const TotalAmount = ( { purchase, data, isFetching }: Props ) => {
 
 	return product?.amount ? (
 		translate( '%(total)s/mo', {
-			args: { total: formatCurrency( parseInt( product.amount ), product.currency ?? 'USD' ) },
+			args: { total: formatCurrency( Number( product.amount ?? 0 ), product.currency ?? 'USD' ) },
 		} )
 	) : (
 		<Gridicon icon="minus" />


### PR DESCRIPTION
## Proposed Changes

This PR fixes the referral price rounding issue.

We were earlier using `parseInt,` which converted the number to a whole number, removing the decimal points. 

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals - Dashboard > Open detailed view of any client > Verify that the price now has decimal points and the value is accurate and matches the Marketplace prices. 

| Before | After |
|--------|--------|
| <img width="1050" alt="Screenshot 2024-07-11 at 11 22 23 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/23b211cf-9634-4ef1-b4e8-9b810731c651">| <img width="1050" alt="Screenshot 2024-07-11 at 11 22 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7f6c05c6-7662-4d3b-b422-41f98185b67c">| 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
