### PR TITLE
LPM API Migration: Replace the Source API version of iDEAL payments

### DIFF
--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -3,6 +3,7 @@ import { camelToSnakeCase } from '@automattic/js-utils';
 import type { CheckoutPaymentMethodSlug, WPCOMPaymentMethod } from '@automattic/wpcom-checkout';
 
 const isP24RedirectEnabled = config.isEnabled( 'stripe-redirect-migration-p24' );
+const StripeRedirectMigrationIdeal = config.isEnabled( 'stripe-redirect-migration-ideal' );
 
 /**
  * Convert a WPCOM payment method class name to a checkout payment method slug
@@ -85,7 +86,10 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'eps':
 			return 'WPCOM_Billing_Stripe_Source_Eps';
 		case 'ideal':
-			return 'WPCOM_Billing_Stripe_Ideal';
+			if ( StripeRedirectMigrationIdeal ) {
+				return 'WPCOM_Billing_Stripe_Ideal';
+			}
+			return 'WPCOM_Billing_Stripe_Source_Ideal';
 		case 'p24':
 			if ( isP24RedirectEnabled ) {
 				return 'WPCOM_Billing_Stripe_P24';

--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -3,7 +3,7 @@ import { camelToSnakeCase } from '@automattic/js-utils';
 import type { CheckoutPaymentMethodSlug, WPCOMPaymentMethod } from '@automattic/wpcom-checkout';
 
 const isP24RedirectEnabled = config.isEnabled( 'stripe-redirect-migration-p24' );
-const StripeRedirectMigrationIdeal = config.isEnabled( 'stripe-redirect-migration-ideal' );
+const isStripeIdealRedirectEnabled = config.isEnabled( 'stripe-redirect-migration-ideal' );
 
 /**
  * Convert a WPCOM payment method class name to a checkout payment method slug
@@ -86,7 +86,7 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'eps':
 			return 'WPCOM_Billing_Stripe_Source_Eps';
 		case 'ideal':
-			if ( StripeRedirectMigrationIdeal ) {
+			if ( isStripeIdealRedirectEnabled ) {
 				return 'WPCOM_Billing_Stripe_Ideal';
 			}
 			return 'WPCOM_Billing_Stripe_Source_Ideal';

--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -32,7 +32,7 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 		case 'WPCOM_Billing_Stripe_Source_Eps':
 			return 'eps';
 		case 'WPCOM_Billing_Stripe_Source_Ideal':
-		case 'WPCOM_Billing_Stripe_IDeal':
+		case 'WPCOM_Billing_Stripe_Ideal':
 			return 'ideal';
 		case 'WPCOM_Billing_Stripe_Source_P24':
 		case 'WPCOM_Billing_Stripe_P24':
@@ -85,7 +85,7 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'eps':
 			return 'WPCOM_Billing_Stripe_Source_Eps';
 		case 'ideal':
-			return 'WPCOM_Billing_Stripe_IDeal';
+			return 'WPCOM_Billing_Stripe_Ideal';
 		case 'p24':
 			if ( isP24RedirectEnabled ) {
 				return 'WPCOM_Billing_Stripe_P24';
@@ -123,7 +123,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Stripe_Source_Bancontact':
 		case 'WPCOM_Billing_Stripe_Source_Eps':
 		case 'WPCOM_Billing_Stripe_Source_Ideal':
-		case 'WPCOM_Billing_Stripe_IDeal':
+		case 'WPCOM_Billing_Stripe_Ideal':
 		case 'WPCOM_Billing_Stripe_Source_P24':
 		case 'WPCOM_Billing_Stripe_Source_Sofort':
 		case 'WPCOM_Billing_Stripe_Source_Three_D_Secure':

--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -32,6 +32,7 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 		case 'WPCOM_Billing_Stripe_Source_Eps':
 			return 'eps';
 		case 'WPCOM_Billing_Stripe_Source_Ideal':
+		case 'WPCOM_Billing_Stripe_IDeal':
 			return 'ideal';
 		case 'WPCOM_Billing_Stripe_Source_P24':
 		case 'WPCOM_Billing_Stripe_P24':
@@ -84,7 +85,7 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 		case 'eps':
 			return 'WPCOM_Billing_Stripe_Source_Eps';
 		case 'ideal':
-			return 'WPCOM_Billing_Stripe_Source_Ideal';
+			return 'WPCOM_Billing_Stripe_IDeal';
 		case 'p24':
 			if ( isP24RedirectEnabled ) {
 				return 'WPCOM_Billing_Stripe_P24';
@@ -122,6 +123,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Stripe_Source_Bancontact':
 		case 'WPCOM_Billing_Stripe_Source_Eps':
 		case 'WPCOM_Billing_Stripe_Source_Ideal':
+		case 'WPCOM_Billing_Stripe_IDeal':
 		case 'WPCOM_Billing_Stripe_Source_P24':
 		case 'WPCOM_Billing_Stripe_Source_Sofort':
 		case 'WPCOM_Billing_Stripe_Source_Three_D_Secure':

--- a/config/development.json
+++ b/config/development.json
@@ -220,6 +220,7 @@
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"stripe-redirect-migration-p24": true,
+		"stripe-redgit irect-migration-ideal": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -145,6 +145,7 @@
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-ideal": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/production.json
+++ b/config/production.json
@@ -191,6 +191,7 @@
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-ideal": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -185,6 +185,7 @@
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-ideal": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -184,6 +184,7 @@
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"stripe-redirect-migration-p24": false,
+		"stripe-redirect-migration-ideal": false,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -349,7 +349,7 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_Stripe_Source_Bancontact'
 	| 'WPCOM_Billing_Stripe_Source_Eps'
 	| 'WPCOM_Billing_Stripe_Source_Ideal'
-	| 'WPCOM_Billing_Stripe_IDeal'
+	| 'WPCOM_Billing_Stripe_Ideal'
 	| 'WPCOM_Billing_Stripe_Source_P24'
 	| 'WPCOM_Billing_Stripe_Source_Sofort'
 	| 'WPCOM_Billing_Stripe_Source_Three_D_Secure'

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -349,6 +349,7 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_Stripe_Source_Bancontact'
 	| 'WPCOM_Billing_Stripe_Source_Eps'
 	| 'WPCOM_Billing_Stripe_Source_Ideal'
+	| 'WPCOM_Billing_Stripe_IDeal'
 	| 'WPCOM_Billing_Stripe_Source_P24'
 	| 'WPCOM_Billing_Stripe_Source_Sofort'
 	| 'WPCOM_Billing_Stripe_Source_Three_D_Secure'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/payments-shilling/issues/2976

## Proposed Changes

* In order to use iDEAL with the Payments Intent API, the Stripe Elements for iDEAL in the payment selector form needs to be directed to use the class`WPCOM_Billing_Stripe_Ideal` when processing the transaction.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Stripe is retiring their Sources API in favor of the PaymentIntent API. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable Store Sandbox
* Start up local Calypso with this PR applied
* Add a product to your cart and proceed to Checkout
* Use the country `Netherlands` and the postal code `1011 AH`
* In the `Payment Options` section, select `iDEAL` and fill in your name and a bank
* You should be redirected to an Authorization page. It should mention `payment_intent` on it

<img width="1061" alt="PR92936" src="https://github.com/user-attachments/assets/6a2a19a4-571f-4c36-b686-92552297ff54">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
