### PR TITLE
Fix: Add siteId to the destination url for the checkout page

### DIFF
--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -95,7 +95,7 @@ const migrationSignup: Flow = {
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
 			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
-			const siteId = getSiteIdBySlug( siteSlug );
+			const siteId = getSiteIdBySlug( siteSlug ) || urlQueryParams.get( 'siteId' );
 
 			switch ( currentStep ) {
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
@@ -161,6 +161,7 @@ const migrationSignup: Flow = {
 							{
 								siteSlug,
 								from: fromQueryParam,
+								siteId,
 							},
 							`/setup/${ FLOW_NAME }/${ MIGRATION_INSTRUCTIONS_STEP.slug }`
 						);

--- a/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
@@ -93,7 +93,7 @@ describe( 'Migration Signup Flow', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( migrationSignupFlow );
 
 			runUseStepNavigationSubmit( {
-				currentURL: `/setup/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com`,
+				currentURL: `/setup/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&siteId=123`,
 				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
 				dependencies: {
 					goToCheckout: true,
@@ -103,7 +103,7 @@ describe( 'Migration Signup Flow', () => {
 			} );
 
 			expect( goToCheckout ).toHaveBeenCalledWith( {
-				destination: `/setup/migration-signup/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com`,
+				destination: `/setup/migration-signup/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com&siteId=123`,
 				extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 				flowName: 'migration-signup',
 				siteSlug: 'example.wordpress.com',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

closes #92722

## Proposed Changes

* Add missing siteId to the checkout redirect_to query param

## Why are these changes being made?
* The instructions page requires the `site` param to continue working when the user reloads the page. 
We can probably get the site ID from the slug, but for some unknown reason, it does not work when the user reloads the page.  It requires further investigation. 


## Testing Instructions
* Start `/setup/migration-signup`
* Follow the steps until reach the instructions page
* Reload the page and check if the process is restarted and the app is making requests to `/atomic/transfers/latest`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
