### PR TITLE
Marketing banner: Add upsell

### DIFF
--- a/client/data/marketing-banner/use-marketing-banner.ts
+++ b/client/data/marketing-banner/use-marketing-banner.ts
@@ -1,0 +1,24 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export type MarketingBanner = {
+	is_visible: boolean;
+};
+
+export const useMarketingBanner = (
+	siteId: number,
+	isEnabled = false
+): UseQueryResult< MarketingBanner > => {
+	const queryKey = [ 'marketing-banner', siteId ];
+
+	return useQuery< MarketingBanner >( {
+		queryKey,
+		queryFn: () => {
+			return wpcom.req.get( {
+				path: `/sites/${ siteId }/marketing-banner`,
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+		enabled: isEnabled && !! siteId,
+	} );
+};

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
+	PLAN_PERSONAL,
 	PLAN_BUSINESS,
+	WPCOM_FEATURES_NO_ADVERTS,
 	WPCOM_FEATURES_NO_WPCOM_BRANDING,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
 	getPlan,
@@ -29,12 +31,14 @@ import SiteLanguagePicker from 'calypso/components/language-picker/site-language
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import Timezone from 'calypso/components/timezone';
+import { useMarketingBanner } from 'calypso/data/marketing-banner/use-marketing-banner';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { preventWidows } from 'calypso/lib/formatting';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import SiteSettingPrivacy from 'calypso/my-sites/site-settings/site-setting-privacy';
+import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -579,6 +583,8 @@ export class SiteSettingsFormGeneral extends Component {
 			isUnlaunchedSite: propsisUnlaunchedSite,
 			adminInterfaceIsWPAdmin,
 			hasBlockTheme,
+			isMarketingBannerVisible,
+			personalPlanMonthlyCost,
 		} = this.props;
 		const classes = clsx( 'site-settings__general-settings', {
 			'is-loading': isRequestingSettings,
@@ -627,46 +633,73 @@ export class SiteSettingsFormGeneral extends Component {
 				/>
 				{ this.renderAdminInterface() }
 				{ ! isWpcomStagingSite && this.giftOptions() }
-				{ ! hasBlockTheme && ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
-					<div className="site-settings__footer-credit-container">
-						<SettingsSectionHeader
-							title={ translate( 'Footer credit' ) }
-							id="site-settings__footer-credit-header"
-						/>
-						<CompactCard className="site-settings__footer-credit-explanation">
-							<p>
-								{ preventWidows(
-									translate(
-										'You can customize your website by changing the footer credit in customizer.'
-									),
-									2
-								) }
-							</p>
-							<div>
-								<Button className="site-settings__footer-credit-change" href={ customizerUrl }>
-									{ translate( 'Change footer credit' ) }
-								</Button>
+				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
+					<>
+						{ hasBlockTheme && isMarketingBannerVisible && (
+							<div className="site-settings__marketing-banner-container">
+								<SettingsSectionHeader
+									title={ translate( 'Marketing banner' ) }
+									id="site-settings__marketing-banner-header"
+								/>
+								<UpsellNudge
+									feature={ WPCOM_FEATURES_NO_ADVERTS }
+									plan={ PLAN_PERSONAL }
+									title={ translate(
+										'Remove the banner displayed to your visitors with any paid plan'
+									) }
+									description={ translate(
+										'Upgrade your plan to remove the banner and unlock more features, from %(monthlyCost)s/month',
+										{ args: { monthlyCost: personalPlanMonthlyCost } }
+									) }
+									showIcon
+									event="settings_remove_marketing_banner"
+									tracksImpressionName="calypso_upgrade_nudge_impression"
+									tracksClickName="calypso_upgrade_nudge_cta_click"
+								/>
 							</div>
-						</CompactCard>
-						{ ! hasNoWpcomBranding && (
-							<UpsellNudge
-								feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
-								plan={ PLAN_BUSINESS }
-								title={ translate(
-									'Remove the footer credit entirely with WordPress.com %(businessPlanName)s',
-
-									{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-								) }
-								description={ translate(
-									'Upgrade to remove the footer credit, use advanced SEO tools and more'
-								) }
-								showIcon
-								event="settings_remove_footer"
-								tracksImpressionName="calypso_upgrade_nudge_impression"
-								tracksClickName="calypso_upgrade_nudge_cta_click"
-							/>
 						) }
-					</div>
+						{ ! hasBlockTheme && (
+							<div className="site-settings__footer-credit-container">
+								<SettingsSectionHeader
+									title={ translate( 'Footer credit' ) }
+									id="site-settings__footer-credit-header"
+								/>
+								<CompactCard className="site-settings__footer-credit-explanation">
+									<p>
+										{ preventWidows(
+											translate(
+												'You can customize your website by changing the footer credit in customizer.'
+											),
+											2
+										) }
+									</p>
+									<div>
+										<Button className="site-settings__footer-credit-change" href={ customizerUrl }>
+											{ translate( 'Change footer credit' ) }
+										</Button>
+									</div>
+								</CompactCard>
+								{ ! hasNoWpcomBranding && (
+									<UpsellNudge
+										feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
+										plan={ PLAN_BUSINESS }
+										title={ translate(
+											'Remove the footer credit entirely with WordPress.com %(businessPlanName)s',
+
+											{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+										) }
+										description={ translate(
+											'Upgrade to remove the footer credit, use advanced SEO tools and more'
+										) }
+										showIcon
+										event="settings_remove_footer"
+										tracksImpressionName="calypso_upgrade_nudge_impression"
+										tracksClickName="calypso_upgrade_nudge_cta_click"
+									/>
+								) }
+							</div>
+						) }
+					</>
 				) }
 				{ this.toolbarOption() }
 			</div>
@@ -702,6 +735,7 @@ const connectComponent = connect( ( state ) => {
 		isLaunchable:
 			! getIsSiteOnECommerceTrial( state, siteId ) && ! getIsSiteOnMigrationTrial( state, siteId ),
 		isSimple: isSimpleSite( state, siteId ),
+		personalPlanMonthlyCost: getProductDisplayCost( state, PLAN_PERSONAL, true ),
 	};
 } );
 
@@ -758,11 +792,15 @@ const SiteSettingsFormGeneralWithGlobalStylesNotice = ( props ) => {
 	const { data: activeThemeData } = useActiveThemeQuery( props.site?.ID ?? -1, !! props.site );
 	const hasBlockTheme = activeThemeData?.[ 0 ]?.is_block_theme ?? false;
 
+	const { data: marketingBannerData } = useMarketingBanner( props.site?.ID ?? -1, !! props.site );
+	const isMarketingBannerVisible = marketingBannerData?.is_visible ?? false;
+
 	return (
 		<SiteSettingsFormGeneral
 			{ ...props }
 			shouldShowPremiumStylesNotice={ globalStylesInUse && shouldLimitGlobalStyles }
 			hasBlockTheme={ hasBlockTheme }
+			isMarketingBannerVisible={ isMarketingBannerVisible }
 		/>
 	);
 };

--- a/client/state/products-list/selectors/get-product-display-cost.js
+++ b/client/state/products-list/selectors/get-product-display-cost.js
@@ -6,13 +6,18 @@ import 'calypso/state/products-list/init';
  * Returns the display price of the specified product.
  * @param {Object} state - global state tree
  * @param {string} productSlug - internal product slug, eg 'jetpack_premium'
+ * @param {?boolean} shouldDisplayMonthlyCost - whether the cost should be per month (defaults to false).
  * @returns {?string} the display price formatted in the user's currency (eg 'A$29.00'), or null otherwise
  */
-export function getProductDisplayCost( state, productSlug ) {
+export function getProductDisplayCost( state, productSlug, shouldDisplayMonthlyCost = false ) {
 	const product = getProductBySlug( state, productSlug );
 
 	if ( ! product ) {
 		return null;
+	}
+
+	if ( shouldDisplayMonthlyCost ) {
+		return product.cost_per_month_display;
 	}
 
 	return product.cost_display;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8273

**Tip**

This is easier to review if you hide the whitespace changes:

<img width="262" alt="Screenshot 2024-07-23 at 15 03 40" src="https://github.com/user-attachments/assets/bb45e105-5d48-4bf3-85eb-a9cbc1795272">

## Proposed Changes

Adds an upsell in `/settings/general/:site` on sites with a block theme to indicate that the marketing banner can be removed with any paid plan.

<img width="829" alt="Screenshot 2024-07-23 at 14 03 24" src="https://github.com/user-attachments/assets/7d153ee2-4813-4343-827f-5a735d7474b4">


## Why are these changes being made?

Because we have removed the footer credit upsell for block themes, so we want to offset a potential loss.

## Testing Instructions

- Use the Calypso live link below
- Go to `/settings/general/:site`
- Pick a site with a block theme
- Make sure the new marketing banner upsell is visible if your site is elegible, see fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Soybt%2Qcyhtvaf%2Sznexrgvat%2Qone.cuc%3Se%3Q2rq7n2np%2378-og)
- Make sure the upsell is not visible if you upgrade
- Make sure the upsell is not visible if your site has a classic theme

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?