### PR TITLE
Nav Redesign: Fix Mobile margin-top

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1117,7 +1117,6 @@ $font-size: rem(14px);
 
 		// client/layout/sidebar/style.scss
 		.sidebar {
-			position: absolute;
 			padding-bottom: 120px;
 		}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8300

## Proposed Changes

Fix menu mobile top margin.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ea622616-0626-4891-ac4f-903d1f6ee3f2) | ![image](https://github.com/user-attachments/assets/3b951e10-a9ea-436f-80d3-cce25ff053ef) |
| ![image](https://github.com/user-attachments/assets/7808eeb2-ad89-422c-89a0-c04a4daf50e2) | ![image](https://github.com/user-attachments/assets/23f33f7f-92e7-4c5b-98cb-3cbd1ee93d55) |
| ![image](https://github.com/user-attachments/assets/f4374221-09db-4a9f-a05f-aca7bbdf15c9) | ![image](https://github.com/user-attachments/assets/2730ef93-2cb0-4b42-b503-b6c29f18d351) |




## Why are these changes being made?
* Margin top in some pages doesn't look good.

## Testing Instructions

* Use mobile view
* Go to `/sites`, `/reader`, `/me`
* Check the Menu top margin
* Also check for no regressions on other pages.
