### PR TITLE
Masterbar: Show notification+help icons on mobile

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -550,7 +550,6 @@ body.is-mobile-app-view {
 
 
 	@media only screen and (max-width: 480px) {
-		width: 48px;
 		// reset flex value on mobile
 		flex: 0 1 auto;
 		padding: 0;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1100,8 +1100,8 @@ body.is-mobile-app-view {
 		height: 27px;
 
 		@media only screen and (max-width: 782px) {
-			width: 32px;
-			height: 32px;
+			width: 36px;
+			height: 36px;
 		}
 	}
 
@@ -1287,7 +1287,9 @@ a.masterbar__quick-language-switcher {
 }
 
 .masterbar__item-help {
-	padding: 0 11px;
+	@media only screen and (min-width: 782px) {
+		padding: 0 11px;
+	}
 
 	svg {
 		fill: var(--color-masterbar-icon);
@@ -1295,8 +1297,8 @@ a.masterbar__quick-language-switcher {
 		height: 24px;
 
 		@media only screen and (max-width: 782px) {
-			width: 32px;
-			height: 32px;
+			width: 36px;
+			height: 36px;
 		}
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -557,13 +557,14 @@ body.is-mobile-app-view {
 			display: block;
 		}
 
-		&.masterbar__item-help {
+		&.masterbar__item-my-site-actions {
 			display: none;
 		}
 	}
 
 	@media only screen and (max-width: 400px) {
-		&.masterbar__item-my-site-actions {
+		&.masterbar__item-my-site-actions,
+		&.masterbar__reader {
 			display: none;
 		}
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -557,11 +557,17 @@ body.is-mobile-app-view {
 			display: block;
 		}
 
-		&.masterbar__item-notifications,
 		&.masterbar__item-help {
 			display: none;
 		}
 	}
+
+	@media only screen and (max-width: 400px) {
+		&.masterbar__item-my-site-actions {
+			display: none;
+		}
+	}
+
 
 	&:disabled {
 		&:hover {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -569,7 +569,6 @@ body.is-mobile-app-view {
 		}
 	}
 
-
 	&:disabled {
 		&:hover {
 			background: initial;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -232,6 +232,13 @@ body.is-mobile-app-view {
 		@include breakpoint-deprecated( ">480px" ) {
 			flex-grow: 0;
 		}
+
+		@media only screen and (max-width: 480px) {
+			position: absolute;
+			top: 0;
+			right: 0;
+			background: var(--color-masterbar-background);
+		}
 	}
 }
 
@@ -555,17 +562,6 @@ body.is-mobile-app-view {
 		&.masterbar__item--always-show-content .masterbar__item-content,
 		&.masterbar__item-me .masterbar__item-content {
 			display: block;
-		}
-
-		&.masterbar__item-my-site-actions {
-			display: none;
-		}
-	}
-
-	@media only screen and (max-width: 400px) {
-		&.masterbar__item-my-site-actions,
-		&.masterbar__reader {
-			display: none;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8366

## Proposed Changes

Show Notifications & help icons on small screens, make right section shows over the left one on small screens.

## Why are these changes being made?
Icon is not showing.

Before:
![image](https://github.com/user-attachments/assets/1a11b2a6-295c-4c82-a4c0-d830f5914a57)

After:

https://github.com/user-attachments/assets/c32a5f72-500b-4ee7-a42b-4e542189454d

## Testing Instructions
* Add something to your cart (like a domain)
* Go to `/home/:SITE_SLUG`
* Check the icons showing on small screens

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
