### PR TITLE
Adding retry for e2e test when receiving error_unclear_prompt response from backend

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -47,8 +47,23 @@ export class FormAiFlow implements BlockFlow {
 		} );
 		await aiInputReadyLocator.fill( this.configurationData.prompt );
 		await sendButtonLocator.click();
-		await aiInputBusyLocator.waitFor();
-		await aiInputReadyLocator.waitFor( { timeout: 30 * 1000 } );
+		await aiInputBusyLocator.waitFor( { state: 'detached' } );
+
+		// Check if we got an error_unclear_prompt and try it again
+		// TODO: Remove this when this bug is fixed: https://github.com/Automattic/wp-calypso/issues/92927
+		for ( let i = 0; i < 5; i++ ) {
+			const errorLocator = await aiInputParentLocator.getByText(
+				'Error: Your request was unclear. Mind trying again?'
+			);
+
+			if ( await errorLocator.count() ) {
+				await sendButtonLocator.click();
+				await aiInputBusyLocator.waitFor( { state: 'detached' } );
+			} else {
+				break;
+			}
+		}
+
 		// Grab a first sample input label and submit button text to use for validation.
 		this.validationData = {
 			sampleInputLabel: await this.getFirstTextFieldLabel( context ),

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/opentable.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/opentable.ts
@@ -48,7 +48,7 @@ export class OpenTableFlow implements BlockFlow {
 		 * Due to API inconsistency of OpenTable, we need to try a few times to get the correct restaurant.
 		 * https://github.com/Automattic/wp-calypso/issues/92836
 		 */
-		for ( let i = 0; i < 5; i++ ) {
+		for ( let i = 0; i < 10; i++ ) {
 			try {
 				await searchLocator.fill( restaurant );
 				const suggestionLocator = editorCanvas


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/92927
Context: p1721823789641259-slack-C054LN8RNVA

## Proposed Changes

* Retrying up to 5 times when receiving the `error_unclear_prompt` response from backend

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure this test passes after running it for 10 times: `VIEWPORT_NAME=mobile GUTENBERG_EDGE=false TEST_ON_ATOMIC=false yarn workspace wp-e2e-tests test -- specs/blocks/blocks__jetpack-forms.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?