### PR TITLE
A4A Dev Sites: Add "Start developing for free" CTA dropdown button

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -27,9 +27,10 @@ type PendingSite = { features: { wpcom_atomic: { state: string; license_key: str
 type Props = {
 	onWPCOMImport?: ( blogIds: number[] ) => void;
 	showMainButtonLabel: boolean;
+	devSite?: boolean;
 };
 
-export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport }: Props ) {
+export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport, devSite }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -92,6 +93,108 @@ export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport }
 		) ?? [];
 
 	const hasPendingWPCOMSites = allAvailableSites.length > 0;
+	const mainButtonLabel = devSite
+		? translate( 'Start developing for free' )
+		: translate( 'Add sites' );
+	const newSitePopoverContent = (
+		<div className="site-selector-and-importer__popover-content">
+			<div className="site-selector-and-importer__popover-column">
+				<div className="site-selector-and-importer__popover-column-heading">
+					{ translate( 'Add existing sites' ).toUpperCase() }
+				</div>
+				{ menuItem( {
+					icon: <WordPressLogo />,
+					heading: translate( 'Via WordPress.com' ),
+					description: translate( 'Add sites bought on{{nbsp/}}WordPress.com', {
+						components: { nbsp: <>&nbsp;</> },
+						comment: 'nbsp is a non-breaking space character',
+					} ),
+					buttonProps: {
+						onClick: handleImportFromWPCOM,
+					},
+				} ) }
+				{ menuItem( {
+					icon: <A4ALogo />,
+					heading: translate( 'Via the Automattic plugin' ),
+					description: translate( 'Connect with the Automattic for Agencies{{nbsp/}}plugin', {
+						components: { nbsp: <>&nbsp;</> },
+						comment: 'nbsp is a non-breaking space character',
+					} ),
+					buttonProps: {
+						onClick: () => {
+							setShowA4AConnectionModal( true );
+							setMenuVisible( false );
+						},
+					},
+				} ) }
+				{ menuItem( {
+					icon: <JetpackLogo />,
+					heading: translate( 'Via Jetpack' ),
+					description: translate( 'Import one or more Jetpack connected sites' ),
+					buttonProps: {
+						onClick: () => {
+							setShowJetpackConnectionModal( true );
+							setMenuVisible( false );
+						},
+					},
+				} ) }
+			</div>
+			<div className="site-selector-and-importer__popover-column">
+				<div className="site-selector-and-importer__popover-column-heading">
+					{ translate( 'Add a new site' ).toUpperCase() }
+				</div>
+				{ menuItem( {
+					icon: <WordPressLogo />,
+					heading: translate( 'WordPress.com' ),
+					description: translate( 'Optimized and hassle-free hosting for business websites' ),
+					buttonProps: {
+						href: hasPendingWPCOMSites
+							? A4A_SITES_LINK_NEEDS_SETUP
+							: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+					},
+					extraContent: hasPendingWPCOMSites ? (
+						<div className="site-selector-and-importer__popover-site-count">
+							{ translate( '%(pendingSites)d site available', '%(pendingSites)d sites available', {
+								args: {
+									pendingSites: allAvailableSites.length,
+								},
+								count: allAvailableSites.length,
+								comment: '%(pendingSites)s is the number of sites available.',
+							} ) }
+						</div>
+					) : undefined,
+				} ) }
+				{ menuItem( {
+					icon: <img src={ pressableIcon } alt="" />,
+					heading: translate( 'Pressable' ),
+					description: translate( 'Best for large-scale businesses and major eCommerce sites' ),
+					buttonProps: {
+						href:
+							pressableOwnership === 'regular'
+								? 'https://my.pressable.com/agency/auth'
+								: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+						target: pressableOwnership === 'regular' ? '_blank' : '_self',
+					},
+				} ) }
+			</div>
+		</div>
+	);
+	const newDevSitePopoverContent = (
+		<div className="site-selector-and-importer__popover-content">
+			<div className="site-selector-and-importer__popover-column">
+				<div className="site-selector-and-importer__popover-column-heading">
+					{ translate( 'Add a new development site' ).toUpperCase() }
+				</div>
+				{ menuItem( {
+					icon: <WordPressLogo />,
+					heading: translate( 'WordPress.com' ),
+					description: translate( 'Create a site and try our hosting features for free' ),
+					extraContent: undefined,
+				} ) }
+			</div>
+		</div>
+	);
+	const popoverContent = devSite ? newDevSitePopoverContent : newSitePopoverContent;
 
 	return (
 		<>
@@ -100,14 +203,14 @@ export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport }
 				ref={ popoverMenuContext }
 				onClick={ toggleMenu }
 			>
