### PR TITLE
Ensure that notifications are fetched then visible for the first time

### DIFF
--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -480,7 +480,8 @@ function setVisibility( { isShowing, isVisible } ) {
 		isVisible: this.isVisible,
 	} );
 
-	if ( isVisible && isShowing ) {
+	// Fetch notification when visible for the first time or visible and showing
+	if ( isVisible && ( ! this.lastSeenTime || isShowing ) ) {
 		this.updateLastSeenTime( 0 );
 		this.main();
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

When loading a site (front end or wp-admin), the unseen notifications indicator does not appear when unseen notifications are present.

| Before  | After |
| ------------- | ------------- |
| https://github.com/user-attachments/assets/7b86dbdb-0a22-4cff-a59f-9ceeeb426307 | https://github.com/user-attachments/assets/c808e9df-ee47-4e62-8aaa-aab738f5adda|



The markup rendered for the icon renders with `wpn-read` by default: https://github.com/Automattic/jetpack/blob/bbcdbee90535764ed91340c583b39c96c33d2604/projects/plugins/jetpack/modules/notes.php#L214

When the icon needs to update to unread it will happen with a slight delay once the pooling request is executed ( ~30 seconds ).

Related to https://github.com/Automattic/jetpack/issues/36725
Fixes https://github.com/Automattic/jetpack/issues/36725

## Proposed Changes

* This PR ensures the request for fetching the notes is executed once when the icon becomes visible to update the icon

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions
- Checkout this branch
- Cd to the folder: `cd apps/notifications`
- Build and sync to your sandbox: `yarn build --sync` ( I had issues running yarn dev --sync )
- Trigger a notification for an admin to an atomic site. I invited the user to another site for testing this. In case the notifications are read, you can always re-invite the same user.
- Navigate to `wp-admin` with the atomic admin
- The notification icon should get updated to reflect that there is a new notification.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?