### PR TITLE
A4A: Implement the WPCOM plan banner and selector in the new Hosting section.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-section/index.tsx
@@ -20,7 +20,7 @@ export default function HostingSection( {
 	background,
 }: HostingSectionProps ) {
 	return (
-		<div
+		<section
 			className="hosting-section-wrapper"
 			style={ {
 				backgroundColor: background?.color,
@@ -43,6 +43,6 @@ export default function HostingSection( {
 				</div>
 				{ children }
 			</div>
-		</div>
+		</section>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -7,13 +7,18 @@ import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-of
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { useURLQueryParams } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import EnterpriseAgencyHosting from './enterprise-agency-hosting';
 import PremierAgencyHosting from './premier-agency-hosting';
 import StandardAgencyHosting from './standard-agency-hosting';
 
 import './style.scss';
 
-export default function HostingV2() {
+type Props = {
+	onAddToCart: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+};
+
+export default function HostingV2( { onAddToCart }: Props ) {
 	const translate = useTranslate();
 
 	const isLargeScreen = useBreakpoint( '>1280px' );
@@ -48,7 +53,7 @@ export default function HostingV2() {
 					setSelectedFeatureId( 'standard' );
 					page.show( '/marketplace/hosting?hosting=standard' );
 				},
-				content: <StandardAgencyHosting />,
+				content: <StandardAgencyHosting onAddToCart={ onAddToCart } />,
 			},
 			{
 				key: 'premier',

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -80,7 +80,7 @@ export default function HostingV2( { onAddToCart }: Props ) {
 				content: <EnterpriseAgencyHosting />,
 			},
 		],
-		[ isLargeScreen, selectedFeatureId, translate ]
+		[ isLargeScreen, onAddToCart, selectedFeatureId, translate ]
 	);
 
 	const navItems = featureTabs.map( ( featureTab ) => {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
@@ -3,29 +3,39 @@ import { blockMeta, code, desktop, globe, login, reusableBlock } from '@wordpres
 import { useTranslate } from 'i18n-calypso';
 import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/standard-testimonial-1.png';
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/standard-testimonial-2.png';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
 import HostingFeaturesSection from '../../../common/hosting-features-section';
 import { BackgroundType1, BackgroundType2 } from '../../../common/hosting-section/backgrounds';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
 import { getHostingLogo } from '../../../lib/hosting';
 import CommonHostingBenefits from '../common-hosting-benefits';
+import WPCOMPlanSelector from './wpcom-plan-selector';
 
 import './style.scss';
 
-export default function StandardAgencyHosting() {
+type Props = {
+	onAddToCart: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+};
+
+export default function StandardAgencyHosting( { onAddToCart }: Props ) {
 	const translate = useTranslate();
 
 	return (
 		<div className="standard-agency-hosting">
 			<section className="standard-agency-hosting__banner">
-				<div className="standard-agency-hosting__banner-logo">
-					{ getHostingLogo( 'wpcom-hosting' ) }
+				<div className="standard-agency-hosting__banner-heading">
+					<div className="standard-agency-hosting__banner-logo">
+						{ getHostingLogo( 'wpcom-hosting' ) }
+					</div>
+					<h1 className="standard-agency-hosting__banner-description">
+						{ translate(
+							'Optimized and hassle-free hosting for business websites, local merchants, and small online retailers.'
+						) }
+					</h1>
 				</div>
-				<h1 className="standard-agency-hosting__banner-description">
-					{ translate(
-						'Optimized and hassle-free hosting for business websites, local merchants, and small online retailers.'
-					) }
-				</h1>
+
+				<WPCOMPlanSelector onSelect={ onAddToCart } />
 			</section>
 
 			<HostingAdditionalFeaturesSection

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
@@ -8,7 +8,6 @@ import HostingAdditionalFeaturesSection from '../../../common/hosting-additional
 import HostingFeaturesSection from '../../../common/hosting-features-section';
 import { BackgroundType1, BackgroundType2 } from '../../../common/hosting-section/backgrounds';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
-import { getHostingLogo } from '../../../lib/hosting';
 import CommonHostingBenefits from '../common-hosting-benefits';
 import WPCOMPlanSelector from './wpcom-plan-selector';
 
@@ -23,18 +22,7 @@ export default function StandardAgencyHosting( { onAddToCart }: Props ) {
 
 	return (
 		<div className="standard-agency-hosting">
-			<section className="standard-agency-hosting__banner">
-				<div className="standard-agency-hosting__banner-heading">
-					<div className="standard-agency-hosting__banner-logo">
-						{ getHostingLogo( 'wpcom-hosting' ) }
-					</div>
-					<div className="standard-agency-hosting__banner-description">
-						{ translate(
-							'Optimized and hassle-free hosting for business websites, local merchants, and small online retailers.'
-						) }
-					</div>
-				</div>
-
+			<section className="standard-agency-hosting__plan-selector-container">
 				<WPCOMPlanSelector onSelect={ onAddToCart } />
 			</section>
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
@@ -28,11 +28,11 @@ export default function StandardAgencyHosting( { onAddToCart }: Props ) {
 					<div className="standard-agency-hosting__banner-logo">
 						{ getHostingLogo( 'wpcom-hosting' ) }
 					</div>
-					<h1 className="standard-agency-hosting__banner-description">
+					<div className="standard-agency-hosting__banner-description">
 						{ translate(
 							'Optimized and hassle-free hosting for business websites, local merchants, and small online retailers.'
 						) }
-					</h1>
+					</div>
 				</div>
 
 				<WPCOMPlanSelector onSelect={ onAddToCart } />

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
@@ -7,14 +7,27 @@ import HostingAdditionalFeaturesSection from '../../../common/hosting-additional
 import HostingFeaturesSection from '../../../common/hosting-features-section';
 import { BackgroundType1, BackgroundType2 } from '../../../common/hosting-section/backgrounds';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
+import { getHostingLogo } from '../../../lib/hosting';
 import CommonHostingBenefits from '../common-hosting-benefits';
+
+import './style.scss';
 
 export default function StandardAgencyHosting() {
 	const translate = useTranslate();
 
 	return (
-		<div>
-			{ /* Sample Hosting sections */ }
+		<div className="standard-agency-hosting">
+			<section className="standard-agency-hosting__banner">
+				<div className="standard-agency-hosting__banner-logo">
+					{ getHostingLogo( 'wpcom-hosting' ) }
+				</div>
+				<h1 className="standard-agency-hosting__banner-description">
+					{ translate(
+						'Optimized and hassle-free hosting for business websites, local merchants, and small online retailers.'
+					) }
+				</h1>
+			</section>
+
 			<HostingAdditionalFeaturesSection
 				icon={ <JetpackLogo size={ 16 } /> }
 				heading={ translate( 'Supercharge your clients’ sites' ) }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
@@ -1,9 +1,22 @@
 .standard-agency-hosting__banner {
 	display: flex;
 	flex-direction: column;
+	gap: 32px;
+
+	padding: 0 0 48px;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		max-width: 1500px;
+		margin-inline: auto !important;
+		padding-inline: 40px;
+	}
+}
+
+.standard-agency-hosting__banner-heading {
+	display: flex;
+	flex-direction: column;
 	align-items: center;
 	gap: 8px;
-	margin-block-end: 32px;
 }
 
 .standard-agency-hosting__banner-description {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
@@ -17,6 +17,7 @@
 	flex-direction: column;
 	align-items: center;
 	gap: 8px;
+	text-align: center;
 }
 
 .standard-agency-hosting__banner-description {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
@@ -1,13 +1,9 @@
-.standard-agency-hosting__banner {
-	display: flex;
-	flex-direction: column;
-	gap: 32px;
-
+.standard-agency-hosting__plan-selector-container {
 	padding: 0 0 48px;
 
 	@include breakpoint-deprecated( ">660px" ) {
 		max-width: 1500px;
-		margin-inline: auto !important;
+		margin-inline: auto;
 		padding-inline: 40px;
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
@@ -1,0 +1,11 @@
+.standard-agency-hosting__banner {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	margin-block-end: 32px;
+}
+
+.standard-agency-hosting__banner-description {
+	@include a4a-font-body-md;
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -50,7 +50,7 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 	const quantity = referralMode ? 1 : ( selectedTier.value as number ) - ownedPlans;
 	const discount = referralMode ? options[ 0 ].discount : selectedTier.discount;
 
-	const originalPrice = Number( plan.amount ) * quantity;
+	const originalPrice = Number( plan?.amount ?? 0 ) * quantity;
 	const actualPrice = originalPrice - originalPrice * discount;
 
 	const { name: planName } = useWPCOMPlanDescription( plan?.slug ?? '' );

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -53,7 +53,7 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 	const originalPrice = Number( plan.amount ) * quantity;
 	const actualPrice = originalPrice - originalPrice * discount;
 
-	const { name: planName, features1, features2 } = useWPCOMPlanDescription( plan?.slug ?? '' );
+	const { name: planName } = useWPCOMPlanDescription( plan?.slug ?? '' );
 
 	const ctaLabel = useMemo( () => {
 		if ( referralMode ) {
@@ -152,8 +152,27 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 				</div>
 
 				<div className="wpcom-plan-selector__features">
-					{ !! features1.length && <SimpleList items={ features1 } /> }
-					{ !! features2.length && <SimpleList items={ features2 } /> }
+					<SimpleList
+						items={ [
+							translate( '50GB of storage' ),
+							translate( 'Unrestricted bandwidth' ),
+							translate( 'Install your own plugins & themes' ),
+							translate( 'High-burst capacity' ),
+							translate( 'Web Application Firewall' ),
+							translate( 'High-frequency CPUs' ),
+							translate( 'Expert live chat & email support' ),
+						] }
+					/>
+					<SimpleList
+						items={ [
+							translate( 'DDOS mitigation' ),
+							translate( 'Free staging environment' ),
+							translate( 'Managed malware protection' ),
+							translate( 'Extremely fast DNS with SSL' ),
+							translate( 'Centralized site management' ),
+							translate( '10 PHP workers with auto-scaling' ),
+						] }
+					/>
 				</div>
 			</div>
 		</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -1,0 +1,150 @@
+import formatCurrency from '@automattic/format-currency';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useContext, useMemo, useState } from 'react';
+import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
+import SimpleList from 'calypso/a8c-for-agencies/sections/marketplace/common/simple-list';
+import { MarketplaceTypeContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
+import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
+import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import WPCOMBulkSelector from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection';
+import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options';
+import { DiscountTier } from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
+import useWPCOMPlanDescription from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+import './style.scss';
+
+type Props = {
+	onSelect: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+};
+
+export default function WPCOMPlanSelector( { onSelect }: Props ) {
+	const translate = useTranslate();
+
+	const { data: licenseCounts, isSuccess: isLicenseCountsReady } = useFetchLicenseCounts();
+
+	const { wpcomPlans } = useProductAndPlans( {} );
+
+	const plan = getWPCOMCreatorPlan( wpcomPlans ) ?? wpcomPlans[ 0 ];
+
+	const ownedPlans = useMemo( () => {
+		if ( isLicenseCountsReady && plan ) {
+			const productStats = licenseCounts?.products?.[ plan.slug ];
+			return productStats?.not_revoked || 0;
+		}
+	}, [ isLicenseCountsReady, licenseCounts?.products, plan ] );
+
+	const options = wpcomBulkOptions( [] );
+
+	const [ selectedTier, setSelectedTier ] = useState< DiscountTier >( options[ 0 ] );
+
+	const onSelectTier = ( tier: DiscountTier ) => {
+		setSelectedTier( tier );
+	};
+
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const referralMode = marketplaceType === 'referral';
+
+	// For referral mode we only display 1 option.
+	const quantity = referralMode ? 1 : ( selectedTier.value as number ) - ownedPlans;
+	const discount = referralMode ? options[ 0 ].discount : selectedTier.discount;
+
+	const originalPrice = Number( plan.amount ) * quantity;
+	const actualPrice = originalPrice - originalPrice * discount;
+
+	const { name: planName, features1, features2 } = useWPCOMPlanDescription( plan?.slug ?? '' );
+
+	const ctaLabel = useMemo( () => {
+		if ( referralMode ) {
+			return translate( 'Add to referral' );
+		}
+
+		return quantity > 1
+			? translate( 'Add %(quantity)s %(planName)s sites to cart', {
+					args: {
+						quantity,
+						planName,
+					},
+					comment:
+						'%(quantity)s is the quantity of plans and %(planName)s is the name of the plan.',
+			  } )
+			: translate( 'Add %(planName)s to cart', {
+					args: {
+						planName,
+					},
+					comment: '%(planName)s is the name of the plan.',
+			  } );
+	}, [ planName, quantity, referralMode, translate ] );
+
+	return (
+		<div className="wpcom-plan-selector">
+			<div className="wpcom-plan-selector__slider-container">
+				{ /* TODO: We will later replace these with different one on a separate PR */ }
+				<WPCOMBulkSelector
+					selectedTier={ selectedTier }
+					onSelectTier={ onSelectTier }
+					ownedPlans={ ownedPlans }
+					isLoading={ ! isLicenseCountsReady }
+				/>
+			</div>
+
+			<div className="wpcom-plan-selector__card">
+				<div className="wpcom-plan-selector__details">
+					<h2 className="wpcom-plan-selector__plan-name">{ planName }</h2>
+
+					{ ! isLicenseCountsReady && (
+						<div className="wpcom-plan-selector__price is-placeholder"></div>
+					) }
+
+					{ isLicenseCountsReady && (
+						<div className="wpcom-plan-selector__price">
+							<b className="wpcom-plan-selector__price-actual-value">
+								{ formatCurrency( actualPrice, plan.currency ) }
+							</b>
+							{ !! discount && (
+								<>
+									<b className="wpcom-plan-selector__price-original-value">
+										{ formatCurrency( originalPrice, plan.currency ) }
+									</b>
+
+									<span className="wpcom-plan-selector__price-discount">
+										{ translate( 'You save %(discount)s%', {
+											args: {
+												discount: Math.floor( discount * 100 ),
+											},
+											comment: '%(discount)s is the discount percentage.',
+										} ) }
+									</span>
+								</>
+							) }
+							<div className="wpcom-plan-selector__price-interval">
+								{ plan.price_interval === 'day' && translate( 'per day' ) }
+								{ plan.price_interval === 'month' && translate( 'per month' ) }
+							</div>
+						</div>
+					) }
+
+					<div className="wpcom-plan-selector__cta">
+						<div className="wpcom-plan-selector__cta-label">
+							{ translate( 'How many sites would you like to buy?' ) }
+						</div>
+
+						<Button
+							variant="primary"
+							onClick={ () => onSelect( plan, quantity ) }
+							disabled={ ! isLicenseCountsReady }
+						>
+							{ ctaLabel }
+						</Button>
+					</div>
+				</div>
+
+				<div className="wpcom-plan-selector__features">
+					{ !! features1.length && <SimpleList items={ features1 } /> }
+					{ !! features2.length && <SimpleList items={ features2 } /> }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -86,6 +86,8 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 					onSelectTier={ onSelectTier }
 					ownedPlans={ ownedPlans }
 					isLoading={ ! isLicenseCountsReady }
+					hideOwnedPlansBadge
+					readOnly
 				/>
 			</div>
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -70,6 +70,10 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 		} );
 	}, [ planName, quantity, referralMode, translate ] );
 
+	if ( ! plan ) {
+		return;
+	}
+
 	return (
 		<div className="wpcom-plan-selector">
 			<div className="wpcom-plan-selector__slider-container">

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -60,21 +60,14 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 			return translate( 'Add to referral' );
 		}
 
-		return quantity > 1
-			? translate( 'Add %(quantity)s %(planName)s sites to cart', {
-					args: {
-						quantity,
-						planName,
-					},
-					comment:
-						'%(quantity)s is the quantity of plans and %(planName)s is the name of the plan.',
-			  } )
-			: translate( 'Add %(planName)s to cart', {
-					args: {
-						planName,
-					},
-					comment: '%(planName)s is the name of the plan.',
-			  } );
+		return translate( 'Add %(quantity)s site to cart', 'Add %(quantity)s sites to cart', {
+			args: {
+				quantity,
+				planName,
+			},
+			count: quantity,
+			comment: '%(quantity)s is the quantity of plans and %(planName)s is the name of the plan.',
+		} );
 	}, [ planName, quantity, referralMode, translate ] );
 
 	return (
@@ -93,6 +86,18 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 
 			<div className="wpcom-plan-selector__card">
 				<div className="wpcom-plan-selector__details">
+					{ ownedPlans && (
+						<div className="wpcom-plan-selector__owned-plan">
+							{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
+								args: {
+									count: ownedPlans,
+								},
+								count: ownedPlans,
+								comment: '%(count)s is the number of WordPress.com sites owned by the user',
+							} ) }
+						</div>
+					) }
+
 					<h2 className="wpcom-plan-selector__plan-name">{ planName }</h2>
 
 					{ ! isLicenseCountsReady && (

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
@@ -1,0 +1,78 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.wpcom-plan-selector {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+}
+
+.wpcom-plan-selector__slider-container {
+	max-width: 800px;
+	width: 100%;
+	margin: 0 auto;
+}
+
+.wpcom-plan-selector__card {
+	border: 1px solid var(--color-neutral-5);
+	border-radius: 4px;
+	padding: 32px;
+
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+
+	@include break-large {
+		flex-direction: row;
+		gap: 108px;
+	}
+}
+
+.wpcom-plan-selector__plan-name {
+	@include a4a-font-heading-xl;
+}
+
+.wpcom-plan-selector__price-actual-value,
+.wpcom-plan-selector__price-original-value {
+	@include a4a-font-heading-lg;
+	color: var(--color-text);
+}
+
+.wpcom-plan-selector__price-original-value {
+	display: inline-block;
+	text-decoration: line-through;
+	margin-inline: 8px;
+}
+
+.wpcom-plan-selector__price-discount {
+	@include a4a-font-body-md;
+	color: var(--color-success);
+}
+
+.wpcom-plan-selector__price-interval {
+	@include a4a-font-body-sm;
+}
+
+.wpcom-plan-selector__cta {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 8px;
+	margin-block-start: 24px;
+}
+
+.wpcom-plan-selector__cta-label {
+	@include a4a-font-body-md;
+}
+
+.wpcom-plan-selector__features {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-evenly;
+	flex-grow: 1;
+
+	@include break-wide {
+		flex-direction: row;
+		gap: 48px;
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
@@ -12,8 +12,10 @@
 	width: 100%;
 	margin: 0 auto;
 
-	.a4a-slider {
-		margin-inline-start: -93px;
+	@include break-huge {
+		.a4a-slider {
+			margin-inline-start: -93px;
+		}
 	}
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
@@ -57,7 +57,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	gap: 8px;
+	gap: 16px;
 	margin-block-start: 24px;
 }
 
@@ -75,4 +75,16 @@
 		flex-direction: row;
 		gap: 48px;
 	}
+}
+
+.wpcom-plan-selector__owned-plan {
+	@include a4a-font-heading-md;
+
+	display: inline-block;
+	border: 1px solid var(--color-neutral-5);
+	background-color: var(--color-neutral-0);
+	padding: 4px 16px;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 16px;
+	margin-block-end: 8px;
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
@@ -8,9 +8,13 @@
 }
 
 .wpcom-plan-selector__slider-container {
-	max-width: 800px;
+	max-width: 900px;
 	width: 100%;
 	margin: 0 auto;
+
+	.a4a-slider {
+		margin-inline-start: -93px;
+	}
 }
 
 .wpcom-plan-selector__card {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
@@ -81,7 +81,7 @@ $tab-background-color: #f4fbff;
 	}
 
 	.hosting-v2__content {
-		padding-block-start: 64px;
+		padding-block-start: 32px;
 	}
 
 	.hosting-overview-features__item {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -14,6 +15,7 @@ import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import ReferralToggle from '../common/referral-toggle';
 import withMarketplaceType from '../hoc/with-marketplace-type';
 import useShoppingCart from '../hooks/use-shopping-cart';
@@ -27,8 +29,28 @@ function Hosting() {
 	const translate = useTranslate();
 	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
-	const { selectedCartItems, onRemoveCartItem, showCart, setShowCart, toggleCart } =
-		useShoppingCart();
+	const {
+		selectedCartItems,
+		setSelectedCartItems,
+		onRemoveCartItem,
+		showCart,
+		setShowCart,
+		toggleCart,
+	} = useShoppingCart();
+
+	const onAddToCart = useCallback(
+		( plan: APIProductFamilyProduct, quantity: number ) => {
+			if ( plan ) {
+				const items = selectedCartItems?.filter(
+					( cartItem ) => cartItem.family_slug !== 'wpcom-hosting'
+				);
+
+				setSelectedCartItems( [ ...items, { ...plan, quantity } ] );
+				setShowCart( true );
+			}
+		},
+		[ selectedCartItems, setSelectedCartItems, setShowCart ]
+	);
 
 	return (
 		<Layout
@@ -70,7 +92,7 @@ function Hosting() {
 			</LayoutTop>
 
 			<LayoutBody className={ clsx( { 'is-full-width': isNewHostingPage } ) }>
-				{ isNewHostingPage ? <HostingV2 /> : <HostingList /> }
+				{ isNewHostingPage ? <HostingV2 onAddToCart={ onAddToCart } /> : <HostingList /> }
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -12,6 +12,8 @@ type Props = {
 	onSelectTier: ( value: DiscountTier ) => void;
 	ownedPlans: number;
 	isLoading?: boolean;
+	hideOwnedPlansBadge?: boolean;
+	readOnly?: boolean;
 };
 
 export default function WPCOMBulkSelector( {
@@ -19,6 +21,8 @@ export default function WPCOMBulkSelector( {
 	onSelectTier,
 	ownedPlans,
 	isLoading,
+	hideOwnedPlansBadge,
+	readOnly,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -63,7 +67,7 @@ export default function WPCOMBulkSelector( {
 
 	return (
 		<div className="bulk-selection">
-			{ !! ownedPlans && (
+			{ !! ownedPlans && ! hideOwnedPlansBadge && (
 				<div className="bulk-selection__owned-plan">
 					<Icon icon={ info } size={ 24 } />
 
@@ -93,6 +97,7 @@ export default function WPCOMBulkSelector( {
 				onChange={ onSelectOption }
 				options={ options }
 				minimum={ minimumQuantity }
+				readOnly={ readOnly }
 			/>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/index.tsx
@@ -21,6 +21,7 @@ type Props = {
 	label?: string;
 	sub?: string;
 	minimum?: number;
+	readOnly?: boolean;
 };
 
 export default function A4AWPCOMSlider( {
@@ -31,6 +32,7 @@ export default function A4AWPCOMSlider( {
 	label,
 	sub,
 	minimum = 0,
+	readOnly,
 }: Props ) {
 	const total = ( options.length + 1 ) * 20;
 	const mappedOptions = useMemo(
@@ -53,6 +55,10 @@ export default function A4AWPCOMSlider( {
 		const selected = sliderPosToValue( sliderPos, mappedOptions );
 
 		const next = selected < minimum ? minimum : selected;
+
+		if ( readOnly ) {
+			return;
+		}
 
 		onChange?.( next );
 		setCurrentValue( next );
@@ -78,7 +84,7 @@ export default function A4AWPCOMSlider( {
 	};
 
 	const onNumberSelect = ( value: number ) => {
-		if ( value >= minimum ) {
+		if ( value >= minimum && ! readOnly ) {
 			onChange?.( value );
 			setCurrentValue( value );
 			setCurrentSliderPos( valueToSliderPos( value, mappedOptions ) );
@@ -104,12 +110,14 @@ export default function A4AWPCOMSlider( {
 			) }
 
 			<div className="a4a-slider__input">
-				<div
-					className="a4a-slider__input-disabled-area"
-					style={ {
-						width: disabledAreaWidth,
-					} }
-				></div>
+				{ ! readOnly && (
+					<div
+						className="a4a-slider__input-disabled-area"
+						style={ {
+							width: disabledAreaWidth,
+						} }
+					></div>
+				) }
 
 				<input
 					ref={ rangeRef }
@@ -119,6 +127,7 @@ export default function A4AWPCOMSlider( {
 					onChange={ onSliderChange }
 					value={ currentSliderPos }
 					step="1"
+					readOnly={ readOnly }
 				/>
 
 				<div className="a4a-slider__marker-container">
@@ -149,13 +158,15 @@ export default function A4AWPCOMSlider( {
 					} ) }
 				</div>
 			</div>
-			<input
-				type="number"
-				className="a4a-slider__number-input"
-				value={ currentValue }
-				onChange={ onNumberInputChange }
-				onBlur={ onNumberInputBlur }
-			></input>
+			{ ! readOnly && (
+				<input
+					type="number"
+					className="a4a-slider__number-input"
+					value={ currentValue }
+					onChange={ onNumberInputChange }
+					onBlur={ onNumberInputBlur }
+				></input>
+			) }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
@@ -27,6 +27,10 @@
 		cursor: default;
 	}
 
+	&:read-only::-moz-range-thumb {
+		cursor: default;
+	}
+
 	@mixin slider-track-style {
 		background: var(--color-primary-40);
 		height: 6px;

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
@@ -23,6 +23,10 @@
 	margin: 0;
 	padding: 0;
 
+	&:read-only::-webkit-slider-thumb {
+		cursor: default;
+	}
+
 	@mixin slider-track-style {
 		background: var(--color-primary-40);
 		height: 6px;


### PR DESCRIPTION
This pull request adds the WPCOM banner and plan selector to the new hosting section.

<img width="1569" alt="Screenshot 2024-07-29 at 6 47 37 PM" src="https://github.com/user-attachments/assets/0a9fcf7d-60d7-4bb9-8567-b0f5d134bd35">



Closes https://github.com/Automattic/jetpack-genesis/issues/442

## Proposed Changes

* Update the `WPCOMBulkSelector` component to support read-only. This is needed for the new design now that the slider acts more as a visual element than an input component. Additionally, we add `hideOwnedPlanBadge` as a flag to hide the badge.
* Implement the WPCOM banner and the plan card with all the details and buttons. Note that the increment/decrement functionality will be addressed in a separate PR.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting` page.
* Check the new banner and selector is visible.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
