### PR TITLE
Adjust top margin on Mobile "hamburger" menu

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1119,8 +1119,11 @@ $font-size: rem(14px);
 		// client/layout/sidebar/style.scss
 		.sidebar {
 			position: absolute;
-			top: 12px;
 			padding-bottom: 120px;
+		}
+
+		.global-sidebar .sidebar {
+			top: 12px;
 		}
 
 		.is-unified-site-sidebar-visible {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1119,6 +1119,7 @@ $font-size: rem(14px);
 		// client/layout/sidebar/style.scss
 		.sidebar {
 			position: absolute;
+			top: 12px;
 			padding-bottom: 120px;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8300

## Proposed Changes

* Adds `top` value to the mobile sidebar to give it some top margin.

/sites
Before | After
--|--
<img width="1013" alt="Screenshot 2024-07-17 at 4 57 05 PM" src="https://github.com/user-attachments/assets/2faa7581-584e-4bdb-a02f-7f48094c8681"> | <img width="1011" alt="Screenshot 2024-07-17 at 4 56 53 PM" src="https://github.com/user-attachments/assets/25a66536-cd4d-4b94-b6a4-486db8dcf2b9">

/read
Before | After
--|--
<img width="1012" alt="Screenshot 2024-07-17 at 4 57 31 PM" src="https://github.com/user-attachments/assets/3ffe470a-5e58-4fb5-ac71-4ceff2f214a9"> |  <img width="1012" alt="Screenshot 2024-07-17 at 4 57 22 PM" src="https://github.com/user-attachments/assets/be6cd211-e5be-4728-b1ee-059da6b15ac6">

/me
Before | After
--|--
<img width="1014" alt="Screenshot 2024-07-17 at 4 58 12 PM" src="https://github.com/user-attachments/assets/2db0899f-5ab4-4b45-8867-62aee3864990"> | <img width="1013" alt="Screenshot 2024-07-17 at 4 58 04 PM" src="https://github.com/user-attachments/assets/5f89d29d-3033-4663-a792-712dbe5dd7fd">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Aesthetics.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-  Use mobile view
-  Go to /sites, /reader, /me
-  Click the "hamburger" menu and make sure the top margin on the sidebar looks good.
- Go to /home/[site], click the "hamburger" menu and ensure that you can scroll the sidebar (this was the reason for the original revert https://github.com/Automattic/wp-calypso/pull/92768), also check that `top` value is not applied, and no extra top margin has been added.
-  Check for regressions on other pages.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
