### PR TITLE
Stats: Empty State: Move Comments into StatsCard

### DIFF
--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -94,6 +94,7 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 				// show data or an overlay
 				<StatsModule
 					skipQuery
+					path="comments"
 					moduleStrings={ moduleString }
 					className={ className }
 					data={ filteredData }

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -157,7 +157,7 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 			{ ! isRequestingData && ! hasPosts && ! shouldGateStatsModule && (
 				// show empty state
 				<StatsCard
-					className={ className }
+					className={ clsx( 'stats-card--empty-variant', className ) }
 					title={ moduleTitle }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -1,10 +1,15 @@
 import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { comment } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { STAT_TYPE_COMMENTS } from 'calypso/my-sites/stats/constants';
+import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
+import StatsCardUpsell from 'calypso/my-sites/stats/stats-card-upsell';
+import StatsListCard from 'calypso/my-sites/stats/stats-list/stats-list-card';
 import { useSelector } from 'calypso/state';
 import {
 	isRequestingSiteStatsForQuery,
@@ -13,40 +18,47 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { INSIGHTS_SUPPORT_URL } from '../../../const';
-import StatsModule from '../../../stats-module';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
 
-interface CommentData {
-	authors: Array< {
-		label: string;
-		value: string;
-		iconClassName: string;
-		icon: string;
-		link: string;
-		className: string;
-		actions: Array< {
-			type: string;
-			data: boolean;
-		} >;
-	} >;
-	posts: Array< {
-		label: string;
-		value: string;
-		page: string;
-		actions: Array< {
-			type: string;
-			data: string;
-		} >;
-	} >;
-}
+type CommentActionType = {
+	type: string;
+	data: boolean;
+};
+
+type CommentDataAuthors< T = string > = {
+	label: string;
+	value: T;
+	iconClassName: string;
+	icon: string;
+	link: string;
+	className: string;
+	actions: CommentActionType[];
+};
+
+type CommentDataPosts< T = string > = {
+	label: string;
+	value: T;
+	page: string;
+	actions: CommentActionType[];
+};
+
+type CommentData = {
+	authors: CommentDataAuthors[];
+	posts: CommentDataPosts[];
+};
+
+type HeaderToggleOptionType = {
+	value: string;
+	label: string;
+};
 
 const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const statType = 'statsComments';
+	const statType = STAT_TYPE_COMMENTS;
 	const moduleTitle = translate( 'Comments' );
-	const [ activeFilter, setActiveFilter ] = useState( 'top-authors' );
+	const [ activeFilter, setActiveFilter ] = useState< string >( 'top-authors' );
 
 	// Use StatsModule to display paywall upsell.
 	const shouldGateStatsModule = useShouldGateStats( statType );
@@ -54,27 +66,34 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
 		isRequestingSiteStatsForQuery( state, siteId, statType, {} )
 	);
-	const data = useSelector( ( state: StatsStateProps ) =>
+	const commentsStatsData = useSelector( ( state: StatsStateProps ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, {} )
 	) as CommentData;
+	const selectOptions = [
+		{
+			value: 'top-authors',
+			label: translate( 'By authors' ),
+		},
+		{
+			value: 'top-content',
+			label: translate( 'By posts & pages' ),
+		},
+	];
 
-	const hasPosts = data?.posts?.length > 0;
-	let filteredData = activeFilter === 'top-authors' ? data?.authors : data?.posts;
+	const commentsAuthors = commentsStatsData?.authors;
+	const commentsPosts = commentsStatsData?.posts;
 
-	filteredData = filteredData?.map( ( item ) => ( {
+	const data = activeFilter === 'top-authors' ? commentsAuthors : commentsPosts;
+
+	const hasPosts = data?.length > 0;
+
+	const dataForBars = data?.map( ( item ) => ( {
 		...item,
 		value: parseInt( item.value, 10 ),
-	} ) );
+	} ) ) as CommentDataAuthors< number >[] | CommentDataPosts< number >[];
 
-	const handleFilterChange = ( selection: { value: React.SetStateAction< string > } ) => {
+	const handleFilterChange = ( selection: HeaderToggleOptionType ) => {
 		setActiveFilter( selection.value );
-	};
-
-	const moduleString = {
-		title: translate( 'Comments' ),
-		item: translate( 'Comments' ),
-		value: translate( 'Comments' ),
-		empty: translate( 'Comments' ),
 	};
 
 	return (
@@ -92,24 +111,46 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 			) }
 			{ ( ( ! isRequestingData && hasPosts ) || shouldGateStatsModule ) && (
 				// show data or an overlay
-				<StatsModule
-					skipQuery
-					path="comments"
-					moduleStrings={ moduleString }
-					className={ className }
-					data={ filteredData }
-					statType={ statType }
-					query={ {} }
-					isLoading={ isRequestingData }
-					gateStats={ shouldGateStatsModule }
+				// @ts-expect-error TODO: Refactor StatsListCard with TypeScript.
+				<StatsListCard
+					moduleType="comments"
+					data={ dataForBars }
+					title={ translate( 'Comments' ) }
+					titleNodes={
+						<StatsInfoArea>
+							{ translate(
+								'Learn about the {{link}}comments{{/link}} your site receives by authors, posts, and pages.',
+								{
+									comment: '{{link}} links to support documentation.',
+									components: {
+										link: (
+											<a href={ localizeUrl( `${ INSIGHTS_SUPPORT_URL }#all-time-insights` ) } />
+										),
+									},
+									context: 'Stats: Info box label when the Comments module is empty',
+								}
+							) }
+						</StatsInfoArea>
+					}
+					mainItemLabel={ translate( 'Author' ) }
+					metricLabel={ translate( 'Comments' ) }
+					splitHeader
+					useShortNumber
 					toggleControl={
-						<SimplifiedSegmentedControl
-							options={ [
-								{ value: 'top-authors', label: translate( 'By authors' ) },
-								{ value: 'top-content', label: translate( 'By posts & pages' ) },
-							] }
-							onSelect={ handleFilterChange }
-						/>
+						// @ts-expect-error TODO: Refactor SimplifiedSegmentedControl with TypeScript - onSelect assumed type is incorrect.
+						<SimplifiedSegmentedControl options={ selectOptions } onSelect={ handleFilterChange } />
+					}
+					className={ clsx( 'stats__modernised-comments', className ) }
+					showLeftIcon
+					overlay={
+						siteId &&
+						shouldGateStatsModule && (
+							<StatsCardUpsell
+								className="stats-module__upsell"
+								statType={ STAT_TYPE_COMMENTS }
+								siteId={ siteId }
+							/>
+						)
 					}
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -63,7 +63,7 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 
 	filteredData = filteredData?.map( ( item ) => ( {
 		...item,
-		value: item.value, // Keep value as string
+		value: parseInt( item.value, 10 ),
 	} ) );
 
 	const handleFilterChange = ( selection: { value: React.SetStateAction< string > } ) => {
@@ -71,10 +71,10 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 	};
 
 	const moduleString = {
-		title: '',
-		item: '',
-		value: '',
-		empty: '',
+		title: translate( 'Comments' ),
+		item: translate( 'Comments' ),
+		value: translate( 'Comments' ),
+		empty: translate( 'Comments' ),
 	};
 
 	return (
@@ -108,7 +108,7 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 								{ value: 'top-authors', label: translate( 'By authors' ) },
 								{ value: 'top-content', label: translate( 'By posts & pages' ) },
 							] }
-							onSelect={ () => handleFilterChange }
+							onSelect={ handleFilterChange }
 						/>
 					}
 				/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* moves the `Comments` logic into the new comments module using StatsCard component
* adds popopver to header

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For the empty states project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch and verify that the `Comments` module works without the feature flag
* apply the flag `stats/empty-module-v2` 
* verify that a page with empty Comments views component works with and without the feature flag
* repeat for blogs with Comments data
* test that module gating still works

![image](https://github.com/user-attachments/assets/186459a3-76a9-4f2a-8b2f-e88ff93a20a8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
