### PR TITLE
Trying up to 5 times to locate the restaurant using the OpenTable block

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/opentable.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/opentable.ts
@@ -43,10 +43,23 @@ export class OpenTableFlow implements BlockFlow {
 		const editorCanvas = await context.editorPage.getEditorCanvas();
 		const restaurant = this.configurationData.restaurant.toString();
 		const searchLocator = editorCanvas.locator( selectors.searchInput );
-		await searchLocator.fill( restaurant );
 
-		const suggestionLocator = editorCanvas.locator( selectors.suggestion( restaurant ) ).first(); // There are many restaurants out there, let's grab the first if the name wasn't specific enough.
-		await suggestionLocator.click();
+		/**
+		 * Due to API inconsistency of OpenTable, we need to try a few times to get the correct restaurant.
+		 * https://github.com/Automattic/wp-calypso/issues/92836
+		 */
+		for ( let i = 0; i < 5; i++ ) {
+			try {
+				await searchLocator.fill( restaurant );
+				const suggestionLocator = editorCanvas
+					.locator( selectors.suggestion( restaurant ) )
+					.first(); // There are many restaurants out there, let's grab the first if the name wasn't specific enough.
+				await suggestionLocator.click();
+				break;
+			} catch ( e ) {
+				await searchLocator.fill( '' );
+			}
+		}
 
 		const embedButtonLocator = editorCanvas.locator( selectors.embedButton );
 		await embedButtonLocator.click();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/39410
Task: https://github.com/Automattic/wp-calypso/issues/92543

## Proposed Changes

* Trying up to 5 times to locate the restaurant using the OpenTable block so we avoid flaky e2e test


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this test a couple of times to ensure it always passes now: `GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test -- specs/blocks/blocks__jetpack-earn.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
