### PR TITLE
Notifications: Update filter items on i18n data changes

### DIFF
--- a/apps/notifications/src/panel/templates/filter-bar.jsx
+++ b/apps/notifications/src/panel/templates/filter-bar.jsx
@@ -20,6 +20,11 @@ export class FilterBar extends Component {
 		if ( ! prevProps.isPanelOpen && this.props.isPanelOpen ) {
 			this.focusOnSelectedTab();
 		}
+
+		// Reset the filter items when i18n data changes, to ensure the translatable fields are properly updated.
+		if ( prevProps.translate !== this.props.translate ) {
+			this.setFilterItems();
+		}
 	}
 
 	componentWillUnmount() {
@@ -28,11 +33,15 @@ export class FilterBar extends Component {
 		}
 	}
 
+	setFilterItems = () => {
+		this.filterItems = Object.keys( Filters )
+			.map( ( name ) => Filters[ name ]() )
+			.sort( ( a, b ) => a.index - b.index );
+	};
+
 	getFilterItems = () => {
 		if ( ! this.filterItems ) {
-			this.filterItems = Object.keys( Filters )
-				.map( ( name ) => Filters[ name ]() )
-				.sort( ( a, b ) => a.index - b.index );
+			this.setFilterItems();
 		}
 
 		return this.filterItems;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 849-gh-Automattic/i18n-issues

## Proposed Changes

* Update the filter items in the Notifications Filter Bar component when the i18n data changes, to ensure the items are properly translated.


**Before:**
![t5zCYGtVa9QoSzhR](https://github.com/user-attachments/assets/502afb2f-38ae-4c4d-afda-0c942e5b1ee8)

**After:**
![4cvsuRdqlux5YEA7](https://github.com/user-attachments/assets/145780e9-0a86-4650-beb3-35f29029f5b7)

Ideally, the [Filters constant](https://github.com/Automattic/wp-calypso/blob/17ca9f8464549fa6dee179368e1d7e68b868126a/apps/notifications/src/panel/templates/filters.js#L5) should be refactored to a custom hook to avoid the use of static `i18n.translate()` calls, but since it's also used [outside of a React component](https://github.com/Automattic/wp-calypso/blob/17ca9f8464549fa6dee179368e1d7e68b868126a/apps/notifications/src/panel/templates/filter-bar-controller.js#L17), it'd make the refactoring rather involved.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The [getFilterItems() getter](https://github.com/Automattic/wp-calypso/blob/17ca9f8464549fa6dee179368e1d7e68b868126a/apps/notifications/src/panel/templates/filter-bar.jsx#L31) builds the filter items object once when it's first called. However, in some conditions, the getter might get called before the translation data is fully loaded, resulting in building the filter items object with missing translations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Since this issue is caused by a race condition between loading the translation data and rendering the filters bar, it may occur incosistently in different cases. However, I was able to reproduce it every time using the following steps:
  * Switch to a Mag-16 language.
  * Navigate to `/me`.
  * Open the Notifications panel from the top bar.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
