### PR TITLE
Stats: Empty States on Insights Page: Tags & Categories

### DIFF
--- a/client/my-sites/stats/features/modules/stats-tags/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-tags/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-tags';

--- a/client/my-sites/stats/features/modules/stats-tags/stats-tags.tsx
+++ b/client/my-sites/stats/features/modules/stats-tags/stats-tags.tsx
@@ -1,6 +1,6 @@
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { mapMarker } from '@wordpress/icons';
+import { tag } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -71,15 +71,15 @@ const StatsTags: React.FC< StatsDefaultModuleProps > = ( {
 					isEmpty
 					emptyMessage={
 						<EmptyModuleCard
-							icon={ mapMarker }
+							icon={ tag }
 							description={ translate(
-								'Stats on visitors and their {{link}}viewing location{{/link}} will appear here to learn from where you are getting visits.',
+								'Learn about your most visited {{link}}tags & categories{{/link}} to track engaging topics. ',
 								{
 									comment: '{{link}} links to support documentation.',
 									components: {
 										link: <a href={ localizeUrl( `${ SUPPORT_URL }#tags-categories` ) } />,
 									},
-									context: 'Stats: Info box label when the Tags and Categories module is empty',
+									context: 'Stats: Info box label when the Tags & Categories module is empty',
 								}
 							) }
 						/>

--- a/client/my-sites/stats/features/modules/stats-tags/stats-tags.tsx
+++ b/client/my-sites/stats/features/modules/stats-tags/stats-tags.tsx
@@ -1,0 +1,93 @@
+import { StatsCard } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { mapMarker } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
+import { useSelector } from 'calypso/state';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { SUPPORT_URL } from '../../../const';
+import StatsModule from '../../../stats-module';
+import StatsCardSkeleton from '../shared/stats-card-skeleton';
+import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
+
+const StatsTags: React.FC< StatsDefaultModuleProps > = ( {
+	period,
+	query,
+	moduleStrings,
+	className,
+} ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsTags';
+
+	// Use StatsModule to display paywall upsell.
+	const shouldGateStatsModule = useShouldGateStats( statType );
+
+	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	return (
+		<>
+			{ ! shouldGateStatsModule && siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } />
+			) }
+			{ isRequestingData && (
+				<StatsCardSkeleton
+					isLoading={ isRequestingData }
+					className={ className }
+					title={ moduleStrings.title }
+					type={ 3 }
+					withHero
+				/>
+			) }
+			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
+				// show data or an overlay
+				<StatsModule
+					path="tags-categories"
+					moduleStrings={ moduleStrings }
+					period={ period }
+					statType={ statType }
+					hideSummaryLink
+					className={ className }
+					skipQuery
+				/>
+			) }
+			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
+				// show empty state
+				<StatsCard
+					className={ className }
+					title={ translate( 'Tags & Categories' ) }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ mapMarker }
+							description={ translate(
+								'Stats on visitors and their {{link}}viewing location{{/link}} will appear here to learn from where you are getting visits.',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: <a href={ localizeUrl( `${ SUPPORT_URL }#tags-categories` ) } />,
+									},
+									context: 'Stats: Info box label when the Tags and Categories module is empty',
+								}
+							) }
+						/>
+					}
+				/>
+			) }
+		</>
+	);
+};
+
+export default StatsTags;

