### PR TITLE
Masterbar items w/ subgroups - enable keyboard flow handling.

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -64,11 +64,11 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 	_preloaded = false;
 
 	componentDidMount() {
-		document.addEventListener( 'touchstart', this.closeMenuOnOutsideTouch );
-		document.addEventListener( 'keydown', this.closeMenuOnOutsideTouch );
+		document.addEventListener( 'touchstart', this.closeMenuOnOutsideInteraction );
+		document.addEventListener( 'keydown', this.closeMenuOnOutsideInteraction );
 		return () => {
-			document.removeEventListener( 'touchstart', this.closeMenuOnOutsideTouch );
-			document.removeEventListener( 'keydown', this.closeMenuOnOutsideTouch );
+			document.removeEventListener( 'touchstart', this.closeMenuOnOutsideInteraction );
+			document.removeEventListener( 'keydown', this.closeMenuOnOutsideInteraction );
 		};
 	}
 
@@ -106,18 +106,12 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 							<Button
 								className="is-link"
 								onClick={ item.onClick }
-								onTouchEnd={ ( ev: React.TouchEvent ) => {
-									ev.preventDefault();
-									this.setState( { isOpenByTouch: false } );
-									item.onClick && item.onClick();
-								} }
-								onKeyDown={ ( ev: React.KeyboardEvent ) => {
-									if ( ev.key === 'Enter' || ev.key === ' ' ) {
-										ev.preventDefault();
-										this.setState( { isOpenByTouch: false } );
-										item.onClick && item.onClick();
-									}
-								} }
+								onTouchEnd={ ( ev: React.TouchEvent ) =>
+									this.submenuButtonTouch( ev, item.onClick )
+								}
+								onKeyDown={ ( ev: React.KeyboardEvent ) =>
+									this.submenuButtonByKey( ev, item.onClick )
+								}
 							>
 								{ item.label }
 							</Button>
@@ -171,7 +165,22 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		}
 	};
 
-	closeMenuOnOutsideTouch = ( event: TouchEvent | KeyboardEvent ) => {
+	submenuButtonTouch = (
+		event: React.TouchEvent | React.KeyboardEvent,
+		onClick: ( () => void ) | undefined
+	) => {
+		event.preventDefault();
+		this.setState( { isOpenByTouch: false } );
+		onClick && onClick();
+	};
+
+	submenuButtonByKey = ( event: React.KeyboardEvent, onClick: ( () => void ) | undefined ) => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			this.submenuButtonTouch( event, onClick );
+		}
+	};
+
+	closeMenuOnOutsideInteraction = ( event: TouchEvent | KeyboardEvent ) => {
 		// If no subItems or the menu is already closed, there is nothing to close.
 		if ( ! this.props.subItems || ! this.state.isOpenByTouch ) {
 			return;

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -55,7 +55,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 	};
 
 	state = {
-		isOpenByTouch: false,
+		isOpenForNonMouseFlow: false,
 	};
 
 	componentButtonRef = React.createRef< HTMLButtonElement >();
@@ -66,9 +66,11 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 	componentDidMount() {
 		document.addEventListener( 'touchstart', this.closeMenuOnOutsideInteraction );
 		document.addEventListener( 'keydown', this.closeMenuOnOutsideInteraction );
+		document.addEventListener( 'click', this.closeMenuOnOutsideInteraction );
 		return () => {
 			document.removeEventListener( 'touchstart', this.closeMenuOnOutsideInteraction );
 			document.removeEventListener( 'keydown', this.closeMenuOnOutsideInteraction );
+			document.addEventListener( 'click', this.closeMenuOnOutsideInteraction );
 		};
 	}
 
@@ -138,7 +140,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		}
 		// Prevent navigation by touching the parent menu item, and trigger toggling the menu instead.
 		event.preventDefault();
