### PR TITLE
A4A > Referrals: Referral list column updates

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge.tsx
@@ -6,7 +6,7 @@ import './style.scss';
 export default function StatusBadge( {
 	statusProps,
 }: {
-	statusProps?: ComponentProps< typeof Badge > & { tooltip?: string };
+	statusProps?: ComponentProps< typeof Badge > & { tooltip?: string | JSX.Element };
 } ) {
 	const [ showPopover, setShowPopover ] = useState( false );
 

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -12,7 +12,7 @@ const getConsolidatedData = ( referrals: Referral[] ) => {
 	};
 
 	referrals.forEach( ( referral ) => {
-		consolidatedData.pendingOrders += referral.statuses.filter(
+		consolidatedData.pendingOrders += referral.purchaseStatuses.filter(
 			( status ) => status === 'pending'
 		).length;
 	} );

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referrals.ts
@@ -15,12 +15,12 @@ const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
 			...product,
 			referral_id: referral.id,
 		} ) );
-		const statuses = purchases.map( ( purchase ) => purchase.status );
 		return {
 			id: referral.client.id,
 			client: referral.client,
 			purchases,
-			statuses,
+			purchaseStatuses: purchases.map( ( purchase ) => purchase.status ),
+			referralStatuses: [ referral.status ],
 		};
 	} );
 
@@ -28,7 +28,8 @@ const getClientReferrals = ( referrals: ReferralAPIResponse[] ) => {
 		const existing = acc.find( ( item ) => item.id === current.id );
 		if ( existing ) {
 			existing.purchases.push( ...current.purchases );
-			existing.statuses.push( ...current.statuses );
+			existing.purchaseStatuses.push( ...current.purchaseStatuses );
+			existing.referralStatuses.push( ...current.referralStatuses );
 		} else {
 			acc.push( current );
 		}

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -30,7 +30,7 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 			<div className="referral-details__subtitle">
 				{ translate( 'Payment status {{badge}}%(status)s{{/badge}}', {
 					args: {
-						status: referral.statuses[ 0 ],
+						status: referral.purchaseStatuses[ 0 ],
 					},
 					comment: '%(status) is subscription status',
 					components: {

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -100,19 +100,20 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 							enableSorting: false,
 						},
 						{
-							id: 'purchases',
-							header: translate( 'Purchases' ).toUpperCase(),
-							getValue: () => '-',
-							render: ( { item }: { item: Referral } ): ReactNode => item.purchases.length,
-							enableHiding: false,
-							enableSorting: false,
-						},
-						{
 							id: 'pending-orders',
 							header: translate( 'Pending Orders' ).toUpperCase(),
 							getValue: () => '-',
 							render: ( { item }: { item: Referral } ): ReactNode =>
-								item.statuses.filter( ( status ) => status === 'pending' ).length,
+								item.referralStatuses.filter( ( status ) => status === 'pending' ).length,
+							enableHiding: false,
+							enableSorting: false,
+						},
+						{
+							id: 'completed-orders',
+							header: translate( 'Completed Orders' ).toUpperCase(),
+							getValue: () => '-',
+							render: ( { item }: { item: Referral } ): ReactNode =>
+								item.referralStatuses.filter( ( status ) => status === 'active' ).length,
 							enableHiding: false,
 							enableSorting: false,
 						},

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -21,7 +21,8 @@ export interface Referral {
 	id: number;
 	client: ReferralClient;
 	purchases: ReferralPurchase[];
-	statuses: string[];
+	purchaseStatuses: string[];
+	referralStatuses: string[];
 }
 
 export interface ReferralAPIResponse {


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/420

## Proposed Changes

This PR makes some updates to the referrals list column, including:

- Reorder the columns
- Change column name `Purchases` to `Completed orders`
- Refactored the code.
- We used to show purchase statuses on the columns, not we are showing the overall referral status.
- Show counts when there is a `Mixed` status.

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals - Dashboard > Verify:

- The order of the columns has been changed as mentioned above & shown below
- The column names have been updated as mentioned above.
- We show the overall referral status for Pending & Completed Orders.
- Show the count when there is a mixed status

| Before | After |
|--------|--------|
| ![screencapture-agencies-automattic-referrals-dashboard-2024-07-12-14_55_03](https://github.com/user-attachments/assets/29b5b232-f54e-4f26-af0f-c6efadc600ec) | ![screencapture-agencies-localhost-3000-referrals-dashboard-2024-07-12-14_54_36](https://github.com/user-attachments/assets/239bbc8a-6c0a-47db-a18a-6d8755729f84) | 
 

<img width="1728" alt="Screenshot 2024-07-12 at 2 58 16 PM" src="https://github.com/user-attachments/assets/2478e46f-8078-4807-80f7-c0af219135f0">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
