### PR TITLE
Stats: Don't restrict dashboard access for VIP

### DIFF
--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -135,6 +135,14 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 			return false;
 		}
 
+		// Do not paywall VIP sites.
+		// `is_vip` is not correctly placed in Odyssey, so we need to check `options.is_vip` as well.
+		const isVip =
+			isVipSite( state as object, siteId as number ) || getSiteOption( state, siteId, 'is_vip' );
+		if ( isVip ) {
+			return false;
+		}
+
 		const isSiteCommercial = getSiteOption( state, siteId, 'is_commercial' ) || false;
 		if ( isSiteCommercial ) {
 			// Paywall basic stats for commercial sites with monthly views reaching the paywall threshold.
@@ -177,17 +185,6 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 export const useShouldGateStats = ( statType: string ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isGatedStats = useSelector( ( state ) => shouldGateStats( state, siteId, statType ) );
-
-	// `is_vip` is not correctly placed in Odyssey, so we need to check `options.is_vip` as well.
-	const isVip = useSelector(
-		( state ) =>
-			!! isVipSite( state as object, siteId as number ) ||
-			!! getSiteOption( state, siteId, 'is_vip' )
-	);
-
-	if ( isVip ) {
-		return false;
-	}
 
 	return isGatedStats;
 };

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -3,6 +3,7 @@ import { FEATURE_STATS_PAID } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
 import getSiteFeatures from 'calypso/state/selectors/get-site-features';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite, getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -176,6 +177,17 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 export const useShouldGateStats = ( statType: string ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isGatedStats = useSelector( ( state ) => shouldGateStats( state, siteId, statType ) );
+
+	// `is_vip` is not correctly placed in Odyssey, so we need to check `options.is_vip` as well.
+	const isVip = useSelector(
+		( state ) =>
+			!! isVipSite( state as object, siteId as number ) ||
+			!! getSiteOption( state, siteId, 'is_vip' )
+	);
+
+	if ( isVip ) {
+		return false;
+	}
 
 	return isGatedStats;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1721768447932729/1721154881.298439-slack-CDD9LQRSN

## Proposed Changes

* don't restrict Stats module access for a VIP type blogs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* fixing a bug described in the related thread

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* verify that VIP type blogs users (admins and editors) still have access to stats

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?