-		this.setState( { isOpenByTouch: ! this.state.isOpenByTouch } );
+		this.setState( { isOpenForNonMouseFlow: ! this.state.isOpenForNonMouseFlow } );
 	};
 
 	toggleMenuByKey = ( event: React.KeyboardEvent ) => {
@@ -156,7 +158,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		if ( url ) {
 			navigate( url );
 		}
-		this.setState( { isOpenByTouch: false } );
+		this.setState( { isOpenForNonMouseFlow: false } );
 	};
 
 	navigateSubAnchorByKey = ( event: React.KeyboardEvent ) => {
@@ -170,7 +172,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		onClick: ( () => void ) | undefined
 	) => {
 		event.preventDefault();
-		this.setState( { isOpenByTouch: false } );
+		this.setState( { isOpenForNonMouseFlow: false } );
 		onClick && onClick();
 	};
 
@@ -180,9 +182,9 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		}
 	};
 
-	closeMenuOnOutsideInteraction = ( event: TouchEvent | KeyboardEvent ) => {
+	closeMenuOnOutsideInteraction = ( event: TouchEvent | KeyboardEvent | MouseEvent ) => {
 		// If no subItems or the menu is already closed, there is nothing to close.
-		if ( ! this.props.subItems || ! this.state.isOpenByTouch ) {
+		if ( ! this.props.subItems || ! this.state.isOpenForNonMouseFlow ) {
 			return;
 		}
 
@@ -193,7 +195,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		const isInComponentDivRef = this.componentDivRef.current?.contains( event.target as Node );
 
 		if ( ! isInComponentButtonRef && ! isInComponentDivRef ) {
-			this.setState( { isOpenByTouch: false } );
+			this.setState( { isOpenForNonMouseFlow: false } );
 		}
 	};
 
@@ -203,7 +205,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 			'has-unseen': this.props.hasUnseen,
 			'masterbar__item--always-show-content': this.props.alwaysShowContent,
 			'has-subitems': this.props.subItems,
-			'is-open': this.state.isOpenByTouch,
+			'is-open': this.state.isOpenForNonMouseFlow,
 		} );
 
 		const attributes = {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -466,6 +466,12 @@ body.is-mobile-app-view {
 		}
 	}
 
+	.accessible-focus & a:focus,
+	.accessible-focus & button:focus {
+		box-shadow: inset 0 0 0 2px var(--color-primary-light);
+		outline: none;
+	}
+
 	&.is-active {
 		background: var(--color-masterbar-item-active-background);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#8459

## Proposed Changes

Adds keyboard navigation handling to masterbar items with submenu groups
* Extends existing touch device handling for usage with keyboard navigation.
    * Enter and Space keys can be used on the main items (that have submenus) to toggle the submenu open and closed.
    * These same keys can be used to select submenu items in the dropdowns.
    * Initiating a keyboard event from outside the menu group will also close an open menu group.
* Adds a11y focus styles to submenu items.
* For masterbar items that have both urls and subitems, we remove the anchor directly inside the button from keyboard navigation. This anchor is intended for click, and can be removed from keyboard flows as we intend the button wrapping it for use to toggle the menu, and we repeat these links in the submenu group. This anchor being in tab navigation was causing the apparent double/nested focus navigation on these items noted on the issue.

BEFORE
![keyboard-nav-in-masterbar](https://github.com/user-attachments/assets/15a2e7dd-4a25-49e6-8d8d-f96a5e2f1176)


AFTER
![keydown-after](https://github.com/user-attachments/assets/3baee907-1470-419a-8b8f-35f3b4d1178b)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* for a11y!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Load a page in calypso and use "tab" to navigate into the masterbar.
* Verify that pressing "enter" or space keys on site menu, +new, and me menus opens the dropdown menus.
* Tab into the dropdown menus and verify selecting an item works as expected.
* Verify the menu closes when selecting an item.
* verify the menu closes when clicking the main/root menu item again.
* verify the menu closes when clicking outside, continuing keyboard navigation while outside of the menu, etc.
* verify other masterbar items without submenu groups still work as expected in keyboard flows.
* Ensure regular mouse flows work for selecting masterbar items and sub items.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
