### PR TITLE
Masterbar: Use solid Help and Notification icons

### DIFF
--- a/client/layout/global-sidebar/menu-items/notifications/icon.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/icon.jsx
@@ -17,12 +17,7 @@ export const BellIcon = ( { newItems, strokeWidth = 1.5 } ) => {
 					fill="var( --color-masterbar-icon )"
 					fillRule="evenodd"
 				></path>
-				<circle
-					cx="19.2759"
-					cy="8.56887"
-					fill="var( --color-masterbar-unread-dot-background )"
-					r="2.97415"
-				></circle>
+				<circle cx="19.2759" cy="8.56887" fill="#e26f56" r="2.97415"></circle>
 			</svg>
 		);
 	}

--- a/client/layout/masterbar/masterbar-help-center.jsx
+++ b/client/layout/masterbar/masterbar-help-center.jsx
@@ -1,12 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenter } from '@automattic/data-stores';
-import { HelpIcon } from '@automattic/help-center';
 import {
 	useDispatch as useDataStoreDispatch,
 	useSelect as useDateStoreSelect,
 } from '@wordpress/data';
+import { helpFilled } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import Item from './item';
@@ -14,7 +13,6 @@ import Item from './item';
 const HELP_CENTER_STORE = HelpCenter.register();
 
 const MasterbarHelpCenter = ( { tooltip } ) => {
-	const helpIconRef = useRef();
 	const sectionName = useSelector( getSectionName );
 
 	const helpCenterVisible = useDateStoreSelect( ( select ) =>
@@ -40,7 +38,7 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 					'is-active': helpCenterVisible,
 				} ) }
 				tooltip={ tooltip }
-				icon={ <HelpIcon ref={ helpIconRef } /> }
+				icon={ helpFilled }
 			/>
 		</>
 	);

