### PR TITLE
i18n: Ignore `.native.js` module from string extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"test-server:watch": "yarn run test-server --watch",
 		"tour-kit:storybook:start": "echo 'Deprecated, run `yarn workspace @automattic/tour-kit run storybook` instead'",
 		"translate": "rm -rf build/strings && mkdirp public && yarn translate:dependencies && yarn translate:calypso",
-		"translate:dependencies": "rm -rf build/dependency-strings && mkdirp build/strings && wp-babel-makepot './node_modules/@wordpress/**/build-module/**/*.js' --base './' --dir './build/dependency-strings' --output './build/strings/calypso-dependencies.pot'",
+		"translate:dependencies": "rm -rf build/dependency-strings && mkdirp build/strings && wp-babel-makepot './node_modules/@wordpress/**/build-module/**/*.js' --ignore '**/*.native.js' --base './' --dir './build/dependency-strings' --output './build/strings/calypso-dependencies.pot'",
 		"translate:calypso": "wp-babel-makepot './{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base './' --dir './build/strings' --output './public/calypso-strings.pot'",
 		"tsc": "NODE_OPTIONS='--max-old-space-size=4096' tsc",
 		"typecheck": "yarn run tsc --project client",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Ignore `.native.js` modules from string extraction scanning in `translate:dependencies` script.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `.native.js` are not relevant to Calypso app and therefore should be excluded from the POT file.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Inspect the TeamCity Translate build artifact.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
