### PR TITLE
Iframed editor: Fix trash post

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -85,6 +85,18 @@ function transmitDraftId( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function handlePostTrash( calypsoPort ) {
+	/**
+	 * As of Gutenberg 18.2, posts are trashed with code that we cannot override
+	 * via the actions registry, so we need to change the behavior overriding the
+	 * onClick event.
+	 *
+	 * See https://github.com/WordPress/gutenberg/blob/379e5f42d11a46dfa29fe4c595ba43f1f3ba9b17/packages/editor/src/components/post-actions/actions.js#L122-L220
+	 */
+	addEditorListener( '.editor-action-modal__move-to-trash button.is-primary', ( e ) => {
+		e.preventDefault();
+		calypsoPort.postMessage( { action: 'trashPost' } );
+	} );
+
 	use( ( registry ) => {
 		return {
 			dispatch: ( store ) => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/92462

## Proposed Changes

Fixes the "move to trash" action when the iframed editor is used. I think this has been broken as of Gutenberg 18.2 when the `trashPost` action was no longer used in favor of a new page panel (see https://github.com/WordPress/gutenberg/pull/60232). Unfortunately, the new behavior cannot be overridden with a custom action in the registry, so we need to override the `onClick` event.

**Before**


https://github.com/Automattic/wp-calypso/assets/1233880/1901a582-4426-4866-abdd-570730a7e8c3

**After**


https://github.com/Automattic/wp-calypso/assets/1233880/f6567016-7f10-492f-8037-67211f6c9c71



## Why are these changes being made?

To ensure uses are able to trash posts when using the iframed editor

## Testing Instructions

- Apply these changes to your sandbox
- Sandbox `widgets.wp.com`
- Go to wordpress.com/post
- Select a site with the default interface (otherwise, you'll be redirected to wp-admin and won't use the iframe editor)
- Enter some content and save the post
- Trash the post from the dropdown menu in the Post tab on the top-right corner.
- Make sure the post is trashed and you are redirected back to the list of posts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
