### PR TITLE
GSV: Remove left/right borders on site panel tabs

### DIFF
--- a/client/hosting/sites/components/style.scss
+++ b/client/hosting/sites/components/style.scss
@@ -542,7 +542,7 @@
 				box-shadow: 0 0 0 1px var(--color-border-subtle), 0 1px 2px var(--color-border-subtle);
 				// Fix the weird box-shadow on the top when the action buttons are wrapped into the newline;
 				padding-top: 1px;
-				clip-path: inset(2px -1px -1px -1px);
+				clip-path: inset(2px 0 -1px 0);
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8251

## Proposed Changes

* Clip out the left and right shadow on the tabs container.

| Before | After |
|--------|--------|
| <img width="1046" alt="Screenshot 2024-07-12 at 11 26 07" src="https://github.com/user-attachments/assets/72a4314d-26dc-4e6c-8ed3-c807be7b4c31"> | <img width="1044" alt="Screenshot 2024-07-12 at 11 25 51" src="https://github.com/user-attachments/assets/fd427f0d-d0c2-49dd-9c34-aaebf9877070"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The rest of the container does not have a border, so the left/right borders on the tabs container looks out of place.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Navigate the global sites view (<http://calypso.localhost:3000/sites>)
* Select a site
* Note that the tabs in the flyout site panel does not have left/right borders

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
