### PR TITLE
A4A: Update sidebar contact sales link copy

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -65,7 +65,9 @@ const A4ASidebar = ( {
 		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_share_product_feedback_click' ) );
 	}, [ dispatch ] );
 
-	const contactUsText = isClient ? translate( 'Contact support' ) : translate( 'Contact sales' );
+	const contactUsText = isClient
+		? translate( 'Contact support' )
+		: translate( 'Contact sales & support' );
 
 	return (
 		<Sidebar className={ clsx( 'a4a-sidebar', className ) }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/781

## Proposed Changes

*  Update the link's label/copy from `Contact sales` to `Contact sales & support`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the A4A live link.
* Observe that the `Contact sales` link at the bottom now says `Contact sales & support`.

| Before | After |
|--------|--------|
| <img width="259" alt="Screenshot 2024-07-15 at 15 25 25" src="https://github.com/user-attachments/assets/ac49e1ef-7434-469d-b378-1474c6eda2fb"> | <img width="256" alt="Screenshot 2024-07-15 at 15 25 04" src="https://github.com/user-attachments/assets/cdb03e19-c323-42aa-aa34-aee96b690183"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
