### PR TITLE
Jetpack: update login form to include explainer micro-copy

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1012,6 +1012,7 @@ class Login extends Component {
 				isSendingEmail={ this.props.isSendingEmail }
 				isSocialFirst={ isSocialFirst }
 				loginButtons={ loginButtons }
+				isJetpack={ isJetpack }
 				isFromAutomatticForAgenciesPlugin={ isFromAutomatticForAgenciesPlugin }
 			/>
 		);

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -111,6 +111,7 @@ export class LoginForm extends Component {
 		sendMagicLoginLink: PropTypes.func,
 		isSendingEmail: PropTypes.bool,
 		cancelSocialAccountConnectLinking: PropTypes.func,
+		isJetpack: PropTypes.bool,
 	};
 
 	state = {
@@ -744,6 +745,7 @@ export class LoginForm extends Component {
 			socialAccountIsLinking: linkingSocialUser,
 			isJetpackWooCommerceFlow,
 			isP2Login,
+			isJetpack,
 			isJetpackWooDnaFlow,
 			currentQuery,
 			showSocialLoginFormOnly,
@@ -892,6 +894,14 @@ export class LoginForm extends Component {
 							value={ this.state.usernameOrEmail }
 							disabled={ isFormDisabled || this.isPasswordView() || isFromGravatar3rdPartyApp }
 						/>
+
+						{ isJetpack && (
+							<p className="login__form-account-tip">
+								{ this.props.translate(
+									'If you don’t have an account, we’ll use this email to create it.'
+								) }
+							</p>
+						) }
 
 						{ requestError && requestError.field === 'usernameOrEmail' && (
 							<Fragment>

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -45,3 +45,8 @@ form {
 		}
 	}
 }
+
+.is-jetpack .login__form-account-tip {
+	margin-block-start: -8px;
+	font-size: 0.75rem;
+}


### PR DESCRIPTION
## Proposed Changes

* Add explainer micro-copy on Jetpack login form

## Why are these changes being made?

* The copy clarifies the email address is used to both check for an existing account or create a new WordPress.com in case the email address is not recognized.

See pfln9p-vV-p2 where the issue was initially brought up by @danjjohnson and pfln9p-vV-p2#comment-604 on the proposed solution from @madebynoam.

## Testing Instructions

* Fire up this PR.
  * Go to http://calypso.localhost:3000/log-in/jetpack and ensure the micro-copy is visible below the input.
  * Go to other login touch points and ensure the micro-copy is not visible. E.g.: http://calypso.localhost:3000/log-in/

## Screenshots

Before | After
--|--
<img width="508" alt="image" src="https://github.com/user-attachments/assets/4cfcd5d2-c72a-4c5e-aed4-d341c7749366"> | <img width="491" alt="image" src="https://github.com/user-attachments/assets/ef5d4a76-cba7-4205-9e2b-10d41a6e00a5">
