### PR TITLE
Stats: Empty State: Update Comments Module

### DIFF
--- a/client/my-sites/stats/features/modules/stats-comments/index.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './stats-comments';

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -13,19 +13,15 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { INSIGHTS_SUPPORT_URL } from '../../../const';
-import StatsModule from '../../../stats-module';
+import Comments from '../../../stats-comments';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
-const StatsComments: React.FC< StatsDefaultModuleProps > = ( {
-	period,
-	query,
-	moduleStrings,
-	className,
-} ) => {
+const StatsComments: React.FC< StatsDefaultModuleProps > = ( { query, className } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsComments';
+	const moduleTitle = translate( 'Comments' );
 
 	// Use StatsModule to display paywall upsell.
 	const shouldGateStatsModule = useShouldGateStats( statType );
@@ -46,28 +42,20 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( {
 				<StatsCardSkeleton
 					isLoading={ isRequestingData }
 					className={ className }
-					title={ moduleStrings.title }
+					title={ moduleTitle }
 					type={ 3 }
 					withHero
 				/>
 			) }
 			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
 				// show data or an overlay
-				<StatsModule
-					path="comments"
-					moduleStrings={ moduleStrings }
-					period={ period }
-					statType={ statType }
-					hideSummaryLink
-					className={ className }
-					skipQuery
-				/>
+				<Comments path="comments" className={ className } />
 			) }
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
 				// show empty state
 				<StatsCard
 					className={ className }
-					title={ translate( 'Comments' ) }
+					title={ moduleTitle }
 					isEmpty
 					emptyMessage={
 						<EmptyModuleCard

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -2,7 +2,7 @@ import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { comment } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import React, { useMemo } from 'react';
+import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { useSelector } from 'calypso/state';
@@ -34,7 +34,7 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 		getSiteStatsNormalizedData( state, siteId, statType, {} )
 	);
 
-	const hasPosts = useMemo( () => ( data?.posts?.length ?? 0 ) > 0, [ data ] );
+	const hasPosts = data?.posts?.length ?? 0;
 
 	return (
 		<>
@@ -52,7 +52,7 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 			) }
 			{ ( ( ! isRequestingData && hasPosts ) || shouldGateStatsModule ) && (
 				// show data or an overlay
-				<Comments path="comments" className={ className } />
+				<Comments path="comments" className={ className } skipQuery />
 			) }
 			{ ! isRequestingData && ! hasPosts && ! shouldGateStatsModule && (
 				// show empty state

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -2,7 +2,7 @@ import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { comment } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import React, { useMemo } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { useSelector } from 'calypso/state';
@@ -29,9 +29,12 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
 		isRequestingSiteStatsForQuery( state, siteId, statType, {} )
 	);
-	const data = useSelector( ( state ) =>
+
+	const data = useSelector( ( state: StatsStateProps ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, {} )
-	) as [ id: number, label: string ];
+	);
+
+	const hasPosts = useMemo( () => ( data?.posts?.length ?? 0 ) > 0, [ data ] );
 
 	return (
 		<>
@@ -47,11 +50,11 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 					withHero
 				/>
 			) }
-			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
+			{ ( ( ! isRequestingData && hasPosts ) || shouldGateStatsModule ) && (
 				// show data or an overlay
 				<Comments path="comments" className={ className } />
 			) }
