### PR TITLE
Site Migration: Add step to gather source site url for assisted migrations if one has not been provided

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -4,6 +4,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Icon, globe, group, shield, backup } from '@wordpress/icons';
 import { createElement, useEffect } from 'react';
+import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -24,6 +25,8 @@ const ImporterMigrateMessage: Step = () => {
 	const siteSlugParam = useSiteSlugParam();
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const siteSlug = siteSlugParam ?? '';
+	const { getSiteSetting } = useSiteSettings( siteSlug );
+	const sourceSiteUrl = getSiteSetting( 'migration_source_site_domain' ) ?? fromUrl ?? '';
 	const { isPending, sendTicket } = useSubmitMigrationTicket();
 
 	useEffect( () => {
@@ -32,7 +35,7 @@ const ImporterMigrateMessage: Step = () => {
 		} );
 		sendTicket( {
 			locale,
-			from_url: fromUrl,
+			from_url: sourceSiteUrl,
 			blog_url: siteSlug,
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -57,7 +60,7 @@ const ImporterMigrateMessage: Step = () => {
 									),
 									{
 										email: user?.email,
-										webSite: fromUrl,
+										webSite: sourceSiteUrl,
 									}
 								),
 								{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
@@ -1,84 +1,31 @@
-import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { StepContainer, Title, SubTitle } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, useEffect, useState, useCallback } from 'react';
 import CaptureInput from 'calypso/blocks/import/capture/capture-input';
-import ScanningStep from 'calypso/blocks/import/scanning';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
-import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
-import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
 import type { Step } from '../../types';
 import type { UrlData } from 'calypso/blocks/import/types';
 
 import './style.scss';
-
-interface HostingDetailsProps {
-	items: { title: string; description: string }[];
-}
-
-const HostingDetails: FC< HostingDetailsProps > = ( { items } ) => {
-	const translate = useTranslate();
-
-	return (
-		<div className="import__site-identify-hosting-details">
-			<p className="import__site-identify-hosting-details--title">
-				{ translate( 'Why should you host with us?' ) }
-			</p>
-			<div className="import__site-identify-hosting-details--list">
-				{ items.map( ( item, index ) => (
-					<div key={ index } className="import__site-identify-hosting-details--list-item">
-						<p className="import__site-identify-hosting-details--list-item-title">{ item.title }</p>
-						<p className="import__site-identify-hosting-details--list-item-description">
-							{ item.description }
-						</p>
-					</div>
-				) ) }
-			</div>
-		</div>
-	);
-};
-
 interface Props {
 	hasError?: boolean;
 	onComplete: ( siteInfo: UrlData ) => void;
-	onSkip: () => void;
-	hideImporterListLink: boolean;
 }
 
-export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
+export const Analyzer: FC< Props > = ( { onComplete } ) => {
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
 
-	// TODO: Remove extra steps for non-English locales once we have translations -- title.
-	const titleInUse = hasEnTranslation( 'Let’s find your site' )
-		? translate( 'Let’s find your site' )
-		: translate( 'Let’s import your content' );
+	const title = translate( 'Share your site address' );
+	const subtitle = translate(
+		"Let's get your migration started. Please share your site address so we can review your site and begin your migration."
+	);
 
-	// TODO: Remove extra steps for non-English locales once we have translations -- subtitle.
-	const subtitleInUse = hasEnTranslation(
-		"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
-	)
-		? translate(
-				"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
-		  )
-		: translate( 'Drop your current site address below to get started.' );
-
-	// TODO: Remove extra steps for non-English locales once we have translations -- CTA text.
-	const nextLabelText = hasEnTranslation( 'Check my site' ) ? translate( 'Check my site' ) : false;
-	const nextLabelProp = nextLabelText ? { nextLabelText } : {}; // If we don't pass anything, the default label 'Continue' will be used.
-
-	const {
-		data: siteInfo,
-		isError: hasError,
-		isFetching,
-		isFetched,
-	} = useAnalyzeUrlQuery( siteURL, siteURL !== '' );
+	const { data: siteInfo, isError: hasError } = useAnalyzeUrlQuery( siteURL, siteURL !== '' );
 
 	useEffect( () => {
 		if ( siteInfo ) {
@@ -86,50 +33,11 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		}
 	}, [ onComplete, siteInfo ] );
 
-	if ( isFetching || ( isFetched && ! hasError ) ) {
-		return <ScanningStep />;
-	}
-
-	// TODO: Remove extra steps and properties for non-English locales once we have translations -- hosting details.
-	const hostingDetailItems = {
-		'unmatched-uptime': {
-			title: translate( 'Unmatched Reliability and Uptime' ),
-			titleString: 'Unmatched Reliability and Uptime', // Temporary string for non-English locales. Remove once we have translations.
-			description: translate(
-				"Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure."
-			),
-			descriptionString:
-				"Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure.", // Temporary string for non-English locales. Remove once we have translations.
-		},
-		'effortless-customization': {
-			title: translate( 'Effortless Customization' ),
-			titleString: 'Effortless Customization',
-			description: translate(
-				'Our tools and options let you easily design a website to meet your needs, whether you’re a beginner or an expert.'
-			),
-			descriptionString:
-				'Our tools and options let you easily design a website to meet your needs, whether you’re a beginner or an expert.',
-		},
-		'blazing-fast-speed': {
-			title: translate( 'Blazing Fast Page Speed' ),
-			titleString: 'Blazing Fast Page Speed',
-			description: translate(
-				'Our global CDN with 28+ locations delivers lightning-fast load times for a seamless visitor experience.'
-			),
-			descriptionString:
-				'Our global CDN with 28+ locations delivers lightning-fast load times for a seamless visitor experience.',
-		},
-	};
-
-	const hasTranslationsForAllItems = Object.values( hostingDetailItems ).every(
-		( item ) => hasEnTranslation( item.titleString ) && hasEnTranslation( item.descriptionString )
-	);
-
 	return (
 		<div className="import__capture-wrapper">
 			<div className="import__heading import__heading-center">
-				<Title>{ titleInUse }</Title>
-				<SubTitle>{ subtitleInUse }</SubTitle>
+				<Title>{ title }</Title>
+				<SubTitle>{ subtitle }</SubTitle>
 			</div>
 			<div className="import__capture-container">
 				<CaptureInput
@@ -137,19 +45,11 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 					onInputChange={ () => setSiteURL( '' ) }
 					hasError={ hasError }
 					skipInitialChecking
-					onDontHaveSiteAddressClick={ onSkip }
 					placeholder={ translate( 'mygreatnewblog.com' ) }
 					label={ translate( 'Enter your site address:' ) }
-					dontHaveSiteAddressLabel={ translate(
-						'Or <button>pick your current platform from a list</button>'
-					) }
-					hideImporterListLink={ hideImporterListLink }
-					{ ...nextLabelProp }
+					hideImporterListLink
 				/>
 			</div>
-			{ hasTranslationsForAllItems && (
-				<HostingDetails items={ Object.values( hostingDetailItems ) } />
-			) }
 		</div>
 	);
 };
@@ -168,10 +68,9 @@ const saveSiteSettings = async ( siteSlug: string, settings: Record< string, unk
 	);
 };
 
-const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
+const SiteMigrationIdentify: Step = function ( { navigation } ) {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
-	const { createScreenshots } = useSitePreviewMShotImageHandler();
 
 	const handleSubmit = useCallback(
 		async ( action: SiteMigrationIdentifyAction, data?: { platform: string; from: string } ) => {
@@ -181,28 +80,10 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 				await saveSiteSettings( siteSlug, { migration_source_site_domain: data.from } );
 			}
 
-			// If we have a URL of the source, we send requests to the mShots API to create screenshots
-			// early in the flow to avoid long loading times in the migration instructions step.
-			// Because mShots API can often take a long time to generate screenshots.
-			if ( data?.from ) {
-				createScreenshots( data?.from );
-			}
-
 			navigation?.submit?.( { action, ...data } );
 		},
 		[ navigation, siteSlug ]
 	);
-
-	const urlQueryParams = useQuery();
-
-	const shouldHideBackButton = () => {
-		const ref = urlQueryParams.get( 'ref' ) || '';
-		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'calypso-importer' ].includes( ref );
-		const shouldHideBasedOnVariant = [ HOSTED_SITE_MIGRATION_FLOW ].includes( variantSlug || '' );
-		const shouldNotHideBasedOnRef = [ GUIDED_ONBOARDING_FLOW_REFERRER ].includes( ref );
-
-		return ( shouldHideBasedOnRef || shouldHideBasedOnVariant ) && ! shouldNotHideBasedOnRef;
-	};
 
 	return (
 		<>
@@ -211,7 +92,7 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 				stepName="site-migration-identify"
 				flowName="site-migration"
 				className="import__onboarding-page"
-				hideBack={ shouldHideBackButton() }
+				hideBack={ false }
 				hideSkip
 				hideFormattedHeader
 				goBack={ navigation?.goBack }
@@ -222,10 +103,6 @@ const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
 						onComplete={ ( { platform, url } ) =>
 							handleSubmit( 'continue', { platform, from: url } )
 						}
-						hideImporterListLink={ urlQueryParams.get( 'hide_importer_link' ) === 'true' }
-						onSkip={ () => {
-							handleSubmit( 'skip_platform_identification' );
-						} }
 					/>
 				}
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
@@ -71,11 +71,9 @@ const SiteMigrationSourceUrl: Step = function ( { navigation } ) {
 	const translate = useTranslate();
 
 	const handleSubmit = useCallback(
-		async ( action: string, data?: { platform: string; from: string } ) => {
-			// If we have a site and URL, and we're coming from a WordPress site,
-			// record the migration source domain.
-			// @todo: do we need the platform?
-			if ( siteSlug && 'wordpress' === data?.platform && data?.from ) {
+		async ( action: string, data?: { from: string } ) => {
+			// If we have a site and URL, record the migration source domain.
+			if ( siteSlug && data?.from ) {
 				await saveSiteSettings( siteSlug, { migration_source_site_domain: data.from } );
 			}
 
@@ -98,8 +96,8 @@ const SiteMigrationSourceUrl: Step = function ( { navigation } ) {
 				isFullLayout
 				stepContent={
 					<SourceSiteInput
-						onComplete={ ( { platform, url } ) =>
-							handleSubmit( 'skip_platform_identification', { platform, from: url } )
+						onComplete={ ( { url } ) =>
+							handleSubmit( 'skip_platform_identification', { from: url } )
 						}
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
@@ -54,8 +54,6 @@ export const Analyzer: FC< Props > = ( { onComplete } ) => {
 	);
 };
 
-export type SiteMigrationIdentifyAction = 'continue' | 'skip_platform_identification';
-
 const saveSiteSettings = async ( siteSlug: string, settings: Record< string, unknown > ) => {
 	return wpcom.req.post(
 		`/sites/${ siteSlug }/settings`,
@@ -68,14 +66,15 @@ const saveSiteSettings = async ( siteSlug: string, settings: Record< string, unk
 	);
 };
 
-const SiteMigrationIdentify: Step = function ( { navigation } ) {
+const SiteMigrationSourceUrl: Step = function ( { navigation } ) {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 
 	const handleSubmit = useCallback(
-		async ( action: SiteMigrationIdentifyAction, data?: { platform: string; from: string } ) => {
+		async ( action: string, data?: { platform: string; from: string } ) => {
 			// If we have a site and URL, and we're coming from a WordPress site,
 			// record the migration source domain.
+			// @todo: should we include the source URL for sites that aren't WP-based?
 			if ( siteSlug && 'wordpress' === data?.platform && data?.from ) {
 				await saveSiteSettings( siteSlug, { migration_source_site_domain: data.from } );
 			}
@@ -92,16 +91,15 @@ const SiteMigrationIdentify: Step = function ( { navigation } ) {
 				stepName="site-migration-identify"
 				flowName="site-migration"
 				className="import__onboarding-page"
-				hideBack={ false }
+				hideBack
 				hideSkip
 				hideFormattedHeader
-				goBack={ navigation?.goBack }
 				goNext={ navigation?.submit }
 				isFullLayout
 				stepContent={
 					<Analyzer
 						onComplete={ ( { platform, url } ) =>
-							handleSubmit( 'continue', { platform, from: url } )
+							handleSubmit( 'skip_platform_identification', { platform, from: url } )
 						}
 					/>
 				}
@@ -111,4 +109,4 @@ const SiteMigrationIdentify: Step = function ( { navigation } ) {
 	);
 };
 
-export default SiteMigrationIdentify;
+export default SiteMigrationSourceUrl;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
@@ -1,0 +1,237 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
+import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import { type FC, useEffect, useState, useCallback } from 'react';
+import CaptureInput from 'calypso/blocks/import/capture/capture-input';
+import ScanningStep from 'calypso/blocks/import/scanning';
+import DocumentHead from 'calypso/components/data/document-head';
+import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
+import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
+import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
+import type { Step } from '../../types';
+import type { UrlData } from 'calypso/blocks/import/types';
+
+import './style.scss';
+
+interface HostingDetailsProps {
+	items: { title: string; description: string }[];
+}
+
+const HostingDetails: FC< HostingDetailsProps > = ( { items } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="import__site-identify-hosting-details">
+			<p className="import__site-identify-hosting-details--title">
+				{ translate( 'Why should you host with us?' ) }
+			</p>
+			<div className="import__site-identify-hosting-details--list">
+				{ items.map( ( item, index ) => (
+					<div key={ index } className="import__site-identify-hosting-details--list-item">
+						<p className="import__site-identify-hosting-details--list-item-title">{ item.title }</p>
+						<p className="import__site-identify-hosting-details--list-item-description">
+							{ item.description }
+						</p>
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+interface Props {
+	hasError?: boolean;
+	onComplete: ( siteInfo: UrlData ) => void;
+	onSkip: () => void;
+	hideImporterListLink: boolean;
+}
+
+export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
+	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
+	const [ siteURL, setSiteURL ] = useState< string >( '' );
+
+	// TODO: Remove extra steps for non-English locales once we have translations -- title.
+	const titleInUse = hasEnTranslation( 'Let’s find your site' )
+		? translate( 'Let’s find your site' )
+		: translate( 'Let’s import your content' );
+
+	// TODO: Remove extra steps for non-English locales once we have translations -- subtitle.
+	const subtitleInUse = hasEnTranslation(
+		"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
+	)
+		? translate(
+				"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
+		  )
+		: translate( 'Drop your current site address below to get started.' );
+
+	// TODO: Remove extra steps for non-English locales once we have translations -- CTA text.
+	const nextLabelText = hasEnTranslation( 'Check my site' ) ? translate( 'Check my site' ) : false;
+	const nextLabelProp = nextLabelText ? { nextLabelText } : {}; // If we don't pass anything, the default label 'Continue' will be used.
+
+	const {
+		data: siteInfo,
+		isError: hasError,
+		isFetching,
+		isFetched,
+	} = useAnalyzeUrlQuery( siteURL, siteURL !== '' );
+
+	useEffect( () => {
+		if ( siteInfo ) {
+			onComplete( siteInfo );
+		}
+	}, [ onComplete, siteInfo ] );
+
+	if ( isFetching || ( isFetched && ! hasError ) ) {
+		return <ScanningStep />;
+	}
+
+	// TODO: Remove extra steps and properties for non-English locales once we have translations -- hosting details.
+	const hostingDetailItems = {
+		'unmatched-uptime': {
+			title: translate( 'Unmatched Reliability and Uptime' ),
+			titleString: 'Unmatched Reliability and Uptime', // Temporary string for non-English locales. Remove once we have translations.
+			description: translate(
+				"Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure."
+			),
+			descriptionString:
+				"Our infrastructure's 99.99% uptime, combined with our automatic update system, ensures your site remains accessible and secure.", // Temporary string for non-English locales. Remove once we have translations.
+		},
+		'effortless-customization': {
+			title: translate( 'Effortless Customization' ),
+			titleString: 'Effortless Customization',
+			description: translate(
+				'Our tools and options let you easily design a website to meet your needs, whether you’re a beginner or an expert.'
+			),
+			descriptionString:
+				'Our tools and options let you easily design a website to meet your needs, whether you’re a beginner or an expert.',
+		},
+		'blazing-fast-speed': {
+			title: translate( 'Blazing Fast Page Speed' ),
+			titleString: 'Blazing Fast Page Speed',
+			description: translate(
+				'Our global CDN with 28+ locations delivers lightning-fast load times for a seamless visitor experience.'
+			),
+			descriptionString:
+				'Our global CDN with 28+ locations delivers lightning-fast load times for a seamless visitor experience.',
+		},
+	};
+
+	const hasTranslationsForAllItems = Object.values( hostingDetailItems ).every(
+		( item ) => hasEnTranslation( item.titleString ) && hasEnTranslation( item.descriptionString )
+	);
+
+	return (
+		<div className="import__capture-wrapper">
+			<div className="import__heading import__heading-center">
+				<Title>{ titleInUse }</Title>
+				<SubTitle>{ subtitleInUse }</SubTitle>
+			</div>
+			<div className="import__capture-container">
+				<CaptureInput
+					onInputEnter={ setSiteURL }
+					onInputChange={ () => setSiteURL( '' ) }
+					hasError={ hasError }
+					skipInitialChecking
+					onDontHaveSiteAddressClick={ onSkip }
+					placeholder={ translate( 'mygreatnewblog.com' ) }
+					label={ translate( 'Enter your site address:' ) }
+					dontHaveSiteAddressLabel={ translate(
+						'Or <button>pick your current platform from a list</button>'
+					) }
+					hideImporterListLink={ hideImporterListLink }
+					{ ...nextLabelProp }
+				/>
+			</div>
+			{ hasTranslationsForAllItems && (
+				<HostingDetails items={ Object.values( hostingDetailItems ) } />
+			) }
+		</div>
+	);
+};
+
+export type SiteMigrationIdentifyAction = 'continue' | 'skip_platform_identification';
+
+const saveSiteSettings = async ( siteSlug: string, settings: Record< string, unknown > ) => {
+	return wpcom.req.post(
+		`/sites/${ siteSlug }/settings`,
+		{
+			apiVersion: '1.4',
+		},
+		{
+			...settings,
+		}
+	);
+};
+
+const SiteMigrationIdentify: Step = function ( { navigation, variantSlug } ) {
+	const siteSlug = useSiteSlug();
+	const translate = useTranslate();
+	const { createScreenshots } = useSitePreviewMShotImageHandler();
+
+	const handleSubmit = useCallback(
+		async ( action: SiteMigrationIdentifyAction, data?: { platform: string; from: string } ) => {
+			// If we have a site and URL, and we're coming from a WordPress site,
+			// record the migration source domain.
+			if ( siteSlug && 'wordpress' === data?.platform && data?.from ) {
+				await saveSiteSettings( siteSlug, { migration_source_site_domain: data.from } );
+			}
+
+			// If we have a URL of the source, we send requests to the mShots API to create screenshots
+			// early in the flow to avoid long loading times in the migration instructions step.
+			// Because mShots API can often take a long time to generate screenshots.
+			if ( data?.from ) {
+				createScreenshots( data?.from );
+			}
+
+			navigation?.submit?.( { action, ...data } );
+		},
+		[ navigation, siteSlug ]
+	);
+
+	const urlQueryParams = useQuery();
+
+	const shouldHideBackButton = () => {
+		const ref = urlQueryParams.get( 'ref' ) || '';
+		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'calypso-importer' ].includes( ref );
+		const shouldHideBasedOnVariant = [ HOSTED_SITE_MIGRATION_FLOW ].includes( variantSlug || '' );
+		const shouldNotHideBasedOnRef = [ GUIDED_ONBOARDING_FLOW_REFERRER ].includes( ref );
+
+		return ( shouldHideBasedOnRef || shouldHideBasedOnVariant ) && ! shouldNotHideBasedOnRef;
+	};
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'Share your site address' ) } />
+			<StepContainer
+				stepName="site-migration-identify"
+				flowName="site-migration"
+				className="import__onboarding-page"
+				hideBack={ shouldHideBackButton() }
+				hideSkip
+				hideFormattedHeader
+				goBack={ navigation?.goBack }
+				goNext={ navigation?.submit }
+				isFullLayout
+				stepContent={
+					<Analyzer
+						onComplete={ ( { platform, url } ) =>
+							handleSubmit( 'continue', { platform, from: url } )
+						}
+						hideImporterListLink={ urlQueryParams.get( 'hide_importer_link' ) === 'true' }
+						onSkip={ () => {
+							handleSubmit( 'skip_platform_identification' );
+						} }
+					/>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default SiteMigrationIdentify;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 	onComplete: ( siteInfo: UrlData ) => void;
 }
 
-export const Analyzer: FC< Props > = ( { onComplete } ) => {
+export const SourceSiteInput: FC< Props > = ( { onComplete } ) => {
 	const translate = useTranslate();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
 
@@ -74,7 +74,7 @@ const SiteMigrationSourceUrl: Step = function ( { navigation } ) {
 		async ( action: string, data?: { platform: string; from: string } ) => {
 			// If we have a site and URL, and we're coming from a WordPress site,
 			// record the migration source domain.
-			// @todo: should we include the source URL for sites that aren't WP-based?
+			// @todo: do we need the platform?
 			if ( siteSlug && 'wordpress' === data?.platform && data?.from ) {
 				await saveSiteSettings( siteSlug, { migration_source_site_domain: data.from } );
 			}
@@ -97,7 +97,7 @@ const SiteMigrationSourceUrl: Step = function ( { navigation } ) {
 				goNext={ navigation?.submit }
 				isFullLayout
 				stepContent={
-					<Analyzer
+					<SourceSiteInput
 						onComplete={ ( { platform, url } ) =>
 							handleSubmit( 'skip_platform_identification', { platform, from: url } )
 						}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/style.scss
@@ -56,22 +56,6 @@
 			}
 		}
 	}
-
-	.action-buttons__importer-list {
-		font-size: 0.875rem;
-		font-weight: 400;
-		text-align: center;
-		text-decoration: none;
-		color: var(--studio-gray-90);
-		margin-top: 1rem;
-
-		button {
-			text-decoration: underline;
-			color: inherit;
-			margin: 0;
-			padding: 0;
-		}
-	}
 }
 
 .import__capture-wrapper {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/style.scss
@@ -1,0 +1,83 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.import__capture-container {
+	max-width: 368px;
+	margin: 0 auto;
+}
+
+.import__capture {
+	.form-label {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--studio-gray-60);
+		margin-bottom: 0.5rem;
+
+		span {
+			font-weight: normal;
+			color: var(--studio-gray-40);
+		}
+	}
+
+	.form-fieldset {
+		margin-bottom: 1em;
+	}
+
+	input[type="text"].form-text-input {
+		font-size: 0.875rem;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		line-height: 2rem;
+		color: var(--studio-gray-90);
+		border-radius: 4px;
+		border-color: var(--studio-gray-10);
+	}
+
+	input[type="text"].form-text-input::placeholder {
+		color: var(--studio-gray-30);
+	}
+
+	button[type="submit"] {
+		width: 100%;
+	}
+
+	.form-setting-explanation {
+		font-style: normal;
+
+		svg {
+			position: relative;
+			top: 4px;
+		}
+
+		.is-error {
+			color: var(--color-error);
+
+			svg {
+				fill: var(--color-error);
+				transform: rotate(180deg);
+			}
+		}
+	}
+
+	.action-buttons__importer-list {
+		font-size: 0.875rem;
+		font-weight: 400;
+		text-align: center;
+		text-decoration: none;
+		color: var(--studio-gray-90);
+		margin-top: 1rem;
+
+		button {
+			text-decoration: underline;
+			color: inherit;
+			margin: 0;
+			padding: 0;
+		}
+	}
+}
+
+.import__capture-wrapper {
+	margin-bottom: 60px;
+
+	@media (min-width: $break-small) {
+		margin-bottom: 0;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -260,6 +260,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-migration-how-to-migrate' ),
 	},
 
+	SITE_MIGRATION_SOURCE_URL: {
+		slug: 'site-migration-source-url',
+		asyncComponent: () => import( './steps-repository/site-migration-source-url' ),
+	},
+
 	SITE_MIGRATION_UPGRADE_PLAN: {
 		slug: 'site-migration-upgrade-plan',
 		asyncComponent: () => import( './steps-repository/site-migration-upgrade-plan' ),

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -47,6 +47,7 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_STARTED,
 			STEPS.ERROR,
 			STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+			STEPS.SITE_MIGRATION_SOURCE_URL,
 		];
 
 		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME )
@@ -337,7 +338,12 @@ const siteMigration: Flow = {
 							providedDependencies?.userAcceptedDeal ||
 							urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME
 						) {
-							redirectAfterCheckout = STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug;
+							// If the user selected "Do it for me" but has not given us a source site, we should take them to the source URL step.
+							if ( ! fromQueryParam ) {
+								redirectAfterCheckout = STEPS.SITE_MIGRATION_SOURCE_URL.slug;
+							} else {
+								redirectAfterCheckout = STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug;
+							}
 						}
 
 						const destination = addQueryArgs(
@@ -377,6 +383,14 @@ const siteMigration: Flow = {
 							siteSlug,
 						} );
 					}
+				}
+
+				case STEPS.SITE_MIGRATION_SOURCE_URL.slug: {
+					// Navigate to the assisted migration step.
+					return navigate( STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug, {
+						siteId,
+						siteSlug,
+					} );
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92731

## Proposed Changes

* After checkout, if a user has selected an assisted migration but has not input a source site URL, redirect to a step that prompts them to enter the source site URL.
* This step has all the benefits of the same component for URL validation.

Open question; do we need to worry about the platform at this stage? Does the URL need to be WordPress-based before we'll save it to site settings/allow the user to proceed?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* p1721123488820649/1721122890.137469-slack-C06PZC1RR5F

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please note, testing these flows may cause tickets to be sent to the WP.com Migrations queue in ZenDesk. Before testing, let folks in #dotcom-developer-and-migration-support know that you'll be testing and they can ignore/close your tickets.

**Test with a source site provided:**

* Switch to this branch, navigate to `/start`
* Select import at the site intention step
* Enter your URL
* Select Migrate Site
* Select Do it for me
* Check out
* You should be brought to the final assisted migration screen with the URL filled out

<img width="1448" alt="Screenshot 2024-07-24 at 2 36 46 PM" src="https://github.com/user-attachments/assets/9d1ff4d7-0a15-4f7b-ba7e-81d9d9029658">

**Test without a source site provided:**

* Switch to this branch, navigate to `/start`
* Select import at the site intention step
* Do not enter a URL; instead, select Pick your current platform from a list
* Choose WordPress
* Select Migrate Site
* Select Do it for me
* Check out
* You should be shown the source site URL collection screen:

<img width="1450" alt="Screenshot 2024-07-24 at 2 39 21 PM" src="https://github.com/user-attachments/assets/f60eedbc-fda4-46ee-824c-4506b43833e1">

* Putting in an incorrect or invalid URL should show warning messages.
* You shouldn't be able to skip this screen or go back.
* Upon putting in a valid URL, you should be brought to the final assisted migration screen with the URL filled out:

<img width="1448" alt="Screenshot 2024-07-24 at 2 36 46 PM" src="https://github.com/user-attachments/assets/9d1ff4d7-0a15-4f7b-ba7e-81d9d9029658">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?