-				{ showMainButtonLabel ? translate( 'Add sites' ) : null }
+				{ showMainButtonLabel ? mainButtonLabel : null }
 				<Gridicon
 					className={ clsx( { reverse: showMainButtonLabel && isMenuVisible } ) }
 					icon={ showMainButtonLabel ? 'chevron-down' : 'plus' }
 				/>
 			</Button>
 			<Popover
-				className="site-selector-and-importer__popover"
+				className={ clsx( 'site-selector-and-importer__popover', { 'dev-site': devSite } ) }
 				context={ popoverMenuContext?.current }
 				isVisible={ isMenuVisible }
 				closeOnEsc
@@ -115,91 +218,7 @@ export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport }
 				autoPosition={ false }
 				position="bottom left"
 			>
-				<div className="site-selector-and-importer__popover-content">
-					<div className="site-selector-and-importer__popover-column">
-						<div className="site-selector-and-importer__popover-column-heading">
-							{ translate( 'Add existing sites' ).toUpperCase() }
-						</div>
-						{ menuItem( {
-							icon: <WordPressLogo />,
-							heading: translate( 'Via WordPress.com' ),
-							description: translate( 'Add sites bought on{{nbsp/}}WordPress.com', {
-								components: { nbsp: <>&nbsp;</> },
-								comment: 'nbsp is a non-breaking space character',
-							} ),
-							buttonProps: {
-								onClick: handleImportFromWPCOM,
-							},
-						} ) }
-						{ menuItem( {
-							icon: <A4ALogo />,
-							heading: translate( 'Via the Automattic plugin' ),
-							description: translate( 'Connect with the Automattic for Agencies{{nbsp/}}plugin', {
-								components: { nbsp: <>&nbsp;</> },
-								comment: 'nbsp is a non-breaking space character',
-							} ),
-							buttonProps: {
-								onClick: () => {
-									setShowA4AConnectionModal( true );
-									setMenuVisible( false );
-								},
-							},
-						} ) }
-						{ menuItem( {
-							icon: <JetpackLogo />,
-							heading: translate( 'Via Jetpack' ),
-							description: translate( 'Import one or more Jetpack connected sites' ),
-							buttonProps: {
-								onClick: () => {
-									setShowJetpackConnectionModal( true );
-									setMenuVisible( false );
-								},
-							},
-						} ) }
-					</div>
-					<div className="site-selector-and-importer__popover-column">
-						<div className="site-selector-and-importer__popover-column-heading">
-							{ translate( 'Add a new site' ).toUpperCase() }
-						</div>
-						{ menuItem( {
-							icon: <WordPressLogo />,
-							heading: translate( 'WordPress.com' ),
-							description: translate( 'Optimized and hassle-free hosting for business websites' ),
-							buttonProps: {
-								href: hasPendingWPCOMSites
-									? A4A_SITES_LINK_NEEDS_SETUP
-									: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
-							},
-							extraContent: hasPendingWPCOMSites ? (
-								<div className="site-selector-and-importer__popover-site-count">
-									{ translate(
-										'%(pendingSites)d site available',
-										'%(pendingSites)d sites available',
-										{
-											args: {
-												pendingSites: allAvailableSites.length,
-											},
-											count: allAvailableSites.length,
-											comment: '%(pendingSites)s is the number of sites available.',
-										}
-									) }
-								</div>
-							) : undefined,
-						} ) }
-						{ menuItem( {
-							icon: <img src={ pressableIcon } alt="" />,
-							heading: translate( 'Pressable' ),
-							description: translate( 'Best for large-scale businesses and major eCommerce sites' ),
-							buttonProps: {
-								href:
-									pressableOwnership === 'regular'
-										? 'https://my.pressable.com/agency/auth'
-										: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
-								target: pressableOwnership === 'regular' ? '_blank' : '_self',
-							},
-						} ) }
-					</div>
-				</div>
+				{ popoverContent }
 			</Popover>
 
 			{ showA4AConnectionModal && (

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -223,7 +223,10 @@ export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport, 
 			>
 				{ showMainButtonLabel ? mainButtonLabel : null }
 				<Gridicon
-					className={ clsx( { reverse: showMainButtonLabel && isMenuVisible } ) }
+					className={ clsx(
+						{ reverse: showMainButtonLabel && isMenuVisible },
+						{ mobile: ! showMainButtonLabel }
+					) }
 					icon={ showMainButtonLabel ? 'chevron-down' : 'plus' }
 				/>
 			</Button>

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -101,6 +101,7 @@ export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport, 
 	const mainButtonLabel = devSite
 		? translate( 'Start developing for free' )
 		: translate( 'Add sites' );
+
 	const newSitePopoverContent = (
 		<div className="site-selector-and-importer__popover-content">
 			<div className="site-selector-and-importer__popover-column">
@@ -184,6 +185,7 @@ export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport, 
 			</div>
 		</div>
 	);
+
 	const newDevSitePopoverContent = (
 		<div className="site-selector-and-importer__popover-content">
 			<div className="site-selector-and-importer__popover-column">
@@ -209,6 +211,7 @@ export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport, 
 			</div>
 		</div>
 	);
+
 	const popoverContent = devSite ? newDevSitePopoverContent : newSitePopoverContent;
 
 	return (

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -93,6 +93,11 @@ export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport, 
 		) ?? [];
 
 	const hasPendingWPCOMSites = allAvailableSites.length > 0;
+
+	// TODO: Replace with actual available dev sites count logic, similar to allAvailableSites above
+	const availableDevSites = [ 'site1', 'site2', 'site3' ];
+	const hasAvailableDevSites = allAvailableSites.length > 0;
+
 	const mainButtonLabel = devSite
 		? translate( 'Start developing for free' )
 		: translate( 'Add sites' );
@@ -189,7 +194,17 @@ export default function AddNewSiteButton( { showMainButtonLabel, onWPCOMImport, 
 					icon: <WordPressLogo />,
 					heading: translate( 'WordPress.com' ),
 					description: translate( 'Create a site and try our hosting features for free' ),
-					extraContent: undefined,
+					extraContent: hasAvailableDevSites ? (
+						<div className="site-selector-and-importer__popover-site-count">
+							{ translate( '%(pendingSites)d site available', '%(pendingSites)d sites available', {
+								args: {
+									pendingSites: availableDevSites.length,
+								},
+								count: availableDevSites.length,
+								comment: '%(pendingSites)s is the number of sites available.',
+							} ) }
+						</div>
+					) : undefined,
 				} ) }
 			</div>
 		</div>

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -10,6 +10,11 @@
 		&.reverse {
 			transform: rotate(180deg);
 		}
+
+		&.mobile {
+			margin-left: 0;
+			top: 2px;
+		}
 	}
 }
 .popover.site-selector-and-importer__popover {

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -25,9 +25,13 @@
 		}
 	}
 
