### PR TITLE
GenerateChunksMapPlugin: Include query params for js files 

### DIFF
--- a/build-tools/webpack/generate-chunks-map-plugin.js
+++ b/build-tools/webpack/generate-chunks-map-plugin.js
@@ -21,7 +21,7 @@ class GenerateChunksMapPlugin {
 			for ( const chunk of chunks ) {
 				// This logic assumes there is only one `.js`. If there are more than one `.js` file linked to a chunk,
 				// this will be non deterministic as `chunk.files` iteration order is not guaranteed.
-				const name = Array.from( chunk.files ).find( ( file ) => /\.js$/.test( file ) );
+				const name = Array.from( chunk.files ).find( ( file ) => /.js(\?.*)?$/.test( file ) );
 				if ( ! name ) {
 					continue;
 				}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/76166 https://github.com/Automattic/red-team/issues/96

## Proposed Changes

* We appended `minify=false` for chunks in https://github.com/Automattic/wp-calypso/pull/76166 to work around the minifying issue of dotcom cdn but the `GenerateChunksMapPlugin` is not able to pick them up. As a result, these lazy loaded files are not translated.
* The PR changed the regex to filter JS files - kudos to @yuliyan, so that all of these files could be extracted for chunks map and properly translated.

More info: pejTkB-1jU-p2#comment-1542

## Testing Instructions

* Comment out this [line](https://href.li/?https://github.com/Automattic/wp-calypso/blob/3d67a40dffa383f7be5fdce9448e710e587445b1/packages/calypso-build/bin/build-app-languages.js#L305) that cleans up chunks map
- cd `apps/odyssey-stats && yarn build`
- Open `apps/odyssey-stats/dist/chunks-map.json`
- Ensure there are file names ending with `minify=false`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?