### PR TITLE
Reading Settings: Fix "unsaved changes" prompt when changing the RSS feed content

### DIFF
--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -85,7 +85,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 		page_on_front: page_on_front ?? '',
 		...( posts_per_page && { posts_per_page } ),
 		...( posts_per_rss && { posts_per_rss } ),
-		...( rss_use_excerpt && { rss_use_excerpt } ),
+		rss_use_excerpt: !! rss_use_excerpt,
 		...( show_on_front && { show_on_front } ),
 		...( subscription_options && { subscription_options } ),
 		wpcom_featured_image_in_email: !! wpcom_featured_image_in_email,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92908

## Proposed Changes

It fixes the "unsaved changes" prompt shown after changing the RSS feed content from "Excerpt" to "Full text" and navigating away.

Related Jetpack PR which is also a part of the fix https://github.com/Automattic/jetpack/pull/38498

<img width="753" alt="Screenshot 2024-07-26 at 09 39 59" src="https://github.com/user-attachments/assets/554374fd-f894-4dc5-9bb3-555819f4d627">

## Testing Instructions

1. Go to Reading settings
2. Change the "For each post in a feed, include" in "RSS feed settings" and click "Save settings"
3. Navigate away
4. Make sure the "unsaved changes" prompt didn't show up
5. Change it again and repeat 3 and 4 step


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
