### PR TITLE
A4A > Referrals: Minor UI fixes

### DIFF
--- a/client/a8c-for-agencies/components/a4a-popover/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-popover/index.tsx
@@ -35,7 +35,7 @@ export default function A4APopover( {
 			onFocusOutside={ onFocusOutside }
 		>
 			<div className="a4a-popover__content">
-				<div className="a4a-popover__title">{ title }</div>
+				{ title && <div className="a4a-popover__title">{ title }</div> }
 				{ children }
 			</div>
 		</Popover>

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
@@ -30,7 +30,6 @@
 }
 
 .consolidated-view__popover-content {
-	padding: 12px;
 	min-width: 200px;
 	@include a4a-font-body-md;
 

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -159,7 +159,10 @@ export default function ReferralsOverview( {
 													'Please confirm your details before referring products to your clients.'
 												) }
 											</div>
-											<Button href="/referrals/payment-settings">
+											<Button
+												className="referrals-overview__notice-button"
+												href="/referrals/payment-settings"
+											>
 												{ translate( 'Go to payment settings' ) }
 											</Button>
 										</A4APopover>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -7,11 +7,19 @@ $data-view-border-color: #f1f1f1;
 	margin-block-end: 48px;
 }
 
-.theme-a8c-for-agencies {
+.theme-a8c-for-agencies .button.referrals-overview__notice-button {
+	background-color: var(--color-accent-100);
+	color: var(--color-surface);
+
+	&:hover,
+	&:focus-visible {
+		background-color: var(--color-accent-100);
+	}
+}
+
+.referrals-overview__notice {
 	.button.referrals-overview__notice-button {
 		margin-block-start: 1rem;
-		background-color: var(--color-accent-100);
-		color: var(--color-surface);
 	}
 }
 
@@ -24,17 +32,6 @@ $data-view-border-color: #f1f1f1;
 
 		.referrals-overview__button-popover-description {
 			@include a4a-font-body-md;
-		}
-
-
-		.button {
-			background-color: var(--color-accent-100);
-			color: var(--color-surface);
-
-			&:hover,
-			&:focus-visible {
-				background-color: var(--color-accent-100);
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

This PR:

- Fixes the on-hover button background color issue
- Fixes the padding issue on the popover

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals > Verify the on-hover background color for the button on the banner stays as-is

| Before | After |
|--------|--------|
| <img width="1644" alt="Screenshot 2024-07-17 at 11 19 50 AM" src="https://github.com/user-attachments/assets/cc4c0da4-e76d-4120-bf8e-8112607a2f9e"> | <img width="1644" alt="Screenshot 2024-07-17 at 11 20 07 AM" src="https://github.com/user-attachments/assets/436c1b6b-bd64-43d8-a71d-508b1a98a683"> |

3. Click the info icon on the `All time commissions` card and verify the padding is fixed:
 
| Before | After |
|--------|--------|
| <img width="558" alt="Screenshot 2024-07-17 at 11 14 20 AM" src="https://github.com/user-attachments/assets/7de0bd0f-d3b3-43e1-9fa6-7bf597550570"> | <img width="558" alt="Screenshot 2024-07-17 at 11 14 25 AM" src="https://github.com/user-attachments/assets/368ab2fb-4efd-46fd-8e9a-5e33f3b115a8"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
