### PR TITLE
Desktop App: Increase the default window size for the desktop app

### DIFF
--- a/desktop/app/config.json
+++ b/desktop/app/config.json
@@ -16,7 +16,7 @@
 		"minWidth": 350,
 		"title": "WordPress.com",
 		"useContentSize": true,
-		"width": 900,
+		"width": 1200,
 		"webPreferences": {
 			"contextIsolation": true,
 			"enableRemoteModule": false,

--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -35,7 +35,7 @@ function showAppWindow() {
 	windowConfig.webPreferences.nativeWindowOpen = true;
 
 	const bounds = {
-		...{ width: 800, height: 600 },
+		...{ width: 1200, height: 800 },
 		...Settings.getSettingGroup( {}, 'window', [ 'x', 'y', 'width', 'height' ] ),
 	};
 

--- a/desktop/desktop-config/config-base.json
+++ b/desktop/desktop-config/config-base.json
@@ -16,7 +16,7 @@
 		"minWidth": 350,
 		"title": "WordPress.com",
 		"useContentSize": true,
-		"width": 900,
+		"width": 1200,
 		"webPreferences": {
 			"contextIsolation": true,
 			"enableRemoteModule": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8406

## Proposed Changes

* Increase the default size of the window to 1200 x 800 pixels

<img width="1313" alt="Screenshot 2024-07-23 at 12 32 58" src="https://github.com/user-attachments/assets/1fddc3e9-f9d3-4745-9341-2f9aed6c3042">

<img width="1313" alt="Screenshot 2024-07-23 at 12 32 52" src="https://github.com/user-attachments/assets/2da7dd35-fd92-49c9-a296-31ec5f43025d">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The current window size is too small to properly display the login page or dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On MacOS, ensure that the `settings.json` file stored at `~/Library/Application Support/WordPress.com/settings.json` is empty. (This will cause the window to launch with the default sizing.)
* Run `yarn run dev`
* Observe that the window opens with the default size of 1200 x 800

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
