### PR TITLE
Style variations package: Try to fix screen blinks when doing click on style variation cards

### DIFF
--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -46,7 +46,7 @@ const ColorPaletteVariation = ( {
 			base,
 			merged: mergeBaseAndUserConfigs( base, colorPaletteVariation ),
 		};
-	}, [ colorPaletteVariation, base ] );
+	}, [ colorPaletteVariation.slug, base ] );
 	return (
 		<CompositeItem
 			role="option"

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -47,7 +47,7 @@ const FontPairingVariation = ( {
 			// When font paring isn't passed, it should be available on the base.
 			merged: mergeBaseAndUserConfigs( base, fontPairingVariation ),
 		};
-	}, [ fontPairingVariation, base ] );
+	}, [ fontPairingVariation.slug, base ] );
 	return (
 		<CompositeItem
 			role="option"

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -44,8 +44,7 @@ const FontPairingVariation = ( {
 		return {
 			user: fontPairingVariation,
 			base,
-			// When font paring isn't passed, it should be available on the base.
-			merged: fontPairingVariation ? base : mergeBaseAndUserConfigs( base, fontPairingVariation ),
+			merged: mergeBaseAndUserConfigs( base, fontPairingVariation ),
 		};
 	}, [ fontPairingVariation?.slug, base ] );
 	return (

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -45,9 +45,9 @@ const FontPairingVariation = ( {
 			user: fontPairingVariation,
 			base,
 			// When font paring isn't passed, it should be available on the base.
-			merged: mergeBaseAndUserConfigs( base, fontPairingVariation ),
+			merged: fontPairingVariation ? base : mergeBaseAndUserConfigs( base, fontPairingVariation ),
 		};
-	}, [ fontPairingVariation.slug, base ] );
+	}, [ fontPairingVariation?.slug, base ] );
 	return (
 		<CompositeItem
 			role="option"

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -54,7 +54,7 @@ const GlobalStylesVariation = ( {
 			merged: mergeBaseAndUserConfigs( base, globalStylesVariation ),
 			inline_css: baseInlineCss + globalStylesVariationInlineCss,
 		};
-	}, [ globalStylesVariation, base ] );
+	}, [ globalStylesVariation.slug, base ] );
 	const selectOnEnter = ( event: React.KeyboardEvent ) => {
 		if ( event.keyCode === ENTER ) {
 			event.preventDefault();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92428

## Proposed Changes

* Update the context when the variation `slug` changes rather than when the object changes.

>[!NOTE]
>This change avoids running `useMemo` unnecessarily! 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Try to fix screen blinks when clicking on style variation cards  https://github.com/Automattic/wp-calypso/issues/92428

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
I have done smoke tests for these changes in the design picker, the theme detail, and assembler previews.

This bug is not reproducible locally or in Calypso Live. Why?

Test after deploying in production
* Go to the global style variation cards and click them
  * Design picker: `/setup/update-design/designSetup?siteSlug={ SITE }&theme=tronar` 
  * Assembler: `/setup/with-theme-assembler/pattern-assembler?siteSlug={ SITE }`
  * Theme detail: `/theme/assembler`
* Verify if the flickering is gone 🤞 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
