### PR TITLE
A4A > Referrals: Implement commissions for Referrals

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pricing-summary.tsx
@@ -2,6 +2,7 @@ import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import CommissionsInfo from '../commissions-info';
 import ShoppingCartMenuItem from '../shopping-cart/shopping-cart-menu/item';
 import { useTotalInvoiceValue } from '../wpcom-overview/hooks/use-total-invoice-value';
 import type { ShoppingCartItem } from '../types';
@@ -76,6 +77,7 @@ export default function PricingSummary( {
 					} ) }
 				</span>
 			</div>
+			{ isAutomatedReferrals && <CommissionsInfo items={ items } /> }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
@@ -1,0 +1,30 @@
+import { formatCurrency } from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { getProductCommissionPercentage } from '../../referrals/lib/commissions';
+import type { ShoppingCartItem } from '../types';
+
+import './style.scss';
+
+export default function CommissionsInfo( { items }: { items: ShoppingCartItem[] } ) {
+	const translate = useTranslate();
+
+	const totalCommissions = items.reduce( ( acc, item ) => {
+		const product = item;
+		const commissionPercentage = getProductCommissionPercentage( product );
+		const totalCommissions = product?.amount ? Number( product.amount ) * commissionPercentage : 0;
+		return acc + totalCommissions;
+	}, 0 );
+
+	return (
+		<div className="commissions-info">
+			<span>{ translate( 'Your estimated commision:' ) }</span>
+			<span>
+				{ translate( '%(total)s/mo', {
+					args: {
+						total: formatCurrency( totalCommissions, 'USD' ),
+					},
+				} ) }
+			</span>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/commissions-info/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/commissions-info/style.scss
@@ -1,0 +1,9 @@
+.commissions-info {
+	color: var(--color-success);
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	font-weight: 500;
+	font-size: 1rem;
+	line-height: 1.5;
+}

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/index.tsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import CommissionsInfo from '../../commissions-info';
 import { MarketplaceTypeContext } from '../../context';
 import { useTotalInvoiceValue } from '../../wpcom-overview/hooks/use-total-invoice-value';
 import ShoppingCartMenuItem from './item';
@@ -73,6 +74,8 @@ export default function ShoppingCartMenu( { onClose, onCheckout, onRemoveItem, i
 							} ) }
 						</span>
 					</div>
+
+					{ marketplaceType === 'referral' && <CommissionsInfo items={ items } /> }
 
 					<Button
 						className="shopping-cart__menu-checkout-button"

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
@@ -83,16 +83,6 @@
 	align-items: stretch;
 }
 
