### PR TITLE
Contrast colorscheme: match active and hover backgrounds

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_contrast.scss
@@ -110,7 +110,7 @@
 	--color-masterbar-icon: var(--studio-white);
 	--color-masterbar-highlight: var(--studio-yellow-20);
 	--color-masterbar-item-hover-background: var(--studio-gray-90);
-	--color-masterbar-item-active-background: var(--studio-gray-60);
+	--color-masterbar-item-active-background: var(--studio-gray-90);
 	--color-masterbar-item-new-editor-background: var(--studio-gray-70);
 	--color-masterbar-item-new-editor-hover-background: var(--studio-gray-90);
 	--color-masterbar-unread-dot-background: var(--studio-yellow-20);


### PR DESCRIPTION
## Proposed Changes

* Matches active with hover color scheme, the -60 value probably made sense when theme is active across multiple global screens (reader, sites, account), in the current form it's only ever shown when the side bar is open on mobile. All other situations it's never seen.

## Testing Instructions

Before
![Screenshot(221)](https://github.com/user-attachments/assets/7243a71a-31e9-4f03-a5f8-80a8f71fe053)


After
![Screenshot(220)](https://github.com/user-attachments/assets/92c333b7-f5f2-4110-af13-abbf8632f340)
