### PR TITLE
Masterbar: Fix shopping cart

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -851,6 +851,7 @@ export default connect(
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
 			isEcommerce: isEcommercePlan( sitePlanSlug ),
+			siteId: siteId,
 			siteSlug: getSiteSlug( state, siteId ),
 			siteTitle: getSiteTitle( state, siteId ),
 			siteUrl: getSiteUrl( state, siteId ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8361

## Proposed Changes

Brings back the shopping cart to the Calypso masterbar after mistakenly being hidden because of a regression introduced in #92800.

Before | After
--- | ---
<img width="297" alt="Screenshot 2024-07-19 at 13 39 01" src="https://github.com/user-attachments/assets/b0497c0f-4538-4cbc-af8a-a88792277086"> | <img width="311" alt="Screenshot 2024-07-19 at 13 38 04" src="https://github.com/user-attachments/assets/3f4e68ef-cfbc-47a7-a83f-de941c81ecb9">


## Why are these changes being made?

Because the shopping cart is missing from Calypso masterbar.

## Testing Instructions

- Use the Calypso live link below
- Go to `/plans`
- Select a Free site
- Choose any paid plan
- Exit the checkout via the "X" button in the top left corner (choose to keep items in the cart)
- Make sure the shopping cart is visible in the masterbar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
