### PR TITLE
Sites dashboard - fix mobile sidebar animation.

### DIFF
--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -286,13 +286,18 @@
 }
 
 // Styles collapsed site list.
-.wpcom-site .is-global-sidebar-visible {
+.wpcom-site .is-global-sidebar-visible.is-group-sites-dashboard,
+.wpcom-site .is-global-sidebar-visible.is-group-sites {
 	.layout__content {
 		transition: padding-left 220ms ease-out;
 		min-height: 100vh;
 	}
 	.layout__secondary {
-		transition: width 220ms ease-out;
+		transition: transform 0.15s ease-in-out, width 220ms ease-out;
+
+		@media (max-width: $break-mobile) {
+			transition: transform 0.15s ease-in-out, opacity 0.15s ease-out;
+		}
 
 		.sidebar__header,
 		.sidebar__body,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#8313

## Proposed Changes

Fixes the slide in animation for toggling the sidebar on /sites. Prevents this style group from bleeding outside the dashboard.
* The general sidebar transition styles were previously overridden by the transition rule here in order to support the collapsed "mini" sidebar in the sites dashboard that is seen at desktop widths when toggling between selections for overview.
   * We update this transition rule to include the general style for ease-in-out that is generally used for our layout__secondary. This also fixes the sidebar slide in animation on tablet viewports here (seen below) as well as mobile.
   * Also updates the transition at mobile viewports to our standard rule with opacity ease-out, since the collapsed mini sidebar is not a thing at these viewports.
   * Adds extra selectors to this style group to prevent these styles from bleeding outside of the sites dashboard after visiting the sites dashboard first. Before this change, if you load a global area other than /sites fresh the animation works as expected - but if you visit the same area after /sites you will see the animation is then broken due to the style bleed. These rules prevent that by limiting these styles to the sites dashboard and overview areas.

BEFORE
![mobile-anim-before](https://github.com/user-attachments/assets/0ceacb06-b7f4-46c5-bc67-9fbc49b3767d)
![tablet-anim-before](https://github.com/user-attachments/assets/1fabf64f-cade-43ca-b980-f819b2d53380)

AFTER
![mobile-anim-after](https://github.com/user-attachments/assets/0f1c193c-2260-4dc8-903c-3c9f98d46f5e)
![tablet-anim-after](https://github.com/user-attachments/assets/a23862e9-4262-416a-9ff7-ce2e45fc0a37)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Broken animations, inconsistent and poor UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the /sites dashboard.
* Test toggling the sidebar open on mobile and tablet viewports. Verify the animation now slides in.
* Go back to desktop width. Test selecting a site for overview and closing. Verify the animations for collapsing/expanding the mini sidebar here have no regressions.
* Go to the reader (and other global areas) on mobile after being at /sites. Verify the sidebar toggles and animation is as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
