### PR TITLE
Stats: Restoring link to a summary page for empty cards

### DIFF
--- a/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
+++ b/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
@@ -19,11 +19,12 @@ import StatsModule from '../../../stats-module';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
-const StatClicks: React.FC< StatsDefaultModuleProps > = ( {
+const StatAuthors: React.FC< StatsDefaultModuleProps > = ( {
 	period,
 	query,
 	moduleStrings,
 	className,
+	summaryUrl,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -101,10 +102,18 @@ const StatClicks: React.FC< StatsDefaultModuleProps > = ( {
 							) }
 						/>
 					}
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
+					}
 				/>
 			) }
 		</>
 	);
 };
 
-export default StatClicks;
+export default StatAuthors;

--- a/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
+++ b/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
@@ -24,6 +24,7 @@ const StatsClicks: React.FC< StatsDefaultModuleProps > = ( {
 	query,
 	moduleStrings,
 	className,
+	summaryUrl,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -99,6 +100,14 @@ const StatsClicks: React.FC< StatsDefaultModuleProps > = ( {
 								}
 							) }
 						/>
+					}
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -24,6 +24,7 @@ const StatsCountries: React.FC< StatsDefaultModuleProps > = ( {
 	query,
 	moduleStrings,
 	className,
+	summaryUrl,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -99,6 +100,14 @@ const StatsCountries: React.FC< StatsDefaultModuleProps > = ( {
 								}
 							) }
 						/>
+					}
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
+++ b/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
@@ -27,6 +27,7 @@ const StatsDownloads: React.FC< StatsDefaultModuleProps > = ( {
 	query,
 	moduleStrings,
 	className,
+	summaryUrl,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -101,6 +102,14 @@ const StatsDownloads: React.FC< StatsDefaultModuleProps > = ( {
 								}
 							) }
 						/>
+					}
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -25,6 +25,7 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 	query,
 	moduleStrings,
 	className,
+	summaryUrl,
 }: StatsDefaultModuleProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -102,6 +103,14 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 							) }
 							cards={ <StatsEmptyActionEmail from="module_emails" /> }
 						/>
+					}
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -24,6 +24,7 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 	query,
 	moduleStrings,
 	className,
+	summaryUrl,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -100,6 +101,14 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 							) }
 							cards={ <StatsEmptyActionSocial from="module_referrers" /> }
 						/>
+					}
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
+++ b/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
@@ -24,6 +24,7 @@ const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
 	query,
 	moduleStrings,
 	className,
+	summaryUrl,
 }: StatsDefaultModuleProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -96,6 +97,14 @@ const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
 								}
 							) }
 						/>
