### PR TITLE
Plans (State): Update checkout upsell-nudge to utilise data-store pricing

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -158,9 +158,13 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 									),
 								},
 								args: {
-									fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
+									fullPrice: formatCurrency( planRawPrice, currencyCode, {
+										stripZeros: true,
+										isSmallestUnit: true,
+									} ),
 									discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
 										stripZeros: true,
+										isSmallestUnit: true,
 									} ),
 									planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
 									comment: 'A monetary value at the end, e.g. $25',

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -506,6 +506,7 @@ const WrappedUpsellNudge = (
 		useCheckPlanAvailabilityForPurchase,
 		coupon: undefined,
 		storageAddOns: null,
+		withProratedDiscounts: true,
 	} );
 
 	return (

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -1,22 +1,22 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	isMonthly,
 	getPlanByPathSlug,
 	TERM_MONTHLY,
-	Product,
 	isPlan,
+	PlanSlug,
 } from '@automattic/calypso-products';
 import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import page from '@automattic/calypso-router';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CompactCard, Gridicon } from '@automattic/components';
+import { Plans, ProductsList } from '@automattic/data-stores';
 import { withShoppingCart, createRequestCartProduct } from '@automattic/shopping-cart';
 import { isURL } from '@wordpress/url';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize, useTranslate } from 'i18n-calypso';
-import { pick } from 'lodash';
 import { Component } from 'react';
-import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -27,29 +27,18 @@ import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url
 import ProfessionalEmailUpsell from 'calypso/my-sites/checkout/upsell-nudge/professional-email-upsell';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
 	persistSignupDestination,
 } from 'calypso/signup/storageUtils';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import {
-	getProductsList,
-	getProductDisplayCost,
-	getProductBySlug,
-	isProductsListFetching,
-} from 'calypso/state/products-list/selectors';
-import getCurrentPlanTerm from 'calypso/state/selectors/get-current-plan-term';
+import { getProductsList, isProductsListFetching } from 'calypso/state/products-list/selectors';
 import getUpgradePlanSlugFromPath from 'calypso/state/selectors/get-upgrade-plan-slug-from-path';
