### PR TITLE
Masterbar: add current site menu

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Button } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { Component, Fragment, forwardRef } from 'react';
@@ -7,6 +7,11 @@ import type { ReactNode, LegacyRef } from 'react';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
+interface MasterbarSubItemProps {
+	label: string;
+	url?: string;
+	onClick?: () => void;
+}
 interface MasterbarItemProps {
 	url?: string;
 	innerRef?: LegacyRef< HTMLButtonElement | HTMLAnchorElement >;
@@ -21,6 +26,7 @@ interface MasterbarItemProps {
 	children?: ReactNode;
 	alwaysShowContent?: boolean;
 	disabled?: boolean;
+	subItems?: Array< MasterbarSubItemProps >;
 }
 
 class MasterbarItem extends Component< MasterbarItemProps > {
@@ -35,6 +41,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		preloadSection: PropTypes.func,
 		hasUnseen: PropTypes.bool,
 		alwaysShowContent: PropTypes.bool,
+		subItems: PropTypes.array,
 	};
 
 	static defaultProps = {
@@ -67,11 +74,33 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		);
 	}
 
+	renderSubItems() {
+		const { subItems } = this.props;
+		if ( ! subItems ) {
+			return null;
+		}
+		return (
+			<ul className="masterbar__item-subitems">
+				{ subItems.map( ( item, i ) => (
+					<li key={ i } className="masterbar__item-subitems-item">
+						{ item.onClick && (
+							<Button className="is-link" onClick={ item.onClick }>
+								{ item.label }
+							</Button>
+						) }
+						{ ! item.onClick && item.url && <a href={ item.url }>{ item.label }</a> }
+					</li>
+				) ) }
+			</ul>
+		);
+	}
+
 	render() {
 		const itemClasses = clsx( 'masterbar__item', this.props.className, {
 			'is-active': this.props.isActive,
 			'has-unseen': this.props.hasUnseen,
 			'masterbar__item--always-show-content': this.props.alwaysShowContent,
+			'has-subitems': this.props.subItems,
 		} );
 
 		const attributes = {
@@ -84,7 +113,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			disabled: this.props.disabled,
 		};
 
-		if ( this.props.url ) {
+		if ( this.props.url && ! this.props.subItems ) {
 			return (
 				<a
 					{ ...attributes }
@@ -96,9 +125,21 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			);
 		}
 
+		if ( this.props.url && this.props.subItems ) {
+			return (
+				<button { ...attributes }>
+					<a href={ this.props.url } ref={ this.props.innerRef as LegacyRef< HTMLAnchorElement > }>
+						{ this.renderChildren() }
+					</a>
+					{ this.renderSubItems() }
+				</button>
+			);
+		}
+
 		return (
 			<button { ...attributes } ref={ this.props.innerRef as LegacyRef< HTMLButtonElement > }>
 				{ this.renderChildren() }
+				{ this.renderSubItems() }
 			</button>
 		);
 	}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -4,7 +4,6 @@ import page from '@automattic/calypso-router';
 import { PromptIcon } from '@automattic/command-palette';
 import { Button, Popover } from '@automattic/components';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
-import { Icon, category } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
@@ -24,10 +23,7 @@ import {
 	getCurrentUserDate,
 	getCurrentUserSiteCount,
 } from 'calypso/state/current-user/selectors';
-import {
-	getShouldShowGlobalSidebar,
-	getShouldShowUnifiedSiteSidebar,
-} from 'calypso/state/global-sidebar/selectors';
+import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -612,43 +608,22 @@ class MasterbarLoggedIn extends Component {
 		return null;
 	}
 
-	renderWordPressIcon() {
-		const { siteAdminUrl } = this.props;
-		return (
-			<Item
-				url={ siteAdminUrl }
-				className="masterbar__item-wordpress"
-				icon={ <span className="dashicons-before dashicons-wordpress" /> }
-			/>
-		);
-	}
+	renderSiteMenu( showLabel = true ) {
+		const { sectionGroup, currentSelectedSiteSlug, translate, siteTitle, siteUrl } = this.props;
 
-	renderAllSites() {
-		const { translate } = this.props;
-		return (
-			<Item
-				url="/sites"
-				className="masterbar__item-all-sites"
-				tipTarget="my-sites"
-				icon={ <Icon icon={ category } /> }
-				tooltip={ translate( 'Manage your sites' ) }
-				preloadSection={ this.preloadAllSites }
-			>
-				{ translate( 'All Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
-			</Item>
-		);
-	}
+		// Only display on site-specific pages.
+		if ( sectionGroup !== 'sites' || ! currentSelectedSiteSlug ) {
+			return null;
+		}
 
-	renderCurrentSite() {
-		const { translate, siteTitle, siteUrl } = this.props;
 		return (
 			<Item
-				className="masterbar__item-current-site"
+				className="masterbar__item-my-site"
 				url={ siteUrl }
 				icon={ <span className="dashicons-before dashicons-admin-home" /> }
-				tooltip={ translate( 'Visit your site' ) }
+				subItems={ [ { label: translate( 'Visit Site' ), url: siteUrl } ] }
 			>
-				{ siteTitle }
+				{ showLabel && siteTitle }
 			</Item>
 		);
 	}
@@ -683,26 +658,6 @@ class MasterbarLoggedIn extends Component {
 			);
 		}
 
-		if ( this.props.isUnifiedSiteView ) {
-			return (
-				<Masterbar className="masterbar__unified">
-					<div className="masterbar__section masterbar__section--left">
-						{ this.state.isResponsiveMenu
-							? this.renderSidebarMobileMenu()
-							: this.renderWordPressIcon() }
-						{ this.renderAllSites() }
-						{ this.renderCurrentSite() }
-					</div>
-					<div className="masterbar__section masterbar__section--right">
-						{ this.renderCart() }
-						{ loadHelpCenterIcon && this.renderHelpCenter() }
-						{ this.renderNotifications() }
-						{ this.renderMe() }
-					</div>
-				</Masterbar>
-			);
-		}
-
 		if ( isMobile ) {
 			if ( isInEditor && loadHelpCenterIcon ) {
 				return (
@@ -724,6 +679,7 @@ class MasterbarLoggedIn extends Component {
 						<div className="masterbar__section masterbar__section--left">
 							{ this.renderMySites() }
 							{ this.renderReader( false ) }
+							{ this.renderSiteMenu( false ) }
 							{ this.renderLanguageSwitcher() }
 							{ this.renderSearch() }
 						</div>
@@ -744,6 +700,7 @@ class MasterbarLoggedIn extends Component {
 					<div className="masterbar__section masterbar__section--left">
 						{ this.renderMySites() }
 						{ this.renderReader() }
+						{ this.renderSiteMenu() }
 						{ this.renderLanguageSwitcher() }
 						{ this.renderSearch() }
 					</div>
@@ -784,12 +741,6 @@ export default connect(
 			sectionGroup,
 			sectionName
 		);
-		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
-			state,
-			currentSelectedSiteId,
-			sectionGroup,
-			sectionName
-		);
 		const isDesktop = isWithinBreakpoint( '>782px' );
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
@@ -824,7 +775,6 @@ export default connect(
 			currentRoute: getCurrentRoute( state ),
 			isSiteTrialExpired: isTrialExpired( state, siteId ),
 			isMobileGlobalNavVisible: shouldShowGlobalSidebar && ! isDesktop,
-			isUnifiedSiteView: shouldShowUnifiedSiteSidebar,
 			isCommandPaletteOpen: getIsCommandPaletteOpen( state ),
 		};
 	},

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -684,7 +684,14 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderPopupSearch() }
 					<Masterbar>
 						<div className="masterbar__section masterbar__section--left">
-							{ this.renderMySites() }
+							{ this.props.isUnifiedSiteView ? (
+								<>
+									{ this.renderSidebarMobileMenu() }
+									{ this.renderGlobalMySites() }
+								</>
+							) : (
+								this.renderMySites()
+							) }
 							{ this.renderReader( false ) }
 							{ this.renderSiteMenu( false ) }
 							{ this.renderLanguageSwitcher() }
@@ -705,7 +712,14 @@ class MasterbarLoggedIn extends Component {
 				{ this.renderPopupSearch() }
 				<Masterbar>
 					<div className="masterbar__section masterbar__section--left">
-						{ this.renderMySites() }
+						{ this.props.isUnifiedSiteView && this.state.isResponsiveMenu ? (
+							<>
+								{ this.renderSidebarMobileMenu() }
+								{ this.renderGlobalMySites() }
+							</>
+						) : (
+							this.renderMySites()
+						) }
 						{ this.renderReader() }
 						{ this.renderSiteMenu() }
 						{ this.renderLanguageSwitcher() }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -23,7 +23,10 @@ import {
 	getCurrentUserDate,
 	getCurrentUserSiteCount,
 } from 'calypso/state/current-user/selectors';
-import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
+import {
+	getShouldShowGlobalSidebar,
+	getShouldShowUnifiedSiteSidebar,
+} from 'calypso/state/global-sidebar/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -609,6 +612,10 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderSiteMenu( showLabel = true ) {
+		if ( ! this.props.isUnifiedSiteView ) {
+			return null;
+		}
+
 		const { sectionGroup, currentSelectedSiteSlug, translate, siteTitle, siteUrl } = this.props;
 
 		// Only display on site-specific pages.
@@ -741,6 +748,12 @@ export default connect(
 			sectionGroup,
 			sectionName
 		);
+		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
+			state,
+			currentSelectedSiteId,
+			sectionGroup,
+			sectionName
+		);
 		const isDesktop = isWithinBreakpoint( '>782px' );
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
@@ -775,6 +788,7 @@ export default connect(
 			currentRoute: getCurrentRoute( state ),
 			isSiteTrialExpired: isTrialExpired( state, siteId ),
 			isMobileGlobalNavVisible: shouldShowGlobalSidebar && ! isDesktop,
+			isUnifiedSiteView: shouldShowUnifiedSiteSidebar,
 			isCommandPaletteOpen: getIsCommandPaletteOpen( state ),
 		};
 	},

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -207,6 +207,10 @@ body.is-mobile-app-view {
 	}
 
 	&--left {
+		.masterbar__item-subitems {
+			left: 0;
+		}
+
 		@include breakpoint-deprecated( "<660px" ) {
 			a .masterbar__item-content {
 				display: none;
@@ -247,10 +251,81 @@ body.is-mobile-app-view {
 	height: var(--masterbar-height);
 	line-height: var(--masterbar-height);
 	padding: 0 8px;
+	gap: 6px;
 	text-decoration: none;
 	cursor: default;
 	transition: all 0.2s ease-in-out;
 	justify-content: center;
+
+	&.has-subitems {
+		display: block;
+	}
+
+	> a {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 5px;
+	}
+
+	.masterbar__item-subitems {
+		margin: 0;
+		padding: 6px 0;
+		box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
+		display: none;
+		position: absolute;
+		float: none;
+		min-width: 100%;
+		text-align: left;
+		top: var(--masterbar-height);
+		background: var(--color-masterbar-item-hover-background);
+		list-style: none;
+		clear: none;
+		text-indent: 0;
+
+		.masterbar__item-subitems-item {
+			margin-right: 6px;
+			padding-left: 6px;
+			white-space: nowrap;
+			min-width: 140px;
+			line-height: 2;
+			a,
+			button {
+				display: inline-block;
+				width: 100%;
+				padding: 0 0 0 6px;
+				color: var(--color-masterbar-text);
+			}
+
+			.is-link {
+				border: none;
+				background: none;
+				text-decoration: none;
+				outline: none;
+				margin: 0;
+				text-align: left;
+
+				&:hover {
+					color: var(--color-masterbar-highlight);
+				}
+			}
+
+			&:hover {
+				background: var(--color-masterbar-item-hover-background);
+				a {
+					color: var(--color-masterbar-highlight);
+				}
+			}
+
+		}
+
+		@media only screen and (max-width: 782px) {
+			position: fixed;
+			.masterbar__item-subitems-item {
+				padding: 8px 16px;
+			}
+		}
+	}
 
 	.masterbar--is-checkout & {
 		height: var(--masterbar-height);
@@ -287,10 +362,6 @@ body.is-mobile-app-view {
 		}
 	}
 
-	.gridicon + .masterbar__item-content {
-		padding: 0 0 0 6px;
-	}
-
 	svg {
 		fill: var(--color-masterbar-text);
 	}
@@ -302,6 +373,11 @@ body.is-mobile-app-view {
 
 	// The hover colors are supposed to be the same as those in wp-admin.
 	&:hover {
+		.masterbar__item-subitems {
+			display: block;
+			z-index: 99999;
+		}
+
 		@include breakpoint-deprecated( ">480px" ) {
 			background: var(--color-masterbar-item-hover-background);
 			color: var(--color-masterbar-highlight);
@@ -630,6 +706,8 @@ body.is-mobile-app-view {
 }
 
 .masterbar__item-me {
+	gap: 0;
+
 	.gravatar {
 		position: absolute;
 		top: 50%;
@@ -689,10 +767,6 @@ body.is-mobile-app-view {
 }
 
 .masterbar__reader {
-	@include breakpoint-deprecated( ">480px" ) {
-		margin-right: auto;
-	}
-
 	@media only screen and (max-width: 782px) {
 		.gridicon + .masterbar__item-content {
 			padding-left: 6px;
@@ -1047,40 +1121,5 @@ a.masterbar__quick-language-switcher {
 		.site__domain {
 			color: var(--color-global-masterbar-text);
 		}
-	}
-}
-
-.masterbar__unified {
-	.masterbar__item {
-		gap: 6px;
-		padding: 0 7px;
-	}
-
-	.masterbar__item-me {
-		gap: 0;
-	}
-
-	.masterbar__item-all-sites {
-		gap: 2px;
-
-		@media only screen and (min-width: 783px) {
-			padding: 0 8px 0 4px;
-		}
-
-		svg {
-			fill: var(--color-masterbar-icon);
-			width: 20px;
-			padding-inline: 2px;
-		}
-
-		&:hover {
-			svg {
-				fill: var(--color-masterbar-highlight);
-			}
-		}
-	}
-
-	.masterbar__item-notifications {
-		margin-right: 0;
 	}
 }


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/8143

## Proposed Changes

This PR extracts the site menu from https://github.com/Automattic/wp-calypso/pull/92472. This is meant to unblock https://github.com/Automattic/dotcom-forge/issues/8147.

~~This will show the site menu to all Calypso masterbars:~~ as discussed on p1721019433589929-slack-C06DN6QQVAQ, I'm pivoting to showing this on Classic-view sites only for now.



|`/home/:site` of Classic sites|
|-|
|Before<br><br>![image](https://github.com/user-attachments/assets/89ac0671-17df-4068-af0a-2722b5ebffa6)|
|After<br><br><img width="799" alt="image" src="https://github.com/user-attachments/assets/e578b961-d3b3-405e-8999-962f7db5bb69">|

Mobile view:

<img width="591" alt="image" src="https://github.com/user-attachments/assets/ab58d18e-c9ee-47b7-b4dc-a991c6e54663">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to show consistent navigation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check on Classic sites as shown above.
2. Check also at various viewport widths.
3. Check no regression on Default sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?