### PR TITLE
Masterbar - remove sidebar toggling for reader, me, etc. buttons

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -143,20 +143,12 @@ class MasterbarLoggedIn extends Component {
 
 	handleToggleMobileMenu = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_menu_clicked' );
-		// this.handleLayoutFocus( 'sites' );
-		if ( 'sidebar' === this.props.currentLayoutFocus ) {
-			this.props.setNextLayoutFocus( 'content' );
-		} else {
-			this.props.setNextLayoutFocus( 'sidebar' );
-		}
+		this.handleLayoutFocus( this.props.section );
 		this.props.activateNextLayoutFocus();
 	};
 
 	clickMySites = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_my_sites_clicked' );
-
-		this.handleLayoutFocus( 'sites' );
-		this.props.activateNextLayoutFocus();
 
 		/**
 		 * Site Migration: Reset a failed migration when clicking on My Sites
@@ -188,18 +180,15 @@ class MasterbarLoggedIn extends Component {
 
 	clickReader = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_reader_clicked' );
-		this.handleLayoutFocus( 'reader' );
 	};
 
 	clickMe = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_me_clicked' );
 		window.scrollTo( 0, 0 );
-		this.handleLayoutFocus( 'me' );
 	};
 
 	clickSearchActions = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_search_actions_clicked' );
-		this.handleLayoutFocus( 'search-actions' );
 		this.setState( { isActionSearchVisible: true } );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#8371

## Proposed Changes

Prevents the sidebar from opening and toggling from various masterbar items.
* Removes the `handleLayoutFocus` call used by many of these items onClick handlers.
* Refactors the logic in the mobile toggle button to use `handleLayoutFocus` for toggling the sidebar, instead of reimplementing its logic locally.

BEFORE
![masterbar-focus-layout-before](https://github.com/user-attachments/assets/c02c3636-6d59-41fc-863a-1271c7871677)


AFTER
![masterbar-layout-focus-after](https://github.com/user-attachments/assets/6a764866-1030-456c-a7f8-280302bf1694)




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Inconsistent behavior on mobile of when sidebars are opened when navigating the app via the masterbar. We also do not want these buttons to toggle the sidebar, as we have a specific masterbar item for that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this build of calypso.
* Use a mobile viewport width.
* Click on the reader link, verify it navigates to /read without opening the sidebar. Click the link a second time verify it does not toggle the sidebar.
* Do the same for /me.
* Test the sites link, verify it continues to work as expected.
* Test the hamburger menu for toggling the sidebar, verify it continues to work as expected.
* Smoke test desktop viewport behaviors, there should be no change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