-			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
+			{ ! isRequestingData && ! hasPosts && ! shouldGateStatsModule && (
 				// show empty state
 				<StatsCard
 					className={ className }
@@ -61,7 +64,7 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 						<EmptyModuleCard
 							icon={ comment }
 							description={ translate(
-								'Learn about the {{link}}comments{{/link}} your site recieves by authors, posts, and pages.',
+								'Learn about the {{link}}comments{{/link}} your site receives by authors, posts, and pages.',
 								{
 									comment: '{{link}} links to support documentation.',
 									components: {

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -1,0 +1,95 @@
+import { StatsCard } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { comment } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
+import { useSelector } from 'calypso/state';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
+import { INSIGHTS_SUPPORT_URL } from '../../../const';
+import StatsModule from '../../../stats-module';
+import StatsCardSkeleton from '../shared/stats-card-skeleton';
+import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
+
+const StatsComments: React.FC< StatsDefaultModuleProps > = ( {
+	period,
+	query,
+	moduleStrings,
+	className,
+} ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const statType = 'statsComments';
+
+	// Use StatsModule to display paywall upsell.
+	const shouldGateStatsModule = useShouldGateStats( statType );
+
+	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
+		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+	);
+	const data = useSelector( ( state ) =>
+		getSiteStatsNormalizedData( state, siteId, statType, query )
+	) as [ id: number, label: string ];
+
+	return (
+		<>
+			{ ! shouldGateStatsModule && siteId && statType && (
+				<QuerySiteStats statType={ statType } siteId={ siteId } />
+			) }
+			{ isRequestingData && (
+				<StatsCardSkeleton
+					isLoading={ isRequestingData }
+					className={ className }
+					title={ moduleStrings.title }
+					type={ 3 }
+					withHero
+				/>
+			) }
+			{ ( ( ! isRequestingData && !! data?.length ) || shouldGateStatsModule ) && (
+				// show data or an overlay
+				<StatsModule
+					path="comments"
+					moduleStrings={ moduleStrings }
+					period={ period }
+					statType={ statType }
+					hideSummaryLink
+					className={ className }
+					skipQuery
+				/>
+			) }
+			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
+				// show empty state
+				<StatsCard
+					className={ className }
+					title={ translate( 'Comments' ) }
+					isEmpty
+					emptyMessage={
+						<EmptyModuleCard
+							icon={ comment }
+							description={ translate(
+								'Learn about the {{link}}comments{{/link}} your site recieves by authors, posts, and pages.',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: (
+											<a href={ localizeUrl( `${ INSIGHTS_SUPPORT_URL }#all-time-insights` ) } />
+										),
+									},
+									context: 'Stats: Info box label when the Comments module is empty',
+								}
+							) }
+						/>
+					}
+				/>
+			) }
+		</>
+	);
+};
+
+export default StatsComments;

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -17,7 +17,7 @@ import Comments from '../../../stats-comments';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
-const StatsComments: React.FC< StatsDefaultModuleProps > = ( { query, className } ) => {
+const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const statType = 'statsComments';
@@ -27,10 +27,10 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { query, className 
 	const shouldGateStatsModule = useShouldGateStats( statType );
 
 	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
-		isRequestingSiteStatsForQuery( state, siteId, statType, query )
+		isRequestingSiteStatsForQuery( state, siteId, statType, {} )
 	);
 	const data = useSelector( ( state ) =>
-		getSiteStatsNormalizedData( state, siteId, statType, query )
+		getSiteStatsNormalizedData( state, siteId, statType, {} )
 	) as [ id: number, label: string ];
 
 	return (

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -34,7 +34,7 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 		getSiteStatsNormalizedData( state, siteId, statType, {} )
 	);
 
-	const hasPosts = data?.posts?.length ?? 0;
+	const hasPosts = data.posts?.length > 0;
 
 	return (
 		<>

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -17,6 +17,30 @@ import Comments from '../../../stats-comments';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
+interface CommentData {
+	authors: Array< {
+		label: string;
+		value: string;
+		iconClassName: string;
+		icon: string;
+		link: string;
+		className: string;
+		actions: Array< {
+			type: string;
+			data: boolean;
+		} >;
+	} >;
+	posts: Array< {
+		label: string;
+		value: string;
+		page: string;
+		actions: Array< {
+			type: string;
+			data: string;
+		} >;
+	} >;
+}
+
 const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -29,12 +53,11 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
 		isRequestingSiteStatsForQuery( state, siteId, statType, {} )
 	);
-
 	const data = useSelector( ( state: StatsStateProps ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, {} )
-	);
+	) as CommentData;
 
-	const hasPosts = data.posts?.length > 0;
+	const hasPosts = data?.posts?.length > 0;
 
 	return (
 		<>

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -15,6 +15,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import AllTimeHighlightsSection from '../../all-time-highlights-section';
 import AllTimeViewsSection from '../../all-time-views-section';
 import AnnualHighlightsSection from '../../annual-highlights-section';
+import StatsModuleComments from '../../features/modules/stats-comments';
 import StatsModuleTags from '../../features/modules/stats-tags';
 import PostingActivity from '../../post-trends';
 import Comments from '../../stats-comments';
@@ -95,13 +96,24 @@ const StatsInsights = ( props ) => {
 							) }
 						/>
 					) }
