### PR TITLE
Fix Form AI Jetpack helper by using the same Desktop selector for mobile

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -1,5 +1,3 @@
-import { Locator } from 'playwright';
-import { envVariables } from '../../..';
 import { makeSelectorFromBlockName, validatePublishedFormFields } from './shared';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
@@ -38,28 +36,19 @@ export class FormAiFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		let aiInputParentLocator: Locator;
-		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// On mobile, it's attached to the editor block toolbar, which is apart from the block DOM.
-			aiInputParentLocator = await context.editorPage.getEditorParent();
-		} else {
-			// On desktop, it's within the block DOM node.
-			aiInputParentLocator = context.addedBlockLocator;
-		}
-
-		const aiInputReadyLocator = aiInputParentLocator.getByPlaceholder( 'Ask Jetpack AI to edit…' );
-		const aiInputBusyLocator = aiInputParentLocator.getByRole( 'button', {
+		const aiInputParentLocator = context.addedBlockLocator;
+		const aiInputReadyLocator =
+			await aiInputParentLocator.getByPlaceholder( 'Ask Jetpack AI to edit…' );
+		const aiInputBusyLocator = await aiInputParentLocator.getByRole( 'button', {
 			name: 'Stop request',
 		} );
 		const sendButtonLocator = aiInputParentLocator.getByRole( 'button', {
 			name: 'Send request',
 		} );
-
 		await aiInputReadyLocator.fill( this.configurationData.prompt );
 		await sendButtonLocator.click();
 		await aiInputBusyLocator.waitFor();
 		await aiInputReadyLocator.waitFor( { timeout: 30 * 1000 } );
-
 		// Grab a first sample input label and submit button text to use for validation.
 		this.validationData = {
 			sampleInputLabel: await this.getFirstTextFieldLabel( context ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [Gutenberg v18.8.0](https://github.com/WordPress/gutenberg/releases/tag/v18.8.0)
Task https://github.com/Automattic/wp-calypso/issues/92543

## Proposed Changes

* Reusing Desktop selector for mobile viewport


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this test `VIEWPORT_NAME=mobile GUTENBERG_EDGE=true TEST_ON_ATOMIC=true  yarn workspace wp-e2e-tests test -- specs/blocks/blocks__jetpack-forms.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
