### PR TITLE
Package "page-pattern-modal": Add style dependencies

### DIFF
--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/page-pattern-modal",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Automattic Page Pattern Modal.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -27,7 +27,9 @@
 	],
 	"types": "dist/types",
 	"dependencies": {
-		"@automattic/typography": "workspace:^",
+		"@automattic/color-studio": "2.6.0",
+		"@automattic/typography": "1.0.0",
+		"@wordpress/base-styles": "5.2.0",
 		"@wordpress/block-editor": "^13.2.0",
 		"@wordpress/blocks": "^13.2.0",
 		"@wordpress/components": "^28.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,8 +1558,10 @@ __metadata:
   resolution: "@automattic/page-pattern-modal@workspace:packages/page-pattern-modal"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    "@automattic/typography": "workspace:^"
+    "@automattic/color-studio": "npm:2.6.0"
+    "@automattic/typography": "npm:1.0.0"
     "@testing-library/react": "npm:^15.0.7"
+    "@wordpress/base-styles": "npm:5.2.0"
     "@wordpress/block-editor": "npm:^13.2.0"
     "@wordpress/blocks": "npm:^13.2.0"
     "@wordpress/components": "npm:^28.2.0"
@@ -1903,7 +1905,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/typography@workspace:^, @automattic/typography@workspace:packages/typography":
+"@automattic/typography@npm:1.0.0, @automattic/typography@workspace:^, @automattic/typography@workspace:packages/typography":
   version: 0.0.0-use.local
   resolution: "@automattic/typography@workspace:packages/typography"
   dependencies:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/92871

## Proposed Changes

* Fix import error by adding style dependencies in package.json

>[!NOTE]
>I have already tested it and it's not affecting the package in ETK, therefore I am not waiting for a review

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This package is imported in jetpack-mu-wpcom but the CSS dependencies are not found when building

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
