### PR TITLE
Horizon test: discard delete variations as cause of production bug with style variation cards

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -97,6 +97,7 @@
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"pattern-assembler/v2": true,
+		"pattern-assembler/debug": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -3,6 +3,7 @@
  * on our own as this kind of internal apis might be drastically changed from time to time.
  * See https://github.com/Automattic/wp-calypso/issues/77048
  */
+import { isEnabled } from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { privateApis as blockEditorPrivateApis, transformStyles } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -30,11 +31,13 @@ const GlobalStylesContext: React.Context< GlobalStylesContextObject > = UntypedG
 const mergeBaseAndUserConfigs = ( base: GlobalStylesObject, user?: GlobalStylesObject ) => {
 	const mergedConfig = user ? deepmerge( base, user, { isMergeableObject: isPlainObject } ) : base;
 
-	// Remove section style variations until we handle them
-	if ( mergedConfig?.styles?.blocks ) {
-		delete mergedConfig.styles.blocks.variations;
-		for ( const key in mergedConfig.styles.blocks ) {
-			delete mergedConfig.styles.blocks[ key ].variations;
+	if ( ! isEnabled( 'pattern-assembler/debug' ) ) {
+		// Remove section style variations until we handle them
+		if ( mergedConfig?.styles?.blocks ) {
+			delete mergedConfig.styles.blocks.variations;
+			for ( const key in mergedConfig.styles.blocks ) {
+				delete mergedConfig.styles.blocks[ key ].variations;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #92626

## Proposed Changes

* Skip the code to delete variations in Horizon

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To discard that as the cause of https://github.com/Automattic/wp-calypso/issues/92428

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the global style variation cards and click them
  - Design picker: /setup/update-design/designSetup?siteSlug={ SITE }&theme=tronar
  - Assembler: /setup/with-theme-assembler/pattern-assembler?siteSlug={ SITE }
  - Theme detail: /theme/assembler
- Verify if the flickering is gone 🤞

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
