### PR TITLE
Nav Redesign i3: Fix notification icon thickness on hover

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -413,12 +413,6 @@ body.is-mobile-app-view {
 			fill: var(--color-masterbar-highlight);
 		}
 
-		// Fix for light color scheme
-		.sidebar_svg-notifications path {
-			stroke: var(--color-masterbar-highlight);
-		}
-
-
 		.masterbar__item-subitems {
 			display: block;
 			z-index: 99999;
@@ -919,7 +913,7 @@ body.is-mobile-app-view {
 
 	.masterbar__item-subitems {
 		min-width: 264px !important;
-		max-height: 94px;
+		max-height: 90px;
 		padding: 12px 0 0 0;
 
 		@media only screen and (max-width: 782px) {
@@ -1259,12 +1253,6 @@ a.masterbar__quick-language-switcher {
 
 		@include breakpoint-deprecated( ">480px" ) {
 			padding: 1.5em;
-		}
-
-		&:hover {
-			.gridicon {
-				fill: var(--studio-gray-90);
-			}
 		}
 	}
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -913,7 +913,7 @@ body.is-mobile-app-view {
 
 	.masterbar__item-subitems {
 		min-width: 264px !important;
-		max-height: 90px;
+		max-height: 94px;
 		padding: 12px 0 0 0;
 
 		@media only screen and (max-width: 782px) {
@@ -1253,6 +1253,12 @@ a.masterbar__quick-language-switcher {
 
 		@include breakpoint-deprecated( ">480px" ) {
 			padding: 1.5em;
+		}
+
+		&:hover {
+			.gridicon {
+				fill: var(--studio-gray-90);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8345

## Proposed Changes

The notification icon with an unread notification was thicker on hover; it's fixed now.

Before:

https://github.com/user-attachments/assets/663f1ef8-c3bf-4411-8547-5cd950e00a39

After:

https://github.com/user-attachments/assets/3f2f1d32-c729-4baa-b149-7e0c8533e63e

## Why are these changes being made?
The icon with a notification looks weird on hover.

## Testing Instructions

* With an unread notification, Go to a Site page `/home/:siteSlug`
* Check the Icon thickness on hover.
* Also test it with different color schemas
