### PR TITLE
Sites Dahboard: Keep the "Add new site" button on mobile

### DIFF
--- a/client/hosting/sites/components/sites-dashboard-header.tsx
+++ b/client/hosting/sites/components/sites-dashboard-header.tsx
@@ -114,7 +114,7 @@ const SitesDashboardHeader = () => {
 					className="sites-add-new-site-split-button"
 					primary
 					whiteSeparator
-					label={ isMobile ? undefined : __( 'Add new site' ) }
+					label={ __( 'Add new site' ) }
 					onClick={ () => {
 						recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
 					} }


### PR DESCRIPTION
## Proposed Changes

* Prevent the "Add new site" button from disappearing on mobile devices

## Why are these changes being made?

* This bug was mentioned on slack: p1721225293450839-slack-C06DN6QQVAQ

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/sites`
* Set the browser on responsive mode emulating a mobile device
* Check that the "Add new site" button is still there

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/ea85a5df-2366-4efa-a4b6-7bb56b425e86)|![image](https://github.com/user-attachments/assets/5c039211-812e-4ac8-9b26-4107af4b97dc)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?