### PR TITLE
Start With Stripe: Create the feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -195,6 +195,7 @@
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
 		"start-with/square-payments": true,
+		"start-with/stripe": true,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,6 +122,7 @@
 		"redirect-fallback-browsers": true,
 		"safari-idb-mitigation": true,
 		"start-with/square-payments": true,
+		"start-with/stripe": false,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/config/production.json
+++ b/config/production.json
@@ -163,6 +163,7 @@
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
 		"start-with/square-payments": true,
+		"start-with/stripe": false,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -159,6 +159,7 @@
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
 		"start-with/square-payments": true,
+		"start-with/stripe": false,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,6 +157,7 @@
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
 		"start-with/square-payments": true,
+		"start-with/stripe": true,
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,


### PR DESCRIPTION


## Proposed Changes

Create the `start-with/stripe` flag. It will be enabled only on development and wpcalypso.

## Why are these changes being made?

As part of [#8254](https://github.com/Automattic/dotcom-forge/issues/8254)

## Testing Instructions

Everything should be working as before and automated tests should pass.
