### PR TITLE
Live preview readymade template

### DIFF
--- a/client/my-sites/patterns/components/readymade-templates/index.tsx
+++ b/client/my-sites/patterns/components/readymade-templates/index.tsx
@@ -1,10 +1,35 @@
+import {
+	PatternsRendererContext,
+	PatternRenderer,
+	BlockRendererProvider,
+} from '@automattic/block-renderer';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
+import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/constants';
 import { useReadymadeTemplates } from 'calypso/my-sites/patterns/hooks/use-readymade-templates';
+import { useRenderReadymadeTemplate } from 'calypso/my-sites/patterns/hooks/use-render-readymade-template';
+import type { ReadymadeTemplate } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
+
+const ReadymadeTemplatePreview = ( {
+	readymadeTemplate,
+}: {
+	readymadeTemplate: ReadymadeTemplate;
+} ) => {
+	const { data: renderedPatterns = {} } = useRenderReadymadeTemplate( readymadeTemplate );
+	return (
+		<BlockRendererProvider siteId={ RENDERER_SITE_ID }>
+			<PatternsRendererContext.Provider value={ { renderedPatterns, shouldShufflePosts: false } }>
+				{ Object.keys( renderedPatterns ).map( ( pattern ) => (
+					<PatternRenderer patternId={ pattern } viewportWidth={ 1200 } key={ pattern } />
+				) ) }
+			</PatternsRendererContext.Provider>
+		</BlockRendererProvider>
+	);
+};
 
 export const ReadymadeTemplates = () => {
 	const translate = useTranslate();
@@ -78,7 +103,7 @@ export const ReadymadeTemplates = () => {
 						key={ readymadeTemplate.template_id }
 					>
 						<div className="readymade-template__content">
-							<img src={ readymadeTemplate.screenshot } alt="" />
+							<ReadymadeTemplatePreview readymadeTemplate={ readymadeTemplate } />
 						</div>
 						<div className="readymade-template__title">{ readymadeTemplate.title }</div>
 					</a>

--- a/client/my-sites/patterns/hooks/use-render-readymade-template.ts
+++ b/client/my-sites/patterns/hooks/use-render-readymade-template.ts
@@ -4,6 +4,15 @@ import wpcom from 'calypso/lib/wp';
 import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/constants';
 import type { ReadymadeTemplate } from 'calypso/my-sites/patterns/types';
 
+// Shouldnt have to do this.
+function makeSlug( text: string ) {
+	return text
+		.trim()
+		.toLowerCase()
+		.replace( /[^a-z0-9]+/g, '-' )
+		.replace( /^-+|-+$/g, '' ); // remove runs of dashes and trailing dashes
+}
+
 export const useRenderReadymadeTemplate = ( readymadeTemplate: ReadymadeTemplate ) =>
 	useQuery< { [ key: string ]: RenderedPattern } >( {
 		queryKey: [ 'pattern-library', 'readymade-template', readymadeTemplate.template_id, 'render' ],
@@ -16,6 +25,12 @@ export const useRenderReadymadeTemplate = ( readymadeTemplate: ReadymadeTemplate
 				{
 					pattern_ids: readymadeTemplate.patterns.map( ( { id } ) => id ).join( ',' ),
 					site_title: readymadeTemplate.title,
+					style_variations: [
+						readymadeTemplate?.styles?.colors,
+						readymadeTemplate?.styles?.typography,
+					]
+						.filter( Boolean )
+						.map( ( value ) => makeSlug( value as string ) ),
 				}
 			);
 		},

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -72,6 +72,11 @@ type ReadymadeTemplatePattern = {
 	source_site_sid: number;
 };
 
+type ReadymadeTemplateStyles = {
+	colors?: string;
+	typography?: string;
+};
+
 export type ReadymadeTemplate = {
 	template_id: number;
 	title: string;
@@ -79,4 +84,5 @@ export type ReadymadeTemplate = {
 	content: string;
 	screenshot: string;
 	patterns: ReadymadeTemplatePattern[];
+	styles: ReadymadeTemplateStyles;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8138

## Proposed Changes

Allow readymade templates to be live previewed on the /patterns page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To save effort generating screenshots each time the RMT is updated, or worse, having outdated screenshots.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply D155285-code and sandbox
2. Use the calypso live link
3. Go to /patterns

Note that the RMTs without a hardcoded pattern list won't render anything.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?