### PR TITLE
Update AI row on comparison page

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
@@ -308,7 +308,17 @@ export const useComparisonData = () => {
 						name: translate( 'AI' ),
 						url: links.ai,
 						icon: AIIcon,
-						info: allChecked,
+						info: {
+							FREE: {
+								content: translate( '20 free requests' ),
+							},
+							SECURITY: {
+								content: translate( '20 free requests' ),
+							},
+							COMPLETE: {
+								content: translate( '20 free requests' ),
+							},
+						},
 					},
 					{
 						id: 'blaze',


### PR DESCRIPTION
## Proposed Changes

* Show 20 free requests for AI for all 3 Jetpack plans

## Why are these changes being made?

We previously showed a checkmark implying there's unlimited AI for all plans, this is incorrect

## Testing Instructions

1. Open up the Calypso Green live link and go to `/features/comparison`
2. Confirm the AI row has been updated correctly
![image](https://github.com/user-attachments/assets/1f36073d-6d73-4f13-a5c4-81c3e582ee61)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
