### PR TITLE
add escape hatch when coming from tools > import

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -86,7 +86,7 @@ function getConfig( {
 			}
 		),
 		overrideDestination:
-			'/setup/site-migration?siteSlug=%SITE_SLUG%&siteId=%SITE_ID%&ref=calypso-importer&hide_importer_link=true',
+			'/setup/site-migration?siteSlug=%SITE_SLUG%&siteId=%SITE_ID%&ref=calypso-importer',
 		weight: 1,
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Remove the `hide_importer_link=true` from the link to migration flow in `Tools > Import`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Based on this Slack thread: p1721063178156089-slack-C048CUFRGFQ we felt that the path to follow when you try to start a migration using an export file from `Tools > Import` is not straightforward. With this change in place the user will have a link to the importers lists where they can select WordPress and upload the XML.

The link was removed before because it feels repetitive, since the list of importers is shown in `Tools > Import` and then again, when clicking on the link. But since there's no easy workaround, it's being reinstated.

To deal with the repetitive screen I created [this issue](https://github.com/Automattic/wp-calypso/issues/92725).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to the calypso.live below
2. Navigate to Home on a site you own
3. Go to `Tools > Import` (`/import/[YOUR_SITE]`)
4. Click on `WordPress` on the importer list
5. Click on the `pick your current platform from a list` link
6. Verify you arrive to another importer list
7. Pick WordPress
8. Click `import content only`
9. Verify you arrive to upload form
<img width="823" alt="image" src="https://github.com/user-attachments/assets/9ec46797-c867-4bf0-9e75-ad4957d54384">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?