### PR TITLE
Admin Bar: Adjust positioning of wpcom logo and gravatar

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -593,7 +593,7 @@ body.is-mobile-app-view {
 
 
 	&.masterbar__item-my-sites {
-		padding: 0 6px; // trying to match core's 35px width
+		padding: 0 7px 0 5px; // trying to match core's 35px width
 
 		@media only screen and (max-width: 782px) {
 			padding: 0;
@@ -889,6 +889,7 @@ body.is-mobile-app-view {
 	.gravatar {
 		border: 1px solid var(--color-masterbar-border);
 		border-radius: unset;
+		margin-left: 1px;
 
 		@media only screen and (max-width: 782px) {
 			width: 26px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/8293

## Proposed Changes

This PR adjust the positions of the wpcom logo and gravatar in the admin bar, so it is pixel-perfect with the wp-admin version.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The admin bar between Calypso and wp-admin is a bit not aligned.

## Testing Instructions

1. Open /home/:site
2. Compare the position of the wpcom logo and gravatar with /wp-admin.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
