### PR TITLE
Overview: Visually show a minimum amount of storage used

### DIFF
--- a/client/hosting/overview/components/plan-storage-bar.tsx
+++ b/client/hosting/overview/components/plan-storage-bar.tsx
@@ -1,6 +1,7 @@
 import { ProgressBar } from '@automattic/components';
 import { SiteMediaStorage } from '@automattic/data-stores';
 import { Icon, cloud } from '@wordpress/icons';
+import clsx from 'clsx';
 import filesize from 'filesize';
 import { useTranslate } from 'i18n-calypso';
 import { FC, PropsWithChildren } from 'react';
@@ -9,6 +10,7 @@ interface Props {
 	mediaStorage: SiteMediaStorage;
 }
 const MINIMUM_DISPLAYED_USAGE = 2.5;
+const ALERT_PERCENT = 80;
 
 const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStorage } ) => {
 	const translate = useTranslate();
@@ -23,6 +25,10 @@ const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStor
 
 	const used = filesize( storageUsedBytes, { round: 0 } );
 	const max = filesize( maxStorageBytes, { round: 0 } );
+
+	const classes = clsx( 'plan-storage__bar', {
+		'is-alert': percent > ALERT_PERCENT,
+	} );
 
 	return (
 		<>
@@ -43,7 +49,10 @@ const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStor
 				</span>
 			</div>
 
-			<ProgressBar value={ percent } total={ 100 } compact={ false } />
+			<div className={ classes }>
+				<div className="plan-storage__bar-used" style={ { width: `${ percent }%` } } />
+				<ProgressBar value={ percent } total={ 100 } compact={ false } />
+			</div>
 
 			{ children }
 		</>

--- a/client/hosting/overview/components/plan-storage-bar.tsx
+++ b/client/hosting/overview/components/plan-storage-bar.tsx
@@ -8,7 +8,7 @@ import { FC, PropsWithChildren } from 'react';
 interface Props {
 	mediaStorage: SiteMediaStorage;
 }
-const MINIMUM_DISPLAYED_USAGE = 1;
+const MINIMUM_DISPLAYED_USAGE = 2;
 
 const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStorage } ) => {
 	const translate = useTranslate();

--- a/client/hosting/overview/components/plan-storage-bar.tsx
+++ b/client/hosting/overview/components/plan-storage-bar.tsx
@@ -43,7 +43,7 @@ const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStor
 				</span>
 			</div>
 
-			<ProgressBar color="var(--studio-red-30)" value={ percent } total={ 100 } compact={ false } />
+			<ProgressBar value={ percent } total={ 100 } compact={ false } />
 
 			{ children }
 		</>

--- a/client/hosting/overview/components/plan-storage-bar.tsx
+++ b/client/hosting/overview/components/plan-storage-bar.tsx
@@ -8,7 +8,7 @@ import { FC, PropsWithChildren } from 'react';
 interface Props {
 	mediaStorage: SiteMediaStorage;
 }
-const MINIMUM_DISPLAYED_USAGE = 2;
+const MINIMUM_DISPLAYED_USAGE = 2.5;
 
 const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStorage } ) => {
 	const translate = useTranslate();

--- a/client/hosting/overview/components/plan-storage-bar.tsx
+++ b/client/hosting/overview/components/plan-storage-bar.tsx
@@ -8,17 +8,21 @@ import { FC, PropsWithChildren } from 'react';
 interface Props {
 	mediaStorage: SiteMediaStorage;
 }
+const MINIMUM_DISPLAYED_USAGE = 1;
 
 const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStorage } ) => {
 	const translate = useTranslate();
+	const { storageUsedBytes, maxStorageBytes } = mediaStorage;
 
-	const percent = Math.min(
-		Math.round( ( ( mediaStorage.storageUsedBytes / mediaStorage.maxStorageBytes ) * 1000 ) / 10 ),
-		100
+	// Ensure that the displayed usage is never fully empty to avoid a confusing UI
+	const displayedUsage = Math.max(
+		MINIMUM_DISPLAYED_USAGE,
+		Math.round( ( ( storageUsedBytes / maxStorageBytes ) * 1000 ) / 10 )
 	);
+	const percent = Math.min( displayedUsage, 100 );
 
-	const used = filesize( mediaStorage.storageUsedBytes, { round: 0 } );
-	const max = filesize( mediaStorage.maxStorageBytes, { round: 0 } );
+	const used = filesize( storageUsedBytes, { round: 0 } );
+	const max = filesize( maxStorageBytes, { round: 0 } );
 
 	return (
 		<>

--- a/client/hosting/overview/components/plan-storage-bar.tsx
+++ b/client/hosting/overview/components/plan-storage-bar.tsx
@@ -16,18 +16,17 @@ const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStor
 	const translate = useTranslate();
 	const { storageUsedBytes, maxStorageBytes } = mediaStorage;
 
+	let usagePercent = Math.round( ( ( storageUsedBytes / maxStorageBytes ) * 1000 ) / 10 );
 	// Ensure that the displayed usage is never fully empty to avoid a confusing UI
-	const displayedUsage = Math.max(
-		MINIMUM_DISPLAYED_USAGE,
-		Math.round( ( ( storageUsedBytes / maxStorageBytes ) * 1000 ) / 10 )
-	);
-	const percent = Math.min( displayedUsage, 100 );
+	usagePercent = Math.max( MINIMUM_DISPLAYED_USAGE, usagePercent );
+	// Make sure displayed usage never exceeds 100%
+	usagePercent = Math.min( usagePercent, 100 );
 
 	const used = filesize( storageUsedBytes, { round: 0 } );
 	const max = filesize( maxStorageBytes, { round: 0 } );
 
 	const classes = clsx( 'plan-storage__bar', {
-		'is-alert': percent > ALERT_PERCENT,
+		'is-alert': usagePercent > ALERT_PERCENT,
 	} );
 
 	return (
@@ -50,8 +49,8 @@ const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStor
 			</div>
 
 			<div className={ classes }>
-				<div className="plan-storage__bar-used" style={ { width: `${ percent }%` } } />
-				<ProgressBar value={ percent } total={ 100 } compact={ false } />
+				<div className="plan-storage__bar-used" style={ { width: `${ usagePercent }%` } } />
+				<ProgressBar value={ usagePercent } total={ 100 } compact={ false } />
 			</div>
 
 			{ children }

--- a/client/hosting/overview/components/style.scss
+++ b/client/hosting/overview/components/style.scss
@@ -2,6 +2,7 @@
 @import "@wordpress/base-styles/breakpoints";
 
 $card-padding: 24px;
+$blueberry-color: #3858e9;
 
 .hosting-overview {
 	margin: 0;
@@ -208,6 +209,15 @@ $card-padding: 24px;
 	font-size: $font-body-extra-small;
 	line-height: 16px;
 	margin-top: 30px;
+
+	.plan-storage__bar .progress-bar__progress {
+		background-color: $blueberry-color;
+
+	}
+
+	.plan-storage__bar.is-alert .progress-bar__progress {
+		background-color: var(--studio-red-30);
+	}
 }
 
 .hosting-overview__plan-storage-title-wrapper,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8460-gh-Automattic/dotcom-forge

## Proposed Changes

- Updates the Storage usage meter on `/overview` to always show a minimum amount of storage used, rather than rendering an empty bar when used storage is very low
- The original issue called for 1% as a starting figure, but after some further conversation we settled on 2.5%, which is where it's set currently. I've kept the following screenshots included below for reference, and I'll update this issue if we change the value again before merging.
- Removed the red color declaration on the progress bar. `ProgressBar` itself will likely be getting a revamp, and this ensures we pick those colors up when it happens. The default blue also fits the overall aesthetic of the page better anyway.

Some visual samples:

| Header | Header |
|--------|--------|
| trunk | <img width="516" alt="image" src="https://github.com/user-attachments/assets/41527dc0-076d-49d8-95b2-96e2978f7a88"> |
| 1% | <img width="508" alt="image" src="https://github.com/user-attachments/assets/dad8712d-fef7-4047-b5ce-ea065c250cd3"> |
| 2% | <img width="514" alt="image" src="https://github.com/user-attachments/assets/0be43a4b-64f8-41b6-b6df-96ce94fa685c"> |
| 3% | <img width="510" alt="image" src="https://github.com/user-attachments/assets/77e8614f-7424-4b09-b183-bee489f2a264"> | 

## Why are these changes being made?

An empty bar can be confusing for a user, because it's just one solid color. Is it full? Empty? It it a progress bar? By always displaying a small amount of 'used' storage, it's more visually clear that the user has a long way to go before they reach their limit.

## Testing Instructions

- Load `/overview` for any site with little to no storage used
- Notice the empty storage progress bar
- Apply this patch
- Notice the new minimum being displayed
- Switch to a site with more storage being used, or experiment by hardcoding a higher value [in place of](https://github.com/Automattic/wp-calypso/blob/2ca6bcca43689b55fae05697d7f30b05364d15d4/client/hosting-overview/components/plan-storage-bar.tsx#L19) `mediaStorage.storageUsedBytes`
- Confirm that when the amount of storage used exceeds the current minimum display value, the actual usage takes over an fills the progress bar appropriately
