### PR TITLE
Domains: Require site domains data for DNS records page

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -172,6 +172,7 @@ export default {
 				component={ DomainManagement.DnsRecords }
 				context={ pageContext }
 				selectedDomainName={ pageContext.params.domain }
+				needsDomains
 			/>
 		);
 		next();
@@ -185,6 +186,7 @@ export default {
 				component={ DomainManagement.AddDnsRecord }
 				context={ pageContext }
 				selectedDomainName={ pageContext.params.domain }
+				needsDomains
 			/>
 		);
 		next();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes #92149.

## Proposed Changes
tl;dr: Sets the `needsDomain` property for the container components of the DNS records page:

Long version:
The DNS records page works correctly _most of the time_ (when the request for `/sites/$siteId/domains` is successful—and **if** this request is actually fired). This happens if users navigate to the management page of a given domain and then click the "DNS records" breadcrumb or go through some flow that somehow requests the site's domains (`/sites/$siteId/domains`).

If a user has many domains, goes to their management page, and clicks the "Manage DNS" item in the ellipsis menu of the domain's row, the page might fail to load if the site's domains' data request hasn't been fulfilled yet or if the browser cancels it since the request would be in the `pending` state and they'd be navigating to a different page. This PR fixes it.

## Testing Instructions
Analyze the code statically and ensure it makes sense.
Additionally:
- For a domain you own, in an anonymous tab (_just to ensure there's no site data stored, you can also clear it through your browser's devtools_), go to `/domains/manage/$domain/dns/$siteSlug` - you should be prompted to log in:
  - Without this PR: 
    - Enter your credentials, proceed, and ensure the page won't load - the component will look broken, with an empty error/warning notice and no data for the page.
  - With this PR:
    - Enter your credentials, proceed, and ensure the page loads correctly, with all the domain's DNS record data, and no warnings.

## Preview

### Before
https://github.com/user-attachments/assets/8c948c9a-e3fd-4102-bca5-b93455c1c866

### After
https://github.com/user-attachments/assets/9823906b-a099-4227-b8fd-f4527affe980

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
