### PR TITLE
[Odie] Apply loading state to the input message field

### DIFF
--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-imports */
+import { Spinner } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useState, KeyboardEvent, FormEvent, useRef, useEffect } from 'react';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
@@ -24,7 +25,7 @@ export const OdieSendMessageButton = ( {
 	const { _x } = useI18n();
 	const [ messageString, setMessageString ] = useState< string >( '' );
 	const divContainerRef = useRef< HTMLDivElement >( null );
-	const { initialUserMessage, chat, isLoading, trackEvent } = useOdieAssistantContext();
+	const { initialUserMessage, chat, trackEvent, isLoading } = useOdieAssistantContext();
 	const { mutateAsync: sendOdieMessage } = useOdieSendMessage();
 
 	useEffect( () => {
@@ -85,26 +86,39 @@ export const OdieSendMessageButton = ( {
 	);
 	const userHasNegativeFeedback = chat.messages.some( ( message ) => message.liked === false );
 
+	const getPlaceholderText = () => {
+		const placeholderText = _x(
+			'Please wait…',
+			'Placeholder text for the message input field (chat)',
+			__i18n_text_domain__
+		);
+
+		// If not loading, decide based on user actions
+		if ( ! isLoading ) {
+			if ( userHasAskedToContactHE || userHasNegativeFeedback ) {
+				return _x(
+					'Continue chatting with Wapuu',
+					'Placeholder text for the message input field (chat)',
+					__i18n_text_domain__
+				);
+			}
+			return _x(
+				'Ask your question',
+				'Placeholder text for the message input field (chat)',
+				__i18n_text_domain__
+			);
+		}
+
+		return placeholderText;
+	};
+
 	return (
 		<>
 			<JumpToRecent scrollToBottom={ scrollToRecent } enableJumpToRecent={ enableJumpToRecent } />
 			<div className="odie-chat-message-input-container" ref={ divContainerRef }>
 				<form onSubmit={ handleSubmit } className="odie-send-message-input-container">
 					<TextareaAutosize
-						placeholder={
-							userHasAskedToContactHE || userHasNegativeFeedback
-								? // translators: Placeholder text for the message input field (chat) */
-								  _x(
-										'Continue chatting with Wapuu',
-										'Placeholder text for the message input field (chat)',
-										__i18n_text_domain__
-								  )
-								: _x(
-										'Ask your question',
-										'Placeholder text for the message input field (chat)',
-										__i18n_text_domain__
-								  )
-						}
+						placeholder={ getPlaceholderText() }
 						className="odie-send-message-input"
 						rows={ 1 }
 						value={ messageString }
@@ -113,6 +127,7 @@ export const OdieSendMessageButton = ( {
 						}
 						onKeyPress={ handleKeyPress }
 					/>
+					{ isLoading && <Spinner className="odie-send-message-input-spinner" /> }
 					<button
 						type="submit"
 						className="odie-send-message-inner-button"

--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -20,6 +20,12 @@
 	}
 }
 
+.odie-send-message-input-spinner {
+	position: absolute !important;
+	right: 60px;
+	top: 20px;
+}
+
 .odie-send-message-input-container .odie-send-message-inner-button {
 	background: none;
 	border: none;


### PR DESCRIPTION
## Proposed Changes

Add a loading state in the input message for Odie Client

## Why are these changes being made?
it has been reported that it is a bit confusing that the user can't send messages, or at least why. It seems that the input falls into a "wrong" or "buggy" state, which is not the case.

## Testing Instructions

1. Open Wapuu in the Help Center (question mark icon in the top bar, then click on "Still Need Help")
2. Send a message
3. Assert that there is a loading state in the input text field.
4. Assert that the user is still able to type, but can't send anything.