### PR TITLE
Masterbar - update icon colors on mobile resolutions

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1132,6 +1132,13 @@ body.is-mobile-app-view {
 		transition: all 150ms ease-in;
 		fill: var(--color-masterbar-item-active-background);
 	}
+
+	@media only screen and (max-width: 782px) {
+		&:not(.has-unread) svg path {
+			stroke: var(--color-masterbar-highlight);
+			fill: none;
+		}
+	}
 }
 
 @keyframes bubble-unread-indication {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -505,6 +505,7 @@ body.is-mobile-app-view {
 	}
 
 	@media only screen and (max-width: 782px) {
+		color: var(--color-masterbar-highlight);
 		font-size: $masterbar-mobile-font-size;
 		width: 52px;
 		padding: 0;
@@ -521,6 +522,7 @@ body.is-mobile-app-view {
 		svg,
 		svg path,
 		.gridicon {
+			fill: var(--color-masterbar-highlight);
 			height: 36px;
 			width: 36px;
 		}
@@ -533,6 +535,7 @@ body.is-mobile-app-view {
 		}
 
 		.dashicons-before {
+			color: var(--color-masterbar-highlight);
 			height: unset;
 			&::before {
 				width: 52px;
@@ -1306,6 +1309,7 @@ a.masterbar__quick-language-switcher {
 		height: 24px;
 
 		@media only screen and (max-width: 782px) {
+			fill: var(--color-masterbar-highlight);
 			width: 36px;
 			height: 36px;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8379

In WP core, the wpadminbar icons for the various color schemes uses the highlight color as default. We need to update calypso to do the same to ensure more consistent UX.

This only address color on calypso masterbar. A follow up PR will be required to fix on wp-admin masterbar.

## Proposed Changes

* Updates the Masterbar icon colors to use the highlight color when viewed on mobile 

## Core
**default**
<img width="235" alt="default" src="https://github.com/user-attachments/assets/18c49158-faf3-422c-9fc4-7acf0f0519fc">
**ectoplasm**
<img width="240" alt="ectoplasm" src="https://github.com/user-attachments/assets/8708c689-a9f5-462f-8fc0-daa45021c13d">
**sunrise**
<img width="228" alt="sunrise" src="https://github.com/user-attachments/assets/80b2dd5d-49a6-4b8c-b83f-a1796a04044d">
**ocean**
<img width="228" alt="ocean" src="https://github.com/user-attachments/assets/8db73995-577e-4188-b3ac-a0062af3f262">
**midnight**
<img width="233" alt="midnight" src="https://github.com/user-attachments/assets/f41185d2-a14f-4494-aa38-f5dc6aad0c46">
**coffee**
<img width="232" alt="coffee" src="https://github.com/user-attachments/assets/e68e3de2-01c3-4aee-b510-c735a2e8ac20">
**blue**
<img width="236" alt="blue" src="https://github.com/user-attachments/assets/5f59652a-dbe7-4767-a1cc-169f9d093b40">
**modern**
<img width="233" alt="modern" src="https://github.com/user-attachments/assets/a455a88b-f28c-4438-8337-0a9e0b8838d7">
**light**
<img width="234" alt="light" src="https://github.com/user-attachments/assets/669052d8-b785-4b29-8ff3-697e18d77579">

## Before
<img width="234" alt="Screenshot 2024-07-22 at 13 03 35" src="https://github.com/user-attachments/assets/b7becd1e-055e-4271-ac2e-61b40947ea24">

## After
**sunset**
<img width="228" alt="calypso-sunset" src="https://github.com/user-attachments/assets/feb36aed-788d-4ac9-ae30-4c6c57964585">
**sunrise**
<img width="224" alt="calypso-sunrise" src="https://github.com/user-attachments/assets/11d0fcf2-06e7-4bd4-af50-e31a573f48f9">
**sakura**
<img width="236" alt="calypso-sakura" src="https://github.com/user-attachments/assets/fbe78c71-d3f3-4f99-824f-ab4ea81f5dfe">
**powder-snow**
<img width="229" alt="calypso-powder-snow" src="https://github.com/user-attachments/assets/c69525f7-dd17-49db-84fd-d79b3e35bd64">
**ocean**
<img width="225" alt="calypso-ocean" src="https://github.com/user-attachments/assets/6fce5af7-f912-40a8-b92a-82a59eb1e67b">
**nightfall**
<img width="229" alt="calypso-nightfall" src="https://github.com/user-attachments/assets/c26e17af-4c97-4e36-a622-3d421944ce8d">
**midnight**
<img width="233" alt="calypso-midnight" src="https://github.com/user-attachments/assets/c82e244f-a4ef-4e2d-8c39-173a46cd3d4c">
**light**
<img width="228" alt="calypso-light" src="https://github.com/user-attachments/assets/ed795733-8301-41e3-a32a-03b92a3b5566">
**ectoplasm**
<img width="234" alt="calypso-ectoplasm" src="https://github.com/user-attachments/assets/88d929b6-8913-455c-951f-364cce068cfc">
**contrast**
<img width="228" alt="calypso-contrast" src="https://github.com/user-attachments/assets/a625b2b2-582b-44af-add2-401fe554f745">
**coffee**
<img width="233" alt="calypso-coffee" src="https://github.com/user-attachments/assets/59a58549-8101-4e66-9634-51c6bf1146e8">
**classic-dark**
<img width="232" alt="calypso-classic-dark" src="https://github.com/user-attachments/assets/052045b8-2840-4713-878c-e98d902b7baf">
**classic-bright**
<img width="229" alt="calypso-classic-bright" src="https://github.com/user-attachments/assets/9ce33673-c612-44f5-b641-47158cd60b17">
**classic-blue**
<img width="227" alt="calypso-classic-blue" src="https://github.com/user-attachments/assets/d30f837e-ae12-4cb6-a967-fdb0c3fce9f7">
**blue**
<img width="228" alt="calypso-blue" src="https://github.com/user-attachments/assets/d2d9ce7b-7116-411f-a0c4-7b98aa3ca01a">
**aquatic**
<img width="225" alt="calypso-aquatic" src="https://github.com/user-attachments/assets/602907d4-1e05-4334-a1fc-173c25687ccd">
**modern**
<img width="233" alt="calypso-modern" src="https://github.com/user-attachments/assets/bbc55a5b-c3b5-4eba-addd-3d005c52638d">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Update to improve UX consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites` page, select a site with a `My Home` to link to home dashboard (so you are on Calypso).
* Confirm the icons render with highlight color for the various color schemes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
