### PR TITLE
A4A: Improve the migration offer support ticket default message to encourage users to provide more info.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
@@ -25,13 +25,18 @@ export default function A4AContactSupportWidget() {
 		setShowUserSupportForm( true );
 	}
 
+	const migrationOfferDefaultMessage =
+		translate( "I'd like to chat more about the migration offer." ) +
+		'\n\n' +
+		translate( '[your message here]' );
+
 	return (
 		<UserContactSupportModalForm
 			show={ showUserSupportForm }
 			onClose={ onCloseUserSupportForm }
 			defaultMessage={
 				window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT
-					? translate( "I'd like to chat more about the migration offer." )
+					? migrationOfferDefaultMessage
 					: undefined
 			}
 		/>


### PR DESCRIPTION
This PR modifies the default message to include placeholder text to encourage users to provide more information when contacting support about the migration offer.

Context: https://github.com/Automattic/automattic-for-agencies-dev/issues/446#issuecomment-2192252925

| Before | After |
|--------|--------|
| <img width="839" alt="Screenshot 2024-07-18 at 1 58 10 PM" src="https://github.com/user-attachments/assets/27e3036d-cded-4031-a438-e56c94f8e507"> | <img width="901" alt="Screenshot 2024-07-18 at 1 57 39 PM" src="https://github.com/user-attachments/assets/4b0ef57c-7781-41ed-a535-45385c5ec710"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/446

## Proposed Changes

* Include the `[your message here]` placeholder in the default migration offer support ticket message to encourage the user to provide more information.


## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* Click the 'Contact us' button on the Migration offer banner.
* Confirm that the default message has the `[your message here]` text.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
