### PR TITLE
Masterbar menu - Display "🏠 & ➕" and hide "❓& 🔔" on mobile

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -483,6 +483,10 @@ body.is-mobile-app-view {
 		background: var(--studio-orange-70);
 	}
 
+	&.masterbar__item-notifications {
+		margin-right: 0;
+	}
+
 	@media only screen and (max-width: 782px) {
 		font-size: $masterbar-mobile-font-size;
 		width: 52px;
@@ -553,14 +557,10 @@ body.is-mobile-app-view {
 			display: block;
 		}
 
-		&.masterbar__item-my-site,
-		&.masterbar__item-my-site-actions,
+		&.masterbar__item-notifications,
+		&.masterbar__item-help,
 		&.masterbar-cart-button {
 			display: none;
-		}
-
-		&.masterbar__item-help {
-			width: 54px;
 		}
 	}
 
@@ -594,10 +594,6 @@ body.is-mobile-app-view {
 				height: 32px;
 			}
 		}
-	}
-
-	&.masterbar__item-notifications {
-		margin-right: 0;
 	}
 
 	&.masterbar__item-help {

--- a/test/e2e/specs/help-center/help-center__general-interaction.ts
+++ b/test/e2e/specs/help-center/help-center__general-interaction.ts
@@ -189,29 +189,32 @@ describe( 'Help Center: Interact with Results', function () {
 		}
 	);
 
-	describe( 'Navigate to Calypso Link', function () {
-		let popupPage: Page;
+	skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
+		'Navigate to Calypso Link',
+		function () {
+			let popupPage: Page;
 
-		it( 'Close article and return to search results', async function () {
-			await supportComponent.goBack();
-		} );
+			it( 'Close article and return to search results', async function () {
+				await supportComponent.goBack();
+			} );
 
-		it( 'Clear search results', async function () {
-			await supportComponent.clearSearch();
-		} );
+			it( 'Clear search results', async function () {
+				await supportComponent.clearSearch();
+			} );
 
-		it( 'Search for "domain"', async function () {
-			await supportComponent.search( 'domain' );
-		} );
+			it( 'Search for "domain"', async function () {
+				await supportComponent.search( 'domain' );
+			} );
 
-		it( 'Click on the first Calypso Link result', async function () {
-			const popupEvent = page.waitForEvent( 'popup' );
-			await supportComponent.clickResultByIndex( 'Calypso Link', 0 );
-			popupPage = await popupEvent;
-		} );
+			it( 'Click on the first Calypso Link result', async function () {
+				const popupEvent = page.waitForEvent( 'popup' );
+				await supportComponent.clickResultByIndex( 'Calypso Link', 0 );
+				popupPage = await popupEvent;
+			} );
 
-		it( 'Calypso Link opens in a new page', async function () {
-			expect( popupPage.url() ).not.toBe( page.url() );
-		} );
-	} );
+			it( 'Calypso Link opens in a new page', async function () {
+				expect( popupPage.url() ).not.toBe( page.url() );
+			} );
+		}
+	);
 } );

--- a/test/e2e/specs/help-center/help-center__general-interaction.ts
+++ b/test/e2e/specs/help-center/help-center__general-interaction.ts
@@ -164,27 +164,30 @@ describe( 'Help Center: Interact with Results', function () {
 		supportComponent = new SupportComponent( page );
 	} );
 
