### PR TITLE
Hide free plan card on `onboarding-with-email` signup flow

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -359,6 +359,7 @@ export function generateSteps( {
 			optionalDependencies: [ 'themeSlugWithRepo' ],
 			props: {
 				useEmailOnboardingSubheader: true,
+				hideFreePlan: true,
 			},
 		},
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8217-gh-Automattic/dotcom-forge

## Proposed Changes

Remove the free plan card on `start/onboarding-with-email/mailbox-plan`

**BEFORE**
<img width="1465" alt="image" src="https://github.com/user-attachments/assets/85d12e2c-3e3d-494f-b99b-2c697bce9480">

**AFTER**
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/5b550320-d8ba-4b3a-90fe-2dcdd8c3e4e9">



I wound up using the `hideFreePlan` prop, even though it's technically been [deprecated in favor of intent](https://github.com/Automattic/wp-calypso/blob/57d1ca63a3bb245e9c3f433da1699acc1e6a7847/client/my-sites/plans-features-main/index.tsx#L129).

None of the [existing intents](https://github.com/Automattic/wp-calypso/blob/57d1ca63a3bb245e9c3f433da1699acc1e6a7847/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx#L129-L205) felt like a good fit for this case (though I'm happy to be corrected if I'm wrong there).

I also looked at the `deemphasizeFreePlan` that's being used to hide Free from `/start/plans`. Unfortunately, this adds its own subheading and inline CTA (the one seen on `/start/plans`), which would end up rendering in addition to the email flow's subheading.

## Why are these changes being made?

During a recent walkthrough it was noticed  that we have two Free plan CTAs on this flow, which potentially draws attention away from our paid plans. Instead, we're mirroring the Plan step from the `/start` flow, and removing the free plan card from the plans table.

See 8217-gh-Automattic/dotcom-forge for additional context and related convos

## Testing Instructions

- Begin on `start/onboarding-with-email/mailbox-domain?ref=professional-email`, which is your first stop after clicking the initial CTA on the [Professional Email landing page](https://wordpress.com/professional-email/).
- Proceed through the onscreen instructions until you reach the Plans step
- Confirm that the Free plan card is hidden, but Premium, Business, Commerce, and Enterprise are all shown
- The plan comparison table on this page should match the one found on `/start/plans`, though the subheading text will be different.