### PR TITLE
Social: Recommend manual sharing where we say Twitter is not supported

### DIFF
--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -616,7 +616,7 @@ export class SharingService extends Component {
 											icon
 											iconSize={ 14 }
 											href={ localizeUrl(
-												'https://jetpack.com/support/jetpack-social/jetpack-social-manual-sharing-posts/'
+												'https://jetpack.com/redirect/?source=jetpack-social-manual-sharing-help'
 											) }
 										/>
 									),

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -595,7 +595,7 @@ export class SharingService extends Component {
 					/>
 					<Notice isCompact status="is-error" className="sharing-service__unsupported">
 						{ this.props.translate(
-							'Twitter is no longer supported. {{a}}Learn more about this{{/a}}',
+							'X (Twitter) is {{a}}no longer supported{{/a}}. You can still use our quick {{a2}}manual sharing{{/a2}} feature from the post editor to share to it!',
 							{
 								components: {
 									a: (
@@ -607,6 +607,16 @@ export class SharingService extends Component {
 												this.props.isJetpack || isJetpackCloud()
 													? 'https://jetpack.com/2023/04/29/the-end-of-twitter-auto-sharing/'
 													: 'https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/'
+											) }
+										/>
+									),
+									a2: (
+										<ExternalLink
+											target="_blank"
+											icon
+											iconSize={ 14 }
+											href={ localizeUrl(
+												'https://jetpack.com/support/jetpack-social/jetpack-social-manual-sharing-posts/'
 											) }
 										/>
 									),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-reach/issues/464

## Proposed Changes

* Added another sentence and a link to the blog post for the usage guide for manual sharing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve visibility over Manual Sharing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the connections page in Calypso and in Jetpack Cloud
* Make sure you see the extra sentence and the hyperlinks work as expected.

![CleanShot 2024-07-18 at 14 01 31 png](https://github.com/user-attachments/assets/c5b41249-3b14-4bc6-bd25-c8b3e94e8bed)

![CleanShot 2024-07-18 at 13 59 23 png](https://github.com/user-attachments/assets/e2da5ea0-4f48-42c4-a9e9-ccab9be22164)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