-.shopping-cart__menu-commission {
-	color: var(--color-success);
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	font-weight: 500;
-	font-size: 1rem;
-	line-height: 1.5;
-}
-
 .shopping-cart__menu-total {
 	display: flex;
 	flex-direction: row;

--- a/client/a8c-for-agencies/sections/referrals/common/referral-details-table/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/referral-details-table/index.tsx
@@ -7,17 +7,15 @@ import type { DataViewsColumn } from 'calypso/a8c-for-agencies/components/items-
 import './style.scss';
 
 interface Props {
-	heading: string;
 	items: ReferralPurchase[]; // Update this when we have more types
 	fields: DataViewsColumn[];
 }
 
-export default function ReferralDetailsTable( { heading, items, fields }: Props ) {
+export default function ReferralDetailsTable( { items, fields }: Props ) {
 	const [ dataViewsState, setDataViewsState ] = useState( initialDataViewsState );
 
 	return (
 		<div className="referrals-details-table__container redesigned-a8c-table">
-			<div className="referrals-details-table__heading">{ heading }</div>
 			<ItemsDataViews
 				data={ {
 					items,

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -1,7 +1,8 @@
-import { Card } from '@automattic/components';
+import { Card, Gridicon } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { getConsolidatedData } from '../lib/commissions';
@@ -16,6 +17,9 @@ export default function ConsolidatedViews( { referrals }: { referrals: Referral[
 	const month = date.toLocaleString( 'default', { month: 'long' } );
 	const { data, isFetching } = useProductsQuery( false, false, true );
 
+	const [ showPopover, setShowPopover ] = useState( false );
+	const wrapperRef = useRef< HTMLSpanElement | null >( null );
+
 	const [ consolidatedData, setConsolidatedData ] = useState( {
 		allTimeCommissions: 0,
 		pendingOrders: 0,
@@ -29,6 +33,8 @@ export default function ConsolidatedViews( { referrals }: { referrals: Referral[
 		}
 	}, [ referrals, data ] );
 
+	const link = 'https://automattic.com/for-agencies/program-incentives/';
+
 	return (
 		<div className="consolidated-view">
 			<Card compact>
@@ -39,7 +45,43 @@ export default function ConsolidatedViews( { referrals }: { referrals: Referral[
 						formatCurrency( consolidatedData.allTimeCommissions, 'USD' )
 					) }
 				</div>
-				<div className="consolidated-view__label">{ translate( 'All time commissions' ) }</div>
+				<div className="consolidated-view__label">
+					{ translate( 'All time commissions' ) }
+					<span
+						className="consolidated-view__info-icon"
+						onClick={ () => setShowPopover( true ) }
+						role="button"
+						tabIndex={ 0 }
+						ref={ wrapperRef }
+						onKeyDown={ ( event ) => {
+							if ( event.key === 'Enter' ) {
+								setShowPopover( true );
+							}
+						} }
+					>
+						<Gridicon icon="info-outline" size={ 16 } />
+						{ showPopover && (
+							<A4APopover
+								title=""
+								offset={ 12 }
+								wrapperRef={ wrapperRef }
+								onFocusOutside={ () => setShowPopover( false ) }
+							>
+								<div className="consolidated-view__popover-content">
+									{ translate(
+										'Every 60 days, we pay out commissions. Learn more about {{a}}partner{{nbsp/}}earnings.{{/a}}',
+										{
+											components: {
+												nbsp: <>&nbsp;</>,
+												a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
+											},
+										}
+									) }
+								</div>
+							</A4APopover>
+						) }
+					</span>
+				</div>
 			</Card>
 			<Card compact>
 				<div className="consolidated-view__value">

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
@@ -28,3 +28,29 @@
 		}
 	}
 }
+
+.consolidated-view__popover-content {
+	padding: 12px;
+	min-width: 200px;
+	@include a4a-font-body-md;
+
+	@include break-mobile {
+		min-width: 300px;
+	}
+
+	a,
+	a:visited {
+		color: var(--color-neutral-100);
+		text-decoration: underline;
+	}
+	a:focus {
+		outline: none;
+	}
+}
+
+.consolidated-view__info-icon {
+	cursor: pointer;
+	position: relative;
+	inset-block-start: 4px;
+	inset-inline-start: 4px;
+}

--- a/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
@@ -43,7 +43,7 @@ export const getConsolidatedData = (
 
 	referrals.forEach( ( referral ) => {
 		const commissions = calculateCommissions( referral, products );
-		consolidatedData.pendingOrders += referral.statuses.filter(
+		consolidatedData.pendingOrders += referral.referralStatuses.filter(
 			( status ) => status === 'pending'
 		).length;
 		consolidatedData.pendingCommission += commissions;

--- a/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
@@ -1,0 +1,53 @@
+import type { Referral } from '../types';
+import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+export const getProductCommissionPercentage = ( product?: APIProductFamilyProduct ) => {
+	if ( ! product ) {
+		return 0;
+	}
+	if ( [ 'wpcom-hosting', 'pressable-hosting' ].includes( product.family_slug ) ) {
+		return 0.2;
+	}
+	if (
+		product.family_slug.startsWith( 'jetpack-' ) ||
+		product.family_slug.startsWith( 'woocommerce-' )
+	) {
+		return 0.5;
+	}
+	return 0;
+};
+
+export const calculateCommissions = ( referral: Referral, products: APIProductFamilyProduct[] ) => {
+	return referral.purchases
+		.filter( ( purchase ) => [ 'pending', 'active' ].includes( purchase.status ) )
+		.map( ( purchase ) => {
+			const product = products.find( ( product ) => product.product_id === purchase.product_id );
+			const commissionPercentage = getProductCommissionPercentage( product );
+			const totalCommissions = product?.amount
+				? Number( product.amount ) * commissionPercentage
+				: 0;
+			return totalCommissions;
+		} )
+		.reduce( ( acc, current ) => acc + current, 0 );
+};
+
+export const getConsolidatedData = (
+	referrals: Referral[],
+	products: APIProductFamilyProduct[]
+) => {
+	const consolidatedData = {
+		allTimeCommissions: 0,
+		pendingOrders: 0,
+		pendingCommission: 0,
+	};
+
+	referrals.forEach( ( referral ) => {
+		const commissions = calculateCommissions( referral, products );
+		consolidatedData.pendingOrders += referral.statuses.filter(
+			( status ) => status === 'pending'
+		).length;
+		consolidatedData.pendingCommission += commissions;
+	} );
+
+	return consolidatedData;
+};

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -28,6 +28,7 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import StepSection from '../../common/step-section';
 import StepSectionItem from '../../common/step-section-item';
+import ConsolidatedViews from '../../consolidated-view';
 import { getAccountStatus } from '../../lib/get-account-status';
 import tipaltiLogo from '../../lib/tipalti-logo';
 import ReferralList from '../../referrals-list';
@@ -115,6 +116,7 @@ export default function LayoutBodyContent( {
 	if ( isAutomatedReferral && referrals?.length ) {
 		return (
 			<>
+				{ ! dataViewsState.selectedItem && <ConsolidatedViews referrals={ referrals } /> }
 				<ReferralList
 					referrals={ referrals }
 					dataViewsState={ dataViewsState }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -130,7 +130,11 @@ $data-view-border-color: #f1f1f1;
 	}
 
 	.consolidated-view {
-		padding-block: 16px 48px;
+		padding: 16px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			padding: 16px 64px 48px;
+		}
 	}
 
 	.referrals-overview__section-heading {

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -5,6 +5,7 @@ import ItemPreviewPane, {
 	createFeaturePreview,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
 import SubscriptionStatus from '../referrals-list/subscription-status';
+import ReferralCommissions from './commissions';
 import ReferralPurchasesMobile from './mobile/purchases-mobile';
 import ReferralPurchases from './purchases';
 import type { Referral } from '../types';
@@ -18,6 +19,7 @@ interface Props {
 }
 
 const REFERRAL_PURCHASES_ID = 'referral-purchases';
+const REFERRAL_COMMISSIONS_ID = 'referral-commissions';
 
 export default function ReferralDetails( { referral, closeSitePreviewPane }: Props ) {
 	const translate = useTranslate();
@@ -57,6 +59,14 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				) : (
 					<ReferralPurchases purchases={ referral.purchases } />
 				)
+			),
+			createFeaturePreview(
+				REFERRAL_COMMISSIONS_ID,
+				translate( 'Commissions' ),
+				true,
+				selectedReferralTab,
+				setSelectedReferralTab,
+				<ReferralCommissions referral={ referral } />
 			),
 		],
 		[ referral, selectedReferralTab, translate, isDesktop ]

--- a/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
@@ -79,11 +79,5 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 		[ translate, data, isFetching, handleAssignToSite ]
 	);
 
-	return (
-		<ReferralDetailsTable
-			heading={ translate( 'Purchases' ) }
-			items={ purchases }
-			fields={ fields }
-		/>
-	);
+	return <ReferralDetailsTable items={ purchases } fields={ fields } />;
 }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/purchases.tsx
@@ -16,7 +16,7 @@ export default function ReferralPurchases( { purchases }: { purchases: ReferralP
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { data, isFetching } = useProductsQuery();
+	const { data, isFetching } = useProductsQuery( false, false, true );
 
 	const handleAssignToSite = useCallback(
 		( url: string ) => {

--- a/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
@@ -19,5 +19,9 @@
 			height: 75vh;
 			padding: 18px;
 		}
+
+		.consolidated-view {
+			padding: 0;
+		}
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
@@ -1,0 +1,19 @@
+import { formatCurrency } from '@automattic/format-currency';
+import { useEffect, useState } from 'react';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import { calculateCommissions } from '../lib/commissions';
+import type { Referral } from '../types';
+
+export default function CommissionsColumn( { referral }: { referral: Referral } ) {
+	const { data, isFetching } = useProductsQuery( false, false, true );
+
+	const [ commissions, setCommissions ] = useState< number >( 0 );
+
+	useEffect( () => {
+		const commissions = calculateCommissions( referral, data || [] );
+		setCommissions( commissions );
+	}, [ referral, data ] );
+
+	return isFetching ? <TextPlaceholder /> : formatCurrency( commissions, 'USD' );
+}

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { formatCurrency } from '@automattic/format-currency';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback, ReactNode, useEffect } from 'react';
@@ -35,6 +36,9 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 		},
 		[ dispatch, setDataViewsState ]
 	);
+
+	// FIXME: Remove this flag once the API is enabled
+	const isAPIEnabled = false;
 
 	const fields = useMemo(
 		() =>
@@ -123,7 +127,11 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							header: translate( 'Commissions' ).toUpperCase(),
 							getValue: () => '-',
 							render: ( { item }: { item: Referral } ): ReactNode => {
-								return <CommissionsColumn referral={ item } />;
+								return isAPIEnabled ? (
+									<CommissionsColumn referral={ item } />
+								) : (
+									formatCurrency( 0, 'USD' )
+								);
 							},
 							enableHiding: false,
 							enableSorting: false,

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -7,6 +7,7 @@ import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import CommissionsColumn from './commissions-column';
 import SubscriptionStatus from './subscription-status';
 import type { Referral } from '../types';
 
@@ -114,6 +115,16 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							getValue: () => '-',
 							render: ( { item }: { item: Referral } ): ReactNode =>
 								item.referralStatuses.filter( ( status ) => status === 'active' ).length,
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'commissions',
+							header: translate( 'Commissions' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: Referral } ): ReactNode => {
+								return <CommissionsColumn referral={ item } />;
+							},
 							enableHiding: false,
 							enableSorting: false,
 						},


### PR DESCRIPTION
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/444

## Proposed Changes

This PR implements commissions for Referrals.

NOTE: 

- The commissions are currently being calculated on the UI, and we will soon have the API for them.
- The current calculations are 20% for hosting (WordPress.com & Pressable) & 50% for products (Jetpack & WooCommerce) 


## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals - Dashboard > Verify:

- You can now see the 3-column cards as shown below.
- You can see the `COMMISSIONS` column on the table.
- The numbers are correct according to the percentage mentioned above.
- It looks good on all screen sizes

![screencapture-agencies-localhost-3000-referrals-dashboard-2024-07-12-15_37_08](https://github.com/user-attachments/assets/a0cccfbf-6a63-4430-aef8-9e3e582524ea)

![screencapture-agencies-localhost-3000-referrals-dashboard-2024-07-12-15_37_22](https://github.com/user-attachments/assets/49089d78-160f-43ac-9254-ab94b0d66a22)


3. Click on any client > Once you are in the detailed view > Verify:

- You can see the 3-column cards as shown below
- The numbers are correct according to the percentage mentioned above.
- It looks good on all screen sizes

<img width="1840" alt="Screenshot 2024-07-11 at 2 27 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/bbd0f0a2-3c77-45b7-a84a-70f0ec5b22cf">

4. Click the `New referral` button on top-right > Add a few products > Click the cart > Verify:

- You can now see a new line, `Your estimated commission:` as shown below.
- The numbers are correct according to the percentage mentioned above.
- Click the tooltip and see the tooltip appear. It will close only if we click outside because the tooltip is interactive.

<img width="1840" alt="Screenshot 2024-07-11 at 2 27 50 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/cc3a3712-f41e-4ad3-ba4f-0df72731fd76">


5. Click the `Checkout` button on the cart > Verify:

- You can now see a new line, `Your estimated commission:` as shown below.
- The numbers are correct according to the percentage mentioned above.

<img width="1840" alt="Screenshot 2024-07-11 at 2 27 58 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/46409f27-9dc2-4ae3-b0c4-06c06371b4c3">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
