### PR TITLE
Calypso-build: Add JS format to build-app-languages

### DIFF
--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -28,7 +28,7 @@
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/help-center",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"translate": "rm -rf dist/strings && wp-babel-makepot './dist/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base './dist' --dir './dist/strings' --output './dist/help-center.pot' && build-app-languages --stringsFilePath='./dist/help-center.pot' --outputPath='./dist/languages'"
+		"translate": "rm -rf dist/strings && wp-babel-makepot './dist/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base './dist' --dir './dist/strings' --output './dist/help-center.pot' && build-app-languages --stringsFilePath='./dist/help-center.pot' --outputPath='./dist/languages' --outputFormat='JS'"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",


### PR DESCRIPTION
## Proposed Changes

Currently, in `jetpack-mu-wpcom` apps, we have to download the translations files in Jetpack, keep them updates, and sync them whenever they're re-deployed from Calypso. This is cumbersome and makes development harder because you have to re-deploy Jetpack whenever you change something.

This is because WP only allows enqueuing translations from local JSON files (vs URLs). This change allows `build-app-languages` to output a standalone JS bundle that can be enqueued as-is without any interference from WP or Jetpack. 

This means changing translations and deploying them to widgets is enough to have them live in simple and atomic. And it also means no need for [a special build process in Jetpack](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/bin/download-help-center-languages.js).


## Testing Instructions

1. Go to `/apps/help-center`.
2. run `yarn build --sync`. 
3. `apps/help-center/languages` should have JS files. 
