### PR TITLE
A4A > Referrals: Enhance the referral table horizontal scroll

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -51,6 +51,44 @@ $data-view-border-color: #f1f1f1;
 }
 
 .referrals-layout--automated {
+	@media (min-width: $break-large) {
+		background: inherit;
+
+		.dataviews-view-table thead {
+			position: sticky;
+			top: 0;
+			z-index: 2;
+		}
+
+		.dataviews-wrapper tr.dataviews-view-table__row th {
+			text-wrap: nowrap;
+		}
+
+		.dataviews-view-table tr th:first-child,
+		.dataviews-view-table tr td:first-child {
+			padding-inline-start: 64px;
+		}
+		.dataviews-view-table tr {
+			th:last-child,
+			td:last-child {
+				padding-inline-end: 64px;
+				width: 20px;
+				white-space: nowrap;
+				position: sticky;
+				right: 0;
+				z-index: 1;
+				background: linear-gradient(to right, transparent 0%, #fff 25%);
+			}
+
+			&:hover {
+				th:last-child,
+				td:last-child {
+					background: linear-gradient(to right, transparent 0%, var(--color-neutral-0) 25%);
+				}
+			}
+		}
+	}
+
 	.referrals-overview__section-container {
 		gap: 32px;
 	}


### PR DESCRIPTION
## Proposed Changes

This PR enhances the referral table scroll. The experience is the same as the sites' dashboard by making the actions sticky.

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals - Dashboard > Switch any view >960px and verify the horizontal scroll on the table works as shown below:


https://github.com/Automattic/wp-calypso/assets/10586875/e38c07c7-76bf-4fd7-b815-1d261fddafe0



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
