### PR TITLE
Fix e2e test

### DIFF
--- a/test/e2e/specs/importer/importer__import-focused.ts
+++ b/test/e2e/specs/importer/importer__import-focused.ts
@@ -107,7 +107,7 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 			await startImportFlow.validateSitePickerPage();
 		} );
 
-		it( 'Should select the second site and press `Upgrade and migrate` on modal prompt', async () => {
+		it( 'Should select the second site and press `Get the plan and migrate` on modal prompt', async () => {
 			await page.getByRole( 'button', { name: 'Select this site' } ).nth( 1 ).click();
 			await page.getByRole( 'button', { name: 'Continue' } ).click();
 		} );
@@ -117,7 +117,7 @@ describe( DataHelper.createSuiteTitle( 'Stepper: setup/import-focused' ), () => 
 		} );
 
 		it( 'Should redirect to "Checkout" page', async () => {
-			await startImportFlow.clickButton( 'Upgrade and migrate' );
+			await startImportFlow.clickButton( 'Get the plan and migrate' );
 			await startImportFlow.validateCheckoutPage();
 		} );
 	} );


### PR DESCRIPTION
## Proposed Changes

* Fix E2E test.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It has a new CTA now and the test is failing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the E2E test passes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
