### PR TITLE
A4A: fix sidebar back button style

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/style.scss
@@ -61,6 +61,7 @@
 	margin: 0;
 }
 
-.sidebar-v2__navigator-sub-menu .components-navigator-back-button {
+.theme-a8c-for-agencies .components-button,
+.theme-a8c-for-agencies .button .sidebar-v2__navigator-sub-menu .components-navigator-back-button {
 	background: none;
 }

--- a/client/a8c-for-agencies/components/sidebar/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/style.scss
@@ -60,3 +60,7 @@
 	list-style: none;
 	margin: 0;
 }
+
+.sidebar-v2__navigator-sub-menu .components-navigator-back-button {
+	background: none;
+}

--- a/client/a8c-for-agencies/components/sidebar/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/style.scss
@@ -20,6 +20,10 @@
 	.sidebar__menu-icon {
 		margin: 0;
 	}
+
+	.sidebar-v2__navigator-sub-menu .components-navigator-back-button {
+		background: none;
+	}
 }
 
 .a4a-sidebar__header {
@@ -59,9 +63,4 @@
 .a4a-sidebar__footer ul {
 	list-style: none;
 	margin: 0;
-}
-
-.theme-a8c-for-agencies .components-button,
-.theme-a8c-for-agencies .button .sidebar-v2__navigator-sub-menu .components-navigator-back-button {
-	background: none;
 }

--- a/client/a8c-for-agencies/components/sidebar/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/style.scss
@@ -23,6 +23,11 @@
 
 	.sidebar-v2__navigator-sub-menu .components-navigator-back-button {
 		background: none;
+
+		&:hover {
+			background: var(--color-primary-80);
+			color: var(--color-text-inverted);
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

While testing another PR I noticed that the styles on the back button of the sidebar are wrong and there's a white background. This PR addresses this issue.

| Before | After |
| ---- | ---- |
| <img width="253" alt="Screenshot 2024-07-18 at 10 42 42 AM" src="https://github.com/user-attachments/assets/75d4d63f-a6ca-40d6-95e7-7fe1053a8e97"> | <img width="247" alt="Screenshot 2024-07-18 at 10 54 40 AM" src="https://github.com/user-attachments/assets/0045d973-8601-411b-8d23-9653fd29f73f"> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use live link below.
- Using Sidebar navigate through different pages and check the sidebar back button styles.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
