### PR TITLE
Contrast colorscheme: Match dropdown background with sidebar submenu background

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
@@ -109,7 +109,7 @@
 	--color-masterbar-text: var(--studio-white);
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--studio-yellow-20);
-	--color-masterbar-item-hover-background: var(--studio-white);
+	--color-masterbar-item-hover-background: var(--studio-gray-90);
 	--color-masterbar-item-active-background: var(--studio-gray-60);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-70);
 	--color-masterbar-item-new-editor-hover-background: var(--studio-gray-90);


### PR DESCRIPTION
Follow up on https://github.com/Automattic/wp-calypso/pull/92472 (i3 masterbar redesign) and https://github.com/Automattic/wp-calypso/pull/92621 (color schemes)

Related https://github.com/Automattic/wp-calypso/pull/92783

## Proposed Changes

* Fixes dropdown menu background on contrast colorscheme

Before

![contrast-before](https://github.com/user-attachments/assets/3e831061-3191-45db-8fc3-db139b02721c)

After

![constrast-after](https://github.com/user-attachments/assets/9b5f7d0a-7ac2-4538-8e07-a56c81042299)

