### PR TITLE
Masterbar site menu - add Dashboard / My Home submenu item

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -47,6 +47,7 @@ import {
 	getSiteTitle,
 	getSiteUrl,
 	getSiteAdminUrl,
+	getSiteHomeUrl,
 } from 'calypso/state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import { isSupportSession } from 'calypso/state/support/selectors';
@@ -341,12 +342,30 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderSiteMenu() {
-		const { currentSelectedSiteSlug, translate, siteTitle, siteUrl } = this.props;
+		const {
+			currentSelectedSiteSlug,
+			translate,
+			siteTitle,
+			siteUrl,
+			isClassicView,
+			siteAdminUrl,
+			siteHomeUrl,
+		} = this.props;
 
 		// Only display when a site is selected.
 		if ( ! currentSelectedSiteSlug ) {
 			return null;
 		}
+
+		const siteHomeOrAdminItem = isClassicView
+			? {
+					label: translate( 'Dashboard' ),
+					url: siteAdminUrl,
+			  }
+			: {
+					label: translate( 'Site Home' ),
+					url: siteHomeUrl,
+			  };
 
 		return (
 			<Item
@@ -354,7 +373,7 @@ class MasterbarLoggedIn extends Component {
 				url={ siteUrl }
 				icon={ <span className="dashicons-before dashicons-admin-home" /> }
 				tipTarget="visit-site"
-				subItems={ [ { label: translate( 'Visit Site' ), url: siteUrl } ] }
+				subItems={ [ { label: translate( 'Visit Site' ), url: siteUrl }, siteHomeOrAdminItem ] }
 			>
 				{ siteTitle }
 			</Item>
@@ -364,7 +383,7 @@ class MasterbarLoggedIn extends Component {
 	renderSiteActionMenu() {
 		const {
 			currentSelectedSiteSlug,
-			currentSelectedSite,
+			isClassicView,
 			translate,
 			siteAdminUrl,
 			newPostUrl,
@@ -383,7 +402,6 @@ class MasterbarLoggedIn extends Component {
 		let siteActions = [];
 
 		if ( currentSelectedSiteSlug ) {
-			const isClassicView = siteUsesWpAdminInterface( currentSelectedSite );
 			siteActions = [
 				{
 					label: translate( 'Post' ),
@@ -838,6 +856,8 @@ export default connect(
 			isSiteMigrationActiveRoute( state );
 
 		const siteCount = getCurrentUserSiteCount( state ) ?? 0;
+		const currentSelectedSite = getSelectedSite( state );
+		const isClassicView = currentSelectedSite && siteUsesWpAdminInterface( currentSelectedSite );
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
@@ -846,6 +866,7 @@ export default connect(
 			siteTitle: getSiteTitle( state, siteId ),
 			siteUrl: getSiteUrl( state, siteId ),
 			siteAdminUrl: getSiteAdminUrl( state, siteId ),
+			siteHomeUrl: getSiteHomeUrl( state, siteId ),
 			sectionGroup,
 			domainOnlySite: isDomainOnlySite( state, siteId ),
 			hasNoSites: siteCount === 0,
@@ -855,7 +876,8 @@ export default connect(
 			isMigrationInProgress,
 			migrationStatus: getSiteMigrationStatus( state, currentSelectedSiteId ),
 			currentSelectedSiteId,
-			currentSelectedSite: getSelectedSite( state ),
+			currentSelectedSite,
+			isClassicView,
 			currentSelectedSiteSlug: currentSelectedSiteId
 				? getSiteSlug( state, currentSelectedSiteId )
 				: undefined,

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -16,7 +16,7 @@ import { getStatsPathForTab } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
-import { isNotAtomicJetpack, siteUsesWpAdminInterface } from 'calypso/sites-dashboard/utils';
+import { siteUsesWpAdminInterface } from 'calypso/sites-dashboard/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { openCommandPalette } from 'calypso/state/command-palette/actions';
 import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
@@ -459,10 +459,7 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderProfileMenu() {
-		const { translate, user, siteUrl, currentSelectedSite } = this.props;
-		const isClassicView = currentSelectedSite
-			? siteUsesWpAdminInterface( currentSelectedSite )
-			: false;
+		const { translate, user, siteUrl, isClassicView } = this.props;
 		const profileActions = [
 			{
 				label: (
@@ -857,10 +854,8 @@ export default connect(
 
 		const siteCount = getCurrentUserSiteCount( state ) ?? 0;
 		const currentSelectedSite = getSelectedSite( state );
-		const isJetpackNotAtomic = currentSelectedSite && isNotAtomicJetpack( currentSelectedSite );
-		const isClassicView =
-			( currentSelectedSite && siteUsesWpAdminInterface( currentSelectedSite ) ) ||
-			isJetpackNotAtomic;
+		const isClassicView = currentSelectedSite && siteUsesWpAdminInterface( currentSelectedSite );
+
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -363,7 +363,7 @@ class MasterbarLoggedIn extends Component {
 					url: siteAdminUrl,
 			  }
 			: {
-					label: translate( 'Site Home' ),
+					label: translate( 'My Home' ),
 					url: siteHomeUrl,
 			  };
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -16,7 +16,7 @@ import { getStatsPathForTab } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
-import { siteUsesWpAdminInterface } from 'calypso/sites-dashboard/utils';
+import { isNotAtomicJetpack, siteUsesWpAdminInterface } from 'calypso/sites-dashboard/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { openCommandPalette } from 'calypso/state/command-palette/actions';
 import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
@@ -857,7 +857,10 @@ export default connect(
 
 		const siteCount = getCurrentUserSiteCount( state ) ?? 0;
 		const currentSelectedSite = getSelectedSite( state );
-		const isClassicView = currentSelectedSite && siteUsesWpAdminInterface( currentSelectedSite );
+		const isJetpackNotAtomic = currentSelectedSite && isNotAtomicJetpack( currentSelectedSite );
+		const isClassicView =
+			( currentSelectedSite && siteUsesWpAdminInterface( currentSelectedSite ) ) ||
+			isJetpackNotAtomic;
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/8234

## Proposed Changes

* Adds a submenu item to the site menu in the new masterbar. This item should lead to /home for default sites and /wp-admin sites for classic view.

BEFORE
<img width="236" alt="Screenshot 2024-07-17 at 10 30 24 AM" src="https://github.com/user-attachments/assets/80eeef87-f6b8-48bc-84c2-e77c3954fcb5">



AFTER
<img width="180" alt="Screenshot 2024-07-17 at 10 30 39 AM" src="https://github.com/user-attachments/assets/f36d6c01-b2a9-4552-af02-fe270d6223b3">
<img width="222" alt="Screenshot 2024-07-17 at 10 32 09 AM" src="https://github.com/user-attachments/assets/aed848f3-23a5-4242-8459-0a658cc27714">





## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Give users the ability to get back to their site home or dashboard after going to global pages. ex. My home -> Reader, how do i get back without going to /sites and searching for that site i was on? well, with this change you now can...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit calypso
* select a classic site. Open the site item on the masterbar and verify a item for "My Home" exists and leads to my home.
* select a default view site. Open the site item on the masterbar and verify a item for "Dashboard" exists and leads to wp-admin.
* Test the profile links in the masterbar - verify these remain as expected between classic and default view sites. There should be no change here, but we consolidated logic that this also used. (Edit Profile should continue to go to /me for default view, and a wp-admin link for classic.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
