### PR TITLE
Help Center: Shorten support URL cache

### DIFF
--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -14,7 +14,7 @@ import {
 	useHelpCenterContext,
 	type HelpCenterRequiredInformation,
 } from '../contexts/HelpCenterContext';
-import { useChatStatus, useStillNeedHelpURL, useActionHooks } from '../hooks';
+import { useChatStatus, useActionHooks } from '../hooks';
 import { useOpeningCoordinates } from '../hooks/use-opening-coordinates';
 import { HELP_CENTER_STORE } from '../stores';
 import { Container } from '../types';
@@ -44,7 +44,6 @@ const HelpCenter: React.FC< Container > = ( {
 		}
 	}, [ currentUser ] );
 
-	useStillNeedHelpURL();
 	useActionHooks();
 
 	const { hasActiveChats, isEligibleForChat } = useChatStatus();

--- a/packages/help-center/src/data/use-support-status.ts
+++ b/packages/help-center/src/data/use-support-status.ts
@@ -28,6 +28,6 @@ export function useSupportStatus( enabled = true ) {
 		enabled,
 		refetchOnWindowFocus: false,
 		placeholderData: keepPreviousData,
-		staleTime: 120 * 1000, // 2 mins. It has to be short, because the user can change the plan to access support.
+		staleTime: 100, // 100  ms, just to prevent refreshing the data on every render.
 	} );
 }


### PR DESCRIPTION
The Help Center caches the support-status (eligibility and whether the user has an ongoing session), this was carried over from Happy Chat where checking for an onging session and availability is extremely costly. This lowers the cache to 100 ms to remove stale results and to prevent re-fetching during re-renders.

Sadly the request is still fired a lot during the session for no reason in 99% of cases, but I tried different approaches to make the cache more selective and they're either too complex or didn't resolve the issue. I tried using the Calypso section as the cache key, but it doesn't work if the user goes to the editor and asks for help there. I tried `refreshOnMount` but also that didn't cut it because people could upgrade while the Help Center is open. 

I tried to invalidate the cache when the "Still need help?" button is clicked and show loading.. But the `useStillNeedHelpURL` hook, which sets the button destination, is used in many places and they won't benefit from this fix.

I finally changed the cache to 100 ms.

#### Testing steps.

1. Don't pay, but using a free user add some paid plan and go to Checkout.
2. Open the Help Center in Checkout, it should still go to forums.
3. Pay for the plan and quickly open the Help Center in the success screen. 
4. It should show Wapuu.

Fixes https://github.com/Automattic/wp-calypso/issues/90903