### PR TITLE
A4A > Marketplace: Add the missing Jetpack VaultPress Backup Add-ons taglines

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -547,6 +547,14 @@ export const getJetpackProductsTaglines = (): Record<
 			default: backupAddonTagLine,
 			owned: backupAddonOwnedTagLine,
 		},
+		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_3TB_MONTHLY ]: {
+			default: backupAddonTagLine,
+			owned: backupAddonOwnedTagLine,
+		},
+		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_5TB_MONTHLY ]: {
+			default: backupAddonTagLine,
+			owned: backupAddonOwnedTagLine,
+		},
 		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_10GB_YEARLY ]: {
 			default: backupAddonTagLine,
 			owned: backupAddonOwnedTagLine,
@@ -556,6 +564,14 @@ export const getJetpackProductsTaglines = (): Record<
 			owned: backupAddonOwnedTagLine,
 		},
 		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_YEARLY ]: {
+			default: backupAddonTagLine,
+			owned: backupAddonOwnedTagLine,
+		},
+		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_3TB_YEARLY ]: {
+			default: backupAddonTagLine,
+			owned: backupAddonOwnedTagLine,
+		},
+		[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_5TB_YEARLY ]: {
 			default: backupAddonTagLine,
 			owned: backupAddonOwnedTagLine,
 		},


### PR DESCRIPTION
## Proposed Changes

This PR adds the missing Jetpack VaultPress Backup Add-ons taglines to fix the Jetpack VaultPress Backup Add-ons not showing up in Checkout.

This was happening because some backup add-ons didn't have a tagline.

## Testing Instructions

1. Open the A4A live link.
2. Go to Marketplace > Add a few products, including **all** the `Jetpack VaultPress Backup Add-ons` > Go to checkout and verify the product is displayed on the left side

| Before | After |
|--------|--------|
| <img width="1728" alt="Screenshot 2024-07-16 at 5 25 32 PM" src="https://github.com/user-attachments/assets/7a1f4e1c-45d0-468c-ad9f-58b94de64493"> | <img width="1728" alt="Screenshot 2024-07-16 at 5 26 11 PM" src="https://github.com/user-attachments/assets/f6b2eb05-1112-4cca-9693-fd45be0bd644"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
