### PR TITLE
Plans Grid: Downgrade button should open support (take 3)

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -1,0 +1,299 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Default mock implementations
+ */
+jest.mock( 'react-redux', () => ( {
+	useSelector: jest.fn(),
+} ) );
+jest.mock( '@automattic/data-stores', () => ( {
+	...jest.requireActual( '@automattic/data-stores' ),
+	Plans: {
+		useCurrentPlan: jest.fn(),
+		useCurrentPlanExpiryDate: jest.fn(),
+	},
+} ) );
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => jest.fn( ( text ) => text ),
+	localize: jest.fn(),
+	translate: jest.fn(),
+} ) );
+
+jest.mock( '../use-generate-action-callback', () => jest.fn( () => jest.fn() ) );
+
+import {
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_BUSINESS_3_YEARS,
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_ENTERPRISE_GRID_WPCOM,
+	PLAN_FREE,
+	PLAN_HOSTING_TRIAL_MONTHLY,
+	PLAN_PERSONAL,
+	PLAN_WOOEXPRESS_MEDIUM,
+	PLAN_WOOEXPRESS_SMALL,
+} from '@automattic/calypso-products';
+import { Plans } from '@automattic/data-stores';
+import { useSelector } from 'react-redux';
+import useGenerateActionHook from '../use-generate-action-hook';
+
+describe( 'useGenerateActionHook', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( useSelector as jest.Mock ).mockReturnValue( 'mock-site-slug' );
+		( Plans.useCurrentPlan as jest.Mock ).mockImplementation( () => ( { [ PLAN_FREE ]: {} } ) );
+		( Plans.useCurrentPlan as jest.Mock ).mockImplementation( () => null );
+	} );
+
+	it( 'should handle enterprise plans', () => {
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_ENTERPRISE_GRID_WPCOM } );
+
+		expect( action.primary.text ).toBe( 'Learn more' );
+		expect( action.primary.status ).toBe( 'enabled' );
+	} );
+
+	it( 'should handle launch page actions for free plan', () => {
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: true } );
+
+		const action = result( { planSlug: PLAN_FREE } );
+
+		expect( action.primary.text ).toBe( 'Keep this plan' );
+	} );
+
+	it( 'should handle launch page actions for paid plans with sticky buttons', () => {
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: true } );
+
+		const action = result( {
+			planSlug: PLAN_BUSINESS,
+			isStuck: true,
+			isLargeCurrency: false,
+			planTitle: 'Business',
+			priceString: '$300',
+		} );
+
+		// The assertion is okay since we don't actually run the translate function
+		expect( action.primary.text ).toBe( 'Select %(plan)s – %(priceString)s' );
+	} );
+
+	it( 'should handle signup actions for free trial', () => {
+		const result = useGenerateActionHook( { isInSignup: true, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_BUSINESS, isFreeTrialAction: true } );
+
+		expect( action.primary.text ).toBe( 'Try for free' );
+	} );
+
+	it( 'should handle signup actions for free plan', () => {
+		const result = useGenerateActionHook( { isInSignup: true, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_FREE } );
+
+		expect( action.primary.text ).toBe( 'Start with Free' );
+	} );
+
+	it( 'should handle signup actions for business plan with ineligible free hosting trial', () => {
+		useSelector.mockImplementation( ( selector ) =>
+			selector( {
+				current_user: {
+					had_hosting_trial: true,
+				},
+				sites: {
+					items: [],
+				},
+			} )
+		);
+		const result = useGenerateActionHook( {
+			isInSignup: true,
+			isLaunchPage: false,
+			plansIntent: 'plans-new-hosted-site',
+		} );
+		const action = result( { planSlug: PLAN_BUSINESS } );
+
+		expect( action.postButtonText ).toBe( "You've already used your free trial! Thanks!" );
+	} );
+
+	it( 'should handle signup actions for plans with sticky buttons and isLargeCurrency as false', () => {
+		const result = useGenerateActionHook( { isInSignup: true, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_BUSINESS, isStuck: true, isLargeCurrency: false } );
+
+		// The assertion is okay since we don't actually run the translate function
+		expect( action.primary.text ).toBe( 'Get %(plan)s – %(priceString)s' );
+	} );
+
+	it( 'should handle signup actions for plans with sticky buttons and isLargeCurrency as true', () => {
+		const result = useGenerateActionHook( { isInSignup: true, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_BUSINESS, isStuck: true, isLargeCurrency: true } );
+
+		expect( action.primary.text ).toBe( 'Get %(plan)s {{span}}%(priceString)s{{/span}}' );
+	} );
+
+	it( 'should handle current free plan', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( { planSlug: PLAN_FREE } );
+
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_FREE } );
+
+		expect( action.primary.text ).toBe( 'Manage add-ons' );
+		expect( action.primary.status ).toBe( 'enabled' );
+	} );
+
+	it( 'should handle upgrade with sticky buttons', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_PERSONAL,
+		} );
+
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( {
+			planSlug: PLAN_BUSINESS,
+			availableForPurchase: true,
+			isStuck: true,
+			priceString: '$300',
+		} );
+
+		expect( action.primary.text ).toBe( 'Upgrade – %(priceString)s' );
+	} );
+
+	it( 'should handle upgrade to longer billing period - annual', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_BUSINESS_MONTHLY,
+		} );
+
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( {
+			planSlug: PLAN_BUSINESS,
+			availableForPurchase: true,
+		} );
+
+		expect( action.primary.text ).toBe( 'Upgrade to Yearly' );
+	} );
+
+	it( 'should handle upgrade to longer billing period - Biennial', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_BUSINESS_MONTHLY,
+		} );
+
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( {
+			planSlug: PLAN_BUSINESS_2_YEARS,
+			availableForPurchase: true,
+		} );
+
+		expect( action.primary.text ).toBe( 'Upgrade to Biennial' );
+	} );
+
+	it( 'should handle upgrade to longer billing period - Triennial', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_BUSINESS_MONTHLY,
+		} );
+
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( {
+			planSlug: PLAN_BUSINESS_3_YEARS,
+			availableForPurchase: true,
+		} );
+
+		expect( action.primary.text ).toBe( 'Upgrade to Triennial' );
+	} );
+
+	it( 'should handle current plan for plan owner', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_BUSINESS,
+		} );
+		( useSelector as jest.Mock ).mockReturnValue( true ); // mocking isCurrentUserCurrentPlanOwner
+
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_BUSINESS } );
+
+		expect( action.primary.text ).toBe( 'Manage plan' );
+	} );
+
+	it( 'should handle expired current plan for plan owner', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_BUSINESS,
+		} );
+		( Plans.useCurrentPlanExpiryDate as jest.Mock ).mockReturnValue(
+			new Date( Date.now() - 86400000 )
+		); // yesterday
+		( useSelector as jest.Mock ).mockReturnValue( true ); // mocking isCurrentUserCurrentPlanOwner
+
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_BUSINESS } );
+
+		expect( action.primary.text ).toBe( 'Renew plan' );
+	} );
+
+	it( 'should handle current plan for domainFromHomeUpsellFlow', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_BUSINESS,
+		} );
+		useSelector.mockImplementation( ( selector ) =>
+			selector( {
+				sites: {
+					items: [],
+				},
+				route: {
+					query: {
+						current: {
+							get_domain: 'mockdomain',
+						},
+					},
+				},
+			} )
+		);
+
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_BUSINESS } );
+
+		expect( action.primary.text ).toBe( 'Keep my plan' );
+	} );
+
+	it( 'should handle WooExpress Medium plan upgrade', () => {
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_WOOEXPRESS_MEDIUM } );
+
+		expect( action.primary.text ).toBe( 'Get Performance' );
+	} );
+
+	it( 'should handle WooExpress Small plan upgrade', () => {
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_WOOEXPRESS_SMALL } );
+
+		expect( action.primary.text ).toBe( 'Get Essential' );
+	} );
+
+	it( 'should handle business trial upgrade', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_HOSTING_TRIAL_MONTHLY,
+		} );
+
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_BUSINESS } );
+
+		expect( action.primary.text ).toBe( 'Get %(plan)s' );
+	} );
+
+	it( 'should handle downgrade actions', () => {
+		const result = useGenerateActionHook( { isInSignup: false, isLaunchPage: false } );
+
+		const action = result( { planSlug: PLAN_PERSONAL, availableForPurchase: false } );
+
+		expect( action.primary.text ).toBe( 'Downgrade' );
+		expect( action.primary.variant ).toBe( 'secondary' );
+	} );
+} );

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -123,7 +123,7 @@ function useGenerateActionCallback( {
 	withDiscount?: string;
 } ): UseActionCallback {
 	const { setShowHelpCenter, setInitialRoute } = useDispatch( HELP_CENTER_STORE );
-	const { url: stillNeedHelpUrl } = useStillNeedHelpURL();
+	const { url: stillNeedHelpUrl } = useStillNeedHelpURL( true );
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
 		eligibleForFreeHostingTrial,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -203,7 +203,7 @@ function useGenerateActionCallback( {
 			}
 
 			/* 3. Handle plan downgrades and plan downgrade tracks events */
-			if ( sitePlanSlug && ! availableForPurchase ) {
+			if ( sitePlanSlug && intent !== 'plans-blog-onboarding' && ! availableForPurchase ) {
 				recordTracksEvent?.( 'calypso_plan_features_downgrade_click', {
 					current_plan: sitePlanSlug,
 					downgrading_to: planSlug,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -124,7 +124,7 @@ function useGenerateActionCallback( {
 	withDiscount?: string;
 } ): UseActionCallback {
 	const { setShowHelpCenter, setInitialRoute } = useDispatch( HELP_CENTER_STORE );
-	const { url: stillNeedHelpUrl } = useStillNeedHelpURL( true );
+	const { url: stillNeedHelpUrl } = useStillNeedHelpURL( false );
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
 		eligibleForFreeHostingTrial,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -15,6 +15,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import { addQueryArgs } from 'calypso/lib/url';
+import { cancelPurchase } from 'calypso/me/purchases/paths';
 import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs';
 import useCurrentPlanManageHref from './use-current-plan-manage-href';
 import type { PlansIntent, UseActionCallback } from '@automattic/plans-grid-next';
@@ -130,10 +131,18 @@ function useGenerateActionCallback( {
 	} );
 	const currentPlanManageHref = useCurrentPlanManageHref();
 	const handleUpgrade = useUpgradeHandler( { siteSlug, withDiscount, cartHandler } );
-	const handleDowngradeClick = useCallback( () => {
-		setInitialRoute( stillNeedHelpUrl );
-		setShowHelpCenter( true );
-	}, [ setInitialRoute, setShowHelpCenter, stillNeedHelpUrl ] );
+	const handleDowngradeClick = useCallback(
+		( planSlug: PlanSlug ) => {
+			// A downgrade to the free plan is essentially cancelling the current plan.
+			if ( isFreePlan( planSlug ) ) {
+				page( cancelPurchase( siteSlug, currentPlan?.purchaseId ) );
+				return;
+			}
+			setInitialRoute( stillNeedHelpUrl );
+			setShowHelpCenter( true );
+		},
+		[ currentPlan?.purchaseId, setInitialRoute, setShowHelpCenter, siteSlug, stillNeedHelpUrl ]
+	);
 
 	return ( { planSlug, cartItemForPlan, selectedStorageAddOn, availableForPurchase } ) => {
 		return () => {
@@ -172,12 +181,17 @@ function useGenerateActionCallback( {
 				return;
 			}
 
+			/* 3. Handle plan downgrades and plan downgrade tracks events */
 			if ( sitePlanSlug && ! availableForPurchase ) {
-				handleDowngradeClick();
+				recordTracksEvent?.( 'calypso_plan_features_downgrade_click', {
+					current_plan: sitePlanSlug,
+					downgrading_to: planSlug,
+				} );
+				handleDowngradeClick( planSlug );
 				return;
 			}
 
-			/* 3. Handle plan upgrade and plan upgrade tracks events */
+			/* 4. Handle plan upgrade and plan upgrade tracks events */
 			if ( ! isFreePlan( planSlug ) ) {
 				recordTracksEvent?.( 'calypso_plan_features_upgrade_click', {
 					current_plan: sitePlanSlug,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -12,6 +12,7 @@ import { AddOns, Plans } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import { addQueryArgs } from 'calypso/lib/url';
 import { cancelPurchase } from 'calypso/me/purchases/paths';
@@ -109,6 +110,7 @@ function useDowngradeHandler( {
 	currentPlan: Plans.SitePlan | undefined;
 } ) {
 	const { setShowHelpCenter, setInitialRoute, setMessage } = useDispatch( HELP_CENTER_STORE );
+	const translate = useTranslate();
 	return useCallback(
 		( planSlug: PlanSlug ) => {
 			// A downgrade to the free plan is essentially cancelling the current plan.
@@ -126,11 +128,11 @@ function useDowngradeHandler( {
 				'disable-gpt': 'true',
 				'skip-resources': 'true',
 			} ).toString() }`;
-			setMessage( 'I want to downgrade my plan' );
+			setMessage( translate( 'I want to downgrade my plan.' ) );
 			setInitialRoute( chatUrl );
 			setShowHelpCenter( true );
 		},
-		[ currentPlan?.purchaseId, setInitialRoute, setMessage, setShowHelpCenter, siteSlug ]
+		[ currentPlan?.purchaseId, setInitialRoute, setMessage, setShowHelpCenter, siteSlug, translate ]
 	);
 }
 

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -146,6 +146,8 @@ function useGenerateActionCallback( {
 	sitePlanSlug,
 	siteSlug,
 	withDiscount,
+	isInSignup,
+	isLaunchPage,
 }: {
 	currentPlan: Plans.SitePlan | undefined;
 	eligibleForFreeHostingTrial: boolean;
@@ -156,6 +158,8 @@ function useGenerateActionCallback( {
 	sitePlanSlug?: PlanSlug | null;
 	siteSlug?: string | null;
 	withDiscount?: string;
+	isInSignup: boolean;
+	isLaunchPage: boolean | null;
 } ): UseActionCallback {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
@@ -203,7 +207,13 @@ function useGenerateActionCallback( {
 			}
 
 			/* 3. Handle plan downgrades and plan downgrade tracks events */
-			if ( sitePlanSlug && intent !== 'plans-blog-onboarding' && ! availableForPurchase ) {
+			if (
+				sitePlanSlug &&
+				! isInSignup &&
+				! isLaunchPage &&
+				intent !== 'plans-blog-onboarding' &&
+				! availableForPurchase
+			) {
 				recordTracksEvent?.( 'calypso_plan_features_downgrade_click', {
 					current_plan: sitePlanSlug,
 					downgrading_to: planSlug,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -9,6 +9,9 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { AddOns, Plans } from '@automattic/data-stores';
+import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -119,14 +122,20 @@ function useGenerateActionCallback( {
 	siteSlug?: string | null;
 	withDiscount?: string;
 } ): UseActionCallback {
+	const { setShowHelpCenter, setInitialRoute } = useDispatch( HELP_CENTER_STORE );
+	const { url: stillNeedHelpUrl } = useStillNeedHelpURL();
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
 		eligibleForFreeHostingTrial,
 	} );
 	const currentPlanManageHref = useCurrentPlanManageHref();
 	const handleUpgrade = useUpgradeHandler( { siteSlug, withDiscount, cartHandler } );
+	const handleDowngradeClick = useCallback( () => {
+		setInitialRoute( stillNeedHelpUrl );
+		setShowHelpCenter( true );
+	}, [ setInitialRoute, setShowHelpCenter, stillNeedHelpUrl ] );
 
-	return ( { planSlug, cartItemForPlan, selectedStorageAddOn } ) => {
+	return ( { planSlug, cartItemForPlan, selectedStorageAddOn, availableForPurchase } ) => {
 		return () => {
 			const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
 			const freeTrialPlanSlug = freeTrialPlanSlugs?.[ planConstantObj.type ];
@@ -160,6 +169,11 @@ function useGenerateActionCallback( {
 				} else {
 					page.redirect( currentPlanManageHref );
 				}
+				return;
+			}
+
+			if ( sitePlanSlug && ! availableForPurchase ) {
+				handleDowngradeClick();
 				return;
 			}
 

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -146,8 +146,6 @@ function useGenerateActionCallback( {
 	sitePlanSlug,
 	siteSlug,
 	withDiscount,
-	isInSignup,
-	isLaunchPage,
 }: {
 	currentPlan: Plans.SitePlan | undefined;
 	eligibleForFreeHostingTrial: boolean;
@@ -158,8 +156,6 @@ function useGenerateActionCallback( {
 	sitePlanSlug?: PlanSlug | null;
 	siteSlug?: string | null;
 	withDiscount?: string;
-	isInSignup: boolean;
-	isLaunchPage: boolean | null;
 } ): UseActionCallback {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
@@ -206,11 +202,11 @@ function useGenerateActionCallback( {
 				return;
 			}
 
-			/* 3. Handle plan downgrades and plan downgrade tracks events */
+			/* 3. In the logged-in plans dashboard, handle plan downgrades and plan downgrade tracks events */
 			if (
 				sitePlanSlug &&
-				! isInSignup &&
-				! isLaunchPage &&
+				! flowName &&
+				intent !== 'plans-p2' &&
 				intent !== 'plans-blog-onboarding' &&
 				! availableForPurchase
 			) {
@@ -223,14 +219,14 @@ function useGenerateActionCallback( {
 			}
 
 			/* 4. Handle plan upgrade and plan upgrade tracks events */
-			if ( ! isFreePlan( planSlug ) ) {
+			if ( isFreePlan( planSlug ) ) {
+				recordTracksEvent( 'calypso_signup_free_plan_click' );
+			} else {
 				recordTracksEvent?.( 'calypso_plan_features_upgrade_click', {
 					current_plan: sitePlanSlug,
 					upgrading_to: planSlug,
 					saw_free_trial_offer: !! freeTrialPlanSlug,
 				} );
-			} else {
-				recordTracksEvent( 'calypso_signup_free_plan_click' );
 			}
 			handleUpgrade( {
 				cartItemForPlan,

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -228,6 +228,7 @@ function useGenerateActionHook( {
 		 */
 		let text = translate( 'Upgrade', { context: 'verb' } );
 		let status: 'enabled' | 'disabled' | 'blocked' | undefined;
+		let classes = '';
 		const current = sitePlanSlug === planSlug;
 		const isTrialPlan =
 			sitePlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ||
@@ -270,9 +271,8 @@ function useGenerateActionHook( {
 			billingPeriod &&
 			currentPlanBillingPeriod > billingPeriod
 		) {
-			// If the current plan is on a higher-term but lower-tier, then show a "Contact support" button.
-			// TODO: We should revisit this. The plan term selector never allows selection of lower term plans so is this condition ever met?
 			text = translate( 'Contact support', { context: 'verb' } );
+			status = 'enabled';
 		} else if (
 			availableForPurchase &&
 			sitePlanSlug &&
@@ -331,14 +331,23 @@ function useGenerateActionHook( {
 				} );
 			}
 		} else if ( ! availableForPurchase ) {
-			text = translate( 'Downgrade', { context: 'verb' } );
+			/** Downgrade plan buttons */
+			status = 'enabled';
+			text = translate( 'Contact support', { context: 'verb' } );
+			classes = 'is-secondary';
 		}
 
 		return {
 			primary: {
-				callback: getActionCallback( { planSlug, cartItemForPlan, selectedStorageAddOn } ),
+				callback: getActionCallback( {
+					planSlug,
+					cartItemForPlan,
+					selectedStorageAddOn,
+					availableForPurchase,
+				} ),
 				status,
 				text,
+				classes,
 			},
 		};
 	};

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -74,8 +74,6 @@ function useGenerateActionHook( {
 		sitePlanSlug,
 		siteSlug,
 		withDiscount,
-		isInSignup,
-		isLaunchPage,
 	} );
 
 	const useActionHook = ( {

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -254,14 +254,9 @@ function useGenerateActionHook( {
 			} );
 		}
 
-		if ( isFreePlan( planSlug ) ) {
-			text = translate( 'Contact support', { context: 'verb' } );
-			status = 'disabled';
-
-			if ( current ) {
-				text = translate( 'Manage add-ons', { context: 'verb' } );
-				status = 'enabled';
-			}
+		if ( isFreePlan( planSlug ) && current ) {
+			text = translate( 'Manage add-ons', { context: 'verb' } );
+			status = 'enabled';
 		} else if (
 			availableForPurchase &&
 			sitePlanSlug &&

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -74,6 +74,8 @@ function useGenerateActionHook( {
 		sitePlanSlug,
 		siteSlug,
 		withDiscount,
+		isInSignup,
+		isLaunchPage,
 	} );
 
 	const useActionHook = ( {

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -228,7 +228,8 @@ function useGenerateActionHook( {
 		 */
 		let text = translate( 'Upgrade', { context: 'verb' } );
 		let status: 'enabled' | 'disabled' | 'blocked' | undefined;
-		let classes = '';
+		let variant: GridAction[ 'primary' ][ 'variant' ] = 'primary';
+
 		const current = sitePlanSlug === planSlug;
 		const isTrialPlan =
 			sitePlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ||
@@ -328,8 +329,8 @@ function useGenerateActionHook( {
 		} else if ( ! availableForPurchase ) {
 			/** Downgrade plan buttons */
 			status = 'enabled';
-			text = translate( 'Contact support', { context: 'verb' } );
-			classes = 'is-secondary';
+			text = translate( 'Downgrade', { context: 'verb' } );
+			variant = 'secondary';
 		}
 
 		return {
@@ -342,7 +343,7 @@ function useGenerateActionHook( {
 				} ),
 				status,
 				text,
-				classes,
+				variant,
 			},
 		};
 	};

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -3,17 +3,14 @@
 import { useSupportStatus } from '../data/use-support-status';
 import { useShouldUseWapuu } from './use-should-use-wapuu';
 
-export function useStillNeedHelpURL( forceContactForm = false ) {
+export function useStillNeedHelpURL() {
 	const { data: supportStatus, isLoading } = useSupportStatus();
 	const shouldUseWapuu = useShouldUseWapuu();
 	const isEligibleForSupport = Boolean( supportStatus?.eligibility?.is_user_eligible );
 
-	if ( isEligibleForSupport && shouldUseWapuu && ! forceContactForm ) {
-		return { url: '/odie', isLoading: false };
-	}
-
 	if ( isEligibleForSupport ) {
-		return { url: '/contact-options', isLoading: false };
+		const url = shouldUseWapuu ? '/odie' : '/contact-options';
+		return { url, isLoading: false };
 	}
 
 	return { url: '/contact-form?mode=FORUM', isLoading };

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -3,14 +3,17 @@
 import { useSupportStatus } from '../data/use-support-status';
 import { useShouldUseWapuu } from './use-should-use-wapuu';
 
-export function useStillNeedHelpURL() {
+export function useStillNeedHelpURL( forceContactForm = false ) {
 	const { data: supportStatus, isLoading } = useSupportStatus();
 	const shouldUseWapuu = useShouldUseWapuu();
 	const isEligibleForSupport = Boolean( supportStatus?.eligibility?.is_user_eligible );
 
+	if ( isEligibleForSupport && shouldUseWapuu && ! forceContactForm ) {
+		return { url: '/odie', isLoading: false };
+	}
+
 	if ( isEligibleForSupport ) {
-		const url = shouldUseWapuu ? '/odie' : '/contact-options';
-		return { url, isLoading: false };
+		return { url: '/contact-options', isLoading: false };
 	}
 
 	return { url: '/contact-form?mode=FORUM', isLoading };

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -80,7 +80,7 @@ const PlanFeatures2023GridActions = ( {
 	);
 
 	const {
-		primary: { callback, text, status, classes },
+		primary: { callback, text, status, variant },
 		postButtonText,
 	} = useAction( {
 		availableForPurchase,
@@ -130,7 +130,7 @@ const PlanFeatures2023GridActions = ( {
 			onClick={ callback }
 			busy={ busy }
 			disabled={ status !== 'enabled' }
-			classes={ classes }
+			classes={ variant === 'secondary' ? 'is-secondary' : '' }
 		>
 			{ text }
 		</PlanButton>

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -7,16 +7,12 @@ import {
 } from '@automattic/calypso-products';
 import { AddOns, WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
-import { isMobile } from '@automattic/viewport';
-import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../grid-context';
 import useIsLargeCurrency from '../hooks/use-is-large-currency';
-import { useManageTooltipToggle } from '../hooks/use-manage-tooltip-toggle';
 import { usePlanPricingInfoFromGridPlans } from '../hooks/use-plan-pricing-info-from-grid-plans';
 import PlanButton from './plan-button';
-import { Plans2023Tooltip } from './plans-2023-tooltip';
 import { useDefaultStorageOption } from './shared/storage';
 import type { GridPlan, PlanActionOverrides } from '../types';
 
@@ -33,18 +29,6 @@ type PlanFeaturesActionsButtonProps = {
 	isStuck: boolean;
 	visibleGridPlans: GridPlan[];
 };
-
-const DummyDisabledButton = styled.div`
-	background-color: var( --studio-white );
-	color: var( --studio-gray-5 );
-	box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
-	font-weight: 500;
-	line-height: 20px;
-	border-radius: 4px;
-	padding: 10px 14px;
-	border: unset;
-	text-align: center;
-`;
 
 const PlanFeatures2023GridActions = ( {
 	planSlug,
@@ -96,7 +80,7 @@ const PlanFeatures2023GridActions = ( {
 	);
 
 	const {
-		primary: { callback, text, status },
+		primary: { callback, text, status, classes },
 		postButtonText,
 	} = useAction( {
 		availableForPurchase,
@@ -110,7 +94,6 @@ const PlanFeatures2023GridActions = ( {
 		currentPlanBillingPeriod,
 		selectedStorageAddOn,
 	} );
-
 	const {
 		primary: { callback: freeTrialCallback, text: freeTrialText },
 	} = useAction( {
@@ -128,7 +111,6 @@ const PlanFeatures2023GridActions = ( {
 	} );
 
 	const busy = isFreePlan( planSlug ) && status === 'blocked';
-	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 
 	const defaultStorageOption = useDefaultStorageOption( { planSlug } );
 	const canPurchaseStorageAddOns = storageAddOns?.some(
@@ -143,20 +125,15 @@ const PlanFeatures2023GridActions = ( {
 		selectedStorageOptionForPlan && defaultStorageOption !== selectedStorageOptionForPlan;
 
 	let actionButton = (
-		<Plans2023Tooltip
-			text={ translate( 'Please contact support to downgrade your plan.' ) }
-			setActiveTooltipId={ setActiveTooltipId }
-			activeTooltipId={ activeTooltipId }
-			showOnMobile={ false }
-			id="downgrade"
+		<PlanButton
+			planSlug={ planSlug }
+			onClick={ callback }
+			busy={ busy }
+			disabled={ status !== 'enabled' }
+			classes={ classes }
 		>
-			<DummyDisabledButton>{ text }</DummyDisabledButton>
-			{ isMobile() && (
-				<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
-					{ translate( 'Please contact support to downgrade your plan.' ) }
-				</div>
-			) }
-		</Plans2023Tooltip>
+			{ text }
+		</PlanButton>
 	);
 
 	if (

--- a/packages/plans-grid-next/src/components/plan-button/style.scss
+++ b/packages/plans-grid-next/src/components/plan-button/style.scss
@@ -15,6 +15,29 @@
 		transition: 0.7s;
 	}
 
+	&.plan-features-2023-grid__actions-button.is-secondary {
+		background: var(--studio-white);
+		border: 1px solid var(--studio-gray-10);
+		border-radius: 4px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+		color: var(--studio-gray-100);
+		font-size: var(--scss-font-body-small);
+		font-weight: 500;
+		height: 48px;
+		justify-content: center;
+		line-height: 20px;
+		padding: 0 24px;
+		width: 100%;
+		max-width: 440px;
+		transition: border-color 0.15s ease-out;
+		&:not([disabled]):hover,
+		&:not([disabled]):focus {
+			border-color: var(--studio-gray-100);
+			box-shadow: none;
+			color: var(--studio-gray-100);
+		}
+	}
+
 	&.is-free-plan {
 		background-color: var(--studio-blue-50);
 		color: var(--studio-blue-0);

--- a/packages/plans-grid-next/src/components/plan-button/style.scss
+++ b/packages/plans-grid-next/src/components/plan-button/style.scss
@@ -23,7 +23,7 @@
 		color: var(--studio-gray-100);
 		font-size: var(--scss-font-body-small);
 		font-weight: 500;
-		height: 48px;
+		height: 40px;
 		justify-content: center;
 		line-height: 20px;
 		padding: 0 24px;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -153,7 +153,7 @@ export interface GridAction {
 		callback: () => void;
 		// TODO: It's not clear if status is ever actually set to 'blocked'. Investigate and remove if not.
 		status?: 'disabled' | 'blocked' | 'enabled';
-		classes?: string;
+		variant?: 'primary' | 'secondary';
 	};
 	postButtonText?: TranslateResult;
 }

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -139,10 +139,12 @@ export type UseActionCallback = ( {
 	planSlug,
 	cartItemForPlan,
 	selectedStorageAddOn,
+	availableForPurchase,
 }: {
 	planSlug: PlanSlug;
 	cartItemForPlan?: MinimalRequestCartProduct | null;
 	selectedStorageAddOn?: AddOns.AddOnMeta | null;
+	availableForPurchase?: boolean;
 } ) => () => void;
 
 export interface GridAction {
@@ -151,6 +153,7 @@ export interface GridAction {
 		callback: () => void;
 		// TODO: It's not clear if status is ever actually set to 'blocked'. Investigate and remove if not.
 		status?: 'disabled' | 'blocked' | 'enabled';
+		classes?: string;
 	};
 	postButtonText?: TranslateResult;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* #92624 had to be reverted because it caused the help centre to open in some cases where an upgrade was expected. This PR contains a hotfix for the that case: https://github.com/Automattic/wp-calypso/pull/92685/commits/f086102a412c59a49cdcbca5ac204905417d3c14

As I mentioned in #92624, this can easily happen again. I have proposed a more complete solution here: https://github.com/Automattic/martech/issues/3170

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Same as #91925 + a bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The new changes are in https://github.com/Automattic/wp-calypso/pull/92624/commits/de76f406b50cf25d9634546a4c02db92471c99be, so I believe that testing only this commit should be enough.
1. Buy a a domain via https://wordpress.com/domains/.
2. Using this PR's live link, go to your domain page and click Add New Site

    <img width="796" alt="image" src="https://github.com/user-attachments/assets/7d546d9a-c82d-4a7f-a91f-109c7f0f5622">

3. Pick any plan.
5. Verify that you can now purchase the plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
