### PR TITLE
Fixed instagram and twitter block flows tests

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -42,7 +42,7 @@ export class InstagramBlockFlow implements BlockFlow {
 			} )
 			.click();
 
-		await editorCanvas.getByTitle( 'Embedded content from instagram.com' ).waitFor();
+		await editorCanvas.getByTitle( 'Embedded content from www.instagram.com' ).waitFor();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -9,7 +9,7 @@ const blockParentSelector = '[aria-label="Block: Twitter"]:has-text("Twitter URL
 const selectors = {
 	embedUrlInput: `${ blockParentSelector } input`,
 	embedButton: `${ blockParentSelector } button:has-text("Embed")`,
-	editorTwitterIframe: `iframe[title="Embedded content from twitter"]`,
+	editorTwitterIframe: `iframe[title="Embedded content from twitter.com"]`,
 	publishedTwitterIframe: `iframe[title="X Post"]`,
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Gutenberg rotation [related to this change](https://github.com/WordPress/gutenberg/pull/63052).
Task: https://github.com/Automattic/wp-calypso/issues/92543

## Testing instructions

* Atomic (Jetpack edge): `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core-jetpack-extended.ts`
* Simple: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core-jetpack-extended.ts`
* Gutenberg edge: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core-jetpack-extended.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
