### PR TITLE
Increase the clickable area for the Action / ellipsis menu in sites list

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/dataviews-fields/actions-field.tsx
+++ b/client/hosting/sites/components/sites-dataviews/dataviews-fields/actions-field.tsx
@@ -4,9 +4,10 @@ import type { MouseEvent, KeyboardEvent } from 'react';
 
 type Props = {
 	site: SiteExcerptData;
+	size?: number;
 };
 
-const ActionsField = ( { site }: Props ) => {
+const ActionsField = ( { site, size }: Props ) => {
 	const handleClickOrKeyDown = ( event: MouseEvent | KeyboardEvent ) => {
 		const target = event.target as HTMLElement;
 
@@ -23,7 +24,7 @@ const ActionsField = ( { site }: Props ) => {
 			onClick={ handleClickOrKeyDown }
 			onKeyDown={ handleClickOrKeyDown }
 		>
-			<SiteActions site={ site } />
+			<SiteActions site={ site } size={ size } />
 		</div>
 	);
 };

--- a/client/hosting/sites/components/sites-dataviews/index.tsx
+++ b/client/hosting/sites/components/sites-dataviews/index.tsx
@@ -180,7 +180,7 @@ const DotcomSitesDataViews = ( {
 			{
 				id: 'actions',
 				header: <span>{ __( 'Actions' ) }</span>,
-				render: ( { item }: { item: SiteInfo } ) => <ActionsField site={ item } />,
+				render: ( { item }: { item: SiteInfo } ) => <ActionsField site={ item } size={ 48 } />,
 				enableHiding: false,
 				enableSorting: false,
 				width: '48px',

--- a/client/hosting/sites/components/sites-dataviews/sites-site-actions.tsx
+++ b/client/hosting/sites/components/sites-dataviews/sites-site-actions.tsx
@@ -4,13 +4,14 @@ import type { SiteExcerptData } from '@automattic/sites';
 
 interface SiteActionsProps {
 	site: SiteExcerptData;
+	size?: number;
 }
 
-export const SiteActions = ( { site }: SiteActionsProps ) => {
+export const SiteActions = ( { site, size }: SiteActionsProps ) => {
 	const { ref, inView } = useInView( { triggerOnce: true } );
 	if ( site.is_deleted ) {
 		return false;
 	}
 
-	return <div ref={ ref }>{ inView && <SitesEllipsisMenu site={ site } /> }</div>;
+	return <div ref={ ref }>{ inView && <SitesEllipsisMenu site={ site } size={ size } /> }</div>;
 };

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -261,17 +261,6 @@ const SiteMenuGroup = styled( MenuGroup )( {
 	},
 } );
 
-const SiteDropdownMenu = styled( DropdownMenu )( {
-	'> .components-button': {
-		padding: 8,
-		margin: -8,
-		minWidth: 0,
-		color: 'var( --color-text-subtle )',
-		height: 'auto',
-		verticalAlign: 'middle',
-	},
-} );
-
 const siteDropdownMenuPopoverClassName = css( {
 	// modalOverlayClassName has z-index: 178
 	zIndex: 177,
@@ -476,9 +465,11 @@ function JetpackSiteItems( { site, recordTracks }: SitesMenuItemProps ) {
 export const SitesEllipsisMenu = ( {
 	className,
 	site,
+	size,
 }: {
 	className?: string;
 	site: SiteExcerptData;
+	size?: number;
 } ) => {
 	const dispatch = useReduxDispatch();
 	const { __ } = useI18n();
@@ -499,6 +490,19 @@ export const SitesEllipsisMenu = ( {
 		wpAdminUrl,
 		recordTracks,
 	};
+
+	const SiteDropdownMenu = styled( DropdownMenu )( {
+		'> .components-button': {
+			padding: 8,
+			margin: -8,
+			minWidth: 0,
+			color: 'var( --color-text-subtle )',
+			width: size ? `${ size }px` : 'auto',
+			height: size ? `${ size }px` : 'auto',
+			verticalAlign: 'middle',
+			justifyContent: 'end',
+		},
+	} );
 
 	const isSiteJetpackNotAtomic = isNotAtomicJetpack( site );
 	const hasHostingFeatures = ! isSiteJetpackNotAtomic && ! isP2Site( site );


### PR DESCRIPTION
Alternative to https://github.com/Automattic/wp-calypso/pull/92881

## Proposed Changes

Increase the clickable area by using the width from the field data.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/bbf1678c-f759-4041-89b2-a3323bb6cf06) | ![image](https://github.com/user-attachments/assets/17faa353-5007-4ce8-a35f-c3ea4aa4e1af) |


## Why are these changes being made?
The clickable area for the ellipsis menu is too small.

## Testing Instructions
* Go to /sites
* Check the clickable size of a Site Action.
* It should not open the overview.
