### PR TITLE
Design Preview & Assembler: Try to avoid screen blinking by turning off the animation on the navigation screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -728,7 +728,10 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					/>
 				</NavigatorScreen>
 
-				<NavigatorScreen path={ NAVIGATOR_PATHS.STYLES_COLORS }>
+				<NavigatorScreen
+					path={ NAVIGATOR_PATHS.STYLES_COLORS }
+					style={ { animationDuration: '0s' } }
+				>
 					<ScreenColorPalettes
 						siteId={ site?.ID }
 						stylesheet={ stylesheet }
@@ -736,7 +739,10 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						onSelect={ onScreenColorsSelect }
 					/>
 				</NavigatorScreen>
-				<NavigatorScreen path={ NAVIGATOR_PATHS.STYLES_FONTS }>
+				<NavigatorScreen
+					path={ NAVIGATOR_PATHS.STYLES_FONTS }
+					style={ { animationDuration: '0s' } }
+				>
 					<ScreenFontPairings
 						siteId={ site?.ID }
 						stylesheet={ stylesheet }

--- a/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-screens.tsx
+++ b/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-screens.tsx
@@ -23,7 +23,7 @@ const useNavigatorScreens = ( screens: NavigatorScreenObject[] ) => {
 			onSubmit,
 			onBack,
 		} ) => (
-			<NavigatorScreen key={ path } path={ path }>
+			<NavigatorScreen key={ path } path={ path } style={ { animationDuration: '0s' } }>
 				<>
 					<NavigatorHeader
 						title={ <>{ title ?? label }</> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92428, p1720770591246829-slack-CRWCHQGUB

## Proposed Changes

* Proposed a workaround to avoid the screen blinking by turning off the animation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The experience is so bad

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The issue is reproducible only on production with Grammarly enabled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?