### PR TITLE
Update domain label for multiyear purchase

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -28,7 +28,7 @@ import {
 } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
+import { translate, useTranslate } from 'i18n-calypso';
 import { useState, PropsWithChildren, useRef } from 'react';
 import { getLabel, DefaultLineItemSublabel } from './checkout-labels';
 import {
@@ -687,7 +687,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		isTitanMail( product )
 	) {
 		if ( product.months_per_bill_period === 12 || product.months_per_bill_period === null ) {
-			const billingInterval = translate( 'billed annually' );
+			const billingInterval = getBillingIntervalLabel( { product } );
 			return (
 				<>
 					<DefaultLineItemSublabel product={ product } />: { billingInterval }
@@ -757,11 +757,12 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 
 	if ( ( isDomainRegistration || isDomainMapping ) && product.months_per_bill_period === 12 ) {
 		const premiumLabel = product.extra?.premium ? translate( 'Premium' ) : '';
-
 		return (
 			<>
 				{ premiumLabel } <DefaultLineItemSublabel product={ product } />
-				{ ! product.is_included_for_100yearplan && <>: { translate( 'billed annually' ) }</> }
+				{ ! product.is_included_for_100yearplan && (
+					<>: { getBillingIntervalLabel( { product } ) }</>
+				) }
 			</>
 		);
 	}
@@ -816,6 +817,15 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	}
 
 	return <DefaultLineItemSublabel product={ product } />;
+}
+
+function getBillingIntervalLabel( { product }: { product: ResponseCartProduct } ) {
+	if ( product.volume > 1 ) {
+		return translate( 'billed %(total_years)s years, then annually', {
+			args: { total_years: product.volume },
+		} );
+	}
+	return translate( 'billed annually' );
 }
 
 export function LineItemBillingInterval( { product }: { product: ResponseCartProduct } ) {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -28,7 +28,7 @@ import {
 } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import styled from '@emotion/styled';
-import { translate, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState, PropsWithChildren, useRef } from 'react';
 import { getLabel, DefaultLineItemSublabel } from './checkout-labels';
 import {
@@ -687,7 +687,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		isTitanMail( product )
 	) {
 		if ( product.months_per_bill_period === 12 || product.months_per_bill_period === null ) {
-			const billingInterval = getBillingIntervalLabel( { product } );
+			const billingInterval = GetBillingIntervalLabel( { product } );
 			return (
 				<>
 					<DefaultLineItemSublabel product={ product } />: { billingInterval }
@@ -761,7 +761,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 			<>
 				{ premiumLabel } <DefaultLineItemSublabel product={ product } />
 				{ ! product.is_included_for_100yearplan && (
-					<>: { getBillingIntervalLabel( { product } ) }</>
+					<>: { GetBillingIntervalLabel( { product } ) }</>
 				) }
 			</>
 		);
@@ -819,7 +819,8 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	return <DefaultLineItemSublabel product={ product } />;
 }
 
-function getBillingIntervalLabel( { product }: { product: ResponseCartProduct } ) {
+function GetBillingIntervalLabel( { product }: { product: ResponseCartProduct } ) {
+	const translate = useTranslate();
 	if ( product.volume > 1 ) {
 		return translate( 'billed %(total_years)s years, then annually', {
 			args: { total_years: product.volume },


### PR DESCRIPTION
Related to # https://github.com/Automattic/martech/issues/3167

The sub label for multi-year domain purchases are incorrectly displayed on the checkout screen. 

## Proposed Changes

Update the sub-label text of Domain Registration to accurately reflect multi-year billing options.

**Before** 
<img width="598" alt="image" src="https://github.com/user-attachments/assets/45c6473f-000e-4428-8dcc-2ef9b82ca32b">


**After**
<img width="586" alt="image" src="https://github.com/user-attachments/assets/f802a6e9-bab1-43af-8252-b52b375ea3c0">


## Testing Instructions

- Checkout branch
- Navigate to /domains to start domain checkout flow `http://calypso.localhost:3000/start/domain/`
- Select a paid domain and continue to final checkout step (click Buy Domain if it pops up)
- Change Domain to multi-year 
- Confirm sub-level is in format :  billed ${total_years} years, then annually

