### PR TITLE
i18n: Localize link to Jetpack CDN page on the Performance settings sreen

### DIFF
--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -7,6 +7,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { CompactCard } from '@automattic/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import cloudflareIllustration from 'calypso/assets/images/illustrations/cloudflare-logo-small.svg';
@@ -19,6 +20,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const Cloudflare = () => {
 	const translate = useTranslate();
+	const localizeUrl = useLocalizeUrl();
 	const dispatch = useDispatch();
 	const showCloudflare = config.isEnabled( 'cloudflare' );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
@@ -59,7 +61,9 @@ const Cloudflare = () => {
 								<p>
 									<a
 										onClick={ recordClick }
-										href="https://jetpack.com/features/design/content-delivery-network/"
+										href={ localizeUrl(
+											'https://jetpack.com/features/design/content-delivery-network/'
+										) }
 										target="_blank"
 										rel="noreferrer"
 									>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 851-gh-Automattic/i18n-issues

## Proposed Changes

* Localize the Learn more link for Jetpack CDN on the Performance settings screen.

![kv19JDioLYcQAw1f](https://github.com/user-attachments/assets/059882b3-981e-497a-a751-e006c33edbdc)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Jetpack CDN page is available in the Mag-16 languages and therefore we need to use a localized link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Switch to a Mag-16 language.
* Naviagate to `/settings/performance/<site>` and verify the "Learn More" link for the Jetpack CDN is localized.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
