### PR TITLE
Hosting Overview: Update Support Card

### DIFF
--- a/client/my-sites/hosting/support-card/index.js
+++ b/client/my-sites/hosting/support-card/index.js
@@ -1,7 +1,9 @@
 import { Button } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
+import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch } from 'react-redux';
 import { HostingCard } from 'calypso/components/hosting-card';
 import {
 	composeAnalytics,
@@ -9,11 +11,10 @@ import {
 	recordGoogleEvent,
 	bumpStat,
 } from 'calypso/state/analytics/actions';
-import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
 
 import './style.scss';
 
-function trackNavigateToContactSupport() {
+function trackNavigateGetHelpClick() {
 	return composeAnalytics(
 		recordGoogleEvent( 'Hosting Configuration', 'Clicked "Contact us" Button in Support card' ),
 		recordTracksEvent( 'calypso_hosting_configuration_contact_support' ),
@@ -25,12 +26,14 @@ const HELP_CENTER_STORE = HelpCenter.register();
 
 export default function SupportCard() {
 	const translate = useTranslate();
-	const { setShowHelpCenter, setInitialRoute } = useDispatch( HELP_CENTER_STORE );
+	const dispatch = useDispatch();
+	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const { url } = useStillNeedHelpURL();
 
 	const onClick = () => {
 		setInitialRoute( url );
 		setShowHelpCenter( true );
+		dispatch( trackNavigateGetHelpClick() );
 	};
 
 	return (

--- a/client/my-sites/hosting/support-card/index.js
+++ b/client/my-sites/hosting/support-card/index.js
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
-import { HappinessEngineersTray } from 'calypso/components/happiness-engineers-tray';
 import { HostingCard } from 'calypso/components/hosting-card';
 import {
 	composeAnalytics,
@@ -26,7 +25,6 @@ export default function SupportCard() {
 
 	return (
 		<HostingCard className="support-card" title={ translate( 'Need some help?' ) }>
-			<HappinessEngineersTray />
 			<p>{ translate( 'Our AI assistant can help, or connect you to our support team.' ) }</p>
 			<Button onClick={ () => dispatch( trackNavigateToContactSupport() ) } href="/help/contact">
 				{ translate( 'Get help' ) }

--- a/client/my-sites/hosting/support-card/index.js
+++ b/client/my-sites/hosting/support-card/index.js
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
+import { useDispatch } from '@wordpress/data';
 import { HostingCard } from 'calypso/components/hosting-card';
 import {
 	composeAnalytics,
@@ -8,6 +9,7 @@ import {
 	recordGoogleEvent,
 	bumpStat,
 } from 'calypso/state/analytics/actions';
+import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
 
 import './style.scss';
 
@@ -19,16 +21,22 @@ function trackNavigateToContactSupport() {
 	);
 }
 
+const HELP_CENTER_STORE = HelpCenter.register();
+
 export default function SupportCard() {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
+	const { setShowHelpCenter, setInitialRoute } = useDispatch( HELP_CENTER_STORE );
+	const { url } = useStillNeedHelpURL();
+
+	const onClick = () => {
+		setInitialRoute( url );
+		setShowHelpCenter( true );
+	};
 
 	return (
 		<HostingCard className="support-card" title={ translate( 'Need some help?' ) }>
 			<p>{ translate( 'Our AI assistant can help, or connect you to our support team.' ) }</p>
-			<Button onClick={ () => dispatch( trackNavigateToContactSupport() ) } href="/help/contact">
-				{ translate( 'Get help' ) }
-			</Button>
+			<Button onClick={ onClick }>{ translate( 'Get help' ) }</Button>
 		</HostingCard>
 	);
 }

--- a/client/my-sites/hosting/support-card/index.js
+++ b/client/my-sites/hosting/support-card/index.js
@@ -25,15 +25,11 @@ export default function SupportCard() {
 	const dispatch = useDispatch();
 
 	return (
-		<HostingCard className="support-card" title={ translate( 'Support' ) }>
+		<HostingCard className="support-card" title={ translate( 'Need some help?' ) }>
 			<HappinessEngineersTray />
-			<p>
-				{ translate(
-					'If you need help or have any questions, our Happiness Engineers are here when you need them.'
-				) }
-			</p>
+			<p>{ translate( 'Our AI assistant can help, or connect you to our support team.' ) }</p>
 			<Button onClick={ () => dispatch( trackNavigateToContactSupport() ) } href="/help/contact">
-				{ translate( 'Contact us' ) }
+				{ translate( 'Get help' ) }
 			</Button>
 		</HostingCard>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8172-gh-Automattic/dotcom-forge

## Proposed Changes

- update title, content, and button copy
- remove HE thumbnails. In the future, a graphic that better reflects effect of clicking this CTA will be added (see the above referenced issue for additional context)
- direct CTA to open Wapuu instead of navigating to `/help`

**Before**
![image](https://github.com/user-attachments/assets/85d60644-6af6-4c73-850f-5d29aaa65098)


**After**
![image](https://github.com/user-attachments/assets/869bc2a5-84de-4e83-881f-c6a6376bf030)

## Why are these changes being made?

The current copy and thumbnails could be misleading, confusing, or frustrating for users, as they imply they'll be taken directly to contacting an HE.

Instead, we'll use this button to launch Wapuu for some AI generated awesomeness, and update the card contents to set proper expectations

## Testing Instructions

- Visit `overview/chadtestingat110217.blog` on an Atomic site (this page is only available after hosting features have been activated)
- On the hosting overview, locate the new support section at the bottom right
- Confirm the new copy is displayed:
	- Title: _Need some help?_
	- Description: _Our AI assistant can help, or connect you to our support team._
	- CTA button text: _Get help_
- Confirm that the HE thumbnails have been removed (they'll be replaced in a followup PR with an AI-related graphic)
- Confirm that CTA now opens the Helpcenter with the Wapuu AI assistant prompt displayed instead of navigating to `/help`
- Confirm that the `calypso_hosting_configuration_contact_support` Tracks event still fires