### PR TITLE
A4A > Partner Directory: Update the application wizard copies and the coming soon messages

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -101,7 +101,7 @@ const PartnerDirectoryDashboard = () => {
 			response && reduxDispatch( setActiveAgency( response ) );
 
 			reduxDispatch(
-				successNotice( translate( 'Your profile has been published!' ), {
+				successNotice( translate( 'Your profile has been saved!!' ), {
 					duration: 6000,
 				} )
 			);

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -101,7 +101,7 @@ const PartnerDirectoryDashboard = () => {
 			response && reduxDispatch( setActiveAgency( response ) );
 
 			reduxDispatch(
-				successNotice( translate( 'Your profile has been saved!!' ), {
+				successNotice( translate( 'Your profile has been saved!' ), {
 					duration: 6000,
 				} )
 			);

--- a/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
@@ -2,7 +2,16 @@ import { WooLogo, WordPressLogo, JetpackLogo } from '@automattic/components';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
 
-export const getBrandMeta = ( brand: string, agency?: Agency | null ) => {
+export type BrandMeta = {
+	brand: string;
+	icon: JSX.Element | undefined;
+	url: string;
+	urlProfile: string;
+	isAvailable: boolean;
+	className?: string;
+};
+
+export const getBrandMeta = ( brand: string, agency?: Agency | null ): BrandMeta => {
 	const agencySlug =
 		agency?.name
 			.toLowerCase()
@@ -14,40 +23,45 @@ export const getBrandMeta = ( brand: string, agency?: Agency | null ) => {
 	switch ( brand ) {
 		case 'WordPress.com':
 			return {
+				brand: brand,
 				icon: <WordPressLogo />,
 				url: 'https://wordpress.com/development-services/',
 				urlProfile: `https://wordpress.com/development-services/${ agencySlug }/${ agencyId }`,
-				isPublic: true,
+				isAvailable: false,
 			};
 
 		case 'WooCommerce.com':
 			return {
+				brand: brand,
 				icon: <WooLogo />,
 				className: 'partner-directory-dashboard__woo-icon',
 				url: 'https://woocommerce.com/development-services/',
 				urlProfile: `https://woocommerce.com/development-services/${ agencySlug }/${ agencyId }`,
-				isPublic: false,
+				isAvailable: false,
 			};
 		case 'Pressable.com':
 			return {
+				brand: brand,
 				icon: <img src={ pressableIcon } alt="" />,
 				url: 'https://pressable.com/development-services/',
 				urlProfile: `https://pressable.com/development-services/${ agencySlug }/${ agencyId }`,
-				isPublic: false,
+				isAvailable: false,
 			};
 		case 'Jetpack.com':
 			return {
+				brand: brand,
 				icon: <JetpackLogo />,
 				url: 'https://jetpack.com/development-services/',
 				urlProfile: `https://jetpack.com/development-services/${ agencySlug }/${ agencyId }`,
-				isPublic: true,
+				isAvailable: false,
 			};
 		default:
 			return {
+				brand: 'Unknown',
 				icon: undefined,
 				url: '',
 				urlProfile: '',
-				isPublic: false,
+				isAvailable: false,
 			};
 	}
 };


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/787

## Proposed Changes

This PR updates the application wizard copies and the coming soon messages:

![image](https://github.com/user-attachments/assets/79f00cf0-2035-4b8a-8a62-8f9c4e647c4a)

![image](https://github.com/user-attachments/assets/0ae8b6fe-6212-46cf-9fe6-5f2df76b90e4)

Check the P2-post and Slack references in the issue.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code
- Go to the Partner Directory section (Dashboard)
- If you already have an application, reset it by updating your agency's blog option. (check the issue description for instructions)
- Apply to a two directories.
- Go to the agency MC Tool: `/agencies` search your agency and click on Manage Partner Directory.
   - Approve and reject each application.
- Go to Calypso and reload.
- If you still need to fill out your profile, fill it out.
- If your profile has already been filled out, you will see the summary.
- The application has been approved, I will have the coming soon message.
- The application was rejected, and we will only have the badge.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
