### PR TITLE
Remove a4a-site-creation-configurations feature flag.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -40,10 +40,6 @@ type NeedsSetupSite = {
 	id: number;
 };
 
-const isA4aSiteCreationConfigurationsEnabled = config.isEnabled(
-	'a4a-site-creation-configurations'
-);
-
 export default function NeedSetup( { licenseKey }: Props ) {
 	const { randomSiteName, isRandomSiteNameLoading } = useRandomSiteName();
 	const translate = useTranslate();
@@ -147,18 +143,6 @@ export default function NeedSetup( { licenseKey }: Props ) {
 		[ refetchPendingSites ]
 	);
 
-	const onCreateSite = useCallback(
-		( id: number ) => {
-			createWPCOMSite(
-				{ id },
-				{
-					onSuccess: () => onCreateSiteSuccess( id ),
-				}
-			);
-		},
-		[ createWPCOMSite, onCreateSiteSuccess ]
-	);
-
 	const onCreateSiteWithConfig = useCallback(
 		( id: number ) => {
 			recordTracksEvent( 'calypso_a4a_create_site_config' );
@@ -218,9 +202,7 @@ export default function NeedSetup( { licenseKey }: Props ) {
 					availablePlans={ availablePlans }
 					isLoading={ isFetching }
 					provisioning={ isProvisioning }
-					onCreateSite={
-						isA4aSiteCreationConfigurationsEnabled ? onCreateSiteWithConfig : onCreateSite
-					}
+					onCreateSite={ onCreateSiteWithConfig }
 					onMigrateSite={ onMigrateSite }
 				/>
 			</LayoutColumn>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-random-site-name.tsx
@@ -4,10 +4,11 @@ import wpcom from 'calypso/lib/wp';
 export const getRandomSiteBaseUrl = async ( title: string ) => {
 	const siteName = '';
 	try {
-		const { body: urlSuggestions } = await wpcom.req.get( {
+		const response = await wpcom.req.get( {
 			apiNamespace: 'rest/v1.1',
 			path: `/domains/suggestions?http_envelope=1&query=${ title }&quantity=1&include_wordpressdotcom=true&include_dotblogsubdomain=false&vendor=dot`,
 		} );
+		const urlSuggestions = response.body || response;
 		const validUrlWpComUrl = urlSuggestions.find( ( suggestion: { domain_name: string } ) =>
 			suggestion.domain_name.includes( 'wordpress.com' )
 		);


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7887

## Proposed Changes

This removes the `a4a-site-creation-configurations` feature flag from site creation configuration.
Also adds a fallback for environments that `wpcom.req` extracts the body from envelop requests.

## Testing Instructions

Open http://agencies.localhost:3002/sites/need-setup.
Click on Create new site, it should open the modal, even if the query parameter is not on the URL.
You should be able to complete the site creation with no problems.

Test both localhost and the live preview links. Random generated site suggestions should work on both envs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
