### PR TITLE
Add Calypso status check

### DIFF
--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -1,13 +1,16 @@
 name: Calypso Channel Status
 run-name: ${{ github.actor }} Checking Calypso Slack Channel Status
-on: [push]
+
+on:
+  merge_group:
+
 jobs:
   CheckCalypsoChannelStatus:
     runs-on: ubuntu-latest
     steps:
       - run: 
         STATUS=$(curl -s https://public-api.wordpress.com/rest/v1.1/internal/calypso-slack-channel --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}")
-        echo $STATUS
+        echo $STATUS  
         if [ "$STATUS" = "GREEN" ]; then
           echo "Calypso Slack channel is green."
           exit 0

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -1,15 +1,17 @@
-name: Calypso Channel Status
+name: Is Calypso Channel Green?
 run-name: ${{ github.actor }} Checking Calypso Slack Channel Status
 
 on:
   merge_group:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  CheckCalypsoChannelStatus:
+  Check if Calypso Slack channel is green:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          STATUS=$(curl -s https://public-api.wordpress.com/wpcom/v2/calypso-slack-channel-status --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}")
+          STATUS=$(curl -s https://public-api.wordpress.com/wpcom/v2/calypso-slack-channel-status --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}" | xargs)
           if [ "$STATUS" = "GREEN" ]; then
             echo "Calypso Slack channel is green."
             exit 0

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          STATUS=$(curl -s https://public-api.wordpress.com/rest/v1.1/internal/calypso-slack-channel --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}")
+          STATUS=$(curl -s https://public-api.wordpress.com/wpcom/v2/calypso-slack-channel-status --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}")
           if [ "$STATUS" = "GREEN" ]; then
             echo "Calypso Slack channel is green."
             exit 0

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -5,4 +5,15 @@ jobs:
   CheckCalypsoChannelStatus:
     runs-on: ubuntu-latest
     steps:
-      - run: curl https://api.aruljohn.com/ip
+      - run: 
+        STATUS=$(curl -s https://public-api.wordpress.com/rest/v1.1/internal/calypso-slack-channel)
+        if [ "$STATUS" = "GREEN" ]; then
+          echo "Calypso Slack channel is green."
+          exit 0
+        elif [ "$STATUS" = "RED" ]; then
+          echo "Calypso Slack channel is red."
+          exit 1
+        else
+          echo "Calypso Slack channel status is unknown."
+          exit 1
+        fi

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-        STATUS=$(curl -s https://public-api.wordpress.com/rest/v1.1/internal/calypso-slack-channel --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}")
-        if [ "$STATUS" = "GREEN" ]; then
-          echo "Calypso Slack channel is green."
-          exit 0
-        elif [ "$STATUS" = "RED" ]; then
-          echo "Calypso Slack channel is red."
-          exit 1
-        else
-          echo "Calypso Slack channel status is unknown."
-          exit 1
-        fi
-      shell: bash
+          STATUS=$(curl -s https://public-api.wordpress.com/rest/v1.1/internal/calypso-slack-channel --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}")
+          if [ "$STATUS" = "GREEN" ]; then
+            echo "Calypso Slack channel is green."
+            exit 0
+          elif [ "$STATUS" = "RED" ]; then
+            echo "Calypso Slack channel is red."
+            exit 1
+          else
+            echo "Calypso Slack channel status is unknown."
+            exit 1
+          fi
+        shell: bash

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -1,0 +1,8 @@
+name: Calypso Channel Status
+run-name: ${{ github.actor }} Checking Calypso Slack Channel Status
+on: [push]
+jobs:
+  CheckCalypsoChannelStatus:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl https://api.aruljohn.com/ip

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -8,9 +8,8 @@ jobs:
   CheckCalypsoChannelStatus:
     runs-on: ubuntu-latest
     steps:
-      - run: 
+      - run: |
         STATUS=$(curl -s https://public-api.wordpress.com/rest/v1.1/internal/calypso-slack-channel --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}")
-        echo $STATUS  
         if [ "$STATUS" = "GREEN" ]; then
           echo "Calypso Slack channel is green."
           exit 0
@@ -21,3 +20,4 @@ jobs:
           echo "Calypso Slack channel status is unknown."
           exit 1
         fi
+      shell: bash

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  Check if Calypso Slack channel is green:
+  check-channel-status:
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -6,7 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 
-        STATUS=$(curl -s https://public-api.wordpress.com/rest/v1.1/internal/calypso-slack-channel)
+        STATUS=$(curl -s https://public-api.wordpress.com/rest/v1.1/internal/calypso-slack-channel --header "Authorization: ${{ secrets.CALYPSO_CHANNEL_STATUS_API_SECRET }}")
+        echo $STATUS
         if [ "$STATUS" = "GREEN" ]; then
           echo "Calypso Slack channel is green."
           exit 0

--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -3,8 +3,6 @@ run-name: ${{ github.actor }} Checking Calypso Slack Channel Status
 
 on:
   merge_group:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   check-channel-status:


### PR DESCRIPTION
## Proposed Changes

This adds a GitHub action that checks the status of Calypso Channel on Slack. It allows us to get rid of this [Tampermonkey script](https://github.com/Automattic/tampermonkey-calypso-checker) and its quirks. Also, not everyone is aware of this script.

## Testing Instructions

Blocked by: D156224-code

1. To install GH actions locally, you can use `act`, it's very straightforward.
2. In Calypso repo's root, install act by running `curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash`.
3. Run the action by running `act -P ubuntu-latest=catthehacker/ubuntu:act-latest merge_group -s CALYPSO_CHANNEL_STATUS_API_SECRET=PING ME FOR THE SECRET`.
4. Sadly, you can't test the endpoint unless it's deployed because Docker requires a business account to use SOCKS proxy (i.e access your sandbox).

## Next steps
1. Enable merge queue.