### PR TITLE
A4A > Partner Directory: Switch to the correct uploading namespace and endpoint for uploading the agency logo

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-submit-form.ts
@@ -19,7 +19,10 @@ const getImageFile = async ( agencyId: number, blobURL: string ) => {
 
 export default function useSubmitForm( { formData, onSubmitSuccess, onSubmitError }: Props ) {
 	const agencyId = useSelector( getActiveAgencyId );
-	const addMedia = useAddMedia();
+	const addMedia = useAddMedia( {
+		apiNamespace: 'wpcom/v2',
+		apiPath: `/agency/${ agencyId }/profile/logo`,
+	} );
 
 	const [ isUploadingImage, setIsUploadingImage ] = useState( false );
 

--- a/client/data/media/use-add-media.js
+++ b/client/data/media/use-add-media.js
@@ -3,7 +3,7 @@ import { getFileUploader, canUseVideoPress } from 'calypso/lib/media/utils';
 import { isFileList } from 'calypso/state/media/utils/is-file-list';
 import { useUploadMediaMutation } from './use-upload-media-mutation';
 
-export const useAddMedia = () => {
+export const useAddMedia = ( apiMetadata ) => {
 	const { uploadMediaAsync } = useUploadMediaMutation();
 	const addVideopressStatusToFile = ( file, site ) => {
 		const siteCanUseVideoPress = canUseVideoPress( site );
@@ -29,7 +29,8 @@ export const useAddMedia = () => {
 				addVideopressStatusToFile( file, site ),
 				site,
 				postId,
-				getFileUploader
+				getFileUploader,
+				apiMetadata
 			);
 		},
 		[ uploadMediaAsync ]

--- a/client/data/media/use-upload-media-mutation.js
+++ b/client/data/media/use-upload-media-mutation.js
@@ -13,7 +13,8 @@ export const useUploadMediaMutation = ( queryOptions = {} ) => {
 	const queryClient = useQueryClient();
 	const dispatch = useDispatch();
 	const mutation = useMutation( {
-		mutationFn: ( { file, siteId, postId, uploader } ) => uploader( file, siteId, postId ),
+		mutationFn: ( { file, siteId, postId, uploader, apiMetadata } ) =>
+			uploader( file, siteId, postId, apiMetadata ),
 		onSuccess( { media: [ uploadedMedia ], found }, { siteId, transientMedia } ) {
 			const uploadedMediaWithTransientId = {
 				...uploadedMedia,
@@ -36,7 +37,7 @@ export const useUploadMediaMutation = ( queryOptions = {} ) => {
 	const { mutateAsync } = mutation;
 
 	const uploadMediaAsync = useCallback(
-		async ( files, site, postId, uploader ) => {
+		async ( files, site, postId, uploader, apiMetadata ) => {
 			// https://stackoverflow.com/questions/25333488/why-isnt-the-filelist-object-an-array
 			if ( isFileList( files ) ) {
 				files = Array.from( files );
@@ -56,7 +57,14 @@ export const useUploadMediaMutation = ( queryOptions = {} ) => {
 					continue;
 				}
 
-				const response = await mutateAsync( { file, siteId, postId, uploader, transientMedia } );
+				const response = await mutateAsync( {
+					file,
+					siteId,
+					postId,
+					uploader,
+					apiMetadata,
+					transientMedia,
+				} );
 
 				uploadedItems.push( response.media[ 0 ] );
 			}

--- a/client/lib/media/utils/get-file-uploader.js
+++ b/client/lib/media/utils/get-file-uploader.js
@@ -3,7 +3,7 @@ import wpcom from 'calypso/lib/wp';
 
 const debug = debugFactory( 'calypso:media' );
 
-export const getFileUploader = ( file, siteId, postId ) => {
+export const getFileUploader = ( file, siteId, postId, apiMetadata ) => {
 	// Determine upload mechanism by object type
 	const isUrl = 'string' === typeof file;
 
@@ -31,5 +31,10 @@ export const getFileUploader = ( file, siteId, postId ) => {
 		return wpcom.site( siteId ).addMediaUrls( {}, file );
 	}
 
-	return wpcom.site( siteId ).addMediaFiles( {}, file );
+	return wpcom.site( siteId ).addMediaFiles(
+		{
+			...( apiMetadata && { ...apiMetadata } ),
+		},
+		file
+	);
 };

--- a/packages/wpcom.js/src/lib/site.media.js
+++ b/packages/wpcom.js/src/lib/site.media.js
@@ -158,9 +158,11 @@ Media.prototype.addFiles = function ( query, files, fn ) {
 	}
 
 	const params = {
-		path: '/sites/' + this._sid + '/media/new',
+		path: query.apiPath ?? `/sites/${ this._sid }/media/new`,
 		formData: buildFormData( files ),
 	};
+
+	query.apiPath && delete query.apiPath;
 
 	return this.wpcom.req.post( params, query, null, fn );
 };


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/790

## Proposed Changes

TBD

**API endpoint reference:** D154719-code


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?