-import {
-	isRequestingSitePlans,
-	getPlansBySiteId,
-	getSitePlanRawPrice,
-	getPlanDiscountedRawPrice,
-} from 'calypso/state/sites/plans/selectors';
-import { getSitePlan, getSiteSlug } from 'calypso/state/sites/selectors';
+import { isRequestingSitePlans, getPlansBySiteId } from 'calypso/state/sites/plans/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PurchaseModal from '../purchase-modal';
 import {
@@ -59,8 +48,6 @@ import {
 import { BusinessPlanUpgradeUpsell } from './business-plan-upgrade-upsell';
 import { QuickstartSessionsRetirement } from './quickstart-sessions-retirement';
 import type { WithShoppingCartProps, MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { IAppState } from 'calypso/state/types';
-
 import './style.scss';
 
 const debug = debugFactory( 'calypso:upsell-nudge' );
@@ -84,20 +71,17 @@ export interface UpsellNudgeManualProps {
 
 // Below are provided by HOCs
 export interface UpsellNudgeAutomaticProps extends WithShoppingCartProps {
-	currencyCode: string | null;
+	currencyCode: string | undefined;
 	isLoading?: boolean;
 	hasProductsList?: boolean;
 	hasSitePlans?: boolean;
 	product: MinimalRequestCartProduct | undefined;
-	productDisplayCost?: string | null;
 	planRawPrice?: number | null;
 	planDiscountedRawPrice?: number | null;
 	isLoggedIn?: boolean;
 	siteSlug?: string | null;
-	currentProduct?: Product | Record< string, never >;
 	selectedSiteId: string | number | undefined | null;
 	hasSevenDayRefundPeriod?: boolean;
-	trackUpsellButtonClick: ( key: string ) => void;
 	translate: ReturnType< typeof useTranslate >;
 	currentPlanTerm: string;
 }
@@ -110,6 +94,12 @@ interface UpsellNudgeState {
 	cartItem: MinimalRequestCartProduct | null;
 	showPurchaseModal: boolean;
 }
+
+const trackUpsellButtonClick = ( eventName: string ) => {
+	// Track upsell get started / accept / decline events
+	recordTracksEvent( eventName, { section: 'checkout' } );
+	return;
+};
 
 export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState > {
 	state: UpsellNudgeState = {
@@ -277,7 +267,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 	};
 
 	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
-		const { trackUpsellButtonClick, upsellType } = this.props;
+		const { upsellType } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
 
@@ -308,7 +298,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 	};
 
 	handleClickAccept = async ( buttonAction: string ) => {
-		const { siteSlug, trackUpsellButtonClick, upgradeItem, upsellType } = this.props;
+		const { siteSlug, upgradeItem, upsellType } = this.props;
 		debug( 'accept upsell clicked' );
 
 		trackUpsellButtonClick(
@@ -448,11 +438,6 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 	};
 }
 
-const trackUpsellButtonClick = ( eventName: string ) => {
-	// Track upsell get started / accept / decline events
-	return recordTracksEvent( eventName, { section: 'checkout' } );
-};
-
 const getProductSlug = ( upsellType: string, productAlias: string, planTerm: string ) => {
 	switch ( upsellType ) {
 		case BUSINESS_PLAN_UPGRADE_UPSELL:
@@ -468,62 +453,81 @@ const getProductSlug = ( upsellType: string, productAlias: string, planTerm: str
 	}
 };
 
-export default connect(
-	( state: IAppState, props: UpsellNudgeManualProps ) => {
-		const { siteSlugParam, upgradeItem, upsellType } = props;
-		const selectedSiteId = getSelectedSiteId( state );
-		const productsList = getProductsList( state );
-		const sitePlans = getPlansBySiteId( state, undefined ).data;
-		const siteSlug = selectedSiteId ? getSiteSlug( state, selectedSiteId ) : siteSlugParam;
-		const planSlug = getUpgradePlanSlugFromPath(
-			state,
-			selectedSiteId ?? 0,
-			props.upgradeItem ?? ''
-		);
-		const annualDiscountPrice = getPlanDiscountedRawPrice( state, selectedSiteId ?? 0, planSlug, {
-			returnMonthly: false,
-		} );
-		const annualPrice = getSitePlanRawPrice( state, selectedSiteId ?? 0, planSlug, {
-			returnMonthly: false,
-		} );
+const WrappedUpsellNudge = (
+	props: UpsellNudgeManualProps & WithIsEligibleForOneClickCheckoutProps & WithShoppingCartProps
+) => {
+	const { siteSlugParam, upgradeItem, upsellType } = props;
+	const translate = useTranslate();
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const products = ProductsList.useProducts();
+	const currentPlanTerm = Plans.useCurrentPlanTerm( { siteId: selectedSiteId } );
+	const upsellProductSlug = getProductSlug(
+		upsellType,
+		upgradeItem ?? '',
+		currentPlanTerm ?? TERM_MONTHLY
+	);
+	const upsellProduct =
+		upsellProductSlug && products.data?.[ upsellProductSlug as ProductsList.StoreProductSlug ];
+	const cartProduct =
+		upsellProduct?.productSlug && upsellProduct?.id
+			? createRequestCartProduct( {
+					product_slug: upsellProduct.productSlug,
+					product_id: upsellProduct.id,
+			  } )
+			: undefined;
+	const planSlug = useSelector( ( state ) =>
+		getUpgradePlanSlugFromPath( state, selectedSiteId ?? 0, upgradeItem ?? '' )
+	);
+	const siteSlug =
+		useSelector( ( state ) => getSiteSlug( state, selectedSiteId ) ) ?? siteSlugParam;
 
-		const currentPlanTerm = getCurrentPlanTerm( state, selectedSiteId ?? 0 ) ?? TERM_MONTHLY;
-		const currentSitePlan = getSitePlan( state, selectedSiteId ?? 0 );
-		const currentProduct = getProductBySlug( state, currentSitePlan?.product_slug ?? '' ) || {};
-		const productSlug = getProductSlug( upsellType, upgradeItem ?? '', currentPlanTerm );
-		const productProperties = pick( getProductBySlug( state, productSlug ?? '' ), [
-			'product_slug',
-			'product_id',
-		] );
-		const product =
-			productProperties.product_slug && productProperties.product_id
-				? createRequestCartProduct( {
-						product_slug: productProperties.product_slug,
-						product_id: productProperties.product_id,
-				  } )
-				: undefined;
+	/**
+	 * Redux site-plans replaceable by data-store `Plans.useSitePlans`
+	 *  - Needs confirmation whether consumed later
+	 */
+	const sitePlans = useSelector(
+		( state ) => getPlansBySiteId( state, selectedSiteId ?? undefined ).data // (the beauty of inconsistency / .data)
+	);
+	const isLoadingSitePlans = useSelector( ( state ) =>
+		isRequestingSitePlans( state, selectedSiteId )
+	);
 
-		return {
-			currencyCode: getCurrentUserCurrencyCode( state ),
-			currentPlanTerm,
-			currentProduct,
-			isLoading: isProductsListFetching( state ) || isRequestingSitePlans( state, selectedSiteId ),
-			hasProductsList: Object.keys( productsList ).length > 0,
-			hasSitePlans: sitePlans ? sitePlans.length > 0 : undefined,
-			product,
-			productDisplayCost: getProductDisplayCost( state, productSlug ?? '' ),
-			planRawPrice: annualPrice,
-			planDiscountedRawPrice: annualDiscountPrice,
-			isLoggedIn: isUserLoggedIn( state ),
-			siteSlug,
-			selectedSiteId,
-			hasSevenDayRefundPeriod: isMonthly( planSlug ),
-			productSlug,
-		};
-	},
-	{
-		trackUpsellButtonClick,
-	}
-)(
-	withIsEligibleForOneClickCheckout( withCartKey( withShoppingCart( localize( UpsellNudge ) ) ) )
+	/**
+	 * Redux products-list replaceable by data-store `Products.useProducts`
+	 *  - Needs confirmation whether consumed later
+	 */
+	const productsList = useSelector( getProductsList ); // (the beauty of inconsistency / no .data)
+	const isLoadingProductsList = useSelector( isProductsListFetching );
+
+	const pricing = Plans.usePricingMetaForGridPlans( {
+		planSlugs: [ planSlug as PlanSlug ],
+		siteId: selectedSiteId,
+		useCheckPlanAvailabilityForPurchase,
+		coupon: undefined,
+		storageAddOns: null,
+	} );
+
+	return (
+		<UpsellNudge
+			{ ...props }
+			hasSevenDayRefundPeriod={ isMonthly( planSlug ) }
+			currencyCode={ pricing?.[ planSlug ]?.currencyCode }
+			planRawPrice={ pricing?.[ planSlug ]?.originalPrice.full ?? 0 }
+			planDiscountedRawPrice={ pricing?.[ planSlug ]?.discountedPrice.full ?? 0 }
+			isLoading={ ! pricing || products.isLoading || isLoadingProductsList || isLoadingSitePlans }
+			hasSitePlans={ sitePlans ? sitePlans.length > 0 : undefined }
+			hasProductsList={ Object.keys( productsList ).length > 0 }
+			currentPlanTerm={ currentPlanTerm ?? TERM_MONTHLY }
+			product={ cartProduct }
+			isLoggedIn={ isLoggedIn }
+			siteSlug={ siteSlug }
+			selectedSiteId={ selectedSiteId }
+			translate={ translate }
+		/>
+	);
+};
+
+export default withIsEligibleForOneClickCheckout(
+	withCartKey( withShoppingCart( localize( WrappedUpsellNudge ) ) )
 );

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -26,6 +26,7 @@ import {
 	PLAN_CENTENNIAL_PERIOD,
 	TERM_CENTENNIALLY,
 } from './constants';
+import { BillingTerm } from './types';
 
 export { getPlanSlugForTermVariant } from './get-plan-term-variant';
 export { getPlanMultipleTermsVariantSlugs } from './get-plan-multiple-terms-variant-slugs';
@@ -73,7 +74,7 @@ export function getTermDuration( term: string ): number | undefined {
  * @param {number} days Term duration in days
  * @returns {string} TERM_ constant
  */
-export function getTermFromDuration( days: number ): string | undefined {
+export function getTermFromDuration( days: number ): BillingTerm[ 'term' ] | undefined {
 	switch ( days ) {
 		case PLAN_MONTHLY_PERIOD:
 			return TERM_MONTHLY;

--- a/packages/data-stores/src/plans/hooks/use-current-plan-term.ts
+++ b/packages/data-stores/src/plans/hooks/use-current-plan-term.ts
@@ -1,0 +1,18 @@
+import { type BillingTerm, getTermFromDuration } from '@automattic/calypso-products';
+import usePlans from '../queries/use-plans';
+import useCurrentPlan from './use-current-plan';
+
+interface Props {
+	siteId?: string | number | null;
+}
+
+const useCurrentPlanTerm = ( { siteId }: Props ): BillingTerm[ 'term' ] | undefined => {
+	const plans = usePlans( { coupon: undefined } ).data;
+	const currentPlan = useCurrentPlan( { siteId } );
+
+	return plans && currentPlan
+		? getTermFromDuration( plans[ currentPlan.planSlug ]?.pricing?.billPeriod )
+		: undefined;
+};
+
+export default useCurrentPlanTerm;

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -28,6 +28,7 @@ export { default as usePlans } from './queries/use-plans';
 export { default as useSitePlans } from './queries/use-site-plans';
 /** Hooks/Selectors */
 export { default as useCurrentPlan } from './hooks/use-current-plan';
+export { default as useCurrentPlanTerm } from './hooks/use-current-plan-term';
 export { default as useIntroOffers } from './hooks/use-intro-offers';
 export { default as useIntroOffersForWooExpress } from './hooks/use-intro-offers-for-woo-express';
 export { default as usePricingMetaForGridPlans } from './hooks/use-pricing-meta-for-grid-plans';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

Primarily updates the `UpsellNudge` in checkout to utilize Plans data-store for pricing. Additionally (as it made sense):

- Migrates the Redux-connected component to a function wrapper (`Upsell Nudge` still in class form)
- Introduces `Plans.useCurrentPlanTerm` hook for fetching the current plan term
- Introduces `ProductsList` for fetching and compiling the upsell product
- Adjusts a few other properties, removes `currentProduct` and `productDisplayCost` props as not used anywhere
- Adds in-line comments for follow-up migrations that need caution/confirmation (and will be handled in a follow-up round)

### Media

**Business Plan Upsell**

<img width="600" alt="Screenshot 2024-07-23 at 11 31 34 AM" src="https://github.com/user-attachments/assets/197062be-e82e-4eeb-8594-b7ffe4a21a71">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We only need one form of handling plan pricing in the code base, more so one framework. Anything else risks having alternative and differing views of the same data propagating across the code base.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are a few cases/paths to render the various upsells, some of which may need activation. 

Luckily, the Business plan upsell covers the whole spectrum of changes (the only one that renders the price) and is easily testable. However, there is an issue with it (see https://github.com/Automattic/wp-calypso/issues/92889) that may or may not need addressing - TLDR the upsell only really makes sense when visiting with a site on a Premium plan (see https://github.com/Automattic/wp-calypso/issues/92889#issuecomment-2244582197) and certainly not a free plan.

- go to `/checkout/[ site ]/offer-plan-upgrade/business` with a site on a paid plan
- confirm the media. the proration credits should be applied to generate the difference and cross out pricing


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
