### PR TITLE
Masterbar cleanup - consolidate siteId values used.

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -58,7 +58,6 @@ import {
 	getMostRecentlySelectedSiteId,
 	getSectionGroup,
 	getSectionName,
-	getSelectedSiteId,
 } from 'calypso/state/ui/selectors';
 import Item from './item';
 import Masterbar from './masterbar';
@@ -167,20 +166,20 @@ class MasterbarLoggedIn extends Component {
 		 *
 		 * This code makes it possible to reset the failed migration state when clicking My Sites too.
 		 */
-		const { migrationStatus, currentSelectedSiteId } = this.props;
+		const { migrationStatus, siteId } = this.props;
 
-		if ( currentSelectedSiteId && migrationStatus === 'error' ) {
+		if ( siteId && migrationStatus === 'error' ) {
 			/**
 			 * Reset the in-memory site lock for the currently selected site
 			 */
-			this.props.updateSiteMigrationMeta( currentSelectedSiteId, 'inactive', null, null );
+			this.props.updateSiteMigrationMeta( siteId, 'inactive', null, null );
 
 			/**
 			 * Reset the migration on the backend
 			 */
 			wpcom.req
 				.post( {
-					path: `/sites/${ currentSelectedSiteId }/reset-migration`,
+					path: `/sites/${ siteId }/reset-migration`,
 					apiNamespace: 'wpcom/v2',
 				} )
 				.catch( () => {} );
@@ -727,12 +726,12 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderHelpCenter() {
-		const { currentSelectedSiteId, translate } = this.props;
+		const { siteId, translate } = this.props;
 
 		return (
 			<AsyncLoad
 				require="./masterbar-help-center"
-				siteId={ currentSelectedSiteId }
+				siteId={ siteId }
 				tooltip={ translate( 'Help' ) }
 				placeholder={ null }
 			/>
@@ -846,13 +845,10 @@ export default connect(
 
 		// Falls back to using the user's primary site if no site has been selected
 		// by the user yet
-		const currentSelectedSiteId = getSelectedSiteId( state );
-		const siteId =
-			currentSelectedSiteId || getMostRecentlySelectedSiteId( state ) || getPrimarySiteId( state );
+		const siteId = getMostRecentlySelectedSiteId( state ) || getPrimarySiteId( state );
 		const sitePlanSlug = getSitePlanSlug( state, siteId );
 		const isMigrationInProgress =
-			isSiteMigrationInProgress( state, currentSelectedSiteId ) ||
-			isSiteMigrationActiveRoute( state );
+			isSiteMigrationInProgress( state, siteId ) || isSiteMigrationActiveRoute( state );
 
 		const siteCount = getCurrentUserSiteCount( state ) ?? 0;
 		const site = getSite( state, siteId );
@@ -875,16 +871,11 @@ export default connect(
 			isSupportSession: isSupportSession( state ),
 			isInEditor: getSectionName( state ) === 'gutenberg-editor',
 			isMigrationInProgress,
-			migrationStatus: getSiteMigrationStatus( state, currentSelectedSiteId ),
-			currentSelectedSiteId,
+			migrationStatus: getSiteMigrationStatus( state, siteId ),
 			isClassicView,
-			currentSelectedSiteSlug: currentSelectedSiteId
-				? getSiteSlug( state, currentSelectedSiteId )
-				: undefined,
+			currentSelectedSiteSlug: siteId ? getSiteSlug( state, siteId ) : undefined,
 			previousPath: getPreviousRoute( state ),
-			isJetpackNotAtomic:
-				isJetpackSite( state, currentSelectedSiteId ) &&
-				! isAtomicSite( state, currentSelectedSiteId ),
+			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			hasDismissedThePopover: getPreference( state, MENU_POPOVER_PREFERENCE_KEY ),
 			isFetchingPrefs: isFetchingPreferences( state ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/92815

## Proposed Changes

Unifies the siteId used by various components of the masterbar. Previously there were some places we were using a `siteId` including most recent selection and primary fallback, in other places we were still using `currentlySelectedSiteId` only.

For the most part there should be no observable change. I think the edge case this should resolve is when the masterbar falls back to showing the primary site, there would not be proper context for help center and migrations.

*  Removes `currentlySelectedSiteId` and `getSelectedSiteId` from the masterbar.
* Instead uses `siteId` for everything, which uses `getMostRecentlySelectedSiteId` and `getPrimarySiteId` as a fallback. Note that `getMostRecentlySelectedSiteId` will always have the same value as the previous `getSelectedSiteId` (if it has a value, otherwise its more recent truthy value), so there should be no changes WRT having a site selected. This ensures the primary site fallback has proper handling throughout the masterbar and cleans up the code a little.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Code cleanup mostly.
* Fix potential edge cases where some of the masterbar components would not have proper context when falling back to render the primary site as its context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test the masterbar and verify there are no observable changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
