### PR TITLE
Help Center: Refactor initialRoute to navigateToRoute

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/migration-error/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-error/index.tsx
@@ -30,7 +30,7 @@ interface Props {
 }
 
 export const MigrationError = ( props: Props ) => {
-	const { setShowHelpCenter, setInitialRoute, resetStore } =
+	const { setShowHelpCenter, setNavigateToRoute, resetStore } =
 		useDataStoreDispatch( HELP_CENTER_STORE );
 	const {
 		sourceSiteUrl,
@@ -66,7 +66,7 @@ export const MigrationError = ( props: Props ) => {
 				},
 			} );
 		} else {
-			setInitialRoute( '/contact-form?mode=CHAT' );
+			setNavigateToRoute( '/contact-form?mode=CHAT' );
 			setShowHelpCenter( true );
 		}
 	}, [
@@ -76,7 +76,7 @@ export const MigrationError = ( props: Props ) => {
 		status,
 		isMessagingAvailable,
 		canConnectToZendeskMessaging,
-		setInitialRoute,
+		setNavigateToRoute,
 		setShowHelpCenter,
 	] );
 

--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -75,7 +75,7 @@ const ChatButton: FC< Props > = ( {
 		messagingGroup,
 		isEligibleForChat
 	);
-	const { setShowHelpCenter, setInitialRoute, resetStore } =
+	const { setShowHelpCenter, setNavigateToRoute, resetStore } =
 		useDataStoreDispatch( HELP_CENTER_STORE );
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
 
@@ -127,7 +127,7 @@ const ChatButton: FC< Props > = ( {
 				},
 			} );
 		} else {
-			setInitialRoute( '/contact-form?mode=CHAT' );
+			setNavigateToRoute( '/contact-form?mode=CHAT' );
 			setShowHelpCenter( true );
 			onClick?.();
 		}

