### PR TITLE
Professional Email Signup Flow: Remove second free plan CTA

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -229,15 +229,8 @@ export class PlansStep extends Component {
 			);
 		}
 
-		const freePlanButton = (
-			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />
-		);
-
 		if ( useEmailOnboardingSubheader ) {
-			return translate(
-				'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.',
-				{ components: { link: freePlanButton } }
-			);
+			return translate( 'Add more features to your professional website with a plan.' );
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8217-gh-Automattic/dotcom-forge

## Proposed Changes

Remove the free plan CTA in the subheading of `start/onboarding-with-email/mailbox-plan`

Because we have a dedicated prop for the subheading as a whole, I've opted to leave the main text in place, and only remove the CTA and link. If we'd like to fully match `/start` we can also [set](https://github.com/Automattic/wp-calypso/blob/b19418b2cc7ea42aa07da083d71fcca7841458dd/client/signup/config/steps-pure.js#L361) `useEmailOnboardingSubheader` to `false`.

## Why are these changes being made?

During a recent walkthrough it was noticed  that we have two Free plan CTAs on this flow, which potentially draws attention away from our paid plans. Instead, we're mirroring the Plan step from the `/start` flow, and removing the additional CTA in the subheader.

See above issue for further context and related conversations.

## Testing Instructions

- Begin on `start/onboarding-with-email/mailbox-domain?ref=professional-email`, which is your first stop after clicking the initial CTA on the [Professional Email landing page](https://wordpress.com/professional-email/).
- Proceed through the on screen instructions until you reach the Plans step
- Confirm that the subheader is present, but does not make any mention of the Free plan
