### PR TITLE
Remove All Sites link and add tour tip to WP logo

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -328,6 +328,7 @@ class Layout extends Component {
 				isCheckoutPending={ this.props.sectionName === 'checkout-pending' }
 				isCheckoutFailed={ isCheckoutFailed }
 				loadHelpCenterIcon={ loadHelpCenterIcon }
+				isGlobalSidebarVisible={ this.props.isGlobalSidebarVisible }
 			/>
 		);
 	}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -291,6 +291,7 @@ class MasterbarLoggedIn extends Component {
 			siteSlug,
 			translate,
 			section,
+			sectionGroup,
 			currentRoute,
 			isFetchingPrefs,
 			hasDismissedAllSitesPopover,
@@ -325,7 +326,10 @@ class MasterbarLoggedIn extends Component {
 					<Popover
 						className="masterbar__all-sites-popover"
 						isVisible={
-							! isGlobalSidebarVisible && ! isFetchingPrefs && ! hasDismissedAllSitesPopover
+							sectionGroup === 'sites' &&
+							! isGlobalSidebarVisible &&
+							! isFetchingPrefs &&
+							! hasDismissedAllSitesPopover
 						}
 						context={ allSitesBtnRef }
 						position="bottom left"
@@ -339,7 +343,7 @@ class MasterbarLoggedIn extends Component {
 						</h1>
 						<p className="masterbar__all-sites-popover-description">
 							{ translate(
-								'Click on the WordPress.com logo to access your sites, domains, Reader, account settings, and more.'
+								'Click on the WordPress.com logo to access your sites, domains, account settings, and more.'
 							) }
 						</p>
 						<div className="masterbar__all-sites-popover-actions">

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -334,7 +334,7 @@ class MasterbarLoggedIn extends Component {
 						context={ allSitesBtnRef }
 						position="bottom left"
 						showDelay={ 500 }
-						offset={ 24 }
+						ignoreViewportSize
 					>
 						<h1 className="masterbar__all-sites-popover-heading">
 							{ translate( 'All your sites', {

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -4,6 +4,7 @@ import page from '@automattic/calypso-router';
 import { PromptIcon } from '@automattic/command-palette';
 import { Button, Popover } from '@automattic/components';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import { Button as WPButton } from '@wordpress/components';
 import { Icon, category } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -67,6 +68,7 @@ import Notifications from './masterbar-notifications/notifications-button';
 
 const NEW_MASTERBAR_SHIPPING_DATE = new Date( 2022, 3, 14 ).getTime();
 const MENU_POPOVER_PREFERENCE_KEY = 'dismissible-card-masterbar-collapsable-menu-popover';
+const ALL_SITES_POPOVER_PREFERENCE_KEY = 'dismissible-card-masterbar-all-sites-popover';
 
 const MOBILE_BREAKPOINT = '<480px';
 const IS_RESPONSIVE_MENU_BREAKPOINT = '<782px';
@@ -79,6 +81,7 @@ class MasterbarLoggedIn extends Component {
 		isResponsiveMenu: isWithinBreakpoint( IS_RESPONSIVE_MENU_BREAKPOINT ),
 		// making the ref a state triggers a re-render when it changes (needed for popover)
 		menuBtnRef: null,
+		allSitesBtnRef: null,
 	};
 
 	static propTypes = {
@@ -94,8 +97,10 @@ class MasterbarLoggedIn extends Component {
 		isCheckoutFailed: PropTypes.bool,
 		isInEditor: PropTypes.bool,
 		hasDismissedThePopover: PropTypes.bool,
+		hasDismissedAllSitesPopover: PropTypes.bool,
 		isUserNewerThanNewNavigation: PropTypes.bool,
 		loadHelpCenterIcon: PropTypes.bool,
+		isGlobalSidebarVisible: PropTypes.bool,
 	};
 
 	subscribeToViewPortChanges() {
@@ -281,8 +286,17 @@ class MasterbarLoggedIn extends Component {
 
 	// will render as back button on mobile and in editor
 	renderMySites() {
-		const { domainOnlySite, siteSlug, translate, section, currentRoute } = this.props;
-		const { isMenuOpen } = this.state;
+		const {
+			domainOnlySite,
+			siteSlug,
+			translate,
+			section,
+			currentRoute,
+			isFetchingPrefs,
+			hasDismissedAllSitesPopover,
+			isGlobalSidebarVisible,
+		} = this.props;
+		const { isMenuOpen, allSitesBtnRef } = this.state;
 
 		const mySitesUrl = domainOnlySite
 			? domainManagementList( siteSlug, currentRoute, true )
@@ -295,16 +309,47 @@ class MasterbarLoggedIn extends Component {
 		}
 
 		return (
-			<Item
-				className="masterbar__item-my-sites"
-				url={ mySitesUrl }
-				tipTarget="my-sites"
-				icon={ icon }
-				onClick={ this.clickMySites }
-				isActive={ this.isActive( 'sites-dashboard' ) && ! isMenuOpen }
-				tooltip={ translate( 'Manage your sites' ) }
-				preloadSection={ this.preloadMySites }
-			/>
+			<>
+				<Item
+					className="masterbar__item-my-sites"
+					url={ mySitesUrl }
+					tipTarget="my-sites"
+					icon={ icon }
+					onClick={ this.clickMySites }
+					isActive={ this.isActive( 'sites-dashboard' ) && ! isMenuOpen }
+					tooltip={ translate( 'Manage your sites' ) }
+					preloadSection={ this.preloadMySites }
+					ref={ ( ref ) => ref !== allSitesBtnRef && this.setState( { allSitesBtnRef: ref } ) }
+				/>
+				{ allSitesBtnRef && (
+					<Popover
+						className="masterbar__all-sites-popover"
+						isVisible={
+							! isGlobalSidebarVisible && ! isFetchingPrefs && ! hasDismissedAllSitesPopover
+						}
+						context={ allSitesBtnRef }
+						position="bottom left"
+						showDelay={ 500 }
+						offset={ 24 }
+					>
+						<h1 className="masterbar__all-sites-popover-heading">
+							{ translate( 'All your sites', {
+								comment: 'This is a popover title under the masterbar',
+							} ) }
+						</h1>
+						<p className="masterbar__all-sites-popover-description">
+							{ translate(
+								'Click on the WordPress.com logo to access your sites, domains, Reader, account settings, and more.'
+							) }
+						</p>
+						<div className="masterbar__all-sites-popover-actions">
+							<WPButton isPrimary onClick={ this.dismissLogoPopover }>
+								{ translate( 'Got it', { comment: 'Got it, as in OK' } ) }
+							</WPButton>
+						</div>
+					</Popover>
+				) }
+			</>
 		);
 	}
 
@@ -314,6 +359,10 @@ class MasterbarLoggedIn extends Component {
 
 	dismissPopover = () => {
 		this.props.savePreference( MENU_POPOVER_PREFERENCE_KEY, true );
+	};
+
+	dismissLogoPopover = () => {
+		this.props.savePreference( ALL_SITES_POPOVER_PREFERENCE_KEY, true );
 	};
 
 	renderCheckout() {
@@ -887,6 +936,7 @@ export default connect(
 				! isAtomicSite( state, currentSelectedSiteId ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			hasDismissedThePopover: getPreference( state, MENU_POPOVER_PREFERENCE_KEY ),
+			hasDismissedAllSitesPopover: getPreference( state, ALL_SITES_POPOVER_PREFERENCE_KEY ),
 			isFetchingPrefs: isFetchingPreferences( state ),
 			// If the user is newer than new navigation shipping date, don't tell them this nav is new. Everything is new to them.
 			isUserNewerThanNewNavigation:

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -199,6 +199,56 @@ body.is-mobile-app-view {
 	right: 16px;
 }
 
+.masterbar__all-sites-popover {
+	.popover__arrow::before {
+		--color-border-inverted: var(--color-neutral-100);
+	}
+
+	.popover__arrow {
+		border: 10px dashed var(--color-neutral-70) !important;
+		border-bottom-style: solid !important;
+		border-top: none !important;
+		border-left-color: transparent !important;
+		border-right-color: transparent !important;
+	}
+	.popover__inner {
+		display: flex;
+		gap: 16px;
+		padding: 16px;
+		flex-direction: column;
+		align-items: flex-start;
+		border-radius: 4px !important;
+		background-color: var(--color-neutral-100) !important;
+		border: 1px solid var(--color-neutral-70) !important;
+		left: 0 !important;
+	}
+
+	.masterbar__all-sites-popover-heading {
+		font-size: rem(16px);
+		color: var(--color-text-inverted);
+		font-weight: 500;
+	}
+
+	.masterbar__all-sites-popover-description {
+		max-width: 325px;
+		margin-top: -8px;
+		font-size: rem(13px);
+		color: var(--color-neutral-0);
+		text-align: left;
+	}
+
+	.masterbar__all-sites-popover-actions {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		width: 100%;
+		button {
+			padding: 4px 8px;
+			font-size: rem(13px);
+		}
+	}
+}
+
 .masterbar__section {
 	display: flex;
 

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import { localize, withRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -41,23 +41,6 @@ class CurrentSite extends Component {
 		this.props.recordTracksEvent( 'calypso_sidebar_all_sites_click' );
 	};
 
-	renderSiteSwitcher = () => {
-		const { translate, isRtl } = this.props;
-		const arrowDirection = isRtl ? 'right' : 'left';
-
-		return (
-			<span className="current-site__switch-sites">
-				<Button borderless href="/sites" onClick={ this.onAllSitesClick }>
-					<span
-						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-						className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
-					></span>
-					<span className="current-site__switch-sites-label">{ translate( 'All Sites' ) }</span>
-				</Button>
-			</span>
-		);
-	};
-
 	render() {
 		const { selectedSite, translate, anySiteSelected } = this.props;
 
@@ -89,8 +72,6 @@ class CurrentSite extends Component {
 		return (
 			<Card className="current-site">
 				<div role="button" tabIndex="0" aria-hidden="true" onClick={ this.expandUnifiedNavSidebar }>
-					{ this.renderSiteSwitcher() }
-
 					{ selectedSite && (
 						<div>
 							<Site site={ selectedSite } homeLink />

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -16,14 +16,6 @@
 			color: var(--color-neutral-50);
 			line-height: 35px;
 		}
-
-		.current-site__switch-sites {
-			cursor: default;
-
-			&::before {
-				visibility: hidden;
-			}
-		}
 	}
 
 	&.is-loading .site-icon {
@@ -49,45 +41,6 @@
 	.all-sites {
 		background: var(--color-sidebar-background);
 		border-bottom: 1px solid var(--color-sidebar-border);
-	}
-}
-
-.current-site__switch-sites {
-	display: block;
-	background: var(--color-sidebar-background);
-	border-bottom: 1px solid var(--color-sidebar-border);
-
-	.button.is-borderless {
-		display: block;
-		width: 100%;
-		text-align: left;
-		padding: 12px 8px 12px 44px;
-		position: relative;
-		font-weight: normal;
-		color: var(--color-sidebar-text);
-
-		.gridicon {
-			height: 24px;
-			width: 24px;
-			fill: var(--color-sidebar-gridicon-fill);
-			position: absolute;
-			top: 12px;
-			left: 14px;
-		}
-	}
-
-	&:hover {
-		background-color: var(--color-sidebar-menu-hover-background);
-
-		.button.is-borderless:hover,
-		.button.is-borderless:focus {
-			background-color: var(--color-sidebar-menu-hover-background);
-			color: var(--color-sidebar-menu-hover-text);
-
-			.gridicon {
-				fill: var(--color-sidebar-menu-hover-text);
-			}
-		}
 	}
 }
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -666,23 +666,6 @@ $font-size: rem(14px);
 		}
 	}
 
-	// client/my-sites/current-site/style.scss
-	.current-site__switch-sites:hover .button.is-borderless:hover {
-		background-color: var(--color-sidebar-menu-hover-background);
-	}
-
-	.current-site__switch-sites .button.is-borderless {
-		color: var(--color-sidebar-text-alternative);
-		padding: 6px 8px 6px 36px;
-	}
-
-	.current-site__switch-sites .button.is-borderless .gridicon {
-		height: 20px;
-		width: 20px;
-		top: 9px;
-		left: 8px;
-	}
-
 	.all-sites .dashicons-admin-site-alt3 {
 		height: 18px;
 	}
@@ -742,18 +725,9 @@ $font-size: rem(14px);
 			transform: rotate(180deg);
 		}
 
-		// client/my-sites/current-site/style.scss
-		.current-site__switch-sites .button.is-borderless {
-			height: 34px;
-			padding: 0;
-		}
 
 		.site-selector .search .search__open-icon {
 			width: auto;
-		}
-
-		.current-site__switch-sites-label {
-			display: none;
 		}
 
 		.current-site .site .site__info {
@@ -1041,17 +1015,9 @@ $font-size: rem(14px);
 				padding: 18px 0 18px 12px;
 			}
 
-			.current-site__switch-sites .button.is-borderless {
-				padding: 11px 8px 11px 38px;
-			}
-
 			.site__home {
 				left: 12px;
 				top: 18px;
-			}
-
-			.current-site__switch-sites .button.is-borderless .gridicon {
-				top: 14px;
 			}
 
 			.sidebar__separator {

--- a/packages/components/src/popover/index.jsx
+++ b/packages/components/src/popover/index.jsx
@@ -33,6 +33,7 @@ class PopoverInner extends Component {
 		onMouseLeave: noop,
 		hideArrow: false,
 		autoRepositionOnInitialLoad: false, // use with caution, read comment about autoRepositionOnInitialLoad below
+		ignoreViewportSize: false, // To avoid constraining the popover to the viewport that causes the arrow shows in the wrong place
 	};
 
 	/**
@@ -282,7 +283,8 @@ class PopoverInner extends Component {
 			{},
 			constrainLeft(
 				offset( suggestedPosition, domContainer, domContext, relativePosition ),
-				domContainer
+				domContainer,
+				this.props.ignoreViewportSize
 			),
 			{ positionClass: this.getPositionClass( suggestedPosition ) }
 		);

--- a/packages/components/src/popover/util.js
+++ b/packages/components/src/popover/util.js
@@ -326,10 +326,11 @@ function _offset( box, doc ) {
  * @param {window.Element} el Element to be constained to viewport
  * @returns {number}    the best width
  */
-export function constrainLeft( off, el ) {
+export function constrainLeft( off, el, ignoreViewport = false ) {
 	const viewport = getViewport();
 	const ew = el.getBoundingClientRect().width;
-	off.left = Math.max( 0, Math.min( off.left, viewport.width - ew ) );
+	const offsetLeft = ignoreViewport ? off.left : Math.min( off.left, viewport.width - ew );
+	off.left = Math.max( 0, offsetLeft );
 
 	return off;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8416

## Proposed Changes

Remove `All Sites` link and add popover to the WP Logo

It will not show when the global sidebar is present or post/page editor

| Color Schema | Popover | No popover |
| --- | --- | --- |
Modern | ![image](https://github.com/user-attachments/assets/6f608c0e-d8d8-4088-9fc0-6fe9f7ad68ea) | ![image](https://github.com/user-attachments/assets/b717baf4-7f33-4399-8370-e88d3c0aa2f1) |
Light | ![image](https://github.com/user-attachments/assets/bfbe1252-1464-4e95-aefc-f37563d317c8) | ![image](https://github.com/user-attachments/assets/475ebd04-3a80-4eb5-8422-8b662ca02544) |
Ectoplasm | ![image](https://github.com/user-attachments/assets/efc19e41-b64b-4915-8fc5-e71e0ec8048b) | ![image](https://github.com/user-attachments/assets/7dcc5d0a-0054-4c41-962b-4e2eb33cf166) |

## Why are these changes being made?
W icon works as All Sites.

## Testing Instructions

* Go to a site Calypso page
* It should show the Popover on the W logo
* After clicking on `Got it` you should not see it anymore
* To re-enable, you should set the `dismissible-card-masterbar-all-sites-popover` preference to false.
