### PR TITLE
Add migration instructions fallback

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -2,7 +2,7 @@ import { captureException } from '@automattic/calypso-sentry';
 import { CircularProgressBar } from '@automattic/components';
 import { LaunchpadContainer } from '@automattic/launchpad';
 import { StepContainer } from '@automattic/onboarding';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-migration-sticker';
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { usePrepareSiteForMigration } from 'calypso/landing/stepper/hooks/use-prepare-site-for-migration';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -96,8 +96,11 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 		migrationKey,
 		error: setupError,
 	} = usePrepareSiteForMigration( siteId );
+	const migrationKeyStatus = detailedStatus.migrationKey;
+
+	// Register events and logs.
 	usePreparationEventsAndLogs( {
-		migrationKeyStatus: detailedStatus.migrationKey,
+		migrationKeyStatus,
 		preparationCompleted,
 		fromUrl,
 		flow,
@@ -113,9 +116,13 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 	const onCompleteSteps = () => {
 		navigation.submit?.( { destination: 'migration-started' } );
 	};
+
+	const showMigrationKeyFallback = migrationKeyStatus === 'error' && preparationCompleted;
+
 	const { steps, completedSteps } = useSteps( {
 		fromUrl,
 		migrationKey: migrationKey ?? '',
+		showMigrationKeyFallback,
 		onComplete: onCompleteSteps,
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -122,6 +122,7 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 	const { steps, completedSteps } = useSteps( {
 		fromUrl,
 		migrationKey: migrationKey ?? '',
+		preparationError,
 		showMigrationKeyFallback,
 		onComplete: onCompleteSteps,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -23,18 +23,18 @@ import './style.scss';
 interface PreparationEventsHookOptions {
 	migrationKeyStatus: Status;
 	preparationCompleted: boolean;
+	preparationError: Error | null;
 	fromUrl: string;
 	flow: string;
-	setupError: Error | null;
 	siteId: number;
 }
 
 const usePreparationEventsAndLogs = ( {
 	migrationKeyStatus,
 	preparationCompleted,
+	preparationError,
 	fromUrl,
 	flow,
-	setupError,
 	siteId,
 }: PreparationEventsHookOptions ) => {
 	useEffect( () => {
@@ -55,10 +55,10 @@ const usePreparationEventsAndLogs = ( {
 	}, [ preparationCompleted ] );
 
 	useEffect( () => {
-		if ( setupError ) {
-			const logError = setupError as unknown as { path: string; message: string };
+		if ( preparationError ) {
+			const logError = preparationError as unknown as { path: string; message: string };
 
-			captureException( setupError, {
+			captureException( preparationError, {
 				extra: {
 					message: logError?.message,
 					path: logError?.path,
@@ -72,7 +72,7 @@ const usePreparationEventsAndLogs = ( {
 				},
 			} );
 		}
-	}, [ flow, setupError, siteId ] );
+	}, [ flow, preparationError, siteId ] );
 };
 
 const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
@@ -93,8 +93,8 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 	const {
 		detailedStatus,
 		completed: preparationCompleted,
+		error: preparationError,
 		migrationKey,
-		error: setupError,
 	} = usePrepareSiteForMigration( siteId );
 	const migrationKeyStatus = detailedStatus.migrationKey;
 
@@ -102,9 +102,9 @@ const SiteMigrationInstructions: Step = function ( { navigation, flow } ) {
 	usePreparationEventsAndLogs( {
 		migrationKeyStatus,
 		preparationCompleted,
+		preparationError,
 		fromUrl,
 		flow,
-		setupError,
 		siteId,
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key-fallback.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key-fallback.tsx
@@ -1,0 +1,38 @@
+import { ExternalLink } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { recordMigrationInstructionsLinkClick } from '../tracking';
+import { getMigrateGuruPageURL } from './utils';
+import type { FC } from 'react';
+
+export const StepAddMigrationKeyFallback: FC = () => {
+	const translate = useTranslate();
+	const site = useSite();
+	const siteUrl = site?.URL ?? '';
+
+	return (
+		<p>
+			{ translate(
+				'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
+				{
+					components: {
+						a: (
+							<ExternalLink
+								href={ getMigrateGuruPageURL( siteUrl ) }
+								icon
+								iconSize={ 14 }
+								target="_blank"
+								onClick={ () => recordMigrationInstructionsLinkClick( 'copy-key-fallback' ) }
+							/>
+						),
+						strong: <strong />,
+					},
+					args: {
+						migrationKeyLabel: 'Migrate Guru Migration Key',
+						migrateLabel: 'Migrate',
+					},
+				}
+			) }
+		</p>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key.tsx
@@ -1,19 +1,25 @@
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { MigrationKeyInput } from '../migration-key-input';
 import type { FC } from 'react';
 
 interface Props {
 	migrationKey: string;
+	preparationError: Error | null;
 }
 
-export const StepAddMigrationKey: FC< Props > = ( { migrationKey } ) => {
+export const StepAddMigrationKey: FC< Props > = ( { migrationKey, preparationError } ) => {
 	const translate = useTranslate();
 
 	if ( '' === migrationKey ) {
 		return (
 			<>
 				<p>{ translate( 'The key will be available here when your new site is ready.' ) }</p>
-				<div className="migration-key-skeleton" />
+				<div
+					className={ clsx( 'migration-key-skeleton', {
+						'migration-key-skeleton--animate': ! preparationError,
+					} ) }
+				/>
 			</>
 		);
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-add-migration-key.tsx
@@ -1,0 +1,37 @@
+import { useTranslate } from 'i18n-calypso';
+import { MigrationKeyInput } from '../migration-key-input';
+import type { FC } from 'react';
+
+interface Props {
+	migrationKey: string;
+}
+
+export const StepAddMigrationKey: FC< Props > = ( { migrationKey } ) => {
+	const translate = useTranslate();
+
+	if ( '' === migrationKey ) {
+		return (
+			<>
+				<p>{ translate( 'The key will be available here when your new site is ready.' ) }</p>
+				<div className="migration-key-skeleton" />
+			</>
+		);
+	}
+
+	return (
+		<>
+			<p>
+				{ translate(
+					'Copy and paste the migration key below in the {{strong}}%(migrationKeyLabel)s{{/strong}} field, customize any of the following migration options, and click {{strong}}%(migrateLabel)s{{/strong}}.',
+					{
+						components: {
+							strong: <strong />,
+						},
+						args: { migrationKeyLabel: 'Migrate Guru Migration Key', migrateLabel: 'Migrate' },
+					}
+				) }
+			</p>
+			<MigrationKeyInput value={ migrationKey } />
+		</>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-get-your-site-ready.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-get-your-site-ready.tsx
@@ -1,0 +1,48 @@
+import { ExternalLink } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { recordMigrationInstructionsLinkClick } from '../tracking';
+import { getMigrateGuruPageURL } from './utils';
+import type { FC } from 'react';
+
+interface Props {
+	fromUrl: string;
+}
+
+export const StepGetYourSiteReady: FC< Props > = ( { fromUrl } ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<p>
+				{ translate(
+					'Head to the {{a}}Migrate Guru plugin screen on your source site{{/a}}, enter your email address, and click {{strong}}%(migrateLabel)s{{/strong}}.',
+					{
+						components: {
+							strong: <strong />,
+							a: fromUrl ? (
+								<ExternalLink
+									href={ getMigrateGuruPageURL( fromUrl ) }
+									icon
+									iconSize={ 14 }
+									target="_blank"
+									onClick={ () => recordMigrationInstructionsLinkClick( 'go-to-plugin-page' ) }
+								/>
+							) : (
+								<strong />
+							),
+						},
+						args: { migrateLabel: 'Migrate' },
+					}
+				) }
+			</p>
+			<p>{ translate( 'Then, pick WordPress.com as your destination host.' ) }</p>
+			<p>
+				{ translate( 'All set? Click {{strong}}Next{{/strong}} below.', {
+					components: {
+						strong: <strong />,
+					},
+				} ) }
+			</p>
+		</>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-install-migation-guru.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/step-install-migation-guru.tsx
@@ -1,0 +1,35 @@
+import { ExternalLink } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { recordMigrationInstructionsLinkClick } from '../tracking';
+import { getPluginInstallationPage } from './utils';
+import type { FC } from 'react';
+
+interface Props {
+	fromUrl: string;
+}
+
+export const StepInstallMigrationGuru: FC< Props > = ( { fromUrl } ) => {
+	const translate = useTranslate();
+
+	return (
+		<p>
+			{ translate(
+				"First you'll need to install and activate the {{a}}Migrate Guru plugin{{/a}} on the site you want to migrate. Click {{strong}}Next{{/strong}} when you're ready.",
+				{
+					components: {
+						strong: <strong />,
+						a: (
+							<ExternalLink
+								href={ getPluginInstallationPage( fromUrl ) }
+								icon
+								iconSize={ 14 }
+								target="_blank"
+								onClick={ () => recordMigrationInstructionsLinkClick( 'install-plugin' ) }
+							/>
+						),
+					},
+				}
+			) }
+		</p>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/style.scss
@@ -20,7 +20,10 @@
 	width: 100%;
 	height: 40px;
 	border-radius: 4px;
-	animation: migration-key-skeleton__animation 1.6s ease-in-out infinite;
+
+	&.migration-key-skeleton--animate {
+		animation: migration-key-skeleton__animation 1.6s ease-in-out infinite;
+	}
 
 	&::after {
 		content: "";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/test/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/test/use-steps.tsx
@@ -8,6 +8,8 @@ describe( 'useSteps', () => {
 	const baseStepsOptions = {
 		fromUrl: 'https://mytestsite.com',
 		migrationKey: '123',
+		preparationError: null,
+		showMigrationKeyFallback: false,
 		onComplete: jest.fn(),
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
@@ -10,6 +10,7 @@ import type { Task, Expandable, ExpandableAction } from '@automattic/launchpad';
 interface StepsDataOptions {
 	fromUrl: string;
 	migrationKey: string;
+	preparationError: Error | null;
 	showMigrationKeyFallback: boolean;
 }
 
@@ -24,6 +25,7 @@ type StepsData = StepData[];
 interface StepsOptions {
 	fromUrl: string;
 	migrationKey: string;
+	preparationError: Error | null;
 	showMigrationKeyFallback: boolean;
 	onComplete: () => void;
 }
@@ -44,6 +46,7 @@ interface StepsObject {
 const useStepsData = ( {
 	fromUrl,
 	migrationKey,
+	preparationError,
 	showMigrationKeyFallback,
 }: StepsDataOptions ): StepsData => {
 	const translate = useTranslate();
@@ -65,7 +68,7 @@ const useStepsData = ( {
 			content: showMigrationKeyFallback ? (
 				<StepAddMigrationKeyFallback />
 			) : (
-				<StepAddMigrationKey migrationKey={ migrationKey } />
+				<StepAddMigrationKey migrationKey={ migrationKey } preparationError={ preparationError } />
 			),
 		},
 	];
@@ -74,13 +77,19 @@ const useStepsData = ( {
 export const useSteps = ( {
 	fromUrl,
 	migrationKey,
+	preparationError,
 	showMigrationKeyFallback,
 	onComplete,
 }: StepsOptions ): StepsObject => {
 	const translate = useTranslate();
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 	const [ lastCompleteStep, setLastCompleteStep ] = useState( -1 );
-	const stepsData = useStepsData( { fromUrl, migrationKey, showMigrationKeyFallback } );
+	const stepsData = useStepsData( {
+		fromUrl,
+		migrationKey,
+		preparationError,
+		showMigrationKeyFallback,
+	} );
 
 	const steps: Steps = stepsData.map( ( step, index, array ) => {
 		const recordCompletedStepEvent = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/use-steps.tsx
@@ -1,26 +1,11 @@
-import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { MigrationKeyInput } from '../migration-key-input';
-import { recordMigrationInstructionsLinkClick } from '../tracking';
+import { StepAddMigrationKey } from './step-add-migration-key';
+import { StepAddMigrationKeyFallback } from './step-add-migration-key-fallback';
+import { StepGetYourSiteReady } from './step-get-your-site-ready';
+import { StepInstallMigrationGuru } from './step-install-migation-guru';
 import type { Task, Expandable, ExpandableAction } from '@automattic/launchpad';
-
-const removeDuplicatedSlashes = ( url: string ) => url.replace( /(https?:\/\/)|(\/)+/g, '$1$2' );
-
-const getPluginInstallationPage = ( fromUrl: string ) => {
-	if ( fromUrl !== '' ) {
-		return removeDuplicatedSlashes(
-			`${ fromUrl }/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term`
-		);
-	}
-
-	return 'https://wordpress.org/plugins/migrate-guru/';
-};
-
-const getMigrateGuruPageURL = ( siteURL: string ) =>
-	removeDuplicatedSlashes( `${ siteURL }/wp-admin/admin.php?page=migrateguru` );
 
 interface StepsDataOptions {
 	fromUrl: string;
@@ -62,119 +47,25 @@ const useStepsData = ( {
 	showMigrationKeyFallback,
 }: StepsDataOptions ): StepsData => {
 	const translate = useTranslate();
-	const site = useSite();
-	const siteUrl = site?.URL ?? '';
 
 	return [
 		{
 			key: 'install-the-migrate-guru-plugin',
 			title: translate( 'Install the Migrate Guru plugin' ),
-			content: (
-				<p>
-					{ translate(
-						"First you'll need to install and activate the {{a}}Migrate Guru plugin{{/a}} on the site you want to migrate. Click {{strong}}Next{{/strong}} when you're ready.",
-						{
-							components: {
-								strong: <strong />,
-								a: (
-									<ExternalLink
-										href={ getPluginInstallationPage( fromUrl ) }
-										icon
-										iconSize={ 14 }
-										target="_blank"
-										onClick={ () => recordMigrationInstructionsLinkClick( 'install-plugin' ) }
-									/>
-								),
-							},
-						}
-					) }
-				</p>
-			),
+			content: <StepInstallMigrationGuru fromUrl={ fromUrl } />,
 		},
 		{
 			key: 'get-your-site-ready',
 			title: translate( 'Get your site ready' ),
-			content: (
-				<>
-					<p>
-						{ translate(
-							'Head to the {{a}}Migrate Guru plugin screen on your source site{{/a}}, enter your email address, and click {{strong}}%(migrateLabel)s{{/strong}}.',
-							{
-								components: {
-									strong: <strong />,
-									a: fromUrl ? (
-										<ExternalLink
-											href={ getMigrateGuruPageURL( fromUrl ) }
-											icon
-											iconSize={ 14 }
-											target="_blank"
-											onClick={ () => recordMigrationInstructionsLinkClick( 'go-to-plugin-page' ) }
-										/>
-									) : (
-										<strong />
-									),
-								},
-								args: { migrateLabel: 'Migrate' },
-							}
-						) }
-					</p>
-					<p>{ translate( 'Then, pick WordPress.com as your destination host.' ) }</p>
-					<p>
-						{ translate( 'All set? Click {{strong}}Next{{/strong}} below.', {
-							components: {
-								strong: <strong />,
-							},
-						} ) }
-					</p>
-				</>
-			),
+			content: <StepGetYourSiteReady fromUrl={ fromUrl } />,
 		},
 		{
 			key: 'add-your-migration-key',
 			title: translate( 'Add your migration key' ),
 			content: showMigrationKeyFallback ? (
-				<p>
-					{ translate(
-						'Go to the {{a}}Migrate Guru page on the new WordPress.com site{{/a}} and copy the migration key. Then paste it on the {{strong}}%(migrationKeyLabel)s{{/strong}} field of your existing site and click {{strong}}%(migrateLabel)s{{/strong}}.',
-						{
-							components: {
-								a: (
-									<ExternalLink
-										href={ getMigrateGuruPageURL( siteUrl ) }
-										icon
-										iconSize={ 14 }
-										target="_blank"
-									/>
-								),
-								strong: <strong />,
-							},
-							args: {
-								migrationKeyLabel: 'Migrate Guru Migration Key',
-								migrateLabel: 'Migrate',
-							},
-						}
-					) }
-				</p>
-			) : '' === migrationKey ? (
-				<>
-					<p>{ translate( 'The key will be available here when your new site is ready.' ) }</p>
-					<div className="migration-key-placeholder" />
-				</>
+				<StepAddMigrationKeyFallback />
 			) : (
-				<>
-					<p>
-						{ translate(
-							'Copy and paste the migration key below in the {{strong}}%(migrationKeyLabel)s{{/strong}} field, customize any of the following migration options, and click {{strong}}%(migrateLabel)s{{/strong}}.',
-							{
-								components: {
-									strong: <strong />,
-								},
-								args: { migrationKeyLabel: 'Migrate Guru Migration Key', migrateLabel: 'Migrate' },
-							}
-						) }
-					</p>
-					<MigrationKeyInput value={ migrationKey } />
-				</>
+				<StepAddMigrationKey migrationKey={ migrationKey } />
 			),
 		},
 	];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/steps/utils.ts
@@ -1,0 +1,14 @@
+const removeDuplicatedSlashes = ( url: string ) => url.replace( /(https?:\/\/)|(\/)+/g, '$1$2' );
+
+export const getPluginInstallationPage = ( fromUrl: string ) => {
+	if ( fromUrl !== '' ) {
+		return removeDuplicatedSlashes(
+			`${ fromUrl }/wp-admin/plugin-install.php?s=%2522migrate%2520guru%2522&tab=search&type=term`
+		);
+	}
+
+	return 'https://wordpress.org/plugins/migrate-guru/';
+};
+
+export const getMigrateGuruPageURL = ( siteURL: string ) =>
+	removeDuplicatedSlashes( `${ siteURL }/wp-admin/admin.php?page=migrateguru` );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -158,4 +158,58 @@ describe( 'SiteMigrationInstructions', () => {
 
 		expect( submit ).toHaveBeenCalledWith( { destination: 'migration-started' } );
 	} );
+
+	it( 'should display a fallback in the last step when preparation completes and there is an error with the migration key', async () => {
+		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
+			detailedStatus: { migrationKey: 'error' },
+			completed: true,
+			migrationKey: '',
+			error: null,
+		} );
+
+		const { getByRole } = render();
+
+		await userEvent.click( getByRole( 'button', { name: /Next/ } ) );
+		await userEvent.click( getByRole( 'button', { name: /Next/ } ) );
+
+		expect(
+			getByRole( 'link', { name: /Migrate Guru page on the new WordPress.com site/ } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should animate skeleton when waiting for completion', async () => {
+		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
+			detailedStatus: {},
+			completed: false,
+			migrationKey: '',
+			error: null,
+		} );
+
+		const { getByRole, container } = render();
+
+		await userEvent.click( getByRole( 'button', { name: /Next/ } ) );
+		await userEvent.click( getByRole( 'button', { name: /Next/ } ) );
+
+		const skeleton = container.querySelector( '.migration-key-skeleton' );
+
+		expect( skeleton!.classList.contains( 'migration-key-skeleton--animate' ) ).toBeTruthy();
+	} );
+
+	it( 'should not animate skeleton when error happens', async () => {
+		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
+			detailedStatus: {},
+			completed: false,
+			migrationKey: '',
+			error: new Error(),
+		} );
+
+		const { getByRole, container } = render();
+
+		await userEvent.click( getByRole( 'button', { name: /Next/ } ) );
+		await userEvent.click( getByRole( 'button', { name: /Next/ } ) );
+
+		const skeleton = container.querySelector( '.migration-key-skeleton' );
+
+		expect( skeleton!.classList.contains( 'migration-key-skeleton--animate' ) ).toBeFalsy();
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix report from pdtkmj-2OT-p2#comment-5368
Based off of https://github.com/Automattic/wp-calypso/pull/92876

## Proposed Changes

* Add a new fallback variation for when there's an error with the migration key and the users can fix it themselves.
* Refactor extracting components from `useSteps` to new files to organize better (most of the changes that you will see in this PR).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We missed the fallback scenario that existed in the previous version and it was reported in the CfT.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Replace the line `const showMigrationKeyFallback = migrationKeyStatus === 'error' && preparationCompleted;` with `const showMigrationKeyFallback = true`.
2. Navigate through the migration flow until the Migration Instructions step.
3. Click "Next" and "Next" to go the the last instruction step.
4. Check that you see a fallback with instructions to copy the key manually.

## Screenshots

<img width="395" alt="Screenshot 2024-07-26 at 17 46 02" src="https://github.com/user-attachments/assets/1142a66d-3c01-4aa1-8694-292ece85d94a">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?