### PR TITLE
Stats: Notify commercial paywall to sites reaching the threshold

### DIFF
--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -5,7 +5,6 @@ import getSiteFeatures from 'calypso/state/selectors/get-site-features';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite, getSiteOption } from 'calypso/state/sites/selectors';
-import { getPlanUsageBillableMonthlyViews } from 'calypso/state/stats/plan-usage/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	STATS_FEATURE_DOWNLOAD_CSV,
@@ -35,8 +34,11 @@ import {
 	STATS_FEATURE_SUMMARY_LINKS_YEAR,
 	STATS_FEATURE_SUMMARY_LINKS_ALL,
 } from '../constants';
-import { MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL } from './use-site-compulsory-plan-selection-qualified-check';
-import { hasSupportedCommercialUse, hasSupportedVideoPressUse } from './use-stats-purchases';
+import {
+	hasSupportedCommercialUse,
+	hasSupportedVideoPressUse,
+	hasReachedPaywallMonthlyViews,
+} from './use-stats-purchases';
 
 // If Jetpack sites don't have any purchase that supports commercial use, gate advanced modules accordingly.
 const jetpackStatsAdvancedPaywall = [ STATS_TYPE_DEVICE_STATS, STATS_FEATURE_UTM_STATS ];
@@ -134,9 +136,8 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 
 		const isSiteCommercial = getSiteOption( state, siteId, 'is_commercial' ) || false;
 		if ( isSiteCommercial ) {
-			const billableMonthlyViews = getPlanUsageBillableMonthlyViews( state, siteId );
-			// Paywall basic stats for commercial sites with monthly views of more than 1k.
-			if ( billableMonthlyViews >= MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL ) {
+			// Paywall basic stats for commercial sites with monthly views reaching the paywall threshold.
+			if ( hasReachedPaywallMonthlyViews( state, siteId ) ) {
 				return [
 					...jetpackStatsCommercialPaywall,
 					...granularControlForJetpackStatsCommercialPaywall,

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -18,6 +18,8 @@ import {
 	hasLoadedSitePurchasesFromServer,
 	getPurchases,
 } from 'calypso/state/purchases/selectors';
+import { getPlanUsageBillableMonthlyViews } from 'calypso/state/stats/plan-usage/selectors';
+import { MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL } from './use-site-compulsory-plan-selection-qualified-check';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 const JETPACK_STATS_TIERED_BILLING_LIVE_DATE_2024_01_04 = '2024-01-04T05:30:00+00:00';
@@ -71,6 +73,12 @@ export const hasSupportedVideoPressUse = ( state: object, siteId: number | null 
 	const sitePurchases = getSitePurchases( state, siteId );
 
 	return isVideoPressOwned( sitePurchases );
+};
+
+export const hasReachedPaywallMonthlyViews = ( state: object, siteId: number | null ): boolean => {
+	const billableMonthlyViews = getPlanUsageBillableMonthlyViews( state, siteId );
+
+	return billableMonthlyViews >= MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL;
 };
 
 const getPurchasesBySiteId = createSelector(

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -43,10 +43,16 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			isSiteJetpackNotAtomic,
 			isCommercial,
 			hasPWYWPlanOnly,
+			shouldShowPaywallNotice,
 		}: StatsNoticeProps ) => {
 			// Show the notice only if the site is commercial.
 			if ( ! isCommercial ) {
 				return false;
+			}
+
+			// Show the upgrade notice with the coming paywall communication.
+			if ( shouldShowPaywallNotice ) {
+				return true;
 			}
 
 			const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -44,11 +44,16 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			isCommercial,
 			hasPWYWPlanOnly,
 		}: StatsNoticeProps ) => {
+			// Show the notice only if the site is commercial.
+			if ( ! isCommercial ) {
+				return false;
+			}
+
 			const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
 			const showUpgradeNoticeForJetpackSites = isOdysseyStats || isSiteJetpackNotAtomic;
 
 			// Test specific to commercial self-hosted sites with PWYW plans.
-			if ( showUpgradeNoticeForJetpackSites && isCommercial && hasPWYWPlanOnly ) {
+			if ( showUpgradeNoticeForJetpackSites && hasPWYWPlanOnly ) {
 				return true;
 			}
 
@@ -56,8 +61,6 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				( showUpgradeNoticeForJetpackSites || showUpgradeNoticeForWpcomSites ) &&
 				// Show the notice if the site has not purchased the paid stats product.
 				! hasPaidStats &&
-				// Show the notice only if the site is commercial.
-				isCommercial &&
 				! isVip
 			);
 		},

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -7,7 +7,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
-import { hasReachedPaywallMonthlyViews } from '../hooks/use-stats-purchases';
 import { trackStatsAnalyticsEvent } from '../utils';
 import { StatsNoticeProps } from './types';
 
@@ -17,12 +16,13 @@ const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) =
 	return purchasePath;
 };
 
