### PR TITLE
Sites dashboard - revert recent changes to selectedSiteId handling.

### DIFF
--- a/client/hosting/sites/controller.tsx
+++ b/client/hosting/sites/controller.tsx
@@ -7,6 +7,7 @@ import { removeQueryArgs } from '@wordpress/url';
 import AsyncLoad from 'calypso/components/async-load';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { removeNotice } from 'calypso/state/notices/actions';
+import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import SitesDashboard from './components/sites-dashboard';
 import type { Context, Context as PageJSContext } from '@automattic/calypso-router';
@@ -118,6 +119,9 @@ export function sitesDashboard( context: Context, next: () => void ) {
 			<SitesDashboard queryParams={ getQueryParams( context ) } />
 		</>
 	);
+
+	// By definition, Sites Dashboard does not select any one specific site
+	context.store.dispatch( setAllSitesSelected() );
 
 	next();
 }

--- a/client/hosting/sites/hooks/use-sync-selected-site.ts
+++ b/client/hosting/sites/hooks/use-sync-selected-site.ts
@@ -1,5 +1,5 @@
 import { SiteDetails } from '@automattic/data-stores';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import type { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -10,16 +10,9 @@ export function useSyncSelectedSite(
 	selectedSite: SiteDetails | null | undefined
 ) {
 	const dispatch = useDispatch();
-	const isInitialLoad = useRef( true );
 
 	// Update selected site globally as soon as it is clicked from the table.
 	useEffect( () => {
-		// Prevent clearing the selected site on initial load.
-		if ( isInitialLoad.current && ! dataViewsState.selectedItem ) {
-			isInitialLoad.current = false;
-			return;
-		}
-		isInitialLoad.current = false;
 		dispatch( setSelectedSiteId( dataViewsState.selectedItem?.ID ) );
 	}, [ dispatch, dataViewsState.selectedItem ] );
 

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -61,18 +61,6 @@ export const getShouldShowGlobalSidebar = (
 	);
 };
 
-interface CollapsedDataHelper {
-	shouldShowForAnimation: boolean;
-	selectedSiteId: number | null | undefined;
-	sectionGroup: string;
-}
-
-const collapsedDataHelper: CollapsedDataHelper = {
-	shouldShowForAnimation: false,
-	selectedSiteId: null,
-	sectionGroup: '',
-};
-
 export const getShouldShowCollapsedGlobalSidebar = (
 	state: AppState,
 	siteId: number | null,
@@ -82,37 +70,21 @@ export const getShouldShowCollapsedGlobalSidebar = (
 	const isSitesDashboard = sectionGroup === 'sites-dashboard';
 	const isSiteDashboard = getShouldShowSiteDashboard( state, siteId, sectionGroup, sectionName );
 
-	if ( collapsedDataHelper.sectionGroup !== sectionGroup ) {
-		if ( isSitesDashboard ) {
-			// Set or refresh the initial value when loading into the dashboard.
-			collapsedDataHelper.selectedSiteId = siteId;
-		} else {
-			// Clear this once we are off the sites dashboard.
-			collapsedDataHelper.shouldShowForAnimation = false;
-		}
-		// Keep track of section group to evaluate things when this changes.
-		collapsedDataHelper.sectionGroup = sectionGroup;
-	}
-
-	// When selected site changes on the dashboard, show for animation.
-	if (
+	// A site is just clicked and the global sidebar is in collapsing animation.
+	const isSiteJustSelectedFromSitesDashboard =
 		isSitesDashboard &&
 		!! siteId &&
-		collapsedDataHelper.selectedSiteId !== siteId &&
-		! collapsedDataHelper.shouldShowForAnimation
-	) {
-		collapsedDataHelper.shouldShowForAnimation = true;
-		collapsedDataHelper.selectedSiteId = siteId;
-	}
+		isInRoute( state, [
+			'/sites', // started collapsing when still in sites dashboard
+			...Object.values( SITE_DASHBOARD_ROUTES ), // has just stopped collapsing when in one of the paths in site dashboard
+		] );
 
 	const isPluginsScheduledUpdatesEditMode =
 		isScheduledUpdatesMultisiteCreateRoute( state ) ||
 		isScheduledUpdatesMultisiteEditRoute( state );
 
 	return (
-		collapsedDataHelper.shouldShowForAnimation ||
-		isSiteDashboard ||
-		isPluginsScheduledUpdatesEditMode
+		isSiteJustSelectedFromSitesDashboard || isSiteDashboard || isPluginsScheduledUpdatesEditMode
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/8325

## Proposed Changes

Removes some changes from https://github.com/Automattic/wp-calypso/pull/92720 now that another solution to the same problem is also in place. This also removes the animation bug introduced by that PR.

* in https://github.com/Automattic/wp-calypso/pull/92720 we made changes to how the dashboard handles the selected site to enable site items in the dashboard here. This had the side effect of introducing [this animation bug](https://github.com/Automattic/wp-calypso/pull/92720).
* A few days later, we came up with another solution more fitting to get this behavior to the other global pages. (https://github.com/Automattic/wp-calypso/pull/92800 and https://github.com/Automattic/wp-calypso/pull/92815)
* The latter solution fits the sites dashboard as well. Therefore, I think we can remove the selection changes from https://github.com/Automattic/wp-calypso/pull/92720. There should be no noticable change other than fixing the animation bug.

BEFORE
![anim-before](https://github.com/user-attachments/assets/249813e4-aba0-44ed-9f41-a37c97e9beb0)


AFTER
![after-anim](https://github.com/user-attachments/assets/3fd0de4d-1cd1-4cd4-94e1-7e38de75c81b)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* noted above

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the sites dashboard in calypso. 
* Smoke test general interactions going to/from this area and other global and non global areas of the app. Verify there are no changes.
* Test the animation bug noted above:
     * Go to a sites "my home" page.
     * Click to visit "all sites".
     * Find that site in the sites dashboard and click on it to open the overview.
     * Verify the animation for the collapsing sidebar is smooth and no longer jumpy in this case.
* Verify this does not break query param handling for setting the selected site. You can add `?origin_site_id={your-site-id}` to the /sites url and reload. Verify it loads and the masterbar now has that site selected for context. This is how we keep site context in the masterbar when navigating from wp-admin to the global areas of calypso.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
