### PR TITLE
[Odie] Open support doc links Within Help Center

### DIFF
--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -12,11 +12,25 @@ export const BackButton = ( { onClick, backToRoot = false, className }: Props ) 
 	const location = useLocation();
 	const navigate = useNavigate();
 	const buttonClassName = clsx( 'back-button__help-center', className );
+	const queryParams = new URLSearchParams( location.search );
+	const backUrl = queryParams.get( 'backUrl' );
 
-	function defaultOnClick() {
-		if ( backToRoot ) {
+	function handleOnClick() {
+		const currentPath = location.pathname;
+		if ( currentPath === '/odie' ) {
 			navigate( '/' );
-		} else if ( location.key === 'default' ) {
+			return;
+		}
+
+		if ( backUrl ) {
+			navigate( backUrl );
+			return;
+		}
+		if ( onClick ) {
+			onClick();
+			return;
+		}
+		if ( backToRoot || location.key === 'default' ) {
 			// Workaround to detect when we don't have prior history
 			// https://github.com/remix-run/react-router/discussions/9922#discussioncomment-4722480
 			navigate( '/' );
@@ -30,7 +44,7 @@ export const BackButton = ( { onClick, backToRoot = false, className }: Props ) 
 			className={ buttonClassName }
 			/* eslint-disable-next-line jsx-a11y/no-autofocus */
 			autoFocus
-			onClick={ onClick || defaultOnClick }
+			onClick={ handleOnClick }
 		>
 			<Icon icon={ chevronLeft } size={ 18 } />
 			{ __( 'Back', __i18n_text_domain__ ) }

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -56,6 +56,15 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 		};
 	}, [] );
 
+	const navigateToSupportDocs = useCallback(
+		( blogId: string, postId: string, title: string, link: string ) => {
+			navigate(
+				`/post?blogId=${ blogId }&postId=${ postId }&title=${ title }&link=${ link }&backUrl=/odie`
+			);
+		},
+		[ navigate ]
+	);
+
 	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_page_open', {
 			pathname: location.pathname,
@@ -142,6 +151,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 									/>
 								}
 								navigateToContactOptions={ navigateToContactOptions }
+								navigateToSupportDocs={ navigateToSupportDocs }
 							>
 								<HelpCenterOdie />
 							</OdieAssistantProvider>