--- a/client/components/support-button/index.tsx
+++ b/client/components/support-button/index.tsx
@@ -21,11 +21,11 @@ const SupportButton: FC< Props > = ( {
 } ) => {
 	const { __ } = useI18n();
 	const { url } = useStillNeedHelpURL();
-	const { setInitialRoute, setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setNavigateToRoute, setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	function handleClick() {
 		if ( skipToContactOptions ) {
-			setInitialRoute( url );
+			setNavigateToRoute( url );
 		}
 		setShowHelpCenter( true );
 		recordTracksEvent( 'calypso_support_button_click', {

--- a/client/me/help/help-contact-us-footer.tsx
+++ b/client/me/help/help-contact-us-footer.tsx
@@ -12,12 +12,12 @@ const HELP_CENTER_STORE = HelpCenter.register();
 
 const HelpContactUsFooter: FC = () => {
 	const { __ } = useI18n();
-	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const { url } = useStillNeedHelpURL();
 
 	const onClick = () => {
 		recordTracksEvent( 'calypso_help_footer_button_click' );
-		setInitialRoute( url );
+		setNavigateToRoute( url );
 		setShowHelpCenter( true );
 	};
 

--- a/client/me/help/help-contact-us-header.tsx
+++ b/client/me/help/help-contact-us-header.tsx
@@ -7,17 +7,16 @@ import { useI18n } from '@wordpress/react-i18n';
 import type { FC } from 'react';
 
 import './style.scss';
-
 const HELP_CENTER_STORE = HelpCenter.register();
 
 const HelpContactUsHeader: FC = () => {
 	const { __ } = useI18n();
-	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const { url } = useStillNeedHelpURL();
 
 	const onClick = () => {
 		recordTracksEvent( 'calypso_help_header_button_click' );
-		setInitialRoute( url );
+		setNavigateToRoute( url );
 		setShowHelpCenter( true );
 	};
 

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -47,11 +47,11 @@ export default function HelpSearch() {
 
 		dispatch( recordTracksEvent( `calypso_inlinehelp_${ type }_open`, tracksData ) );
 	};
-	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const { url } = useStillNeedHelpURL();
 
 	const onClick = () => {
-		setInitialRoute( url );
+		setNavigateToRoute( url );
 		setShowHelpCenter( true );
 		dispatch( recordTracksEvent( 'calypso_inlinehelp_get_help_click' ) );
 	};

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -39,7 +39,7 @@ type Props = {
 function SupportLink( { children }: { children?: JSX.Element } ) {
 	const translate = useTranslate();
 	// Create URLSearchParams for send feedback by email command
-	const { setInitialRoute, setShowHelpCenter, setSubject } =
+	const { setNavigateToRoute, setShowHelpCenter, setSubject } =
 		useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const emailUrl = `/contact-form?${ new URLSearchParams( {
@@ -53,7 +53,7 @@ function SupportLink( { children }: { children?: JSX.Element } ) {
 			variant="link"
 			className="difm-lite-in-progress__help-button"
 			onClick={ () => {
-				setInitialRoute( emailUrl );
+				setNavigateToRoute( emailUrl );
 				setSubject( translate( 'I have a question about my project' ) );
 				setShowHelpCenter( true );
 			} }

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -109,7 +109,7 @@ function useDowngradeHandler( {
 	siteSlug: string | null | undefined;
 	currentPlan: Plans.SitePlan | undefined;
 } ) {
-	const { setShowHelpCenter, setInitialRoute, setMessage } = useDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setNavigateToRoute, setMessage } = useDispatch( HELP_CENTER_STORE );
 	const translate = useTranslate();
 	return useCallback(
 		( planSlug: PlanSlug ) => {
@@ -129,10 +129,17 @@ function useDowngradeHandler( {
 				'skip-resources': 'true',
 			} ).toString() }`;
 			setMessage( translate( 'I want to downgrade my plan.' ) );
-			setInitialRoute( chatUrl );
+			setNavigateToRoute( chatUrl );
 			setShowHelpCenter( true );
 		},
-		[ currentPlan?.purchaseId, setInitialRoute, setMessage, setShowHelpCenter, siteSlug, translate ]
+		[
+			currentPlan?.purchaseId,
+			setNavigateToRoute,
+			setMessage,
+			setShowHelpCenter,
+			siteSlug,
+			translate,
+		]
 	);
 }
 

--- a/client/state/jitm/actions.js
+++ b/client/state/jitm/actions.js
@@ -93,7 +93,7 @@ export const openHelpCenterFromJITM =
 	( { route } ) =>
 	( dispatch ) => {
 		const HELP_CENTER_STORE = HelpCenter.register();
-		dataStoreDispatch( HELP_CENTER_STORE ).setInitialRoute( route );
+		dataStoreDispatch( HELP_CENTER_STORE ).setNavigateToRoute( route );
 		dataStoreDispatch( HELP_CENTER_STORE ).setShowHelpCenter( true );
 		dispatch( {
 			type: JITM_OPEN_HELP_CENTER,

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -1,10 +1,8 @@
-import { select } from '@wordpress/data';
 import { apiFetch } from '@wordpress/data-controls';
 import { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
 import { wpcomRequest } from '../wpcom-request-controls';
-import { STORE_KEY } from './constants';
 import type { APIFetchOptions } from './types';
 
 export const receiveHasSeenWhatsNewModal = ( value: boolean | undefined ) =>
@@ -38,16 +36,16 @@ export function* setHasSeenWhatsNewModal( value: boolean ) {
 	return receiveHasSeenWhatsNewModal( response.has_seen_whats_new_modal );
 }
 
+export const setNavigateToRoute = ( route?: string ) =>
+	( {
+		type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
+		route,
+	} ) as const;
+
 export const setUnreadCount = ( count: number ) =>
 	( {
 		type: 'HELP_CENTER_SET_UNREAD_COUNT',
 		count,
-	} ) as const;
-
-export const setInitialRoute = ( route?: string ) =>
-	( {
-		type: 'HELP_CENTER_SET_INITIAL_ROUTE',
-		route,
 	} ) as const;
 
 export const setIsMinimized = ( minimized: boolean ) =>
@@ -70,7 +68,7 @@ export const setShowMessagingWidget = ( show: boolean ) =>
 
 export const setShowHelpCenter = function* ( show: boolean ) {
 	if ( ! show ) {
-		yield setInitialRoute( undefined );
+		yield setNavigateToRoute( undefined );
 	} else {
 		yield setShowMessagingWidget( false );
 	}
@@ -119,12 +117,6 @@ export const setShowMessagingChat = function* () {
 	yield resetStore();
 };
 
-export const setNavigateToRoute = ( route: string ) =>
-	( {
-		type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
-		route,
-	} ) as const;
-
 export const setShowSupportDoc = function* ( link: string, postId: number, blogId?: number ) {
 	const params = new URLSearchParams( {
 		link,
@@ -133,14 +125,8 @@ export const setShowSupportDoc = function* ( link: string, postId: number, blogI
 		cacheBuster: String( Date.now() ),
 	} );
 
-	const showHelpCenter = select( STORE_KEY ).isHelpCenterShown();
-
-	if ( showHelpCenter ) {
-		yield setNavigateToRoute( `/post/?${ params }` );
-	} else {
-		yield setInitialRoute( `/post/?${ params }` );
-		yield setShowHelpCenter( true );
-	}
+	yield setNavigateToRoute( `/post/?${ params }` );
+	yield setShowHelpCenter( true );
 	yield setIsMinimized( false );
 };
 
@@ -156,7 +142,6 @@ export type HelpCenterAction =
 			| typeof setUserDeclaredSiteUrl
 			| typeof setUnreadCount
 			| typeof setIsMinimized
-			| typeof setInitialRoute
 			| typeof setNavigateToRoute
 	  >
 	| GeneratorReturnType< typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal >;

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -97,13 +97,6 @@ const userDeclaredSite: Reducer< SiteDetails | undefined, HelpCenterAction > = (
 	return state;
 };
 
-const initialRoute: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
-	if ( action.type === 'HELP_CENTER_SET_INITIAL_ROUTE' ) {
-		return action.route;
-	}
-	return state;
-};
-
 const navigateToRoute: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
 	if ( action.type === 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE' ) {
 		return action.route;
@@ -122,7 +115,6 @@ const reducer = combineReducers( {
 	hasSeenWhatsNewModal,
 	isMinimized,
 	unreadCount,
-	initialRoute,
 	navigateToRoute,
 } );
 

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -104,6 +104,13 @@ const initialRoute: Reducer< string | undefined, HelpCenterAction > = ( state, a
 	return state;
 };
 
+const navigateToRoute: Reducer< string | undefined, HelpCenterAction > = ( state, action ) => {
+	if ( action.type === 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE' ) {
+		return action.route;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	showHelpCenter,
 	showMessagingLauncher,
@@ -116,6 +123,7 @@ const reducer = combineReducers( {
 	isMinimized,
 	unreadCount,
 	initialRoute,
+	navigateToRoute,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -10,5 +10,4 @@ export const getUserDeclaredSite = ( state: State ) => state.userDeclaredSite;
 export const getUnreadCount = ( state: State ) => state.unreadCount;
 export const getIsMinimized = ( state: State ) => state.isMinimized;
 export const getHasSeenWhatsNewModal = ( state: State ) => state.hasSeenWhatsNewModal;
-export const getInitialRoute = ( state: State ) => state.initialRoute;
 export const getNavigateToRoute = ( state: State ) => state.navigateToRoute;

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -11,3 +11,4 @@ export const getUnreadCount = ( state: State ) => state.unreadCount;
 export const getIsMinimized = ( state: State ) => state.isMinimized;
 export const getHasSeenWhatsNewModal = ( state: State ) => state.hasSeenWhatsNewModal;
 export const getInitialRoute = ( state: State ) => state.initialRoute;
+export const getNavigateToRoute = ( state: State ) => state.navigateToRoute;

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -39,12 +39,12 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	currentRoute,
 	openingCoordinates,
 } ) => {
-	const { show, isMinimized, initialRoute } = useSelect( ( select ) => {
+	const { show, isMinimized, navigateToRoute } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
 			show: store.isHelpCenterShown(),
 			isMinimized: store.getIsMinimized(),
-			initialRoute: store.getInitialRoute(),
+			navigateToRoute: store.getNavigateToRoute(),
 		};
 	}, [] );
 
@@ -109,7 +109,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	}
 
 	return (
-		<MemoryRouter initialEntries={ initialRoute ? [ initialRoute ] : undefined }>
+		<MemoryRouter initialEntries={ navigateToRoute ? [ navigateToRoute ] : undefined }>
 			<FeatureFlagProvider>
 				<OptionalDraggable
 					draggable={ ! isMobile && ! isMinimized }

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -46,7 +46,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const location = useLocation();
 	const containerRef = useRef< HTMLDivElement >( null );
 	const navigate = useNavigate();
-	const { setInitialRoute } = useDispatch( HELP_CENTER_STORE );
+	const { setInitialRoute, setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
 	const { sectionName, currentUser, site } = useHelpCenterContext();
 	const shouldUseWapuu = useShouldUseWapuu();
 	const { isMinimized } = useSelect( ( select ) => {
@@ -81,6 +81,20 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 		} ),
 		[]
 	);
+
+	const { navigateToRoute } = useSelect(
+		( select ) => ( {
+			navigateToRoute: ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getNavigateToRoute(),
+		} ),
+		[]
+	);
+
+	useEffect( () => {
+		if ( navigateToRoute ) {
+			navigate( navigateToRoute );
+			setNavigateToRoute( null );
+		}
+	}, [ navigate, navigateToRoute, setNavigateToRoute ] );
 
 	// reset the scroll location on navigation, TODO: unless there's an anchor
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -46,7 +46,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const location = useLocation();
 	const containerRef = useRef< HTMLDivElement >( null );
 	const navigate = useNavigate();
-	const { setInitialRoute, setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
+	const { setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
 	const { sectionName, currentUser, site } = useHelpCenterContext();
 	const shouldUseWapuu = useShouldUseWapuu();
 	const { isMinimized } = useSelect( ( select ) => {
@@ -75,13 +75,6 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 		} );
 	}, [ location, sectionName ] );
 
-	const { initialRoute } = useSelect(
-		( select ) => ( {
-			initialRoute: ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getInitialRoute(),
-		} ),
-		[]
-	);
-
 	const { navigateToRoute } = useSelect(
 		( select ) => ( {
 			navigateToRoute: ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).getNavigateToRoute(),
@@ -104,13 +97,6 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 		}
 	}, [ location ] );
 
-	// reset the initial route after it's been used
-	useEffect( () => {
-		if ( initialRoute ) {
-			setInitialRoute( null );
-		}
-	}, [ initialRoute, setInitialRoute ] );
-
 	const trackEvent = useCallback(
 		( eventName: string, properties: Record< string, unknown > = {} ) => {
 			recordTracksEvent( eventName, properties );
@@ -131,8 +117,8 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 					<Route
 						path="/"
 						element={
-							initialRoute ? (
-								<Navigate to={ initialRoute } />
+							navigateToRoute ? (
+								<Navigate to={ navigateToRoute } />
 							) : (
 								<HelpCenterSearch onSearchChange={ setSearchTerm } currentRoute={ currentRoute } />
 							)

--- a/packages/help-center/src/hooks/use-action-hooks.ts
+++ b/packages/help-center/src/hooks/use-action-hooks.ts
@@ -6,7 +6,7 @@ import { useEffect } from '@wordpress/element';
  * Add your conditions here to open the Help Center automatically when they're met.
  */
 export const useActionHooks = () => {
-	const { setShowHelpCenter, setShowSupportDoc, setInitialRoute } =
+	const { setShowHelpCenter, setShowSupportDoc, setNavigateToRoute } =
 		useDispatch( 'automattic/help-center' );
 	const queryParams = new URLSearchParams( window.location.search );
 
@@ -34,7 +34,7 @@ export const useActionHooks = () => {
 				return queryParams.get( 'help-center' ) === 'wapuu';
 			},
 			action() {
-				setInitialRoute( '/odie' );
+				setNavigateToRoute( '/odie' );
 				setShowHelpCenter( true );
 			},
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/8408

## Proposed Changes

* ~Updates the Help Center page when its open and a new support doc link is pressed. It should now properly navigate to the correct support doc.~

This PR will rename the navigation-related logic to better communicate its expected usage and behavior. The fix for https://github.com/Automattic/dotcom-forge/issues/8408 will be handled in https://github.com/Automattic/wp-calypso/pull/92745.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* ~Previously, if you clicked a support doc or opened the Help Center and then clicked another support doc, the page would not update to display the selected doc. These changes will update this logic to correctly update the page.~

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or use live link.
* Navigate to `/home` , scroll down and click on a support doc link. The Help Center should open to display the selected doc.
* Keep the Help Center open and select another doc, the Help Center should update to display the selected doc.
* Minimize the Help Center and select another doc.
* Verify the Help Center is maximized and displays the correct doc.
* Test other support doc links to ensure theyre still working correctly ( such as the `paid newsletter` sub header link on the subscribers page (`/subscribers/{SITE_SLUG}`)
* Regression testing to ensure existing functionality isn't broken when opening Help Center.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
