### PR TITLE
Monetize: pass nteui to login form

### DIFF
--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -71,9 +71,24 @@ export const fetchMagicLoginAuthenticate =
 	( dispatch ) => {
 		dispatch( { type: MAGIC_LOGIN_REQUEST_AUTH_FETCH } );
 
+		const getCookieValue = ( key ) => {
+			if ( document.cookie ) {
+				const pairs = document.cookie.split( ';' );
+				const filtered = pairs.filter( ( pair ) => {
+					const [ pairKey ] = pair.split( '=' );
+					return key === pairKey.trim();
+				} );
+				if ( filtered.length === 1 ) {
+					return filtered[ 0 ].split( '=' )[ 1 ].trim();
+				}
+			}
+			return '';
+		};
+
 		postMagicLoginRequest( AUTHENTICATE_URL, {
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
+			nteui: getCookieValue( 'netui' ),
 			token,
 			redirect_to: redirectTo,
 			flow,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 433-gh-automattic/gold

## Proposed Changes

* Pass `nteui` if present in cookie along with magic-login request.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See p5TWut-1dD-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See D155988-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?