### PR TITLE
Stats: Empty States: Update empty state for Videos

### DIFF
--- a/client/my-sites/stats/features/modules/shared/stats-empty-action-video.tsx
+++ b/client/my-sites/stats/features/modules/shared/stats-empty-action-video.tsx
@@ -1,0 +1,37 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { upload } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import EmptyStateAction from '../../../components/empty-state-action';
+
+type StatsEmptyActionEmailProps = {
+	from: string;
+};
+
+// TODO: move to a shared file if this is the final URL
+const JETPACK_SUPPORT_VIDEOPRESS_URL = 'https://jetpack.com/support/videopress';
+
+const StatsEmptyActionEmail: React.FC< StatsEmptyActionEmailProps > = ( { from } ) => {
+	const translate = useTranslate();
+
+	return (
+		<EmptyStateAction
+			icon={ upload }
+			text={ translate( 'Upload videos with VideoPress' ) }
+			analyticsDetails={ {
+				from: from,
+				feature: 'videopress',
+			} }
+			onClick={ () => {
+				// analytics event tracting handled in EmptyStateAction component
+
+				setTimeout(
+					() => ( window.location.href = localizeUrl( JETPACK_SUPPORT_VIDEOPRESS_URL ) ),
+					250
+				);
+			} }
+		/>
+	);
+};
+
+export default StatsEmptyActionEmail;

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -19,7 +19,7 @@ import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import StatsEmptyActionEmail from '../shared/stats-empty-action-email';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
-const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
+const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 	period,
 	query,
 	moduleStrings,
@@ -105,4 +105,4 @@ const StatEmails: React.FC< StatsDefaultModuleProps > = ( {
 	);
 };
 
-export default StatEmails;
+export default StatsEmails;

--- a/client/my-sites/stats/features/modules/stats-referrers/index.ts
+++ b/client/my-sites/stats/features/modules/stats-referrers/index.ts
@@ -1,1 +1,1 @@
-export { default } from './stats-referrers';
+export { default } from './stats-videos';

--- a/client/my-sites/stats/features/modules/stats-referrers/index.ts
+++ b/client/my-sites/stats/features/modules/stats-referrers/index.ts
@@ -1,1 +1,1 @@
-export { default } from './stats-videos';
+export { default } from './stats-referrers';

--- a/client/my-sites/stats/features/modules/stats-videos/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/index.tsx
@@ -1,1 +1,1 @@
-export { default } from './stats-emails';
+export { default } from './stats-videos';

--- a/client/my-sites/stats/features/modules/stats-videos/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-emails';

