### PR TITLE
Readymade Templates: Added Generate content step to the readymade template flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
@@ -8,6 +8,7 @@ import { actions as emailActions } from './email';
 import { actions as paymentsActions } from './payments';
 import { actions as planActions } from './plan';
 import { actions as postActions } from './post';
+import { actions as readymadeTemplateActions } from './readymade-templates';
 import { actions as setupActions } from './setup';
 import { actions as siteActions } from './site';
 import { actions as subscribersActions } from './subscribers';
@@ -28,6 +29,7 @@ const DEFINITIONS: TaskActionTable = {
 	...emailActions,
 	...subscribersActions,
 	...contentActions,
+	...readymadeTemplateActions,
 	...bioActions,
 	...paymentsActions,
 	...videoPressActions,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/readymade-templates/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/readymade-templates/index.tsx
@@ -1,0 +1,12 @@
+import { TaskAction } from '../../types';
+
+export const getGenerateContentTask: TaskAction = ( task ) => {
+	return {
+		...task,
+		useCalypsoPath: true,
+	};
+};
+
+export const actions = {
+	generate_content: getGenerateContentTask,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/readymade-templates/test/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/readymade-templates/test/index.ts
@@ -1,0 +1,21 @@
+import { getGenerateContentTask } from '../';
+import { buildTask } from '../../../test/lib/fixtures';
+import { type TaskContext } from '../../../types';
+
+const buildContext = ( options?: Partial< TaskContext > ) => {
+	return {
+		tasks: [],
+		...options,
+	} as TaskContext;
+};
+
+describe( 'getGenerateContentTask', () => {
+	const task = buildTask( { id: 'task', calypso_path: 'some-path' } );
+
+	it( 'use the calypso path from backend', () => {
+		expect( getGenerateContentTask( task, 'flowId', buildContext() ) ).toMatchObject( {
+			useCalypsoPath: true,
+			calypso_path: 'some-path',
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
@@ -1,0 +1,24 @@
+import { __experimentalNavigatorProvider as NavigatorProvider } from '@wordpress/components';
+import { useInitialPath } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks';
+import type { Step } from '../../types';
+
+const ReadymadeTemplateGenerateContent = () => {
+	return (
+		<div>
+			<h1>Generate Content with Me</h1>
+			<p>Launchpad things here for reasons</p>
+		</div>
+	);
+};
+
+const ReadymadeTemplateGenerateContentStep: Step = () => {
+	const initialPath = useInitialPath();
+
+	return (
+		<NavigatorProvider initialPath={ initialPath } tabIndex={ -1 }>
+			<ReadymadeTemplateGenerateContent />
+		</NavigatorProvider>
+	);
+};
+
+export default ReadymadeTemplateGenerateContentStep;

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -60,6 +60,11 @@ export const STEPS = {
 
 	GOALS: { slug: 'goals', asyncComponent: () => import( './steps-repository/goals' ) },
 
+	GENERATE_CONTENT: {
+		slug: 'generateContent',
+		asyncComponent: () => import( './steps-repository/readymade-template-generate-content' ),
+	},
+
 	IMPORT: { slug: 'import', asyncComponent: () => import( './steps-repository/import' ) },
 
 	IMPORT_LIGHT: {

--- a/client/landing/stepper/declarative-flow/readymade-template.tsx
+++ b/client/landing/stepper/declarative-flow/readymade-template.tsx
@@ -56,11 +56,7 @@ const readymadeTemplateFlow: Flow = {
 			STEPS.DOMAINS,
 			STEPS.SITE_LAUNCH,
 			STEPS.CELEBRATION,
-			{
-				slug: 'generateContent',
-				asyncComponent: () =>
-					import( './internals/steps-repository/readymade-template-generate-content' ),
-			},
+			STEPS.GENERATE_CONTENT,
 		] );
 	},
 

--- a/client/landing/stepper/declarative-flow/readymade-template.tsx
+++ b/client/landing/stepper/declarative-flow/readymade-template.tsx
@@ -24,7 +24,9 @@ import {
 	AssertConditionResult,
 	AssertConditionState,
 	Flow,
+	Navigate,
 	ProvidedDependencies,
+	StepperStep,
 } from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { GlobalStylesObject } from '@automattic/global-styles';
@@ -54,6 +56,11 @@ const readymadeTemplateFlow: Flow = {
 			STEPS.DOMAINS,
 			STEPS.SITE_LAUNCH,
 			STEPS.CELEBRATION,
+			{
+				slug: 'generateContent',
+				asyncComponent: () =>
+					import( './internals/steps-repository/readymade-template-generate-content' ),
+			},
 		] );
 	},
 
@@ -66,23 +73,10 @@ const readymadeTemplateFlow: Flow = {
 		const { setPendingAction, setSelectedSite } = useDispatch( ONBOARD_STORE );
 		const { saveSiteSettings, setIntentOnSite, assembleSite } = useDispatch( SITE_STORE );
 		const { site, siteSlug, siteId } = useSiteData();
-
 		const reduxDispatch = useReduxDispatch();
-
 		const selectedTheme = getAssemblerDesign().slug;
-
 		const { value: readymadeTemplateId } = useUrlQueryParam( 'readymadeTemplateId' );
 		const readymadeTemplate = useReadymadeTemplate( readymadeTemplateId );
-
-		const exitFlow = ( to: string ) => {
-			setPendingAction( () => {
-				return new Promise( () => {
-					window.location.assign( to );
-				} );
-			} );
-
-			return navigate( 'processing' );
-		};
 
 		const handleSelectSite = ( providedDependencies: ProvidedDependencies = {} ) => {
 			const selectedSiteSlug = providedDependencies?.siteSlug as string;
@@ -95,7 +89,9 @@ const readymadeTemplateFlow: Flow = {
 				enableAssemblerThemeAndConfigureTemplates(
 					selectedTheme,
 					selectedSiteId,
+					selectedSiteSlug,
 					readymadeTemplate,
+					navigate,
 					assembleSite,
 					reduxDispatch
 				)
@@ -147,17 +143,7 @@ const readymadeTemplateFlow: Flow = {
 						return navigate( 'celebration-step' );
 					}
 
-					if ( providedDependencies?.goToCheckout ) {
-						// Do nothing and wait for checkout redirect
-						return;
-					}
-
-					const params = new URLSearchParams( {
-						canvas: 'edit',
-						assembler: '1',
-					} );
-
-					return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
+					return;
 				}
 
 				case 'launchpad': {
@@ -244,7 +230,9 @@ const readymadeTemplateFlow: Flow = {
 function enableAssemblerThemeAndConfigureTemplates(
 	themeId: string,
 	siteId: number,
+	siteSlug: string,
 	readymadeTemplate: ReadymadeTemplate & { globalStyles: GlobalStylesObject },
+	navigate: Navigate< StepperStep[] >,
 	assembleSite: (
 		arg0: any,
 		arg1: string,
@@ -302,7 +290,7 @@ function enableAssemblerThemeAndConfigureTemplates(
 					siteSetupOption: 'readymade-template',
 				} )
 			)
-			.then( () => window.location.assign( `/site-editor/${ siteId }?canvas=edit&assembler=1` ) );
+			.then( () => navigate( `launchpad?siteSlug=${ siteSlug }` ) );
 }
 
 function useReadymadeTemplate( templateId: number, options: object = { enabled: true } ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/7500

## Proposed Changes

* Added a new launchpad step for Readymade templates.
* The new step is a screen where we will generate content with AI.
* When selecting an RT we now land on the launchpad instead of the site editor.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In order to support generating content with AI we need a new launchpad step to do so.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Apply this patch if it isn't in production: https://github.com/Automattic/jetpack/pull/38507
* Go to `/patterns` and pick a readymade template
* You should land on the launchpad.
* When clicking on `Customize content with AI` you should land on a dummy screen.

<img width="1725" alt="Screenshot 2024-07-24 at 17 19 30" src="https://github.com/user-attachments/assets/de94fae5-ee4a-4cd8-b243-a9681a4b3584">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
