### PR TITLE
Improved test to ensure it won't be flaky

### DIFF
--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -68,6 +68,11 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC )( 'Site Editor: Limited Global Styl
 			return;
 		}
 
+		// Since we only want to show the notice when the user is attempting to change a style,
+		// when reloading the styles page, we need to ensure we first have the Default style applied.
+		// https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js#L80
+		await fullSiteEditorPage.setStyleVariation( 'Default' );
+
 		// Style variation names depend on the theme.
 		// If the spec ever begins to permafail, check here.
 		await fullSiteEditorPage.setStyleVariation( 'Aubergine' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Gutenberg [18.8.0 release
](https://github.com/WordPress/gutenberg/releases/tag/v18.8.0)
Task: https://github.com/Automattic/wp-calypso/issues/92543

## Testing Instructions

Run the following E2E tests:

 `GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test -- specs/fse/fse__limited-global-styles.ts`
 `GUTENBERG_EDGE=false yarn workspace wp-e2e-tests test -- specs/fse/fse__limited-global-styles.ts`



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
