### PR TITLE
Readymade Templates: Disable the wrapping group block for RMTs

### DIFF
--- a/client/landing/stepper/declarative-flow/readymade-template.tsx
+++ b/client/landing/stepper/declarative-flow/readymade-template.tsx
@@ -262,6 +262,7 @@ function enableAssemblerThemeAndConfigureTemplates(
 			canReplaceContent: boolean;
 			// All sites using the assembler set the option wpcom_site_setup
 			siteSetupOption: string;
+			wrapMainHtmlInMainGroup: boolean;
 		}
 	) => Promise< never >,
 	reduxDispatch: CalypsoDispatch
@@ -300,6 +301,7 @@ function enableAssemblerThemeAndConfigureTemplates(
 					globalStyles: readymadeTemplate.globalStyles,
 					canReplaceContent: true,
 					siteSetupOption: 'readymade-template',
+					wrapMainHtmlInMainGroup: false,
 				} )
 			)
 			.then( () => window.location.assign( `/site-editor/${ siteId }?canvas=edit&assembler=1` ) );

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -471,6 +471,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			globalStyles,
 			canReplaceContent,
 			siteSetupOption,
+			wrapMainHtmlInMainGroup = true,
 		}: AssembleSiteOptions = {}
 	) {
 		const templates = [
@@ -483,7 +484,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 					!! headerHtml,
 					!! footerHtml,
 					!! homeHtml,
-					homeHtml
+					homeHtml,
+					wrapMainHtmlInMainGroup
 				),
 			},
 			headerHtml && {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -664,6 +664,7 @@ export interface AssembleSiteOptions {
 	globalStyles?: GlobalStyles;
 	canReplaceContent?: boolean;
 	siteSetupOption?: string;
+	wrapMainHtmlInMainGroup?: boolean;
 }
 
 /**

--- a/packages/data-stores/src/site/utils.ts
+++ b/packages/data-stores/src/site/utils.ts
@@ -3,7 +3,8 @@ export const createCustomHomeTemplateContent = (
 	hasHeader: boolean,
 	hasFooter: boolean,
 	hasSections: boolean,
-	mainHtml = ''
+	mainHtml = '',
+	wrapMainHtmlInMainGroup = true
 ): string => {
 	const content: string[] = [];
 	if ( hasHeader ) {
@@ -13,13 +14,17 @@ export const createCustomHomeTemplateContent = (
 	}
 
 	if ( hasSections ) {
-		// blockGap":"0" removes the theme blockGap from the main group while allowing users to change it from the editor
-		content.push( `
+		if ( wrapMainHtmlInMainGroup ) {
+			// blockGap":"0" removes the theme blockGap from the main group while allowing users to change it from the editor
+			content.push( `
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0"}}} -->
 	<main class="wp-block-group">
 		${ mainHtml }
 	</main>
 <!-- /wp:group -->` );
+		} else {
+			content.push( mainHtml );
+		}
 	}
 
 	if ( hasFooter ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
When applying the RMTs on newly created target sites, the templates contained an additional gap between the header and the content. This PR adds a flag in the methods that, when set to true, doesn't add the group wrapper on the content.

## Proposed Changes

* Add a flag to the assembleSite code that skips wrapping the content blocks with a group

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bugfixing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Use the live link
* Go to patterns?flags=readymade-templates/showcase
* Select Bakery
* After the site is created, you are redirected to the Site Editor
* Notice that there's no gap between the header and the content

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
