### PR TITLE
A4A: Fix site selector to support A4A client sites.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -8,9 +8,11 @@ import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dash
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import getRawSite from 'calypso/state/selectors/get-raw-site';
 import getSites from 'calypso/state/selectors/get-sites';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import A4ALogo from '../../a4a-logo';
 import useManagedSitesMap from './hooks/use-managed-sites-map';
 import WPCOMSitesTableContent from './table-content';
 import WPCOMSitesTablePlaceholder from './table-placeholder';
@@ -25,9 +27,13 @@ export type SiteItem = {
 const TypeIcon = ( { siteId }: { siteId: number } ) => {
 	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isA4AClient = useSelector( ( state ) => getRawSite( state, siteId )?.is_a4a_client );
 
 	if ( isWPCOM ) {
 		return <Icon className="wpcom-sites-table__icon" icon={ <WordPressLogo /> } />;
+	}
+	if ( isA4AClient ) {
+		return <Icon className="wpcom-sites-table__icon" icon={ <A4ALogo /> } />;
 	}
 	if ( isJetpack ) {
 		return <Icon className="wpcom-sites-table__icon" icon={ <JetpackLogo /> } />;
@@ -75,7 +81,7 @@ export default function WPCOMSitesTable( {
 				( site ) =>
 					site &&
 					! site.is_wpcom_staging_site &&
-					( site.is_wpcom_atomic || site.jetpack ) &&
+					( site.is_wpcom_atomic || site.jetpack || site.is_a4a_client ) &&
 					! managedSitesMap?.[ site.ID as number ]
 			)
 			.map( ( site ) =>

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -8,10 +8,10 @@ import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dash
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import getRawSite from 'calypso/state/selectors/get-raw-site';
 import getSites from 'calypso/state/selectors/get-sites';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import isA4AClientSite from 'calypso/state/sites/selectors/is-a4a-client-site';
 import A4ALogo from '../../a4a-logo';
 import useManagedSitesMap from './hooks/use-managed-sites-map';
 import WPCOMSitesTableContent from './table-content';
@@ -27,7 +27,7 @@ export type SiteItem = {
 const TypeIcon = ( { siteId }: { siteId: number } ) => {
 	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const isA4AClient = useSelector( ( state ) => getRawSite( state, siteId )?.is_a4a_client );
+	const isA4AClient = useSelector( ( state ) => isA4AClientSite( state, siteId ) );
 
 	if ( isWPCOM ) {
 		return <Icon className="wpcom-sites-table__icon" icon={ <WordPressLogo /> } />;

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -29,6 +29,7 @@ export const SITE_REQUEST_FIELDS = [
 	'description',
 	'user_interactions',
 	'is_deleted',
+	'is_a4a_client',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [

--- a/client/state/sites/selectors/is-a4a-client-site.ts
+++ b/client/state/sites/selectors/is-a4a-client-site.ts
@@ -1,0 +1,16 @@
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns true if site is a A4A client site
+ */
+export default function isA4AClientSite(
+	state: AppState,
+	siteId: number | undefined | null
+): boolean {
+	if ( ! siteId ) {
+		return false;
+	}
+
+	return !! getRawSite( state, siteId )?.is_a4a_client;
+}

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -131,6 +131,7 @@ export interface SiteDetails {
 	is_vip?: boolean;
 	is_wpcom_atomic?: boolean;
 	is_wpcom_staging_site?: boolean;
+	is_a4a_client?: boolean;
 	jetpack: boolean;
 	lang?: string;
 	launch_status: string;


### PR DESCRIPTION
This PR is part of a multi-patch that fixes the issue with the Site selector being unable to support sites connected via the A4A plugin.

We want to distinguish which sites are connected via the A4A plugin. To do this, we need to introduce a new `is_a4a_client` property to the 'me/sites' endpoint. 

This PR handles the frontend side by recognizing the `is_a4a_client` property to filter out importable sites in the A4A dashboard.

<img width="838" alt="Screenshot 2024-07-19 at 8 16 26 PM" src="https://github.com/user-attachments/assets/773de3e1-4621-4981-bacb-e65349e62f85">

**Context:**

p1720798646587609-slack-C06JY8QL0TU

**Other Patches**
D155869-code
https://github.com/Automattic/jetpack/pull/38403


## Proposed Changes

* Update the `me/sites` fetch variable to include `is_a4a_client` property in the request parameter.
* Update a few constants and interfaces to officially recognize the new property.
* Update site selector filter logic to include sites with the new property as importable site. 

## Why are these changes being made?

* One primary option for connecting sites in the A4A platform is the A4A client plugin itself, and the site selector must be able to support this.

## Testing Instructions

Before testing this, you need to setup your sandbox to support the new `is_a4a_client` property. Please see D155869-code for the setup instructions.

* Once you have applied D155869-code patch to your sandbox and point public-api.wordpress.com to your sandbox.
* Spin up a JN site (without Jetpack) and install the A4A plugin to connect it to the A4A platform.
* Use the A4A live link and go to the `/sites` page.
* Test that you can remove and add A4A client sites using the site selector.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?