### PR TITLE
Guided Onboarding: Fix Import back button

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -392,7 +392,7 @@ const siteMigration: Flow = {
 				}
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
 					if ( urlQueryParams.get( 'ref' ) === GUIDED_ONBOARDING_FLOW_REFERRER ) {
-						window.location.assign( '/start/guided/initial-intent' );
+						return exitFlow( '/start/initial-intent' );
 					}
 					return exitFlow( `/setup/site-setup/goals?${ urlQueryParams }` );
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92693

## Proposed Changes

Use `return` to fix the bug in the back button on import flow during the guided onboarding. As it was we would have an `assign` after the other.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On guided onboarding when you click the Import option, if you then click the Back link on the next screen it takes you out of the signup flow completely and back to your main Dashboard

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/initial-intent`
* Choose last option and go to the import flow
* Click back
* You should return to the Guided onboarding flow