### PR TITLE
Footer credit: Remove setting/upsell for block themes

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -29,6 +29,7 @@ import SiteLanguagePicker from 'calypso/components/language-picker/site-language
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import Timezone from 'calypso/components/timezone';
+import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { preventWidows } from 'calypso/lib/formatting';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
@@ -577,6 +578,7 @@ export class SiteSettingsFormGeneral extends Component {
 			isWpcomStagingSite,
 			isUnlaunchedSite: propsisUnlaunchedSite,
 			adminInterfaceIsWPAdmin,
+			hasBlockTheme,
 		} = this.props;
 		const classes = clsx( 'site-settings__general-settings', {
 			'is-loading': isRequestingSettings,
@@ -625,7 +627,7 @@ export class SiteSettingsFormGeneral extends Component {
 				/>
 				{ this.renderAdminInterface() }
 				{ ! isWpcomStagingSite && this.giftOptions() }
-				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
+				{ ! hasBlockTheme && ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
 					<div className="site-settings__footer-credit-container">
 						<SettingsSectionHeader
 							title={ translate( 'Footer credit' ) }
@@ -753,11 +755,14 @@ const SiteSettingsFormGeneralWithGlobalStylesNotice = ( props ) => {
 	const { globalStylesInUse, shouldLimitGlobalStyles } = useSiteGlobalStylesStatus(
 		props.site?.ID
 	);
+	const { data: activeThemeData } = useActiveThemeQuery( props.site?.ID ?? -1, !! props.site );
+	const hasBlockTheme = activeThemeData?.[ 0 ]?.is_block_theme ?? false;
 
 	return (
 		<SiteSettingsFormGeneral
 			{ ...props }
 			shouldShowPremiumStylesNotice={ globalStylesInUse && shouldLimitGlobalStyles }
+			hasBlockTheme={ hasBlockTheme }
 		/>
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8230

## Proposed Changes

Removes the "Footer credit" setting from `/settings/general/:site` if the site has a block theme.

Before | After
--- | ---
<img width="1264" alt="Screenshot 2024-07-22 at 15 26 16" src="https://github.com/user-attachments/assets/65905ca6-1bca-4e33-bc3f-0b746a8316e9"> | <img width="1271" alt="Screenshot 2024-07-22 at 15 26 30" src="https://github.com/user-attachments/assets/a9b2a446-e599-481b-bc55-351aac12d4a8">


## Why are these changes being made?

Because as of D156038-code we are no longer displaying a custom WP.com footer credit on block themes, effectively allowing users to freely edit/remove the default footer credit in the site editor.

## Testing Instructions

- Use the Calypso live link below
- Go to `/settings/general`
- Select a site with a block theme
- Make sure the "Footer credit" setting/upsell is not visible
- Switch to a site with a classic theme
- Make sure the "Footer credit" setting/upsell is visible now

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?