### PR TITLE
WIP - try to set referrer as selected site on dashboard load.

### DIFF
--- a/client/hosting/sites/index.tsx
+++ b/client/hosting/sites/index.tsx
@@ -1,7 +1,9 @@
 import page from '@automattic/calypso-router';
+import { getSiteIdBySlug } from '@automattic/data-stores/src/site/selectors';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation } from 'calypso/my-sites/controller';
 import { getSiteBySlug, getSiteHomeUrl } from 'calypso/state/sites/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import {
 	maybeRemoveCheckoutSuccessNotice,
 	sanitizeQueryParameters,
@@ -23,8 +25,21 @@ export default function () {
 		maybeRemoveCheckoutSuccessNotice,
 		sanitizeQueryParameters,
 		navigation,
+		checkReferrerForSiteSelection,
 		sitesDashboard,
 		makeLayout,
 		clientRender
 	);
+}
+
+function checkReferrerForSiteSelection( context, next ) {
+	// this would change the selected site back to the referrer every time we load back to the dashboard.
+	// we will likely need to manage this somehow, maybe setting and clearing an initial referrer in the store?
+	const { referrer } = document;
+	const referringSite = referrer && getSiteIdBySlug( context.store.getState(), referrer );
+	if ( referringSite ) {
+		context.store.dispatch( setSelectedSiteId( referringSite ) );
+	}
+
+	next();
 }

--- a/client/hosting/sites/index.tsx
+++ b/client/hosting/sites/index.tsx
@@ -38,6 +38,7 @@ function checkReferrerForSiteSelection( context, next ) {
 	// accurate for what we want, but on initial inspection it seems promising.
 	if ( ! context.init || ! referrer ) {
 		next();
+		return;
 	}
 
 	const potentialSiteSlug = new URL( referrer ).hostname || '';

--- a/client/hosting/sites/index.tsx
+++ b/client/hosting/sites/index.tsx
@@ -33,8 +33,7 @@ export default function () {
 }
 
 function checkReferrerForSiteSelection( context, next ) {
-	// const { referrer } = document;
-	const referrer = 'https://atomicblog20240228.wpcomstaging.com/';
+	const { referrer } = document;
 	// Only evluate this on initialization. Note im not 100% sure if this init value is fully
 	// accurate for what we want, but on initial inspection it seems promising.
 	if ( ! context.init || ! referrer ) {

--- a/client/hosting/sites/index.tsx
+++ b/client/hosting/sites/index.tsx
@@ -25,20 +25,26 @@ export default function () {
 		maybeRemoveCheckoutSuccessNotice,
 		sanitizeQueryParameters,
 		navigation,
-		checkReferrerForSiteSelection,
 		sitesDashboard,
 		makeLayout,
+		checkReferrerForSiteSelection,
 		clientRender
 	);
 }
 
 function checkReferrerForSiteSelection( context, next ) {
-	// this would change the selected site back to the referrer every time we load back to the dashboard.
-	// we will likely need to manage this somehow, maybe setting and clearing an initial referrer in the store?
-	const { referrer } = document;
-	const referringSite = referrer && getSiteIdBySlug( context.store.getState(), referrer );
-	if ( referringSite ) {
-		context.store.dispatch( setSelectedSiteId( referringSite ) );
+	// const { referrer } = document;
+	const referrer = 'https://atomicblog20240228.wpcomstaging.com/';
+	// Only evluate this on initialization. Note im not 100% sure if this init value is fully
+	// accurate for what we want, but on initial inspection it seems promising.
+	if ( ! context.init || ! referrer ) {
+		next();
+	}
+
+	const potentialSiteSlug = new URL( referrer ).hostname || '';
+	const referringSiteId = getSiteIdBySlug( context.store.getState(), potentialSiteSlug );
+	if ( referringSiteId ) {
+		context.store.dispatch( setSelectedSiteId( referringSiteId ) );
 	}
 
 	next();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
