### PR TITLE
Fix submenu selected hover color in global sidebar

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -53,6 +53,7 @@ $brand-text: "SF Pro Text", $sans;
 		--color-sidebar-submenu-text: var(--color-sidebar-text);
 		--color-sidebar-submenu-selected-text: var(--color-sidebar-menu-selected-text);
 		--color-sidebar-submenu-hover-text: var(--color-sidebar-menu-selected-text);
+		--color-sidebar-submenu-selected-hover-text: var(--color-sidebar-menu-selected-text);
 		--color-sidebar-gridicon-fill: var(--color-sidebar-text);
 		--color-sidebar-gridicon-hover-fill: var(--color-sidebar-text);
 		--color-sidebar-gridicon-selected-fill: var(--color-sidebar-menu-selected-text);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1721216090512409-slack-C03NLNTPZ2T

## Proposed Changes

* Defines a specific color variable for use inside the context of the global sidebar. This prevents masterbar scheme colors from bleeding into the global sidebar. 
* We didn't previously have a separate hover color for these selected items in the submenu groups, so I am applying the same color as the selected style so it is the same as it was before recent masterbar changes.

BEFORE (hover of selected submenu)
![image](https://github.com/user-attachments/assets/0352b37c-cf4a-4fbd-b551-f0df8a2b6517)


AFTER
<img width="146" alt="Screenshot 2024-07-17 at 10 02 00 AM" src="https://github.com/user-attachments/assets/f2bdaf56-1338-408e-848d-6011d6385ab2">




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Color style bleed where it shouldn't be

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader
* Open a submenu group (lists, tags, a8c, etc.)
* select and item and hover over that menu item after selected. verify it is no longer bright green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?