### PR TITLE
A4A > Partner Directory: Add a new hook to upload a logo using particular endpoint

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-upload-logo.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-upload-logo.ts
@@ -1,0 +1,16 @@
+import wpcom from 'calypso/lib/wp';
+
+export const useUploadLogo = () => async ( agencyId: number | undefined, file: File ) => {
+	if ( agencyId === undefined ) {
+		return;
+	}
+
+	const formData = new FormData();
+	formData.append( 'media', file );
+
+	return await wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/agency/' + agencyId + '/profile/logo',
+		body: formData,
+	} );
+};


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/790

## Proposed Changes

This PR implements a hook for uploading the logo image for the agencies using a specific endpoint for uploading the logo.

This should work like before, but you must be sandboxed, pointing the endpoint to your sandbox. If not, it won't work until Systems add this endpoint to the whitelisted for uploading media.

This is the previous PR with the initial implementation, already closed: https://github.com/Automattic/wp-calypso/pull/92635

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Turn on your sandbox and point the public endpoint `public-api.wordpress.com` to your sandbox IP.
- Now go to the Partner Directory section and if you have a directory application, go to edit your profile and upload a logo.
- After clicking on save, the logo should be uploaded.
- Go to the profile form, and you will see it there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
