### PR TITLE
Migrate upgrade step: pass site ID to pricing hook

### DIFF
--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -165,12 +165,7 @@ const WrappedStepUpgrade = ( props ) => {
 	const pricingMeta = Plans.usePricingMetaForGridPlans( {
 		planSlugs: [ planSlug ],
 		coupon: undefined,
-		/**
-		 * null site ID means we're fetching global (non-site-specific) pricing.
-		 * once https://github.com/Automattic/martech/issues/3142 is addressed, we should be able
-		 * to grab currency discounts with a site ID.
-		 */
-		siteId: null,
+		siteId: targetSite.ID,
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/92270#issuecomment-2222211490

## Proposed Changes

* Passes the `siteId` to the `usePricingMetaForGridPlans` hook in the upgrade step of the migration flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes a case where currency discounts were shown for paid plans. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as #92270.
* For a site on a free plan, currency discounts should be shown:
* ![image](https://github.com/Automattic/wp-calypso/assets/5436027/e01f1684-45a9-4dc9-8e18-5f07070ca489)
* For a site on a paid plan, currency discounts should not be shown:
* ![image](https://github.com/Automattic/wp-calypso/assets/5436027/4c0cc2ad-21c3-4003-9f29-9156eac9c2e3)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
