### PR TITLE
Sites Dashboard - Add P2 sites filter

### DIFF
--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -155,7 +155,7 @@ const SitesDashboard = ( {
 		initialSiteFeature,
 		dataViewsState,
 		featureToRouteMap: FEATURE_TO_ROUTE_MAP,
-		queryParamKeys: [ 'page', 'per-page', 'status', 'search', 'type' ],
+		queryParamKeys: [ 'page', 'per-page', 'status', 'search', 'siteType' ],
 	} );
 
 	// Ensure site sort preference is applied when it loads in. This isn't always available on

--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -8,7 +8,6 @@ import {
 	useSitesListSorting,
 } from '@automattic/sites';
 import { GroupableSiteLaunchStatuses } from '@automattic/sites/src/use-sites-list-grouping';
-import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -97,7 +96,6 @@ const SitesDashboard = ( {
 	initialSiteFeature = DOTCOM_OVERVIEW,
 	selectedSiteFeaturePreview = undefined,
 }: SitesDashboardProps ) => {
-	const { __ } = useI18n();
 	const [ initialSortApplied, setInitialSortApplied ] = useState( false );
 
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
@@ -292,6 +290,8 @@ const SitesDashboard = ( {
 
 	const showA8CForAgenciesBanner = paginatedSites.length >= 5;
 
+	const dashboardTitle = siteType === 'p2' ? translate( 'P2s' ) : translate( 'Sites' );
+
 	return (
 		<Layout
 			className={ clsx(
@@ -300,23 +300,23 @@ const SitesDashboard = ( {
 				! dataViewsState.selectedItem && 'preview-hidden'
 			) }
 			wide
-			title={ dataViewsState.selectedItem ? null : translate( 'Sites' ) }
+			title={ dataViewsState.selectedItem ? null : dashboardTitle }
 			disableGuidedTour
 		>
-			<DocumentHead title={ __( 'Sites' ) } />
+			<DocumentHead title={ dashboardTitle } />
 
 			{ ! hideListing && (
 				<LayoutColumn className="sites-overview" wide>
 					<LayoutTop withNavigation={ false }>
 						<LayoutHeader>
-							{ ! isNarrowView && <Title>{ translate( 'Sites' ) }</Title> }
+							{ ! isNarrowView && <Title>{ dashboardTitle }</Title> }
 							<Actions>
 								<SitesDashboardHeader />
 							</Actions>
 						</LayoutHeader>
 					</LayoutTop>
 
-					<DocumentHead title={ __( 'Sites' ) } />
+					<DocumentHead title={ dashboardTitle } />
 					{ showA8CForAgenciesBanner && (
 						<div className="sites-a8c-for-agencies-banner-container">
 							<Banner

--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -79,6 +79,7 @@ const siteSortingKeys = [
 
 const DEFAULT_PER_PAGE = 50;
 const DEFAULT_STATUS_GROUP = 'all';
+const DEFAULT_SITE_TYPE = 'all';
 
 const SitesDashboard = ( {
 	// Note - control params (eg. search, page, perPage, status...) are currently meant for
@@ -89,6 +90,7 @@ const SitesDashboard = ( {
 		search,
 		newSiteID,
 		status = DEFAULT_STATUS_GROUP,
+		type = DEFAULT_SITE_TYPE,
 	},
 	selectedSite,
 	initialSiteFeature = DOTCOM_OVERVIEW,
@@ -98,10 +100,20 @@ const SitesDashboard = ( {
 	const [ initialSortApplied, setInitialSortApplied ] = useState( false );
 
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
+	const sitesFilterCallback = ( site: SiteExcerptData ) => {
+		return ! site.options?.is_domain_only;
+	};
+
+	const getFilterArgs = ( type: string ): string[] => {
+		if ( type === 'all' ) {
+			return [ 'non-p2' ];
+		}
+		return [ 'p2' ];
+	};
 
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
-		[],
-		( site ) => ! site.options?.is_domain_only,
+		getFilterArgs( type ),
+		sitesFilterCallback,
 		'all',
 		[],
 		[ 'theme_slug' ]
@@ -143,7 +155,7 @@ const SitesDashboard = ( {
 		initialSiteFeature,
 		dataViewsState,
 		featureToRouteMap: FEATURE_TO_ROUTE_MAP,
-		queryParamKeys: [ 'page', 'per-page', 'status', 'search' ],
+		queryParamKeys: [ 'page', 'per-page', 'status', 'search', 'type' ],
 	} );
 
 	// Ensure site sort preference is applied when it loads in. This isn't always available on
@@ -166,7 +178,13 @@ const SitesDashboard = ( {
 
 			setInitialSortApplied( true );
 		}
-	}, [ hasSitesSortingPreferenceLoaded, sitesSorting, dataViewsState.sort, initialSortApplied ] );
+	}, [
+		hasSitesSortingPreferenceLoaded,
+		sitesSorting,
+		dataViewsState.sort,
+		initialSortApplied,
+		type,
+	] );
 
 	// Get the status group slug.
 	const statusSlug = useMemo( () => {

--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -90,7 +90,7 @@ const SitesDashboard = ( {
 		search,
 		newSiteID,
 		status = DEFAULT_STATUS_GROUP,
-		type = DEFAULT_SITE_TYPE,
+		siteType = DEFAULT_SITE_TYPE,
 	},
 	selectedSite,
 	initialSiteFeature = DOTCOM_OVERVIEW,
@@ -104,15 +104,15 @@ const SitesDashboard = ( {
 		return ! site.options?.is_domain_only;
 	};
 
-	const getFilterArgs = ( type: string ): string[] => {
-		if ( type === 'all' ) {
+	const getFilterArgs = ( siteType: string ): string[] => {
+		if ( siteType === 'all' ) {
 			return [ 'non-p2' ];
 		}
 		return [ 'p2' ];
 	};
 
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
-		getFilterArgs( type ),
+		getFilterArgs( siteType ),
 		sitesFilterCallback,
 		'all',
 		[],
@@ -183,7 +183,7 @@ const SitesDashboard = ( {
 		sitesSorting,
 		dataViewsState.sort,
 		initialSortApplied,
-		type,
+		siteType,
 	] );
 
 	// Get the status group slug.

--- a/client/hosting/sites/controller.tsx
+++ b/client/hosting/sites/controller.tsx
@@ -21,14 +21,13 @@ function getQueryParams( context: Context ) {
 		perPage: context.query[ 'per-page' ] ? parseInt( context.query[ 'per-page' ] ) : undefined,
 		search: context.query.search,
 		status: context.query.status,
-		type: context.query.type,
+		siteType: context.query.siteType,
 	};
 }
 
 export function sanitizeQueryParameters( context: PageJSContext, next: () => void ) {
-	const siteType = context.query?.type?.trim();
-	if ( siteType ) {
-		context.query.type = siteType;
+	if ( context.pathname.includes( '/p2s' ) ) {
+		context.query.siteType = 'p2';
 	}
 	/**
 	 * We need a base case because `page.replace` triggers a re-render for every middleware

--- a/client/hosting/sites/controller.tsx
+++ b/client/hosting/sites/controller.tsx
@@ -26,7 +26,7 @@ function getQueryParams( context: Context ) {
 }
 
 export function sanitizeQueryParameters( context: PageJSContext, next: () => void ) {
-	if ( context.pathname.includes( '/p2s' ) ) {
+	if ( context.pathname.startsWith( '/p2s' ) ) {
 		context.query.siteType = 'p2';
 	}
 	/**

--- a/client/hosting/sites/controller.tsx
+++ b/client/hosting/sites/controller.tsx
@@ -21,10 +21,15 @@ function getQueryParams( context: Context ) {
 		perPage: context.query[ 'per-page' ] ? parseInt( context.query[ 'per-page' ] ) : undefined,
 		search: context.query.search,
 		status: context.query.status,
+		type: context.query.type,
 	};
 }
 
 export function sanitizeQueryParameters( context: PageJSContext, next: () => void ) {
+	const siteType = context.query?.type?.trim();
+	if ( siteType ) {
+		context.query.type = siteType;
+	}
 	/**
 	 * We need a base case because `page.replace` triggers a re-render for every middleware
 	 * in the route.

--- a/client/hosting/sites/index.tsx
+++ b/client/hosting/sites/index.tsx
@@ -19,6 +19,17 @@ export default function () {
 	} );
 
 	page(
+		'/p2s',
+		maybeRemoveCheckoutSuccessNotice,
+		sanitizeQueryParameters,
+		navigation,
+		setSelectedSiteIdByOrigin,
+		sitesDashboard,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/sites',
 		maybeRemoveCheckoutSuccessNotice,
 		sanitizeQueryParameters,

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -41,7 +41,7 @@ export const MySitesSidebarUnifiedBody = ( {
 					const isSelected =
 						( item?.url && itemLinkMatches( item.url, path ) ) ||
 						// Keep the Sites icon selected when there is a selected site.
-						( item.slug === 'sites' && site );
+						( item.slug === 'sites' && site && ! path.includes( 'p2s' ) );
 
 					if ( 'current-site' === item?.type ) {
 						return (

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -1,7 +1,9 @@
 import { useSelector } from 'react-redux';
 import Site from 'calypso/blocks/site';
 import SidebarSeparator from 'calypso/layout/sidebar/separator';
+import { isP2Theme } from 'calypso/lib/site/utils';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSidebarIsCollapsed,
@@ -29,6 +31,10 @@ export const MySitesSidebarUnifiedBody = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
+	// TODO: This doesn't work as I'd expect - the options aren't available for some reason
+	const isP2Site =
+		useSelector( ( state ) => isSiteWPForTeams( state, siteId ) ) ||
+		( site?.options?.theme_slug && isP2Theme( site?.options?.theme_slug ) );
 
 	// Jetpack self-hosted sites should open external links to WP Admin in new tabs,
 	// since WP Admin is considered a separate area from Calypso on those sites.
@@ -41,7 +47,9 @@ export const MySitesSidebarUnifiedBody = ( {
 					const isSelected =
 						( item?.url && itemLinkMatches( item.url, path ) ) ||
 						// Keep the Sites icon selected when there is a selected site.
-						( item.slug === 'sites' && site && ! path.includes( 'p2s' ) );
+						( item.slug === 'sites' && site && ! isP2Site && ! path.startsWith( '/p2s' ) ) ||
+						// Keep the P2s icon selected when there is a selected site and that site is a P2.
+						( item.slug === 'sites-p2' && site && isP2Site && ! path.startsWith( '/sites' ) );
 
 					if ( 'current-site' === item?.type ) {
 						return (

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -31,7 +31,6 @@ export const MySitesSidebarUnifiedBody = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
-	// TODO: This doesn't work as I'd expect - the options aren't available for some reason
 	const isP2Site =
 		useSelector( ( state ) => isSiteWPForTeams( state, siteId ) ) ||
 		( site?.options?.theme_slug && isP2Theme( site?.options?.theme_slug ) );

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -1,5 +1,6 @@
 import { category, Icon, brush } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
+import ReaderP2Icon from 'calypso/reader/components/icons/p2-icon';
 
 export const SidebarIconPlugins = () => (
 	<svg
@@ -30,6 +31,14 @@ export default function globalSidebarMenu() {
 			navigationLabel: translate( 'Manage all my sites' ),
 			type: 'menu-item',
 			url: '/sites',
+		},
+		{
+			icon: <ReaderP2Icon />,
+			slug: 'sites-p2',
+			title: translate( 'P2s' ),
+			navigationLabel: translate( 'Manage all my P2 sites' ),
+			type: 'menu-item',
+			url: '/sites?type=p2',
 		},
 		{
 			icon: 'dashicons-admin-site-alt3',

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -1,6 +1,6 @@
 import { category, Icon, brush } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
-import ReaderP2Icon from 'calypso/reader/components/icons/p2-icon';
+import ReaderA8cIcon from 'calypso/reader/components/icons/a8c-icon';
 
 export const SidebarIconPlugins = () => (
 	<svg
@@ -35,7 +35,7 @@ export default function globalSidebarMenu( { showP2s = false } = {} ) {
 		...( showP2s
 			? [
 					{
-						icon: <ReaderP2Icon />,
+						icon: <ReaderA8cIcon size={ 24 } />,
 						slug: 'sites-p2',
 						title: translate( 'P2s' ),
 						navigationLabel: translate( 'Manage all my P2 sites' ),

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -35,7 +35,7 @@ export default function globalSidebarMenu( { showP2s = false } = {} ) {
 		...( showP2s
 			? [
 					{
-						icon: <ReaderA8cIcon size={ 24 } />,
+						icon: <ReaderA8cIcon size={ 22 } />,
 						slug: 'sites-p2',
 						title: translate( 'P2s' ),
 						navigationLabel: translate( 'Manage all my P2 sites' ),

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -38,7 +38,7 @@ export default function globalSidebarMenu() {
 			title: translate( 'P2s' ),
 			navigationLabel: translate( 'Manage all my P2 sites' ),
 			type: 'menu-item',
-			url: '/sites?type=p2',
+			url: '/p2s',
 		},
 		{
 			icon: 'dashicons-admin-site-alt3',

--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -22,7 +22,7 @@ export const SidebarIconPlugins = () => (
 /**
  * Menu items that support all sites screen.
  */
-export default function globalSidebarMenu() {
+export default function globalSidebarMenu( { showP2s = false } = {} ) {
 	return [
 		{
 			icon: <Icon icon={ category } className="sidebar__menu-icon svg_all-sites" size={ 24 } />,
@@ -32,14 +32,18 @@ export default function globalSidebarMenu() {
 			type: 'menu-item',
 			url: '/sites',
 		},
-		{
-			icon: <ReaderP2Icon />,
-			slug: 'sites-p2',
-			title: translate( 'P2s' ),
-			navigationLabel: translate( 'Manage all my P2 sites' ),
-			type: 'menu-item',
-			url: '/p2s',
-		},
+		...( showP2s
+			? [
+					{
+						icon: <ReaderP2Icon />,
+						slug: 'sites-p2',
+						title: translate( 'P2s' ),
+						navigationLabel: translate( 'Manage all my P2 sites' ),
+						type: 'menu-item',
+						url: '/p2s',
+					},
+			  ]
+			: [] ),
 		{
 			icon: 'dashicons-admin-site-alt3',
 			slug: 'domains',

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -257,9 +257,10 @@ $font-size: rem(14px);
 			color: var(--color-sidebar-gridicon-fill);
 			margin-right: 8px;
 
-			&.sidebar_svg-p2 {
+			&.sidebar_svg-a8c {
 				path {
-					fill: var(--color-sidebar-gridicon-fill);
+					stroke: var(--color-sidebar-gridicon-fill);
+					fill: none;
 				}
 			}
 		}
@@ -290,9 +291,10 @@ $font-size: rem(14px);
 			.sidebar__menu-icon {
 				color: var(--color-sidebar-menu-selected-text);
 
-				&.sidebar_svg-p2 {
+				&.sidebar_svg-a8c {
 					path {
-						fill: var(--color-sidebar-menu-selected-text);
+						stroke: var(--color-sidebar-menu-selected-text);
+						fill: none;
 					}
 				}
 			}
@@ -362,9 +364,10 @@ $font-size: rem(14px);
 				.sidebar__menu-icon {
 					color: var(--color-sidebar-menu-selected-text);
 
-					&.sidebar_svg-p2 {
+					&.sidebar_svg-a8c {
 						path {
-							fill: var(--color-sidebar-menu-selected-text);
+							stroke: var(--color-sidebar-menu-selected-text);
+							fill: none;
 						}
 					}
 				}

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -256,6 +256,12 @@ $font-size: rem(14px);
 			background-size: contain;
 			color: var(--color-sidebar-gridicon-fill);
 			margin-right: 8px;
+
+			&.sidebar_svg-p2 {
+				path {
+					fill: var(--color-sidebar-gridicon-fill);
+				}
+			}
 		}
 
 		img.sidebar__menu-icon {
@@ -283,6 +289,12 @@ $font-size: rem(14px);
 
 			.sidebar__menu-icon {
 				color: var(--color-sidebar-menu-selected-text);
+
+				&.sidebar_svg-p2 {
+					path {
+						fill: var(--color-sidebar-menu-selected-text);
+					}
+				}
 			}
 
 			img.sidebar__menu-icon {
@@ -349,6 +361,12 @@ $font-size: rem(14px);
 
 				.sidebar__menu-icon {
 					color: var(--color-sidebar-menu-selected-text);
+
+					&.sidebar_svg-p2 {
+						path {
+							fill: var(--color-sidebar-menu-selected-text);
+						}
+					}
 				}
 				img.sidebar__menu-icon {
 					opacity: 1;

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -7,10 +7,10 @@ import domainOnlyFallbackMenu from 'calypso/my-sites/sidebar/static-data/domain-
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
-import { canAnySiteHaveP2 } from 'calypso/state/selectors/can-any-site-have-p2';
 import { canAnySiteHavePlugins } from 'calypso/state/selectors/can-any-site-have-plugins';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
+import { hasSiteWithP2 } from 'calypso/state/selectors/has-site-with-p2';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
@@ -73,12 +73,12 @@ const useSiteMenuItems = () => {
 	const shouldShowAddOns = isEnabled( 'my-sites/add-ons' ) && ! isAtomic && ! isStagingSite;
 
 	const hasSiteWithPlugins = useSelector( canAnySiteHavePlugins );
-	const hasSiteWithP2 = useSelector( canAnySiteHaveP2 );
+	const showP2s = useSelector( hasSiteWithP2 );
 
 	const hasUnifiedImporter = isEnabled( 'importer/unified' );
 
 	if ( shouldShowGlobalSidebar ) {
-		return globalSidebarMenu( { showP2s: hasSiteWithP2 } );
+		return globalSidebarMenu( { showP2s: showP2s } );
 	}
 
 	/**

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -7,6 +7,7 @@ import domainOnlyFallbackMenu from 'calypso/my-sites/sidebar/static-data/domain-
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
+import { canAnySiteHaveP2 } from 'calypso/state/selectors/can-any-site-have-p2';
 import { canAnySiteHavePlugins } from 'calypso/state/selectors/can-any-site-have-plugins';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
@@ -72,11 +73,12 @@ const useSiteMenuItems = () => {
 	const shouldShowAddOns = isEnabled( 'my-sites/add-ons' ) && ! isAtomic && ! isStagingSite;
 
 	const hasSiteWithPlugins = useSelector( canAnySiteHavePlugins );
+	const hasSiteWithP2 = useSelector( canAnySiteHaveP2 );
 
 	const hasUnifiedImporter = isEnabled( 'importer/unified' );
 
 	if ( shouldShowGlobalSidebar ) {
-		return globalSidebarMenu();
+		return globalSidebarMenu( { showP2s: hasSiteWithP2 } );
 	}
 
 	/**

--- a/client/reader/components/icons/a8c-icon.jsx
+++ b/client/reader/components/icons/a8c-icon.jsx
@@ -4,7 +4,7 @@ export default function ReaderA8cIcon( { size = 20 } ) {
 			className="sidebar__menu-icon sidebar_svg-a8c"
 			fill="none"
 			height={ size }
-			viewBox={ `0 0 ${ size } ${ size }` }
+			viewBox="0 0 20 20"
 			width={ size }
 			xmlns="http://www.w3.org/2000/svg"
 		>

--- a/client/reader/components/icons/a8c-icon.jsx
+++ b/client/reader/components/icons/a8c-icon.jsx
@@ -1,11 +1,11 @@
-export default function ReaderA8cIcon() {
+export default function ReaderA8cIcon( { size = 20 } ) {
 	return (
 		<svg
 			className="sidebar__menu-icon sidebar_svg-a8c"
 			fill="none"
-			height="20"
-			viewBox="0 0 20 20"
-			width="20"
+			height={ size }
+			viewBox={ `0 0 ${ size } ${ size }` }
+			width={ size }
 			xmlns="http://www.w3.org/2000/svg"
 		>
 			<g stroke="#a2aab2" strokeLinecap="round" strokeWidth="1.5">

--- a/client/sections.js
+++ b/client/sections.js
@@ -21,6 +21,12 @@ const sections = [
 		group: 'sites-dashboard',
 	},
 	{
+		name: 'sites-dashboard',
+		paths: [ '/p2s' ],
+		module: 'calypso/hosting/sites',
+		group: 'sites-dashboard',
+	},
+	{
 		name: 'switch-site',
 		paths: [ '/switch-site' ],
 		module: 'calypso/switch-site',

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -21,7 +21,7 @@ export interface SitesDashboardQueryParams {
 	showHidden?: boolean;
 	status?: GroupableSiteLaunchStatuses;
 	newSiteID?: number;
-	type?: SiteTypes;
+	siteType?: SiteTypes;
 }
 
 const FilterBar = styled.div( {

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -12,7 +12,7 @@ import { MEDIA_QUERIES } from '../utils';
 import { SitesSearch } from './sites-search';
 import { SitesSortingDropdown } from './sites-sorting-dropdown';
 
-type SiteTypes = 'p2' | 'all';
+type SiteTypes = 'p2' | 'non-p2';
 
 export interface SitesDashboardQueryParams {
 	page?: number;

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -12,6 +12,8 @@ import { MEDIA_QUERIES } from '../utils';
 import { SitesSearch } from './sites-search';
 import { SitesSortingDropdown } from './sites-sorting-dropdown';
 
+type SiteTypes = 'p2' | 'all';
+
 export interface SitesDashboardQueryParams {
 	page?: number;
 	perPage?: number;
@@ -19,6 +21,7 @@ export interface SitesDashboardQueryParams {
 	showHidden?: boolean;
 	status?: GroupableSiteLaunchStatuses;
 	newSiteID?: number;
+	type?: SiteTypes;
 }
 
 const FilterBar = styled.div( {

--- a/client/state/selectors/can-any-site-have-p2.ts
+++ b/client/state/selectors/can-any-site-have-p2.ts
@@ -1,0 +1,16 @@
+import { createSelector } from '@automattic/state-utils';
+import getSites from 'calypso/state/selectors/get-sites';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/ui/init';
+
+/**
+ * Return true if is user has P2 enabled on any of their sites.
+ * @param state Global state tree
+ */
+
+export const canAnySiteHaveP2 = createSelector(
+	( state: AppState ): boolean =>
+		getSites( state ).some( ( site ) => site && site?.options?.is_wpforteams_site ),
+	( state ) => [ state.sites.items ]
+);

--- a/client/state/selectors/has-site-with-p2.ts
+++ b/client/state/selectors/has-site-with-p2.ts
@@ -12,6 +12,13 @@ import 'calypso/state/ui/init';
 
 export const hasSiteWithP2 = createSelector(
 	( state: AppState ): boolean =>
-		getSites( state ).some( ( site ) => site && !! ( site?.options?.is_wpforteams_site || ( site?.options?.theme_slug && isP2Theme( site?.options?.theme_slug ) ) ) ),
+		getSites( state ).some(
+			( site ) =>
+				site &&
+				!! (
+					site?.options?.is_wpforteams_site ||
+					( site?.options?.theme_slug && isP2Theme( site?.options?.theme_slug ) )
+				)
+		),
 	( state ) => [ state.sites.items ]
 );

--- a/client/state/selectors/has-site-with-p2.ts
+++ b/client/state/selectors/has-site-with-p2.ts
@@ -1,4 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
+import { isP2Theme } from 'calypso/lib/site/utils';
 import getSites from 'calypso/state/selectors/get-sites';
 import type { AppState } from 'calypso/types';
 
@@ -9,8 +10,8 @@ import 'calypso/state/ui/init';
  * @param state Global state tree
  */
 
-export const canAnySiteHaveP2 = createSelector(
+export const hasSiteWithP2 = createSelector(
 	( state: AppState ): boolean =>
-		getSites( state ).some( ( site ) => site && site?.options?.is_wpforteams_site ),
+		getSites( state ).some( ( site ) => site && !! ( site?.options?.is_wpforteams_site || ( site?.options?.theme_slug && isP2Theme( site?.options?.theme_slug ) ) ) ),
 	( state ) => [ state.sites.items ]
 );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -79,6 +79,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'site_source_slug',
 	'is_difm_lite_in_progress',
 	'site_intent',
+	'theme_slug',
 	'launchpad_screen',
 	'launchpad_checklist_tasks_statuses',
 	'wpcom_production_blog_id',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8402

This adds a P2s sidebar menu that when clicked will redirect the user to `/p2s`. This option is only visible if the user has a p2. 

This PR removes P2s from the list of sites at `/sites` and instead lists them all under `/p2s`. 

This should make the sites list easier to navigate.

## Proposed Changes

* Add `P2s` option to global sidebar to allow user to list their P2 sites
* Update `Sites` to exclude P2 sites by default

## Example

https://github.com/user-attachments/assets/0b3d781d-43d1-4b17-a53f-397e65b03ec1


## TODO

- [x] Tidy up styles
- [x] Add logic to only show `P2s` in global sidebar if user has P2 sites
- [x] Fix the selected sidebar sites/p2s option (both are selected now)
- [x] Figure out how to select p2s sidebar when collapsed and viewing p2 hosting overview

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the sites list less noisy (especially for A8C's)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites` - confirm you see the P2s icon in sidebar
* Go to `/p2s` - confirm that only P2s are listed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
