### PR TITLE
Add Context to 'Paid' string

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.ts
@@ -55,7 +55,7 @@ export default function useProductFilterOptions() {
 			{ key: PRODUCT_PRICE_FREE, label: translate( 'Free' ) },
 			{
 				key: PRODUCT_PRICE_PAID,
-				label: translate( 'Paid', { context: 'Refers to paid service, such as paid theme' } ),
+				label: translate( 'Paid', { context: 'Label for a paid subscription plan' } ),
 			},
 		],
 	};

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.ts
@@ -53,7 +53,10 @@ export default function useProductFilterOptions() {
 		],
 		[ PRODUCT_FILTER_KEY_PRICES ]: [
 			{ key: PRODUCT_PRICE_FREE, label: translate( 'Free' ) },
-			{ key: PRODUCT_PRICE_PAID, label: translate( 'Paid' ) },
+			{
+				key: PRODUCT_PRICE_PAID,
+				label: translate( 'Paid', { context: 'Refers to paid service, such as paid theme' } ),
+			},
 		],
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#829

## Proposed Changes

Adds context to the word 'Paid'.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In a4a, under Marketplace > Products, there is a price filter that has the options "Free" and "Paid". We need to add context to "Paid" to mean that it's not free. It is currently translated as the past tense of the word pay, which isn't correct in many languages.

![image](https://github.com/user-attachments/assets/1f9549d7-b5fc-4f03-9f24-67411e98b291)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
