### PR TITLE
Fix collapsed global sidebar being toggle-able

### DIFF
--- a/client/hosting/sites/components/style.scss
+++ b/client/hosting/sites/components/style.scss
@@ -1118,21 +1118,3 @@
 	}
 }
 
-// Styles need to ensure they do not bleed into other areas of calypso once loaded.
-// If we only apply to layout__primary, etc., we will have bleed going from the dashboard to site level calypso.
-.is-global-sidebar-visible.is-group-sites-dashboard,
-.is-global-sidebar-visible.is-group-sites {
-	/* See wp-calypso/client/layout/style.scss for the original style - this is removed on sites dashboard to enable pagination to display properly. */
-	.layout__primary .preview-hidden {
-		@include breakpoint-deprecated( ">960px" ) {
-			padding-bottom: 0 !important;
-		}
-	}
-
-	.layout__content {
-		@include breakpoint-deprecated( "<960px" ) {
-			padding: 70px 24px 24px calc(var(--sidebar-width-min) + 1px);
-		}
-	}
-}
-

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -12,7 +12,6 @@
 		background: var(--studio-gray-0);
 
 		.layout__content {
-			padding: calc(var(--masterbar-height) + 16px) 16px 16px calc(var(--sidebar-width-max));
 			min-height: 100vh;
 		}
 

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -1,4 +1,3 @@
-import { isWithinBreakpoint } from '@automattic/viewport';
 import isScheduledUpdatesMultisiteRoute, {
 	isScheduledUpdatesMultisiteCreateRoute,
 	isScheduledUpdatesMultisiteEditRoute,
@@ -84,15 +83,8 @@ export const getShouldShowCollapsedGlobalSidebar = (
 		isScheduledUpdatesMultisiteCreateRoute( state ) ||
 		isScheduledUpdatesMultisiteEditRoute( state );
 
-	const isBulkDomainsDashboard = isInRoute( state, [ '/domains/manage' ] );
-	const isSmallScreenDashboard =
-		( isSitesDashboard || isBulkDomainsDashboard ) && isWithinBreakpoint( '<782px' );
-
 	return (
-		isSiteJustSelectedFromSitesDashboard ||
-		isSiteDashboard ||
-		isPluginsScheduledUpdatesEditMode ||
-		isSmallScreenDashboard
+		isSiteJustSelectedFromSitesDashboard || isSiteDashboard || isPluginsScheduledUpdatesEditMode
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/8250 

## Proposed Changes

* Removes the `isSmallscreenDashboard` check from the collapsed global sidebar selector, as this no longer seems to make sense. This is what causes the collapsed sidebar to appear in the states noted on the issue. We can instead show the full sidebar when it is toggleable, the collapsed sidebar will continue to appear in other previous conditions (such as selecting a site in fullscreen dashboard view).
* Removes some unnecessary CSS that was overwriting padding behavior across breakpoints. These style rules caused the following issues when the sidebar was toggle-able on /sites, /themes, etc.:
<img width="300" alt="Screenshot 2024-07-12 at 11 22 57 AM" src="https://github.com/user-attachments/assets/970e0aac-e2a3-4137-adad-c41b561ecb68">
 
Removing these styles allowed other existing styles with less specificity to take effect, and seems to have the desired behavior across all breakpoints. I did explore trying to add some other rules or specificity to existing styles, but this seemed to quickly become whack-a-mole with other layout bugs and that seems like a bad way to go about things anyways. These styles seem to be covered elsewhere with less generic rules, removing them seems to be the cleanest option.



BEFORE
![collapsed-sidebar-bad](https://github.com/user-attachments/assets/74de6a20-65c3-44e7-8b94-e02a267a253f)


AFTER
![collapsed-sidebar-good](https://github.com/user-attachments/assets/3b634cf3-4739-4772-a941-f78c1d14dcd1)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

User experience and layout feels broken at `660px < width < 782px`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the various areas of the dashboard (themes, sites, domains, etc.) both `width > 960px`  and `782px < width < 960px). Verify the layout is unchanged.
* Test the sites and domains dashboards at `660px < width < 782px`. Verify the collapsed sidebar does not appear here, and that the full width sidebar is toggle-able. Verify the layout is good when navigating to/from different sections and when toggling the sidebar.
* Test below 660px width and verify no changes.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
