### PR TITLE
Fixes an e2e test error caused by changes to the site-assembler

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__site-assembler.ts
+++ b/test/e2e/specs/onboarding/onboarding__site-assembler.ts
@@ -115,7 +115,7 @@ describe( 'Onboarding: Site Assembler', () => {
 
 		it( 'Select another Header pattern', async function () {
 			await siteAssemblerFlow.clickLayoutComponentType( 'Header' );
-			await siteAssemblerFlow.selectLayoutComponent( { index: 1 } );
+			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
 
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 4 );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

* p1721144596285389-slack-C02FMH4G8
* p1721145290393229-slack-C02DQP0FP

**NOTE: We will want to unpause the `onboarding__site-assembler.ts` test once this has shipped.**

## Proposed Changes

Fixed the `onboarding__site-assembler.ts` so it no longer thinks it's finding two of the same element (which it wasn't, they just had similar names).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We were seeing persistent failures of the `onboarding__site-assembler.ts` pre-release e2e test and had to pause the test. This fixes the test.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally.
* Start calypso (`yarn start`) in a terminal.
* Run `export CALYPSO_BASE_URL=http://calypso.localhost:3000` in a different terminal.
* In the same terminal that you ran the `export` command, run the test

```
yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/onboarding__site-assembler.ts
```

* Verify the tests pass

If you get a ` Cannot find module '/Users/mark/dev/a8c/calypso/node_modules/@automattic/jest-circus-allure-reporter/dist/esm/src/index.js'. Please verify that the package.json has a valid "main" entry` error, you may have to remove your `node_modules/` directory and run `yarn` again.

![CleanShot 2024-07-17 at 14 19 27](https://github.com/user-attachments/assets/7bd0b248-4516-413b-b97e-5c43e08f8e52)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?