+					}
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -24,6 +24,7 @@ const StatsTopPosts: React.FC< StatsDefaultModuleProps > = ( {
 	query,
 	moduleStrings,
 	className,
+	summaryUrl,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -106,6 +107,14 @@ const StatsTopPosts: React.FC< StatsDefaultModuleProps > = ( {
 								</>
 							}
 						/>
+					}
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-wrapper.tsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-wrapper.tsx
@@ -20,6 +20,7 @@ const StatsModuleUTMWrapper: React.FC< StatsAdvancedModuleWrapperProps > = ( {
 	query,
 	summary,
 	className,
+	summaryUrl,
 } ) => {
 	const isNewEmptyStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 	const isGatedByShouldGateStats = config.isEnabled( 'stats/restricted-dashboard' );
@@ -77,6 +78,7 @@ const StatsModuleUTMWrapper: React.FC< StatsAdvancedModuleWrapperProps > = ( {
 					hideSummaryLink={ hideSummaryLink }
 					postId={ postId }
 					summary={ summary }
+					summaryUrl={ summaryUrl }
 				/>
 			) }
 		</>

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -65,6 +65,7 @@ const StatsModuleUTM = ( {
 	isLoading,
 	query,
 	postId,
+	summaryUrl,
 } ) => {
 	const isNewEmptyStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 	const siteId = useSelector( getSelectedSiteId );
@@ -161,7 +162,7 @@ const StatsModuleUTM = ( {
 					{ ! showLoader &&
 						! data?.length && ( // no data and new empty state enabled
 							<StatsCard
-								className={ className }
+								className={ clsx( 'stats-card--empty-variant', className ) }
 								title={ moduleStrings.title }
 								titleNodes={ <StatsInfoArea isNew /> }
 								isEmpty
@@ -186,6 +187,14 @@ const StatsModuleUTM = ( {
 										) }
 										cards={ <UTMBuilder trigger={ <StatsEmptyActionUTMBuilder /> } /> }
 									/>
+								}
+								footerAction={
+									summaryUrl
+										? {
+												url: summaryUrl,
+												label: translate( 'View more' ),
+										  }
+										: undefined
 								}
 							/>
 						) }

--- a/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
@@ -25,6 +25,7 @@ const StatsVideos: React.FC< StatsDefaultModuleProps > = ( {
 	query,
 	moduleStrings,
 	className,
+	summaryUrl,
 }: StatsDefaultModuleProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -99,6 +100,14 @@ const StatsVideos: React.FC< StatsDefaultModuleProps > = ( {
 							) }
 							cards={ <StatsEmptyActionVideo from="module_videos" /> }
 						/>
+					}
+					footerAction={
+						summaryUrl
+							? {
+									url: summaryUrl,
+									label: translate( 'View more' ),
+							  }
+							: undefined
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/types.d.ts
+++ b/client/my-sites/stats/features/modules/types.d.ts
@@ -10,6 +10,7 @@ type StatsDefaultModuleProps = {
 		value: string;
 		empty: string;
 	};
+	summaryUrl?: string;
 };
 
 type StatsAdvancedModuleWrapperProps = {
@@ -19,6 +20,7 @@ type StatsAdvancedModuleWrapperProps = {
 	query: StatsQueryType;
 	summary?: boolean;
 	className?: string;
+	summaryUrl?: string;
 };
 
 type StatsPeriodType = {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -211,6 +211,19 @@ class StatsSite extends Component {
 		}
 	}
 
+	getStatHref( period, path, siteSlug ) {
+		return period && path && siteSlug
+			? '/stats/' +
+					period?.period +
+					'/' +
+					path +
+					'/' +
+					siteSlug +
+					'?startDate=' +
+					period?.startOf?.format( 'YYYY-MM-DD' )
+			: undefined;
+	}
+
 	renderStats( isInternal ) {
 		const {
 			date,
@@ -431,6 +444,7 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.posts }
 								period={ this.props.period }
 								query={ query }
+								summaryUrl={ this.getStatHref( this.props.period, 'posts', slug ) }
 								className={ clsx(
 									'stats__flexible-grid-item--60',
 									'stats__flexible-grid-item--full--large',
@@ -458,6 +472,7 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.referrers }
 								period={ this.props.period }
 								query={ query }
+								summaryUrl={ this.getStatHref( this.props.period, 'referrers', slug ) }
 								className={ clsx(
 									'stats__flexible-grid-item--40--once-space',
 									'stats__flexible-grid-item--full--large',
@@ -480,7 +495,7 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.countries }
 								period={ this.props.period }
 								query={ query }
-								summary={ false }
+								summaryUrl={ this.getStatHref( this.props.period, 'countryviews', slug ) }
 								className={ clsx( 'stats__flexible-grid-item--full' ) }
 							/>
 						) }
@@ -491,6 +506,7 @@ class StatsSite extends Component {
 								siteId={ siteId }
 								period={ this.props.period }
 								query={ query }
+								summaryUrl={ this.getStatHref( this.props.period, 'utm', slug ) }
 								summary={ false }
 								className={ clsx(
 									'stats__flexible-grid-item--60',
@@ -521,12 +537,10 @@ class StatsSite extends Component {
 						{ /* If UTM card or update card is not visible, shift "Clicks" and reduct to 1/2 for easier stacking */ }
 						{ isNewStateEnabled && (
 							<StatsModuleClicks
-								path="clicks"
 								moduleStrings={ moduleStrings.clicks }
 								period={ this.props.period }
 								query={ query }
-								statType="statsClicks"
-								showSummaryLink
+								summaryUrl={ this.getStatHref( this.props.period, 'clicks', slug ) }
 								className={ clsx(
 									{
 										'stats__flexible-grid-item--40--once-space': supportsUTMStats,
@@ -589,6 +603,7 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.authors }
 								period={ this.props.period }
 								query={ query }
+								summaryUrl={ this.getStatHref( this.props.period, 'authors', slug ) }
 								className={ clsx(
 									{
 										'stats__author-views': ! supportsUTMStats,
@@ -627,6 +642,7 @@ class StatsSite extends Component {
 								period={ this.props.period }
 								moduleStrings={ moduleStrings.emails }
 								query={ query }
+								summaryUrl={ this.getStatHref( this.props.period, 'emails', slug ) }
 								className={ clsx(
 									{
 										// half if odd number of modules after countries - UTM + Clicks + Authors or Clicks
@@ -649,6 +665,7 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.search }
 								period={ this.props.period }
 								query={ query }
+								summaryUrl={ this.getStatHref( this.props.period, 'searchterms', slug ) }
 								className={ clsx(
 									{
 										// Show "Search terms" as 1/3 when it's not Jetpack ("Downloads" visible) + "Videos" is visible
@@ -703,6 +720,7 @@ class StatsSite extends Component {
 								moduleStrings={ moduleStrings.videoplays }
 								period={ this.props.period }
 								query={ query }
+								summaryUrl={ this.getStatHref( this.props.period, 'videoplays', slug ) }
 								className={ clsx(
 									{
 										'stats__flexible-grid-item--one-third--two-spaces': ! isJetpack, // 1/3 when Downloads is supported, 1/2 for Jetpack
@@ -740,6 +758,7 @@ class StatsSite extends Component {
 									moduleStrings={ moduleStrings.filedownloads }
 									period={ this.props.period }
 									query={ query }
+									summaryUrl={ this.getStatHref( this.props.period, 'filedownloads', slug ) }
 									className={ clsx(
 										{
 											'stats__flexible-grid-item--half': this.isModuleHidden( 'videos' ),

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -145,7 +145,12 @@
 	.stats-card--header-and-body {
 		display: flex;
 		flex-direction: column;
-		min-height: 100%;
+		justify-content: space-between;
+		flex-grow: 1;
+	}
+
+	.stats-card--footer {
+		margin-top: 2px;
 	}
 
 	.stats-card--body-empty {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1721094506960349-slack-C04UE0ANHDY

## Proposed Changes

* adding a link to a summary page for all empty cards

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* to allow users to navigate to a summary page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch
* verify that all empty stats cards (Devices excluded) have a link that points to a correct summary page

![SCR-20240723-nokn](https://github.com/user-attachments/assets/0a271ad7-2b33-4627-87f5-1c97998add42)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?