-	describe( 'Search for Help article', function () {
-		it( 'Open Help Center', async function () {
-			await supportComponent.openPopover();
-		} );
+	skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
+		'Search for Help article',
+		function () {
+			it( 'Open Help Center', async function () {
+				await supportComponent.openPopover();
+			} );
 
-		it( 'Search for posts-related help article', async function () {
-			// We use domains below, but one of the domain-adjacent articles is currently broken:
-			// https://github.com/Automattic/wp-calypso/issues/79576
-			// Until that's fixed, let's steer clear and search a different topic.
-			await supportComponent.search( 'posts' );
-		} );
+			it( 'Search for posts-related help article', async function () {
+				// We use domains below, but one of the domain-adjacent articles is currently broken:
+				// https://github.com/Automattic/wp-calypso/issues/79576
+				// Until that's fixed, let's steer clear and search a different topic.
+				await supportComponent.search( 'posts' );
+			} );
 
-		it( 'Click on the second Help Docs result', async function () {
-			await supportComponent.clickResultByIndex( 'Docs', 1 );
-		} );
+			it( 'Click on the second Help Docs result', async function () {
+				await supportComponent.clickResultByIndex( 'Docs', 1 );
+			} );
 
-		it( 'Help Doc article is shown', async function () {
-			const articleTitle = await supportComponent.getOpenArticleTitle();
-			expect( articleTitle ).not.toBe( '' );
-		} );
-	} );
+			it( 'Help Doc article is shown', async function () {
+				const articleTitle = await supportComponent.getOpenArticleTitle();
+				expect( articleTitle ).not.toBe( '' );
+			} );
+		}
+	);
 
 	describe( 'Navigate to Calypso Link', function () {
 		let popupPage: Page;

--- a/test/e2e/specs/help-center/help-center__general-interaction.ts
+++ b/test/e2e/specs/help-center/help-center__general-interaction.ts
@@ -40,19 +40,22 @@ describe.each( [ { accountName: 'defaultUser' as TestAccountName } ] )(
 			await page.close();
 		} );
 
-		describe( 'Verify Help Center is opened and visible in Calypso', function () {
-			it( 'Verify Help Center is initially closed', async function () {
-				expect( await page.locator( '.help-center__container' ).isVisible() ).toBeFalsy();
-			} );
+		skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
+			'Verify Help Center is opened and visible in Calypso',
+			function () {
+				it( 'Verify Help Center is initially closed', async function () {
+					expect( await page.locator( '.help-center__container' ).isVisible() ).toBeFalsy();
+				} );
 
-			it( 'Open Help Center', async function () {
-				await supportComponent.openPopover();
-			} );
+				it( 'Open Help Center', async function () {
+					await supportComponent.openPopover();
+				} );
 
-			it( 'Verify Help Center is opened', async function () {
-				expect( await page.locator( '.help-center__container' ).isVisible() ).toBeTruthy();
-			} );
-		} );
+				it( 'Verify Help Center is opened', async function () {
+					expect( await page.locator( '.help-center__container' ).isVisible() ).toBeTruthy();
+				} );
+			}
+		);
 
 		skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 			'Verify Help Center is opened and visible in Editor',
@@ -65,6 +68,7 @@ describe.each( [ { accountName: 'defaultUser' as TestAccountName } ] )(
 					await page.goto( postURL );
 				} );
 
