### PR TITLE
Cart totals: Add translation context to 'Total' text across Calypso

### DIFF
--- a/client/my-sites/checkout/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/purchase-modal/content.tsx
@@ -190,7 +190,12 @@ function OrderReview( {
 			{ shouldDisplayTax && <dt className="purchase-modal__tax">{ translate( 'Taxes' ) }</dt> }
 			{ shouldDisplayTax && <dd className="purchase-modal__tax">{ tax }</dd> }
 
-			<dt>{ translate( 'Total' ) }</dt>
+			<dt>
+				{ translate( 'Total', {
+					context: 'The label of the total line item in checkout',
+					textOnly: true,
+				} ) }
+			</dt>
 			<dd>{ total }</dd>
 		</dl>
 	);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -221,7 +221,12 @@ function CheckoutSummaryPriceList() {
 				</CheckoutSubtotalSection>
 
 				<CheckoutSummaryTotal>
-					<span className="wp-checkout-order-summary__label">{ translate( 'Total' ) }</span>
+					<span className="wp-checkout-order-summary__label">
+						{ translate( 'Total', {
+							context: 'The label of the total line item in checkout',
+							textOnly: true,
+						} ) }
+					</span>
 					<span className="wp-checkout-order-summary__total-price">
 						{ totalLineItem.formattedAmount }
 					</span>

--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -101,10 +101,10 @@ function TaxAddedLineItem() {
 }
 
 function MiniCartTotal( { responseCart }: { responseCart: ResponseCart } ) {
-	const { __ } = useI18n();
+	const { _x } = useI18n();
 	return (
 		<MiniCartTotalWrapper className="mini-cart__total">
-			<span>{ __( 'Total' ) }</span>
+			<span>{ _x( 'Total', 'The label of the total line item in checkout' ) }</span>
 			<span>
 				{ formatCurrency( responseCart.total_cost_integer, responseCart.currency, {
 					isSmallestUnit: true,


### PR DESCRIPTION
As summarized in https://github.com/Automattic/wp-calypso/issues/92565 

> We should give translators some context for the translation of "Total" in checkout.

> However, we need to do that consistently (not just that one place in the code) so that the translation of the word "Total" is the same throughout checkout

This PR adds context to the translation functions for Checkout, the mini-cart package, and the PurchaseModal.

Adding a context to the translation functions for the 'Total' text tells our translators to use more specific language when translating the text.

Related to #92565

### Test
**Checkout**
- Checkout this branch and go to `http://calypso.localhost:3000/checkout/[YOUR-SITE]/`
- Ensure that the Total text found in the sidebar is still displayed correctly

**Purchase modal**
- Now, make sure you have a payment method on your account, or add a testing method
- Go to `http://calypso.localhost:3000/checkout/[YOUR-SITE]/offer-plan-upgrade/business/12345` and click on 'Upgrade now'  to load the PurchaseModal component
- Ensure the Total text is displayed correctly

**Mini-cart**
- Make sure you have an item in your cart, then go to `http://calypso.localhost:3000/home/[SITE-URL-WITH-PURCHASE-IN-CART]`
- Click on the mini-cart icon in the masterbar
- Ensure that the Total text is displayed correctly