### PR TITLE
Stats: Change the commercial paywall notice banner level to "error"

### DIFF
--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -95,7 +95,7 @@ const CommercialSiteUpgradeNotice = ( {
 			}` }
 		>
 			<NoticeBanner
-				level="info"
+				level={ shouldShowPaywallNotice ? 'error' : 'info' }
 				title={ translate( 'Upgrade to Stats Commercial' ) }
 				onClose={ () => {} }
 				hideCloseButton


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1721280540598069/1721274799.001899-slack-C04UCBZMBAA.

## Proposed Changes

* Change the commercial paywall notice banner level to `error` for highlighting.

|Before|After|
|-|-|
|<img width="1257" alt="截圖 2024-07-19 上午1 29 44" src="https://github.com/user-attachments/assets/af07ec90-a969-49df-9e81-fcd44e6589a7">|<img width="1257" alt="截圖 2024-07-19 上午1 30 36" src="https://github.com/user-attachments/assets/2b621bdb-c04e-4c27-9206-83d90efd71ae">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This PR is a follow-up for https://github.com/Automattic/wp-calypso/pull/92724, which makes the commercial paywall notice banner more critical.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions of https://github.com/Automattic/wp-calypso/pull/92724.
* Ensure the commercial upgrade notice shows with the commercial paywall communication at the `error` level.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?