### PR TITLE
Use Sites page as main page for WP icon in the desktop app

### DIFF
--- a/client/lib/desktop-listeners/index.js
+++ b/client/lib/desktop-listeners/index.js
@@ -2,7 +2,6 @@ import debugFactory from 'debug';
 import { navigate } from 'calypso/lib/navigate';
 import * as oAuthToken from 'calypso/lib/oauth-token';
 import { newPost } from 'calypso/lib/paths';
-import { getStatsPathForTab } from 'calypso/lib/route';
 import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUserId, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -135,10 +134,8 @@ const DesktopListeners = {
 
 	onShowMySites: function () {
 		debug( 'Showing my sites' );
-		const site = this.selectedSite;
-		const siteSlug = site ? site.slug : null;
 
-		this.navigate( getStatsPathForTab( 'day', siteSlug ) );
+		this.navigate( '/sites' );
 	},
 
 	onShowReader: function () {

--- a/desktop/app/lib/menu/calypso-menu.js
+++ b/desktop/app/lib/menu/calypso-menu.js
@@ -18,7 +18,7 @@ module.exports = function ( { view, window }, status ) {
 				if ( isCalypso( view ) ) {
 					ipc.showMySites( view );
 				} else {
-					view.webContents.loadURL( webBase + 'stats/day' );
+					view.webContents.loadURL( webBase + 'sites' );
 				}
 			},
 		},

--- a/desktop/app/window-handlers/navigation/index.js
+++ b/desktop/app/window-handlers/navigation/index.js
@@ -24,7 +24,7 @@ module.exports = function ( { view, window } ) {
 			if ( isCalypso( view ) ) {
 				ipc.showMySites( view );
 			} else {
-				view.webContents.loadURL( webBase + 'stats/day' );
+				view.webContents.loadURL( webBase + 'sites' );
 			}
 		} else {
 			view.webContents.loadURL( Config.loginURL() );

--- a/desktop/public_desktop/failed-to-start.html
+++ b/desktop/public_desktop/failed-to-start.html
@@ -45,7 +45,7 @@
 						><a href="#" onclick="return showme()">Using a proxy?</a></span
 					>
 				</p>
-				<p><a class="button-emphasis" href="https://wordpress.com/stats/day">Try again</a></p>
+				<p><a class="button-emphasis" href="https://wordpress.com/sites">Try again</a></p>
 
 				<div style="display: none" id="showme">
 					<h2>How to bypass your proxy for this app</h2>

--- a/desktop/public_desktop/network-failed.html
+++ b/desktop/public_desktop/network-failed.html
@@ -32,7 +32,7 @@
 
 				<h3>Network Disconnected</h3>
 				<p>WordPress.com requires an active internet connection (code <code></code>).<br /></p>
-				<p><a class="button-emphasis" href="https://wordpress.com/stats/day">Try again</a></p>
+				<p><a class="button-emphasis" href="https://wordpress.com/sites">Try again</a></p>
 			</div>
 		</div>
 		<script type="text/javascript">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-hGx-p2

## Proposed Changes

I propose always pointing the users to the Sites page when they click the WP icon in the desktop app.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make it consistent with default page which is Sites, and not Stats.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Boot Calpyso from the root of the Calypso repository with `yarn start`
2. Enter the desktop app directory
3. Once Calypso is ready, the desktop app can be booted with `yarn run dev:localhost` to load the local instance of Calypso.
4. Confirm that WP icon points to Sites page from Calypso pages and from WP Admin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?