### PR TITLE
Checkout: Fix neon green hover color for exit icon

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1260,6 +1260,12 @@ a.masterbar__quick-language-switcher {
 		@include breakpoint-deprecated( ">480px" ) {
 			padding: 1.5em;
 		}
+
+		&:hover {
+			.gridicon {
+				fill: var(--studio-gray-90);
+			}
+		}
 	}
 
 	.masterbar__secure-checkout-text {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8343

## Proposed Changes

* This PR explicitly sets the hover color on the Checkout exit icon.

Before | After
--|--
<img width="971" alt="Screenshot 2024-07-18 at 2 17 14 PM" src="https://github.com/user-attachments/assets/de7e3b4e-c8f4-46cf-ac70-85360798b972">  | <img width="967" alt="Screenshot 2024-07-18 at 2 17 31 PM" src="https://github.com/user-attachments/assets/dc20c893-f6de-4754-9ed7-4944c6a1f2a9">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When the "Modern" color scheme is set, the X icon takes on a neon green color that is hard to see. Setting the hover color explicitly overrides the profile color scheme and ensures the exit icon is properly visible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/me/account and set your color profile to "Modern"
* Visit a checkout page by any mean and view that the X icon is the upper left is a neon green color when you hover over it.
* Apply this PR or use Calypso live and view the same checkout page. The X icon should now be a dark gray (almost black) when you hover over it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
