### PR TITLE
Fix screen reader text styles

### DIFF
--- a/packages/components/src/screen-reader-text/style.scss
+++ b/packages/components/src/screen-reader-text/style.scss
@@ -2,6 +2,11 @@
 .screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
 
 	&:hover,
 	&:active,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix screen reader text styles to avoid taking space on the screen on Chrome.
  * The approach used here was basically to bring some more properties from [this WordPress class](https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I was adding an `ExternalLink` on the right of a page. It has an element with the `screen-reader-text` saying that it's a link to open in a new tab. But the element is taking space on the screen, creating an horizontal scroll.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Chrome.
* Navigate to `http://calypso.localhost:3000/start`.
* Open the browser inspector in your browser and edit the HTML.
* Add the following HTML after the body is open: `<div style="float:right">Test<button class="screen-reader-text">screen reader text</button></div>`.
* Check that it doesn't create a horizontal scroll in the page.
* Also, navigate through your keyboard, focusing on the element, and make sure the text is still properly displayed on the screen during the focus.

## Screenshots

#### Before

Notice that the screen is scrolled to the right (see where the WordPress logo is).
<img width="1271" alt="Screenshot 2024-07-15 at 17 04 55" src="https://github.com/user-attachments/assets/644e4de3-874a-426a-9984-9bc34fd347f7">

#### After

<img width="1272" alt="Screenshot 2024-07-15 at 17 06 37" src="https://github.com/user-attachments/assets/06fccd8a-e710-4efd-b59b-5b8c0fdabd8c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
