### PR TITLE
Domain-only users: Masterbar inconsistencies on global views

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -290,7 +290,7 @@ class MasterbarLoggedIn extends Component {
 
 		if ( ! siteSlug && section === 'sites-dashboard' ) {
 			// we are the /sites page but there is no site. Disable the home link
-			return <Item icon={ icon } disabled />;
+			return <Item icon={ icon } className="masterbar__item-no-sites" disabled />;
 		}
 
 		return (
@@ -342,11 +342,19 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderSiteMenu() {
-		const { siteSlug, translate, siteTitle, siteUrl, isClassicView, siteAdminUrl, siteHomeUrl } =
-			this.props;
+		const {
+			siteSlug,
+			translate,
+			siteTitle,
+			siteUrl,
+			isClassicView,
+			siteAdminUrl,
+			siteHomeUrl,
+			domainOnlySite,
+		} = this.props;
 
-		// Only display when a site is selected.
-		if ( ! siteSlug ) {
+		// Only display when a site is selected and is not domain-only site.
+		if ( ! siteSlug || domainOnlySite ) {
 			return null;
 		}
 
@@ -384,11 +392,12 @@ class MasterbarLoggedIn extends Component {
 			domainOnlySite,
 			isMigrationInProgress,
 			isEcommerce,
+			hasNoSites,
 		} = this.props;
 
 		// Only display on site-specific pages.
 		// domainOnlySite's still get currentSelectedSiteSlug, removing this check would require changing checks below.
-		if ( domainOnlySite || isMigrationInProgress || isEcommerce ) {
+		if ( domainOnlySite || isMigrationInProgress || isEcommerce || hasNoSites ) {
 			return null;
 		}
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -599,7 +599,8 @@ body.is-mobile-app-view {
 	}
 
 
-	&.masterbar__item-my-sites {
+	&.masterbar__item-my-sites,
+	&.masterbar__item-no-sites {
 		padding: 0 7px 0 5px; // trying to match core's 35px width
 
 		@media only screen and (max-width: 782px) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8433

## Proposed Changes
Fix inconsistencies when the `W` logo icon is disabled, remove the `+ New` button when there are no sites or domains, and remove the site name menu when 0 sites and >0 domain.

- [x]  Fix the left padding inconsistency when 0 sites & 0 domains
- [x] Remove the + New button when 0 sites
- [x] Remove the site name menu when 0 sites, at least 1 domain

#### 0 Sites, 0 domains
Before

https://github.com/user-attachments/assets/a21e15fc-0564-4103-b7e1-68c32ce306fa

After

https://github.com/user-attachments/assets/d4c62790-e416-4a8a-aa62-366c717ea716

#### 0 Sites, at least 1 domain
Before:

https://github.com/user-attachments/assets/2d8e4846-a807-4b37-9d28-270ee16a6f75

After:

https://github.com/user-attachments/assets/b22701cb-32a1-41ba-8c64-0b57f973022b



## Why are these changes being made?
It looks inconsistent

## Testing Instructions

#### With 0 sites and 0 domains
- Go to /sites
- Switch to /domains
- Check the masterbar icons padding
- The `+ New` menu should disappear.

#### With 0 sites and >0 domains
- Go to /sites
- Switch to /domains
- Check the masterbar icons padding
- The `+ New` menu should disappear.
- The `Visit site` menu should disappear too.
