### PR TITLE
Frictionless Email Subscriptions: Only include non-empty last name when creating user account

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -55,7 +55,6 @@ const getEmailSubscriptionFlow = () => {
 						'mailing_list',
 						'from',
 						'first_name',
-						'last_name',
 					],
 					hideProgressIndicator: true,
 				},

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -122,12 +122,17 @@ function SubscribeEmailStep( props ) {
 	useEffect( () => {
 		// 1. User is not logged in and the email submitted to the flow is valid
 		if ( ! currentUser && emailValidator.validate( email ) ) {
+			// Last name is an optional field in the subscription form, and an empty value may be
+			// submitted. However the API will deem an empty last name invalid and return an error,
+			// so we only include it in the API request if it's a non-empty string.
+			const includeLastName = queryArguments.last_name?.length > 0;
+
 			createNewAccount( {
 				userData: {
 					email,
 					extra: {
 						first_name: queryArguments.first_name,
-						last_name: queryArguments.last_name,
+						...( includeLastName && { last_name: queryArguments.last_name } ),
 					},
 				},
 				flowName,


### PR DESCRIPTION
Related to https://github.com/Automattic/martech/issues/3194

## Proposed Changes

* Only include the `last_name` property in the `/users/new` API request when the value is a non-empty string.

## Why are these changes being made?

* Followup to https://github.com/Automattic/wp-calypso/pull/92814. 
* The user's last name is an optional field in the subscription form, and an empty value may be submitted. However the API will deem an empty last name invalid and return an error, so we only include it in the API request if it's a non-empty string.

## Testing Instructions

* Navigate to the following address with test values for `user_email` & `first_name`
  `/start/email-subscription/subscribe?user_email=hello@email.com&first_name=Bob&last_name=&mailing_list=zzz&redirect_to=https%3A%2F%2Fh4tests.wordpress.com%2Ftest-email-subscription&from=%2Ftest-email-subscription%2F`
    * Note the empty `last_name=&...`
* Inspect the `/users/new` API request
  * The payload should not contain a `last_name` property
  * The response should be a 200 with a `user_id` property

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
