### PR TITLE
Masterbar: Fix icon overlap issue at smaller resolutions

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -571,6 +571,7 @@ body.is-mobile-app-view {
 		// reset flex value on mobile
 		flex: 0 1 auto;
 		padding: 0;
+		width: 46px;
 
 		.masterbar__item-content {
 			display: none;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -587,6 +587,12 @@ body.is-mobile-app-view {
 		}
 	}
 
+	@media only screen and (max-width: 360px) {
+		&.masterbar__reader {
+			display: none;
+		}
+	}
+
 	&:disabled {
 		&:hover {
 			background: initial;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -581,6 +581,10 @@ body.is-mobile-app-view {
 		&.masterbar__item-me .masterbar__item-content {
 			display: block;
 		}
+
+		&.masterbar__item-my-site-actions {
+			display: none;
+		}
 	}
 
 	&:disabled {


### PR DESCRIPTION
## Description

This PR aims to be a short-term remedy for https://github.com/Automattic/dotcom-forge/issues/8378

In the current masterbar, at lower resolutions, it's possible to have overlap in our icons.

Here are the updates I made in this PR:

- Below 480px, I reduced the width of icons in masterbar down to 46px to make more space
- Below 480px I hid the "+" icon
- Below 360px I hide the reader icon

## Before

https://github.com/user-attachments/assets/1966f251-5081-4473-a907-50860d65c34c

## After

https://github.com/user-attachments/assets/562f7f90-183d-4c64-9ecd-14d2039875bb

## Testing instructions

- Apply this PR
- Add something to your cart, so the cart icons shows
- Open dev tools
- Click into responsive mode
- Select "Responsive" from the device dropdown


