### PR TITLE
A4A > Referrals: Fix horizontal scroll on referral details

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -45,7 +45,7 @@ export default function ConsolidatedViews( { referrals }: { referrals: Referral[
 						formatCurrency( consolidatedData.allTimeCommissions, 'USD' )
 					) }
 				</div>
-				<div className="consolidated-view__label">
+				<div className="consolidated-view__label consolidated-view__label--all-time">
 					{ translate( 'All time commissions' ) }
 					<span
 						className="consolidated-view__info-icon"

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
@@ -25,6 +25,10 @@
 		.consolidated-view__label {
 			color: var(--color-accent);
 			font-size: rem(12px);
+
+			&.consolidated-view__label--all-time {
+				text-wrap: nowrap;
+			}
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/style.scss
@@ -24,4 +24,8 @@
 			padding: 0;
 		}
 	}
+
+	.section-nav-tabs__list {
+		width: auto;
+	}
 }


### PR DESCRIPTION
## Proposed Changes

This PR:

- Fixes the horizontal scroll on referral details
- Adds `text-wrap: nowrap` to the `All time commissions` label so that the icon always stays on the same line. 

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals Dashboard > Open the detailed view of any client > Switch to `> 961px` view > Verify:

- The scroll is no longer shown on the detailed view
- The icon on the `All time commissions` label is not breaking to the next line

| Before | After |
|--------|--------|
| <img width="959" alt="Screenshot 2024-07-16 at 5 05 57 PM" src="https://github.com/user-attachments/assets/54e95935-849d-4594-a337-d5e10c1bfb73"> | <img width="1038" alt="Screenshot 2024-07-16 at 4 18 52 PM" src="https://github.com/user-attachments/assets/1dfe1b41-b71b-40a3-b983-8352cb0e4685"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
