### PR TITLE
A4A > Referrals: Show payment status indicator on sidebar menu item

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
@@ -1,6 +1,9 @@
 import { category, cog, help } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import StatusBadge from 'calypso/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge';
+import useGetTipaltiPayee from 'calypso/a8c-for-agencies/sections/referrals/hooks/use-get-tipalti-payee';
+import { getAccountStatus } from 'calypso/a8c-for-agencies/sections/referrals/lib/get-account-status';
 import {
 	A4A_REFERRALS_LINK,
 	A4A_REFERRALS_DASHBOARD,
@@ -11,6 +14,12 @@ import { createItem } from '../lib/utils';
 
 const useReferralsMenuItems = ( path: string ) => {
 	const translate = useTranslate();
+
+	const { data } = useGetTipaltiPayee();
+	const accountStatus = getAccountStatus( data, translate );
+
+	const showIndicator = accountStatus?.actionRequired;
+
 	const menuItems = useMemo( () => {
 		return [
 			createItem(
@@ -34,6 +43,18 @@ const useReferralsMenuItems = ( path: string ) => {
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Referrals / Payment Settings',
 					},
+					...( showIndicator && {
+						extraContent: (
+							<StatusBadge
+								statusProps={ {
+									children: 1,
+									type: accountStatus.statusType,
+									isRounded: true,
+									tooltip: accountStatus.statusReason,
+								} }
+							/>
+						),
+					} ),
 				},
 				path
 			),
@@ -55,7 +76,7 @@ const useReferralsMenuItems = ( path: string ) => {
 				...item,
 				isSelected: item.link === path,
 			} ) ); //FIXME: Fix this once we enable the automated referrals feature flag
-	}, [ path, translate ] );
+	}, [ accountStatus, path, showIndicator, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/utils.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/utils.ts
@@ -11,6 +11,7 @@ type MenuItemProps = {
 	isExternalLink?: boolean;
 	isSelected?: boolean;
 	trackEventProps?: { [ key: string ]: string };
+	extraContent?: JSX.Element;
 };
 
 export const createItem = ( props: MenuItemProps, path: string ) => {

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/status-badge.tsx
@@ -1,4 +1,5 @@
 import { Badge, Tooltip } from '@automattic/components';
+import clsx from 'clsx';
 import { useRef, useState, ComponentProps } from 'react';
 
 import './style.scss';
@@ -6,20 +7,28 @@ import './style.scss';
 export default function StatusBadge( {
 	statusProps,
 }: {
-	statusProps?: ComponentProps< typeof Badge > & { tooltip?: string | JSX.Element };
+	statusProps?: ComponentProps< typeof Badge > & {
+		tooltip?: string | JSX.Element;
+		isRounded?: boolean;
+	};
 } ) {
 	const [ showPopover, setShowPopover ] = useState( false );
 
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 
-	const { tooltip, ...badgeProps } = statusProps || {};
+	const { tooltip, isRounded, ...badgeProps } = statusProps || {};
+
+	const badge = (
+		<Badge
+			className={ clsx( 'step-section-item__status', {
+				'step-section-item__status--rounded': isRounded,
+			} ) }
+			{ ...badgeProps }
+		/>
+	);
 
 	if ( ! tooltip ) {
-		return (
-			<span className="step-section-item__status-wrapper">
-				<Badge className="step-section-item__status" { ...badgeProps } />
-			</span>
-		);
+		return <span className="step-section-item__status-wrapper">{ badge }</span>;
 	}
 
 	return (
@@ -32,7 +41,7 @@ export default function StatusBadge( {
 			tabIndex={ 0 }
 			ref={ wrapperRef }
 		>
-			<Badge className="step-section-item__status" { ...badgeProps } />
+			{ badge }
 
 			<Tooltip context={ wrapperRef.current } isVisible={ showPopover } position="bottom">
 				{ tooltip }

--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -71,6 +71,15 @@
 		}
 	}
 
+	&.step-section-item__status--rounded {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+	}
+
 	.step-section-item__status-wrapper {
 		margin-left: auto;
 	}

--- a/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-account-status.ts
@@ -1,3 +1,10 @@
+interface StatusMeta {
+	statusType: 'success' | 'warning' | 'error';
+	status: string;
+	statusReason?: string;
+	actionRequired: boolean;
+}
+
 export const getAccountStatus = (
 	data: {
 		Status: string;
@@ -5,19 +12,16 @@ export const getAccountStatus = (
 		PayableReason: string[];
 	} | null,
 	translate: ( key: string ) => string
-): {
-	statusType: 'success' | 'warning' | 'error';
-	status: string;
-	statusReason?: string;
-} | null => {
+): StatusMeta | null => {
 	if ( ! data ) {
 		return null;
 	}
 	const { Status, IsPayable, PayableReason } = data;
+	let statusMeta = null;
 	switch ( Status ) {
 		case 'Active':
 			if ( ! IsPayable ) {
-				return {
+				statusMeta = {
 					statusType: 'warning',
 					status: translate( 'Not Payable' ),
 					statusReason: PayableReason?.map( ( reason ) => {
@@ -30,29 +34,43 @@ export const getAccountStatus = (
 						return reason;
 					} ).join( ', ' ),
 				};
+				break;
 			}
-			return {
+			statusMeta = {
 				statusType: 'success',
 				status: translate( 'Confirmed' ),
 			};
+			break;
 		case 'Suspended':
-			return {
+			statusMeta = {
 				statusType: 'error',
 				status: translate( 'Suspended' ),
 			};
+			break;
 		case 'Blocked':
-			return {
+			statusMeta = {
 				statusType: 'error',
 				status: translate( 'Blocked' ),
 				statusReason: translate( 'Your account is blocked' ),
 			};
+			break;
 		case 'Closed':
-			return {
+			statusMeta = {
 				statusType: 'error',
 				status: translate( 'Closed' ),
 				statusReason: translate( 'Your account is closed' ),
 			};
+			break;
 		default:
-			return null;
+			break;
 	}
+
+	if ( ! statusMeta ) {
+		return null;
+	}
+
+	return {
+		...statusMeta,
+		actionRequired: [ 'warning', 'error' ].includes( statusMeta?.statusType ),
+	} as StatusMeta;
 };

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -30,6 +30,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useFetchReferrals from '../../hooks/use-fetch-referrals';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
+import { getAccountStatus } from '../../lib/get-account-status';
 import ReferralDetails from '../../referral-details';
 import ReferralsFooter from '../footer';
 import AutomatedReferralComingSoonBanner from './automated-referral-coming-soon-banner';
@@ -63,6 +64,8 @@ export default function ReferralsOverview( {
 			: translate( 'Referrals' );
 
 	const { data: tipaltiData, isFetching } = useGetTipaltiPayee();
+	const accountStatus = getAccountStatus( tipaltiData, translate );
+
 	const isPayable = !! tipaltiData?.IsPayable;
 	const [ showPopover, setShowPopover ] = useState( false );
 	const wrapperRef = useRef< HTMLButtonElement | null >( null );
@@ -73,7 +76,7 @@ export default function ReferralsOverview( {
 	const hasReferrals = !! referrals?.length;
 
 	const actionRequiredNotice =
-		! isFetching && ! isPayable && ! isFetchingReferrals && hasReferrals && ! requiredNoticeClose;
+		hasReferrals && accountStatus?.actionRequired && ! requiredNoticeClose;
 
 	const makeAReferral = useCallback( () => {
 		sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, MARKETPLACE_TYPE_REFERRAL );

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -23,6 +23,7 @@ interface Props {
 	isExternalLink?: boolean;
 	isSelected?: boolean;
 	openInSameTab?: boolean;
+	extraContent?: JSX.Element;
 }
 
 export const SidebarNavigatorMenuItem = ( {
@@ -36,6 +37,7 @@ export const SidebarNavigatorMenuItem = ( {
 	isExternalLink = false,
 	isSelected = false,
 	openInSameTab = false,
+	extraContent,
 }: Props ) => {
 	const SidebarItem = ( { children }: { children?: JSX.Element } ) => {
 		return (
@@ -63,6 +65,7 @@ export const SidebarNavigatorMenuItem = ( {
 					{ isExternalLink && (
 						<Icon className="sidebar-v2__external-icon" icon={ external } size={ ICON_SIZE } />
 					) }
+					{ extraContent }
 				</HStack>
 			</Item>
 		);


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/422

## Proposed Changes

This PR adds an indicator to the `Payment Settings` sidebar menu item.

## Testing Instructions

1. Open the A4A live link.
2. Go to Referrals > Verify that an indicator is shown whenever the account is not payable.

<img width="1728" alt="Screenshot 2024-07-17 at 12 16 50 PM" src="https://github.com/user-attachments/assets/e419de2a-f383-4101-931f-ca36c5bd83fc">
<img width="1728" alt="Screenshot 2024-07-17 at 12 20 43 PM" src="https://github.com/user-attachments/assets/e8b3b3e9-8ed8-484c-b90b-aea26a325184">
<img width="1728" alt="Screenshot 2024-07-17 at 12 23 48 PM" src="https://github.com/user-attachments/assets/aea8e0a0-52a8-4dc3-a9a6-f4ca899403d7">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
