### PR TITLE
Hosting Overview: Add feature flag for refinements project

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -1,4 +1,4 @@
-import configApi from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import React, { useState } from 'react';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
@@ -83,7 +83,7 @@ export default function ItemPreviewPane( {
 	const shouldHideNav =
 		hideNavIfSingleTab &&
 		featureTabs.length <= 1 &&
-		! configApi.isEnabled( 'hosting-overview-refinements' );
+		! config.isEnabled( 'hosting-overview-refinements' );
 
 	return (
 		<div className={ clsx( 'item-preview__pane', className ) }>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -1,3 +1,4 @@
+import configApi from '@automattic/calypso-config';
 import clsx from 'clsx';
 import React, { useState } from 'react';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
@@ -79,7 +80,10 @@ export default function ItemPreviewPane( {
 		);
 	} );
 
-	const shouldHideNav = hideNavIfSingleTab && featureTabs.length <= 1;
+	const shouldHideNav =
+		hideNavIfSingleTab &&
+		featureTabs.length <= 1 &&
+		! configApi.isEnabled( 'hosting-overview-refinements' );
 
 	return (
 		<div className={ clsx( 'item-preview__pane', className ) }>

--- a/client/hosting-overview/components/hosting-overview.tsx
+++ b/client/hosting-overview/components/hosting-overview.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -21,6 +22,15 @@ const HostingOverview: FC = () => {
 
 	return (
 		<div className="hosting-overview">
+			<p
+				className="hosting-overview-refinement-flag-test"
+				style={ {
+					display: config.isEnabled( 'hosting-overview-refinements' ) ? 'auto' : 'none',
+					gridArea: '1 / 2',
+				} }
+			>
+				Hello World
+			</p>
 			<NavigationHeader
 				className="hosting-overview__navigation-header"
 				title={ translate( 'Overview' ) }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -43,7 +43,7 @@
 		"a4a-partner-directory": true,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": true,
-		"hosting-overview-refinements": true
+		"hosting-overview-refinements": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -42,7 +42,8 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": true,
 		"a4a-hosting-page-redesign": true,
-		"a4a-dev-sites": true
+		"a4a-dev-sites": true,
+		"hosting-overview-refinements": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -35,7 +35,8 @@
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": true,
 		"a4a-hosting-page-redesign": true,
-		"a4a-dev-sites": false
+		"a4a-dev-sites": false,
+		"hosting-overview-refinements": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -34,7 +34,8 @@
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
-		"a4a-dev-sites": false
+		"a4a-dev-sites": false,
+		"hosting-overview-refinements": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -37,7 +37,8 @@
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
-		"a4a-dev-sites": false
+		"a4a-dev-sites": false,
+		"hosting-overview-refinements": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/development.json
+++ b/config/development.json
@@ -76,7 +76,7 @@
 		"help/gpt-response": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
-		"hosting-overview-refinements": true,
+		"hosting-overview-refinements": false,
 		"i18n/community-translator": false,
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,

--- a/config/development.json
+++ b/config/development.json
@@ -76,6 +76,7 @@
 		"help/gpt-response": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
+		"hosting-overview-refinements": true,
 		"i18n/community-translator": false,
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,6 +42,7 @@
 		"google-my-business": false,
 		"help": true,
 		"home/layout-dev": true,
+		"hosting-overview-refinements": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/production.json
+++ b/config/production.json
@@ -52,6 +52,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help/gpt-response": true,
+		"hosting-overview-refinements": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,6 +51,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help/gpt-response": true,
+		"hosting-overview-refinements": false,
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,
 		"importer/unified": true,

--- a/config/test.json
+++ b/config/test.json
@@ -43,6 +43,7 @@
 		"cookie-banner": false,
 		"google-my-business": false,
 		"help": true,
+		"hosting-overview-refinements": false,
 		"importers/newsletter": true,
 		"importers/substack": true,
 		"individual-subscriber-stats": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -60,6 +60,7 @@
 		"help/gpt-response": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
+		"hosting-overview-refinements": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,
 		"importer/unified": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8395-gh-Automattic/dotcom-forge

## Proposed Changes

- Adds a `hosting-overview-refinements` feature flag
- Sets the flag to `true` only in `development.json` and `a8c-for-agencies-development.json`
- Updates the `shouldHidNave` declaration to only hide nav when `hosting-overview-refinements` is `false`
- Adds a "Hello World" to the Overview page, set to `display: none` based on the state of the new feature flag, for testing purposes

**Overview, with the new "Hello World" test being rendered:**
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/89641ede-ae2d-4434-b3e2-a4f5cba33452">

## Why are these changes being made?

Upcoming work on Hosting Overview will be completed in stages. The new flag will allow us to control how these new features are released and tested.

## Testing Instructions
- For any wpcom site, visit `/overview`
- Confirm that 'Hello World' is not displayed to the right of the page title (as shown in screenshot above)
- Activating the local feature flag:
	- Create a `.env` file in the root of your local calypso repo
	- In that file, add `ACTIVE_FEATURE_FLAGS='hosting-overview-refinements'`
	- `yarn start`
- Refresh `/overview` an confirm that 'Hello World' is now displayed to the right of the page title (as shown in screenshot above)