### PR TITLE
A4A > Marketplace:  Implement Schedule Demo for Pressable hosting

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -5,15 +5,29 @@ import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/premi
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-2.png';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
 import HostingFeaturesSection from '../../../common/hosting-features-section';
+import HostingOverview from '../../../common/hosting-overview';
 import { BackgroundType1, BackgroundType2 } from '../../../common/hosting-section/backgrounds';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
+import PressableOverviewPlanSelection from '../../../pressable-overview/plan-selection';
 import CommonHostingBenefits from '../common-hosting-benefits';
 
 export default function PremierAgencyHosting() {
 	const translate = useTranslate();
 
+	const onAddToCart = () => {
+		// TODO: Implement this function
+	};
+
 	return (
 		<div>
+			<HostingOverview
+				title=""
+				slug="pressable-hosting"
+				subtitle={ translate(
+					'Premier Agency hosting best for large-scale businesses and major eCommerce sites.'
+				) }
+			/>
+			<PressableOverviewPlanSelection onAddToCart={ onAddToCart } />
 			<HostingAdditionalFeaturesSection
 				icon={ <JetpackLogo size={ 16 } /> }
 				heading={ translate( "Supercharge your clients' sites" ) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -1,6 +1,7 @@
-import { Button } from '@automattic/components';
+import { isEnabled } from '@automattic/calypso-config';
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
+import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -22,6 +23,8 @@ type Props = {
 export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLoading }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
 	const info = selectedPlan?.slug ? getPressablePlan( selectedPlan?.slug ) : null;
 
@@ -53,7 +56,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 		<section className="pressable-overview-plan-selection__details">
 			<div className="pressable-overview-plan-selection__details-card">
 				<div className="pressable-overview-plan-selection__details-card-header">
-					<h3 className="pressable-overview-plan-selection__details-card-header-title">
+					<h3 className="pressable-overview-plan-selection__details-card-header-title plan-name">
 						{ translate( '%(planName)s plan', {
 							args: {
 								planName: selectedPlan ? getPressableShortName( selectedPlan.name ) : customString,
@@ -105,6 +108,10 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 							components: { b: <b /> },
 							comment: '%(size)s is the amount of storage in gigabytes.',
 						} ),
+						isNewHostingPage &&
+							translate( '{{b}}Unmetered{{/b}} bandwidth', {
+								components: { b: <b /> },
+							} ),
 					] }
 				/>
 
@@ -112,7 +119,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 					<Button
 						className="pressable-overview-plan-selection__details-card-cta-button"
 						onClick={ onSelectPlan }
-						primary
+						variant="primary"
 					>
 						{ translate( 'Select %(planName)s plan', {
 							args: {
@@ -129,27 +136,58 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 						onClick={ onContactUs }
 						href={ PRESSABLE_CONTACT_LINK }
 						target="_blank"
-						primary
+						variant="primary"
 					>
 						{ translate( 'Contact us' ) } <Icon icon={ external } size={ 16 } />
 					</Button>
 				) }
 			</div>
 
-			<div className="pressable-overview-plan-selection__details-card is-aside">
-				<h3 className="pressable-overview-plan-selection__details-card-header-title">
-					{ translate( 'All plans include:' ) }{ ' ' }
-				</h3>
+			{ isNewHostingPage ? (
+				<div className="pressable-overview-plan-selection__details-card is-aside">
+					<h3 className="pressable-overview-plan-selection__details-card-header-title">
+						{ translate( 'Schedule a demo and personal consultation' ) }
+					</h3>
+					<div className="pressable-overview-plan-selection__details-card-header-subtitle">
+						{ translate(
+							'One of our friendly experts would be happy to give you a one-on-one tour of our platform and discuss:'
+						) }
+					</div>
 
-				<SimpleList
-					items={ [
-						translate( '24/7 WordPress hosting support' ),
-						translate( 'WP Cloud platform' ),
-						translate( 'Jetpack Security (optional)' ),
-						translate( 'Free site migrations' ),
-					] }
-				/>
-			</div>
+					<SimpleList
+						items={ [
+							translate( 'Our support, service, and pricing flexibility' ),
+							translate( 'The best hosting plan for your needs' ),
+							translate( 'How to launch and manage WordPress sites' ),
+							translate( 'The free perks that come with Pressable' ),
+						] }
+					/>
+					<Button
+						className="pressable-overview-plan-selection__details-card-cta-button"
+						onClick={ onContactUs }
+						href={ PRESSABLE_CONTACT_LINK }
+						target="_blank"
+						variant="secondary"
+					>
+						{ translate( 'Schedule a Demo' ) } <Icon icon={ external } size={ 18 } />
+					</Button>
+				</div>
+			) : (
+				<div className="pressable-overview-plan-selection__details-card is-aside">
+					<h3 className="pressable-overview-plan-selection__details-card-header-title">
+						{ translate( 'All plans include:' ) }
+					</h3>
+
+					<SimpleList
+						items={ [
+							translate( '24/7 WordPress hosting support' ),
+							translate( 'WP Cloud platform' ),
+							translate( 'Jetpack Security (optional)' ),
+							translate( 'Free site migrations' ),
+						] }
+					/>
+				</div>
+			) }
 		</section>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+import clsx from 'clsx';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -17,6 +19,8 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 	const dispatch = useDispatch();
 
 	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
+
+	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
 	const onSelectPlan = useCallback(
 		( plan: APIProductFamilyProduct | null ) => {
@@ -52,7 +56,11 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 	}, [ dispatch, onAddToCart, selectedPlan ] );
 
 	return (
-		<div className="pressable-overview-plan-selection">
+		<div
+			className={ clsx( 'pressable-overview-plan-selection', {
+				'is-new-hosting-page': isNewHostingPage,
+			} ) }
+		>
 			<PlanSelectionFilter
 				selectedPlan={ selectedPlan }
 				plans={ pressablePlans }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -54,6 +54,10 @@
 	font-weight: 600;
 }
 
+.pressable-overview-plan-selection__details-card-header-subtitle {
+	@include a4a-font-body-md;
+}
+
 .pressable-overview-plan-selection__details-card-header-price {
 	display: flex;
 	flex-direction: column;
@@ -218,5 +222,43 @@
 		border-radius: 4px;
 		max-width: 350px;
 		height: 256px;
+	}
+}
+
+.is-new-hosting-page.pressable-overview-plan-selection {
+
+	@include break-huge {
+		width: 1000px;
+	}
+
+	.pressable-overview-plan-selection__filter-owned-plan {
+		margin-block-start: 32px;
+	}
+
+	.pressable-overview-plan-selection__details-card {
+		flex: 1;
+		border: 1px solid var(--color-neutral-5);
+		justify-content: space-between;
+	}
+
+	.pressable-overview-plan-selection__details-card-header-title {
+		@include a4a-font-heading-lg;
+
+		&.plan-name {
+			margin-block-end: 8px;
+			@include a4a-font-heading-xl;
+		}
+	}
+
+	.pressable-overview-plan-selection__details-card-header-price {
+		gap: 8px;
+	}
+
+	.pressable-overview-plan-selection__details-card-header-price-value {
+		@include a4a-font-heading-xl;
+	}
+
+	.pressable-overview-plan-selection__details > * {
+		gap: 24px;
 	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/450

## Proposed Changes

This PR:

- Adds a schedule demo section
- Adds the existing Pressable plan selection section with some minor design changes.

Note:

- Add to cart functionality will be implemented in another PR.
- The section is not responsive on all the devices, it will be fixed in a different PR. 


## Why are these changes being made?

* For the new hosting page

## Testing Instructions

* Open the A4A live link
* Go to Marketplace > Hosting > Click the Pressable tab > Verify the UI looks as shown below:


<img width="1728" alt="Screenshot 2024-07-26 at 2 43 29 PM" src="https://github.com/user-attachments/assets/8ad36a7f-dd97-496b-9d7b-103ca6a8beeb">

- Disable the feature flag:`?flags=-a4a-hosting-page-redesign` and verify the old UI didn't change by comparing it with the production version:

<img width="1728" alt="Screenshot 2024-07-26 at 2 44 26 PM" src="https://github.com/user-attachments/assets/4cd7d92f-1b86-45c4-89f6-1d71a37a6513">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
