### PR TITLE
Advertising A4A: Update sites dashboard promotional banner

### DIFF
--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -311,8 +311,8 @@ const SitesDashboard = ( {
 								) }
 								target="_blank"
 								title={
-									hasEnTranslation( "Here's how to earn more" )
-										? translate( "Here's how to earn more" )
+									hasEnTranslation( "Building sites for customers? Here's how to earn more." )
+										? translate( "Building sites for customers? Here's how to earn more." )
 										: translate( 'Managing multiple sites? Meet our agency hosting' )
 								}
 								tracksClickName="calypso_sites_dashboard_a4a_banner_click"

--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -311,12 +311,8 @@ const SitesDashboard = ( {
 								) }
 								target="_blank"
 								title={
-									hasEnTranslation(
-										'Building sites for customers? Earn more with our agency program.'
-									)
-										? translate(
-												'Building sites for customers? Earn more with our agency program.'
-										  )
+									hasEnTranslation( "Here's how to earn more" )
+										? translate( "Here's how to earn more" )
 										: translate( 'Managing multiple sites? Meet our agency hosting' )
 								}
 								tracksClickName="calypso_sites_dashboard_a4a_banner_click"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8059

## Proposed Changes

* Updates title of sites dashboard to read "Building sites for customers? Here's how to earn more"

<img width="1381" alt="Screenshot 2024-07-12 at 3 23 30 PM" src="https://github.com/user-attachments/assets/5804d318-33a4-4e10-9e0a-d4b517d0233f">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/dotcom-forge/issues/8059

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /sites with a user with 5 or more sites
* Verify that the A4A promotional banner title now reads "Building sites for customers? Here's how to earn more" 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
