### PR TITLE
[DO NOT MERGE] ETK Migration: Unload ported ETK features

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -72,33 +72,3 @@ function get_iso_639_locale( $language ) {
 
 	return $language;
 }
-
-/**
- * Overrides the block editor preview button url with one that accounts for third party cookie
- * blocking.
- */
-function enqueue_override_preview_button_url() {
-	if ( defined( 'MU_WPCOM_OVERRIDE_PREVIEW_BUTTON_URL' ) && MU_WPCOM_OVERRIDE_PREVIEW_BUTTON_URL ) {
-		return;
-	}
-
-	if ( ! function_exists( 'is_blog_atomic' ) ) {
-		return;
-	};
-
-	$blog_details = get_blog_details( get_current_blog_id() );
-
-	if ( is_blog_atomic( $blog_details ) ) {
-		return;
-	}
-
-	wp_enqueue_script(
-		'a8c_override_preview_button_url',
-		plugins_url( 'dist/override-preview-button-url.min.js', __FILE__ ),
-		array(),
-		filemtime( plugin_dir_path( __FILE__ ) . 'dist/override-preview-button-url.min.js' ),
-		true
-	);
-}
-
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_override_preview_button_url' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -240,19 +240,6 @@ function load_mailerlite() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_mailerlite' );
 
 /**
- * Load WPCOM block editor nav sidebar.
- */
-function load_wpcom_block_editor_sidebar() {
-	if (
-		( defined( 'WPCOM_BLOCK_EDITOR_SIDEBAR' ) && WPCOM_BLOCK_EDITOR_SIDEBAR ) ||
-		apply_filters( 'a8c_enable_nav_sidebar', false )
-	) {
-		require_once __DIR__ . '/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php';
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_sidebar' );
-
-/**
  * Load WP.com Global Styles.
  */
 function load_wpcom_global_styles() {

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -127,36 +127,6 @@ function load_starter_page_templates() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_starter_page_templates' );
 
 /**
- * Load Global Styles plugin.
- */
-function load_global_styles() {
-	if ( defined( 'MU_WPCOM_JETPACK_GLOBAL_STYLES' ) && MU_WPCOM_JETPACK_GLOBAL_STYLES ) {
-		return;
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
-
-/**
- * Load Event Countdown Block.
- */
-function load_countdown_block() {
-	if ( defined( 'MU_WPCOM_JETPACK_COUNTDOWN_BLOCK' ) && MU_WPCOM_JETPACK_COUNTDOWN_BLOCK ) {
-		return;
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_countdown_block' );
-
-/**
- * Load Timeline Block.
- */
-function load_timeline_block() {
-	if ( defined( 'MU_WPCOM_JETPACK_TIMELINE_BLOCK' ) && MU_WPCOM_JETPACK_TIMELINE_BLOCK ) {
-		return;
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_timeline_block' );
-
-/**
  * Add front-end CoBlocks gallery block scripts.
  *
  * This function performs the same enqueueing duties as `CoBlocks_Block_Assets::frontend_scripts`,
@@ -258,16 +228,6 @@ function load_wpcom_block_editor_nux() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );
 
 /**
- * Load Block Inserter Modifications module.
- */
-function load_block_inserter_modifications() {
-	if ( defined( 'MU_WPCOM_BLOCK_INSERTER_MODIFICATIONS' ) && MU_WPCOM_BLOCK_INSERTER_MODIFICATIONS ) {
-		return;
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_inserter_modifications' );
-
-/**
  * Load Mailerlite module.
  */
 function load_mailerlite() {
@@ -280,54 +240,17 @@ function load_mailerlite() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_mailerlite' );
 
 /**
- * What's New section of the Tools menu.
+ * Load WPCOM block editor nav sidebar.
  */
-function load_whats_new() {
-	if ( defined( 'MU_WPCOM_WHATS_NEW' ) && MU_WPCOM_WHATS_NEW ) {
-		return;
+function load_wpcom_block_editor_sidebar() {
+	if (
+		( defined( 'WPCOM_BLOCK_EDITOR_SIDEBAR' ) && WPCOM_BLOCK_EDITOR_SIDEBAR ) ||
+		apply_filters( 'a8c_enable_nav_sidebar', false )
+	) {
+		require_once __DIR__ . '/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php';
 	}
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_whats_new' );
-
-/**
- * Tags Education
- */
-function load_tags_education() {
-	if ( defined( 'MU_WPCOM_TAGS_EDUCATION' ) && MU_WPCOM_TAGS_EDUCATION ) {
-		return;
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
-
-/**
- * Load paragraph block
- */
-function load_paragraph_block() {
-	if ( defined( 'MU_WPCOM_PARAGRAPH_BLOCK' ) && MU_WPCOM_PARAGRAPH_BLOCK ) {
-		return;
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_paragraph_block' );
-
-/**
- * Override org documentation links.
- */
-function load_wpcom_documentation_links() {
-	if ( defined( 'MU_WPCOM_DOCUMENTATION_LINKS' ) && MU_WPCOM_DOCUMENTATION_LINKS ) {
-		return;
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_documentation_links' );
-
-/**
- * Add support links to block description.
- */
-function load_block_description_links() {
-	if ( defined( 'MU_WPCOM_BLOCK_DESCRIPTION_LINKS' ) && MU_WPCOM_BLOCK_DESCRIPTION_LINKS ) {
-		return;
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_description_links' );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_sidebar' );
 
 /**
  * Load WP.com Global Styles.

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -133,8 +133,6 @@ function load_global_styles() {
 	if ( defined( 'MU_WPCOM_JETPACK_GLOBAL_STYLES' ) && MU_WPCOM_JETPACK_GLOBAL_STYLES ) {
 		return;
 	}
-
-	require_once __DIR__ . '/global-styles/class-global-styles.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_global_styles' );
 
@@ -145,8 +143,6 @@ function load_countdown_block() {
 	if ( defined( 'MU_WPCOM_JETPACK_COUNTDOWN_BLOCK' ) && MU_WPCOM_JETPACK_COUNTDOWN_BLOCK ) {
 		return;
 	}
-
-	require_once __DIR__ . '/event-countdown-block/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_countdown_block' );
 
@@ -157,8 +153,6 @@ function load_timeline_block() {
 	if ( defined( 'MU_WPCOM_JETPACK_TIMELINE_BLOCK' ) && MU_WPCOM_JETPACK_TIMELINE_BLOCK ) {
 		return;
 	}
-
-	require_once __DIR__ . '/jetpack-timeline/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_timeline_block' );
 
@@ -270,8 +264,6 @@ function load_block_inserter_modifications() {
 	if ( defined( 'MU_WPCOM_BLOCK_INSERTER_MODIFICATIONS' ) && MU_WPCOM_BLOCK_INSERTER_MODIFICATIONS ) {
 		return;
 	}
-
-	require_once __DIR__ . '/block-inserter-modifications/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_inserter_modifications' );
 
@@ -294,8 +286,6 @@ function load_whats_new() {
 	if ( defined( 'MU_WPCOM_WHATS_NEW' ) && MU_WPCOM_WHATS_NEW ) {
 		return;
 	}
-
-	require_once __DIR__ . '/whats-new/class-whats-new.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_whats_new' );
 
@@ -306,8 +296,6 @@ function load_tags_education() {
 	if ( defined( 'MU_WPCOM_TAGS_EDUCATION' ) && MU_WPCOM_TAGS_EDUCATION ) {
 		return;
 	}
-
-	require_once __DIR__ . '/tags-education/class-tags-education.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_tags_education' );
 
@@ -318,8 +306,6 @@ function load_paragraph_block() {
 	if ( defined( 'MU_WPCOM_PARAGRAPH_BLOCK' ) && MU_WPCOM_PARAGRAPH_BLOCK ) {
 		return;
 	}
-
-	require_once __DIR__ . '/paragraph-block/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_paragraph_block' );
 
@@ -330,8 +316,6 @@ function load_wpcom_documentation_links() {
 	if ( defined( 'MU_WPCOM_DOCUMENTATION_LINKS' ) && MU_WPCOM_DOCUMENTATION_LINKS ) {
 		return;
 	}
-
-	require_once __DIR__ . '/wpcom-documentation-links/class-wpcom-documentation-links.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_documentation_links' );
 
@@ -342,8 +326,6 @@ function load_block_description_links() {
 	if ( defined( 'MU_WPCOM_BLOCK_DESCRIPTION_LINKS' ) && MU_WPCOM_BLOCK_DESCRIPTION_LINKS ) {
 		return;
 	}
-
-	require_once __DIR__ . '/wpcom-block-description-links/class-wpcom-block-description-links.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_description_links' );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8032, https://github.com/Automattic/dotcom-forge/issues/8243

## Proposed Changes

⚠️ This PR should be merged AFTER jetpack-mu-wpcom > 5.43.0 is shipped to both Simple and Atomic: p1720767280711619/1720757410.848969-slack-CRWCHQGUB.

This PR unloads ported ETK features. 

(I have a separate PR for removing some functions: https://github.com/Automattic/wp-calypso/pull/92620.)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I referred to the status in pbxlJb-5WO-p2 and flags on jetpack-mu-wpcom. 

Smoke tests;

* Apply this patch 
	* install-plugin.sh editing-toolkit update/unload-etk-features
	* install-plugin.sh notifications update/unload-etk-features
* Go to Site Editor/Post Editor
* See if nothing is broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?