### PR TITLE
A4A > Referrals: Add info icon with popover for referral consolidated commission cards

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -10,6 +10,38 @@ import type { Referral, ReferralInvoice } from '../types';
 
 import './style.scss';
 
+const InfoIconWithPopover = ( { children }: { children: React.ReactNode } ) => {
+	const [ showPopover, setShowPopover ] = useState( false );
+	const wrapperRef = useRef< HTMLSpanElement | null >( null );
+
+	return (
+		<span
+			className="consolidated-view__info-icon"
+			onClick={ () => setShowPopover( true ) }
+			role="button"
+			tabIndex={ 0 }
+			ref={ wrapperRef }
+			onKeyDown={ ( event ) => {
+				if ( event.key === 'Enter' ) {
+					setShowPopover( true );
+				}
+			} }
+		>
+			<Gridicon icon="info-outline" size={ 16 } />
+			{ showPopover && (
+				<A4APopover
+					title=""
+					offset={ 12 }
+					wrapperRef={ wrapperRef }
+					onFocusOutside={ () => setShowPopover( false ) }
+				>
+					{ children }
+				</A4APopover>
+			) }
+		</span>
+	);
+};
+
 export default function ConsolidatedViews( {
 	referrals,
 	referralInvoices,
@@ -25,9 +57,6 @@ export default function ConsolidatedViews( {
 	const month = date.toLocaleString( 'default', { month: 'long' } );
 	const { data, isFetching } = useProductsQuery( false, false, true );
 
-	const [ showPopover, setShowPopover ] = useState( false );
-	const wrapperRef = useRef< HTMLSpanElement | null >( null );
-
 	const [ consolidatedData, setConsolidatedData ] = useState( {
 		allTimeCommissions: 0,
 		pendingOrders: 0,
@@ -41,7 +70,8 @@ export default function ConsolidatedViews( {
 		}
 	}, [ referrals, data, referralInvoices ] );
 
-	const link = 'https://automattic.com/for-agencies/program-incentives/';
+	const link =
+		'https://agencieshelp.automattic.com/knowledge-base/about-automattic-for-agencies/#payout-calculation-and-schedule';
 
 	const showLoader = isFetching || isFetchingInvoices;
 
@@ -55,42 +85,21 @@ export default function ConsolidatedViews( {
 						formatCurrency( consolidatedData.allTimeCommissions, 'USD' )
 					) }
 				</div>
-				<div className="consolidated-view__label consolidated-view__label--all-time">
+				<div className="consolidated-view__label">
 					{ translate( 'All time commissions' ) }
-					<span
-						className="consolidated-view__info-icon"
-						onClick={ () => setShowPopover( true ) }
-						role="button"
-						tabIndex={ 0 }
-						ref={ wrapperRef }
-						onKeyDown={ ( event ) => {
-							if ( event.key === 'Enter' ) {
-								setShowPopover( true );
-							}
-						} }
-					>
-						<Gridicon icon="info-outline" size={ 16 } />
-						{ showPopover && (
-							<A4APopover
-								title=""
-								offset={ 12 }
-								wrapperRef={ wrapperRef }
-								onFocusOutside={ () => setShowPopover( false ) }
-							>
-								<div className="consolidated-view__popover-content">
-									{ translate(
-										'Every 60 days, we pay out commissions. Learn more about {{a}}partner{{nbsp/}}earnings.{{/a}}',
-										{
-											components: {
-												nbsp: <>&nbsp;</>,
-												a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
-											},
-										}
-									) }
-								</div>
-							</A4APopover>
-						) }
-					</span>
+					<InfoIconWithPopover>
+						<div className="consolidated-view__popover-content">
+							{ translate(
+								'Every 60 days, we pay out commissions. {{a}}Learn more about payouts and commissions{{/a}}.',
+								{
+									components: {
+										nbsp: <>&nbsp;</>,
+										a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
+									},
+								}
+							) }
+						</div>
+					</InfoIconWithPopover>
 				</div>
 			</Card>
 			<Card compact>
@@ -106,6 +115,21 @@ export default function ConsolidatedViews( {
 						args: { month },
 						comment: 'month is the name of the current month',
 					} ) }
+					<InfoIconWithPopover>
+						<div className="consolidated-view__popover-content">
+							{ translate(
+								'When your client buys products or hosting from Automattic for Agencies, they are billed on the first of every month rather than immediately.' +
+									' We estimate the commission based on the active use for the current month. {{a}}Learn more about payouts and commissions{{/a}}.',
+								{
+									components: {
+										nbsp: <>&nbsp;</>,
+										a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
+									},
+									comment: 'This is a tooltip explaining how the commission is calculated',
+								}
+							) }
+						</div>
+					</InfoIconWithPopover>
 				</div>
 			</Card>
 			<Card compact>

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/style.scss
@@ -25,10 +25,7 @@
 		.consolidated-view__label {
 			color: var(--color-accent);
 			font-size: rem(12px);
-
-			&.consolidated-view__label--all-time {
-				text-wrap: nowrap;
-			}
+			text-wrap: nowrap;
 		}
 	}
 }


### PR DESCRIPTION

Closes https://github.com/Automattic/jetpack-genesis/issues/447

## Proposed Changes

This PR 

- Adds an info icon with popover to the `Expected commissions this {month}` card
- updates the text & link for the `All time commissions` card.

## Testing Instructions

1. Open the A4A live link.
2. Go to Referral dashboard > Click the info icons on `All time commissions` & Commissions expected this {month` card and verify the tooltip is displayed when clicked as shown below. Also, verify the link for both takes you to https://agencieshelp.automattic.com/knowledge-base/about-automattic-for-agencies/#payout-calculation-and-schedule

<img width="1727" alt="Screenshot 2024-07-25 at 3 39 29 PM" src="https://github.com/user-attachments/assets/37851702-8d00-4544-8e3f-fc536aeeb082">

<img width="1727" alt="Screenshot 2024-07-25 at 3 39 36 PM" src="https://github.com/user-attachments/assets/8f47f571-5da7-4261-8055-6a8066745604">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
