### PR TITLE
Jetpack Backup: Fix restore retry link and add a Tracks event

### DIFF
--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -396,15 +396,6 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			) }
 			<Card>{ render() }</Card>
 			{ ( isInProgress || isFinished ) && <JetpackReviewPrompt align="center" type="restore" /> }
-			<ul>
-				<li>inProgressRewindStatus: { JSON.stringify( inProgressRewindStatus ) }</li>
-				<li>isInProgress: { JSON.stringify( isInProgress ) }</li>
-				<li>userHasRequestedRestore: { JSON.stringify( userHasRequestedRestore ) }</li>
-				<li>restoreInitiated: { JSON.stringify( restoreInitiated ) }</li>
-				<li>restoreFailed: { JSON.stringify( restoreFailed ) }</li>
-				<li>showConfirm: { JSON.stringify( showConfirm ) }</li>
-				<li>isRestoreInProgress: { JSON.stringify( isRestoreInProgress ) }</li>
-			</ul>
 		</>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -80,6 +80,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 
 	const [ userHasRequestedRestore, setUserHasRequestedRestore ] = useState< boolean >( false );
 	const [ restoreInitiated, setRestoreInitiated ] = useState( false );
+	const [ restoreFailed, setRestoreFailed ] = useState( false );
 	const [ showConfirm, setShowConfirm ] = useState( false );
 
 	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
@@ -161,6 +162,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const onRetryClick = useCallback( () => {
 		// Reset the restore state
 		setRestoreInitiated( false );
+		setRestoreFailed( false );
 		setUserHasRequestedRestore( false );
 
 		// Show the restore confirmation screen
@@ -338,7 +340,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const isInProgress =
 		( ! inProgressRewindStatus && userHasRequestedRestore ) ||
 		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) ) ||
-		( userHasRequestedRestore && inProgressRewindStatus === 'failed' );
+		( userHasRequestedRestore && inProgressRewindStatus === 'failed' && ! restoreFailed );
 	const isFinished = inProgressRewindStatus !== null && inProgressRewindStatus === 'finished';
 
 	useEffect( () => {
@@ -346,11 +348,13 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_completed' ) );
 			setRestoreInitiated( false );
 			setUserHasRequestedRestore( false );
+			setRestoreFailed( false );
 		}
 
 		if ( ! isRestoreInProgress && restoreInitiated && inProgressRewindStatus === 'failed' ) {
 			setRestoreInitiated( false );
 			setUserHasRequestedRestore( false );
+			setRestoreFailed( true );
 		}
 	}, [
 		dispatch,
@@ -392,6 +396,15 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			) }
 			<Card>{ render() }</Card>
 			{ ( isInProgress || isFinished ) && <JetpackReviewPrompt align="center" type="restore" /> }
+			<ul>
+				<li>inProgressRewindStatus: { JSON.stringify( inProgressRewindStatus ) }</li>
+				<li>isInProgress: { JSON.stringify( isInProgress ) }</li>
+				<li>userHasRequestedRestore: { JSON.stringify( userHasRequestedRestore ) }</li>
+				<li>restoreInitiated: { JSON.stringify( restoreInitiated ) }</li>
+				<li>restoreFailed: { JSON.stringify( restoreFailed ) }</li>
+				<li>showConfirm: { JSON.stringify( showConfirm ) }</li>
+				<li>isRestoreInProgress: { JSON.stringify( isRestoreInProgress ) }</li>
+			</ul>
 		</>
 	);
 };

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -337,7 +337,8 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 
 	const isInProgress =
 		( ! inProgressRewindStatus && userHasRequestedRestore ) ||
-		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) );
+		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) ) ||
+		( userHasRequestedRestore && inProgressRewindStatus === 'failed' );
 	const isFinished = inProgressRewindStatus !== null && inProgressRewindStatus === 'finished';
 
 	useEffect( () => {
@@ -346,15 +347,24 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			setRestoreInitiated( false );
 			setUserHasRequestedRestore( false );
 		}
-	}, [ dispatch, inProgressRewindStatus, isFinished, restoreInitiated, userHasRequestedRestore ] );
+
+		if ( ! isRestoreInProgress && restoreInitiated && inProgressRewindStatus === 'failed' ) {
+			setRestoreInitiated( false );
+			setUserHasRequestedRestore( false );
+		}
+	}, [
+		dispatch,
+		inProgressRewindStatus,
+		isFinished,
+		isRestoreInProgress,
+		restoreInitiated,
+		userHasRequestedRestore,
+	] );
 
 	const render = () => {
 		if ( loading ) {
 			return <Loading />;
-		} else if (
-			( ! inProgressRewindStatus && ! userHasRequestedRestore ) ||
-			( inProgressRewindStatus === 'failed' && showConfirm )
-		) {
+		} else if ( ( ! inProgressRewindStatus && ! userHasRequestedRestore ) || showConfirm ) {
 			return renderConfirm();
 		} else if ( ! inProgressRewindStatus && needCredentials ) {
 			return (


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-backup-team/issues/565

## Proposed Changes

* Fix the restore retry link that is displayed when a restore fails.
  * Now clicking on `try your restore again` will display the confirmation screen where the user can select the items they want to restore.
* Trigger `calypso_jetpack_backup_restore_failed_retry` event when user clicks on the retry link.

### Screenshot

![CleanShot 2024-07-12 at 23 31 28@2x](https://github.com/user-attachments/assets/20f43609-54c8-407b-a44a-b813c6d6cc8a)

### Demo

https://github.com/user-attachments/assets/3c02dbf3-efa7-4bce-9628-d8d7b5740412

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The retry link is not currently working.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
> [!NOTE]
> To test this, you might need to force the restore to fail. Some options where discussed in p1720711694224909-slack-CS8UYNPEE. One optimal option could be to restore SQL only and remove alter table permissions in the MySQL user temporarily.
> 
> For brevity describing the test steps, when we say `validate the event X was triggered`, it means that you should see a request to `t.gif` with the described event name.

* Spin up a Jetpack Cloud live branch
* * Open the Network tab in your developer tools
* Navigate to Jetpack Cloud > Backup
* On any available backup, click on `Restore to this point` to start the restore process.
* Select all items you want to restore and click on `Restore now`.
* When the restore fails, click on `try your restore again` link.
* Validate the event `calypso_jetpack_backup_restore_failed_retry` was triggered by validating there is a `t.gif` request with said event.
* Try restoring the site again and ensure it fails again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?