### PR TITLE
Revert "Adding retry for e2e test when receiving error_unclear_prompt response from backend"

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -47,23 +47,8 @@ export class FormAiFlow implements BlockFlow {
 		} );
 		await aiInputReadyLocator.fill( this.configurationData.prompt );
 		await sendButtonLocator.click();
-		await aiInputBusyLocator.waitFor( { state: 'detached' } );
-
-		// Check if we got an error_unclear_prompt and try it again
-		// TODO: Remove this when this bug is fixed: https://github.com/Automattic/wp-calypso/issues/92927
-		for ( let i = 0; i < 5; i++ ) {
-			const errorLocator = await aiInputParentLocator.getByText(
-				'Error: Your request was unclear. Mind trying again?'
-			);
-
-			if ( await errorLocator.count() ) {
-				await sendButtonLocator.click();
-				await aiInputBusyLocator.waitFor( { state: 'detached' } );
-			} else {
-				break;
-			}
-		}
-
+		await aiInputBusyLocator.waitFor();
+		await aiInputReadyLocator.waitFor( { timeout: 30 * 1000 } );
 		// Grab a first sample input label and submit button text to use for validation.
 		this.validationData = {
 			sampleInputLabel: await this.getFirstTextFieldLabel( context ),

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-ai.ts
@@ -47,8 +47,7 @@ export class FormAiFlow implements BlockFlow {
 		} );
 		await aiInputReadyLocator.fill( this.configurationData.prompt );
 		await sendButtonLocator.click();
-		await aiInputBusyLocator.waitFor();
-		await aiInputReadyLocator.waitFor( { timeout: 30 * 1000 } );
+		await aiInputBusyLocator.waitFor( { state: 'detached' } );
 		// Grab a first sample input label and submit button text to use for validation.
 		this.validationData = {
 			sampleInputLabel: await this.getFirstTextFieldLabel( context ),

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/opentable.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/opentable.ts
@@ -48,7 +48,7 @@ export class OpenTableFlow implements BlockFlow {
 		 * Due to API inconsistency of OpenTable, we need to try a few times to get the correct restaurant.
 		 * https://github.com/Automattic/wp-calypso/issues/92836
 		 */
-		for ( let i = 0; i < 10; i++ ) {
+		for ( let i = 0; i < 5; i++ ) {
 			try {
 				await searchLocator.fill( restaurant );
 				const suggestionLocator = editorCanvas

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/opentable.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/opentable.ts
@@ -48,7 +48,7 @@ export class OpenTableFlow implements BlockFlow {
 		 * Due to API inconsistency of OpenTable, we need to try a few times to get the correct restaurant.
 		 * https://github.com/Automattic/wp-calypso/issues/92836
 		 */
-		for ( let i = 0; i < 5; i++ ) {
+		for ( let i = 0; i < 10; i++ ) {
 			try {
 				await searchLocator.fill( restaurant );
 				const suggestionLocator = editorCanvas


### PR DESCRIPTION
Reverts Automattic/wp-calypso#92932
Related to https://github.com/Automattic/wp-calypso/issues/92927

After these changes (p1721846440633919/1721823789.641259-slack-C054LN8RNVA) we ran this test 15 times with no failure so we can remove the workaround created.