### PR TITLE
Update CSS for languages whose translations are longer than English

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -10,10 +10,6 @@
 		position: relative;
 		padding-bottom: 46px;
 
-		display: flex;
-		flex-direction: column;
-		min-height: 100%;
-
 		.button {
 			width: 100%;
 			text-wrap: balance;
@@ -89,13 +85,12 @@
 		@include a4a-font-body-lg;
 		margin: 0;
 		color: var(--studio-gray-80, #2c3338);
-		word-break: break-word;
 
 		@include break-large {
-			height: 85px;
+			height: 125px;
 		}
 		@include break-huge {
-			height: 65px;
+			height: 105px;
 		}
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -84,6 +84,8 @@
 	.hosting-card__description {
 		@include a4a-font-body-lg;
 		margin: 0;
+		margin-block-end: 20px;
+
 		color: var(--studio-gray-80, #2c3338);
 
 		@include break-large {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-card/style.scss
@@ -10,6 +10,10 @@
 		position: relative;
 		padding-bottom: 46px;
 
+		display: flex;
+		flex-direction: column;
+		min-height: 100%;
+
 		.button {
 			width: 100%;
 			text-wrap: balance;
@@ -85,6 +89,7 @@
 		@include a4a-font-body-lg;
 		margin: 0;
 		color: var(--studio-gray-80, #2c3338);
+		word-break: break-word;
 
 		@include break-large {
 			height: 85px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#843

## Proposed Changes

Increase the height of the description to prevent overflowing text in languages whose translations use more characters than English.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
