### PR TITLE
Fix centered "Back to dashboard" message on thank you page

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -22,6 +22,7 @@ interface MasterbarItemProps {
 	tooltip?: string;
 	icon?: ReactNode;
 	className?: string;
+	wrapperClassName?: string;
 	isActive?: boolean;
 	preloadSection?: () => void;
 	hasUnseen?: boolean;
@@ -207,7 +208,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		}
 
 		return (
-			<div ref={ this.componentDivRef }>
+			<div className={ this.props.wrapperClassName } ref={ this.componentDivRef }>
 				<button
 					{ ...attributes }
 					ref={ this.props.innerRef as LegacyRef< HTMLButtonElement > }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
@@ -1,56 +1,9 @@
 import { Global, css } from '@emotion/react';
-import styled from '@emotion/styled';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import { DefaultMasterbarContact } from './default-contact';
-
-const MasterbarStyledBlock = styled( Masterbar )`
-	--color-masterbar-background: var( --studio-white );
-	--color-masterbar-text: var( --studio-gray-60 );
-	padding-right: 24px;
-	border-bottom: 0;
-`;
-
-const WordPressLogoStyled = styled( WordPressLogo )`
-	fill: rgb( 54, 54, 54 );
-	margin: 24px 12px 24px 24px;
-	@media ( min-width: 480px ) {
-		margin: 24px;
-	}
-`;
-
-const ItemStyled = styled( Item )`
-	cursor: pointer;
-	font-size: 14px;
-	font-weight: 500;
-	padding: 0;
-	flex: none;
-	margin-right: auto;
-	width: auto;
-
-	&:hover {
-		background: var( --studio-white );
-
-		.masterbar__item-content {
-			color: var( --color-masterbar-text );
-			text-decoration: underline;
-		}
-	}
-	.gridicon {
-		height: 17px;
-		fill: var( --studio-black );
-		@media ( max-width: 480px ) {
-			margin: 0;
-		}
-	}
-	@media ( max-width: 480px ) {
-		.gridicon + .masterbar__item-content {
-			display: block;
-			padding: 0 0 0 2px;
-		}
-	}
-`;
+import './style.scss';
 
 const MasterbarStyled = ( {
 	onClick,
@@ -65,7 +18,7 @@ const MasterbarStyled = ( {
 	contact?: JSX.Element | null;
 	showContact?: boolean;
 } ) => (
-	<MasterbarStyledBlock>
+	<Masterbar className="checkout-thank-you__masterbar">
 		<Global
 			styles={ css`
 				body {
@@ -73,14 +26,19 @@ const MasterbarStyled = ( {
 				}
 			` }
 		/>
-		<WordPressLogoStyled size={ 24 } />
+		<WordPressLogo className="checkout-thank-you__logo" size={ 24 } />
 		{ canGoBack && backText && onClick && (
-			<ItemStyled icon="chevron-left" onClick={ onClick }>
+			<Item
+				icon="chevron-left"
+				onClick={ onClick }
+				className="checkout-thank-you__item"
+				wrapperClassName="checkout-thank-you__item-wrapper"
+			>
 				{ backText }
-			</ItemStyled>
+			</Item>
 		) }
 		{ showContact && contact }
-	</MasterbarStyledBlock>
+	</Masterbar>
 );
 
 export default MasterbarStyled;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
@@ -29,6 +29,10 @@
 			color: var(--color-masterbar-text);
 			text-decoration: underline;
 		}
+
+		.gridicon {
+			fill: var(--studio-black);
+		}
 	}
 	.gridicon {
 		height: 17px;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
@@ -1,0 +1,46 @@
+.checkout-thank-you__masterbar {
+	--color-masterbar-background: var(--studio-white);
+	--color-masterbar-text: var(--studio-gray-60);
+	padding-right: 24px;
+	border-bottom: 0;
+}
+
+.checkout-thank-you__logo {
+	fill: rgb(54, 54, 54);
+	margin: 24px 12px 24px 24px;
+	@media (min-width: 480px) {
+		margin: 24px;
+	}
+}
+
+.checkout-thank-you__item-wrapper {
+	flex: 1;
+}
+
+.checkout-thank-you__item {
+	cursor: pointer;
+	font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
+	font-weight: 500;
+
+	&:hover {
+		background: var(--studio-white);
+
+		.masterbar__item-content {
+			color: var(--color-masterbar-text);
+			text-decoration: underline;
+		}
+	}
+	.gridicon {
+		height: 17px;
+		fill: var(--studio-black);
+		@media (max-width: 480px) {
+			margin: 0;
+		}
+	}
+	@media (max-width: 480px) {
+		.gridicon + .masterbar__item-content {
+			display: block;
+			padding: 0 0 0 2px;
+		}
+	}
+}


### PR DESCRIPTION
Bug surfaced on slack: p1721744155254479-slack-C06DN6QQVAQ

## Proposed Changes

* The styles currently in place are not working properly because of the `div` wrapper added to the `MasterbarItem` `button` on https://github.com/Automattic/wp-calypso/pull/92472:

https://github.com/Automattic/wp-calypso/blob/519b629bd43cb57361e15aa08d85125a1d0b9ab7/client/layout/masterbar/item.tsx#L210-L219

* I'm adding a `wrapperClassName` to that `div`, and adjusting the styles on the masterbar accordingly.
* I'm getting rid of `styled` because I would either need to have a stylesheet and `styled` at the same time; or have the `className`  proper on the wrapper `div`, and that would probably break styles elsewhere. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The "Back to dashboard" message is not properly aligned.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/marketplace/thank-you/{siteSlug}?themes=reverie`
* Check that the "Back to dashboard" message is aligned to the left

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/42b5602a-cb03-48e4-8299-68f5725b8bdb)|![image](https://github.com/user-attachments/assets/7bad3e3a-dfc9-4ea2-9b52-a199136fe5c5)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?