### PR TITLE
Help Center: Allow Domain only users to acesss support

### DIFF
--- a/packages/help-center/src/hooks/use-should-render-email-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-email-option.tsx
@@ -3,14 +3,8 @@ import { useSupportStatus } from '../data/use-support-status';
 export function useShouldRenderEmailOption() {
 	const { data: supportStatus, isFetching } = useSupportStatus();
 
-	// Domain only customers should always see the email option
-	// Domain only users have this combination of support level === free, and is_user_eligible === true.
-	const isDomainOnlyUser =
-		supportStatus?.eligibility.is_user_eligible &&
-		supportStatus?.eligibility.support_level === 'free';
-
 	return {
 		isLoading: isFetching,
-		render: isDomainOnlyUser || ( supportStatus?.availability.force_email_support ?? false ),
+		render: Boolean( supportStatus?.availability.force_email_support ),
 	};
 }


### PR DESCRIPTION
Related to peCdcN-Iu-p2 

## Proposed Changes

This allows Domain only users to access support as the paid users they actually are!

## Why are these changes being made?
There was a bug that affected them that has been fixed in D155932-code

## Testing Instructions

1. Login using a domain only user.
2. Try to reach support by asking Wapuu for a human.
3. You should get "Contact WordPress.com Support".
4. Click it, the ZD widget should open.