### PR TITLE
Checkout Plan Upsell: Improve UX by adding a "Plan" column heading

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -208,7 +208,9 @@ export function CheckoutSidebarPlanUpsell() {
 				<div className="checkout-sidebar-plan-upsell__plan-grid">
 					{ isComparisonWithIntroOffer && (
 						<>
-							<div className="checkout-sidebar-plan-upsell__plan-grid-cell"></div>
+							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
+								<strong>{ __( 'Plan' ) }</strong>
+							</div>
 							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 								<strong>{ cellLabel }</strong>
 							</div>

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -213,7 +213,7 @@ export function CheckoutSidebarPlanUpsell() {
 						<strong>{ isComparisonWithIntroOffer ? cellLabel : __( 'Cost' ) }</strong>
 					</div>
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-						{ currentVariant.variantLabel }
+						{ currentVariant.variantLabel.adjective }
 					</div>
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 						{ formatCurrency(
@@ -227,7 +227,7 @@ export function CheckoutSidebarPlanUpsell() {
 						) }
 					</div>
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-						{ upsellVariant.variantLabel }
+						{ upsellVariant.variantLabel.adjective }
 					</div>
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 						{ compareToPriceForVariantTerm && (

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -206,16 +206,12 @@ export function CheckoutSidebarPlanUpsell() {
 		<>
 			<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell">
 				<div className="checkout-sidebar-plan-upsell__plan-grid">
-					{ isComparisonWithIntroOffer && (
-						<>
-							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-								<strong>{ __( 'Plan' ) }</strong>
-							</div>
-							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-								<strong>{ cellLabel }</strong>
-							</div>
-						</>
-					) }
+					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
+						<strong>{ __( 'Plan' ) }</strong>
+					</div>
+					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
+						<strong>{ isComparisonWithIntroOffer ? cellLabel : __( 'Cost' ) }</strong>
+					</div>
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 						{ currentVariant.variantLabel }
 					</div>

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -179,7 +179,7 @@ function ItemVariantOptionList( {
 		<OptionList role="listbox" tabIndex={ -1 }>
 			{ variants.map( ( variant, index ) => (
 				<ItemVariantOption
-					key={ variant.productSlug + variant.variantLabel }
+					key={ variant.productSlug + variant.variantLabel.noun }
 					isSelected={ index === highlightedVariantIndex }
 					onSelect={ () =>
 						handleChange(
@@ -219,7 +219,7 @@ function ItemVariantOption( {
 		<Option
 			id={ productId.toString() }
 			className={ isSelected ? 'item-variant-option--selected' : undefined }
-			aria-label={ variantLabel }
+			aria-label={ variantLabel.noun }
 			data-product-slug={ productSlug }
 			role="option"
 			onClick={ onSelect }

--- a/client/my-sites/checkout/src/components/item-variation-picker/jetpack-variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/jetpack-variant-dropdown-price.tsx
@@ -60,7 +60,7 @@ export const JetpackItemVariantDropDownPrice: FunctionComponent< {
 	return (
 		<Variant>
 			<Label>
-				{ variant.variantLabel }
+				{ variant.variantLabel.noun }
 				{ isMobile && discountInteger > 0 && (
 					<JetpackDiscountDisplay
 						finalPriceInteger={ variant.priceInteger }

--- a/client/my-sites/checkout/src/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/types.ts
@@ -2,6 +2,11 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 export type WPCOMProductSlug = string;
 
+export type WPCOMProductVariantLabel = {
+	noun: string;
+	adjective: string;
+};
+
 export type WPCOMProductVariant = {
 	priceInteger: number;
 	termIntervalInMonths: number;
@@ -9,7 +14,7 @@ export type WPCOMProductVariant = {
 	currency: string;
 	productId: number;
 	productSlug: WPCOMProductSlug;
-	variantLabel: string;
+	variantLabel: WPCOMProductVariantLabel;
 	introductoryTerm: string;
 	introductoryInterval: number;
 	priceBeforeDiscounts: number;

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -168,7 +168,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	return (
 		<Variant>
 			<Label>
-				{ variant.variantLabel }
+				{ variant.variantLabel.noun }
 				{ hasDiscount && isMobile && <DiscountPercentage percent={ discountPercentage } /> }
 			</Label>
 			<PriceTextContainer>

--- a/client/my-sites/checkout/src/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/src/hooks/product-variants.tsx
@@ -94,7 +94,10 @@ export function useGetProductVariants(
 					const term = getBillingTermForMonths( variant.bill_period_in_months );
 					const introductoryTerms = variant.introductory_offer_terms;
 					return {
-						variantLabel: getTermText( term, translate ),
+						variantLabel: {
+							noun: getTermText( term, translate, 'noun' ),
+							adjective: getTermText( term, translate, 'adjective' ),
+						},
 						productSlug: variant.product_slug,
 						productId: variant.product_id,
 						priceInteger: variant.price_integer,
@@ -143,43 +146,93 @@ function sortVariant( a: ResponseCartProductVariant, b: ResponseCartProductVaria
 	return 0;
 }
 
-function getTermText( term: string, translate: ReturnType< typeof useTranslate > ): string {
+function getTermText(
+	term: string,
+	translate: ReturnType< typeof useTranslate >,
+	type: 'noun' | 'adjective' = 'noun'
+): string {
+	const asAdjective = type === 'adjective';
+
 	switch ( term ) {
 		case TERM_CENTENNIALLY:
 			return String( translate( 'Hundred years' ) );
 
 		case TERM_DECENNIALLY:
-			return String( translate( 'Ten years' ) );
+			return String(
+				asAdjective
+					? translate( 'Ten-year', { context: 'adjective' } )
+					: translate( 'Ten years', { context: 'noun' } )
+			);
 
 		case TERM_NOVENNIALLY:
-			return String( translate( 'Nine years' ) );
+			return String(
+				asAdjective
+					? translate( 'Nine-year', { context: 'adjective' } )
+					: translate( 'Nine years', { context: 'noun' } )
+			);
 
 		case TERM_OCTENNIALLY:
-			return String( translate( 'Eight years' ) );
+			return String(
+				asAdjective
+					? translate( 'Eight-year', { context: 'adjective' } )
+					: translate( 'Eight years', { context: 'noun' } )
+			);
 
 		case TERM_SEPTENNIALLY:
-			return String( translate( 'Seven years' ) );
+			return String(
+				asAdjective
+					? translate( 'Seven-year', { context: 'adjective' } )
+					: translate( 'Seven years', { context: 'noun' } )
+			);
 
 		case TERM_SEXENNIALLY:
-			return String( translate( 'Six years' ) );
+			return String(
+				asAdjective
+					? translate( 'Six-year', { context: 'adjective' } )
+					: translate( 'Six years', { context: 'noun' } )
+			);
 
 		case TERM_QUINQUENNIALLY:
-			return String( translate( 'Five years' ) );
+			return String(
+				asAdjective
+					? translate( 'Five-year', { context: 'adjective' } )
+					: translate( 'Five years', { context: 'noun' } )
+			);
 
 		case TERM_QUADRENNIALLY:
-			return String( translate( 'Four years' ) );
+			return String(
+				asAdjective
+					? translate( 'Four-year', { context: 'adjective' } )
+					: translate( 'Four years', { context: 'noun' } )
+			);
 
 		case TERM_TRIENNIALLY:
-			return String( translate( 'Three years' ) );
+			return String(
+				asAdjective
+					? translate( 'Three-year', { context: 'adjective' } )
+					: translate( 'Three years', { context: 'noun' } )
+			);
 
 		case TERM_BIENNIALLY:
-			return String( translate( 'Two years' ) );
+			return String(
+				asAdjective
+					? translate( 'Two-year', { context: 'adjective' } )
+					: translate( 'Two years', { context: 'noun' } )
+			);
 
 		case TERM_ANNUALLY:
-			return String( translate( 'One year' ) );
+			return String(
+				asAdjective
+					? translate( 'One-year', { context: 'adjective' } )
+					: translate( 'One year', { context: 'noun' } )
+			);
 
 		case TERM_MONTHLY:
-			return String( translate( 'One month' ) );
+			return String(
+				asAdjective
+					? translate( 'One-month', { context: 'adjective' } )
+					: translate( 'One month', { context: 'noun' } )
+			);
 
 		default:
 			return '';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1720709664946129-slack-C02NWDZBL0H and p1721070418619219-slack-C02NWDZBL0H

## Proposed Changes

* Add a "Plan" column to the checkout plan upsell component.
* Show the "Cost" column when there is no intro offer. When there is an intro offer, the "Two-year cost" column is shown as before.
* Use the adjective form of the plan label.

| Before (with intro offer) | After (with intro offer) |
|-|-|
| ![image](https://github.com/user-attachments/assets/8d68fa23-62d4-4fa0-a1a6-53d13077d006) | ![image](https://github.com/user-attachments/assets/c977420c-f54e-45dc-b216-965b02277e54) |

| Before (without intro offer) | After (without intro offer) |
|-|-|
| ![image](https://github.com/user-attachments/assets/aa721362-19fe-45cd-adb3-0c11ffb56d22) | ![image](https://github.com/user-attachments/assets/4731ab1f-e9e7-4dad-a3bb-c0cb2fab66b2) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We found the upsell component a bit confusing when discounts are involved. This change attempts to lower the confusion. You can read more about it in the Slack threads mentioned above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup/migration/
* Choose WordPress.
* On the checkout page, make sure the upsell component in the sidebar has the "Plan" column heading and the adjective form of the plan label is used.
* To test the upsell without an intro offer, go through the standard checkout http://calypso.localhost:3000/start/ flow and make sure the columns are there.
* Make sure the plan variants are using the noun form (same as before) on the variant dropdown:
![image](https://github.com/user-attachments/assets/7c16792f-4fd3-4048-9226-bf4b464ba1a0)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?