### PR TITLE
Show a link to add credentials when a credential-less restore failed

### DIFF
--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -177,6 +177,14 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_goback' ) );
 	}, [ dispatch ] );
 
+	const onAddingCredentialsClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_adding_credentials' ) );
+	}, [ dispatch ] );
+
+	const onLearnAddingCredentialsClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_learn_adding_credentials' ) );
+	}, [ dispatch ] );
+
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	const loading = rewindState.state === 'uninitialized';
@@ -347,12 +355,14 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 												? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
 												: `${ settingsPath( siteSlug ) }#credentials`
 										}
+										onClick={ onAddingCredentialsClick }
 									/>
 								),
 								linkGuide: (
 									<ExternalLink
 										href="https://jetpack.com/support/adding-credentials-to-jetpack/"
 										target="_blank"
+										onClick={ onLearnAddingCredentialsClick }
 									/>
 								),
 							},

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -9,6 +9,7 @@ import QueryJetpackCredentialsStatus from 'calypso/components/data/query-jetpack
 import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import ExternalLink from 'calypso/components/external-link';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import { backupPath, settingsPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -349,10 +350,9 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 									/>
 								),
 								linkGuide: (
-									<a
+									<ExternalLink
 										href="https://jetpack.com/support/adding-credentials-to-jetpack/"
 										target="_blank"
-										rel="noreferrer"
 									/>
 								),
 							},

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Button, Card, Gridicon } from '@automattic/components';
+import { ExternalLink } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useState } from 'react';
@@ -9,7 +10,6 @@ import QueryJetpackCredentialsStatus from 'calypso/components/data/query-jetpack
 import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
-import ExternalLink from 'calypso/components/external-link';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import { backupPath, settingsPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -361,8 +361,8 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 								linkGuide: (
 									<ExternalLink
 										href="https://jetpack.com/support/adding-credentials-to-jetpack/"
-										target="_blank"
 										onClick={ onLearnAddingCredentialsClick }
+										children={ null }
 									/>
 								),
 							},

--- a/client/state/data-layer/wpcom/sites/rewind/type.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/type.ts
@@ -4,4 +4,5 @@ export interface RewindState {
 		status: 'queued' | 'running' | 'finished' | 'fail';
 		restoreId?: number;
 	};
+	canAutoconfigure: boolean;
 }

--- a/client/state/selectors/get-rewind-state.ts
+++ b/client/state/selectors/get-rewind-state.ts
@@ -5,6 +5,7 @@ import 'calypso/state/rewind/init';
 
 const uninitialized = {
 	state: 'uninitialized',
+	canAutoconfigure: false,
 };
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-backup-team/issues/575

## Proposed Changes

* Add a link to add credentials when a credential-less restore failed
<img width="441" alt="Screenshot 2024-07-25 at 22 43 13" src="https://github.com/user-attachments/assets/a6e29474-946b-475c-8723-300154518d8e">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Since restore credential-less have been added, it useful to have a link to add credentials if a restore failed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Jetpack Cloud link
* Run a restore in a site without credentials where the restore will fail. For example, you can remove all the directory permissions in `wp-content/uploads`
* When the restore fails, verify the links
* For each link, check that `t.gif` is called with `calypso_jetpack_backup_restore_adding_credentials` and `calypso_jetpack_backup_restore_learn_adding_credentials`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
