### PR TITLE
`SiteField`: Check whether a site is a p2 by checking its theme

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -15,7 +15,8 @@ export type SiteVisibility = 'all' | 'deleted';
 const fetchSites = (
 	site_visibility: SiteVisibility = 'all',
 	siteFilter = config< string[] >( 'site_filter' ),
-	additional_fields: string[] = []
+	additional_fields: string[] = [],
+	additional_options: string[] = []
 ): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	return wpcom.me().sites( {
 		apiVersion: '1.2',
@@ -23,7 +24,7 @@ const fetchSites = (
 		include_domain_only: true,
 		site_activity: 'active',
 		fields: additional_fields.concat( SITE_EXCERPT_REQUEST_FIELDS ).join( ',' ),
-		options: SITE_EXCERPT_REQUEST_OPTIONS.join( ',' ),
+		options: additional_options.concat( SITE_EXCERPT_REQUEST_OPTIONS ).join( ',' ),
 		filters: siteFilter.length > 0 ? siteFilter.join( ',' ) : undefined,
 	} );
 };
@@ -32,7 +33,8 @@ export const useSiteExcerptsQuery = (
 	fetchFilter?: string[],
 	sitesFilterFn?: ( site: SiteExcerptData ) => boolean,
 	site_visibility: SiteVisibility = 'all',
-	additional_fields: string[] = []
+	additional_fields: string[] = [],
+	additional_options: string[] = []
 ) => {
 	const store = useStore();
 
@@ -44,8 +46,10 @@ export const useSiteExcerptsQuery = (
 			fetchFilter,
 			site_visibility,
 			additional_fields,
+			additional_options,
 		],
-		queryFn: () => fetchSites( site_visibility, fetchFilter, additional_fields ),
+		queryFn: () =>
+			fetchSites( site_visibility, fetchFilter, additional_fields, additional_options ),
 		select: ( data ) => {
 			const sites = data?.sites.map( computeFields( data?.sites ) ) || [];
 			return sitesFilterFn ? sites.filter( sitesFilterFn ) : sites;

--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -101,7 +101,10 @@ const SitesDashboard = ( {
 
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
 		[],
-		( site ) => ! site.options?.is_domain_only
+		( site ) => ! site.options?.is_domain_only,
+		'all',
+		[],
+		[ 'theme_slug' ]
 	);
 
 	const hasEnTranslation = useHasEnTranslation();

--- a/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -8,6 +8,7 @@ import * as React from 'react';
 //import { useInView } from 'react-intersection-observer';
 import SiteFavicon from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
 import { navigate } from 'calypso/lib/navigate';
+import { isP2Theme } from 'calypso/lib/site/utils';
 import SitesMigrationTrialBadge from 'calypso/sites-dashboard/components/sites-migration-trial-badge';
 import SitesP2Badge from 'calypso/sites-dashboard/components/sites-p2-badge';
 import { SiteName } from 'calypso/sites-dashboard/components/sites-site-name';
@@ -73,7 +74,7 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const title = __( 'View Site Details' );
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( site.ID );
 
-	const isP2Site = site.options?.is_wpforteams_site;
+	const isP2Site = site.options?.theme_slug && isP2Theme( site.options?.theme_slug );
 	const isWpcomStagingSite = isStagingSite( site );
 	const isTrialSitePlan = useSelector( ( state ) => isTrialSite( state, site.ID ) );
 

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -139,3 +139,14 @@ export function getJetpackSiteCollisions( siteList ) {
 		} )
 		.map( ( siteItem ) => siteItem.ID );
 }
+
+const P2_THEMES = [ 'pub/p2', 'pub/p2-breathe', 'pub/p2-hub', 'pub/p2020' ];
+
+/**
+ * Returns whether the theme is a P2 theme
+ * @param {string} themeSlug The slug of the theme to check
+ * @returns {boolean} Whether the theme is a P2 theme
+ */
+export function isP2Theme( themeSlug ) {
+	return P2_THEMES.includes( themeSlug );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8052

## Proposed Changes

* Some p2 sites don't have the `is_wpforteams_site` option enabled, so we'll use the theme instead to show the p2 badge on the sites page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/sites`
* Check that all P2 sites have the P2 badge

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/022beb09-dd44-4da3-ace2-82de0974d415)|![image](https://github.com/user-attachments/assets/20cbd0f1-6e84-40b7-9c70-5628b69e4c03)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