-const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
+const CommercialSiteUpgradeNotice = ( {
+	siteId,
+	isOdysseyStats,
+	shouldShowPaywallNotice,
+}: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
-	const hasReachedMonthlyViewsToApplyPaywall = useSelector( ( state ) => {
-		return hasReachedPaywallMonthlyViews( state, siteId );
-	} );
 
 	const gotoJetpackStatsProduct = () => {
 		isOdysseyStats
@@ -49,7 +49,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
 		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
 
-	const bannerBody = hasReachedMonthlyViewsToApplyPaywall
+	const bannerBody = shouldShowPaywallNotice
 		? translate(
 				'Commercial sites with a significant number of visitors require a commercial license. Upgrade to get access to all the stats features and priority support.'
 		  )

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -45,39 +45,65 @@ const CommercialSiteUpgradeNotice = ( {
 			: recordTracksEvent( 'calypso_stats_commercial_site_upgrade_notice_viewed' );
 	}, [ isOdysseyStats ] );
 
-	const learnMoreLink = isWPCOMSite
+	let learnMoreLink = isWPCOMSite
 		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
 		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
 
-	const bannerBody = shouldShowPaywallNotice
-		? translate(
-				'Commercial sites with a significant number of visitors require a commercial license. Upgrade to get access to all the stats features and priority support.'
-		  )
-		: translate(
-				'{{p}}Upgrade to get priority support and access to upcoming advanced features. You’ll need to purchase a commercial license based on your site type. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
-				{
-					components: {
-						p: <p />,
-						jetpackStatsProductLink: (
-							<button
-								type="button"
-								className="notice-banner__action-button"
-								onClick={ gotoJetpackStatsProduct }
-							/>
-						),
-						commercialUpgradeLink: (
-							<a
-								className="notice-banner__action-link"
-								href={ localizeUrl( learnMoreLink ) }
-								target="_blank"
-								rel="noreferrer"
-							/>
-						),
-						commercialUpgradeLinkText: <span />,
-						externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
-					},
-				}
-		  );
+	let bannerBody = translate(
+		'{{p}}Upgrade to get priority support and access to upcoming advanced features. You’ll need to purchase a commercial license based on your site type. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
+		{
+			components: {
+				p: <p />,
+				jetpackStatsProductLink: (
+					<button
+						type="button"
+						className="notice-banner__action-button"
+						onClick={ gotoJetpackStatsProduct }
+					/>
+				),
+				commercialUpgradeLink: (
+					<a
+						className="notice-banner__action-link"
+						href={ localizeUrl( learnMoreLink ) }
+						target="_blank"
+						rel="noreferrer"
+					/>
+				),
+				commercialUpgradeLinkText: <span />,
+				externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
+			},
+		}
+	);
+
+	// Paywall notice content.
+	if ( shouldShowPaywallNotice ) {
+		learnMoreLink = 'https://jetpack.com/support/jetpack-stats/free-or-paid/';
+		bannerBody = translate(
+			'{{p}}Commercial sites with a significant number of visitors require a commercial license. Upgrade to get access to all the stats features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}}{{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
+			{
+				components: {
+					p: <p />,
+					jetpackStatsProductLink: (
+						<button
+							type="button"
+							className="notice-banner__action-button"
+							onClick={ gotoJetpackStatsProduct }
+						/>
+					),
+					commercialUpgradeLink: (
+						<a
+							className="notice-banner__action-link"
+							href={ localizeUrl( learnMoreLink ) }
+							target="_blank"
+							rel="noreferrer"
+						/>
+					),
+					commercialUpgradeLinkText: <span />,
+					externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
+				},
+			}
+		);
+	}
 
 	return (
 		<div

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -49,61 +49,44 @@ const CommercialSiteUpgradeNotice = ( {
 		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
 		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
 
-	let bannerBody = translate(
-		'{{p}}Upgrade to get priority support and access to upcoming advanced features. You’ll need to purchase a commercial license based on your site type. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
-		{
-			components: {
-				p: <p />,
-				jetpackStatsProductLink: (
-					<button
-						type="button"
-						className="notice-banner__action-button"
-						onClick={ gotoJetpackStatsProduct }
-					/>
-				),
-				commercialUpgradeLink: (
-					<a
-						className="notice-banner__action-link"
-						href={ localizeUrl( learnMoreLink ) }
-						target="_blank"
-						rel="noreferrer"
-					/>
-				),
-				commercialUpgradeLinkText: <span />,
-				externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
-			},
-		}
-	);
-
-	// Paywall notice content.
 	if ( shouldShowPaywallNotice ) {
 		learnMoreLink = 'https://jetpack.com/support/jetpack-stats/free-or-paid/';
-		bannerBody = translate(
-			'{{p}}Commercial sites with a significant number of visitors require a commercial license. Upgrade to get access to all the stats features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}}{{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
-			{
-				components: {
-					p: <p />,
-					jetpackStatsProductLink: (
-						<button
-							type="button"
-							className="notice-banner__action-button"
-							onClick={ gotoJetpackStatsProduct }
-						/>
-					),
-					commercialUpgradeLink: (
-						<a
-							className="notice-banner__action-link"
-							href={ localizeUrl( learnMoreLink ) }
-							target="_blank"
-							rel="noreferrer"
-						/>
-					),
-					commercialUpgradeLinkText: <span />,
-					externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
-				},
-			}
-		);
 	}
+
+	const sharedTranslationComponents = {
+		p: <p />,
+		jetpackStatsProductLink: (
+			<button
+				type="button"
+				className="notice-banner__action-button"
+				onClick={ gotoJetpackStatsProduct }
+			/>
+		),
+		commercialUpgradeLink: (
+			<a
+				className="notice-banner__action-link"
+				href={ localizeUrl( learnMoreLink ) }
+				target="_blank"
+				rel="noreferrer"
+			/>
+		),
+		commercialUpgradeLinkText: <span />,
+		externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
+	};
+
+	const bannerBody = shouldShowPaywallNotice
+		? translate(
+				'{{p}}Commercial sites with a significant number of visitors require a commercial license. Upgrade to get access to all the stats features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}}{{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
+				{
+					components: sharedTranslationComponents,
+				}
+		  ) // Paywall notice content.
+		: translate(
+				'{{p}}Upgrade to get priority support and access to upcoming advanced features. You’ll need to purchase a commercial license based on your site type. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
+				{
+					components: sharedTranslationComponents,
+				}
+		  );
 
 	return (
 		<div

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -7,6 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import { hasReachedPaywallMonthlyViews } from '../hooks/use-stats-purchases';
 import { trackStatsAnalyticsEvent } from '../utils';
 import { StatsNoticeProps } from './types';
 
@@ -19,6 +20,9 @@ const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) =
 const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
+	const hasReachedMonthlyViewsToApplyPaywall = useSelector( ( state ) => {
+		return hasReachedPaywallMonthlyViews( state, siteId );
+	} );
 
 	const gotoJetpackStatsProduct = () => {
 		isOdysseyStats
@@ -45,6 +49,36 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
 		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
 
+	const bannerBody = hasReachedMonthlyViewsToApplyPaywall
+		? translate(
+				'Commercial sites with a significant number of visitors require a commercial license. Upgrade to get access to all the stats features and priority support.'
+		  )
+		: translate(
+				'{{p}}Upgrade to get priority support and access to upcoming advanced features. You’ll need to purchase a commercial license based on your site type. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
+				{
+					components: {
+						p: <p />,
+						jetpackStatsProductLink: (
+							<button
+								type="button"
+								className="notice-banner__action-button"
+								onClick={ gotoJetpackStatsProduct }
+							/>
+						),
+						commercialUpgradeLink: (
+							<a
+								className="notice-banner__action-link"
+								href={ localizeUrl( learnMoreLink ) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+						commercialUpgradeLinkText: <span />,
+						externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
+					},
+				}
+		  );
+
 	return (
 		<div
 			className={ `inner-notice-container has-odyssey-stats-bg-color ${
@@ -57,31 +91,7 @@ const CommercialSiteUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticePro
 				onClose={ () => {} }
 				hideCloseButton
 			>
-				{ translate(
-					'{{p}}Upgrade to get priority support and access to upcoming advanced features. You’ll need to purchase a commercial license based on your site type. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
-					{
-						components: {
-							p: <p />,
-							jetpackStatsProductLink: (
-								<button
-									type="button"
-									className="notice-banner__action-button"
-									onClick={ gotoJetpackStatsProduct }
-								/>
-							),
-							commercialUpgradeLink: (
-								<a
-									className="notice-banner__action-link"
-									href={ localizeUrl( learnMoreLink ) }
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
-							commercialUpgradeLinkText: <span />,
-							externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
-						},
-					}
-				) }
+				{ bannerBody }
 			</NoticeBanner>
 		</div>
 	);

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -21,7 +21,7 @@ import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-si
 import hasSiteProductJetpackStatsPWYWOnly from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
-import useStatsPurchases from '../hooks/use-stats-purchases';
+import useStatsPurchases, { hasReachedPaywallMonthlyViews } from '../hooks/use-stats-purchases';
 import ALL_STATS_NOTICES from './all-notice-definitions';
 import { StatsNoticeProps, StatsNoticesProps } from './types';
 import './style.scss';
@@ -96,6 +96,10 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		hasSiteProductJetpackStatsPWYWOnly( state, siteId )
 	);
 
+	const shouldShowPaywallNotice = useSelector( ( state ) => {
+		return hasReachedPaywallMonthlyViews( state, siteId );
+	} );
+
 	const noticeOptions = {
 		siteId,
 		isOdysseyStats,
@@ -110,6 +114,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		isCommercial,
 		isCommercialOwned,
 		hasPWYWPlanOnly,
+		shouldShowPaywallNotice,
 	};
 
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -90,7 +90,8 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		wpcomSiteHasPaidStatsFeature;
 	const hasFreeStats = useSelector( ( state ) => hasSiteProductJetpackStatsFree( state, siteId ) );
 
-	const { isRequestingSitePurchases, isCommercialOwned } = useStatsPurchases( siteId );
+	const { isRequestingSitePurchases, isCommercialOwned, supportCommercialUse } =
+		useStatsPurchases( siteId );
 
 	const hasPWYWPlanOnly = useSelector( ( state ) =>
 		hasSiteProductJetpackStatsPWYWOnly( state, siteId )
@@ -101,7 +102,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	const shouldShowPaywallNotice =
 		useSelector( ( state ) => {
 			return hasReachedPaywallMonthlyViews( state, siteId );
-		} ) && ! isCommercialOwned;
+		} ) && ! supportCommercialUse;
 
 	const noticeOptions = {
 		siteId,

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -96,9 +96,12 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		hasSiteProductJetpackStatsPWYWOnly( state, siteId )
 	);
 
-	const shouldShowPaywallNotice = useSelector( ( state ) => {
-		return hasReachedPaywallMonthlyViews( state, siteId );
-	} );
+	// Show the paywall notice if the site has reached the monthly views limit
+	// and no commercial purchase.
+	const shouldShowPaywallNotice =
+		useSelector( ( state ) => {
+			return hasReachedPaywallMonthlyViews( state, siteId );
+		} ) && ! isCommercialOwned;
 
 	const noticeOptions = {
 		siteId,

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -13,7 +13,6 @@
 	a,
 	a:visited {
 		color: var(--studio-gray-80);
-		text-decoration: underline;
 	}
 
 	&.inner-notice-container--calypso {

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -20,6 +20,7 @@ export interface StatsNoticeProps {
 	isCommercial?: boolean;
 	isCommercialOwned?: boolean;
 	hasPWYWPlanOnly?: boolean;
+	shouldShowPaywallNotice?: boolean;
 }
 
 export interface NoticeBodyProps {

--- a/client/state/stats/plan-usage/selectors.ts
+++ b/client/state/stats/plan-usage/selectors.ts
@@ -3,7 +3,11 @@ import { PlanUsage } from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
 
 import 'calypso/state/stats/init';
 
-export function getPlanUsageBillableMonthlyViews( state: object, siteId: number ) {
+export function getPlanUsageBillableMonthlyViews( state: object, siteId: number | null ) {
+	if ( ! siteId ) {
+		return 0;
+	}
+
 	const data = get( state, [ 'stats', 'planUsage', 'data', siteId ], null ) as PlanUsage;
 	// TODO: Use `data.billable_monthly_views` instead?
 	const recentViews =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/98

## Proposed Changes

* Apply commercial paywall copy to `CommercialSiteUpgradeNotice` for commercial sites with monthly views reaching the paywall threshold.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Communicate with users approaching the paywall threshold to prompt a commercial upgrade: pejTkB-1xd-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare a Jetpack site **_without_** any Stats commercial or Jetpack plan purchase.
* Mark the site as **_commercial_** forcibly.
* Modify the recent usages to have at least 1k `views_count` on the API end and sandbox `public-api.wordpress.com`.
* Spin this change up with the Calypso Live branch.
* Navigate to Stats > `Traffic` page.
* Ensure the commercial upgrade notice shows with the commercial paywall communication.

#### Shows for Commercial sites
|Billable monthly views < 1k|Billable monthly views >= 1k|
|-|-|
|<img width="1260" alt="截圖 2024-07-17 下午8 52 50" src="https://github.com/user-attachments/assets/5d9fda1c-4c34-4a33-843d-91864e21077d">|<img width="1260" alt="截圖 2024-07-17 下午8 36 47" src="https://github.com/user-attachments/assets/65a2350e-3225-4862-87c8-0bb15c1ca8eb">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?