### PR TITLE
Revert "Masterbar - update icon colors on mobile resolutions (#92869)"

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -561,7 +561,6 @@ body.is-mobile-app-view {
 	}
 
 	@media only screen and (max-width: 782px) {
-		color: var(--color-masterbar-highlight);
 		font-size: $masterbar-mobile-font-size;
 		width: 52px;
 		padding: 0;
@@ -578,7 +577,6 @@ body.is-mobile-app-view {
 		svg,
 		svg path,
 		.gridicon {
-			fill: var(--color-masterbar-highlight);
 			height: 36px;
 			width: 36px;
 		}
@@ -593,7 +591,6 @@ body.is-mobile-app-view {
 		}
 
 		.dashicons-before {
-			color: var(--color-masterbar-highlight);
 			height: unset;
 			&::before {
 				width: 52px;
@@ -1210,13 +1207,6 @@ body.is-mobile-app-view {
 		transition: all 150ms ease-in;
 		fill: var(--color-masterbar-item-active-background);
 	}
-
-	@media only screen and (max-width: 782px) {
-		&:not(.has-unread) svg path {
-			stroke: var(--color-masterbar-highlight);
-			fill: none;
-		}
-	}
 }
 
 @keyframes bubble-unread-indication {
@@ -1394,7 +1384,6 @@ a.masterbar__quick-language-switcher {
 		height: 24px;
 
 		@media only screen and (max-width: 782px) {
-			fill: var(--color-masterbar-highlight);
 			width: 36px;
 			height: 36px;
 			padding: 3px 8px 5px;


### PR DESCRIPTION
This reverts #92869.


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/8379

## Proposed Changes

We want to instead force the mobile admin bar to always have the same color as Desktop viewport.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Core's default behavior, which shows highlight color on mobile viewport, looks bad.

## Testing Instructions

Verify that the previous behavior seen on #92869 is restored.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