+				// eslint-disable-next-line jest/no-identical-title
 				it( 'Verify Help Center is initially closed', async function () {
 					expect(
 						await page
@@ -74,6 +78,7 @@ describe.each( [ { accountName: 'defaultUser' as TestAccountName } ] )(
 					).toBeFalsy();
 				} );
 
+				// eslint-disable-next-line jest/no-identical-title
 				it( 'Open Help Center', async function () {
 					try {
 						await page
@@ -87,6 +92,7 @@ describe.each( [ { accountName: 'defaultUser' as TestAccountName } ] )(
 					}
 				} );
 
+				// eslint-disable-next-line jest/no-identical-title
 				it( 'Verify Help Center is opened', async function () {
 					const helpCenterContainerIsVisible = await page
 						.frameLocator( '.calypsoify iframe' )

--- a/test/e2e/specs/infrastructure/notifications__general-interaction.ts
+++ b/test/e2e/specs/infrastructure/notifications__general-interaction.ts
@@ -10,8 +10,10 @@ import {
 	TestAccount,
 	NewCommentResponse,
 	PostResponse,
+	envVariables,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
@@ -19,112 +21,115 @@ declare const browser: Browser;
  * Tests general interaction with the notification panel, running through
  * all actions once.
  */
-describe( 'Notifications: General Interactions', function () {
-	const comment = DataHelper.getRandomPhrase() + ' notification-actions-spec';
+skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
+	'Notifications: General Interactions',
+	function () {
+		const comment = DataHelper.getRandomPhrase() + ' notification-actions-spec';
 
-	// TestAccount and RestAPI instances.
-	let commentingUser: TestAccount;
-	let notificationsUser: TestAccount;
-	let commentingUserRestAPIClient: RestAPIClient;
-	let notificationUserRestAPIClient: RestAPIClient;
+		// TestAccount and RestAPI instances.
+		let commentingUser: TestAccount;
+		let notificationsUser: TestAccount;
+		let commentingUserRestAPIClient: RestAPIClient;
+		let notificationUserRestAPIClient: RestAPIClient;
 
-	// API responses.
-	let newPost: PostResponse;
-	let newComment: NewCommentResponse;
+		// API responses.
+		let newPost: PostResponse;
+		let newComment: NewCommentResponse;
 
-	let notificationsComponent: NotificationsComponent;
-	let page: Page;
+		let notificationsComponent: NotificationsComponent;
+		let page: Page;
 
-	beforeAll( async function () {
-		// Create an instance of RestAPI as the user making the comment.
-		commentingUser = new TestAccount( 'commentingUser' );
-		commentingUserRestAPIClient = new RestAPIClient( commentingUser.credentials );
+		beforeAll( async function () {
+			// Create an instance of RestAPI as the user making the comment.
+			commentingUser = new TestAccount( 'commentingUser' );
+			commentingUserRestAPIClient = new RestAPIClient( commentingUser.credentials );
 
-		// Create an instance of RestAPI as the user receiving notification.
-		notificationsUser = new TestAccount( 'notificationsUser' );
-		notificationUserRestAPIClient = new RestAPIClient( notificationsUser.credentials );
+			// Create an instance of RestAPI as the user receiving notification.
+			notificationsUser = new TestAccount( 'notificationsUser' );
+			notificationUserRestAPIClient = new RestAPIClient( notificationsUser.credentials );
 
-		// Create a new post and store the response.
-		newPost = await notificationUserRestAPIClient.createPost(
-			notificationsUser.credentials.testSites?.primary.id as number,
-			{ title: DataHelper.getRandomPhrase() }
-		);
-
-		// Create a new comment on the post as the commentingUser and
-		// store the response.
-		newComment = await commentingUserRestAPIClient.createComment(
-			notificationsUser.credentials.testSites?.primary.id as number,
-			newPost.ID,
-			comment
-		);
-
-		// Log in as the user receiving the notification.
-		page = await browser.newPage();
-		await notificationsUser.authenticate( page, { waitUntilStable: true } );
-	} );
-
-	it( 'Open Notifications panel', async function () {
-		const navbarComponent = new NavbarComponent( page );
-		await navbarComponent.openNotificationsPanel();
-	} );
-
-	it( 'Click notification for the comment', async function () {
-		notificationsComponent = new NotificationsComponent( page );
-		await notificationsComponent.openNotification( comment );
-	} );
-
-	it( 'Approve comment', async function () {
-		await notificationsComponent.clickNotificationAction( 'Approve' );
-	} );
-
-	it( 'Like comment', async function () {
-		await notificationsComponent.clickNotificationAction( 'Like' );
-	} );
-
-	it( 'Mark comment as spam', async function () {
-		await notificationsComponent.clickNotificationAction( 'Spam' );
-		await notificationsComponent.clickUndo();
-	} );
-
-	it( 'Trash comment', async function () {
-		await notificationsComponent.clickNotificationAction( 'Trash' );
-	} );
-
-	afterAll( async function () {
-		if ( ! newComment ) {
-			return;
-		}
-
-		// Clean up the comment.
-		try {
-			await notificationUserRestAPIClient.deleteComment(
+			// Create a new post and store the response.
+			newPost = await notificationUserRestAPIClient.createPost(
 				notificationsUser.credentials.testSites?.primary.id as number,
-				newComment.ID
+				{ title: DataHelper.getRandomPhrase() }
 			);
-		} catch ( e: unknown ) {
-			console.warn(
-				`Failed to clean up test comment in notification_action spec for site ${
-					notificationsUser.credentials.testSites?.primary.id as number
-				}, comment ${ newComment.ID }`
-			);
-		}
 
-		if ( ! newPost ) {
-			return;
-		}
-
-		// Clean up the post.
-		try {
-			await notificationUserRestAPIClient.deletePost(
+			// Create a new comment on the post as the commentingUser and
+			// store the response.
+			newComment = await commentingUserRestAPIClient.createComment(
 				notificationsUser.credentials.testSites?.primary.id as number,
-				newPost.ID
+				newPost.ID,
+				comment
 			);
-		} catch ( e: unknown ) {
-			console.warn(
-				`Failed to clean up test comment in notification_action spec for site ${
-					notificationsUser.credentials.testSites?.primary.id as number
-				}, comment ${ newComment.ID }`
-			);
-		}
-	} );
-} );
+
+			// Log in as the user receiving the notification.
+			page = await browser.newPage();
+			await notificationsUser.authenticate( page, { waitUntilStable: true } );
+		} );
+
+		it( 'Open Notifications panel', async function () {
+			const navbarComponent = new NavbarComponent( page );
+			await navbarComponent.openNotificationsPanel();
+		} );
+
+		it( 'Click notification for the comment', async function () {
+			notificationsComponent = new NotificationsComponent( page );
+			await notificationsComponent.openNotification( comment );
+		} );
+
+		it( 'Approve comment', async function () {
+			await notificationsComponent.clickNotificationAction( 'Approve' );
+		} );
+
+		it( 'Like comment', async function () {
+			await notificationsComponent.clickNotificationAction( 'Like' );
+		} );
+
+		it( 'Mark comment as spam', async function () {
+			await notificationsComponent.clickNotificationAction( 'Spam' );
+			await notificationsComponent.clickUndo();
+		} );
+
+		it( 'Trash comment', async function () {
+			await notificationsComponent.clickNotificationAction( 'Trash' );
+		} );
+
+		afterAll( async function () {
+			if ( ! newComment ) {
+				return;
+			}
+
+			// Clean up the comment.
+			try {
+				await notificationUserRestAPIClient.deleteComment(
+					notificationsUser.credentials.testSites?.primary.id as number,
+					newComment.ID
+				);
+			} catch ( e: unknown ) {
+				console.warn(
+					`Failed to clean up test comment in notification_action spec for site ${
+						notificationsUser.credentials.testSites?.primary.id as number
+					}, comment ${ newComment.ID }`
+				);
+			}
+
+			if ( ! newPost ) {
+				return;
+			}
+
+			// Clean up the post.
+			try {
+				await notificationUserRestAPIClient.deletePost(
+					notificationsUser.credentials.testSites?.primary.id as number,
+					newPost.ID
+				);
+			} catch ( e: unknown ) {
+				console.warn(
+					`Failed to clean up test comment in notification_action spec for site ${
+						notificationsUser.credentials.testSites?.primary.id as number
+					}, comment ${ newComment.ID }`
+				);
+			}
+		} );
+	}
+);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/38419

## Proposed Changes

This PR displays "🏠 (Site menu)" & "➕ (+New)" and hides "❓ (Help)" & "🔔 (Notifications)" on the mobile's masterbar.

| before | after |
|--------|--------|
| <img width="375" alt="Screenshot 2024-07-19 at 16 16 00" src="https://github.com/user-attachments/assets/284280d7-7723-411b-966a-1c99bbcc123a"> | <img width="377" alt="Screenshot 2024-07-19 at 16 15 51" src="https://github.com/user-attachments/assets/ec92edf7-f7f2-401b-8181-5ed34bebd7e2"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To unify masterbar in Simple and Atomic Default sites. See this comment: https://github.com/Automattic/jetpack/pull/38419#issuecomment-2238175035.

Also, this enables the flow where users go back to the site's dashboard on mobile as well: https://github.com/Automattic/wp-calypso/pull/92720 and https://github.com/Automattic/wp-calypso/pull/92777. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test with device-width < 480px
* Go to /sites
* See the masterbar items are correctly shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
