### PR TITLE
A4A > Partner Directory: Update the KB links

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -206,29 +206,33 @@ const PartnerDirectoryDashboard = () => {
 		return 0;
 	}, [ isCompleted, hasDirectoryApproval, isValidFormData, applicationWasSubmitted ] );
 
-	// todo: to remove this when we have the links.
-	const displayProgramLinks = false;
+	// todo: to remove this when we the KB links are published.
+	const displayProgramLinks = true;
 
 	const programLinks = (
 		<StepSection
 			className="partner-directory-dashboard__learn-more-section"
 			heading={ translate( 'Learn more about the program' ) }
 		>
-			{
-				// FIXME: Add link
-				<Button className="a8c-blue-link" borderless href="#">
-					{ translate( 'How does the approval process work?' ) }
-					<Icon icon={ external } size={ 18 } />
-				</Button>
-			}
+			<Button
+				className="a8c-blue-link"
+				borderless
+				target="_blank"
+				href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings"
+			>
+				{ translate( 'How does the approval process work?' ) }
+				<Icon icon={ external } size={ 18 } />
+			</Button>
 			<br />
-			{
-				// FIXME: Add link
-				<Button className="a8c-blue-link" borderless href="#">
-					{ translate( 'What can I put on my public profile?' ) }
-					<Icon icon={ external } size={ 18 } />
-				</Button>
-			}
+			<Button
+				className="a8c-blue-link"
+				borderless
+				target="_blank"
+				href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings/#profile-content"
+			>
+				{ translate( 'What can I put on my public profile?' ) }
+				<Icon icon={ external } size={ 18 } />
+			</Button>
 		</StepSection>
 	);
 


### PR DESCRIPTION
Resolve: https://github.com/Automattic/automattic-for-agencies-dev/issues/743

## Proposed Changes

This PR updates the KB links:

**How does the approval process work?**

[https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings](https://href.li/?https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings)

**What can I put on my public profile?**

[https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings/#profile-content](https://href.li/?https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings/#profile-content)

Context: pfunGA-22K-p2#comment-3815

Before merging this PR, I'll set it to false `displayProgramLinks` until the links are effectively published.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the links that match the links provided in the post-comment.
- The links are not public, so you will get a Not found error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?