### PR TITLE
A4A > Marketplace: Fix the Jetpack VaultPress Backup Add-ons not showing up in Checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -15,7 +15,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 	let productIcon =
 		productInfo?.productSlug && getProductIcon( { productSlug: productInfo?.productSlug } );
 	let productTitle = title;
-	let productDescription = productInfo?.lightboxDescription;
+	let productDescription = productInfo?.lightboxDescription || productInfo?.tagline;
 
 	if ( product.family_slug === 'pressable-hosting' ) {
 		const presablePlan = getPressablePlan( product.slug );


### PR DESCRIPTION
## Proposed Changes

This PR fixes the Jetpack VaultPress Backup Add-ons not showing up in Checkout.

This was happening because the Backup add-ons don't have a description. Now we have a falling backup to the `tagline`. 

## Testing Instructions

1. Open the A4A live link.
2. Go to Marketplace > Add a few products, including the `Jetpack VaultPress Backup Add-ons` > Go to checkout and verify the product is displayed on the left side



| Before | After |
|--------|--------|
| <img width="1593" alt="Screenshot 2024-07-16 at 2 56 17 PM" src="https://github.com/user-attachments/assets/655bf19b-e4a6-4a76-8739-0fa0170ac392"> | <img width="1593" alt="Screenshot 2024-07-16 at 2 56 01 PM" src="https://github.com/user-attachments/assets/6f9e7373-97c3-4fe1-bbf8-5e6cd428ec73"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
