### PR TITLE
Plans (State): Update useMaxPlanUpgradeCredits to utilise Plans data-store pricing

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
@@ -9,6 +9,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React, { type ComponentPropsWithoutRef } from 'react';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { useUpgradePlanHostingDetailsList } from '../hooks/use-get-upgrade-plan-hosting-details-list';
 import { UpgradePlan, UnwrappedUpgradePlan } from '../index';
@@ -18,6 +19,11 @@ jest.mock( '../upgrade-plan-details', () => ( {
 	__esModule: true,
 	default: ( { children } ) => <div>{ children }</div>,
 } ) );
+
+jest.mock(
+	'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase',
+	() => jest.fn()
+);
 
 jest.mock( '@automattic/calypso-analytics' );
 
@@ -165,8 +171,17 @@ describe( 'UpgradePlan', () => {
 	beforeAll( () => nock.disableNetConnect() );
 
 	beforeEach( () => {
+		jest.clearAllMocks();
 		mockUseUpgradePlanHostingDetailsList( false );
 		mockUsePricingMetaForGridPlans();
+		useCheckPlanAvailabilityForPurchase.mockImplementation( ( { planSlugs } ) =>
+			planSlugs.reduce( ( acc, planSlug ) => {
+				return {
+					...acc,
+					[ planSlug ]: true,
+				};
+			}, {} )
+		);
 	} );
 
 	it( 'should call onCtaClick when the user clicks on the Continue button', async () => {

--- a/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice-credit-update.tsx
@@ -56,7 +56,10 @@ const PlanNoticeCreditUpgrade = ( {
 							args: {
 								amountInCurrency: formatCurrency(
 									planUpgradeCreditsApplicable,
-									currencyCode ?? ''
+									currencyCode ?? '',
+									{
+										isSmallestUnit: true,
+									}
 								),
 							},
 							components: {

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -104,14 +104,14 @@ describe( '<PlanNotice /> Tests', () => {
 		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
 		mIsRequestingSitePlans.mockImplementation( () => true );
 		mGetCurrentUserCurrencyCode.mockImplementation( () => 'USD' );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 1 );
+		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 100 );
 		mGetByPurchaseId.mockImplementation( () => ( { isInAppPurchase: false } ) as Purchase );
 		mIsProPlan.mockImplementation( () => false );
 	} );
 
 	test( 'A contact site owner <PlanNotice /> should be shown no matter what other conditions are met, when the current site owner is not logged in, and the site plan is paid', () => {
 		mGetDiscountByName.mockImplementation( () => discount );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 1 );
+		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 100 );
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => false );
 
@@ -132,7 +132,7 @@ describe( '<PlanNotice /> Tests', () => {
 		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mGetDiscountByName.mockImplementation( () => discount );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 1 );
+		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 100 );
 
 		renderWithProvider(
 			<PlanNotice
@@ -149,7 +149,7 @@ describe( '<PlanNotice /> Tests', () => {
 		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mGetDiscountByName.mockImplementation( () => false );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 100 );
+		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 10000 );
 
 		renderWithProvider(
 			<PlanNotice

--- a/client/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits.ts
+++ b/client/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits.ts
@@ -42,7 +42,7 @@ export function useMaxPlanUpgradeCredits( { siteId, plans }: Props ): number {
 			return 0;
 		}
 
-		return discountedPrice - originalPrice;
+		return originalPrice - discountedPrice;
 	} );
 
 	return Math.max( ...creditsPerPlan );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/86638

## Proposed Changes

- Updates the hook for computing the max plan-upgrade credits for showing in notices to utilize the Plans data-store for the discounted/original prices.
- A bit of tuning/refactor on same hook

This should be the last usage of `getPlanDiscountedRawPrice` and `getPlanRawPrice`, so we can safely remove in a follow-up.

### Media

<img width="500" alt="Screenshot 2024-07-25 at 2 20 16 PM" src="https://github.com/user-attachments/assets/f1506013-e6f3-45a0-bb7a-beef985bb882">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We only need one form of handling plan pricing in the code base, more so one framework. Anything else risks having alternative and differing views of the same data propagating across the code base.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/:site` with a site on Personal or Premium plan
* Confirm the plan notice is shown with correct number of "upgrade credits"
* Repeat with Free plan to ensure no "upgrade credits" notice is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
