### PR TITLE
A4A: Update cell label to better communicate it is about plugin updates

### DIFF
--- a/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
+++ b/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
@@ -161,7 +161,9 @@ const useFormatPluginData = () => {
 				};
 			}
 			return {
-				value: `${ pluginUpdates?.length } ${ translate( 'Available' ) }`,
+				value: `${ pluginUpdates?.length } ${
+					pluginUpdates?.length === 1 ? translate( 'Update' ) : translate( 'Updates' )
+				}`,
 				status: pluginUpdates?.length > 0 ? 'warning' : 'success',
 				type: 'plugin',
 				updates: pluginUpdates?.length,

--- a/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
+++ b/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
@@ -162,9 +162,13 @@ const useFormatPluginData = () => {
 			}
 
 			return {
-				value: `${ pluginUpdates?.length } ${ translate( 'Update', 'Updates', {
+				value: translate( '%(count)d Update', '%(count)d Updates', {
 					count: pluginUpdates?.length,
-				} ) }`,
+					args: {
+						count: pluginUpdates?.length,
+					},
+					comment: '%(count)d is the number of plugin updates available',
+				} ) as string,
 				status: pluginUpdates?.length > 0 ? 'warning' : 'success',
 				type: 'plugin',
 				updates: pluginUpdates?.length,

--- a/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
+++ b/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
@@ -160,10 +160,11 @@ const useFormatPluginData = () => {
 					updates: 0,
 				};
 			}
+
 			return {
-				value: `${ pluginUpdates?.length } ${
-					pluginUpdates?.length === 1 ? translate( 'Update' ) : translate( 'Updates' )
-				}`,
+				value: `${ pluginUpdates?.length } ${ translate( 'Update', 'Updates', {
+					count: pluginUpdates?.length,
+				} ) }`,
 				status: pluginUpdates?.length > 0 ? 'warning' : 'success',
 				type: 'plugin',
 				updates: pluginUpdates?.length,


### PR DESCRIPTION
Discussed here: pfunGA-2bd-p2#comment-3898

## Proposed Changes

* Changes "1 Available" to "1 Update" in the Plugins column on the sites list to better communicate that the warning is about plugin updates.

<img width="454" alt="Screenshot 2024-07-26 at 12 05 21" src="https://github.com/user-attachments/assets/f9d90183-1486-4bee-82e7-f2279b3d0909">

## Testing Instructions

* Open the live link, login with demo account, and go to the sites dashboard
* Confirm that the Plugins cell now says `1 Update` / `X Updates`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?