### PR TITLE
Package "page-pattern-modal": publishing to npm

### DIFF
--- a/packages/i18n-utils/tsconfig.json
+++ b/packages/i18n-utils/tsconfig.json
@@ -7,5 +7,9 @@
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],
-	"references": [ { "path": "../languages" }, { "path": "../calypso-url" } ]
+	"references": [
+		{ "path": "../languages" },
+		{ "path": "../calypso-url" },
+		{ "path": "../calypso-config" }
+	]
 }

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -24,7 +24,7 @@
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets && npx copyfiles ./styles/** dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run -T copy-assets && npx copyfiles ./styles/** dist",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
@@ -59,6 +59,5 @@
 	"peerDependencies": {
 		"@wordpress/i18n": "^5.2.0",
 		"react": "^18.2.0"
-	},
-	"private": true
+	}
 }

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -29,6 +29,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
 		"@wordpress/components": "^28.2.0",

--- a/packages/onboarding/tsconfig.json
+++ b/packages/onboarding/tsconfig.json
@@ -7,5 +7,9 @@
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],
-	"references": [ { "path": "../components" }, { "path": "../data-stores" } ]
+	"references": [
+		{ "path": "../components" },
+		{ "path": "../data-stores" },
+		{ "path": "../calypso-config" }
+	]
 }

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/page-pattern-modal",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Automattic Page Pattern Modal.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/page-pattern-modal",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Automattic Page Pattern Modal.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/page-pattern-modal",
-	"version": "1.0.0-alpha.0",
+	"version": "1.1.0",
 	"description": "Automattic Page Pattern Modal.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -54,8 +54,9 @@
 		"redux": "^4.2.1"
 	},
 	"scripts": {
+		"copy-assets": "../calypso-build/bin/copy-assets.js",
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run copy-assets",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/page-pattern-modal",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Automattic Page Pattern Modal.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/page-pattern-modal",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "Automattic Page Pattern Modal.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -27,7 +27,6 @@
 	],
 	"types": "dist/types",
 	"dependencies": {
-		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@wordpress/block-editor": "^13.2.0",
 		"@wordpress/blocks": "^13.2.0",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -54,9 +54,8 @@
 		"redux": "^4.2.1"
 	},
 	"scripts": {
-		"copy-assets": "../calypso-build/bin/copy-assets.js",
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -1,9 +1,9 @@
-@import "node_modules/@automattic/color-studio/dist/color-variables";
+@import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/typography/styles/variables";
-@import "node_modules/@wordpress/base-styles/mixins";
-@import "node_modules/@wordpress/base-styles/variables";
-@import "node_modules/@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 @mixin screen-reader-text() {
 	border: 0;

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -1,9 +1,9 @@
-@import "@automattic/color-studio/dist/color-variables";
+@import "node_modules/@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/typography/styles/variables";
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/base-styles/variables";
-@import "@wordpress/base-styles/breakpoints";
+@import "node_modules/@wordpress/base-styles/mixins";
+@import "node_modules/@wordpress/base-styles/variables";
+@import "node_modules/@wordpress/base-styles/breakpoints";
 
 @mixin screen-reader-text() {
 	border: 0;

--- a/packages/page-pattern-modal/tsconfig.json
+++ b/packages/page-pattern-modal/tsconfig.json
@@ -8,5 +8,5 @@
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],
-	"references": [ { "path": "../onboarding" } ]
+	"references": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,6 +1523,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/onboarding@workspace:packages/onboarding"
   dependencies:
+    "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
@@ -1557,7 +1558,6 @@ __metadata:
   resolution: "@automattic/page-pattern-modal@workspace:packages/page-pattern-modal"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/onboarding": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"
     "@wordpress/block-editor": "npm:^13.2.0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Changes to publish [@automattic/page-pattern-modal](https://www.npmjs.com/package/@automattic/page-pattern-modal)
* Update version to `1.1.4`
* Fix dependency error: "Could not find a declaration file for module '@automattic/calypso-build'"
* Fix "Command not found: copy-assets"

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

[ETK Migration: Start Page Templates Feature](https://github.com/Automattic/dotcom-forge/issues/8242) will reuse the package from `jetpack-mu-wpcom`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
