### PR TITLE
Build onboarding flow in Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/onboarding.ts
@@ -1,0 +1,116 @@
+import { OnboardSelect } from '@automattic/data-stores';
+import { addPlanToCart, addProductsToCart, ONBOARDING_FLOW } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+import { useEffect } from 'react';
+import {
+	clearSignupDestinationCookie,
+	persistSignupDestination,
+} from 'calypso/signup/storageUtils';
+import { ONBOARD_STORE } from '../stores';
+import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { Flow, ProvidedDependencies } from './internals/types';
+
+const onboarding: Flow = {
+	name: ONBOARDING_FLOW,
+	isSignupFlow: true,
+	useSteps() {
+		return stepsWithRequiredLogin( [
+			{
+				slug: 'domains',
+				asyncComponent: () => import( './internals/steps-repository/domains' ),
+			},
+			{
+				slug: 'plans',
+				asyncComponent: () => import( './internals/steps-repository/plans' ),
+			},
+			{
+				slug: 'create-site',
+				asyncComponent: () => import( './internals/steps-repository/create-site' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+		] );
+	},
+
+	useSideEffect() {
+		useEffect( () => {
+			clearSignupDestinationCookie();
+		}, [] );
+	},
+
+	useStepNavigation( currentStepSlug, navigate ) {
+		const flowName = this.name;
+
+		const { domainCartItem, planCartItem } = useSelect(
+			( select: ( key: string ) => OnboardSelect ) => ( {
+				domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
+				planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
+			} ),
+			[]
+		);
+
+		const { resetStore } = useDispatch( ONBOARD_STORE );
+
+		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
+			recordSubmitStep( providedDependencies, '', flowName, currentStepSlug );
+
+			switch ( currentStepSlug ) {
+				case 'domains':
+					return navigate( 'plans' );
+				case 'plans':
+					return navigate( 'create-site', undefined, true );
+				case 'create-site':
+					return navigate( 'processing', undefined, true );
+				case 'processing': {
+					const destination = addQueryArgs( '/setup/site-setup/goals', {
+						siteSlug: providedDependencies.siteSlug,
+					} );
+					persistSignupDestination( destination );
+
+					if ( providedDependencies.goToCheckout ) {
+						const siteSlug = providedDependencies.siteSlug as string;
+						if ( planCartItem && siteSlug && flowName ) {
+							await addPlanToCart( siteSlug, flowName, true, '', planCartItem );
+						}
+
+						if ( domainCartItem && siteSlug && flowName ) {
+							await addProductsToCart( siteSlug, flowName, [ domainCartItem ] );
+						}
+
+						resetStore();
+
+						// replace the location to delete processing step from history.
+						window.location.replace(
+							addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
+								redirect_to: destination,
+								signup: 1,
+							} )
+						);
+					} else {
+						// replace the location to delete processing step from history.
+						window.location.replace( destination );
+					}
+				}
+				default:
+					return;
+			}
+		};
+
+		const goBack = () => {
+			switch ( currentStepSlug ) {
+				case 'plans':
+					return navigate( 'domains' );
+				default:
+					return;
+			}
+		};
+
+		return { goBack, submit };
+	},
+};
+
+export default onboarding;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -17,6 +17,7 @@ import {
 	ENTREPRENEUR_FLOW,
 	HOSTED_SITE_MIGRATION_FLOW,
 	NEW_HOSTED_SITE_FLOW_USER_INCLUDED,
+	ONBOARDING_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -128,6 +129,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ GOOGLE_TRANSFER ]: () =>
 		import( /* webpackChunkName: "google-transfer" */ './google-transfer' ),
+
+	[ ONBOARDING_FLOW ]: () => import( /* webpackChunkName: "onboarding-flow" */ './onboarding' ),
 
 	[ 'plugin-bundle' ]: () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' ),

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -45,6 +45,7 @@ export const GOOGLE_TRANSFER = 'google-transfer';
 export const HUNDRED_YEAR_PLAN_FLOW = 'hundred-year-plan';
 export const REBLOGGING_FLOW = 'reblogging';
 export const DOMAIN_FOR_GRAVATAR_FLOW = 'domain-for-gravatar';
+export const ONBOARDING_FLOW = 'onboarding';
 export const ONBOARDING_GUIDED_FLOW = 'onboarding';
 export const EMAIL_SUBSCRIPTION_FLOW = 'email-subscription';
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/92878

## Proposed Changes
This builds a replica of /start non-segmented flow in Stepper. 

It does have some visual and UX inconsistencies with /start; that's by design, it's meant to be a benchmark to detect these inconsistencies and to fix them in follow-up PRs

## Why are these changes being made?
pdDR7T-1Ed-p2

## Testing Instructions
1. Go to /setup/onboarding.
2. Make a free site with a free domain and plan. It should work and should redirect you to Goals.
3. Make a paid site with a paid domain. Should work and take you to checkout then goals.
4. Make a site with a paid domain and sites. Should work and take you to checkout then goals.