--- a/client/my-sites/stats/features/modules/stats-tags/stats-tags.tsx
+++ b/client/my-sites/stats/features/modules/stats-tags/stats-tags.tsx
@@ -12,7 +12,7 @@ import {
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
-import { SUPPORT_URL } from '../../../const';
+import { INSIGHTS_SUPPORT_URL } from '../../../const';
 import StatsModule from '../../../stats-module';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
@@ -77,7 +77,9 @@ const StatsTags: React.FC< StatsDefaultModuleProps > = ( {
 								{
 									comment: '{{link}} links to support documentation.',
 									components: {
-										link: <a href={ localizeUrl( `${ SUPPORT_URL }#tags-categories` ) } />,
+										link: (
+											<a href={ localizeUrl( `${ INSIGHTS_SUPPORT_URL }#all-time-insights` ) } />
+										),
 									},
 									context: 'Stats: Info box label when the Tags & Categories module is empty',
 								}

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -15,9 +15,10 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import AllTimeHighlightsSection from '../../all-time-highlights-section';
 import AllTimeViewsSection from '../../all-time-views-section';
 import AnnualHighlightsSection from '../../annual-highlights-section';
+import StatsModuleTags from '../../features/modules/stats-tags';
 import PostingActivity from '../../post-trends';
 import Comments from '../../stats-comments';
-import StatsModule from '../../stats-module';
+// import StatsModule from '../../stats-module';
 import PageViewTracker from '../../stats-page-view-tracker';
 import StatShares from '../../stats-shares';
 import statsStrings from '../../stats-strings';
@@ -61,7 +62,20 @@ const StatsInsights = ( props ) => {
 				<PostingActivity siteId={ siteId } />
 				<AllTimeViewsSection siteId={ siteId } slug={ siteSlug } />
 				<div className={ statsModuleListClass }>
-					<StatsModule
+					<StatsModuleTags
+						moduleStrings={ moduleStrings.tags }
+						hideSummaryLink
+						className={ clsx(
+							{
+								'stats__flexible-grid-item--half': isJetpack,
+								'stats__flexible-grid-item--full--large': isJetpack,
+							},
+							{
+								'stats__flexible-grid-item--full': ! isJetpack,
+							}
+						) }
+					/>
+					{ /* <StatsModule
 						path="tags-categories"
 						moduleStrings={ moduleStrings.tags }
 						statType="statsTags"
@@ -75,7 +89,7 @@ const StatsInsights = ( props ) => {
 								'stats__flexible-grid-item--full': ! isJetpack,
 							}
 						) }
-					/>
+					/> */ }
 					<Comments
 						path="comments"
 						className={ clsx(

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -18,7 +18,7 @@ import AnnualHighlightsSection from '../../annual-highlights-section';
 import StatsModuleTags from '../../features/modules/stats-tags';
 import PostingActivity from '../../post-trends';
 import Comments from '../../stats-comments';
-// import StatsModule from '../../stats-module';
+import StatsModule from '../../stats-module';
 import PageViewTracker from '../../stats-page-view-tracker';
 import StatShares from '../../stats-shares';
 import statsStrings from '../../stats-strings';
@@ -26,6 +26,7 @@ import statsStrings from '../../stats-strings';
 const StatsInsights = ( props ) => {
 	const { siteId, siteSlug, translate, isOdysseyStats, isJetpack } = props;
 	const moduleStrings = statsStrings();
+	const isEmptyStateV2 = config.isEnabled( 'stats/empty-module-v2' );
 
 	const statsModuleListClass = clsx(
 		'stats__module-list--insights',
@@ -62,34 +63,38 @@ const StatsInsights = ( props ) => {
 				<PostingActivity siteId={ siteId } />
 				<AllTimeViewsSection siteId={ siteId } slug={ siteSlug } />
 				<div className={ statsModuleListClass }>
-					<StatsModuleTags
-						moduleStrings={ moduleStrings.tags }
-						hideSummaryLink
-						className={ clsx(
-							{
-								'stats__flexible-grid-item--half': isJetpack,
-								'stats__flexible-grid-item--full--large': isJetpack,
-							},
-							{
-								'stats__flexible-grid-item--full': ! isJetpack,
-							}
-						) }
-					/>
-					{ /* <StatsModule
-						path="tags-categories"
-						moduleStrings={ moduleStrings.tags }
-						statType="statsTags"
-						hideSummaryLink
-						className={ clsx(
-							{
-								'stats__flexible-grid-item--half': isJetpack,
-								'stats__flexible-grid-item--full--large': isJetpack,
-							},
-							{
-								'stats__flexible-grid-item--full': ! isJetpack,
-							}
-						) }
-					/> */ }
+					{ isEmptyStateV2 && (
+						<StatsModuleTags
+							moduleStrings={ moduleStrings.tags }
+							hideSummaryLink
+							className={ clsx(
+								{
+									'stats__flexible-grid-item--half': isJetpack,
+									'stats__flexible-grid-item--full--large': isJetpack,
+								},
+								{
+									'stats__flexible-grid-item--full': ! isJetpack,
+								}
+							) }
+						/>
+					) }
+					{ isEmptyStateV2 && (
+						<StatsModule
+							path="tags-categories"
+							moduleStrings={ moduleStrings.tags }
+							statType="statsTags"
+							hideSummaryLink
+							className={ clsx(
+								{
+									'stats__flexible-grid-item--half': isJetpack,
+									'stats__flexible-grid-item--full--large': isJetpack,
+								},
+								{
+									'stats__flexible-grid-item--full': ! isJetpack,
+								}
+							) }
+						/>
+					) }
 					<Comments
 						path="comments"
 						className={ clsx(

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -78,7 +78,7 @@ const StatsInsights = ( props ) => {
 							) }
 						/>
 					) }
-					{ isEmptyStateV2 && (
+					{ ! isEmptyStateV2 && (
 						<StatsModule
 							path="tags-categories"
 							moduleStrings={ moduleStrings.tags }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Stats: [#81](https://github.com/Automattic/red-team/issues/81)

## Proposed Changes

* Updates the empty state for Tags on the insights page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* update the tags module in the insights tab with a new empty state and place it behind a feature flag
* refactor TS definitions
* add the new skeleton loader to the module
* add the new `useShouldGateStats` check

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* apply `stats/empty-module-v2` feature flag
* navigate to the insights tab
* verify that a page with an empty tags & categories component works with and without the feature flag
* repeat for blogs with tags & categories data
* check that the new empty state only shows up after applying the feature flag

![yR9FtF.png](https://github.com/user-attachments/assets/95ef0d9a-4ec2-4fd0-b741-2b1017ee19a1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?