### PR TITLE
Launchpad: Don't redirect from the course page

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -39,6 +39,14 @@ export async function maybeRedirect( context, next ) {
 		return;
 	}
 
+	const { verified, courseSlug } = getQueryArgs() || {};
+
+	// The courseSlug is to display pages with onboarding videos for learning,
+	// so we should not redirect the page to launchpad.
+	if ( courseSlug ) {
+		return next();
+	}
+
 	const siteId = getSelectedSiteId( state );
 	const site = getSelectedSite( state );
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
@@ -66,8 +74,7 @@ export async function maybeRedirect( context, next ) {
 			// The new stepper launchpad onboarding flow isn't registered within the "page"
 			// client-side router, so page.redirect won't work. We need to use the
 			// traditional window.location Web API.
-			const verifiedParam = getQueryArgs()?.verified;
-			redirectToLaunchpad( slug, siteIntentOption, verifiedParam );
+			redirectToLaunchpad( slug, siteIntentOption, verified );
 			return;
 		}
 	} catch ( error ) {}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/90428

## Proposed Changes

* Prevent the laucnpad redirection from the course page
* The close behavior seems to be broken but I think we can address it later

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* People cannot watch the onboarding videos for learning

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new site from wordpress.com/start using the theme assembler.
- After the site is created, you should be taken to the editor. (If not, you can access the site Editor by going to Appearance > Editor).
- The first time you see the editor, you should see a Welcome Guide (If the Welcome guide is not showing, click the 3 dots in the upper right and select "Welcome Guide" to display the welcome guide.)
- The first part of the module has the link to the videos. The link is going to display the Site Editor Quick Start course.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
