### PR TITLE
A4A Dev Sites: Add the `a4a-dev-sites` feature flag

### DIFF
--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -41,7 +41,8 @@
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": true,
-		"a4a-hosting-page-redesign": true
+		"a4a-hosting-page-redesign": true,
+		"a4a-dev-sites": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -34,7 +34,8 @@
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": true,
-		"a4a-hosting-page-redesign": true
+		"a4a-hosting-page-redesign": true,
+		"a4a-dev-sites": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -33,7 +33,8 @@
 		"oauth": true,
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
-		"a4a-partner-directory": false
+		"a4a-partner-directory": false,
+		"a4a-dev-sites": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -36,7 +36,8 @@
 		"a4a/site-migration": false,
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
-		"a4a-partner-directory": false
+		"a4a-partner-directory": false,
+		"a4a-dev-sites": false
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/8349.

## Proposed Changes

* add the `a4a-dev-sites` feature flag: enabled in development, disabled everywhere else

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the _Free A4A Development Sites_ project: pdDOJh-3Cl-p2.

## Testing Instructions

Please review the code, no testing required.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?