--- a/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
@@ -60,6 +60,7 @@ const StatsVideos: React.FC< StatsDefaultModuleProps > = ( {
 					statType="statsVideoPlays"
 					showSummaryLink
 					className={ className }
+					skipQuery
 				/>
 			) }
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (

--- a/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
@@ -1,6 +1,6 @@
 import { StatsCard } from '@automattic/components';
-import { mail } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { video } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -85,7 +85,7 @@ const StatVideos: React.FC< StatsDefaultModuleProps > = ( {
 					isEmpty
 					emptyMessage={
 						<EmptyModuleCard
-							icon={ mail }
+							icon={ video }
 							description={ translate(
 								'Learn about your {{link}}most popular videos{{/link}} to better understand how they performed. Start uploading!',
 								{

--- a/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
@@ -16,7 +16,7 @@ import { SUPPORT_URL } from '../../../const';
 import { useShouldGateStats } from '../../../hooks/use-should-gate-stats';
 import StatsModule from '../../../stats-module';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
-// import StatsEmptyActionVideo from '../shared/stats-empty-action-video';
+import StatsEmptyActionVideo from '../shared/stats-empty-action-video';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
 const StatsVideos: React.FC< StatsDefaultModuleProps > = ( {
@@ -80,7 +80,7 @@ const StatsVideos: React.FC< StatsDefaultModuleProps > = ( {
 									context: 'Stats: Info box label when the Videos module is empty',
 								}
 							) }
-							// cards={ <StatsEmptyActionVideo from="module_videos" /> }
+							cards={ <StatsEmptyActionVideo from="module_videos" /> }
 						/>
 					}
 				/>

--- a/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
@@ -16,10 +16,10 @@ import { SUPPORT_URL } from '../../../const';
 import { useShouldGateStats } from '../../../hooks/use-should-gate-stats';
 import StatsModule from '../../../stats-module';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
-import StatsEmptyActionVideo from '../shared/stats-empty-action-email';
+// import StatsEmptyActionVideo from '../shared/stats-empty-action-video';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
-const StatVideos: React.FC< StatsDefaultModuleProps > = ( {
+const StatsVideos: React.FC< StatsDefaultModuleProps > = ( {
 	period,
 	query,
 	moduleStrings,
@@ -80,7 +80,7 @@ const StatVideos: React.FC< StatsDefaultModuleProps > = ( {
 									context: 'Stats: Info box label when the Videos module is empty',
 								}
 							) }
-							cards={ <StatsEmptyActionVideo from="module_videos" /> }
+							// cards={ <StatsEmptyActionVideo from="module_videos" /> }
 						/>
 					}
 				/>
@@ -89,4 +89,4 @@ const StatVideos: React.FC< StatsDefaultModuleProps > = ( {
 	);
 };
 
-export default StatVideos;
+export default StatsVideos;

--- a/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
@@ -27,7 +27,7 @@ const StatVideos: React.FC< StatsDefaultModuleProps > = ( {
 }: StatsDefaultModuleProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const statType = 'statsVideosSummary';
+	const statType = 'statsVideoPlays';
 
 	const shouldGateStatsModule = useShouldGateStats( statType );
 

--- a/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
@@ -53,29 +53,13 @@ const StatVideos: React.FC< StatsDefaultModuleProps > = ( {
 			) }
 			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
 				<StatsModule
-					additionalColumns={ {
-						header: (
-							<>
-								<span>{ translate( 'Opens' ) }</span>
-							</>
-						),
-						body: ( item: { opens: number } ) => (
-							<>
-								<span>{ item.opens }</span>
-							</>
-						),
-					} }
-					path="videos"
+					path="videoplays"
 					moduleStrings={ moduleStrings }
 					period={ period }
 					query={ query }
-					statType="statsVideosSummary"
-					mainItemLabel={ translate( 'Latest Videos' ) }
-					metricLabel={ translate( 'Clicks' ) }
+					statType="statsVideoPlays"
 					showSummaryLink
 					className={ className }
-					hasNoBackground
-					skipQuery
 				/>
 			) }
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (

--- a/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
@@ -1,0 +1,108 @@
+import { StatsCard } from '@automattic/components';
+import { mail } from '@automattic/components/src/icons';
+import { localizeUrl } from '@automattic/i18n-utils';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { useSelector } from 'calypso/state';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { SUPPORT_URL } from '../../../const';
+import { useShouldGateStats } from '../../../hooks/use-should-gate-stats';
+import StatsModule from '../../../stats-module';
+import StatsCardSkeleton from '../shared/stats-card-skeleton';
+import StatsEmptyActionVideo from '../shared/stats-empty-action-email';
+import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
+
+const StatVideos: React.FC< StatsDefaultModuleProps > = ( {
+	period,
+	query,
+	moduleStrings,
+	className,
+}: StatsDefaultModuleProps ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsVideosSummary';
+
+	const shouldGateStatsModule = useShouldGateStats( statType );
+
+	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	return (
+		<>
+			{ ! shouldGateStatsModule && siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
+			) }
+			{ isRequestingData && (
+				<StatsCardSkeleton
+					isLoading={ isRequestingData }
+					className={ className }
+					title={ moduleStrings.title }
+					type={ 2 }
+				/>
+			) }
+			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
+				<StatsModule
+					additionalColumns={ {
+						header: (
+							<>
+								<span>{ translate( 'Opens' ) }</span>
+							</>
+						),
+						body: ( item: { opens: number } ) => (
+							<>
+								<span>{ item.opens }</span>
+							</>
+						),
+					} }
+					path="videos"
+					moduleStrings={ moduleStrings }
+					period={ period }
+					query={ query }
+					statType="statsVideosSummary"
+					mainItemLabel={ translate( 'Latest Videos' ) }
+					metricLabel={ translate( 'Clicks' ) }
+					showSummaryLink
+					className={ className }
+					hasNoBackground
+					skipQuery
+				/>
+			) }
+			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
+				<StatsCard
+					className={ clsx( 'stats-card--empty-variant', className ) }
+					title={ translate( 'Videos' ) }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ mail }
+							description={ translate(
+								'Learn about your {{link}}most popular videos{{/link}} to better understand how they performed. Start uploading!',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: <a href={ localizeUrl( `${ SUPPORT_URL }#videos` ) } />,
+									},
+									context: 'Stats: Info box label when the Videos module is empty',
+								}
+							) }
+							cards={ <StatsEmptyActionVideo from="module_videos" /> }
+						/>
+					}
+				/>
+			) }
+		</>
+	);
+};
+
+export default StatVideos;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -698,7 +698,24 @@ class StatsSite extends Component {
 							/>
 						) }
 
