### PR TITLE
Stats: Release empty state updates on the Insights page

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -139,7 +139,7 @@
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": false,
+		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
 		"stepper-woocommerce-poc": true,

--- a/config/production.json
+++ b/config/production.json
@@ -183,7 +183,7 @@
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": false,
+		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
 		"stepper-woocommerce-poc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -177,7 +177,7 @@
 		"site-profiler/metrics": false,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": false,
+		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
 		"stepper-woocommerce-poc": true,

--- a/config/test.json
+++ b/config/test.json
@@ -118,7 +118,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": false,
+		"stats/empty-module-v2": true,
 		"stats/restricted-dashboard": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -175,7 +175,7 @@
 		"site-profiler/metrics": true,
 		"ssr/prefetch-timebox": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": false,
+		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
 		"stepper-woocommerce-poc": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to n/a

## Proposed Changes

* release changes made on the Insights page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* finalising project work

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* verify that both the Insights and Traffic pages work on all environemnts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?