### PR TITLE
Gravatar: Hide the "Sign in another way" link on the signup page

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -923,6 +923,7 @@ class MagicLogin extends Component {
 		const { isRequestingEmail, requestEmailErrorMessage } = this.state;
 
 		const isGravatar = isGravatarOAuth2Client( oauth2Client );
+		const isFromGravatarSignup = isGravatar && query?.gravatar_from === 'signup';
 		const submitButtonLabel = isGravatar
 			? translate( 'Continue' )
 			: translate( 'Send me sign in link' );
@@ -1079,23 +1080,25 @@ class MagicLogin extends Component {
 					{ ! isGravatar && (
 						<hr className="grav-powered-magic-login__divider grav-powered-magic-login__divider--email-form" />
 					) }
-					<footer className="grav-powered-magic-login__footer grav-powered-magic-login__footer--email-form">
-						{ translate( '{{a}}Sign in another way{{/a}}', {
-							components: {
-								a: (
-									<a
-										href={ loginUrl }
-										onClick={ () =>
-											this.props.recordTracksEvent(
-												'calypso_gravatar_powered_magic_login_click_login_page_link',
-												{ client_id: oauth2Client.id, client_name: oauth2Client.name }
-											)
-										}
-									/>
-								),
-							},
-						} ) }
-					</footer>
+					{ ! isFromGravatarSignup && (
+						<footer className="grav-powered-magic-login__footer grav-powered-magic-login__footer--email-form">
+							{ translate( '{{a}}Sign in another way{{/a}}', {
+								components: {
+									a: (
+										<a
+											href={ loginUrl }
+											onClick={ () =>
+												this.props.recordTracksEvent(
+													'calypso_gravatar_powered_magic_login_click_login_page_link',
+													{ client_id: oauth2Client.id, client_name: oauth2Client.name }
+												)
+											}
+										/>
+									),
+								},
+							} ) }
+						</footer>
+					) }
 				</div>
 				{ ! isGravatar && (
 					<div className="grav-powered-magic-login__gravatar-info">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 108332-gh-Automattic/gravatar

## Proposed Changes

* Hide the "Sign in another way" link on the signup page only

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Please refer to 108332-gh-Automattic/gravatar

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Setup Calypso](https://github.com/Automattic/wp-calypso?tab=readme-ov-file#getting-started)
* Check out this PR, and run `yarn start`
* Logout your account
* Go to the Gravatar signup page via [this URL](http://calypso.localhost:3000/log-in/link?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D501c992bba35eec2a189fa5ac204305203ce020aa5a1490255a94cc904783d57%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26gravatar_from%3Dsignup%26from-calypso%3D1&gravatar_from=signup), and you won't see the "Sign in another way" link:

<img width="507" alt="截圖 2024-07-11 下午3 01 08" src="https://github.com/Automattic/wp-calypso/assets/21308003/050d6ec2-18b8-46d3-ab1a-ee1fa0530966">

* Go to the Gravatar login page via [this URL](http://calypso.localhost:3000/log-in/link?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D501c992bba35eec2a189fa5ac204305203ce020aa5a1490255a94cc904783d57%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26gravatar_from%3Dsignup%26from-calypso%3D1), you will see the "Sign in another way" link:

<img width="503" alt="截圖 2024-07-11 下午3 07 34" src="https://github.com/Automattic/wp-calypso/assets/21308003/07ad8486-8b37-4b0b-b32f-4cbe96c88401">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
