### PR TITLE
i18n utils: Get rid of i18n-calypso dependency

### DIFF
--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -12,6 +12,16 @@ import {
 	translationExists,
 	isMagnificentLocale,
 } from '@automattic/i18n-utils';
+import { getWpI18nLocaleSlug } from '@automattic/i18n-utils/src/locale-context';
+
+jest.mock( '@automattic/i18n-utils/src/locale-context', () => {
+	const originalModule = jest.requireActual( '@automattic/i18n-utils/src/locale-context' );
+	return {
+		__esModule: true,
+		...originalModule,
+		getWpI18nLocaleSlug: jest.fn( () => '' ),
+	};
+} );
 
 jest.mock( '@automattic/calypso-config', () => ( key ) => {
 	if ( 'i18n_default_locale_slug' === key ) {
@@ -70,17 +80,6 @@ jest.mock( '@automattic/calypso-config', () => ( key ) => {
 		];
 	}
 } );
-
-// Mock only the getLocaleSlug function from i18n-calypso, and use
-// original references for all the other functions
-function mockFunctions() {
-	const original = jest.requireActual( 'i18n-calypso' ).default;
-	return Object.assign( Object.create( Object.getPrototypeOf( original ) ), original, {
-		getLocaleSlug: jest.fn( () => 'en' ),
-	} );
-}
-jest.mock( 'i18n-calypso', () => mockFunctions() );
-const { getLocaleSlug } = jest.requireMock( 'i18n-calypso' );
 
 describe( 'utils', () => {
 	describe( '#isDefaultLocale', () => {
@@ -244,12 +243,12 @@ describe( 'utils', () => {
 			);
 		} );
 
-		test( 'client/lib/i18n-utils/localizeUrl still uses getLocaleSlug', () => {
-			getLocaleSlug.mockImplementationOnce( () => 'en' );
+		test( 'localizeUrl still uses getLocaleSlug', () => {
+			getWpI18nLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/support/'
 			);
-			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			getWpI18nLocaleSlug.mockImplementationOnce( () => 'de' );
 			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/de/support/'
 			);
@@ -311,7 +310,7 @@ describe( 'utils', () => {
 		} );
 
 		it( 'should return false for a string without translation', function () {
-			getLocaleSlug.mockImplementationOnce( () => 'fr' );
+			getWpI18nLocaleSlug.mockImplementationOnce( () => 'fr' );
 			expect(
 				translationExists(
 					'It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness…'

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-utils",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "WordPress.com i18n utils.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -36,12 +36,20 @@ function mapWpI18nLangToLocaleSlug( locale: Locale = '' ): Locale {
 }
 
 /**
- * Get the current locale slug from the @wordpress/i18n locale data
+ * Get the lang from the @wordpress/i18n locale data
+ * @returns lang e.g. "en_US"
  */
-function getWpI18nLocaleSlug(): string | undefined {
+function getWpI18nLocaleLang(): string | undefined {
 	const localeData = i18n.getLocaleData() || {};
-	const language = localeData[ '' ]?.lang || localeData[ '' ]?.language || '';
+	return localeData[ '' ]?.lang || localeData[ '' ]?.language || '';
+}
 
+/**
+ * Get the lang from the @wordpress/i18n locale data and map the value to the locale slug
+ * @returns lang e.g. "en", "pt-br", "zh-tw"
+ */
+export function getWpI18nLocaleSlug(): string | undefined {
+	const language = getWpI18nLocaleLang();
 	return mapWpI18nLangToLocaleSlug( language );
 }
 

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -1,7 +1,6 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { getLocaleSlug } from 'i18n-calypso';
 import { useCallback, ComponentType } from 'react';
-import { useLocale } from './locale-context';
+import { useLocale, getWpI18nLocaleSlug } from './locale-context';
 import {
 	localesWithBlog,
 	localesWithGoBlog,
@@ -20,7 +19,7 @@ import {
 const INVALID_URL = `http://__domain__.invalid`;
 
 function getDefaultLocale(): Locale {
-	return getLocaleSlug?.() ?? 'en';
+	return getWpI18nLocaleSlug() ?? 'en';
 }
 
 const setLocalizedUrlHost =

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -1,8 +1,9 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import languages, { Language, SubLanguage } from '@automattic/languages';
-import i18n, { getLocaleSlug } from 'i18n-calypso';
+import { hasTranslation } from '@wordpress/i18n';
 import { find, map, pickBy, includes } from 'lodash';
+import { getWpI18nLocaleSlug } from './locale-context';
 
 /**
  * This regex is defined as a string so that it can be combined with other regexes.
@@ -77,8 +78,8 @@ export function canBeTranslated( locale: string ) {
  * @returns {boolean} true when a user would see text they can read.
  */
 export function translationExists( phrase: string ) {
-	const localeSlug = typeof getLocaleSlug === 'function' ? getLocaleSlug() : 'en';
-	return isDefaultLocale( localeSlug ) || i18n.hasTranslation( phrase );
+	const localeSlug = getWpI18nLocaleSlug() || 'en';
+	return isDefaultLocale( localeSlug ) || hasTranslation( phrase );
 }
 
 /**
@@ -235,7 +236,7 @@ export function isTranslatedIncompletely( locale: string ) {
  * @returns original path with new locale slug
  */
 export function addLocaleToPathLocaleInFront( path: string, locale?: string ) {
-	const localeOrDefault = locale || getLocaleSlug();
+	const localeOrDefault = locale || getWpI18nLocaleSlug();
 	const urlParts = getUrlParts( path );
 	const queryString = urlParts.search || '';
 	if ( ! localeOrDefault || isDefaultLocale( localeOrDefault ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/38318#discussion_r1675596948

## Proposed Changes

* We want to introduce the package to the `jetpack-mu-wpcom` plugin, and it would be better to use the i18n packages from `@wordpress/i18n` rather than `i18n-calypso`
* Currently, there are 2 usages of the `i18n-calypso`
  * `hasTranslation` - it can be replaced by the `hasTranslation` from the `@wordpress/i18n` directly
  * `getLocaleSlug` - The return value is from the `localeSlug` value from the `localeData`. As a result, we can get the local slug from the `localeData` instead of relying on the `i18n-calypso` package. The `localeSlug` property exists only on wpcom translation json file, so this PR makes changes to get the language from the `localeData` and convert it to the localeSlug via the `mapWpI18nLangToLocaleSlug`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's better to use the `@wordprss/i18n` package instead of the `i18n-calypso` for the package that publishes to the npm and is used by elsewhere

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the Calypso with languages other than en
* Make sure the translation still works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
