### PR TITLE
Add `pull_request` trigger to `merge_group` action

### DIFF
--- a/.github/workflows/is-calypso-channel-green.yml
+++ b/.github/workflows/is-calypso-channel-green.yml
@@ -2,6 +2,9 @@ name: Is Calypso Channel Green?
 run-name: ${{ github.actor }} Checking Calypso Slack Channel Status
 
 on:
+  pull_request:
+    branches:
+      - trunk
   merge_group:
 
 jobs:


### PR DESCRIPTION
Add `pull_request` trigger to Calypso channel status checker. Otherwise it won't run.

See: https://github.com/orgs/community/discussions/51120