### PR TITLE
A4A: Fix filtering and pagination on license search

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
@@ -40,7 +40,9 @@ export default function useFetchLicenses(
 				},
 				{
 					...( agencyId && { agency_id: agencyId } ),
-					...( search ? { search: search } : { filter: filter, page: page } ),
+					...( search && { search: search } ),
+					filter: filter,
+					page: page,
 					sort_field: sortField,
 					sort_direction: sortDirection,
 					per_page: LICENSES_PER_PAGE,

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-search/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-search/index.tsx
@@ -1,3 +1,5 @@
+import page from '@automattic/calypso-router';
+import { removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import Search from 'calypso/components/search';
@@ -18,6 +20,7 @@ const LicenseSearch = ( { doSearch }: Props ) => {
 
 	const onSearch = ( query: string ) => {
 		dispatch( recordTracksEvent( 'calypso_a4a_license_list_search', { query } ) );
+		page( removeQueryArgs( window.location.pathname, 'page' ) ); // remove page query param before searching
 		doSearch( query );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

* https://github.com/Automattic/wp-calypso/pull/92757
* D155523-code

## Proposed Changes

Fixes a few issues related to the license search functionality:

* Search not including the current view filter.
* Pagination not working for search queries.
* Page number not resetting on each search query.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Apply D155523-code
* Open the live link, login with demo account, and go to /purchases/licenses
* Sandbox public-api to test with the changes from D155523-code.

Test the following:

| Scenario | Expected Outcome |
| -------- | ---------------- |
| Search for "boost" | You should see only the active Jetpack Boost license, not the revoked license from the "Revoked" view. |
| Search for "w" | This will give you all products that start with that letter. Test the pagination. |
| Go to page 2 on any view and search for a product | Pagination should reset back to 1. |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?