### PR TITLE
Stats: Do not show upgrade notice for dotcom sites

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -102,7 +102,10 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	const shouldShowPaywallNotice =
 		useSelector( ( state ) => {
 			return hasReachedPaywallMonthlyViews( state, siteId );
-		} ) && ! supportCommercialUse;
+		} ) &&
+		! supportCommercialUse &&
+		isSiteJetpackNotAtomic &&
+		! isVip;
 
 	const noticeOptions = {
 		siteId,


### PR DESCRIPTION


Related to p1721314329095569-slack-C0438NHCLSY

## Proposed Changes

Hide paywall notice for dotcom sites.

## Why are these changes being made?

* Upgrade banners should only be applicable to Jetpack self hosted

## Testing Instructions


* Switch to the example in Slack
* Ensure no red upgrade banner shows up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?