### PR TITLE
Site Assembler: Remove margins between the header, content and footer

### DIFF
--- a/packages/data-stores/src/site/utils.ts
+++ b/packages/data-stores/src/site/utils.ts
@@ -15,8 +15,8 @@ export const createCustomHomeTemplateContent = (
 	if ( hasSections ) {
 		// blockGap":"0" removes the theme blockGap from the main group while allowing users to change it from the editor
 		content.push( `
-<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0"}}} -->
-	<main class="wp-block-group">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}}} -->
+	<main class="wp-block-group" style="margin-top:0;margin-bottom:0">
 		${ mainHtml }
 	</main>
 <!-- /wp:group -->` );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78097

## Proposed Changes

* Remove the margins for the content blocks so that there's no spacing between header, content and footer

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bugfixing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the assembler /setup/with-theme-assembler/patternAssembler?siteSlug={ YOUR SITE }
- Add a header, two section patterns, and a footer. Choose patterns with a background color, not white background, so it's easier to see if there are gaps
- Verify that there aren't gaps between patterns in the assembler large preview
- Click "Continue" and you will land on the editor
- Verify you don't see any gaps between header and footer patterns in the editor
- Go to /plugins 
- Select Bakery RMT
- Land in the launchpad
- Notice that there aren't any white spaces between the header and content

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
