### PR TITLE
Fix E2E test for P2 flow

### DIFF
--- a/test/e2e/specs/p2/p2__post.ts
+++ b/test/e2e/specs/p2/p2__post.ts
@@ -50,6 +50,8 @@ describe( DataHelper.createSuiteTitle( 'P2: Post' ), function () {
 
 	it( 'Submit post', async function () {
 		await isolatedBlockEditorComponent.submitPost();
+		// Click twice since the first "Publish" click will open the publish confirmation sidebar
+		await isolatedBlockEditorComponent.submitPost();
 	} );
 
 	it( 'Validate post submission was successful', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Gutenberg 18.8.0 rotation: https://github.com/Automattic/wp-calypso/issues/92543

## Proposed Changes

* We want to ensure e2e tests for P2 will work as expected

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the test `VIEWPORT_NAME=desktop GUTENBERG_EDGE=false TEST_ON_ATOMIC=false yarn workspace wp-e2e-tests test -- specs/p2/p2__post.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
