### PR TITLE
WIP Packages: Bump versions of components, tour-kit and viewport-react

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/components",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"description": "Automattic Components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/components/src/loading-placeholder/loading-placeholder.scss
+++ b/packages/components/src/loading-placeholder/loading-placeholder.scss
@@ -1,0 +1,15 @@
+@keyframes pulse-light-animation {
+	50% {
+		background-color: var(--color-neutral-0);
+	}
+}
+
+.loading-placeholder {
+	animation: pulse-light-animation 1.8s ease-in-out infinite;
+	background-color: var(--color-neutral-10);
+	min-height: 18px;
+	width: 100%;
+	border-radius: 0;
+	animation-delay: 0;
+	display: block;
+}

--- a/packages/components/src/loading-placeholder/loading-placeholder.stories.tsx
+++ b/packages/components/src/loading-placeholder/loading-placeholder.stories.tsx
@@ -1,23 +1,22 @@
-import { css } from '@emotion/css';
 import { LoadingPlaceholder } from '.';
 
 export default { title: 'packages/components/LoadingPlaceholder' };
 
 export const Normal = () => <LoadingPlaceholder />;
-export const Width = () => <LoadingPlaceholder className={ css( { maxWidth: 300 } ) } />;
+export const Width = () => <LoadingPlaceholder style={ { maxWidth: 300 } } />;
 export const Delay = () => (
-	<div className={ css( { display: 'grid', gap: 5 } ) }>
+	<div style={ { display: 'grid', gap: 5 } }>
 		<LoadingPlaceholder delayMS={ 0 } />
 		<LoadingPlaceholder delayMS={ 150 } />
 		<LoadingPlaceholder delayMS={ 300 } />
 	</div>
 );
 export const ComplexLayout = () => (
-	<div className={ css( { display: 'flex', gap: 5 } ) }>
-		<LoadingPlaceholder className={ css( { maxWidth: 50, height: 50 } ) } />
-		<div className={ css( { display: 'flex', flexDirection: 'column', flex: 1, gap: 5 } ) }>
+	<div style={ { display: 'flex', gap: 5 } }>
+		<LoadingPlaceholder style={ { maxWidth: 50, height: 50 } } />
+		<div style={ { display: 'flex', flexDirection: 'column', flex: 1, gap: 5 } }>
 			<LoadingPlaceholder />
-			<LoadingPlaceholder className={ css( { maxWidth: '33%' } ) } />
+			<LoadingPlaceholder style={ { maxWidth: '33%' } } />
 		</div>
 	</div>
 );

