### PR TITLE
Site Logs: Localize Severity table column

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
@@ -54,7 +54,7 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
 		date: sprintf( __( 'Date & time (%s)' ), siteGsmOffsetDisplay ),
 		status: __( 'Status' ),
-		severity: 'Severity',
+		severity: __( 'Severity' ),
 		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
 		timestamp: sprintf( __( 'Date & time (%s)' ), siteGsmOffsetDisplay ),
 		message: __( 'Message' ),

--- a/client/my-sites/site-monitoring/components/site-logs-table/site-logs-table-row.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/site-logs-table-row.tsx
@@ -27,6 +27,12 @@ export default function SiteLogsTableRow( { columns, log, siteGmtOffset, logType
 	const locale = useSelector( getCurrentUserLocale );
 
 	const firstColumnValue = log[ columns[ 0 ] ] as string; // Get the value of the first column
+	const formattedSeverities = {
+		User: __( 'User' ),
+		Warning: __( 'Warning' ),
+		Deprecated: __( 'Deprecated' ),
+		'Fatal error': __( 'Fatal error' ),
+	};
 
 	const specifiedLogs =
 		logType === 'php'
@@ -45,7 +51,8 @@ export default function SiteLogsTableRow( { columns, log, siteGmtOffset, logType
 					<td key={ column } className={ column }>
 						{ index === 0 ? (
 							<Badge className={ `badge--${ firstColumnValue }` }>
-								{ log[ column ] as React.ReactNode }
+								{ formattedSeverities[ log[ column ] as keyof typeof formattedSeverities ] ??
+									( log[ column ] as React.ReactNode ) }
 							</Badge>
 						) : (
 							renderCell( column, log[ column ], moment, siteGmtOffset, locale )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 846-gh-Automattic/i18n-issues

## Proposed Changes

* Localize severity column in Site Logs table.

**Before:**
![yPSxFE5na70rd0jf](https://github.com/user-attachments/assets/1a65e652-8f53-4f20-ab49-b99c103c197d)

**After:**
![FRLXBltJOCJUaZcz](https://github.com/user-attachments/assets/c3e7f36f-0ff1-46ca-93bf-f3a0d9f67853)

Note that the string [Deprecated is not translated in all Mag-16 languages](https://translate.wordpress.com/projects/wpcom/-all-translations/24611/) at the moment of creating this PR, and therefore it's expected that it appears untranslated.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The changes needed in order to get the table fully translated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Switch to a Mag-16 language.
* Navigate to `/site-logs/<atomic-site>/php` and confirm the severity column (shown in the screenshots) is translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
