### PR TITLE
ETK Migration: Remove ported functions from ETK

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -32,41 +32,6 @@ function register_data_stores() {
 add_action( 'init', __NAMESPACE__ . '\register_data_stores' );
 
 /**
- * Can be used to determine if the current screen is the block editor.
- *
- * @return bool True if the current screen is a block editor screen. False otherwise.
- */
-function is_block_editor_screen() {
-	return is_callable( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor();
-}
-
-/**
- * Detects if the site is using Gutenberg 9.2 or above, which contains a bug in the
- * interface package, causing some "slider" blocks (such as Jetpack's Slideshow) to
- * incorrectly calculate their width as 33554400px when set at full width.
- *
- * @see https://github.com/WordPress/gutenberg/pull/26552
- *
- * @return bool True if the site needs a temporary fix for the incorrect slider width.
- */
-function needs_slider_width_workaround() {
-	global $post;
-
-	if ( defined( 'MU_WPCOM_SLIDER_WIDTH' ) && MU_WPCOM_SLIDER_WIDTH ) {
-		return;
-	}
-
-	if (
-		( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE ) ||
-		( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '9.2', '>=' ) )
-	) {
-		// Workaround only needed when in the editor.
-		return isset( $post );
-	}
-	return false;
-}
-
-/**
  * Enable line-height settings for all themes with Gutenberg.
  *
  * Prior to Gutenberg 8.6, line-height was always enabled, which meant that wpcom


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/92618, https://github.com/Automattic/dotcom-forge/issues/8032, https://github.com/Automattic/jetpack/pull/38315

## Proposed Changes

This PR removes some already ported functions from ETK.

- `is_homepage_title_hidden` now always returns false
	- https://github.com/Automattic/jetpack/pull/38190
- Thus, `admin_body_classes` can be removed
- `use_font_smooth_antialiased` now always returns false
	- https://github.com/Automattic/jetpack/pull/38195
- Thus, `should_load_assets` now always returns false
- Thus, `enqueue_script_and_style` can be removed
- Since `should_load_assets`, `use_font_smooth_antialiased`, and `is_homepage_title_hidden` are no longer used, they can be removed

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Please see pbxlJb-5WO-p2 for more context. 

## Testing Instructions

I referred to the status in pbxlJb-5WO-p2 and flags on jetpack-mu-wpcom. 

Smoke tests;

* Apply this patch 
	* install-plugin.sh editing-toolkit update/etk-remove-ported-functions
	* install-plugin.sh notifications update/etk-remove-ported-functions
* Go to Site Editor/Post Editor
* See if nothing is broken

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
