### PR TITLE
e2e: Fix instagram and twitter block flows tests

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/instagram.ts
@@ -42,7 +42,11 @@ export class InstagramBlockFlow implements BlockFlow {
 			} )
 			.click();
 
-		await editorCanvas.getByTitle( 'Embedded content from www.instagram.com' ).waitFor();
+		// @todo Remove the first option once Gutenberg v18.8.0 is deployed everywhere.
+		await Promise.race( [
+			editorCanvas.getByTitle( 'Embedded content from instagram.com' ).waitFor(),
+			editorCanvas.getByTitle( 'Embedded content from www.instagram.com' ).waitFor(),
+		] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -9,7 +9,8 @@ const blockParentSelector = '[aria-label="Block: Twitter"]:has-text("Twitter URL
 const selectors = {
 	embedUrlInput: `${ blockParentSelector } input`,
 	embedButton: `${ blockParentSelector } button:has-text("Embed")`,
-	editorTwitterIframe: `iframe[title="Embedded content from twitter.com"]`,
+	// @todo Remove first option once Gutenberg v18.8.0 is deployed everywhere.
+	editorTwitterIframe: `iframe[title="Embedded content from twitter"],iframe[title="Embedded content from twitter.com"]`,
 	publishedTwitterIframe: `iframe[title="X Post"]`,
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It appears that #92736 updated the tests for WordPress/gutenberg#63052 to make the Gutenberg edge tests pass, and in doing so broke tests against Atomic and Simple that haven't been updated to that version yet.

Update the tests to temporarily accept either option. This can be reverted once Atomic and Simple are updated to (AFAICT) Gutenberg v18.8.0.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Atomic (Jetpack edge): `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core-jetpack-extended.ts`
* Simple: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core-jetpack-extended.ts`
* Gutenberg edge: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core-jetpack-extended.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