--- a/packages/odie-client/src/components/foldable/index.tsx
+++ b/packages/odie-client/src/components/foldable/index.tsx
@@ -89,7 +89,7 @@ const FoldableCard: FC< FoldableCardProps > = ( {
 		const clickAction = ! clickableHeader ? getClickAction() : undefined;
 		if ( actionButton ) {
 			return (
-				<div className="foldable-card__action" role="presentation" onClick={ clickAction }>
+				<div className="odie-foldable-card__action" role="presentation" onClick={ clickAction }>
 					{ getActionButton() }
 				</div>
 			);
@@ -100,7 +100,7 @@ const FoldableCard: FC< FoldableCardProps > = ( {
 				<button
 					disabled={ disabled }
 					type="button"
-					className="foldable-card__action foldable-card__expand"
+					className="odie-foldable-card__action odie-foldable-card__expand"
 					aria-expanded={ isExpanded }
 					onClick={ clickAction }
 				>
@@ -114,14 +114,14 @@ const FoldableCard: FC< FoldableCardProps > = ( {
 	const renderContent = () => {
 		const additionalStyle = isExpanded ? contentExpandedStyle : contentCollapsedStyle;
 		return (
-			<div className="foldable-card__content" style={ additionalStyle }>
+			<div className="odie-foldable-card__content" style={ additionalStyle }>
 				{ children }
 			</div>
 		);
 	};
 
 	const Container = compact ? CompactCard : Card;
-	const itemSiteClasses = clsx( 'foldable-card', className, {
+	const itemSiteClasses = clsx( 'odie-foldable-card', className, {
 		'is-disabled': disabled,
 		'is-expanded': isExpanded,
 		'has-expanded-summary': !! expandedSummary,
@@ -131,11 +131,11 @@ const FoldableCard: FC< FoldableCardProps > = ( {
 	return (
 		<Container className={ itemSiteClasses } highlight={ highlight }>
 			<div
-				className="foldable-card__header is-clickable"
+				className="odie-foldable-card__header is-clickable"
 				role="presentation"
 				onClick={ getClickAction() }
 			>
-				<span className="foldable-card__main">{ header }</span>
+				<span className="odie-foldable-card__main">{ header }</span>
 				{ renderActionButton() }
 			</div>
 			{ ( isExpanded || smooth ) && renderContent() }

--- a/packages/odie-client/src/components/foldable/style.scss
+++ b/packages/odie-client/src/components/foldable/style.scss
@@ -2,8 +2,7 @@
 @import "@automattic/typography/styles/variables";
 @import "../styles/clear-fix";
 
-// Multisite
-.foldable-card.card {
+.odie-foldable-card.card {
 	@include a8c-clear-fix;
 	position: relative;
 	transition: margin 0.15s linear;
@@ -14,7 +13,7 @@
 	}
 }
 
-.foldable-card__header {
+.odie-foldable-card__header {
 	min-height: 64px;
 	width: 100%;
 	padding: 16px;
@@ -29,56 +28,56 @@
 	}
 
 	&.has-border {
-		.foldable-card__summary,
-		.foldable-card__summary-expanded {
+		.odie-foldable-card__summary,
+		.odie-foldable-card__summary-expanded {
 			margin-right: 48px;
 		}
 
-		.foldable-card__expand {
+		.odie-foldable-card__expand {
 			border-left: 1px var(--color-neutral-5) solid;
 		}
 	}
 }
 
-.foldable-card.is-compact .foldable-card__header {
+.odie-foldable-card.is-compact .odie-foldable-card__header {
 	padding: 8px 16px;
 	min-height: 40px;
 }
 
-.foldable-card.is-expanded .foldable-card__header {
+.odie-foldable-card.is-expanded .odie-foldable-card__header {
 	margin-bottom: 0;
 	height: inherit;
 	min-height: 64px;
 }
 
-.foldable-card.is-expanded.is-compact .foldable-card__header {
+.odie-foldable-card.is-expanded.is-compact .odie-foldable-card__header {
 	min-height: 40px;
 }
 
-.foldable-card.is-disabled .foldable-card__header {
+.odie-foldable-card.is-disabled .odie-foldable-card__header {
 	opacity: 0.2;
 }
 
-.foldable-card__action {
+.odie-foldable-card__action {
 	position: absolute;
 	top: 0;
 	right: 0;
 	height: 100%;
 }
 
-.foldable-card.is-expanded .foldable-card__action {
+.odie-foldable-card.is-expanded .odie-foldable-card__action {
 	height: 100%;
 }
 
-.foldable-card.is-disabled .foldable-card__action {
+.odie-foldable-card.is-disabled .odie-foldable-card__action {
 	cursor: default;
 }
 
-.accessible-focus .foldable-card__action:focus {
+.accessible-focus .odie-foldable-card__action:focus {
 	outline: thin dotted;
 }
 
-button.foldable-card__action {
+button.odie-foldable-card__action {
 	cursor: pointer;
 	// Reset button styles to protect against wp-admin styles.
 	background: #0000;
@@ -90,7 +89,7 @@ button.foldable-card__action {
 	vertical-align: initial;
 }
 
-.foldable-card__main {
+.odie-foldable-card__main {
 	max-width: calc(100% - 36px);
 	display: flex;
 	align-items: center;
@@ -102,7 +101,7 @@ button.foldable-card__action {
 	}
 }
 
-.foldable-card__secondary {
+.odie-foldable-card__secondary {
 	display: flex;
 	align-items: center;
 	flex: 1 1;
@@ -113,7 +112,7 @@ button.foldable-card__action {
 	}
 }
 
-.foldable-card__expand {
+.odie-foldable-card__expand {
 	width: 48px;
 
 	.gridicon {
@@ -135,15 +134,15 @@ button.foldable-card__action {
 	}
 }
 
-.foldable-card.is-expanded > .foldable-card__header .foldable-card__expand .gridicon {
+.odie-foldable-card.is-expanded > .odie-foldable-card__header .odie-foldable-card__expand .gridicon {
 	transform: rotate(180deg);
 }
 
-.foldable-card__content {
+.odie-foldable-card__content {
 	display: none;
 }
 
-.foldable-card.is-smooth .foldable-card__content {
+.odie-foldable-card.is-smooth .odie-foldable-card__content {
 	display: block;
 	overflow: hidden;
 
@@ -151,25 +150,24 @@ button.foldable-card__action {
 	max-height: 0;
 }
 
-.foldable-card.is-expanded.is-smooth .foldable-card__content {
+.odie-foldable-card.is-expanded.is-smooth .odie-foldable-card__content {
 	height: auto;
 	max-height: 250px; // fallback if not set inline with js
 	transition: max-height 0.25s ease;
 	padding: 0;
 }
 
-.foldable-card.is-expanded .foldable-card__content {
+.odie-foldable-card.is-expanded .odie-foldable-card__content {
 	display: block;
-	padding: 16px;
 	border-top: 1px solid var(--color-neutral-5);
 }
 
-.foldable-card.is-compact .foldable-card.is-expanded .foldable-card__content {
+.odie-foldable-card.is-compact .odie-foldable-card.is-expanded .odie-foldable-card__content {
 	padding: 8px;
 }
 
-.foldable-card__summary,
-.foldable-card__summary-expanded {
+.odie-foldable-card__summary,
+.odie-foldable-card__summary-expanded {
 	margin-right: 40px;
 	color: var(--color-text-subtle);
 	font-size: $font-body-extra-small;
@@ -181,30 +179,30 @@ button.foldable-card__action {
 	}
 }
 
-.foldable-card.has-expanded-summary .foldable-card__summary,
-.foldable-card.has-expanded-summary .foldable-card__summary-expanded {
+.odie-foldable-card.has-expanded-summary .odie-foldable-card__summary,
+.odie-foldable-card.has-expanded-summary .odie-foldable-card__summary-expanded {
 	transition: none;
 	flex: 2;
 	text-align: right;
 }
 
-.foldable-card__summary {
+.odie-foldable-card__summary {
 	opacity: 1;
 	display: inline-block;
 }
 
-.foldable-card.is-expanded .foldable-card__summary {
+.odie-foldable-card.is-expanded .odie-foldable-card__summary {
 	display: none;
 }
 
-.has-expanded-summary .foldable-card.is-expanded .foldable-card__summary {
+.has-expanded-summary .odie-foldable-card.is-expanded .odie-foldable-card__summary {
 	display: none;
 }
 
-.foldable-card__summary-expanded {
+.odie-foldable-card__summary-expanded {
 	display: none;
 }
 
-.foldable-card.is-expanded .foldable-card__summary-expanded {
+.odie-foldable-card.is-expanded .odie-foldable-card__summary-expanded {
 	display: inline-block;
 }

--- a/packages/odie-client/src/components/message/custom-a-link.tsx
+++ b/packages/odie-client/src/components/message/custom-a-link.tsx
@@ -37,6 +37,7 @@ const CustomALink = ( {
 				onClick={ () => {
 					trackEvent( 'chat_message_action_click', {
 						action: 'link',
+						in_chat_view: false,
 						href: transformedHref,
 					} );
 				} }

--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -17,10 +17,11 @@ import { useOdieAssistantContext } from '../../context';
 import useTyper from '../../utils/user-typer';
 import Button from '../button';
 import FoldableCard from '../foldable';
+import SupportDocLink from '../support-link';
 import CustomALink from './custom-a-link';
 import { uriTransformer } from './uri-transformer';
 import WasThisHelpfulButtons from './was-this-helpful-buttons';
-import type { CurrentUser, Message, Source } from '../../types/';
+import type { CurrentUser, Message } from '../../types/';
 
 import './style.scss';
 
@@ -35,8 +36,14 @@ const ChatMessage = (
 	ref: React.Ref< HTMLDivElement >
 ) => {
 	const isUser = message.role === 'user';
-	const { botName, extraContactOptions, addMessage, trackEvent, navigateToContactOptions } =
-		useOdieAssistantContext();
+	const {
+		botName,
+		extraContactOptions,
+		addMessage,
+		trackEvent,
+		navigateToContactOptions,
+		navigateToSupportDocs,
+	} = useOdieAssistantContext();
 	const [ scrolledToBottom, setScrolledToBottom ] = useState( false );
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 	const { __, _x } = useI18n();
@@ -343,10 +350,34 @@ const ChatMessage = (
 				>
 					<div className="odie-chatbox-message-sources">
 						{ sources.length > 0 &&
-							sources.map( ( source: Source, index: number ) => (
-								<CustomALink key={ index } href={ source.url } inline={ false }>
-									{ source?.title }
-								</CustomALink>
+							sources.map( ( source, index ) => (
+								<>
+									{ navigateToSupportDocs && (
+										<SupportDocLink
+											key={ index }
+											link={ source.url }
+											onLinkClickHandler={ () => {
+												trackEvent( 'chat_message_action_click', {
+													action: 'link',
+													in_chat_view: true,
+													href: source.url,
+												} );
+												navigateToSupportDocs(
+													String( source.blog_id ),
+													String( source.post_id ),
+													source.url,
+													source.title
+												);
+											} }
+											title={ source.title }
+										/>
+									) }
+									{ ! navigateToSupportDocs && (
+										<CustomALink key={ index } href={ source.url } inline={ false }>
+											{ source?.title }
+										</CustomALink>
+									) }
+								</>
 							) ) }
 					</div>
 				</FoldableCard>

--- a/packages/odie-client/src/components/support-link/index.tsx
+++ b/packages/odie-client/src/components/support-link/index.tsx
@@ -1,0 +1,28 @@
+import { decodeEntities } from '@wordpress/html-entities';
+import { Icon, chevronRight, page } from '@wordpress/icons';
+import './styles.scss';
+
+type SearchResultItemProps = {
+	link: string;
+	title: string;
+	onLinkClickHandler: () => void;
+};
+
+const SupportDocLink = ( { title, onLinkClickHandler }: SearchResultItemProps ) => {
+	const anchor = '#';
+	return (
+		<div className="odie-support-doc-link__container">
+			<div className="odie-support-doc-link__link">
+				<a href={ anchor } onClick={ onLinkClickHandler }>
+					<div className="icon-background">
+						<Icon icon={ page } />
+					</div>
+					<span>{ decodeEntities( title ) }</span>
+					<Icon width={ 20 } height={ 20 } icon={ chevronRight } />
+				</a>
+			</div>
+		</div>
+	);
+};
+
+export default SupportDocLink;

--- a/packages/odie-client/src/components/support-link/styles.scss
+++ b/packages/odie-client/src/components/support-link/styles.scss
@@ -1,0 +1,51 @@
+@import "@automattic/typography/styles/variables";
+.odie-support-doc-link__container {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 8px;
+
+	.odie-support-doc-link__link {
+		display: flex;
+		align-items: center;
+		background-color: var(--color-body-background);
+		text-decoration: none;
+		color: var(--color-text);
+		border-radius: 4px;
+
+		&:hover {
+			background-color: var(--studio-gray-0);
+		}
+
+		a {
+			display: flex;
+			align-items: center;
+			width: 100%;
+			text-decoration: none;
+			color: var(--studio-gray-100);
+
+			svg:last-child {
+				fill: var(--studio-gray-20);
+			}
+
+			.icon-background {
+				background-color: var(--studio-gray-0);
+				padding: 8px;
+				border-radius: 4px;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				margin-right: 8px;
+				svg {
+					fill: var(--studio-blue-50);
+				}
+			}
+
+			span {
+				flex-grow: 2;
+				font-size: $font-body-small;
+				-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+				color: var(--studio-gray-100);
+			}
+		}
+	}
+}

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -34,6 +34,7 @@ type OdieAssistantContextInterface = {
 	extraContactOptions?: ReactNode;
 	lastNudge: Nudge | null;
 	navigateToContactOptions?: () => void;
+	navigateToSupportDocs?: ( blogId: string, postId: string, title: string, link: string ) => void;
 	odieClientId: string;
 	sendNudge: ( nudge: Nudge ) => void;
 	selectedSiteId?: number | null;
@@ -63,6 +64,7 @@ const defaultContextInterfaceValues = {
 	isVisible: false,
 	lastNudge: null,
 	navigateToContactOptions: noop,
+	navigateToSupportDocs: noop,
 	odieClientId: '',
 	currentUser: { display_name: 'Me' },
 	sendNudge: noop,
@@ -99,6 +101,7 @@ type OdieAssistantProviderProps = {
 	logger?: ( message: string, properties: Record< string, unknown > ) => void;
 	loggerEventNamePrefix?: string;
 	navigateToContactOptions?: () => void;
+	navigateToSupportDocs?: ( blogId: string, postId: string, title: string, link: string ) => void;
 	selectedSiteId?: number | null;
 	version?: string | null;
 	children?: ReactNode;
@@ -114,6 +117,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 	logger,
 	loggerEventNamePrefix,
 	navigateToContactOptions,
+	navigateToSupportDocs,
 	selectedSiteId,
 	version = null,
 	currentUser,
@@ -242,6 +246,7 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 				isVisible,
 				lastNudge,
 				navigateToContactOptions,
+				navigateToSupportDocs,
 				odieClientId,
 				selectedSiteId,
 				sendNudge: setLastNudge,

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -4,6 +4,9 @@ export type Source = {
 	title: string;
 	url: string;
 	heading: string;
+	blog_id: number;
+	post_id: number;
+	content: string;
 };
 
 export type CurrentUser = {


### PR DESCRIPTION
## Proposed Changes

Open support doc links within the Wapuu experience.

## Why are these changes being made?
We think that opening links on a different tab might be a bit disturbing. We are proposing to open the support links as the Help Center did in the past, within the same container.

## Testing Instructions

1. Click on the help center icon (top right hand)
2. Click on "Still need help?"
3. As a real question about WordPress
4. Assert that you can see the styling of the links as per the video above, also, assert that you can navigate back and forth.

https://github.com/user-attachments/assets/f8ee6f46-1132-407f-a9c0-b8f8f2c967cb

Regression Test.
This has changed some components that might cause some regression, it would be ideal to test the flows where the back button is used.

Extra details.
We 've changed the class names for the component "foldable", as it needed to be tweaked a bit. Now it contains unique class names.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
