### PR TITLE
Update Auto fix all threats button message

### DIFF
--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -245,7 +245,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 								onClick={ openFixAllThreatsDialog }
 								disabled={ ! hasFixableThreats || updatingThreats.length > 0 }
 							>
-								{ translate( 'Show fixable threats' ) }
+								{ translate( 'Show auto fixers' ) }
 							</Button>
 							<Button className="scan-threats__scan-secondary-button" onClick={ dispatchScanRun }>
 								{ translate( 'Scan now' ) }

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -245,7 +245,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 								onClick={ openFixAllThreatsDialog }
 								disabled={ ! hasFixableThreats || updatingThreats.length > 0 }
 							>
-								{ translate( 'Auto fix all' ) }
+								{ translate( 'Show fixable threats' ) }
 							</Button>
 							<Button className="scan-threats__scan-secondary-button" onClick={ dispatchScanRun }>
 								{ translate( 'Scan now' ) }

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -148,7 +148,6 @@
 	}
 
 	&__fix-all-threats-button {
-		width: 105px;
 		height: 40px;
 		border-radius: 2px;
 		font-weight: 600;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
- https://github.com/Automattic/jetpack-scan-team/issues/1285

## Proposed Changes
* Update the Auto fix all button test to make it more clear that the action still allows for the review and selection of threats before the fixers are triggered.

## Testing Instructions
* Checkout this branch and start your dev environment
* Proceed to the Scan dashboard for a site with fixable threats
* Verify that the button displays the new message

## Screenshots
![Screen Shot on 2024-07-17 at 15-20-46](https://github.com/user-attachments/assets/72c0ec41-0281-4cba-8768-47773edace55)
