### PR TITLE
Checkout Hide variant picker for domain connections since it cannot be altered

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -3,6 +3,7 @@ import {
 	isAkismetProduct,
 	isJetpackPurchasableItem,
 	AKISMET_PRO_500_PRODUCTS,
+	isDomainMapping,
 } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { isCopySiteFlow } from '@automattic/onboarding';
@@ -266,6 +267,7 @@ function LineItemWrapper( {
 	akQuantityOpenId: string | null;
 } ) {
 	const isRenewal = isWpComProductRenewal( product );
+	const isDomainConnection = isDomainMapping( product );
 	const isWooMobile = isWcMobileApp();
 	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 	const has100YearPlanProduct = has100YearPlan( responseCart );
@@ -283,6 +285,10 @@ function LineItemWrapper( {
 		}
 
 		if ( isRenewal && ! product.is_domain_registration ) {
+			return false;
+		}
+
+		if ( isDomainConnection ) {
 			return false;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/payments-shilling/issues/2875

## Proposed Changes

* This PR adds a logic check for domain connection / domain mapping products in `shouldShowVariantSelector`. This the first filter for showing the variant picker. By setting `shouldShowVariantSelector` to return false if `isDomainMapping` returns true, then we can skip showing the variant picker.
* `shouldShowVariantSelector` already hides the variant pickers for renewal Checkouts (other than domains) and so we don't need to address renewals for domain connections separately.

**Before**
<img width="694" alt="Screenshot 2024-07-15 at 12 39 34" src="https://github.com/user-attachments/assets/e6a78add-934d-4e2e-90cd-de73cc03f5b1">

**After**
<img width="693" alt="Screenshot 2024-07-15 at 12 57 03" src="https://github.com/user-attachments/assets/73878701-92e6-499f-8d1f-542700d80735">

## Why are these changes being made?

* Currently, in a new-site purchase flow, when a user selects `I have a domain` and adds a domain registered outside of WordPress.com to their Cart, the variant picker is shown for the domain connection product at Checkout. 

* The expiration of a domain connection product is linked to either a domain registration product or to a plan product. To account for this, the options for the variant picker are disabled. This leads to an experience where users see an option to change how long the domain connection is valid for, but are not able to act on it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* **Do Not Sandbox Store (yet)**
* From `Trunk` in your local Calypso environment 
* Go to http://calypso.localhost:3000/start/domains
* Click on `Use a domain I own` 
* Enter a domain that exists but is not attached to a WordPress.com site yet. You can use `industrywp.com` if you need one
* On the next page, click on the `Select` button for `Connect your domain`
* On the plans page, select a paid plan
* When you get to Checkout, you will see the variant picker under the domain connection product
* **Without closing the browser**
* Apply this branch to your local Calypso environment
* Go back to your browser window with Checkout and Refresh
* Notice the variant picker is no longer shown
* Click on the `Dev` environment badge and find the option for Store Sandbox, **enable it**
* In the variant picker under your plan product, change the number of years to two or three
* Checkout with a test card
* See the `Thank You` page
* Go to Store Admin for your account, make sure you have `Test` data enabled, and find that the plan and domain connection which you just purchased
* Confirm they have matching expiration dates

<img width="1447" alt="Screenshot 2024-07-15 at 13 04 44" src="https://github.com/user-attachments/assets/f543a085-62cd-4c39-87ec-27d1c710d9c8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ NA ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ NA ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ NA ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ NA ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