-	&.dev-site .popover__inner {
-		width: 280px;
-		text-align: unset;
+	&.dev-site {
+		margin-inline-start: 82px;
+
+		.popover__inner {
+			width: 280px;
+			text-align: unset;
+		}
 	}
 }
 

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -24,6 +24,11 @@
 			width: 650px;
 		}
 	}
+
+	&.dev-site .popover__inner {
+		width: 280px;
+		text-align: unset;
+	}
 }
 
 .site-selector-and-importer__popover-content {

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -23,7 +24,9 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 
 	return (
 		<div className="sites-header__actions">
-			<AddNewSiteButton showMainButtonLabel={ ! isMobile } devSite />
+			{ config.isEnabled( 'a4a-dev-sites' ) && (
+				<AddNewSiteButton showMainButtonLabel={ ! isMobile } devSite />
+			) }
 			<div ref={ ( ref ) => setTourStepRef( ref ) }>
 				<AddNewSiteButton showMainButtonLabel={ ! isMobile } onWPCOMImport={ onWPCOMImport } />
 			</div>

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -23,6 +23,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 
 	return (
 		<div className="sites-header__actions">
+			<AddNewSiteButton showMainButtonLabel={ ! isMobile } devSite />
 			<div ref={ ( ref ) => setTourStepRef( ref ) }>
 				<AddNewSiteButton showMainButtonLabel={ ! isMobile } onWPCOMImport={ onWPCOMImport } />
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/8350.

## Proposed Changes

* extend the `AddNewSiteButton` component logic and styling to be able to render the new "Start developing for free" CTA button with popover
* add the new "Start developing for free" CTA button to the A4A Sites page header section, hidden behind the `a4a-dev-sites` feature flag

![Markup on 2024-07-24 at 16:30:52](https://github.com/user-attachments/assets/31a014c4-eed8-4d8e-ac50-de0269e37730)

Please note that the `X sites available` text is static; actual logic will be addressed in a separate task. Also, the button in the popover doesn't lead anywhere at the moment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the _Free A4A Development Sites_ project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR locally and build the app with `yarn start-a8c-for-agencies`.
2. Head over to Sites section at http://agencies.localhost:3000/sites/need-setup?flags=a4a-dev-sites and click on the new "Start developing for free" CTA button. A popover should appear.
3. If the `a4a-dev-sites` feature flag is disabled (http://agencies.localhost:3000/sites/need-setup?flags=-a4a-dev-sites), the button shouldn't be visible.

Questions for discussion:


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
