### PR TITLE
Stepper: Allow flows to replace history state

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -42,7 +42,7 @@ export const useFlowNavigation = (): FlowNavigation => {
 	const [ currentSearchParams ] = useSearchParams();
 
 	const customNavigate = useCallback< Navigate< StepperStep[] > >(
-		( nextStep: string, extraData = {} ) => {
+		( nextStep: string, extraData = {}, replace = false ) => {
 			const hasQueryParams = nextStep.includes( '?' );
 			const queryParams = ! hasQueryParams ? currentSearchParams : null;
 
@@ -59,7 +59,7 @@ export const useFlowNavigation = (): FlowNavigation => {
 				step: nextStep,
 			} );
 
-			navigate( addQueryParams( newPath, queryParams ) );
+			navigate( addQueryParams( newPath, queryParams ), { replace } );
 		},
 		[ currentSearchParams, flow, intent, lang, navigate, setStepData, currentStepSlug ]
 	);

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -79,7 +79,11 @@ export type StepperStep = DeprecatedStepperStep | AsyncStepperStep;
 
 export type Navigate< FlowSteps extends StepperStep[] > = (
 	stepName: FlowSteps[ number ][ 'slug' ] | `${ FlowSteps[ number ][ 'slug' ] }?${ string }`,
-	extraData?: any
+	extraData?: any,
+	/**
+	 * If true, the current step will be replaced in the history stack.
+	 */
+	replace?: boolean
 ) => void;
 
 /**


### PR DESCRIPTION
## Proposed Changes

This allows Stepper flows to replace history state when navigating. This enables them to navigate away from processing steps without re-running them when the user clicks the back button.

## Why are these changes being made?
To prevent site recreation and awkward states when the user re-lands on the processing step.
