### PR TITLE
Light Color Scheme: fix selected menu item colors

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_light.scss
@@ -142,10 +142,10 @@ Primary+Accent is studio blue.
 	--color-sidebar-gridicon-fill: var(--theme-icon-color);
 
 	/* Sidebar Selected */
-	--color-sidebar-menu-selected-background: #fff;
-	--color-sidebar-menu-selected-background-rgb: 255, 255, 255;
-	--color-sidebar-menu-selected-text: #333;
-	--color-sidebar-menu-selected-text-rgb: 51, 51, 51;
+	--color-sidebar-menu-selected-text: #fff;
+	--color-sidebar-menu-selected-text-rgb: 255, 255, 255;
+	--color-sidebar-menu-selected-background: #888;
+	--color-sidebar-menu-selected-background-rgb: 136, 136, 136;
 
 	/* Sidebar Hover */
 	--color-sidebar-menu-hover-background: #888;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 7884-gh-Automattic/dotcom-forge

## Proposed Changes

* Fixes the text and background colors of the currently selected menu item on the Light color scheme

## Why are these changes being made?

It looks like they were missed, or more likely overwritten during a merge/rebase during work on the issue linked above. This PR will fix the affected variables so the Light color scheme renders selected menu items properly (they should match the scheme's menu item hover effect)

## Testing Instructions

- Activate the Light color scheme
- Using a Simple site, select a menu item (in Calypso, not wp-admin) like **Posts** or **Pages**
- Confirm the selected menu item's text is white, and the background is light gray (`#888`)
- Using an Atomic site with the Light color scheme, open **Settings > General** and select the Classic admin interface (aka wp-admin)
- Select the **Hosting** sidebar item. This will be Calypso, in spite of your admin preference. That is expected.
- Make sure you're view calypso.localhost:3000, and you didn't get bumped out to production as you navigated your site's settings. That can happen, trust me i've been there 😆 
- Confirm that the text of "Hosting" is once again while, and the background is `#888`.