### PR TITLE
Help Center: adjust initial route redirect

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -5,10 +5,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import OdieAssistantProvider, { useSetOdieStorage } from '@automattic/odie-client';
 import { CardBody, Disabled } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import React, { useCallback, useState } from 'react';
-import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Route, Routes, useLocation, Navigate } from 'react-router-dom';
 /**
  * Internal Dependencies
  */
@@ -44,9 +44,9 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 } ) => {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const location = useLocation();
-	const navigate = useNavigate();
 	const containerRef = useRef< HTMLDivElement >( null );
 
+	const { setInitialRoute } = useDispatch( HELP_CENTER_STORE );
 	const { sectionName, currentUser, site } = useHelpCenterContext();
 	const shouldUseWapuu = useShouldUseWapuu();
 	const { isMinimized } = useSelect( ( select ) => {
@@ -73,12 +73,6 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 		[]
 	);
 
-	useEffect( () => {
-		if ( initialRoute ) {
-			navigate( initialRoute );
-		}
-	}, [ initialRoute ] );
-
 	// reset the scroll location on navigation, TODO: unless there's an anchor
 	useEffect( () => {
 		setSearchTerm( '' );
@@ -86,6 +80,13 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 			containerRef.current.scrollTo( 0, 0 );
 		}
 	}, [ location ] );
+
+	// reset the initial route after it's been used
+	useEffect( () => {
+		if ( initialRoute ) {
+			setInitialRoute( null );
+		}
+	}, [ initialRoute, setInitialRoute ] );
 
 	const trackEvent = useCallback(
 		( eventName: string, properties: Record< string, unknown > = {} ) => {
@@ -103,7 +104,11 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 					<Route
 						path="/"
 						element={
-							<HelpCenterSearch onSearchChange={ setSearchTerm } currentRoute={ currentRoute } />
+							initialRoute ? (
+								<Navigate to={ initialRoute } />
+							) : (
+								<HelpCenterSearch onSearchChange={ setSearchTerm } currentRoute={ currentRoute } />
+							)
 						}
 					/>
 					<Route path="/post" element={ <HelpCenterEmbedResult /> } />


### PR DESCRIPTION
## Proposed Changes

Change the redirect to `initialRoute` from `navigate()` to `<Navigate>` within the root route.

## Why are these changes being made?

When we use the `navigate()` hook it creates a location KEY effectively making it seem as the current path that you get initially is NOT the start. React Router DOM sets the key to `default` on the root route. This makes it hard to detect if its the first path that has been opened.

## Testing Instructions

1. Open Calypso live link
2. Click on an inline help link from the bottom of `/home`
3. Help Center should open to the predefined article.
4. Click the back button and you should be taken to the help center home page.