### PR TITLE
A4A: Update Guide Modal styling to allow vertical expansion

### DIFF
--- a/client/a8c-for-agencies/components/guide-modal/style.scss
+++ b/client/a8c-for-agencies/components/guide-modal/style.scss
@@ -1,6 +1,6 @@
 .guide-modal__wrapper {
 	width: 400px;
-	height: 500px;
+	align-self: start;
 
 	.components-modal__content {
 		margin: 0;
@@ -28,15 +28,14 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	height: 500px;
+	min-height: 500px;
 }
 
 .guide-modal__header {
 	width: 100%;
 	text-align: center;
 	margin-bottom: 20px;
-	height: 48%;
-
+	height: 240px;
 
 	// FIXME: remove this after proper video aspect ratio added
 	video {
@@ -75,7 +74,7 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	height: 48%;
+	flex: 1 0 auto;
 }
 
 .guide-modal__body {
@@ -119,4 +118,3 @@
 	gap: 1rem;
 	align-self: flex-end;
 }
-


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 844-gh-Automattic/i18n-issues

## Proposed Changes

* Updating `GuideModal` component on A4A to allow vertical expansion when content doesn't fit, while preserving the current layout when content fits.

**Before:**
![XowxYaiRrxJJzljm](https://github.com/user-attachments/assets/01281b61-9ec1-45df-9c30-89dc2fac33fe)

**After:**
![W1OE61BIgpHEPGiB](https://github.com/user-attachments/assets/d9db747d-0805-4e52-8713-fe05161e060f)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In some languages, the content of the guide modal takes up more space, causing the action buttons to be positioned close to the edge of the modal. Refer to the attached Before/After screenshots.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change UI language to Indonesian.
* Navigate to `/marketplace/hosting` on the A4A environment.
* Open the guide modal from the info icon next to the "Refer products" toggle at the top (See the screenshot).
* Navigate to the last step of the guide modal and confirm the modal expands in height so there's a padding between the action buttons and the modal edge.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
