### PR TITLE
i18n: Use `useI18n` for Status labels in Sites Dashboard

### DIFF
--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -49,7 +49,7 @@ import {
 import { DOTCOM_OVERVIEW, FEATURE_TO_ROUTE_MAP } from './site-preview-pane/constants';
 import DotcomPreviewPane from './site-preview-pane/dotcom-preview-pane';
 import SitesDashboardHeader from './sites-dashboard-header';
-import DotcomSitesDataViews, { siteStatusGroups } from './sites-dataviews';
+import DotcomSitesDataViews, { useSiteStatusGroups } from './sites-dataviews';
 import { getSitesPagination, addDummyDataViewPrefix } from './sites-dataviews/utils';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -111,6 +111,8 @@ const SitesDashboard = ( {
 
 	useShowSiteCreationNotice( allSites, newSiteID );
 	useShowSiteTransferredNotice();
+
+	const siteStatusGroups = useSiteStatusGroups();
 
 	// Create the DataViews state based on initial values
 	const defaultDataViewsState = {
@@ -176,7 +178,7 @@ const SitesDashboard = ( {
 		const statusNumber = statusFilter?.value || 1;
 		return ( siteStatusGroups.find( ( status ) => status.value === statusNumber )?.slug ||
 			'all' ) as GroupableSiteLaunchStatuses;
-	}, [ dataViewsState.filters ] );
+	}, [ dataViewsState.filters, siteStatusGroups ] );
 
 	// Filter sites list by status group.
 	const { currentStatusGroup } = useSitesListGrouping( allSites, {

--- a/client/hosting/sites/components/sites-dataviews/index.tsx
+++ b/client/hosting/sites/components/sites-dataviews/index.tsx
@@ -1,6 +1,5 @@
 import { DESKTOP_BREAKPOINT, WIDE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
@@ -34,14 +33,21 @@ type Props = {
 	setDataViewsState: ( callback: ( prevState: DataViewsState ) => DataViewsState ) => void;
 };
 
-export const siteStatusGroups = [
-	{ value: 1, label: __( 'All sites' ), slug: 'all' },
-	{ value: 2, label: __( 'Public' ), slug: 'public' },
-	{ value: 3, label: __( 'Private' ), slug: 'private' },
-	{ value: 4, label: __( 'Coming soon' ), slug: 'coming-soon' },
-	{ value: 5, label: __( 'Redirect' ), slug: 'redirect' },
-	{ value: 6, label: __( 'Deleted' ), slug: 'deleted' },
-];
+export function useSiteStatusGroups() {
+	const { __ } = useI18n();
+
+	return useMemo(
+		() => [
+			{ value: 1, label: __( 'All sites' ), slug: 'all' },
+			{ value: 2, label: __( 'Public' ), slug: 'public' },
+			{ value: 3, label: __( 'Private' ), slug: 'private' },
+			{ value: 4, label: __( 'Coming soon' ), slug: 'coming-soon' },
+			{ value: 5, label: __( 'Redirect' ), slug: 'redirect' },
+			{ value: 6, label: __( 'Deleted' ), slug: 'deleted' },
+		],
+		[ __ ]
+	);
+}
 
 const DotcomSitesDataViews = ( {
 	sites,
@@ -106,6 +112,8 @@ const DotcomSitesDataViews = ( {
 			}
 		};
 	}, [] );
+
+	const siteStatusGroups = useSiteStatusGroups();
 
 	// Generate DataViews table field-columns
 	const fields = useMemo< DataViewsColumn[] >(
@@ -220,7 +228,16 @@ const DotcomSitesDataViews = ( {
 				enableSorting: false,
 			},
 		],
-		[ __, openSitePreviewPane, userId, dataViewsState, setDataViewsState, isWide, isDesktop ]
+		[
+			__,
+			openSitePreviewPane,
+			userId,
+			dataViewsState,
+			setDataViewsState,
+			isWide,
+			isDesktop,
+			siteStatusGroups,
+		]
 	);
 
 	// Create the itemData packet state


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 821-gh-Automattic/i18n-issues

## Proposed Changes

* Refactor the `siteStatusGroups` to a custom hook using `useI18n()` to ensure the component is re-rendered when the i18n data changes.

**After:**
![3NtUfyFtE0VZVEFn](https://github.com/user-attachments/assets/689cdaa7-1b42-4424-84c7-f0deb4df68ee)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The status labels appeared untranslated, because the constant `siteStatusGroups` was defined before the translation data was loaded.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change UI to a Mag-16 language.
* Navigate to `/sites`.
* Expand the Status dropdown and confirm the labels are translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
