### PR TITLE
DotPager: Switch to WP button and deprecate Button from `@automattic/components`

### DIFF
--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -123,6 +123,7 @@
 }
 
 .theme-a8c-for-agencies {
+	.components-button,
 	.button {
 		display: inline-flex;
 		align-items: center;
@@ -156,6 +157,7 @@
 		border-radius: 4px 0 0 4px;
 	}
 
+	.components-button.is-primary,
 	.button.is-primary {
 		background-color: var(--color-primary-50);
 		border-color: var(--color-primary-50);

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -123,6 +123,7 @@
 }
 
 .theme-a8c-for-agencies {
+
 	.components-button,
 	.button {
 		display: inline-flex;
@@ -144,11 +145,19 @@
 		&:focus-visible {
 			background-color: var(--color-accent-0);
 		}
+
+		&.is-borderless.is-primary.is-active,
+		&.is-borderless.is-primary:active,
+		&.is-borderless.is-primary:focus,
+		&.is-borderless.is-primary:hover {
+			color: var(--color-primary-60);
+		}
 	}
 
 	.button.split-button__toggle {
 		border-radius: 0 4px 4px 0;
-		@include breakpoint-deprecated( "<660px" ) {
+
+		@include breakpoint-deprecated("<660px") {
 			border-radius: 4px;
 		}
 	}
@@ -278,6 +287,7 @@
 		min-height: 36px;
 
 		:not(.components-form-token-field__input-container) {
+
 			&.is-active,
 			&:focus {
 				border-color: var(--color-primary);
@@ -317,20 +327,14 @@
 			border-radius: 4px;
 		}
 
-		> * {
+		>* {
 			margin: 0;
 			padding: 0;
 		}
 	}
 
-	.button.is-borderless.is-primary.is-active,
-	.button.is-borderless.is-primary:active,
-	.button.is-borderless.is-primary:focus,
-	.button.is-borderless.is-primary:hover {
-		color: var(--color-primary-60);
-	}
-
 	.search {
+
 		&,
 		& > *,
 		input[type="search"] {
@@ -362,7 +366,7 @@
 		padding: 16px;
 	}
 
-	@include breakpoint-deprecated( ">660px" ) {
+	@include breakpoint-deprecated(">660px") {
 		padding-block-start: 0;
 
 		.layout__content {
@@ -437,7 +441,7 @@ html {
 		font-weight: 600;
 		line-height: 32px;
 
-		@include breakpoint-deprecated( ">660px" ) {
+		@include breakpoint-deprecated(">660px") {
 			font-size: $font-headline-small;
 			line-height: 40px;
 		}
@@ -448,7 +452,7 @@ html {
 		font-weight: 600;
 		line-height: 23px;
 
-		@include breakpoint-deprecated( ">660px" ) {
+		@include breakpoint-deprecated(">660px") {
 			font-size: $font-title-small;
 			line-height: 23px;
 		}
@@ -458,7 +462,7 @@ html {
 		font-size: $font-body;
 		line-height: 24px;
 
-		@include breakpoint-deprecated( ">660px" ) {
+		@include breakpoint-deprecated(">660px") {
 			font-size: $font-title-small;
 			line-height: 24px;
 		}
@@ -544,6 +548,7 @@ html {
 			inset-block-start: 1px;
 		}
 	}
+
 	.popover__inner {
 		background: var(--color-accent-60);
 		color: var(--color-text-white);
@@ -565,6 +570,7 @@ html {
 	}
 
 	.dataviews-view-table tr {
+
 		td,
 		th {
 			.action-button {
@@ -578,11 +584,13 @@ html {
 					top: 0;
 				}
 			}
+
 			&:first-child {
 				text-align: left;
 				padding-inline-start: 16px;
 			}
 		}
+
 		th[data-field-id="actions"] {
 			text-align: right;
 			padding-inline-end: 16px;
@@ -606,18 +614,21 @@ html {
 	}
 
 	.redesigned-a8c-table .dataviews-view-table tr {
+
 		td:first-child,
 		th:first-child {
 			padding-inline-start: 16px;
 
-			@include breakpoint-deprecated( ">660px" ) {
+			@include breakpoint-deprecated(">660px") {
 				padding-inline-start: 64px;
 			}
 		}
+
 		td:last-child,
 		th:last-child {
 			padding-inline-end: 16px;
-			@include breakpoint-deprecated( ">660px" ) {
+
+			@include breakpoint-deprecated(">660px") {
 				padding-inline-end: 64px;
 			}
 		}

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -82,6 +82,7 @@
 	}
 }
 
+.components-button,
 .button {
 	color: var(--color-accent);
 	background: var(--studio-white);
@@ -114,6 +115,7 @@
 	}
 }
 
+.components-button.is-primary,
 .button.is-primary {
 	background-color: var(--studio-jetpack-green-50);
 	border-color: var(--studio-jetpack-green-50);

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -104,7 +104,10 @@ const Button: ForwardRefRenderFunction<
 		<button { ...buttonProps } className={ classes } ref={ ref as Ref< HTMLButtonElement > } />
 	);
 };
-
+/**
+ * @deprecated This button has been deprecated in favor of the `Button` component from `@wordpress/components`.
+ * Please use the `Button` component from `@wordpress/components` instead. This button has aggressive and generic CSS that breaks many other buttons when imported.
+ */
 const ButtonWithForwardedRef = forwardRef( Button );
 
 ButtonWithForwardedRef.defaultProps = {

--- a/packages/components/src/dot-pager/index.tsx
+++ b/packages/components/src/dot-pager/index.tsx
@@ -1,10 +1,9 @@
+import { Button } from '@wordpress/components';
 import { Icon, arrowRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate, useRtl } from 'i18n-calypso';
 import { times } from 'lodash';
 import { Children, useState, useEffect, ReactNode } from 'react';
-// REPLACE ME WITH WP BUTTON. THIS BUTTON IS BAD (has aggressive styles with generic class names).
-import Button from '../button';
 import { Swipeable } from '../swipeable';
 
 import './style.scss';


### PR DESCRIPTION
## Proposed Changes

The `DotPager` has a flag called `includeNextButton` that is only used in two places: Jetpack cloud and A4A. This flag renders a Button from `@automattic/button`. This button has way generic CSS and breaks many UIs when imported. I switched to `@wordpress/components`.



## Testing Instructions

### A4A
Go to a4a using the link below "Automattic for Agencies live" and make sure the Button in the card below looks like production
![image](https://github.com/user-attachments/assets/f045e846-4253-4d1e-a697-ce25ad243b52)

### Jetpack Cloud
1. Edit this [line](https://github.com/Automattic/wp-calypso/blob/dot-pager/switch-to-wp-button/client/jetpack-cloud/sections/overview/controller.tsx#L14) locally to return true. 
2. run Jetpack cloud by running `yarn start-jetpack-cloud`.
3. Go to http://jetpack.cloud.localhost:3000/overview.
4. Make sure the card looks like this

![image](https://github.com/user-attachments/assets/64073ad1-e99b-4091-b2c7-38a0423547c7)
 
### Jetpack cloud - Regression testing

Hi @gogdzl! I need your help a bit. Can you please retest his PR https://github.com/Automattic/wp-calypso/pull/87760 and make sure the Site Link button works well. I added styles to WP Button in all Jetpack cloud and wanted to make sure that I didn't break this button. But I can't access /sites. 
