### PR TITLE
Add global color scheme for masterbar on top level pages

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -251,17 +251,17 @@ class Layout extends Component {
 	/**
 	 * Refresh the color scheme if
 	 * - the color scheme has changed
-	 * - the global sidebar is visible and the color scheme is not `modern`
-	 * - the global sidebar was visible and is now hidden and the color scheme is not `modern`
+	 * - the global sidebar is visible and the color scheme is not `global`
+	 * - the global sidebar was visible and is now hidden and the color scheme is not `global`
 	 * @param prevProps object
 	 */
 	componentDidUpdate( prevProps ) {
 		if (
 			prevProps.colorScheme !== this.props.colorScheme ||
-			( this.props.isGlobalSidebarVisible && this.props.colorScheme !== 'modern' ) ||
+			( this.props.isGlobalSidebarVisible && this.props.colorScheme !== 'global' ) ||
 			( prevProps.isGlobalSidebarVisible &&
 				! this.props.isGlobalSidebarVisible &&
-				this.props.colorScheme !== 'modern' )
+				this.props.colorScheme !== 'global' )
 		) {
 			this.refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
 		}
@@ -274,7 +274,7 @@ class Layout extends Component {
 
 		if ( typeof document !== 'undefined' ) {
 			const classList = document.querySelector( 'body' ).classList;
-			const globalColorScheme = 'modern';
+			const globalColorScheme = 'global';
 
 			if ( this.props.isGlobalSidebarVisible ) {
 				// Force the global color scheme when the global sidebar is visible.

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -320,7 +320,7 @@ body.is-mobile-app-view {
 				display: inline-block;
 				width: 100%;
 				padding: 0 0 0 6px;
-				color: var(--color-masterbar-text);
+				color: var(--color-masterbar-submenu-text, var(--color-masterbar-text));
 			}
 
 			.is-link {
@@ -332,14 +332,14 @@ body.is-mobile-app-view {
 				text-align: left;
 
 				&:hover {
-					color: var(--color-masterbar-highlight);
+					color: var(--color-masterbar-submenu-hover-text, var(--color-masterbar-highlight));
 				}
 			}
 
 			&:hover {
 				background: var(--color-masterbar-item-hover-background);
 				a {
-					color: var(--color-masterbar-highlight);
+					color: var(--color-masterbar-submenu-hover-text, var(--color-masterbar-highlight));
 				}
 			}
 

--- a/packages/calypso-color-schemes/src/calypso-color-schemes.scss
+++ b/packages/calypso-color-schemes/src/calypso-color-schemes.scss
@@ -10,6 +10,7 @@
 @import "shared/color-schemes/contrast";
 @import "shared/color-schemes/ectoplasm";
 @import "shared/color-schemes/fresh";
+@import "shared/color-schemes/global";
 @import "shared/color-schemes/light";
 @import "shared/color-schemes/midnight";
 @import "shared/color-schemes/modern";

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
@@ -20,7 +20,7 @@ $link-focus: darken($highlight-color, 10%);
 Uses custom theme highlight monochromatic palette for primary + accent
 */
 
-.color-scheme.is-modern {
+.color-scheme.is-global {
 	/* Variables used in Calypso Modern */
 	--theme-text-color: #fff; /* Direct from wp-admin */
 	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
@@ -22,13 +22,13 @@ Uses custom theme highlight monochromatic palette for primary + accent
 
 .color-scheme.is-global {
 	/* Variables used in Calypso Modern */
-	--theme-text-color: #fff; /* Direct from wp-admin */
-	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */
-	--theme-base-color: #1e1e1e; /* Direct from wp-admin */
-	--theme-base-color-rgb: 30, 30, 30; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
-	--theme-submenu-text-color: #bcbcbc; /* mix( $base-color, $text-color, 30% ) */
-	--theme-submenu-background-color: #0c0c0c; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
-	--theme-icon-color: #ece6f6; /* Direct from wp-admin */
+	--theme-text-color: #f6f7f7; /* Direct from wp-admin */
+	--theme-text-color-rgb: 44, 51, 56; /* Manual conversion */
+	--theme-base-color: #2c3338; /* Direct from wp-admin */
+	--theme-base-color-rgb: 246, 247, 247; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
+	--theme-submenu-text-color: #f6f7f7; /* mix( $base-color, $text-color, 30% ) */
+	--theme-submenu-background-color: #1e1e1e; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
+	--theme-icon-color: #f6f7f7; /* Direct from wp-admin */
 	--theme-highlight-color: #3858e9; /* Direct from wp-admin */
 	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
 	--theme-notification-color: #3858e9; /* Direct from wp-admin */
@@ -133,11 +133,13 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	--color-masterbar-border: var(--theme-submenu-background-color);
 	--color-masterbar-text: var(--theme-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
-	--color-masterbar-highlight: var(--theme-highlight-color);
+	--color-masterbar-highlight: var(--theme-text-color);
 	--color-masterbar-unread-dot-background: var(--theme-notification-color);
-
 	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);
 	--color-masterbar-item-active-background: var(--theme-submenu-background-color);
+	--color-masterbar-submenu-text: var(--studio-gray-10);
+	--color-masterbar-submenu-hover-text: var(--theme-text-color);
+
 	--color-masterbar-item-new-editor-background: var(--studio-gray-50);
 	--color-masterbar-item-new-editor-hover-background: var(--studio-gray-60);
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
@@ -22,13 +22,13 @@ Uses custom theme highlight monochromatic palette for primary + accent
 
 .color-scheme.is-global {
 	/* Variables used in Calypso Modern */
-	--theme-text-color: #fff; /* Direct from wp-admin */
-	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */
-	--theme-base-color: #1e1e1e; /* Direct from wp-admin */
-	--theme-base-color-rgb: 30, 30, 30; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
-	--theme-submenu-text-color: #bcbcbc; /* mix( $base-color, $text-color, 30% ) */
-	--theme-submenu-background-color: #0c0c0c; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
-	--theme-icon-color: #ece6f6; /* Direct from wp-admin */
+	--theme-text-color: #2c3338; /* Direct from wp-admin */
+	--theme-text-color-rgb: 44, 51, 56; /* Manual conversion */
+	--theme-base-color: #f6f7f7; /* Direct from wp-admin */
+	--theme-base-color-rgb: 246, 247, 247; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
+	--theme-submenu-text-color: #1e1e1e; /* mix( $base-color, $text-color, 30% ) */
+	--theme-submenu-background-color: #f6f7f7; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
+	--theme-icon-color: #1e1e1e; /* Direct from wp-admin */
 	--theme-highlight-color: #3858e9; /* Direct from wp-admin */
 	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
 	--theme-notification-color: #3858e9; /* Direct from wp-admin */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
@@ -22,13 +22,13 @@ Uses custom theme highlight monochromatic palette for primary + accent
 
 .color-scheme.is-global {
 	/* Variables used in Calypso Modern */
-	--theme-text-color: #2c3338; /* Direct from wp-admin */
-	--theme-text-color-rgb: 44, 51, 56; /* Manual conversion */
-	--theme-base-color: #f6f7f7; /* Direct from wp-admin */
-	--theme-base-color-rgb: 246, 247, 247; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
-	--theme-submenu-text-color: #1e1e1e; /* mix( $base-color, $text-color, 30% ) */
-	--theme-submenu-background-color: #f6f7f7; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
-	--theme-icon-color: #1e1e1e; /* Direct from wp-admin */
+	--theme-text-color: #fff; /* Direct from wp-admin */
+	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */
+	--theme-base-color: #1e1e1e; /* Direct from wp-admin */
+	--theme-base-color-rgb: 30, 30, 30; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
+	--theme-submenu-text-color: #bcbcbc; /* mix( $base-color, $text-color, 30% ) */
+	--theme-submenu-background-color: #0c0c0c; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
+	--theme-icon-color: #ece6f6; /* Direct from wp-admin */
 	--theme-highlight-color: #3858e9; /* Direct from wp-admin */
 	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
 	--theme-notification-color: #3858e9; /* Direct from wp-admin */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
@@ -1,34 +1,16 @@
 /*
-WP Admin Unthemed definitions:
-
-$text-color: #fff !default;
-$base-color: #23282d !default;
-$icon-color: hsl( hue( $base-color ), 7%, 95% ) !default;
-$highlight-color: #0073aa !default;
-$notification-color: #d54e21 !default;
-
-WP Admin Modern Definition:
-
-$base-color: #1e1e1e;
-$highlight-color: #3858e9;
-$menu-submenu-focus-text: #33f078;     <-- Applied to --color-sidebar-submenu-hover-text.
-$notification-color: $highlight-color;
-
-$link: $highlight-color;
-$link-focus: darken($highlight-color, 10%);
-
-Uses custom theme highlight monochromatic palette for primary + accent
+WPCom Global theme, Modern theme adjusted for use in calypso non site contexts
 */
 
 .color-scheme.is-global {
 	/* Variables used in Calypso Modern */
-	--theme-text-color: #f6f7f7; /* Direct from wp-admin */
-	--theme-text-color-rgb: 44, 51, 56; /* Manual conversion */
-	--theme-base-color: #2c3338; /* Direct from wp-admin */
-	--theme-base-color-rgb: 246, 247, 247; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
-	--theme-submenu-text-color: #f6f7f7; /* mix( $base-color, $text-color, 30% ) */
-	--theme-submenu-background-color: #1e1e1e; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
-	--theme-icon-color: #f6f7f7; /* Direct from wp-admin */
+	--theme-text-color: #fff; /* Direct from wp-admin */
+	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */
+	--theme-base-color: #1e1e1e; /* Direct from wp-admin */
+	--theme-base-color-rgb: 30, 30, 30; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
+	--theme-submenu-text-color: #bcbcbc; /* mix( $base-color, $text-color, 30% ) */
+	--theme-submenu-background-color: #0c0c0c; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
+	--theme-icon-color: #ece6f6; /* Direct from wp-admin */
 	--theme-highlight-color: #3858e9; /* Direct from wp-admin */
 	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
 	--theme-notification-color: #3858e9; /* Direct from wp-admin */

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_global.scss
@@ -1,0 +1,184 @@
+/*
+WP Admin Unthemed definitions:
+
+$text-color: #fff !default;
+$base-color: #23282d !default;
+$icon-color: hsl( hue( $base-color ), 7%, 95% ) !default;
+$highlight-color: #0073aa !default;
+$notification-color: #d54e21 !default;
+
+WP Admin Modern Definition:
+
+$base-color: #1e1e1e;
+$highlight-color: #3858e9;
+$menu-submenu-focus-text: #33f078;     <-- Applied to --color-sidebar-submenu-hover-text.
+$notification-color: $highlight-color;
+
+$link: $highlight-color;
+$link-focus: darken($highlight-color, 10%);
+
+Uses custom theme highlight monochromatic palette for primary + accent
+*/
+
+.color-scheme.is-modern {
+	/* Variables used in Calypso Modern */
+	--theme-text-color: #fff; /* Direct from wp-admin */
+	--theme-text-color-rgb: 255, 255, 255; /* Manual conversion */
+	--theme-base-color: #1e1e1e; /* Direct from wp-admin */
+	--theme-base-color-rgb: 30, 30, 30; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
+	--theme-submenu-text-color: #bcbcbc; /* mix( $base-color, $text-color, 30% ) */
+	--theme-submenu-background-color: #0c0c0c; /* darken( $base-color, 7% ), computed: http://scg.ar-ch.org/ */
+	--theme-icon-color: #ece6f6; /* Direct from wp-admin */
+	--theme-highlight-color: #3858e9; /* Direct from wp-admin */
+	--theme-highlight-color-rgb: 56, 88, 233; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
+	--theme-notification-color: #3858e9; /* Direct from wp-admin */
+
+	/* Theme highlight monochromatic palette */
+	--theme-highlight-color-0: #d5dffa;
+	--theme-highlight-color-0-rgb: 213, 223, 250;
+	--theme-highlight-color-5: #d7defa;
+	--theme-highlight-color-5-rgb: 215, 222, 250;
+	--theme-highlight-color-10: #abc0f5;
+	--theme-highlight-color-10-rgb: 171, 192, 245;
+	--theme-highlight-color-20: #82a1f0;
+	--theme-highlight-color-20-rgb: 130, 161, 240;
+	--theme-highlight-color-30: #5882eb;
+	--theme-highlight-color-30-rgb: 88, 130, 235;
+	--theme-highlight-color-40: #2f63e6;
+	--theme-highlight-color-40-rgb: 47, 99, 230;
+	--theme-highlight-color-50: var(--theme-highlight-color);
+	--theme-highlight-color-50-rgb: var(--theme-highlight-color-rgb);
+	--theme-highlight-color-60: #2145e6; /* Direct from Gutenberg */
+	--theme-highlight-color-60-rgb: 33, 69, 230; /* Manually computed https://www.rapidtables.com/convert/color/hex-to-rgb.html */
+	--theme-highlight-color-70: #133ca6;
+	--theme-highlight-color-70-rgb: 19, 60, 166;
+	--theme-highlight-color-80: #0e2d7c;
+	--theme-highlight-color-80-rgb: 14, 45, 124;
+	--theme-highlight-color-90: #091e53;
+	--theme-highlight-color-90-rgb: 9, 30, 83;
+	--theme-highlight-color-100: #040f29;
+	--theme-highlight-color-100-rgb: 4, 15, 41;
+
+	/* Links */
+	--color-link: var(--theme-highlight-color);
+	--color-link-dark: var(--theme-highlight-color-70);
+	--color-link-light: var(--theme-highlight-color-30);
+
+	/* Primary */
+	--color-primary: var(--theme-highlight-color);
+	--color-primary-rgb: var(--theme-highlight-color-rgb);
+	--color-primary-dark: var(--theme-highlight-color-70);
+	--color-primary-dark-rgb: var(--theme-highlight-color-70-rgb);
+	--color-primary-light: var(--theme-highlight-color-30);
+	--color-primary-light-rgb: var(--theme-highlight-color-30-rgb);
+	--color-primary-0: var(--theme-highlight-color-0);
+	--color-primary-0-rgb: var(--theme-highlight-color-0-rgb);
+	--color-primary-5: var(--theme-highlight-color-5);
+	--color-primary-5-rgb: var(--theme-highlight-color-5-rgb);
+	--color-primary-10: var(--theme-highlight-color-10);
+	--color-primary-10-rgb: var(--theme-highlight-color-10-rgb);
+	--color-primary-20: var(--theme-highlight-color-20);
+	--color-primary-20-rgb: var(--theme-highlight-color-20-rgb);
+	--color-primary-30: var(--theme-highlight-color-30);
+	--color-primary-30-rgb: var(--theme-highlight-color-30-rgb);
+	--color-primary-40: var(--theme-highlight-color-40);
+	--color-primary-40-rgb: var(--theme-highlight-color-40-rgb);
+	--color-primary-50: var(--theme-highlight-color-50);
+	--color-primary-50-rgb: var(--theme-highlight-color-50-rgb);
+	--color-primary-60: var(--theme-highlight-color-60);
+	--color-primary-60-rgb: var(--theme-highlight-color-60-rgb);
+	--color-primary-70: var(--theme-highlight-color-70);
+	--color-primary-70-rgb: var(--theme-highlight-color-70-rgb);
+	--color-primary-80: var(--theme-highlight-color-80);
+	--color-primary-80-rgb: var(--theme-highlight-color-80-rgb);
+	--color-primary-90: var(--theme-highlight-color-90);
+	--color-primary-90-rgb: var(--theme-highlight-color-90-rgb);
+	--color-primary-100: var(--theme-highlight-color-100);
+	--color-primary-100-rgb: var(--theme-highlight-color-100-rgb);
+
+	/* Accent */
+	--color-accent: var(--theme-highlight-color);
+	--color-accent-rgb: var(--theme-highlight-color-rgb);
+	--color-accent-dark: var(--theme-highlight-color-70);
+	--color-accent-dark-rgb: var(--theme-highlight-color-70-rgb);
+	--color-accent-light: var(--theme-highlight-color-30);
+	--color-accent-light-rgb: var(--theme-highlight-color-30-rgb);
+	--color-accent-0: var(--theme-highlight-color-0);
+	--color-accent-0-rgb: var(--theme-highlight-color-0-rgb);
+	--color-accent-5: var(--theme-highlight-color-5);
+	--color-accent-5-rgb: var(--theme-highlight-color-5-rgb);
+	--color-accent-10: var(--theme-highlight-color-10);
+	--color-accent-10-rgb: var(--theme-highlight-color-10-rgb);
+	--color-accent-20: var(--theme-highlight-color-20);
+	--color-accent-20-rgb: var(--theme-highlight-color-20-rgb);
+	--color-accent-30: var(--theme-highlight-color-30);
+	--color-accent-30-rgb: var(--theme-highlight-color-30-rgb);
+	--color-accent-40: var(--theme-highlight-color-40);
+	--color-accent-40-rgb: var(--theme-highlight-color-40-rgb);
+	--color-accent-50: var(--theme-highlight-color-50);
+	--color-accent-50-rgb: var(--theme-highlight-color-50-rgb);
+	--color-accent-60: var(--theme-highlight-color-60);
+	--color-accent-60-rgb: var(--theme-highlight-color-60-rgb);
+	--color-accent-70: var(--theme-highlight-color-70);
+	--color-accent-70-rgb: var(--theme-highlight-color-70-rgb);
+	--color-accent-80: var(--theme-highlight-color-80);
+	--color-accent-80-rgb: var(--theme-highlight-color-80-rgb);
+	--color-accent-90: var(--theme-highlight-color-90);
+	--color-accent-90-rgb: var(--theme-highlight-color-90-rgb);
+	--color-accent-100: var(--theme-highlight-color-100);
+	--color-accent-100-rgb: var(--theme-highlight-color-100-rgb);
+
+	/* Masterbar */
+	--color-masterbar-background: var(--theme-base-color);
+	--color-masterbar-border: var(--theme-submenu-background-color);
+	--color-masterbar-text: var(--theme-text-color);
+	--color-masterbar-icon: var(--theme-icon-color);
+	--color-masterbar-highlight: var(--theme-highlight-color);
+	--color-masterbar-unread-dot-background: var(--theme-notification-color);
+
+	--color-masterbar-item-hover-background: var(--theme-submenu-background-color);
+	--color-masterbar-item-active-background: var(--theme-submenu-background-color);
+	--color-masterbar-item-new-editor-background: var(--studio-gray-50);
+	--color-masterbar-item-new-editor-hover-background: var(--studio-gray-60);
+
+	--color-masterbar-toggle-drafts-editor-background: var(--studio-gray-60);
+	--color-masterbar-toggle-drafts-editor-hover-background: var(--studio-gray-40);
+	--color-masterbar-toggle-drafts-editor-border: var(--studio-gray-10);
+
+	/* Sidebar */
+	--color-sidebar-background: var(--theme-base-color);
+	--color-sidebar-background-rgb: var(--theme-base-color-rgb);
+	--color-sidebar-border: var(--theme-submenu-background-color);
+	--color-sidebar-text: var(--theme-text-color);
+	--color-sidebar-text-rgb: var(--theme-text-color-rgb);
+	--color-sidebar-text-alternative: var(--studio-gray-10);
+	--color-sidebar-gridicon-fill: var(--studio-gray-0);
+
+	/* Sidebar Selected */
+	--color-sidebar-menu-selected-background: var(--theme-highlight-color);
+	--color-sidebar-menu-selected-background-rgb: var(--theme-highlight-color-rgb);
+	--color-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-sidebar-menu-selected-text-rgb: var(--theme-text-color-rgb);
+
+	/* Sidebar Hover */
+	--color-sidebar-menu-hover-background: var(--theme-highlight-color);
+	--color-sidebar-menu-hover-background-rgb: var(--theme-highlight-color-rgb);
+	--color-sidebar-menu-hover-text: var(--theme-text-color);
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var(--theme-submenu-background-color);
+	--color-sidebar-submenu-text: var(--theme-submenu-text-color);
+	--color-sidebar-submenu-hover-background: transparent;
+	--color-sidebar-submenu-hover-text: var(--theme-highlight-color); /* $menu-submenu-focus-text */
+	--color-sidebar-submenu-selected-hover-text: var(--color-sidebar-submenu-hover-text);
+
+	/* Sidebar Submenu - Nav Redesign */
+	--color-navredesign-sidebar-submenu-text: var(--color-sidebar-submenu-text);
+	--color-navredesign-sidebar-menu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-selected-text: var(--theme-text-color);
+	--color-navredesign-sidebar-submenu-hover-text: var(--theme-highlight-color); /* $menu-submenu-focus-text */
+	--color-navredesign-sidebar-submenu-selected-hover-text: var(--color-sidebar-submenu-hover-text);
+
+	/* Command Palette Items */
+	--wp-admin-theme-color: var(--theme-highlight-color);
+}


### PR DESCRIPTION
Follow up on https://github.com/Automattic/wp-calypso/pull/92472 (i3 masterbar redesign) and https://github.com/Automattic/wp-calypso/pull/92621 (color schemes)

## Proposed Changes

* Adds a new color scheme called "global" for use when the global side bar is active. e.g. top level contexts without any site.

Before
![Screenshot_2024-07-18_15-06-21](https://github.com/user-attachments/assets/0020d78f-1cd7-4255-bf96-8998c3a4d80e)

After
![Screenshot_2024-07-18_15-05-46](https://github.com/user-attachments/assets/8137b6da-ae22-46ef-afd2-7b2432aac11a)
