### PR TITLE
Stats: Remove tier upgrade feature flag

### DIFF
--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	PRODUCT_JETPACK_STATS_YEARLY,
 	PRODUCT_JETPACK_STATS_MONTHLY,
@@ -40,7 +39,6 @@ const StatsPurchasePage = ( {
 	query: { redirect_uri: string; from: string; productType: 'commercial' | 'personal' };
 } ) => {
 	const translate = useTranslate();
-	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
 
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
@@ -123,18 +121,15 @@ const StatsPurchasePage = ( {
 
 	const maxSliderPrice = commercialMonthlyProduct?.cost;
 
-	// Redirect to commercial is there is the query param is set and the site doesn't have commercial license yet
-	const redirectToCommercial = ! isTierUpgradeSliderEnabled
-		? query?.productType === 'commercial' && ! supportCommercialUse
-		: query?.productType === 'commercial'; // allow multiple visit to upgrade commercial tier.
+	const redirectToCommercial = query?.productType === 'commercial'; // allow multiple visit to upgrade commercial tier.
 	// Redirect to personal is there is the query param is set, the site doesn't have personal license yet, and it's not redirecting to commercial
 	const redirectToPersonal =
 		query?.productType === 'personal' && ! isPWYWOwned && ! redirectToCommercial;
 	// Whether it's forced to redirect to a product
 	const isForceProductRedirect = redirectToPersonal || redirectToCommercial;
 	const noPlanOwned = ! supportCommercialUse && ! isFreeOwned && ! isPWYWOwned;
-	const allowCommercialTierUpgrade =
-		isTierUpgradeSliderEnabled && isCommercialOwned && ! isLegacyCommercialLicense;
+	// Legacy commercial licenses don't have limits.
+	const allowCommercialTierUpgrade = isCommercialOwned && ! isLegacyCommercialLicense;
 
 	// We show purchase page if there is no plan owned or if we are forcing a product redirect
 	// VIP sites are exempt from being shown this page.

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { NoticeIdType } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import CommercialSiteUpgradeNotice from './commercial-site-upgrade-notice';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
@@ -113,7 +112,6 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			return !! (
 				! isWpcom &&
 				( showTierUpgradeNoticeOnOdyssey || showTierUpgradeNoticeForJetpackNotAtomic ) &&
-				config.isEnabled( 'stats/tier-upgrade-slider' ) &&
 				isCommercialOwned
 			);
 		},

--- a/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
@@ -9,7 +9,7 @@ import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/tier-upgrade-slider&from=${ from }-stats-tier-upgrade-notice&productType=commercial`;
+	const purchasePath = `/stats/purchase/${ siteId }?from=${ from }-stats-tier-upgrade-notice&productType=commercial`;
 
 	return purchasePath;
 };

--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -20,7 +20,7 @@ interface StatsPlanUsageProps {
 
 const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/tier-upgrade-slider&from=${ from }-stats-tier-upgrade-usage-section&productType=commercial`;
+	const purchasePath = `/stats/purchase/${ siteId }?from=${ from }-stats-tier-upgrade-usage-section&productType=commercial`;
 
 	return purchasePath;
 };

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -68,15 +68,12 @@ type StatsCommercialUpgradeSliderProps = {
 	onSliderChange: ( quantity: number ) => void;
 };
 
-const getTierQuentity = ( tiers: StatsPlanTierUI, isTierUpgradeSliderEnabled: boolean ) => {
-	if ( isTierUpgradeSliderEnabled ) {
-		if ( tiers?.views === null && tiers?.transform_quantity_divide_by ) {
-			// handle extension an tier by muliplying the limit of the highest tier
-			return EXTENSION_THRESHOLD_IN_MILLION * tiers.transform_quantity_divide_by; // TODO: this will use a dynamic multiplier (#85246)
-		}
-		return tiers?.views;
+const getTierQuentity = ( tiers: StatsPlanTierUI ) => {
+	if ( tiers?.views === null && tiers?.transform_quantity_divide_by ) {
+		// handle extension an tier by muliplying the limit of the highest tier
+		return EXTENSION_THRESHOLD_IN_MILLION * tiers.transform_quantity_divide_by; // TODO: this will use a dynamic multiplier (#85246)
 	}
-	return 0;
+	return tiers?.views;
 };
 
 function StatsCommercialUpgradeSlider( {
@@ -133,7 +130,7 @@ function StatsCommercialUpgradeSlider( {
 	const steps = getStepsForTiers( tiers, currencyCode );
 
 	const handleSliderChanged = ( index: number ) => {
-		const quantity = getTierQuentity( tiers[ index ], true );
+		const quantity = getTierQuentity( tiers[ index ] );
 
 		if ( analyticsEventName ) {
 			recordTracksEvent( analyticsEventName, {
@@ -147,7 +144,7 @@ function StatsCommercialUpgradeSlider( {
 
 	useEffect( () => {
 		// Update fetched tier quantity of the first step back to the parent component for checkout.
-		const firstStepQuantity = getTierQuentity( tiers[ 0 ], true );
+		const firstStepQuantity = getTierQuentity( tiers[ 0 ] );
 		onSliderChange( firstStepQuantity as number );
 	}, [ JSON.stringify( tiers ), onSliderChange ] );
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -152,6 +152,7 @@ const gotoCheckoutPage = ( {
 			product = PRODUCT_JETPACK_STATS_FREE;
 			break;
 		case 'commercial':
+			eventName = 'commercial';
 			product = quantity
 				? `${ PRODUCT_JETPACK_STATS_YEARLY }:-q-${ quantity }`
 				: PRODUCT_JETPACK_STATS_YEARLY;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -140,8 +140,6 @@ const gotoCheckoutPage = ( {
 	let eventName = '';
 	let product: string;
 
-	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
-
 	switch ( type ) {
 		case 'pwyw':
 			eventName = 'pwyw';
@@ -154,15 +152,9 @@ const gotoCheckoutPage = ( {
 			product = PRODUCT_JETPACK_STATS_FREE;
 			break;
 		case 'commercial':
-			// Default to yearly/annual billing
-			eventName = 'commercial';
-			product = PRODUCT_JETPACK_STATS_YEARLY;
-
-			if ( isTierUpgradeSliderEnabled ) {
-				product = quantity
-					? `${ PRODUCT_JETPACK_STATS_YEARLY }:-q-${ quantity }`
-					: PRODUCT_JETPACK_STATS_YEARLY;
-			}
+			product = quantity
+				? `${ PRODUCT_JETPACK_STATS_YEARLY }:-q-${ quantity }`
+				: PRODUCT_JETPACK_STATS_YEARLY;
 
 			break;
 	}

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -1,11 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import {
-	PricingSlider,
-	RenderThumbFunction,
-	Button as CalypsoButton,
-} from '@automattic/components';
-import formatCurrency from '@automattic/format-currency';
+import { Button as CalypsoButton } from '@automattic/components';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
@@ -53,49 +48,12 @@ const PersonalPurchase = ( {
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
 	const [ isDonationChecked, setDonationChecked ] = useState( false );
 	const [ isPostponeBusy, setPostponeBusy ] = useState( false );
-	const {
-		sliderStepPrice,
-		minSliderPrice,
-		maxSliderPrice,
-		uiEmojiHeartTier,
-		uiImageCelebrationTier,
-	} = sliderSettings;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
 	const { hasAnyStatsPlan } = useStatsPurchases( siteId );
-
-	const sliderLabel = ( ( props, state ) => {
-		let emoji;
-
-		if ( subscriptionValue < uiEmojiHeartTier ) {
-			emoji = String.fromCodePoint( 0x1f60a ); /* Smiling face emoji */
-		} else if ( subscriptionValue < uiImageCelebrationTier ) {
-			emoji = String.fromCodePoint( 0x2764, 0xfe0f ); /* Heart emoji */
-		} else if ( subscriptionValue >= uiImageCelebrationTier ) {
-			emoji = String.fromCodePoint( 0x1f525 ); /* Fire emoji */
-		}
-
-		return (
-			<div { ...props }>
-				{ translate( '%(value)s/month', {
-					args: {
-						value: formatCurrency(
-							( state?.valueNow || subscriptionValue ) * sliderStepPrice,
-							currencyCode
-						),
-					},
-					comment: 'Price per month selected by the user via the pricing slider',
-				} ) }
-				{ ` ${ subscriptionValue > 0 ? emoji : '' }` }
-			</div>
-		);
-	} ) as RenderThumbFunction;
 
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	// The button of @automattic/components has built-in color scheme support for Calypso.
 	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
-	// TODO: Remove old slider code paths.
-	const showOldSlider = ! isTierUpgradeSliderEnabled;
 
 	const continueButtonText = translate( 'Contribute now and continue' );
 	const { refetch: refetchNotices } = useNoticeVisibilityQuery( siteId, 'focus_jetpack_purchase' );
@@ -164,38 +122,15 @@ const PersonalPurchase = ( {
 				) }
 			</div>
 
-			{ showOldSlider && (
-				<>
-					<PricingSlider
-						className={ `${ COMPONENT_CLASS_NAME }__slider` }
-						value={ subscriptionValue }
-						renderThumb={ sliderLabel }
-						onChange={ setSubscriptionValue }
-						maxValue={ Math.floor( maxSliderPrice / sliderStepPrice ) }
-						minValue={ Math.round( minSliderPrice / sliderStepPrice ) }
-					/>
-
-					<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>
-						{ translate( 'Our users pay %(value)s per month on average', {
-							args: {
-								value: formatCurrency( defaultStartingValue * sliderStepPrice, currencyCode ),
-							},
-						} ) }
-					</p>
-				</>
-			) }
-
-			{ isTierUpgradeSliderEnabled && (
-				<StatsPWYWUpgradeSlider
-					settings={ sliderSettings }
-					currencyCode={ currencyCode }
-					analyticsEventName={ `${
-						isOdysseyStats ? 'jetpack_odyssey' : 'calypso'
-					}_stats_purchase_pwyw_slider_clicked` }
-					defaultStartingValue={ defaultStartingValue }
-					onSliderChange={ handleSliderChanged }
-				/>
-			) }
+			<StatsPWYWUpgradeSlider
+				settings={ sliderSettings }
+				currencyCode={ currencyCode }
+				analyticsEventName={ `${
+					isOdysseyStats ? 'jetpack_odyssey' : 'calypso'
+				}_stats_purchase_pwyw_slider_clicked` }
+				defaultStartingValue={ defaultStartingValue }
+				onSliderChange={ handleSliderChanged }
+			/>
 
 			{ subscriptionValue === 0 && (
 				<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist` }>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -172,39 +172,37 @@ const StatsCommercialPurchase = ( {
 				</>
 			) }
 			{ isCommercialOwned && <StatsUpgradeInstructions /> }
-			<>
-				<p>{ translate( 'Pick your Stats tier below:' ) }</p>
-				<StatsCommercialUpgradeSlider
-					currencyCode={ currencyCode }
-					analyticsEventName={ `${
-						isOdysseyStats ? 'jetpack_odyssey' : 'calypso'
-					}_stats_purchase_commercial_slider_clicked` }
-					onSliderChange={ handleSliderChanged }
-				/>
-				<div className="stats-purchase-wizard__actions">
-					<ButtonComponent
-						variant="primary"
-						primary={ isWPCOMSite ? true : undefined }
-						onClick={ () =>
-							gotoCheckoutPage( {
-								from,
-								type: 'commercial',
-								siteSlug,
-								adminUrl,
-								redirectUri,
-								price: undefined,
-								quantity: purchaseTierQuantity,
-								isUpgrade: hasAnyStatsPlan, // All cross grades are not possible for the site-only flow.
-							} )
-						}
-					>
-						{ continueButtonText }
-					</ButtonComponent>
-				</div>
-				<div className="stats-purchase-page__footnotes">
-					<p>{ translate( '(*) 14-day money-back guarantee' ) }</p>
-				</div>
-			</>
+			<p>{ translate( 'Pick your Stats tier below:' ) }</p>
+			<StatsCommercialUpgradeSlider
+				currencyCode={ currencyCode }
+				analyticsEventName={ `${
+					isOdysseyStats ? 'jetpack_odyssey' : 'calypso'
+				}_stats_purchase_commercial_slider_clicked` }
+				onSliderChange={ handleSliderChanged }
+			/>
+			<div className="stats-purchase-wizard__actions">
+				<ButtonComponent
+					variant="primary"
+					primary={ isWPCOMSite ? true : undefined }
+					onClick={ () =>
+						gotoCheckoutPage( {
+							from,
+							type: 'commercial',
+							siteSlug,
+							adminUrl,
+							redirectUri,
+							price: undefined,
+							quantity: purchaseTierQuantity,
+							isUpgrade: hasAnyStatsPlan, // All cross grades are not possible for the site-only flow.
+						} )
+					}
+				>
+					{ continueButtonText }
+				</ButtonComponent>
+			</div>
+			<div className="stats-purchase-page__footnotes">
+				<p>{ translate( '(*) 14-day money-back guarantee' ) }</p>
+			</div>
 		</>
 	);
 };

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -24,7 +24,6 @@ import {
 } from './stats-purchase-consts';
 import PersonalPurchase from './stats-purchase-personal';
 import {
-	StatsCommercialPriceDisplay,
 	StatsBenefitsCommercial,
 	StatsSingleItemPagePurchaseFrame,
 	StatsSingleItemCard,
@@ -137,7 +136,6 @@ const useLocalizedStrings = ( isCommercial: boolean ) => {
 const StatsCommercialPurchase = ( {
 	siteId,
 	siteSlug,
-	planValue,
 	currencyCode,
 	from,
 	adminUrl,
@@ -145,13 +143,12 @@ const StatsCommercialPurchase = ( {
 }: StatsCommercialPurchaseProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
-	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
 	const tiers = useAvailableUpgradeTiers( siteId ) || [];
 	const { isCommercialOwned, hasAnyStatsPlan } = useStatsPurchases( siteId );
 
 	// The button of @automattic/components has built-in color scheme support for Calypso.
 	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
-	const startingTierQuantity = getTierQuentity( tiers[ 0 ], isTierUpgradeSliderEnabled );
+	const startingTierQuantity = getTierQuentity( tiers[ 0 ] );
 	const [ purchaseTierQuantity, setPurchaseTierQuantity ] = useState( startingTierQuantity ?? 0 );
 
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
@@ -165,8 +162,6 @@ const StatsCommercialPurchase = ( {
 	) as boolean;
 	const { pageTitle, infoText, continueButtonText } = useLocalizedStrings( isCommercial );
 
-	// TODO: Remove isTierUpgradeSliderEnabled code paths.
-
 	return (
 		<>
 			<h1>{ pageTitle }</h1>
@@ -177,55 +172,39 @@ const StatsCommercialPurchase = ( {
 				</>
 			) }
 			{ isCommercialOwned && <StatsUpgradeInstructions /> }
-			{ ! isTierUpgradeSliderEnabled && (
-				<>
-					<StatsCommercialPriceDisplay planValue={ planValue } currencyCode={ currencyCode } />
+			<>
+				<p>{ translate( 'Pick your Stats tier below:' ) }</p>
+				<StatsCommercialUpgradeSlider
+					currencyCode={ currencyCode }
+					analyticsEventName={ `${
+						isOdysseyStats ? 'jetpack_odyssey' : 'calypso'
+					}_stats_purchase_commercial_slider_clicked` }
+					onSliderChange={ handleSliderChanged }
+				/>
+				<div className="stats-purchase-wizard__actions">
 					<ButtonComponent
 						variant="primary"
 						primary={ isWPCOMSite ? true : undefined }
 						onClick={ () =>
-							gotoCheckoutPage( { from, type: 'commercial', siteSlug, adminUrl, redirectUri } )
+							gotoCheckoutPage( {
+								from,
+								type: 'commercial',
+								siteSlug,
+								adminUrl,
+								redirectUri,
+								price: undefined,
+								quantity: purchaseTierQuantity,
+								isUpgrade: hasAnyStatsPlan, // All cross grades are not possible for the site-only flow.
+							} )
 						}
 					>
-						{ translate( 'Get Stats' ) }
+						{ continueButtonText }
 					</ButtonComponent>
-				</>
-			) }
-			{ isTierUpgradeSliderEnabled && (
-				<>
-					<p>{ translate( 'Pick your Stats tier below:' ) }</p>
-					<StatsCommercialUpgradeSlider
-						currencyCode={ currencyCode }
-						analyticsEventName={ `${
-							isOdysseyStats ? 'jetpack_odyssey' : 'calypso'
-						}_stats_purchase_commercial_slider_clicked` }
-						onSliderChange={ handleSliderChanged }
-					/>
-					<div className="stats-purchase-wizard__actions">
-						<ButtonComponent
-							variant="primary"
-							primary={ isWPCOMSite ? true : undefined }
-							onClick={ () =>
-								gotoCheckoutPage( {
-									from,
-									type: 'commercial',
-									siteSlug,
-									adminUrl,
-									redirectUri,
-									price: undefined,
-									quantity: purchaseTierQuantity,
-									isUpgrade: hasAnyStatsPlan, // All cross grades are not possible for the site-only flow.
-								} )
-							}
-						>
-							{ continueButtonText }
-						</ButtonComponent>
-					</div>
-					<div className="stats-purchase-page__footnotes">
-						<p>{ translate( '(*) 14-day money-back guarantee' ) }</p>
-					</div>
-				</>
-			) }
+				</div>
+				<div className="stats-purchase-page__footnotes">
+					<p>{ translate( '(*) 14-day money-back guarantee' ) }</p>
+				</div>
+			</>
 		</>
 	);
 };

--- a/config/client.json
+++ b/config/client.json
@@ -25,7 +25,6 @@
 	"stats/empty-module-traffic",
 	"stats/empty-module-v2",
 	"stats/restricted-dashboard",
-	"stats/tier-upgrade-slider",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -215,7 +215,6 @@
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
-		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -141,7 +141,6 @@
 		"stats/empty-module-v2": false,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
-		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -185,7 +185,6 @@
 		"stats/empty-module-v2": false,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
-		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -179,7 +179,6 @@
 		"stats/empty-module-v2": false,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
-		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -120,7 +120,6 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": false,
 		"stats/restricted-dashboard": true,
-		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -177,7 +177,6 @@
 		"stats/empty-module-v2": false,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
-		"stats/tier-upgrade-slider": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION


## Proposed Changes

* Remove feature flag `stats/tier-upgrade-slider`

## Why are these changes being made?

* Maintenance

## Testing Instructions

* Read through the code and ensure the logic didn't change after the removal of `stats/tier-upgrade-slider` feature flag
* Ensure new purchase and upgrade flow still work well on Odyssey and Calypso

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?