-					<Comments
-						path="comments"
-						className={ clsx(
-							'stats__flexible-grid-item--half',
-							'stats__flexible-grid-item--full--large'
-						) }
-					/>
+					{ isEmptyStateV2 && (
+						<StatsModuleComments
+							className={ clsx(
+								'stats__flexible-grid-item--half',
+								'stats__flexible-grid-item--full--large'
+							) }
+						/>
+					) }
+
+					{ ! isEmptyStateV2 && (
+						<Comments
+							path="comments"
+							className={ clsx(
+								'stats__flexible-grid-item--half',
+								'stats__flexible-grid-item--full--large'
+							) }
+						/>
+					) }
 
 					{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for all Jetpack Sites for now. */ }
 					{ ! isJetpack && (

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -37,6 +37,12 @@ class StatsComments extends Component {
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
 		className: PropTypes.string,
+		gateStatsComments: PropTypes.bool,
+		skipQuery: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		skipQuery: false,
 	};
 
 	state = {
@@ -111,6 +117,7 @@ class StatsComments extends Component {
 			translate,
 			className,
 			gateStatsComments,
+			skipQuery,
 		} = this.props;
 		const commentsAuthors = get( commentsStatsData, 'authors' );
 		const commentsPosts = get( commentsStatsData, 'posts' );
@@ -133,8 +140,10 @@ class StatsComments extends Component {
 
 		return (
 			<>
-				{ siteId && <QuerySiteStats statType={ STAT_TYPE_COMMENTS } siteId={ siteId } /> }
-				{ siteId && (
+				{ ! skipQuery && siteId && (
+					<QuerySiteStats statType={ STAT_TYPE_COMMENTS } siteId={ siteId } />
+				) }
+				{ ! skipQuery && siteId && (
 					<QuerySiteStats statType="statsCommentFollowers" siteId={ siteId } query={ { max: 7 } } />
 				) }
 				<StatsListCard
@@ -191,7 +200,7 @@ class StatsComments extends Component {
 }
 
 const connectComponent = connect(
-	( state ) => {
+	( state, ownProps ) => {
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSiteSlug( state, siteId );
 		const gateStatsComments = shouldGateStats( state, siteId, STAT_TYPE_COMMENTS );
@@ -212,6 +221,7 @@ const connectComponent = connect(
 			siteId,
 			siteSlug,
 			gateStatsComments,
+			skipQuery: ownProps.skipQuery,
 		};
 	},
 	{ recordGoogleEvent }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#82](https://github.com/Automattic/red-team/issues/82)

## Proposed Changes

* adding empty state to `Comments` on the Insights page
* adds a `skipQuery` prop to the original comments module to fix infinite loading issue
* adds skeleton loading to module
* adds `shouldGateStatsModule` check to module

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For the empty states project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch and verify that the `Comments` module works without the feature flag
* apply the flag `stats/empty-module-v2` 
* verify that a page with empty Comments views component works with and without the feature flag
* repeat for blogs with Comments data

![image](https://github.com/user-attachments/assets/186459a3-76a9-4f2a-8b2f-e88ff93a20a8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
