### PR TITLE
A4A: remove signup feature flag

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-form/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { loadScript } from '@automattic/load-script';
 import { useTranslate } from 'i18n-calypso';
@@ -31,8 +30,7 @@ export default function SignupForm() {
 	const queryParams = new URLSearchParams( window.location.search );
 	const referer = queryParams.get( 'ref' );
 	const userLoggedIn = useSelector( isUserLoggedIn );
-	const isA4ALoggedOutSignup = isEnabled( 'a4a-logged-out-signup' );
-	const shouldRedirectToWPCOM = ! userLoggedIn && isA4ALoggedOutSignup;
+	const shouldRedirectToWPCOM = ! userLoggedIn;
 	const handleWPCOMRedirect = useHandleWPCOMRedirect();
 
 	const createAgency = useCreateAgencyMutation( {

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -171,9 +171,7 @@ const oauthTokenMiddleware = () => {
 		}
 
 		if ( isA8CForAgencies() ) {
-			if ( config.isEnabled( 'a4a-logged-out-signup' ) ) {
-				loggedOutRoutes.push( ...A4A_PUBLIC_ROUTES );
-			}
+			loggedOutRoutes.push( ...A4A_PUBLIC_ROUTES );
 		}
 
 		// Forces OAuth users to the /login page if no token is present

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -39,7 +39,6 @@
 		"oauth": true,
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
-		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
 		"a4a-site-selector-and-importer": true,
 		"a4a-partner-directory": true

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -32,7 +32,6 @@
 		"oauth": false,
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": true,
-		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
 		"a4a-site-selector-and-importer": true,
 		"a4a-partner-directory": true

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -32,7 +32,6 @@
 		"a8c-for-agencies/wpcom-creator-plan-purchase-flow": true,
 		"cookie-banner": true,
 		"oauth": true,
-		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
 		"a4a-site-selector-and-importer": true,
 		"a4a-partner-directory": false

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -35,7 +35,6 @@
 		"oauth": true,
 		"a4a/site-details-pane": true,
 		"a4a/site-migration": false,
-		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
 		"a4a-site-selector-and-importer": true,
 		"a4a-partner-directory": false


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/755

## Proposed Changes

Clearing up a feature flag that we no longer need.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check the code and signup flow with thins branch.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
