### PR TITLE
Domains: Fix email management page href

### DIFF
--- a/packages/domains-table/src/domains-table/domains-table-email-indicator.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-email-indicator.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { type as domainTypes } from '../utils/constants';
 import { getDomainType } from '../utils/get-domain-type';
 import { emailManagementEdit } from '../utils/paths';
+import type { MouseEvent } from 'react';
 
 interface DomainsTableEmailIndicatorProps {
 	domain: PartialDomainData;
@@ -64,6 +65,7 @@ export const DomainsTableEmailIndicator = ( {
 			<a
 				className="domains-table-view-email-button"
 				href={ emailManagementEdit( siteSlug, domain.domain ) }
+				onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 			>
 				{ message }
 			</a>
@@ -78,6 +80,7 @@ export const DomainsTableEmailIndicator = ( {
 		<a
 			className="domains-table-add-email-button"
 			href={ emailManagementEdit( siteSlug, domain.domain ) }
+			onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 		>
 			{ __( '+ Add email' ) }
 		</a>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Fixes the `href` to the email management on the new `DomainsTable` component - event propagation was causing the `a`'s `click` callback function to fire its parent's callback - thus redirecting the user every time to the domain management page every time the link was clicked, as in the recording below.


## Testing Instructions
Analyze the code statically and ensure it looks good. Also, ensure the email management page loads when you click the link in the domains table.

## Preview
### Before
https://github.com/user-attachments/assets/a1f007b7-383c-453d-a01e-c72333f47008

### After
https://github.com/user-attachments/assets/25e86cb9-d735-4483-ab9e-4d71fce73e6f

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
