### PR TITLE
Nav redesign - update themes showcase to use global styles

### DIFF
--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -712,12 +712,3 @@
 		}
 	}
 }
-
-.wpcom-site div.is-section-themes.is-global-sidebar-visible {
-	&.focus-content .layout__content,
-	&.focus-sidebar .layout__content {
-		@include break-medium {
-			padding-left: calc(var(--sidebar-width-max) + 33px);
-		}
-	}
-}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -169,12 +169,6 @@ body.is-mobile-app-view {
 	}
 }
 
-.is-section-themes.is-global-sidebar-visible {
-	.layout__content {
-		padding: calc(var(--masterbar-height) + 16px) 16px 16px calc(var(--sidebar-width-max));
-		min-height: 100vh;
-	}
-}
 // Setup the secondary element, which contains the sidebar and
 // the site-selector elements.
 .layout__secondary {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -168,6 +168,12 @@ body.is-mobile-app-view {
 		display: none;
 	}
 }
+
+.is-section-themes.is-global-sidebar-visible {
+	.layout__content {
+		padding: calc(var(--masterbar-height) + 16px) 16px 16px calc(var(--sidebar-width-max));
+	}
+}
 // Setup the secondary element, which contains the sidebar and
 // the site-selector elements.
 .layout__secondary {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -172,6 +172,7 @@ body.is-mobile-app-view {
 .is-section-themes.is-global-sidebar-visible {
 	.layout__content {
 		padding: calc(var(--masterbar-height) + 16px) 16px 16px calc(var(--sidebar-width-max));
+		min-height: 100vh;
 	}
 }
 // Setup the secondary element, which contains the sidebar and

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -168,7 +168,6 @@ body.is-mobile-app-view {
 		display: none;
 	}
 }
-
 // Setup the secondary element, which contains the sidebar and
 // the site-selector elements.
 .layout__secondary {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -19,7 +19,7 @@
 			max-width: none;
 			overflow-y: auto;
 
-			@include breakpoint-deprecated( ">782px" ) {
+			@include break-small {
 				height: calc(100vh - var(--masterbar-height) - 32px);
 			}
 		}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -11,6 +11,11 @@
 	&.is-global-sidebar-visible {
 		background: var(--studio-gray-0);
 
+		.layout__content {
+			padding: calc(var(--masterbar-height) + 16px) 16px 16px calc(var(--sidebar-width-max));
+			min-height: 100vh;
+		}
+
 		.layout__primary > * {
 			background-color: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -2,9 +2,65 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+
 .is-section-themes {
 	&.theme-default.color-scheme {
 		--color-surface-backdrop: var(--studio-white);
+	}
+
+	&.is-global-sidebar-visible {
+		background: var(--studio-gray-0);
+
+		.layout__primary > * {
+			background-color: var(--color-surface);
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+			height: calc(100vh - var(--masterbar-height));
+			max-width: none;
+			overflow-y: auto;
+
+			@include breakpoint-deprecated( ">782px" ) {
+				height: calc(100vh - var(--masterbar-height) - 32px);
+			}
+		}
+
+		.navigation-header {
+			padding-top: 24px;
+			padding-inline: 16px;
+
+			.navigation-header__main {
+				align-items: center;
+			}
+
+			@include break-medium {
+				border-block-end: 1px solid var(--color-border-secondary);
+			}
+
+			@include break-huge {
+				padding-inline: 64px;
+			}
+
+			@include break-xhuge {
+				max-width: 100%;
+
+				.navigation-header__main {
+					max-width: 1400px;
+					margin: 0 auto;
+					padding-inline: 64px;
+				}
+			}
+
+			.formatted-header__title {
+				font-size: 1.5rem;
+				line-height: 1.2;
+			}
+		}
+
+		.themes__content {
+			margin-top: 40px;
+			padding-left: 2rem;
+			padding-right: 2rem;
+		}
 	}
 
 	.main > .notice.is-error {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/92563

This doesn't adopt the sticky header and some other styles from figma in comment - https://github.com/Automattic/wp-calypso/issues/92563#issuecomment-2221274288

This can be done in a follow up. This PR just updates the frame and header to match other global view pages.

## Proposed Changes

* Updates themes showcase to use global styles when global sidebar is detected

## Before

![image](https://github.com/Automattic/wp-calypso/assets/28742426/7404d8e7-43cb-4e8c-82cb-02b058b88c16)

## After

<img width="1469" alt="Screenshot 2024-07-11 at 12 34 14" src="https://github.com/Automattic/wp-calypso/assets/5560595/1f575059-be14-49b9-90f5-1f003000c2a1">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy up UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/themes` and confirm styles work ok at different dimensions 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
