### PR TITLE
Hide coupon link and Update Coupon Label in Checkout for Affiliate Onboarding Flows

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -23,8 +23,10 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import useCartKey from '../../use-cart-key';
-import { isCouponDisplayHidden } from '../../utils';
+import { getAffiliateCouponLabel } from '../../utils';
 import type { Theme } from '@automattic/composite-checkout';
 import type { LineItemCostOverrideForDisplay } from '@automattic/wpcom-checkout';
 
@@ -320,18 +322,18 @@ export function CouponCostOverride( {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
+	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
 
-	if (
-		! responseCart.coupon ||
-		! responseCart.coupon_savings_total_integer ||
-		isCouponDisplayHidden()
-	) {
+	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
 		return null;
 	}
+
 	// translators: The label of the coupon line item in checkout, including the coupon code
-	const label = translate( 'Coupon: %(couponCode)s', {
-		args: { couponCode: responseCart.coupon },
-	} );
+	const label = isOnboardingAffiliateFlow
+		? getAffiliateCouponLabel()
+		: translate( 'Coupon: %(couponCode)s', {
+				args: { couponCode: responseCart.coupon },
+		  } );
 	return (
 		<CostOverridesListStyle>
 			<div className="cost-overrides-list-item cost-overrides-list-item--coupon">

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -24,6 +24,7 @@ import {
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import useCartKey from '../../use-cart-key';
+import { isCouponDisplayHidden } from '../../utils';
 import type { Theme } from '@automattic/composite-checkout';
 import type { LineItemCostOverrideForDisplay } from '@automattic/wpcom-checkout';
 
@@ -320,7 +321,11 @@ export function CouponCostOverride( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
-	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
+	if (
+		! responseCart.coupon ||
+		! responseCart.coupon_savings_total_integer ||
+		isCouponDisplayHidden()
+	) {
 		return null;
 	}
 	// translators: The label of the coupon line item in checkout, including the coupon code

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -14,8 +14,8 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
-import { isCouponDisplayHidden } from '../../utils';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -195,6 +195,7 @@ export function CouponFieldArea( {
 	const { formStatus } = useFormStatus();
 	const translate = useTranslate();
 	const { setCouponFieldValue } = couponFieldStateProps;
+	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
 
 	useEffect( () => {
 		if ( couponStatus === 'applied' ) {
@@ -203,7 +204,7 @@ export function CouponFieldArea( {
 		}
 	}, [ couponStatus, setCouponFieldValue ] );
 
-	if ( isPurchaseFree || couponStatus === 'applied' || isCouponDisplayHidden() ) {
+	if ( isPurchaseFree || couponStatus === 'applied' || isOnboardingAffiliateFlow ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -15,6 +15,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import { isCouponDisplayHidden } from '../../utils';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -202,7 +203,7 @@ export function CouponFieldArea( {
 		}
 	}, [ couponStatus, setCouponFieldValue ] );
 
-	if ( isPurchaseFree || couponStatus === 'applied' ) {
+	if ( isPurchaseFree || couponStatus === 'applied' || isCouponDisplayHidden() ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -23,8 +23,10 @@ import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
+import { getAffiliateCouponLabel } from '../../utils';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeAkProQuantity } from './akismet-pro-quantity-dropdown';
@@ -90,6 +92,10 @@ export function WPOrderReviewLineItems( {
 	const reduxDispatch = useDispatch();
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
+	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
+	if ( isOnboardingAffiliateFlow && couponLineItem ) {
+		couponLineItem.label = getAffiliateCouponLabel();
+	}
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const hasPartnerCoupon = getPartnerCoupon( {

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -129,3 +129,13 @@ export function isContextJetpackSitelessCheckout( context: Context ): boolean {
 export function isContextSourceMyJetpack( context: Context ): boolean {
 	return context.query?.source === 'my-jetpack';
 }
+
+export function isCouponDisplayHidden(): boolean {
+	const location = window.location;
+	const searchParams = new URLSearchParams( location.search );
+	const ref = searchParams.get( 'ref' );
+	const isAffiliateLP = ( referer: string | null ): boolean => {
+		return referer ? referer.includes( 'aff' ) : false;
+	};
+	return searchParams.has( 'coupon' ) || isAffiliateLP( ref );
+}

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -1,4 +1,5 @@
 import { doesStringResembleDomain } from '@automattic/onboarding';
+import { translate } from 'i18n-calypso';
 import { untrailingslashit } from 'calypso/lib/route';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -130,12 +131,7 @@ export function isContextSourceMyJetpack( context: Context ): boolean {
 	return context.query?.source === 'my-jetpack';
 }
 
-export function isCouponDisplayHidden(): boolean {
-	const location = window.location;
-	const searchParams = new URLSearchParams( location.search );
-	const ref = searchParams.get( 'ref' );
-	const isAffiliateLP = ( referer: string | null ): boolean => {
-		return referer ? referer.includes( 'aff' ) : false;
-	};
-	return searchParams.has( 'coupon' ) || isAffiliateLP( ref );
+export function getAffiliateCouponLabel(): string {
+	// translators: The label of the coupon line item in checkout
+	return translate( 'Exclusive Offer Applied' );
 }


### PR DESCRIPTION
Related to # https://github.com/Automattic/martech/issues/3190
Update to Requirement: [comment](https://wp.me/pau2Xa-6bu#comment-15890)

## Proposed Changes

Changes are related to Affiliate Onboarding Flows
- Remove Coupon link in Checkout
- Update Coupon label to `Exclusive Offer Applied`

## Testing Instructions

1. Checkout Code 
2. Start purchasing an item to trigger the checkout flow
3. Note in checkout you should see the `Have a Coupon` link 
 <img width="208" alt="image" src="https://github.com/user-attachments/assets/be719568-749c-4d4b-8357-4a77f5bda4d8">

4. Start the Affiliate onboarding flow by navigating to /start/onboarding-affiliate/domains`
5. The `Have a Coupon` link should not be displayed on the checkout page
6. Add a coupon to the url add `&coupon=[TEST_COUPON]` and hit enter
7. **Exclusive Offer Applied** should be display in the coupon area  on the checkout page
![image](https://github.com/user-attachments/assets/a513a1eb-e8ef-4c0d-bcce-e96645ff4694)
