### PR TITLE
Update 'Contact Support' button on My Home

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -1,4 +1,5 @@
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Card, Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
@@ -79,7 +80,7 @@ export default function HelpSearch() {
 					</div>
 				</div>
 				<div className="help-search__footer">
-					<Button borderless className="help-search__cta" onClick={ onClick }>
+					<Button className="help-search__cta" onClick={ onClick }>
 						<span className="help-search__help-icon">
 							<Gridicon icon="help" size={ 36 } />
 						</span>

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -1,7 +1,7 @@
 import { Card, Gridicon } from '@automattic/components';
-import { Button } from '@wordpress/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
+import { Button } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -1,4 +1,7 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Button, Card, Gridicon } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
+import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -11,6 +14,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import './style.scss';
 
 const HELP_COMPONENT_LOCATION = 'customer-home';
+const HELP_CENTER_STORE = HelpCenter.register();
 
 const amendYouTubeLink = ( link = '' ) =>
 	link.replace( 'youtube.com/embed/', 'youtube.com/watch?v=' );
@@ -42,6 +46,14 @@ export default function HelpSearch() {
 
 		dispatch( recordTracksEvent( `calypso_inlinehelp_${ type }_open`, tracksData ) );
 	};
+	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { url } = useStillNeedHelpURL();
+
+	const onClick = () => {
+		setInitialRoute( url );
+		setShowHelpCenter( true );
+		dispatch( recordTracksEvent( 'calypso_inlinehelp_get_help_click' ) );
+	};
 
 	return (
 		<>
@@ -67,12 +79,12 @@ export default function HelpSearch() {
 					</div>
 				</div>
 				<div className="help-search__footer">
-					<a className="help-search__cta" href="/help/contact">
+					<Button borderless className="help-search__cta" onClick={ onClick }>
 						<span className="help-search__help-icon">
 							<Gridicon icon="help" size={ 36 } />
 						</span>
-						{ translate( 'Contact support' ) }
-					</a>
+						{ translate( 'Get help' ) }
+					</Button>
 				</div>
 			</Card>
 		</>

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -41,9 +41,7 @@ $min_results_height: 180px;
 		padding: 10px $card_padding_small;
 		color: var(--color-text);
 		line-height: 1;
-		font-size: $font-body;
-		font-weight: 400;
-		text-rendering: optimizeLegibility; /* match rest of inline help */
+		font-size: inherit;
 
 		@include break-mobile {
 			padding: 10px $card_padding_large;
@@ -52,13 +50,6 @@ $min_results_height: 180px;
 		&:hover,
 		&:focus {
 			background: var(--color-neutral-0);
-		}
-
-		// Resetting these values for proper Gridicon
-		// placement while nested in a Button.
-		&.button .gridicon {
-			top: inherit;
-			margin-top: inherit;
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -42,6 +42,7 @@ $min_results_height: 180px;
 		color: var(--color-text);
 		line-height: 1;
 		font-size: inherit;
+		height: auto; /* necessary to reset @wordpress/components button height */
 
 		@include break-mobile {
 			padding: 10px $card_padding_large;

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -37,9 +37,13 @@ $min_results_height: 180px;
 	.help-search__cta {
 		display: flex;
 		align-items: center;
+		width: 100%;
 		padding: 10px $card_padding_small;
 		color: var(--color-text);
 		line-height: 1;
+		font-size: $font-body;
+		font-weight: 400;
+		text-rendering: optimizeLegibility; /* match rest of inline help */
 
 		@include break-mobile {
 			padding: 10px $card_padding_large;
@@ -48,6 +52,13 @@ $min_results_height: 180px;
 		&:hover,
 		&:focus {
 			background: var(--color-neutral-0);
+		}
+
+		// Resetting these values for proper Gridicon
+		// placement while nested in a Button.
+		&.button .gridicon {
+			top: inherit;
+			margin-top: inherit;
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -42,7 +42,7 @@ $min_results_height: 180px;
 		color: var(--color-text);
 		line-height: 1;
 		font-size: inherit;
-		height: auto; /* necessary to reset @wordpress/components button height */
+		height: auto;
 
 		@include break-mobile {
 			padding: 10px $card_padding_large;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8193-gh-Automattic/dotcom-forge

## Proposed Changes

- Update the CTA text from 'Contact Support' to 'Get Help'
- Open Wapuu, instead of `/help`
- Add a Tracks event
- Minor style updates to address markup changes


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The button currently leads to a page with docs and a search field, and a second "Contact Support" button, which actually opens the AI assistant, and not an actual support contact.

There's a doc search just above this CTA, so Wapuu is a more useful path than /`help`, which is essentially another doc search any way.

Updating the text to "Get Help" will more accurately reflect the button's intent, and provide clearer expectations to the user.

I've added the Tracks event because data is always good to have, but it can be easily removed if we don't think it'll be potentially useful in the future. I kind of wish we already had one so we could see if this change has any impact, but that's just my inquisitive nature.

## Testing Instructions

- Load `/home` for any wpcom site
- Scroll down and confirm that CTA at the bottom of the "Get Help" section now also reads "Get help" instead of "Contact Support"
- When clicking the CTA, confirm that Wapuu opens instead of navigating to `/help`
- Visually compare to trunk, to confirm the styling and positioning are the same. Please look extra closely at the help icon, as that needed some minor positioning tweaks.
- Confirm that the new `calypso_inlinehelp_get_help_click` event fires once when clicking the button.