--- a/client/layout/masterbar/masterbar-notifications/notifications-bell-icon.tsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-bell-icon.tsx
@@ -6,12 +6,12 @@ interface Props {
 export const BellIcon: React.FC< Props > = ( { newItems, active } ) => (
 	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<defs>
-			<circle id="bubble" cx="8" cy="4" r="4" />
+			<circle id="bubble" cx="20" cy="4" r="4" />
 		</defs>
 		<g>
 			<path
 				fill="var( --color-masterbar-icon )"
-				d="M6.14 14.97l2.828 2.827c-.362.362-.862.586-1.414.586-1.105 0-2-.895-2-2 0-.552.224-1.052.586-1.414zm8.867 5.324L14.3 21 3 9.7l.706-.707 1.102.157c.754.108 1.69-.122 2.077-.51l3.885-3.884c2.34-2.34 6.135-2.34 8.475 0s2.34 6.135 0 8.475l-3.885 3.886c-.388.388-.618 1.323-.51 2.077l.157 1.1z"
+				d="M9.9,20h4c0,0.5-0.2,1-0.6,1.4   c-0.8,0.8-2,0.8-2.8,0C10.1,21,9.9,20.5,9.9,20z M20,17.5v1H4v-1l0.9-0.7C5.5,16.3,6,15.5,6,15l0-5.5c0-3.3,2.7-6,6-6   c3.3,0,6,2.7,6,6V15c0,0.5,0.5,1.4,1.1,1.8L20,17.5z"
 			/>
 			{ newItems && (
 				<g className="notifications-bell-icon__bubble">

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import TranslatableString from 'calypso/components/translatable/proptype';
-import { BellIcon } from 'calypso/layout/global-sidebar/menu-items/notifications/icon';
 import { setUnseenCount } from 'calypso/state/notifications/actions';
 import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
 import hasUnseenNotifications from 'calypso/state/selectors/has-unseen-notifications';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import MasterbarItem from '../item';
+import { BellIcon } from './notifications-bell-icon';
 
 import './notifications-style.scss';
 
@@ -94,13 +94,7 @@ class MasterbarItemNotifications extends Component {
 			<>
 				<MasterbarItem
 					url="/notifications"
-					icon={
-						<BellIcon
-							newItems={ this.state.newNote }
-							active={ this.props.isActive }
-							strokeWidth={ 1 }
-						/>
-					}
+					icon={ <BellIcon newItems={ this.state.newNote } active={ this.props.isActive } /> }
 					onClick={ this.toggleNotesFrame }
 					isActive={ this.props.isActive }
 					tooltip={ this.props.tooltip }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -159,12 +159,6 @@ body.is-mobile-app-view {
 			}
 		}
 	}
-	.masterbar__item-notifications {
-		svg.sidebar_svg-notifications {
-			margin: 0;
-			fill: none;
-		}
-	}
 }
 
 .masterbar__new-menu-popover {
@@ -1182,8 +1176,8 @@ body.is-mobile-app-view {
 .masterbar-notifications {
 	svg {
 		overflow: overlay;
-		width: 27px;
-		height: 27px;
+		width: 24px;
+		height: 24px;
 
 		@media only screen and (max-width: 782px) {
 			width: 36px;
@@ -1195,11 +1189,11 @@ body.is-mobile-app-view {
 	.notifications-bell-icon__bubble {
 		animation: bubble-unread-indication 0.5s linear both;
 		transition: all 150ms ease-in;
-		transform-origin: 8px 4px;
+		transform-origin: 20px 4px;
 
 		use {
 			transition: all 150ms ease-in;
-			transform-origin: 8px 4px;
+			transform-origin: 20px 4px;
 		}
 	}
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1173,6 +1173,15 @@ body.is-mobile-app-view {
 	}
 }
 
+.masterbar-cart-button {
+	svg {
+		@media only screen and (max-width: 782px) {
+			width: 32px;
+			height: 32px;
+		}
+	}
+}
+
 .masterbar-notifications {
 	svg {
 		overflow: overlay;
@@ -1180,8 +1189,8 @@ body.is-mobile-app-view {
 		height: 24px;
 
 		@media only screen and (max-width: 782px) {
-			width: 36px;
-			height: 36px;
+			width: 32px;
+			height: 32px;
 		}
 	}
 
@@ -1373,12 +1382,12 @@ a.masterbar__quick-language-switcher {
 
 	svg {
 		fill: var(--color-masterbar-icon);
-		width: 24px;
-		height: 24px;
+		width: 22px;
+		height: 22px;
 
 		@media only screen and (max-width: 782px) {
-			width: 36px;
-			height: 36px;
+			width: 30px;
+			height: 30px;
 		}
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1182,7 +1182,6 @@ body.is-mobile-app-view {
 		@media only screen and (max-width: 782px) {
 			width: 36px;
 			height: 36px;
-			padding: 3px 8px 5px;
 		}
 	}
 
@@ -1380,7 +1379,6 @@ a.masterbar__quick-language-switcher {
 		@media only screen and (max-width: 782px) {
 			width: 36px;
 			height: 36px;
-			padding: 3px 8px 5px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8454

## Proposed Changes

* This PR reverts the bell and help icons to the solid version.

Note: This PR only applies to Calypso pages. An update for wp-admin pages will follow.

Mobile
Before | After
--|--
<img width="397" alt="Screenshot 2024-07-26 at 11 21 11 AM" src="https://github.com/user-attachments/assets/58d2f153-5563-48f8-9930-737958b794d4"> | <img width="399" alt="Screenshot 2024-07-26 at 11 20 56 AM" src="https://github.com/user-attachments/assets/f3c95783-a5dd-4c5e-90c1-c5bc10a36e82">

Desktop
Before | After
--|--
<img width="1147" alt="Screenshot 2024-07-26 at 11 20 26 AM" src="https://github.com/user-attachments/assets/bba058c1-ee80-41a1-853d-12a92c19d60a"> |  <img width="1147" alt="Screenshot 2024-07-26 at 11 20 01 AM" src="https://github.com/user-attachments/assets/a1710a46-80c1-45fb-a35c-e235c079770c">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency in branding and design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the Calypso Live version of this PR
* Look at the Masterbar on Calypso pages, and ensure the help and notification icons appear as the solid versions shown in the screenshots above.
* View the icons on mobile and desktop.
* Try clicking and hovering over the icons.
* View the Notification icon with and without a notification. It should always appear as a solid bell, but when you have a notification, there should be a red circle at the top right of the bell.
* Try different color schemes.
* Check for regressions on the other Masterbar icons.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
