### PR TITLE
Sites dashboard - remove click from area around site actions ellipsis.

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/sites-site-actions.tsx
+++ b/client/hosting/sites/components/sites-dataviews/sites-site-actions.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled';
 import { useInView } from 'react-intersection-observer';
 import { SitesEllipsisMenu } from 'calypso/sites-dashboard/components/sites-ellipsis-menu';
 import type { SiteExcerptData } from '@automattic/sites';
@@ -7,18 +6,11 @@ interface SiteActionsProps {
 	site: SiteExcerptData;
 }
 
-const SiteActionsDiv = styled.div`
-	flex: 1;
-	justify-content: 'end';
-`;
-
 export const SiteActions = ( { site }: SiteActionsProps ) => {
 	const { ref, inView } = useInView( { triggerOnce: true } );
 	if ( site.is_deleted ) {
 		return false;
 	}
 
-	return (
-		<SiteActionsDiv ref={ ref }>{ inView && <SitesEllipsisMenu site={ site } /> }</SiteActionsDiv>
-	);
+	return <div ref={ ref }>{ inView && <SitesEllipsisMenu site={ site } /> }</div>;
 };

--- a/client/hosting/sites/components/sites-dataviews/style.scss
+++ b/client/hosting/sites/components/sites-dataviews/style.scss
@@ -1,6 +1,15 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.dataviews-view-table__row td:last-of-type {
+	pointer-events: none;
+
+	button,
+	a {
+		pointer-events: auto;
+	}
+}
+
 .sites-dataviews__site {
 	display: flex;
 	flex-direction: row;

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -262,17 +262,13 @@ const SiteMenuGroup = styled( MenuGroup )( {
 } );
 
 const SiteDropdownMenu = styled( DropdownMenu )( {
-	display: 'block',
-
 	'> .components-button': {
-		padding: '8px 0',
-		margin: '8px 0',
+		padding: 8,
+		margin: -8,
 		minWidth: 0,
 		color: 'var( --color-text-subtle )',
 		height: 'auto',
 		verticalAlign: 'middle',
-		width: '100%',
-		justifyContent: 'end',
 	},
 } );
 

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -263,11 +263,11 @@ const SiteMenuGroup = styled( MenuGroup )( {
 
 const SiteDropdownMenu = styled( DropdownMenu )( {
 	'> .components-button': {
-		padding: 8,
-		margin: -8,
+		height: '44px',
+		width: '44px',
+		marginRight: '-12px',
 		minWidth: 0,
 		color: 'var( --color-text-subtle )',
-		height: 'auto',
 		verticalAlign: 'middle',
 	},
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #  Automattic/dotcom-forge#8431

## Proposed Changes

* Undoes changes from https://github.com/Automattic/wp-calypso/pull/92881
* Updates the ellipsis menu button here to be the minimum recommended size for touch interaction (44x44), and reshapes square for better look with focus styles.
* Removes pointer events from the last table data section to prevent the onClick (open overview) that is set to the table row from firing here, while still allowing them for interior buttons and anchors.

BEFORE

![table-ellipsis-before](https://github.com/user-attachments/assets/248afcc5-d6d2-422e-97fe-0ca1ee07d18c)


AFTER

![table-clicky-after](https://github.com/user-attachments/assets/50553f5b-fd5c-47e9-a4f6-c191e7fb7bfd)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The touch interaction is too easy to misclick, since the area surrounding the ellispsis menu has a different onClick handler for the entire table row.
* The button to toggle the ellipsis menu is shaped awkward and out of balance, making the focus styles for a11y look poor.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the sites dashboard.
* Click just outside the ellipsis menu. the overview should not open.
* Click inside the ellipsis menu, the site actions should open. Verify these continue to work as expected.
* Click outisde the site actions area in the row, verify overview is still opened.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