-						{ ! this.isModuleHidden( 'videos' ) && (
+						{ isNewStateEnabled && ! this.isModuleHidden( 'videos' ) && (
+							<StatsModule
+								moduleStrings={ moduleStrings.videoplays }
+								period={ this.props.period }
+								query={ query }
+								showSummaryLink
+								className={ clsx(
+									{
+										'stats__flexible-grid-item--one-third--two-spaces': ! isJetpack, // 1/3 when Downloads is supported, 1/2 for Jetpack
+										'stats__flexible-grid-item--half': isJetpack,
+									},
+									'stats__flexible-grid-item--full--large',
+									'stats__flexible-grid-item--full--medium'
+								) }
+							/>
+						) }
+
+						{ ! isNewStateEnabled && ! this.isModuleHidden( 'videos' ) && (
 							<StatsModule
 								path="videoplays"
 								moduleStrings={ moduleStrings.videoplays }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -57,6 +57,7 @@ import StatsModuleReferrers from './features/modules/stats-referrers';
 import StatsModuleSearch from './features/modules/stats-search';
 import StatsModuleTopPosts from './features/modules/stats-top-posts';
 import StatsModuleUTM, { StatsModuleUTMOverlay } from './features/modules/stats-utm';
+import StatsModuleVideos from './features/modules/stats-videos';
 import HighlightsSection from './highlights-section';
 import { shouldGateStats } from './hooks/use-should-gate-stats';
 import MiniCarousel from './mini-carousel';
@@ -648,7 +649,6 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.search }
 								period={ this.props.period }
 								query={ query }
-								showSummaryLink
 								className={ clsx(
 									{
 										// Show "Search terms" as 1/3 when it's not Jetpack ("Downloads" visible) + "Videos" is visible
@@ -699,11 +699,10 @@ class StatsSite extends Component {
 						) }
 
 						{ isNewStateEnabled && ! this.isModuleHidden( 'videos' ) && (
-							<StatsModule
+							<StatsModuleVideos
 								moduleStrings={ moduleStrings.videoplays }
 								period={ this.props.period }
 								query={ query }
-								showSummaryLink
 								className={ clsx(
 									{
 										'stats__flexible-grid-item--one-third--two-spaces': ! isJetpack, // 1/3 when Downloads is supported, 1/2 for Jetpack


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/68

## Proposed Changes

* update the Video module with a new empty state and place it behind a feature flag
* refactor TS definitions
* add the new skeleton loader to the module
* add the new `useShouldGateStats` check

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* for the empty states project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply `stats/empty-module-traffic` feature flag
* verify that a page with an empty Video component works with and without the feature flag
* repeat for blogs with Video data
* check that the advanced feature overlay works properly
* check that the new empty state only shows up after applying the feature flag

![image](https://github.com/Automattic/wp-calypso/assets/30754158/7c9630e6-73ac-458d-8160-fae7565d7e57)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
