### PR TITLE
Enable wapuu for free users

### DIFF
--- a/packages/help-center/src/hooks/use-should-use-wapuu.ts
+++ b/packages/help-center/src/hooks/use-should-use-wapuu.ts
@@ -10,9 +10,7 @@ function isWapuuFlagSetInURL(): boolean {
 
 export const useShouldUseWapuu = () => {
 	const { data: supportStatus } = useSupportStatus();
-
-	// All users eligible for support should see the Wapuu assistant.
-	const isEligibleForSupport = Boolean( supportStatus?.eligibility?.is_user_eligible );
+	const wapuuAssistantEnabled = Boolean( supportStatus?.eligibility?.wapuu_assistant_enabled );
 
 	// Force Wapuu via URL flag (config is not available in wp-admin)
 	const isFlagSetInURL = isWapuuFlagSetInURL();
@@ -20,5 +18,5 @@ export const useShouldUseWapuu = () => {
 	// Wapuu can be enabled via config
 	const isConfigEnabled = config.isEnabled( 'wapuu' );
 
-	return isEligibleForSupport || isFlagSetInURL || isConfigEnabled;
+	return wapuuAssistantEnabled || isFlagSetInURL || isConfigEnabled;
 };

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -8,7 +8,7 @@ export function useStillNeedHelpURL() {
 	const shouldUseWapuu = useShouldUseWapuu();
 	const isEligibleForSupport = Boolean( supportStatus?.eligibility?.is_user_eligible );
 
-	if ( isEligibleForSupport ) {
+	if ( isEligibleForSupport || shouldUseWapuu ) {
 		const url = shouldUseWapuu ? '/odie' : '/contact-options';
 		return { url, isLoading: false };
 	}

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -87,6 +87,7 @@ interface Availability {
 
 interface Eligibility {
 	is_user_eligible: boolean;
+	wapuu_assistant_enabled: boolean;
 	support_level:
 		| 'free'
 		| 'personal'


### PR DESCRIPTION


## Proposed Changes

* Allow free users to see Wapuu if they are part of the A/B experiment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See pflv1o-rb-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply and refer to D156356.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
