### PR TITLE
Update `/help` header and footer copy

### DIFF
--- a/client/me/help/help-contact-us-footer.tsx
+++ b/client/me/help/help-contact-us-footer.tsx
@@ -27,13 +27,13 @@ const HelpContactUsFooter: FC = () => {
 			<CompactCard className="help__contact-us-card" onClick={ onClick }>
 				<Gridicon icon="help" size={ 36 } />
 				<div className="help__contact-us-section">
-					<h3 className="help__contact-us-title">{ __( 'Contact support' ) }</h3>
+					<h3 className="help__contact-us-title">{ __( "Haven't found your answer?" ) }</h3>
 					<p className="help__contact-us-content">
-						{ __( "Can't find the answer? Drop us a line and we'll lend a hand." ) }
+						{ __( 'Our AI assistant can help, or connect you to our support team.' ) }
 					</p>
 				</div>
 				<Button primary className="help__contact-us-button">
-					{ __( 'Contact support' ) }
+					{ __( 'Get help' ) }
 				</Button>
 			</CompactCard>
 		</>

--- a/client/me/help/help-contact-us-header.tsx
+++ b/client/me/help/help-contact-us-header.tsx
@@ -23,7 +23,9 @@ const HelpContactUsHeader: FC = () => {
 
 	return (
 		<div className="help__contact-us-header-button">
-			<Button onClick={ onClick }>{ __( 'Contact support' ) }</Button>
+			<Button primary onClick={ onClick }>
+				{ __( 'Get help' ) }
+			</Button>
 		</div>
 	);
 };

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -241,7 +241,7 @@ class Help extends PureComponent {
 				<NavigationHeader
 					navigationItems={ [] }
 					title={ translate( 'Support' ) }
-					subtitle={ translate( 'Get help with your WordPress.com site' ) }
+					subtitle={ translate( 'Get help with your WordPress.com site.' ) }
 				>
 					<HelpContactUsHeader />
 				</NavigationHeader>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8122-gh-Automattic/dotcom-forge

## Proposed Changes

**Header**
- Add `.` to the end of the tagline.
- Change CTA to “Get help” and apply primary button style.

|Before|After|
|------|------|
|<img width="757" alt="Screen Shot 2024-07-11 at 3 36 39 PM" src="https://github.com/Automattic/dotcom-forge/assets/104910361/90cfc4fe-fbc6-42a5-9426-4f27ba1e5ac5">|<img width="768" alt="Screen Shot 2024-07-11 at 3 37 31 PM" src="https://github.com/Automattic/dotcom-forge/assets/104910361/c505542e-df6e-4a1c-9726-1c6abacfcf89">|

**Footer**
- Change banner title to "Haven’t found your answer?"
- Change banner tagline to "Our AI assistant can help, or connect you to our support team."
- Change CTA to “Get help”.

|Before|After|
|------|------|
|<img width="752" alt="Screen Shot 2024-07-11 at 3 38 07 PM" src="https://github.com/Automattic/dotcom-forge/assets/104910361/c74f3a2b-c24f-4693-a4d5-74787173ba57">|<img width="762" alt="Screen Shot 2024-07-11 at 3 38 58 PM" src="https://github.com/Automattic/dotcom-forge/assets/104910361/325a3a4f-c083-4597-9426-2b5990330912">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current "Contact support" CTA and tagline give the expectation that users will reach a human, but instead, when users click on "Contact support", we first bring them to Wapuu. This PR updates the content to create more accurate expectations around what happens when the CTA is clicked.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Load `/help` for any WordPress.com site
- Confirm the following copy is displayed with no typos:
	- Header:
		- Title: _Haven't found your answer?_
		- Tagline: _Get help with your WordPress.com site._ (emphasis on the trailing `.` as that is the only change to this part)
		- CTA button label: _Get help_
		- Also confirm the `primary` variant is applied to the header CTA, rendering in blue with white text
	- Footer:
		- Title: _Haven't found your answer?_  
		- Tagline: _ Our AI assistant can help, or connect you to our support team_
		- CTA button label: _Get help_