### PR TITLE
Stats: Adding empty state for Total views component

### DIFF
--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -1,16 +1,32 @@
-import { Card, SimplifiedSegmentedControl } from '@automattic/components';
+import config from '@automattic/calypso-config';
+import {
+	Card,
+	SimplifiedSegmentedControl,
+	StatsCard,
+	LoadingPlaceholder,
+} from '@automattic/components';
+import { seen } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import EmptyModuleCard from 'calypso/my-sites/stats/components/empty-module-card/empty-module-card';
+import {
+	StatsEmptyActionAI,
+	StatsEmptyActionSocial,
+} from 'calypso/my-sites/stats/features/modules/shared';
 import { useSelector } from 'calypso/state';
-import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsViewSummary,
+} from 'calypso/state/stats/lists/selectors';
 import { STAT_TYPE_INSIGHTS_ALL_TIME_INSIGHTS } from '../constants';
 import { useShouldGateStats } from '../hooks/use-should-gate-stats';
 import StatsCardUpsell from '../stats-card-upsell';
 import StatsHeatMapLegend from '../stats-heap-map/legend';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import Months from '../stats-views/months';
+import type { StatsStateProps } from 'calypso/my-sites/stats/features/modules/types';
 
 import './style.scss';
 
@@ -21,8 +37,9 @@ type chartOption = {
 };
 
 export default function AllTimeViewsSection( { siteId, slug }: { siteId: number; slug: string } ) {
-	const query = { quantity: -1, stat_fields: 'views' };
+	const query = { quantity: -1, stat_fields: 'views' }; // duplicate from getSiteStatsViewSummary or vice versa
 	const translate = useTranslate();
+	const statType = 'statsVisits';
 	const [ chartOption, setChartOption ] = useState( 'total' );
 	const viewData = useSelector( ( state ) => getSiteStatsViewSummary( state, siteId ) );
 	const monthViewOptions = useMemo( () => {
@@ -45,42 +62,93 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 		'is-loading': ! viewData,
 	} );
 
+	const isEmptyStateV2 = config.isEnabled( 'stats/empty-module-v2' );
+	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+
 	return (
 		<div className="stats__all-time-views-section stats__modernized-stats-table">
-			{ siteId && <QuerySiteStats statType="statsVisits" siteId={ siteId } query={ query } /> }
+			{ siteId && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 
 			<div className="highlight-cards">
 				<h3 className="highlight-cards-heading">{ translate( 'All-time insights' ) }</h3>
 
-				<div className="highlight-cards-list">
-					{ /* 
-						TODO: Refactor this card along with other similar structure cards to a component
-						supporting overlay inside highlight-cards
-					*/ }
-					<Card className={ cardWrapperClassName }>
-						<div className="highlight-card-heading">
-							<h4>{ translate( 'Total views' ) }</h4>
-							{ viewData && (
-								<SimplifiedSegmentedControl options={ monthViewOptions } onSelect={ toggleViews } />
-							) }
-						</div>
-
-						<div className="highlight-card-content">
-							<div className={ tableWrapperClass }>
-								<StatsModulePlaceholder isLoading={ ! viewData } />
-								<Months dataKey={ chartOption } data={ viewData } siteSlug={ slug } showYearTotal />
+				{ isEmptyStateV2 && isRequestingData && (
+					<div className="highlight-cards-list">
+						<Card className={ cardWrapperClassName }>
+							<div className="highlight-card-heading">
+								<h4>{ translate( 'Total views' ) }</h4>
 							</div>
-							<StatsHeatMapLegend />
-						</div>
-
-						{ shouldGateStats && (
-							<StatsCardUpsell
-								statType={ STAT_TYPE_INSIGHTS_ALL_TIME_INSIGHTS }
-								siteId={ siteId }
+							<LoadingPlaceholder
+								className="stats-card-skeleton__placeholder"
+								width="100%"
+								height="200px"
 							/>
-						) }
-					</Card>
-				</div>
+						</Card>
+					</div>
+				) }
+				{ isEmptyStateV2 && ! isRequestingData && ! viewData && ! shouldGateStats && (
+					<StatsCard
+						className={ clsx( 'stats-card--empty-variant' ) }
+						title={ translate( 'Total views' ) }
+						isEmpty
+						emptyMessage={
+							<EmptyModuleCard
+								icon={ seen }
+								description={ translate(
+									'Total and average daily views to your site will display here and learn about views patterns. Start creating and sharing!'
+								) }
+								cards={
+									<>
+										<StatsEmptyActionAI from="module_insights_top_views" />
+										<StatsEmptyActionSocial from="module_insights_top_views" />
+									</>
+								}
+							/>
+						}
+					/>
+				) }
+
+				{ ( ( ! isRequestingData && viewData ) || ! isEmptyStateV2 ) && (
+					<div className="highlight-cards-list">
+						{ /*
+								TODO: Refactor this card along with other similar structure cards to a component
+								supporting overlay inside highlight-cards
+							*/ }
+						<Card className={ cardWrapperClassName }>
+							<div className="highlight-card-heading">
+								<h4>{ translate( 'Total views' ) }</h4>
+								{ viewData && (
+									<SimplifiedSegmentedControl
+										options={ monthViewOptions }
+										onSelect={ toggleViews }
+									/>
+								) }
+							</div>
+
+							<div className="highlight-card-content">
+								<div className={ tableWrapperClass }>
+									<StatsModulePlaceholder isLoading={ ! viewData } />
+									<Months
+										dataKey={ chartOption }
+										data={ viewData }
+										siteSlug={ slug }
+										showYearTotal
+									/>
+								</div>
+								<StatsHeatMapLegend />
+							</div>
+
+							{ shouldGateStats && (
+								<StatsCardUpsell
+									statType={ STAT_TYPE_INSIGHTS_ALL_TIME_INSIGHTS }
+									siteId={ siteId }
+								/>
+							) }
+						</Card>
+					</div>
+				) }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/80

## Proposed Changes

* adding empty state to `Total views` on the Insights page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* it's part of the empty states project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch and verify that the `Total views` module works without the feature flag
* verify that it respects feature restriction
* on your local environment, verify that the new empty state module works properly


![SCR-20240719-ihkm](https://github.com/user-attachments/assets/2dbdec45-bb1b-450d-ab99-a00a3335f2dd)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?