### PR TITLE
A4A > Referrals: API implementation for referral commissions

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
@@ -10,7 +10,7 @@ export default function CommissionsInfo( { items }: { items: ShoppingCartItem[] 
 
 	const totalCommissions = items.reduce( ( acc, item ) => {
 		const product = item;
-		const commissionPercentage = getProductCommissionPercentage( product );
+		const commissionPercentage = getProductCommissionPercentage( product.family_slug );
 		const totalCommissions = product?.amount ? Number( product.amount ) * commissionPercentage : 0;
 		return acc + totalCommissions;
 	}, 0 );

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -6,11 +6,19 @@ import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import { getConsolidatedData } from '../lib/commissions';
-import type { Referral } from '../types';
+import type { Referral, ReferralInvoice } from '../types';
 
 import './style.scss';
 
-export default function ConsolidatedViews( { referrals }: { referrals: Referral[] } ) {
+export default function ConsolidatedViews( {
+	referrals,
+	referralInvoices,
+	isFetchingInvoices,
+}: {
+	referrals: Referral[];
+	referralInvoices: ReferralInvoice[];
+	isFetchingInvoices?: boolean;
+} ) {
 	const translate = useTranslate();
 
 	const date = new Date();
@@ -28,18 +36,20 @@ export default function ConsolidatedViews( { referrals }: { referrals: Referral[
 
 	useEffect( () => {
 		if ( data?.length ) {
-			const consolidatedData = getConsolidatedData( referrals, data || [] );
+			const consolidatedData = getConsolidatedData( referrals, data || [], referralInvoices );
 			setConsolidatedData( consolidatedData );
 		}
-	}, [ referrals, data ] );
+	}, [ referrals, data, referralInvoices ] );
 
 	const link = 'https://automattic.com/for-agencies/program-incentives/';
+
+	const showLoader = isFetching || isFetchingInvoices;
 
 	return (
 		<div className="consolidated-view">
 			<Card compact>
 				<div className="consolidated-view__value">
-					{ isFetching ? (
+					{ showLoader ? (
 						<TextPlaceholder />
 					) : (
 						formatCurrency( consolidatedData.allTimeCommissions, 'USD' )
@@ -85,7 +95,7 @@ export default function ConsolidatedViews( { referrals }: { referrals: Referral[
 			</Card>
 			<Card compact>
 				<div className="consolidated-view__value">
-					{ isFetching ? (
+					{ showLoader ? (
 						<TextPlaceholder />
 					) : (
 						formatCurrency( consolidatedData.pendingCommission, 'USD' )

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referral-invoices.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referral-invoices.ts
@@ -1,0 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import type { ReferralInvoiceAPIResponse, ReferralInvoice } from '../types';
+
+export const getReferralInvoicesQueryKey = ( agencyId?: number ) => {
+	return [ 'a4a-referral-invoices', agencyId ];
+};
+
+const getReferralInvoices = ( data: {
+	invoices: { [ clientId: string ]: ReferralInvoiceAPIResponse[] };
+} ): ReferralInvoice[] => {
+	if ( ! data ) {
+		return [];
+	}
+	const clientIds = Object.keys( data.invoices );
+
+	return clientIds
+		.map( ( clientId ) => {
+			const clientInvoices = data.invoices[ clientId ];
+			return clientInvoices.reduce( ( acc: ReferralInvoice[], invoice ) => {
+				if ( invoice.status === 'void' ) {
+					return acc;
+				}
+
+				let isPaid = false;
+				let isDue = false;
+				if ( invoice.amount_due > 0 ) {
+					isDue = true;
+				} else if ( invoice.amount_paid > 0 ) {
+					isPaid = true;
+				}
+
+				acc.push( {
+					...invoice,
+					clientId: parseInt( clientId ),
+					isPaid,
+					isDue,
+				} );
+
+				return acc;
+			}, [] );
+		} )
+		.flat();
+};
+
+export default function useFetchReferralInvoices( isEnabled: boolean ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	const data = useQuery( {
+		queryKey: getReferralInvoicesQueryKey( agencyId ),
+		queryFn: () =>
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/referrals/invoices`,
+			} ),
+		enabled: isEnabled && !! agencyId,
+		select: getReferralInvoices,
+		refetchOnWindowFocus: false,
+	} );
+
+	return data;
+}

--- a/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
@@ -1,17 +1,14 @@
-import type { Referral } from '../types';
+import type { Referral, ReferralInvoice } from '../types';
 import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
-export const getProductCommissionPercentage = ( product?: APIProductFamilyProduct ) => {
-	if ( ! product ) {
+export const getProductCommissionPercentage = ( slug?: string ) => {
+	if ( ! slug ) {
 		return 0;
 	}
-	if ( [ 'wpcom-hosting', 'pressable-hosting' ].includes( product.family_slug ) ) {
+	if ( [ 'wpcom-hosting', 'pressable-hosting' ].includes( slug ) ) {
 		return 0.2;
 	}
-	if (
-		product.family_slug.startsWith( 'jetpack-' ) ||
-		product.family_slug.startsWith( 'woocommerce-' )
-	) {
+	if ( slug.startsWith( 'jetpack-' ) || slug.startsWith( 'woocommerce-' ) ) {
 		return 0.5;
 	}
 	return 0;
@@ -22,7 +19,7 @@ export const calculateCommissions = ( referral: Referral, products: APIProductFa
 		.filter( ( purchase ) => [ 'pending', 'active' ].includes( purchase.status ) )
 		.map( ( purchase ) => {
 			const product = products.find( ( product ) => product.product_id === purchase.product_id );
-			const commissionPercentage = getProductCommissionPercentage( product );
+			const commissionPercentage = getProductCommissionPercentage( product?.family_slug );
 			const totalCommissions = product?.amount
 				? Number( product.amount ) * commissionPercentage
 				: 0;
@@ -33,12 +30,34 @@ export const calculateCommissions = ( referral: Referral, products: APIProductFa
 
 export const getConsolidatedData = (
 	referrals: Referral[],
-	products: APIProductFamilyProduct[]
+	products: APIProductFamilyProduct[],
+	invoices: ReferralInvoice[]
 ) => {
+	const { totalAmountDue, totalAmountPaid } = invoices.reduce(
+		( acc, invoice ) => {
+			const total = invoice.products.reduce( ( acc, product ) => {
+				const commissionPercentage = getProductCommissionPercentage( product.product_family_slug );
+				const totalCommissions = product.amount
+					? Number( product.amount ) * commissionPercentage
+					: 0;
+				return acc + totalCommissions;
+			}, 0 );
+
+			if ( invoice.isPaid ) {
+				acc.totalAmountPaid += total;
+			}
+			if ( invoice.isDue ) {
+				acc.totalAmountDue += total;
+			}
+			return acc;
+		},
+		{ totalAmountDue: 0, totalAmountPaid: 0 }
+	);
+
 	const consolidatedData = {
-		allTimeCommissions: 0,
+		allTimeCommissions: totalAmountPaid,
 		pendingOrders: 0,
-		pendingCommission: 0,
+		pendingCommission: totalAmountDue,
 	};
 
 	referrals.forEach( ( referral ) => {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -28,6 +28,7 @@ import {
 } from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import useFetchReferralInvoices from '../../hooks/use-fetch-referral-invoices';
 import useFetchReferrals from '../../hooks/use-fetch-referrals';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
 import { getAccountStatus } from '../../lib/get-account-status';
@@ -72,6 +73,9 @@ export default function ReferralsOverview( {
 
 	const { data: referrals, isFetching: isFetchingReferrals } =
 		useFetchReferrals( isAutomatedReferral );
+
+	const { data: referralInvoices, isFetching: isFetchingReferralInvoices } =
+		useFetchReferralInvoices( isAutomatedReferral );
 
 	const hasReferrals = !! referrals?.length;
 
@@ -184,6 +188,8 @@ export default function ReferralsOverview( {
 						isLoading={ isLoading }
 						dataViewsState={ dataViewsState }
 						setDataViewsState={ setDataViewsState }
+						referralInvoices={ referralInvoices ?? [] }
+						isFetchingInvoices={ isFetchingReferralInvoices }
 					/>
 					{ ! isFetching && ! isAutomatedReferral && <ReferralsFooter /> }
 				</LayoutBody>
@@ -192,6 +198,7 @@ export default function ReferralsOverview( {
 				<LayoutColumn wide>
 					<ReferralDetails
 						referral={ dataViewsState.selectedItem }
+						referralInvoices={ referralInvoices ?? [] }
 						closeSitePreviewPane={ () =>
 							setDataViewsState( {
 								...dataViewsState,

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -32,7 +32,7 @@ import ConsolidatedViews from '../../consolidated-view';
 import { getAccountStatus } from '../../lib/get-account-status';
 import tipaltiLogo from '../../lib/tipalti-logo';
 import ReferralList from '../../referrals-list';
-import type { Referral } from '../../types';
+import type { Referral, ReferralInvoice } from '../../types';
 
 interface Props {
 	isAutomatedReferral?: boolean;
@@ -41,6 +41,8 @@ interface Props {
 	isLoading: boolean;
 	dataViewsState: DataViewsState;
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
+	referralInvoices: ReferralInvoice[];
+	isFetchingInvoices: boolean;
 }
 
 export default function LayoutBodyContent( {
@@ -50,6 +52,8 @@ export default function LayoutBodyContent( {
 	isLoading,
 	dataViewsState,
 	setDataViewsState,
+	referralInvoices,
+	isFetchingInvoices,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -117,9 +121,16 @@ export default function LayoutBodyContent( {
 	if ( isAutomatedReferral && referrals?.length ) {
 		return (
 			<>
-				{ ! dataViewsState.selectedItem && <ConsolidatedViews referrals={ referrals } /> }
+				{ ! dataViewsState.selectedItem && (
+					<ConsolidatedViews
+						referrals={ referrals }
+						referralInvoices={ referralInvoices }
+						isFetchingInvoices={ isFetchingInvoices }
+					/>
+				) }
 				<ReferralList
 					referrals={ referrals }
+					referralInvoices={ referralInvoices }
 					dataViewsState={ dataViewsState }
 					setDataViewsState={ setDataViewsState }
 				/>

--- a/client/a8c-for-agencies/sections/referrals/referral-details/commissions.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/commissions.tsx
@@ -1,6 +1,12 @@
 import ConsolidatedViews from '../consolidated-view';
-import type { Referral } from '../types';
+import type { Referral, ReferralInvoice } from '../types';
 
-export default function ReferralCommissions( { referral }: { referral: Referral } ) {
-	return <ConsolidatedViews referrals={ [ referral ] } />;
+export default function ReferralCommissions( {
+	referral,
+	referralInvoices,
+}: {
+	referral: Referral;
+	referralInvoices: ReferralInvoice[];
+} ) {
+	return <ConsolidatedViews referrals={ [ referral ] } referralInvoices={ referralInvoices } />;
 }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx
@@ -8,7 +8,7 @@ import SubscriptionStatus from '../referrals-list/subscription-status';
 import ReferralCommissions from './commissions';
 import ReferralPurchasesMobile from './mobile/purchases-mobile';
 import ReferralPurchases from './purchases';
-import type { Referral } from '../types';
+import type { Referral, ReferralInvoice } from '../types';
 import type { ItemData } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane/types';
 
 import './style.scss';
@@ -16,12 +16,17 @@ import './style.scss';
 interface Props {
 	referral: Referral;
 	closeSitePreviewPane: () => void;
+	referralInvoices: ReferralInvoice[];
 }
 
 const REFERRAL_PURCHASES_ID = 'referral-purchases';
 const REFERRAL_COMMISSIONS_ID = 'referral-commissions';
 
-export default function ReferralDetails( { referral, closeSitePreviewPane }: Props ) {
+export default function ReferralDetails( {
+	referral,
+	closeSitePreviewPane,
+	referralInvoices,
+}: Props ) {
 	const translate = useTranslate();
 
 	const [ selectedReferralTab, setSelectedReferralTab ] = useState( REFERRAL_PURCHASES_ID );
@@ -46,6 +51,10 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 
 	const isDesktop = useDesktopBreakpoint();
 
+	const clientReferralInvoices = referralInvoices.filter(
+		( invoice ) => invoice.clientId === referral.client.id
+	);
+
 	const features = useMemo(
 		() => [
 			createFeaturePreview(
@@ -66,10 +75,10 @@ export default function ReferralDetails( { referral, closeSitePreviewPane }: Pro
 				true,
 				selectedReferralTab,
 				setSelectedReferralTab,
-				<ReferralCommissions referral={ referral } />
+				<ReferralCommissions referral={ referral } referralInvoices={ clientReferralInvoices } />
 			),
 		],
-		[ referral, selectedReferralTab, translate, isDesktop ]
+		[ translate, selectedReferralTab, isDesktop, referral, clientReferralInvoices ]
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
@@ -52,20 +52,18 @@ export default function CommissionsColumn( {
 				{ allTimeCommissions }
 			</span>
 			<Tooltip context={ wrapperRef.current } isVisible={ showPopover } position="bottom">
-				<div>
-					<ul>
-						<li>
-							{ translate( 'All time: %(allTimeCommissions)s', {
-								args: { allTimeCommissions },
-							} ) }
-						</li>
-						<li>
-							{ translate( 'Expected: %(pendingCommission)s', {
-								args: { pendingCommission },
-							} ) }
-						</li>
-					</ul>
-				</div>
+				<ul>
+					<li>
+						{ translate( 'All time: %(allTimeCommissions)s', {
+							args: { allTimeCommissions },
+						} ) }
+					</li>
+					<li>
+						{ translate( 'Expected: %(pendingCommission)s', {
+							args: { pendingCommission },
+						} ) }
+					</li>
+				</ul>
 			</Tooltip>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/referrals/types.ts
+++ b/client/a8c-for-agencies/sections/referrals/types.ts
@@ -31,3 +31,30 @@ export interface ReferralAPIResponse {
 	products: ReferralPurchaseAPIResponse[];
 	status: string;
 }
+
+export interface ReferralInvoiceAPIResponse {
+	id: string;
+	metadata: {
+		invalid: string;
+		jetpack_partner_key_id: string;
+		jetpack_partner_type: string;
+		period_end: string;
+		period_start: string;
+		user_id: string;
+	};
+	status: string;
+	amount_due: number;
+	amount_paid: number;
+	amount_remaining: number;
+	products: {
+		wpcom_product_id: string;
+		product_family_slug: string;
+		amount: number;
+	}[];
+}
+
+export interface ReferralInvoice extends ReferralInvoiceAPIResponse {
+	clientId: number;
+	isPaid: boolean;
+	isDue: boolean;
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/447

## Proposed Changes

This PR implements an API endpoint to show the commissions for Referrals.

NOTE: 

- The current calculations are 20% for hosting (WordPress.com & Pressable) & 50% for products (Jetpack & WooCommerce) 
- The All time commissions will be `$0` for now as the billing queue is not run yet.
- We go through each invoice and its products, calculating the commission for each: 20% of the paid amount for hosting ad 50% for other products. 

## Testing Instructions

1. Open the A4A live link.
2. Patch D155131-code
3. Go to Referrals - Dashboard > Verify (in the 3-card column on top):

- The `All time commissions` is the total of all paid invoices
- The `Commissions expected in {month}` is the total of all pending & active referrals + the total of all pending invoices. 

![screencapture-agencies-localhost-3000-referrals-dashboard-2024-07-12-15_37_08](https://github.com/user-attachments/assets/a0cccfbf-6a63-4430-aef8-9e3e582524ea)

4. Hover on the commissions column on any table row > Verify you can see the all-time and expected commissions for that client:

<img width="1728" alt="Screenshot 2024-07-23 at 9 24 06 AM" src="https://github.com/user-attachments/assets/94e26d14-98c7-4ce2-ba51-bb3cf05d73cd">


5. Click on any client > Once you are in the detailed view > Click the `Commissions` tab  > Verify:

- The `All time commissions` is the total of all paid invoices for that client
- The `Commissions expected in {month}` is the total of all pending & active referrals + the total of all pending invoices for that client.

<img width="1728" alt="Screenshot 2024-07-23 at 9 24 46 AM" src="https://github.com/user-attachments/assets/6617f6c0-3c21-4da9-b01d-16aaaebf64d9">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?