### PR TITLE
Check if the the request hasn't started

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
@@ -172,7 +172,10 @@ describe( 'UpgradePlan', () => {
 	it( 'should call onCtaClick when the user clicks on the Continue button', async () => {
 		const mockOnCtaClick = jest.fn();
 
-		renderUpgradePlanComponent( getUpgradePlanProps( { onCtaClick: mockOnCtaClick } ) );
+		renderUpgradePlanComponent(
+			getUpgradePlanProps( { onCtaClick: mockOnCtaClick } ),
+			UnwrappedUpgradePlan
+		);
 
 		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
 
@@ -183,7 +186,8 @@ describe( 'UpgradePlan', () => {
 		const mockOnCtaClick = jest.fn();
 
 		renderUpgradePlanComponent(
-			getUpgradePlanProps( { ctaText: 'My Custom CTA', onCtaClick: mockOnCtaClick } )
+			getUpgradePlanProps( { ctaText: 'My Custom CTA', onCtaClick: mockOnCtaClick } ),
+			UnwrappedUpgradePlan
 		);
 
 		await userEvent.click( screen.getByRole( 'button', { name: /My Custom CTA/ } ) );

--- a/client/blocks/importer/wordpress/upgrade-plan/with-migration-sticker.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/with-migration-sticker.tsx
@@ -12,7 +12,7 @@ const withMigrationSticker =
 
 		const {
 			addMigrationSticker,
-			addMutationRest: { isPending },
+			addMutationRest: { isIdle, isPending },
 			deleteMigrationSticker,
 		} = useMigrationStickerMutation();
 
@@ -32,7 +32,7 @@ const withMigrationSticker =
 			};
 		}, [ addMigrationSticker, deleteMigrationSticker, siteId ] );
 
-		if ( isPending ) {
+		if ( isIdle || isPending ) {
 			return <Skeleton />;
 		}
 


### PR DESCRIPTION
E2E started failing, but it doesn't happen always.
Also our testers reported they sometimes see weird behaviour.

It was not enough to check isPending, because isIdle is the status that we have before performing the request. Here, isPending is false, so it lets us to render component. That results in flakiness in the component and tests' behaviours.

## Proposed Changes

* Check isIdle before rendering the actual component.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix tests and avoid unexpected behaviour for users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* E2E and unit tests should be green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
