### PR TITLE
Increase the clickable area for the Action / ellipsis menu in /sites (CSS)

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/sites-site-actions.tsx
+++ b/client/hosting/sites/components/sites-dataviews/sites-site-actions.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { useInView } from 'react-intersection-observer';
 import { SitesEllipsisMenu } from 'calypso/sites-dashboard/components/sites-ellipsis-menu';
 import type { SiteExcerptData } from '@automattic/sites';
@@ -6,11 +7,18 @@ interface SiteActionsProps {
 	site: SiteExcerptData;
 }
 
+const SiteActionsDiv = styled.div`
+	flex: 1;
+	justify-content: 'end';
+`;
+
 export const SiteActions = ( { site }: SiteActionsProps ) => {
 	const { ref, inView } = useInView( { triggerOnce: true } );
 	if ( site.is_deleted ) {
 		return false;
 	}
 
-	return <div ref={ ref }>{ inView && <SitesEllipsisMenu site={ site } /> }</div>;
+	return (
+		<SiteActionsDiv ref={ ref }>{ inView && <SitesEllipsisMenu site={ site } /> }</SiteActionsDiv>
+	);
 };

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -262,13 +262,17 @@ const SiteMenuGroup = styled( MenuGroup )( {
 } );
 
 const SiteDropdownMenu = styled( DropdownMenu )( {
+	display: 'block',
+
 	'> .components-button': {
-		padding: 8,
-		margin: -8,
+		padding: '8px 0',
+		margin: '8px 0',
 		minWidth: 0,
 		color: 'var( --color-text-subtle )',
 		height: 'auto',
 		verticalAlign: 'middle',
+		width: '100%',
+		justifyContent: 'end',
 	},
 } );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8051

## Proposed Changes
Increase the clickable area to the full field width.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c8137e6a-165a-402a-8b46-61968f0e5fa0) | ![image](https://github.com/user-attachments/assets/07c1b62e-84a5-42a1-921e-74fc2d8eb992) |
| ![image](https://github.com/user-attachments/assets/d218ad93-5385-49a3-aff9-7b5a3ca4a518) |![image](https://github.com/user-attachments/assets/e1a9a509-35de-49df-8f3b-09ffc7ad0964) |
| ![image](https://github.com/user-attachments/assets/266c8f70-e44d-4c27-b207-3f97aa21a1e8) |![image](https://github.com/user-attachments/assets/531d2a28-99a0-4849-b2c8-56e44368c8a8) |

## Why are these changes being made?
The clickable area for the ellipsis menu is too small

## Testing Instructions
* Go to /sites
* Check the clickable size of a Site Action.
* It should not open the overview.

