### PR TITLE
Plans (State): Update manage-purchase component to utilise data-store pricing

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -939,7 +939,6 @@ export function purchaseType( purchase: Purchase ) {
 }
 
 export function getRenewalPrice( purchase: Purchase ) {
-	// TODO clk this returns non-integer values, which breaks comparisons/operations with plan integer-based pricing
 	return purchase.saleAmount || purchase.amount;
 }
 

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -939,6 +939,7 @@ export function purchaseType( purchase: Purchase ) {
 }
 
 export function getRenewalPrice( purchase: Purchase ) {
+	// TODO clk this returns non-integer values, which breaks comparisons/operations with plan integer-based pricing
 	return purchase.saleAmount || purchase.amount;
 }
 

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -456,6 +456,7 @@ class ManagePurchase extends Component<
 			return null;
 		}
 		const annualPrice = getRenewalPrice( purchase ) / 12;
+		// TODO clk this breaks due to comparing integer (plan) with non-integer (purchase) pricing
 		const savings = Math.floor(
 			( 100 * ( relatedMonthlyPlanPrice - annualPrice ) ) / relatedMonthlyPlanPrice
 		);

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -48,6 +48,7 @@ import {
 	PlanPrice,
 	MaterialIcon,
 } from '@automattic/components';
+import { Plans, type SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
 import clsx from 'clsx';
@@ -102,6 +103,7 @@ import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import WordAdsEligibilityWarningDialog from 'calypso/me/purchases/wordads-eligibility-warning-dialog';
 import PlanRenewalMessage from 'calypso/my-sites/plans/jetpack-plans/plan-renewal-message';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import {
 	getCancelPurchaseUrlFor,
 	getAddNewPaymentMethodUrlFor,
@@ -128,7 +130,6 @@ import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { useGetWebsiteContentQuery } from 'calypso/state/signup/steps/website-content/hooks/use-get-website-content-query';
 import { hasLoadedSiteDomains, getAllDomains } from 'calypso/state/sites/domains/selectors';
-import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
 import { getSite, getSiteSlug, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { CalypsoDispatch, IAppState } from 'calypso/state/types';
@@ -148,8 +149,7 @@ import {
 import PurchaseNotice from './notices';
 import PurchasePlanDetails from './plan-details';
 import PurchaseMeta from './purchase-meta';
-import type { FilteredPlan } from '@automattic/calypso-products';
-import type { SiteDetails } from '@automattic/data-stores';
+import type { FilteredPlan, PlanSlug } from '@automattic/calypso-products';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { TracksProps } from 'calypso/lib/purchases';
 import type {
@@ -1561,6 +1561,32 @@ function PurchasesQueryComponent( {
 	return <QueryUserPurchases />;
 }
 
+/**
+ * Gradually move more of the `connect` logic to this component
+ */
+const WrappedManagePurchase = (
+	props: Omit<
+		ManagePurchaseProps & ManagePurchaseConnectedProps & LocalizeProps,
+		'relatedMonthlyPlanPrice'
+	>
+) => {
+	const { siteId, relatedMonthlyPlanSlug } = props;
+	const pricing = Plans.usePricingMetaForGridPlans( {
+		planSlugs: [ relatedMonthlyPlanSlug as PlanSlug ],
+		siteId,
+		coupon: undefined,
+		storageAddOns: null,
+		useCheckPlanAvailabilityForPurchase,
+	} );
+
+	return (
+		<ManagePurchase
+			{ ...props }
+			relatedMonthlyPlanPrice={ pricing?.[ relatedMonthlyPlanSlug ]?.originalPrice.monthly ?? 0 }
+		/>
+	);
+};
+
 export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
 
@@ -1581,9 +1607,6 @@ export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 	const hasLoadedSites = ! isRequestingSites( state );
 	const hasLoadedDomains = hasLoadedSiteDomains( state, siteId );
 	const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug ?? '' );
-	const relatedMonthlyPlanPrice = siteId
-		? getSitePlanRawPrice( state, siteId, relatedMonthlyPlanSlug ) ?? 0
-		: 0;
 	const primaryDomain = getPrimaryDomainBySiteId( state, siteId );
 	const currentRoute = getCurrentRoute( state );
 
@@ -1612,7 +1635,6 @@ export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 		purchase,
 		purchaseAttachedTo,
 		purchases,
-		relatedMonthlyPlanPrice,
 		relatedMonthlyPlanSlug,
 		renewableSitePurchases,
 		selectedSiteId,
@@ -1620,7 +1642,7 @@ export default connect( ( state: IAppState, props: ManagePurchaseProps ) => {
 		siteId,
 		theme: isPurchaseTheme && siteId && getCanonicalTheme( state, siteId, purchase.meta ?? null ),
 	};
-}, mapDispatchToProps )( localize( ManagePurchase ) );
+}, mapDispatchToProps )( localize( WrappedManagePurchase ) );
 
 function mapDispatchToProps( dispatch: CalypsoDispatch ) {
 	return {

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1271,7 +1271,6 @@ class ManagePurchase extends Component<
 						isProductOwner={ isProductOwner }
 					/>
 				) }
-
 				{ isProductOwner && ! purchase.isLocked && (
 					<>
 						{ preventRenewal && this.renderSelectNewNavItem() }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -76,7 +76,7 @@ import {
 	getDomainRegistrationAgreementUrl,
 	getDisplayName,
 	getPartnerName,
-	getRenewalPrice,
+	getRenewalPriceInSmallestUnit,
 	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
 	hasAmountAvailableToRefund,
@@ -455,11 +455,11 @@ class ManagePurchase extends Component<
 		if ( ! purchase ) {
 			return null;
 		}
-		const annualPrice = getRenewalPrice( purchase ) / 12;
-		// TODO clk this breaks due to comparing integer (plan) with non-integer (purchase) pricing
+		const annualPrice = getRenewalPriceInSmallestUnit( purchase ) / 12;
 		const savings = Math.floor(
 			( 100 * ( relatedMonthlyPlanPrice - annualPrice ) ) / relatedMonthlyPlanPrice
 		);
+
 		return this.renderRenewalNavItem(
 			<div>
 				{ translate( 'Renew annually' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

Updates the "manage purchase" screen to utilize pricing from the Plans data-store for the yearly renewal nudge/upsell. 

<img width="600" alt="Screenshot 2024-07-18 at 2 02 20 PM" src="https://github.com/user-attachments/assets/c6472dc3-e1db-44d6-a21b-d8310fd79905">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We only need one form of handling plan pricing in the code base, more so one framework. Anything else risks having alternative and differing views of the same data propagating across the code base.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site on a paid annual plan
* Go to SA and change the expiration date on the purchase to be < 30 days
* Go to `/me/purchases/[site]/[purchase-id]` and confirm `%` savings to renewing yearly are visible and correct (per media above / production)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
