### PR TITLE
A4A > Marketplace: Add Hosting page redesign feature flag

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -27,6 +27,8 @@ export default function HostingList( { selectedSite }: Props ) {
 	const { data } = useProductsQuery( false, true );
 
 	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
+	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
+
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 
 	// Hide the section if it's automated referrals marketplace
@@ -106,10 +108,18 @@ export default function HostingList( { selectedSite }: Props ) {
 	return (
 		<div className="hosting-list">
 			<ListingSection
-				title={ translate( 'Hosting' ) }
-				description={ translate(
-					'Choose from a variety of world-class managed hosting that will scale with your business.'
-				) }
+				title={
+					isNewHostingPage
+						? translate( "Choose the hosting tailored for your client's needs." )
+						: translate( 'Hosting' )
+				}
+				description={
+					isNewHostingPage
+						? ''
+						: translate(
+								'Choose from a variety of world-class managed hosting that will scale with your business.'
+						  )
+				}
 				isTwoColumns
 				extraContent={ <MigrationOffer foldable /> }
 			>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-list/index.tsx
@@ -27,7 +27,6 @@ export default function HostingList( { selectedSite }: Props ) {
 	const { data } = useProductsQuery( false, true );
 
 	const isAutomatedReferrals = isEnabled( 'a4a-automated-referrals' );
-	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 
@@ -108,18 +107,10 @@ export default function HostingList( { selectedSite }: Props ) {
 	return (
 		<div className="hosting-list">
 			<ListingSection
-				title={
-					isNewHostingPage
-						? translate( "Choose the hosting tailored for your client's needs." )
-						: translate( 'Hosting' )
-				}
-				description={
-					isNewHostingPage
-						? ''
-						: translate(
-								'Choose from a variety of world-class managed hosting that will scale with your business.'
-						  )
-				}
+				title={ translate( 'Hosting' ) }
+				description={ translate(
+					'Choose from a variety of world-class managed hosting that will scale with your business.'
+				) }
 				isTwoColumns
 				extraContent={ <MigrationOffer foldable /> }
 			>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -1,0 +1,12 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function HostingV2() {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<span>{ translate( "Choose the hosting tailored for your client's needs." ) }</span>
+			Append the URL with `?flags=-a4a-hosting-page-redesign` to see the old design.
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -18,9 +19,11 @@ import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';
 import ShoppingCart from '../shopping-cart';
 import HostingList from './hosting-list';
+import HostingV2 from './hosting-v2';
 
 function Hosting() {
 	const translate = useTranslate();
+	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
 	const { selectedCartItems, onRemoveCartItem, showCart, setShowCart, toggleCart } =
 		useShoppingCart();
@@ -64,9 +67,7 @@ function Hosting() {
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>
-				<HostingList />
-			</LayoutBody>
+			<LayoutBody>{ isNewHostingPage ? <HostingV2 /> : <HostingList /> }</LayoutBody>
 		</Layout>
 	);
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -40,7 +40,8 @@
 		"a4a/site-migration": true,
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
-		"a4a-partner-directory": true
+		"a4a-partner-directory": true,
+		"a4a-hosting-page-redesign": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -33,7 +33,8 @@
 		"a4a/site-migration": true,
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
-		"a4a-partner-directory": true
+		"a4a-partner-directory": true,
+		"a4a-hosting-page-redesign": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/423
Closes https://github.com/Automattic/jetpack-genesis/issues/424
Closes https://github.com/Automattic/jetpack-genesis/issues/434


## Proposed Changes

This PR:

- Adds feature flag for the hosting redesign and enables it in Dev & Horizon environments
- Updates the heading for the hosting page when the feature flag is enabled

## Testing Instructions

1. Open the A4A live link.
2. Go to Marketplace - Hosting > Verify that the heading is changed & the subheading is hidden:

<img width="1726" alt="Screenshot 2024-07-24 at 10 25 08 AM" src="https://github.com/user-attachments/assets/af858363-0004-4ff3-b5f6-44593f0bae1c">


3. Disable the feature flag by appending the URL with `?flags=-a4a-hosting-page-redesign` and verify the changes aren't reflected.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
