### PR TITLE
Site Migration: Only show site picker if there are sites to show.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -7,6 +7,7 @@ import {
 	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
 	GroupableSiteLaunchStatuses,
 } from '@automattic/sites';
+import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { defer } from 'lodash';
@@ -15,10 +16,12 @@ import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
 import DocumentHead from 'calypso/components/data/document-head';
 import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SitesDashboardQueryParams } from 'calypso/sites-dashboard/components/sites-content-controls';
 import SitePicker from './site-picker';
 import type { Step } from '../../types';
+import type { UserSelect } from '@automattic/data-stores';
 import type { SiteExcerptData } from '@automattic/sites';
 
 import './styles.scss';
@@ -35,8 +38,20 @@ const SitePickerStep: Step = function SitePickerStep( { navigation, flow } ) {
 	const [ destinationSite, setDestinationSite ] = useState< SiteExcerptData >();
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const [ , setMigrationConfirmed ] = useMigrationConfirmation();
+	const siteCount = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count ?? 0,
+		[]
+	);
 
 	useEffect( () => setMigrationConfirmed( false ), [] );
+
+	useEffect( () => {
+		// If the user has no sites, we should skip the site picker and go straight to the site creation step
+		if ( siteCount === 0 ) {
+			navigation.submit?.( { action: 'create-site' } );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ siteCount ] );
 
 	const onQueryParamChange = ( params: Partial< SitesDashboardQueryParams > ) => {
 		recordTracksEvent( 'calypso_import_site_picker_query_param_change', params );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -7,7 +7,6 @@ import {
 	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
 	GroupableSiteLaunchStatuses,
 } from '@automattic/sites';
-import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { defer } from 'lodash';
@@ -16,12 +15,12 @@ import ConfirmModal from 'calypso/blocks/importer/components/confirm-modal';
 import DocumentHead from 'calypso/components/data/document-head';
 import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SitesDashboardQueryParams } from 'calypso/sites-dashboard/components/sites-content-controls';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import SitePicker from './site-picker';
 import type { Step } from '../../types';
-import type { UserSelect } from '@automattic/data-stores';
 import type { SiteExcerptData } from '@automattic/sites';
 
 import './styles.scss';
@@ -38,10 +37,7 @@ const SitePickerStep: Step = function SitePickerStep( { navigation, flow } ) {
 	const [ destinationSite, setDestinationSite ] = useState< SiteExcerptData >();
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const [ , setMigrationConfirmed ] = useMigrationConfirmation();
-	const siteCount = useSelect(
-		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count ?? 0,
-		[]
-	);
+	const siteCount = useSelector( getCurrentUserSiteCount );
 
 	useEffect( () => setMigrationConfirmed( false ), [] );
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -49,13 +49,10 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_SOURCE_URL,
 		];
 
+		const maybeSitePickerStep = siteCount > 0 ? [ STEPS.PICK_SITE ] : [];
 		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME )
-			? [ STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ]
+			? maybeSitePickerStep.concat( [ STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ] )
 			: [];
-
-		if ( isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME ) && siteCount > 0 ) {
-			hostedVariantSteps.unshift( STEPS.PICK_SITE );
-		}
 
 		return stepsWithRequiredLogin( [ ...baseSteps, ...hostedVariantSteps ] );
 	},

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -32,6 +32,10 @@ const siteMigration: Flow = {
 	isSignupFlow: false,
 
 	useSteps() {
+		const siteCount = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count ?? 0,
+			[]
+		);
 		const baseSteps = [
 			STEPS.SITE_MIGRATION_IDENTIFY,
 			STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
@@ -46,8 +50,12 @@ const siteMigration: Flow = {
 		];
 
 		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME )
-			? [ STEPS.PICK_SITE, STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ]
+			? [ STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ]
 			: [];
+
+		if ( isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME ) && siteCount > 0 ) {
+			hostedVariantSteps.unshift( STEPS.PICK_SITE );
+		}
 
 		return stepsWithRequiredLogin( [ ...baseSteps, ...hostedVariantSteps ] );
 	},

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -32,11 +32,6 @@ const siteMigration: Flow = {
 	isSignupFlow: false,
 
 	useSteps() {
-		// We'll assume the user has no sites until we know otherwise.
-		const siteCount = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count ?? 0,
-			[]
-		);
 		const baseSteps = [
 			STEPS.SITE_MIGRATION_IDENTIFY,
 			STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
@@ -50,9 +45,8 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_SOURCE_URL,
 		];
 
-		const maybeSitePickerStep = siteCount > 0 ? [ STEPS.PICK_SITE ] : [];
 		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME )
-			? maybeSitePickerStep.concat( [ STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ] )
+			? [ STEPS.PICK_SITE, STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ]
 			: [];
 
 		return stepsWithRequiredLogin( [ ...baseSteps, ...hostedVariantSteps ] );

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -32,6 +32,7 @@ const siteMigration: Flow = {
 	isSignupFlow: false,
 
 	useSteps() {
+		// We'll assume the user has no sites until we know otherwise.
 		const siteCount = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser()?.site_count ?? 0,
 			[]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92558

## Proposed Changes

* If a user has no sites, there's no point in showing them the site picker. Let's just create a new site for them.
* Since we're coming into the sitePicker from a hard-coded URL from a landing page outisde of Stepper, we need to add this logic directly to the sitePicker step itself rather than at the flow level.
* Check the site count once we land on the sitePicker and automatically skip to create a new site if there are no existing sites. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Discussion in https://github.com/Automattic/wp-calypso/issues/92558 and pcmemI-3dx-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From a logged-out state (or logged into an account with no sites), visit `wordpress.com/move`
* Put in the URL to migrate
* Replace the `wordpress.com` part of the URL with the calypso.live base URL or `calypso.localhost:3000` if you're running this branch locally
* You'll be asked to create a new user; do so by email.
* You should be brought directly to the step where you put in your URL. Do so and continue.
* You should *not* be shown the site picker.
* On the same branch, while logged into an account that has multiple sites, go to `wordpress.com/sites`
* Select the dropdown on the Add new site button -> Import an existing site
* You should be shown the step where you put in your URL; do so.
* You should still be shown the site picker.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- N/A Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?