### PR TITLE
Stats: Fix commercial upgrade notice display logic

### DIFF
--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -45,7 +45,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			hasPWYWPlanOnly,
 			shouldShowPaywallNotice,
 		}: StatsNoticeProps ) => {
-			if ( ! isCommercial || isVip || hasPaidStats ) {
+			if ( ! isCommercial || isVip ) {
 				return false;
 			}
 
@@ -62,7 +62,9 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				return true;
 			}
 
-			return !! ( showUpgradeNoticeForJetpackSites || showUpgradeNoticeForWpcomSites );
+			return (
+				!! ( showUpgradeNoticeForJetpackSites || showUpgradeNoticeForWpcomSites ) && ! hasPaidStats
+			);
 		},
 		disabled: false,
 	},

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -45,12 +45,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			hasPWYWPlanOnly,
 			shouldShowPaywallNotice,
 		}: StatsNoticeProps ) => {
-			// Show the notice only if the site is commercial.
-			if ( ! isCommercial ) {
-				return false;
-			}
-
-			if ( isVip ) {
+			if ( ! isCommercial || isVip || hasPaidStats ) {
 				return false;
 			}
 
@@ -67,12 +62,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				return true;
 			}
 
-			return !! (
-				( showUpgradeNoticeForJetpackSites || showUpgradeNoticeForWpcomSites ) &&
-				// Show the notice if the site has not purchased the paid stats product.
-				! hasPaidStats &&
-				! isVip
-			);
+			return !! ( showUpgradeNoticeForJetpackSites || showUpgradeNoticeForWpcomSites );
 		},
 		disabled: false,
 	},

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -104,8 +104,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 			return hasReachedPaywallMonthlyViews( state, siteId );
 		} ) &&
 		! supportCommercialUse &&
-		isSiteJetpackNotAtomic &&
-		! isVip;
+		isSiteJetpackNotAtomic;
 
 	const noticeOptions = {
 		siteId,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/92882

## Proposed Changes

* Fix the `CommercialSiteUpgradeNotice` display logic.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This PR is a follow-up fix for the situation similar to https://github.com/Automattic/wp-calypso/pull/92882.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the commercial upgrade notice does not show on the site has the feature `paid-stats`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
