### PR TITLE
Fix migration instructions complete event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
@@ -169,21 +169,25 @@ export const useSteps = ( { fromUrl, migrationKey, onComplete }: StepsOptions ):
 	const stepsData = useStepsData( { fromUrl, migrationKey } );
 
 	const steps: Steps = stepsData.map( ( step, index, array ) => {
+		const recordCompletedStepEvent = () => {
+			recordTracksEvent( 'calypso_site_migration_instructions_substep_complete', {
+				step: step.key,
+			} );
+		};
+
 		const onNextClick = () => {
 			setCurrentStep( index + 1 );
 
 			// When completing a step that wasn't completed yet.
 			if ( lastCompleteStep < index ) {
 				setLastCompleteStep( index );
-
-				recordTracksEvent( 'calypso_site_migration_instructions_step_complete', {
-					step: step.key,
-				} );
+				recordCompletedStepEvent();
 			}
 		};
 
 		const onDoneClick = () => {
 			onComplete();
+			recordCompletedStepEvent();
 		};
 
 		// Allow clicking on visited steps only, so users can see the previous steps again.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #92734

## Proposed Changes

* After some changes in parallel, we stopped registering the event of the last step of the migration instructions. This PR fixes it.
* I also took the opportunity to rename the event name from `calypso_site_migration_instructions_step_complete` to `calypso_site_migration_instructions_substep_complete` to avoid confusion with the whole migration flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The last event was not recording.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site with the Import intent.
2. Follow all the steps until the Migration Started step.
3. Watch the network requests in your browser.
4. Check that the event `calypso_site_migration_instructions_substep_complete` is registered for every step completed (You can filter `t.gif`).
5. Make sure that when you click on a previous step and complete it again, it's not recorded a second time.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
