### PR TITLE
Frictionless Email Subscriptions: Move first/last name params into account creation

### DIFF
--- a/client/signup/hooks/use-subscribe-to-mailing-list.ts
+++ b/client/signup/hooks/use-subscribe-to-mailing-list.ts
@@ -8,9 +8,7 @@ interface APIResponse {
 
 interface SubscribeToMailingListParams {
 	email_address: string;
-	first_name: string;
 	from: string;
-	last_name: string;
 	mailing_list_category: string;
 }
 

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -83,18 +83,9 @@ function SubscribeEmailStep( props ) {
 				email_address,
 				mailing_list_category: queryArguments.mailing_list,
 				from: queryArguments.from,
-				first_name: queryArguments.first_name,
-				last_name: queryArguments.last_name,
 			} );
 		},
-		[
-			email,
-			queryArguments.first_name,
-			queryArguments.from,
-			queryArguments.last_name,
-			queryArguments.mailing_list,
-			subscribeToMailingList,
-		]
+		[ email, queryArguments.from, queryArguments.mailing_list, subscribeToMailingList ]
 	);
 
 	const handlerecordRegistration = useCallback(
@@ -134,6 +125,10 @@ function SubscribeEmailStep( props ) {
 			createNewAccount( {
 				userData: {
 					email,
+					extra: {
+						first_name: queryArguments.first_name,
+						last_name: queryArguments.last_name,
+					},
 				},
 				flowName,
 				isPasswordless: true,
@@ -144,7 +139,15 @@ function SubscribeEmailStep( props ) {
 		if ( currentUser?.email === email ) {
 			handleSubscribeToMailingList();
 		}
-	}, [ createNewAccount, currentUser, email, flowName, handleSubscribeToMailingList ] );
+	}, [
+		createNewAccount,
+		currentUser,
+		email,
+		flowName,
+		handleSubscribeToMailingList,
+		queryArguments.first_name,
+		queryArguments.last_name,
+	] );
 
 	return (
 		<div className="subscribe-email">


### PR DESCRIPTION
Related to https://github.com/Automattic/martech/issues/3194

## Proposed Changes

* Pass the first & last name params into the `/users/new` call, and remove these params from the `/pigeon` call.
* Requires: D155683-code & D155827-code

## Why are these changes being made?

* We want to save the user's first/last names to their WP profile when a new account is created (handled by the `/users/new` endpoint), rather than storing these details as separate user attributes (previously handled by the `/pigeon` endpoint).

## Testing Instructions

* Navigate to the following address with test values for `user_email`, `first_name`, `last_name`
  *  `/start/email-subscription/subscribe?user_email=hello@email.com&first_name=Bob&last_name=Smith&mailing_list=zzz&redirect_to=https%3A%2F%2Fh4tests.wordpress.com%2Ftest-email-subscription&from=%2Ftest-email-subscription%2F`
* Inspect the `/users/new` API request
  * The payload should contain an `extra` property with `first_name` and `last_name`
  * The response should be a 200 with a `user_id` property
* Inspect the `/pigeon` API request
  * The payload should no longer contain `first_name` and `last_name` properties

---

`/users/new`

<img width=400 src="https://github.com/user-attachments/assets/b00ecf7f-c481-41e7-bf09-e41acf7ab3b2" />

`/pigeon`

<img width=400 src="https://github.com/user-attachments/assets/1cd28fd3-f57c-4d37-bad8-42120d1126ac" />




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?