### PR TITLE
Revert "Horizon test: discard delete variations as cause of production bug with style variation cards"

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -97,7 +97,6 @@
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"pattern-assembler/v2": true,
-		"pattern-assembler/debug": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -3,7 +3,6 @@
  * on our own as this kind of internal apis might be drastically changed from time to time.
  * See https://github.com/Automattic/wp-calypso/issues/77048
  */
-import { isEnabled } from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { privateApis as blockEditorPrivateApis, transformStyles } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -31,13 +30,11 @@ const GlobalStylesContext: React.Context< GlobalStylesContextObject > = UntypedG
 const mergeBaseAndUserConfigs = ( base: GlobalStylesObject, user?: GlobalStylesObject ) => {
 	const mergedConfig = user ? deepmerge( base, user, { isMergeableObject: isPlainObject } ) : base;
 
-	if ( ! isEnabled( 'pattern-assembler/debug' ) ) {
-		// Remove section style variations until we handle them
-		if ( mergedConfig?.styles?.blocks ) {
-			delete mergedConfig.styles.blocks.variations;
-			for ( const key in mergedConfig.styles.blocks ) {
-				delete mergedConfig.styles.blocks[ key ].variations;
-			}
+	// Remove section style variations until we handle them
+	if ( mergedConfig?.styles?.blocks ) {
+		delete mergedConfig.styles.blocks.variations;
+		for ( const key in mergedConfig.styles.blocks ) {
+			delete mergedConfig.styles.blocks[ key ].variations;
 		}
 	}
 


### PR DESCRIPTION
I still can reproduce it so it's not this.

Reverts Automattic/wp-calypso#92627