### PR TITLE
Help Center: Fix navigation for ToC links

### DIFF
--- a/packages/help-center/src/components/help-center-article-content.scss
+++ b/packages/help-center/src/components/help-center-article-content.scss
@@ -226,6 +226,10 @@
 		& > button {
 			display: none;
 		}
+		+ h2 {
+			// fix scrolling issues due to sticky header
+			scroll-margin-top: 69px;
+		}
 	}
 
 	.wp-block-wpsupport3-update-plan-cta {

--- a/packages/help-center/src/components/help-center-article-content.tsx
+++ b/packages/help-center/src/components/help-center-article-content.tsx
@@ -17,6 +17,29 @@ const ArticleContent = ( {
 	articleUrl,
 }: ArticleContentProps ) => {
 	const post = { title, link };
+
+	const handleTableOfContentClick = ( event: React.MouseEvent ) => {
+		// Check if the clicked element is a link
+		if ( event.target instanceof HTMLAnchorElement ) {
+			const url = event.target.getAttribute( 'href' );
+
+			// Only target links with '#'
+			if ( url && url.indexOf( '#' ) !== -1 ) {
+				// Avoid app url changes
+				event.preventDefault();
+				setTimeout( () => {
+					const anchorId = url.split( '#' ).pop();
+					if ( anchorId ) {
+						const element = document.getElementById( anchorId );
+						if ( element ) {
+							element.scrollIntoView();
+						}
+					}
+				}, 0 );
+			}
+		}
+	};
+
 	return (
 		<article className="help-center-article-content__story">
 			{ isLoading || ! post ? (
@@ -25,10 +48,12 @@ const ArticleContent = ( {
 				<>
 					<SupportArticleHeader post={ post } isLoading={ false } />
 					<EmbedContainer>
+						{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */ }
 						<div
 							className="help-center-article-content__story-content"
 							// eslint-disable-next-line react/no-danger
 							dangerouslySetInnerHTML={ { __html: content } }
+							onClick={ handleTableOfContentClick }
 						/>
 						<HelpCenterFeedbackForm
 							postId={ postId }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/8199

## Proposed Changes

* Fix Help Center article anchor link scrolling


https://github.com/user-attachments/assets/d916cd50-d582-454b-888a-607b363f90be



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are currently having issues with some anchor links not scrolling to the proper position

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Sync to WPCOM ( `apps/help-center` -> `yarn dev --sync`), sandbox Widgets and test site
* Open the Help Center, select a random article, and verify the table of content anchor links are working properly)
* Test in Calypso and WP-Admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
