### PR TITLE
Stats: Determine the paywall logic according to usage API directly

### DIFF
--- a/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
@@ -290,17 +290,7 @@ describe( 'shouldGateStats in Odyssey stats', () => {
 				planUsage: {
 					data: {
 						[ siteId ]: {
-							recent_usages: [
-								{
-									views_count: 1000,
-								},
-								{
-									views_count: 1001,
-								},
-								{
-									views_count: 1002,
-								},
-							],
+							should_show_paywall: true,
 						},
 					},
 				},

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -18,6 +18,8 @@ export interface PlanUsage {
 	current_tier: PriceTierListItemProps;
 	is_internal: boolean;
 	billable_monthly_views: number;
+	should_show_paywall: boolean;
+	paywall_date_from: string | null;
 	validMonthlyViews: number;
 }
 

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -38,7 +38,7 @@ import {
 import {
 	hasSupportedCommercialUse,
 	hasSupportedVideoPressUse,
-	hasReachedPaywallMonthlyViews,
+	shouldShowPaywallAfterGracePeriod,
 } from './use-stats-purchases';
 
 // If Jetpack sites don't have any purchase that supports commercial use, gate advanced modules accordingly.
@@ -145,8 +145,10 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 
 		const isSiteCommercial = getSiteOption( state, siteId, 'is_commercial' ) || false;
 		if ( isSiteCommercial ) {
-			// Paywall basic stats for commercial sites with monthly views reaching the paywall threshold.
-			if ( hasReachedPaywallMonthlyViews( state, siteId ) ) {
+			// Paywall basic stats for commercial sites with:
+			// 1. Monthly views reached the paywall threshold.
+			// 2. Current usage passed over grace period days.
+			if ( shouldShowPaywallAfterGracePeriod( state, siteId ) ) {
 				return [
 					...jetpackStatsCommercialPaywall,
 					...granularControlForJetpackStatsCommercialPaywall,

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -18,8 +18,10 @@ import {
 	hasLoadedSitePurchasesFromServer,
 	getPurchases,
 } from 'calypso/state/purchases/selectors';
-import { getPlanUsageBillableMonthlyViews } from 'calypso/state/stats/plan-usage/selectors';
-import { MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL } from './use-site-compulsory-plan-selection-qualified-check';
+import {
+	getShouldShowPaywallNotice,
+	getShouldShowPaywallAfterGracePeriod,
+} from 'calypso/state/stats/plan-usage/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 const JETPACK_STATS_TIERED_BILLING_LIVE_DATE_2024_01_04 = '2024-01-04T05:30:00+00:00';
@@ -75,10 +77,21 @@ export const hasSupportedVideoPressUse = ( state: object, siteId: number | null 
 	return isVideoPressOwned( sitePurchases );
 };
 
-export const hasReachedPaywallMonthlyViews = ( state: object, siteId: number | null ): boolean => {
-	const billableMonthlyViews = getPlanUsageBillableMonthlyViews( state, siteId );
+export const shouldShowPaywallNotice = ( state: object, siteId: number | null ): boolean => {
+	return (
+		! hasSupportedCommercialUse( state, siteId ) && getShouldShowPaywallNotice( state, siteId )
+	);
+};
 
-	return billableMonthlyViews >= MIN_MONTHLY_VIEWS_TO_APPLY_PAYWALL;
+export const shouldShowPaywallAfterGracePeriod = (
+	state: object,
+	siteId: number | null
+): boolean => {
+	// Make the paywall check more robust by checking the purchase.
+	return (
+		! hasSupportedCommercialUse( state, siteId ) &&
+		getShouldShowPaywallAfterGracePeriod( state, siteId )
+	);
 };
 
 const getPurchasesBySiteId = createSelector(

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -43,7 +43,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			isSiteJetpackNotAtomic,
 			isCommercial,
 			hasPWYWPlanOnly,
-			shouldShowPaywallNotice,
+			showPaywallNotice,
 		}: StatsNoticeProps ) => {
 			// Show the notice only if the site is commercial.
 			if ( ! isCommercial ) {
@@ -55,7 +55,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			}
 
 			// Show the upgrade notice with the coming paywall communication.
-			if ( shouldShowPaywallNotice ) {
+			if ( showPaywallNotice ) {
 				return true;
 			}
 

--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -19,7 +19,7 @@ const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) =
 const CommercialSiteUpgradeNotice = ( {
 	siteId,
 	isOdysseyStats,
-	shouldShowPaywallNotice,
+	showPaywallNotice,
 }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
@@ -49,7 +49,7 @@ const CommercialSiteUpgradeNotice = ( {
 		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
 		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
 
-	if ( shouldShowPaywallNotice ) {
+	if ( showPaywallNotice ) {
 		learnMoreLink = 'https://jetpack.com/support/jetpack-stats/free-or-paid/';
 	}
 
@@ -74,7 +74,7 @@ const CommercialSiteUpgradeNotice = ( {
 		externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
 	};
 
-	const bannerBody = shouldShowPaywallNotice
+	const bannerBody = showPaywallNotice
 		? translate(
 				'{{p}}Commercial sites with a significant number of visitors require a commercial license. Upgrade to get access to all the stats features and priority support.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}}{{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
 				{
@@ -95,7 +95,7 @@ const CommercialSiteUpgradeNotice = ( {
 			}` }
 		>
 			<NoticeBanner
-				level={ shouldShowPaywallNotice ? 'error' : 'info' }
+				level={ showPaywallNotice ? 'error' : 'info' }
 				title={ translate( 'Upgrade to Stats Commercial' ) }
 				onClose={ () => {} }
 				hideCloseButton

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -21,7 +21,7 @@ import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-si
 import hasSiteProductJetpackStatsPWYWOnly from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
-import useStatsPurchases, { hasReachedPaywallMonthlyViews } from '../hooks/use-stats-purchases';
+import useStatsPurchases, { shouldShowPaywallNotice } from '../hooks/use-stats-purchases';
 import ALL_STATS_NOTICES from './all-notice-definitions';
 import { StatsNoticeProps, StatsNoticesProps } from './types';
 import './style.scss';
@@ -99,9 +99,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 
 	// Show the paywall notice if the site has reached the monthly views limit
 	// and no commercial purchase.
-	const shouldShowPaywallNotice =
+	const showPaywallNotice =
 		useSelector( ( state ) => {
-			return hasReachedPaywallMonthlyViews( state, siteId );
+			return shouldShowPaywallNotice( state, siteId );
 		} ) &&
 		! supportCommercialUse &&
 		isSiteJetpackNotAtomic &&
@@ -121,7 +121,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		isCommercial,
 		isCommercialOwned,
 		hasPWYWPlanOnly,
-		shouldShowPaywallNotice,
+		showPaywallNotice,
 	};
 
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -20,7 +20,7 @@ export interface StatsNoticeProps {
 	isCommercial?: boolean;
 	isCommercialOwned?: boolean;
 	hasPWYWPlanOnly?: boolean;
-	shouldShowPaywallNotice?: boolean;
+	showPaywallNotice?: boolean;
 }
 
 export interface NoticeBodyProps {

--- a/client/state/stats/plan-usage/selectors.ts
+++ b/client/state/stats/plan-usage/selectors.ts
@@ -3,17 +3,26 @@ import { PlanUsage } from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
 
 import 'calypso/state/stats/init';
 
-export function getPlanUsageBillableMonthlyViews( state: object, siteId: number | null ) {
+export function getShouldShowPaywallNotice( state: object, siteId: number | null ): boolean {
 	if ( ! siteId ) {
-		return 0;
+		return false;
 	}
 
 	const data = get( state, [ 'stats', 'planUsage', 'data', siteId ], null ) as PlanUsage;
-	// TODO: Use `data.billable_monthly_views` instead?
-	const recentViews =
-		data?.recent_usages
-			?.map( ( usage ) => usage?.views_count ?? 0 )
-			.filter( ( views ) => views > 0 ) ?? [];
 
-	return recentViews.length > 0 ? Math.min( ...recentViews ) : 0;
+	// Sites with a paywall_date_from means they have a paywall mark regardless of the grace period.
+	return !! data?.paywall_date_from;
+}
+
+export function getShouldShowPaywallAfterGracePeriod(
+	state: object,
+	siteId: number | null
+): boolean {
+	if ( ! siteId ) {
+		return false;
+	}
+
+	const data = get( state, [ 'stats', 'planUsage', 'data', siteId ], null ) as PlanUsage;
+
+	return data?.should_show_paywall;
 }

--- a/client/state/stats/plan-usage/selectors.ts
+++ b/client/state/stats/plan-usage/selectors.ts
@@ -10,7 +10,8 @@ export function getShouldShowPaywallNotice( state: object, siteId: number | null
 
 	const data = get( state, [ 'stats', 'planUsage', 'data', siteId ], null ) as PlanUsage;
 
-	// Sites with a paywall_date_from means they have a paywall mark regardless of the grace period.
+	// Sites with a `paywall_date_from` have a paywall sticker,
+	// and the date is when the sticker is added, not when the paywall is in effect.
 	return !! data?.paywall_date_from;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/98

## Proposed Changes

* Use the newly introduced usage API results `should_show_paywall` and `paywall_date_from` to determine whether to show the paywall and paywall notice: D156052-code.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Check the paywall condition on the API end to make the check more robust.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare a Jetpack site **_without_** any Stats commercial or Jetpack plan purchase.
* Mark the site as **_commercial_** forcibly.
* Follow up testing instructions of D156052-code to make your site has a paywall sticker.
* Spin this change up with the Calypso Live branch.
* Navigate to Stats > `Traffic` page.
* Ensure the paywall notice shows as previously.
* Manually change the `should_show_paywall` result to `true`.
* Navigate to Stats `Traffic` and `Insights` pages.
* Ensure the modules are paywalled as previously.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?