### PR TITLE
Plans Grid: move logic from action component to action hook

### DIFF
--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -109,7 +109,7 @@ const PlansPageSubheader = ( {
 	deemphasizeFreePlan?: boolean;
 	offeringFreePlan?: boolean;
 	showPlanBenefits?: boolean;
-	onFreePlanCTAClick: () => void;
+	onFreePlanCTAClick: ( () => void ) | null;
 } ) => {
 	const translate = useTranslate();
 
@@ -121,7 +121,7 @@ const PlansPageSubheader = ( {
 						`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
 						{
 							components: {
-								link: <Button onClick={ onFreePlanCTAClick } borderless />,
+								link: <Button onClick={ onFreePlanCTAClick ?? ( () => {} ) } borderless />,
 							},
 						}
 					) }

--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -30,6 +30,9 @@ jest.mock( '../use-generate-action-callback', () => () => jest.fn() );
 jest.mock(
 	'@automattic/plans-grid-next/src/components/shared/storage/hooks/use-default-storage-option'
 );
+jest.mock( '@automattic/calypso-router', () => ( {
+	redirect: jest.fn(),
+} ) );
 
 import {
 	PLAN_BUSINESS,
@@ -44,6 +47,7 @@ import {
 	PLAN_WOOEXPRESS_MEDIUM,
 	PLAN_WOOEXPRESS_SMALL,
 } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
 import { AddOns, Plans } from '@automattic/data-stores';
 import { useDefaultStorageOption } from '@automattic/plans-grid-next/src/components/shared/storage';
 import { renderHook } from '@testing-library/react';
@@ -379,7 +383,8 @@ describe( 'useGenerateActionHook', () => {
 		);
 		const action = result.current( { planSlug: PLAN_BUSINESS, isMonthlyPlan: false } );
 		expect( action.primary.text ).toBe( 'Upgrade' );
-		expect( action.primary.href ).toEqual( 'mockcheckoutlink' );
+		action.primary.callback();
+		expect( page.redirect ).toHaveBeenCalledWith( 'mockcheckoutlink' );
 	} );
 
 	it( 'should handle expired current plan for plan owner', () => {

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -426,7 +426,7 @@ function getLoggedInPlansAction( {
 		// No CTA if the current plan is the P2 free plan
 		if ( isP2FreePlan( planSlug ) ) {
 			return {
-				primary: { text: '', callback: () => {} },
+				primary: { text: '', callback: null },
 			};
 		}
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -718,7 +718,7 @@ const PlansFeaturesMain = ( {
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
 					offeringFreePlan={ offeringFreePlan }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
-					onFreePlanCTAClick={ onFreePlanCTAClick }
+					onFreePlanCTAClick={ onFreePlanCTAClick || ( () => undefined ) }
 				/>
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -718,7 +718,7 @@ const PlansFeaturesMain = ( {
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
 					offeringFreePlan={ offeringFreePlan }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
-					onFreePlanCTAClick={ onFreePlanCTAClick || ( () => undefined ) }
+					onFreePlanCTAClick={ onFreePlanCTAClick }
 				/>
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -306,7 +306,7 @@
 			display: none;
 		}
 
-		.plan-features-2023-gridrison__actions {
+		.plan-features-2023-grid__actions {
 			width: 200px;
 		}
 	}

--- a/packages/plans-grid-next/src/components/plan-button/index.tsx
+++ b/packages/plans-grid-next/src/components/plan-button/index.tsx
@@ -14,7 +14,6 @@ const PlanButton = ( {
 	onClick = () => {},
 	busy = false,
 	borderless = false,
-	current = false,
 	disabled = false,
 	isStuck = false,
 	isLargeCurrency = false,
@@ -26,7 +25,6 @@ const PlanButton = ( {
 	onClick?: () => void;
 	busy?: boolean;
 	borderless?: boolean;
-	current?: boolean;
 	disabled?: boolean;
 	isStuck?: boolean;
 	isLargeCurrency?: boolean;
@@ -36,7 +34,6 @@ const PlanButton = ( {
 		'plan-features-2023-grid__actions-button',
 		planSlug ? getPlanClass( planSlug ) : 'is-default',
 		{
-			'is-current-plan': current,
 			'is-stuck': isStuck,
 			'is-large-currency': isLargeCurrency,
 		}

--- a/packages/plans-grid-next/src/components/plan-button/style.scss
+++ b/packages/plans-grid-next/src/components/plan-button/style.scss
@@ -120,7 +120,6 @@
 	// since it's too early to say the current plan button will always
 	// be the default style, i.e. the secondary CTA button style
 	&.is-secondary,
-	&.is-current-plan,
 	&.is-default {
 		background-color: var(--studio-white);
 		color: var(--studio-gray-100);

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-default-storage-option.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-default-storage-option.ts
@@ -18,9 +18,11 @@ export default function useDefaultStorageOption( {
 }: Props ): AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug | undefined {
 	const { siteId, gridPlansIndex } = usePlansGridContext();
 	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
-	if ( ! gridPlansIndex?.features ) {
+
+	if ( ! gridPlansIndex?.[ planSlug ]?.features ) {
 		return;
 	}
+
 	const {
 		features: { storageFeature },
 	} = gridPlansIndex[ planSlug ];

--- a/packages/plans-grid-next/src/components/shared/storage/hooks/use-default-storage-option.ts
+++ b/packages/plans-grid-next/src/components/shared/storage/hooks/use-default-storage-option.ts
@@ -17,10 +17,13 @@ export default function useDefaultStorageOption( {
 	planSlug,
 }: Props ): AddOns.StorageAddOnSlug | WPComPlanStorageFeatureSlug | undefined {
 	const { siteId, gridPlansIndex } = usePlansGridContext();
+	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
+	if ( ! gridPlansIndex?.features ) {
+		return;
+	}
 	const {
 		features: { storageFeature },
 	} = gridPlansIndex[ planSlug ];
-	const storageAddOns = AddOns.useStorageAddOns( { siteId } );
 	const purchasedAddOn = storageAddOns?.find( ( storageAddOn ) => storageAddOn?.purchased );
 
 	return purchasedAddOn && ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE.includes( planSlug )

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -158,19 +158,7 @@ export interface GridAction {
 	postButtonText?: TranslateResult;
 }
 
-export type UseAction = ( {
-	availableForPurchase,
-	billingPeriod,
-	cartItemForPlan,
-	currentPlanBillingPeriod,
-	isFreeTrialAction,
-	isLargeCurrency,
-	isStuck,
-	planSlug,
-	planTitle,
-	priceString,
-	selectedStorageAddOn,
-}: {
+export type UseActionProps = {
 	availableForPurchase?: boolean;
 	billingPeriod?: PlanPricing[ 'billPeriod' ];
 	cartItemForPlan?: MinimalRequestCartProduct | null;
@@ -182,7 +170,10 @@ export type UseAction = ( {
 	planTitle?: TranslateResult;
 	priceString?: string;
 	selectedStorageAddOn?: AddOns.AddOnMeta | null;
-} ) => GridAction;
+	isMonthlyPlan?: boolean;
+};
+
+export type UseAction = ( props: UseActionProps ) => GridAction;
 
 export type GridContextProps = {
 	gridPlans: GridPlan[];

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -150,7 +150,7 @@ export type UseActionCallback = ( {
 export interface GridAction {
 	primary: {
 		text: TranslateResult;
-		callback: () => Promise< void > | void;
+		callback: ( () => Promise< void > | void ) | null;
 		// TODO: It's not clear if status is ever actually set to 'blocked'. Investigate and remove if not.
 		status?: 'disabled' | 'blocked' | 'enabled';
 		variant?: 'primary' | 'secondary';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR moves the storage addon selection logic from the plans-grid package (`packages/plans-grid-next/src/components/actions.tsx`) to `client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx` where this kind of logic is stored.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Storage addon selection is Calypso-specific logic that does not belong in the `PlanFeatures2023GridActions` component of the `plans-grid-next` package. By moving this logic to the Calypso hook, this component becomes a presentational-style component with minimal logic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test /start, /plans/<site slug> and confirm that the Upgrade buttons work as expected.
* Confirm that selecting a custom storage option for the Business/Commerce plans in those flows works the same as production. Clicking on the button should redirect to checkout with the storage addon in cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
