### PR TITLE
A4A: Update licenses search placeholder

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-search/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-search/index.tsx
@@ -29,7 +29,7 @@ const LicenseSearch = ( { doSearch }: Props ) => {
 			initialValue={ search }
 			hideClose={ ! search }
 			onSearch={ onSearch }
-			placeholder={ translate( 'Search by license code' ) }
+			placeholder={ translate( 'Search by product name or license code' ) }
 			delaySearch
 		/>
 	);


### PR DESCRIPTION
Related https://github.com/Automattic/automattic-for-agencies-dev/issues/532

Don't merge without D155523-code being deployed first.

## Proposed Changes

* Update search label to "Search by product name or license code"

## Testing Instructions

* Open the A4A live link.
* Observe that the Licenses search placeholder now says "Search by product name or license code"
 
<img width="705" alt="Screenshot 2024-07-17 at 16 41 12" src="https://github.com/user-attachments/assets/ef7ee921-40bc-4b15-90ff-2d65fd4288b3">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?