### PR TITLE
Fix Masterbar Profile subitem alignment

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1000,11 +1000,10 @@ body.is-mobile-app-view {
 	.masterbar__item-subitems-item {
 		&.account-link,
 		&.logout-link {
-			background-color: transparent !important;
 			position: relative;
 			float: left;
 			top: -35px;
-			left: 77px;
+			left: 79px;
 		}
 	}
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1000,6 +1000,7 @@ body.is-mobile-app-view {
 	.masterbar__item-subitems-item {
 		&.account-link,
 		&.logout-link {
+			background-color: transparent !important;
 			position: relative;
 			float: left;
 			top: -35px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* In the Masterbar, if you hover over "My Account" or "Log Out," the background of those `li` items overlaps other elements. This PR addresses that by adjusting the item alignment.

Before | After
--|--
 <img width="283" alt="Screenshot 2024-07-25 at 5 42 25 PM" src="https://github.com/user-attachments/assets/40d81e42-75c1-448a-8df9-a7493e9ab89b"> | <img width="305" alt="Screenshot 2024-07-25 at 5 42 16 PM" src="https://github.com/user-attachments/assets/5e97c794-ca4e-4b85-88bd-ad96f3a46093">




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Making the UI look nicer.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR in Calypso Live
* Visit /sites and hover over your Profile pic
* The "My Account" and "Log Out" background should not bleed on top of other elements (such as your profile picture).
* Click the links to be sure they still work.
* Test the mobile version of /sites to make sure it looks good.
* View this change on other pages like 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
