### PR TITLE
A4A: Implement a reusable hosting benefits section component.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/index.tsx
@@ -1,0 +1,51 @@
+import { Icon, check } from '@wordpress/icons';
+import HostingSection, { HostingSectionProps } from '../hosting-section';
+
+import './style.scss';
+
+type Props = Omit< HostingSectionProps, 'children' > & {
+	items: {
+		title: string;
+		description: string;
+		benefits: string[];
+	}[];
+};
+
+export default function HostingBenefitsSection( {
+	icon,
+	heading,
+	subheading,
+	background,
+	description,
+	items,
+}: Props ) {
+	return (
+		<HostingSection
+			icon={ icon }
+			heading={ heading }
+			subheading={ subheading }
+			background={ background }
+			description={ description }
+		>
+			<div className="hosting-benefits">
+				{ items.map( ( item, index ) => (
+					<div className="hosting-benefits-card" key={ `hosting-benfits-card-${ index }` }>
+						<div className="hosting-benefits-card__header">
+							<h3 className="hosting-benefits-card__title">{ item.title }</h3>
+							<p className="hosting-benefits-card__description">{ item.description }</p>
+						</div>
+
+						<ul className="hosting-benefits-card__list">
+							{ item.benefits.map( ( benefit, benefitIndex ) => (
+								<li key={ `hosting-benefits-card__item-${ index }-${ benefitIndex }` }>
+									<Icon className="gridicon" icon={ check } size={ 24 } />
+									{ benefit }
+								</li>
+							) ) }
+						</ul>
+					</div>
+				) ) }
+			</div>
+		</HostingSection>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/style.scss
@@ -1,0 +1,61 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.hosting-benefits {
+	display: grid;
+
+	grid-template-rows: 1fr;
+	gap: 24px;
+
+	@include break-medium {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	@include break-huge {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+.hosting-benefits-card {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	gap: 24px;
+	padding: 32px;
+	border-radius: 4px;
+	border: 1px solid var(--color-neutral-5);
+	background-color: var(--color-surface);
+}
+
+.hosting-benefits-card__title {
+	@include a4a-font-heading-xl;
+	margin-block-end: 24px;
+}
+
+.hosting-benefits-card__description {
+	@include a4a-font-body-lg;
+}
+
+.hosting-benefits-card__list {
+	margin-block-start: auto;
+	display: flex;
+	flex-direction: column;
+	list-style-type: none;
+	gap: 8px;
+	margin: 0;
+	padding: 0;
+
+	li {
+		@include a4a-font-body-lg;
+
+		display: flex;
+		flex-direction: row;
+		align-content: center;
+		margin: 0;
+		padding: 0;
+	}
+
+	.gridicon {
+		fill: var(--color-primary-50);
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-section/backgrounds/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-section/backgrounds/index.tsx
@@ -22,5 +22,4 @@ export const BackgroundType2: SectionBackground = {
 export const BackgroundType3: SectionBackground = {
 	image: `url(${ Background3Image })`,
 	color: '#EBF4FA',
-	size: 'auto 100%',
 };

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
@@ -2,8 +2,13 @@ import { JetpackLogo } from '@automattic/components';
 import { blockMeta, code, desktop, globe, login, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
+import HostingBenefitsSection from '../../../common/hosting-benefits-section';
 import HostingFeaturesSection from '../../../common/hosting-features-section';
-import { BackgroundType1, BackgroundType2 } from '../../../common/hosting-section/backgrounds';
+import {
+	BackgroundType1,
+	BackgroundType2,
+	BackgroundType3,
+} from '../../../common/hosting-section/backgrounds';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
 import ProfileAvatar1 from './profile-1.jpeg';
 import ProfileAvatar2 from './profile-2.png';
@@ -126,6 +131,32 @@ export default function StandardAgencyHosting() {
 						},
 						testimonial:
 							'This should be another WordPress.com specific testimonial. Let’s make sure it touches upon how they love the hosting, the support service, and especially the UI. This is just dummy text.',
+					},
+				] }
+			/>
+
+			<HostingBenefitsSection
+				heading="How can Automattic help"
+				subheading="Improve your client relationships with our hosting"
+				background={ BackgroundType3 }
+				items={ [
+					{
+						title: 'Create trust',
+						description:
+							'With over 15 years of experience running hundreds of millions of sites on WordPress.com, including the highest-trafficked sites globally, we’ve developed a platform we confidently put up against any cloud service.',
+						benefits: [ '99.999% Uptime', 'High availability with automated scaling' ],
+					},
+					{
+						title: 'Minimize risk',
+						description:
+							'Automattic hosting plans offer exceptional security from day one, with the option to include or sell additional client-facing security features like real-time backups, anti-spam, and malware scanning.',
+						benefits: [ 'Web Application Firewall', 'DDoS protection' ],
+					},
+					{
+						title: 'Increase speed',
+						description:
+							'We’re the only cloud platform team fully dedicated to optimizing WordPress. Your customers will feel the difference.',
+						benefits: [ 'Incredibly low page speed index', 'Automated WordPress edge caching' ],
 					},
 				] }
 			/>


### PR DESCRIPTION

<img width="1464" alt="Screenshot 2024-07-26 at 11 17 34 AM" src="https://github.com/user-attachments/assets/d4188814-fed2-4911-a167-1242dbe09498">


Closes https://github.com/Automattic/jetpack-genesis/issues/433

## Proposed Changes

* Implement `HostingBenefitsSection` component.

## Testing Instructions

* Use the A4A live link below and go to the `/marketplace/hosting` page.
* Scroll down and confirm you can see the new reusable section sample usage.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
