### PR TITLE
Add touch device handling masterbar submenus

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -1,7 +1,8 @@
 import { Gridicon, Button } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { Component, Fragment, forwardRef } from 'react';
+import React, { Component, Fragment, forwardRef } from 'react';
+import { navigate } from 'calypso/lib/navigate';
 import type { ReactNode, LegacyRef } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -51,7 +52,19 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		url: '',
 	};
 
+	state = {
+		isOpenByTouch: false,
+	};
+
+	componentButtonRef = React.createRef< HTMLButtonElement >();
+	componentDivRef = React.createRef< HTMLDivElement >();
+
 	_preloaded = false;
+
+	componentDidMount() {
+		document.addEventListener( 'touchstart', this.closeMenuOnOutsideTouch );
+		return () => document.removeEventListener( 'touchstart', this.closeMenuOnOutsideTouch );
+	}
 
 	preload = () => {
 		if ( ! this._preloaded && typeof this.props.preloadSection === 'function' ) {
@@ -84,16 +97,67 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 				{ subItems.map( ( item, i ) => (
 					<li key={ i } className="masterbar__item-subitems-item">
 						{ item.onClick && (
-							<Button className="is-link" onClick={ item.onClick }>
+							<Button
+								className="is-link"
+								onClick={ item.onClick }
+								onTouchEnd={ ( ev: React.TouchEvent ) => {
+									ev.preventDefault();
+									this.setState( { isOpenByTouch: false } );
+									item.onClick && item.onClick();
+								} }
+							>
 								{ item.label }
 							</Button>
 						) }
-						{ ! item.onClick && item.url && <a href={ item.url }>{ item.label }</a> }
+						{ ! item.onClick && item.url && (
+							<a href={ item.url } onTouchEnd={ this.navigateSubAnchorTouch }>
+								{ item.label }
+							</a>
+						) }
 					</li>
 				) ) }
 			</ul>
 		);
 	}
+
+	toggleMenuByTouch = ( event: React.TouchEvent ) => {
+		// If there are no subItems, there is nothing to toggle.
+		if ( ! this.props.subItems ) {
+			return;
+		}
+		// Prevent navigation by touching the parent menu item, and trigger toggling the menu instead.
+		event.preventDefault();
+		this.setState( { isOpenByTouch: ! this.state.isOpenByTouch } );
+	};
+
+	navigateSubAnchorTouch = ( event: React.TouchEvent ) => {
+		// We must prevent the default anchor behavior and navigate manually. Otherwise there is a
+		// race condition between the click on the anchor firing and the menu closing before that
+		// can happen.
+		event.preventDefault();
+		const url = event.currentTarget.getAttribute( 'href' );
+		if ( url ) {
+			navigate( url );
+		}
+		this.setState( { isOpenByTouch: false } );
+	};
+
+	closeMenuOnOutsideTouch = ( event: TouchEvent ) => {
+		// If no subItems or the menu is already closed, there is nothing to close.
+		if ( ! this.props.subItems || ! this.state.isOpenByTouch ) {
+			return;
+		}
+
+		// Check refs to see if the touch event started inside our component, if it didn't, close the menu.
+		const isInComponentButtonRef = this.componentButtonRef.current?.contains(
+			event.target as Node
+		);
+		const isInComponentDivRef = this.componentDivRef.current?.contains( event.target as Node );
+
+		if ( ! isInComponentButtonRef && ! isInComponentDivRef ) {
+			this.setState( { isOpenByTouch: false } );
+		}
+	};
 
 	render() {
 		const itemClasses = clsx( 'masterbar__item', this.props.className, {
@@ -101,6 +165,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			'has-unseen': this.props.hasUnseen,
 			'masterbar__item--always-show-content': this.props.alwaysShowContent,
 			'has-subitems': this.props.subItems,
+			'is-open': this.state.isOpenByTouch,
 		} );
 
 		const attributes = {
@@ -127,8 +192,12 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 
 		if ( this.props.url && this.props.subItems ) {
 			return (
-				<button { ...attributes }>
-					<a href={ this.props.url } ref={ this.props.innerRef as LegacyRef< HTMLAnchorElement > }>
+				<button { ...attributes } ref={ this.componentButtonRef }>
+					<a
+						href={ this.props.url }
+						ref={ this.props.innerRef as LegacyRef< HTMLAnchorElement > }
+						onTouchEnd={ this.toggleMenuByTouch }
+					>
 						{ this.renderChildren() }
 					</a>
 					{ this.renderSubItems() }
@@ -137,10 +206,16 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		}
 
 		return (
-			<button { ...attributes } ref={ this.props.innerRef as LegacyRef< HTMLButtonElement > }>
-				{ this.renderChildren() }
-				{ this.renderSubItems() }
-			</button>
+			<div ref={ this.componentDivRef }>
+				<button
+					{ ...attributes }
+					ref={ this.props.innerRef as LegacyRef< HTMLButtonElement > }
+					onTouchEnd={ this.props.subItems && this.toggleMenuByTouch }
+				>
+					{ this.renderChildren() }
+					{ this.renderSubItems() }
+				</button>
+			</div>
 		);
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -372,7 +372,8 @@ body.is-mobile-app-view {
 	}
 
 	// The hover colors are supposed to be the same as those in wp-admin.
-	&:hover {
+	&:hover,
+	&.is-open {
 		.masterbar__item-subitems {
 			display: block;
 			z-index: 99999;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/92609 and https://github.com/Automattic/wp-calypso/pull/92636

## Proposed Changes
* Adds touch device support for masterbar items with submenu items.
* Brings the changes from https://github.com/Automattic/wp-calypso/pull/92609 - view this link for more context and testing instructions. That PR was based off of a larger PR we are no longer looking to ship. This PR is based off of https://github.com/Automattic/wp-calypso/pull/92636 instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