--- a/packages/components/src/loading-placeholder/loading-placeholder.tsx
+++ b/packages/components/src/loading-placeholder/loading-placeholder.tsx
@@ -1,7 +1,8 @@
-import { keyframes } from '@emotion/react';
-import styled from '@emotion/styled';
+import * as React from 'react';
+import './loading-placeholder.scss';
 
 interface LoadingPlaceholderProps {
+	style?: React.CSSProperties;
 	delayMS?: number;
 	display?: 'block' | 'inline-block';
 	width?: string | number;
@@ -10,20 +11,29 @@ interface LoadingPlaceholderProps {
 	borderRadius?: string;
 }
 
-const pulseLightKeyframes = keyframes`
-	50% {
-		background-color: var( --color-neutral-0 );
-	}`;
-
-const LoadingPlaceholder = styled.div< LoadingPlaceholderProps >`
-	animation: ${ pulseLightKeyframes } 1.8s ease-in-out infinite;
-	background-color: var( --color-neutral-10 );
-	min-height: ${ ( { minHeight = '18px' } ) => minHeight };
-	${ ( { height } ) => height && `height: ${ height }` };
-	width: ${ ( { width = '100%' } ) => width };
-	border-radius: ${ ( { borderRadius = '0' } ) => borderRadius };
-	animation-delay: ${ ( { delayMS = 0 } ) => delayMS }ms;
-	display: ${ ( { display = 'block' } ) => display };
-`;
+const LoadingPlaceholder = ( {
+	style = {},
+	delayMS = 0,
+	display = 'block',
+	width = '100%',
+	height,
+	minHeight,
+	borderRadius,
+}: LoadingPlaceholderProps ) => {
+	return (
+		<div
+			className="loading-placeholder"
+			style={ {
+				...style,
+				animationDelay: `${ delayMS }ms`,
+				...( display && { display } ),
+				...( width && { width } ),
+				...( height && { height } ),
+				...( minHeight && { minHeight } ),
+				...( borderRadius && { borderRadius } ),
+			} }
+		/>
+	);
+};
 
 export default LoadingPlaceholder;

--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/css';
 import clsx from 'clsx';
 import { ReactNode } from 'react';
 import './style.scss';
@@ -8,8 +7,6 @@ import { getTextColorFromBackground } from './utils';
 export type SizeCss = { width: number; height: number };
 
 export const DEFAULT_THUMBNAIL_SIZE = { width: 106, height: 76.55 };
-
-const DEFAULT_CLASSNAME = css( DEFAULT_THUMBNAIL_SIZE );
 
 const VIEWPORT_BASE = 1200;
 
@@ -59,7 +56,6 @@ export const SiteThumbnail = ( {
 	const classes = clsx(
 		'site-thumbnail',
 		isLoading ? 'site-thumbnail-loading' : 'site-thumbnail-visible',
-		DEFAULT_CLASSNAME,
 		className
 	);
 

--- a/packages/components/src/site-thumbnail/style.scss
+++ b/packages/components/src/site-thumbnail/style.scss
@@ -3,6 +3,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	width: 106;
+	height: 76.55px;
 	position: relative;
 	overflow: hidden;
 	transition: background-color 1s ease-out;

--- a/packages/components/src/upsell-menu-group/index.tsx
+++ b/packages/components/src/upsell-menu-group/index.tsx
@@ -1,44 +1,13 @@
-import styled from '@emotion/styled';
 import React from 'react';
 import Gridicon from '../gridicon';
-
-const Row = styled.div( {
-	display: 'flex',
-	flexDirection: 'row',
-	paddingTop: 8,
-	paddingBottom: 8,
-	gap: 8,
-} );
-
-const Content = styled.div( {
-	display: 'flex',
-	flexDirection: 'column',
-	gap: 8,
-	width: 210,
-	whiteSpace: 'break-spaces',
-	maxWidth: '80vw',
-} );
-
-const BackgroundIcon = styled.div( {
-	backgroundColor: 'var(--color-accent)',
-	width: 16,
-	height: 16,
-	borderRadius: '100%',
-	display: 'flex',
-	alignItems: 'center',
-	justifyContent: 'center',
-	marginTop: 1,
-} );
-
-const StarIcon = styled( Gridicon )( {
-	color: '#FFF',
-} );
+import './style.scss';
 
 export function UpsellIcon() {
 	return (
-		<BackgroundIcon>
-			<StarIcon icon="star" size={ 10 } />
-		</BackgroundIcon>
+		<div className="upsell-menu-group__upsell-icon">
+			{ /* eslint-disable-next-line wpcalypso/jsx-gridicon-size */ }
+			<Gridicon className="upsell-menu-group__star-icon" icon="star" size={ 10 } />
+		</div>
 	);
 }
 
@@ -50,9 +19,9 @@ interface UpsellCardProps {
 export function UpsellMenuGroup( props: UpsellCardProps ) {
 	const { icon = <UpsellIcon />, children, ...rest } = props;
 	return (
-		<Row { ...rest }>
+		<div className="upsell-menu-group__row" { ...rest }>
 			{ icon }
-			<Content>{ children }</Content>
-		</Row>
+			<div className="upsell-menu-group__content">{ children }</div>
+		</div>
 	);
 }

--- a/packages/components/src/upsell-menu-group/style.scss
+++ b/packages/components/src/upsell-menu-group/style.scss
@@ -1,0 +1,33 @@
+
+.upsell-menu-group__row {
+	display: flex;
+	flex-direction: row;
+	padding-top: 8px;
+	padding-bottom: 8px;
+	gap: 8px;
+}
+
+.upsell-menu-group__content {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	width: 210px;
+	white-space: break-spaces;
+	max-width: 80vw;
+}
+
+
+.upsell-menu-group__upsell-icon {
+	background-color: var(--color-accent);
+	width: 16;
+	height: 16;
+	border-radius: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-top: 1px;
+}
+
+.upsell-menu-group__star-icon {
+	color: #fff;
+}

--- a/packages/tour-kit/package.json
+++ b/packages/tour-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/tour-kit",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Tour lib for guided walkthroughs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/viewport-react/package.json
+++ b/packages/viewport-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/viewport-react",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "React helpers for tracking viewport changes.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8241

## Proposed Changes

* We want to migrate Block Editor Nux Feature to jetpack-mu-wpcom, and require the latest automattic packages as follows
  * `@automattic/components`
  * `@automattic/tour-kit`
  * `@automattic/viewport-react`
* TODO: check is there anything missing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bump versions of packages to update their peer dependencies

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Walkthrough pages
* Make sure the placeholder displays correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
