### PR TITLE
A4A: Update referral FAQ footer wording

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/footer/index.tsx
@@ -5,12 +5,13 @@ import './style.scss';
 export default function ReferralsFooter() {
 	const translate = useTranslate();
 
-	const link = 'https://automattic.com/for-agencies/program-incentives/';
+	const link =
+		'https://agencieshelp.automattic.com/knowledge-base/about-automattic-for-agencies/#payout-calculation-and-schedule';
 
 	return (
 		<div className="referrals-footer">
 			{ translate(
-				"Every 60 days, we'll calculate and pay out your commissions based on your clients’ purchases. Learn more about {{a}}partner earnings.{{/a}}",
+				'Payments are issued once a quarter with 60 day terms and are net of refunds and chargebacks. See the {{a}}payout schedule{{/a}} for more exact dates.',
 				{
 					components: {
 						a: <a href={ link } target="_blank" rel="noreferrer" />,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/780

## Proposed Changes

As mentioned in the issue we need to replace old wording with the new one.

<img width="700" alt="Screenshot 2024-07-18 at 10 27 36 AM" src="https://github.com/user-attachments/assets/f840a7ed-c68a-4cd9-bb75-bae06ded416f">

Note: The link should navigate us to `Payout Calculation and Schedule` on `https://agencieshelp.automattic.com/knowledge-base/about-automattic-for-agencies` page. In my testing it was working randomly. I wonder if it's just my browser.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using Live Link for A4A in this branch navigate to `/referrals/faq` and check the footer text on the bottom of the page.
- Check that link works properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
