### PR TITLE
Revert "Revert "Enable migration instructions feature for English locale""

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/site-preview/hooks/test/use-site-preview-mshot-image-handler.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/site-preview/hooks/test/use-site-preview-mshot-image-handler.test.ts
@@ -14,16 +14,6 @@ jest.mock( 'react', () => {
 	};
 } );
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	...jest.requireActual( '@automattic/calypso-config' ),
-	isEnabled: ( feature: string ) => {
-		if ( 'migration-flow/new-migration-instructions-step' === feature ) {
-			return true;
-		}
-		return jest.requireActual( '@automattic/calypso-config' ).isEnabled( feature );
-	},
-} ) );
-
 describe( 'useSitePreviewMShotImageHandler', () => {
 	let mockRef: { current: HTMLDivElement | null };
 	const mockElement = document.createElement( 'div' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler.ts
@@ -1,5 +1,5 @@
-import config from '@automattic/calypso-config';
 import { useEffect, useRef, useState } from '@wordpress/element';
+import { getLocaleSlug } from 'i18n-calypso';
 import { throttle } from 'lodash';
 
 interface MShotConfig {
@@ -89,7 +89,7 @@ export const useSitePreviewMShotImageHandler = ( url: string = '' ) => {
 	}, [ previewRef ] );
 
 	const createScreenshots = ( url: string ) => {
-		const isEnabled = config.isEnabled( 'migration-flow/new-migration-instructions-step' );
+		const isEnabled = getLocaleSlug()?.startsWith( 'en' ); // Previous 'migration-flow/new-migration-instructions-step'.
 
 		if ( ! isEnabled ) {
 			return;

--- a/client/landing/stepper/declarative-flow/migration-signup.ts
+++ b/client/landing/stepper/declarative-flow/migration-signup.ts
@@ -1,7 +1,7 @@
-import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { MIGRATION_SIGNUP_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { getLocaleSlug } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -17,9 +17,7 @@ import { type SiteMigrationIdentifyAction } from './internals/steps-repository/s
 import type { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
 
-const MIGRATION_INSTRUCTIONS_STEP = config.isEnabled(
-	'migration-flow/new-migration-instructions-step'
-)
+const MIGRATION_INSTRUCTIONS_STEP = getLocaleSlug()?.startsWith( 'en' ) // Previous 'migration-flow/new-migration-instructions-step'.
 	? STEPS.SITE_MIGRATION_INSTRUCTIONS
 	: STEPS.SITE_MIGRATION_INSTRUCTIONS_I2;
 
@@ -42,6 +40,7 @@ const migrationSignup: Flow = {
 			STEPS.PROCESSING,
 			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
 			MIGRATION_INSTRUCTIONS_STEP,
+			STEPS.SITE_MIGRATION_STARTED,
 			STEPS.ERROR,
 		] );
 	},
@@ -178,6 +177,16 @@ const migrationSignup: Flow = {
 									: {},
 						} );
 						return;
+					}
+				}
+
+				case STEPS.SITE_MIGRATION_INSTRUCTIONS.slug: {
+					// Take the user to the migration started step.
+					if ( providedDependencies?.destination === 'migration-started' ) {
+						return navigate( STEPS.SITE_MIGRATION_STARTED.slug, {
+							siteId,
+							siteSlug,
+						} );
 					}
 				}
 			}

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -3,6 +3,7 @@ import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isHostedSiteMigrationFlow } from '@automattic/onboarding';
 import { SiteExcerptData } from '@automattic/sites';
 import { useSelect } from '@wordpress/data';
+import { getLocaleSlug } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
@@ -25,9 +26,7 @@ import { AssertConditionState } from './internals/types';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
 
-const MIGRATION_INSTRUCTIONS_STEP = config.isEnabled(
-	'migration-flow/new-migration-instructions-step'
-)
+const MIGRATION_INSTRUCTIONS_STEP = getLocaleSlug()?.startsWith( 'en' ) // Previous 'migration-flow/new-migration-instructions-step'.
 	? STEPS.SITE_MIGRATION_INSTRUCTIONS
 	: STEPS.SITE_MIGRATION_INSTRUCTIONS_I2;
 

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -172,7 +172,7 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`,
+				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }`,
 				state: {
 					siteSlug: 'example.wordpress.com',
 				},
@@ -229,7 +229,7 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 
 			expect( goToCheckout ).toHaveBeenCalledWith( {
-				destination: `/setup/hosted-site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
+				destination: `/setup/hosted-site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
 				extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 				flowName: 'hosted-site-migration',
 				siteSlug: 'example.wordpress.com',
@@ -263,7 +263,7 @@ describe( 'Hosted site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: '/site-migration-instructions-i2',
+				path: '/site-migration-instructions',
 				state: { siteSlug: 'example.wordpress.com' },
 			} );
 		} );

--- a/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/migration-signup-flow.tsx
@@ -103,7 +103,7 @@ describe( 'Migration Signup Flow', () => {
 			} );
 
 			expect( goToCheckout ).toHaveBeenCalledWith( {
-				destination: `/setup/migration-signup/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com&siteId=123`,
+				destination: `/setup/migration-signup/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }?siteSlug=example.wordpress.com&siteId=123`,
 				extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 				flowName: 'migration-signup',
 				siteSlug: 'example.wordpress.com',

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -215,7 +215,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`,
+				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }`,
 				state: {
 					siteSlug: 'example.wordpress.com',
 				},
@@ -272,7 +272,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( goToCheckout ).toHaveBeenCalledWith( {
-				destination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
+				destination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
 				extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 				flowName: 'site-migration',
 				siteSlug: 'example.wordpress.com',
@@ -325,7 +325,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS_I2.slug }`,
+				path: `/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }`,
 				state: { siteSlug: 'example.wordpress.com' },
 			} );
 		} );

--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,6 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/new-migration-instructions-step": false,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"oauth": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,7 +91,6 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/new-migration-instructions-step": false,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -118,7 +118,6 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/new-migration-instructions-step": false,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -114,7 +114,6 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/new-migration-instructions-step": false,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/test.json
+++ b/config/test.json
@@ -84,7 +84,6 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/new-migration-instructions-step": false,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"p2-enabled": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -111,7 +111,6 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/new-migration-instructions-step": false,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#92842

- This was originally added through this PR: https://github.com/Automattic/wp-calypso/pull/92766
- Then we reverted to update some metrics: https://github.com/Automattic/wp-calypso/pull/92845
- After the metrics are updated, we can deploy it again.