### PR TITLE
A4A > Referrals: Remove the referral purchases table sticky header

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -54,12 +54,6 @@ $data-view-border-color: #f1f1f1;
 	@media (min-width: $break-large) {
 		background: inherit;
 
-		.dataviews-view-table thead {
-			position: sticky;
-			top: 0;
-			z-index: 2;
-		}
-
 		.dataviews-wrapper tr.dataviews-view-table__row th {
 			text-wrap: nowrap;
 		}


### PR DESCRIPTION
## Proposed Changes

This PR enhances the referral table scroll. The experience is the same as the sites' dashboard by making the actions sticky.

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals - Dashboard > Click on any client for the detailed view > Verify the Purchases table doesn't have a sticky table head.


| Before | After |
|--------|--------|
| <img width="1198" alt="Screenshot 2024-07-15 at 10 32 29 AM" src="https://github.com/user-attachments/assets/f90b8f14-087e-4b93-94dd-412940369253"> | <img width="1198" alt="Screenshot 2024-07-15 at 10 32 35 AM" src="https://github.com/user-attachments/assets/b57a2148-1239-4f52-a1ed-595dbd047f4d"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
