### PR TITLE
Masterbar: Prevent box overlap from showing in profile dropdown

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -919,7 +919,7 @@ body.is-mobile-app-view {
 
 	.masterbar__item-subitems {
 		min-width: 264px !important;
-		max-height: 90px;
+		max-height: 94px;
 		padding: 12px 0 0 0;
 
 		@media only screen and (max-width: 782px) {


### PR DESCRIPTION
## Description

We have a max-height on the profile dropdown. The last link caused a couple pixel overlap to be seen. I increased the max-height by a few pixels and fixed the issue.

## Before

![weird-hover_360](https://github.com/user-attachments/assets/f5273935-6003-4afe-95de-f71c474b8249)


## After

![CleanShot 2024-07-18 at 14 17 27](https://github.com/user-attachments/assets/5d47cad4-cf7a-4896-8f0e-e7caebccff53)
