### PR TITLE
Site Migration: Update the Tools>Import> Wordpress link to import or migrate screen

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -86,7 +86,7 @@ function getConfig( {
 			}
 		),
 		overrideDestination:
-			'/setup/site-migration?siteSlug=%SITE_SLUG%&siteId=%SITE_ID%&ref=calypso-importer',
+			'/setup/site-migration/site-migration-import-or-migrate?siteSlug=%SITE_SLUG%&siteId=%SITE_ID%&ref=calypso-importer',
 		weight: 1,
 	};
 


### PR DESCRIPTION


Closes #92725

## Proposed Changes

* Update the Tools>Import> Wordpress Link to point to import-or-migrate step

## Why are these changes being made?
* As explained on the issue, we are requiring redundant clicks to have the user import its site content. This PR redirects the user directly to the Import or Migrate step and if they select "import" the flows go directly to the import file step.

## Testing Instructions
* Access the`/home/[siteSLug]`  using simple site.
* Click on Tools>Import > WordPress
* Check if you are not one the Import or Migrate screen
* Try to follow both paths to see they are finished with success.

> [!NOTE]  
> The `from=` is not available in this flow, so the instructions page will be a bit different, not showing the from site preview.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
