### PR TITLE
Masterbar: Show shopping cart in mobile

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -558,8 +558,7 @@ body.is-mobile-app-view {
 		}
 
 		&.masterbar__item-notifications,
-		&.masterbar__item-help,
-		&.masterbar-cart-button {
+		&.masterbar__item-help {
 			display: none;
 		}
 	}


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/wp-calypso/pull/92830
See p1721391905391319/1721386643.123449-slack-C06DN6QQVAQ

## Proposed Changes

Displays the shopping cart in the Calypso masterbar for mobile viewports

Before | After
--- | ---
<img width="373" alt="Screenshot 2024-07-19 at 16 29 50" src="https://github.com/user-attachments/assets/a0268a9c-54e8-4c45-befb-9886fa897bfc"> |  <img width="388" alt="Screenshot 2024-07-19 at 16 43 43" src="https://github.com/user-attachments/assets/609f3b41-bc44-4e34-af2a-a373296be773">


## Why are these changes being made?

Because the shopping cart is missing from Calypso masterbar for mobiles.

## Testing Instructions

- Use the Calypso live link below
- Resize your browser to use a mobile viewport
- Go to `/plans`
- Select a Free site
- Choose any paid plan
- Exit the checkout via the "X" button in the top left corner (choose to keep items in the cart)
- Make sure the shopping cart is visible in the masterbar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?