### PR TITLE
Console logs for Bug: Screen blinks when doing click on style variation cards

### DIFF
--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -41,6 +41,7 @@ const ColorPaletteVariation = ( {
 }: ColorPaletteVariationProps ) => {
 	const { base } = useContext( GlobalStylesContext );
 	const context = useMemo( () => {
+		console.log( 'useMemo:', { colorPaletteVariation, base } );
 		return {
 			user: colorPaletteVariation,
 			base,

--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -52,12 +52,15 @@ const useGlobalStylesContext = ( siteId: number | string, stylesheet: string ) =
 		stylesheet
 	);
 	const mergedConfig = useMemo( () => {
+		console.log( 'mergedConfig:', { userConfig, baseConfig } );
 		if ( ! baseConfig || ! userConfig ) {
 			return DEFAULT_GLOBAL_STYLES;
 		}
 		return mergeBaseAndUserConfigs( baseConfig, userConfig );
 	}, [ userConfig, baseConfig ] );
 	const context = useMemo( () => {
+		console.log( 'many:' );
+
 		return {
 			isReady: isUserConfigReady && isBaseConfigReady,
 			user: userConfig,

--- a/packages/global-styles/src/components/global-styles-variation-container/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variation-container/index.tsx
@@ -28,6 +28,8 @@ const GlobalStylesVariationContainer = ( {
 	const [ styles ] = useSafeGlobalStylesOutput();
 	// Reset leaked styles from WP common.css and remove main content layout padding and border.
 	const editorStyles = useMemo( () => {
+		console.log( 'editorStyles:', { styles } );
+
 		if ( styles ) {
 			return [
 				...styles,

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -46,6 +46,8 @@ const GlobalStylesVariation = ( {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const { base } = useContext( GlobalStylesContext );
 	const context = useMemo( () => {
+		console.log( 'context:', { globalStylesVariation, base } );
+
 		const { inline_css: globalStylesVariationInlineCss = '' } = globalStylesVariation;
 		const baseInlineCss = base.inline_css || '';
 		return {
@@ -110,20 +112,22 @@ const GlobalStylesVariations = ( {
 		{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
 	);
 
-	const baseGlobalStyles = useMemo(
-		() =>
+	const baseGlobalStyles = useMemo( () => {
+		console.log( 'baseGlobalStyles:', { globalStylesVariations } );
+
+		return (
 			globalStylesVariations.find( ( globalStylesVariation ) =>
 				isDefaultGlobalStyleVariationSlug( globalStylesVariation )
-			) ?? ( {} as GlobalStylesObject ),
-		[ globalStylesVariations ]
-	);
-	const globalStylesVariationsWithoutDefault = useMemo(
-		() =>
-			globalStylesVariations.filter(
-				( globalStylesVariation ) => ! isDefaultGlobalStyleVariationSlug( globalStylesVariation )
-			),
-		[ globalStylesVariations ]
-	);
+			) ?? ( {} as GlobalStylesObject )
+		);
+	}, [ globalStylesVariations ] );
+	const globalStylesVariationsWithoutDefault = useMemo( () => {
+		console.log( 'globalStylesVariationsWithoutDefault:', { globalStylesVariations } );
+
+		return globalStylesVariations.filter(
+			( globalStylesVariation ) => ! isDefaultGlobalStyleVariationSlug( globalStylesVariation )
+		);
+	}, [ globalStylesVariations ] );
 
 	const nonDefaultStylesDescription = description ?? premiumStylesDescription;
 	const nonDefaultStyles = globalStylesVariationsWithoutDefault.map(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92428

## Proposed Changes

* Added console logs on useMemo

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For debugging

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the global style variation cards and click them
* Verify there is a flickering happening

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
