### PR TITLE
Stats: Empty States: Small updates to comments module

### DIFF
--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -70,7 +70,6 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 					className={ className }
 					title={ moduleTitle }
 					type={ 3 }
-					withHero
 				/>
 			) }
 			{ ( ( ! isRequestingData && hasPosts ) || shouldGateStatsModule ) && (

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -41,10 +41,6 @@ class StatsComments extends Component {
 		skipQuery: PropTypes.bool,
 	};
 
-	static defaultProps = {
-		skipQuery: false,
-	};
-
 	state = {
 		activeFilter: 'top-authors',
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This small PR addresses two feedback comments from https://github.com/Automattic/wp-calypso/pull/92779/
* Removes Hero from skeleton loader, as it adds a large box above the title and is used to approximate things like a map for the Countries modules. 
* Remove default props for skipQuery in the original comments component, as if a property is not passed, it will be false by default.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch and verify that the `Comments` module still works fine without the feature flag
* apply the flag `stats/empty-module-v2` 
* verify that a page with empty Comments views component  still works as expected with and without the feature flag
* repeat for blogs with Comments data

![image](https://github.com/user-attachments/assets/186459a3-76a9-4f2a-8b2f-e88ff93a20a8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
