### PR TITLE
Domains Table: Fix overlapping columns when user only has domains

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -181,7 +181,7 @@
 			}
 		}
 
-		table {
+		table.is-7-column.has-checkbox {
 			@include break-huge {
 				grid-template-columns: 100px 2fr 1fr 1fr auto auto auto auto;
 

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -5,8 +5,12 @@ import { getSimpleSortFunctionBy, getStatusSortFunctions } from '../utils';
 import { DomainStatusPurchaseActions } from '../utils/resolve-domain-status';
 import { DomainsTableColumn } from '.';
 
-const domainLabel = ( count: number, isBulkSelection: boolean ) =>
-	isBulkSelection
+const domainLabel = ( count: number, isBulkSelection: boolean, showCount: boolean = true ) => {
+	if ( ! showCount ) {
+		return __( 'Domain', __i18n_text_domain__ );
+	}
+
+	return isBulkSelection
 		? sprintf(
 				/* translators: Heading which displays the number of selected domains in a table */
 				_n(
@@ -22,6 +26,7 @@ const domainLabel = ( count: number, isBulkSelection: boolean ) =>
 				_n( '%(count)d domain', '%(count)d domains', count, __i18n_text_domain__ ),
 				{ count }
 		  );
+};
 
 export const allSitesViewColumns = (
 	translate: I18N[ 'translate' ],

--- a/packages/domains-table/src/domains-table-header/index.tsx
+++ b/packages/domains-table/src/domains-table-header/index.tsx
@@ -13,7 +13,10 @@ export type DomainsTableBulkSelectionStatus = 'no-domains' | 'some-domains' | 'a
 
 interface BaseDomainsTableColumn {
 	name: string;
-	label: string | ( ( count: number, isBulkSelection: boolean ) => string ) | null;
+	label:
+		| string
+		| ( ( count: number, isBulkSelection: boolean, showCount?: boolean ) => string )
+		| null;
 	sortFunctions?: Array<
 		( first: DomainData, second: DomainData, sortOrder: number, sites?: SiteDetails[] ) => number
 	>;
@@ -127,7 +130,8 @@ export const DomainsTableHeader = ( {
 									( typeof column?.label === 'function'
 										? column.label(
 												isBulkSelection ? selectedDomainsCount : domainCount,
-												isBulkSelection
+												isBulkSelection,
+												canSelectAnyDomains
 										  )
 										: column?.label ) }
 								{ column?.name === 'status' && domainsRequiringAttention && (


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8434

## Proposed Changes

* Fix the CSS selector that is causing the table to look bad. Since the `grid-template-columns` has 8 values, it can only apply to 7-column + checkbox tables.

## Testing Instructions

* Use a user that has no sites but does have domains
* Open the live preview
* Go to `/sites`
* Then click on `Domains`
* Check that the table looks as usual:

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/48339565-72d9-496b-8ac8-2139ecb682f5)|![image](https://github.com/user-attachments/assets/7db663ac-5706-4ddd-8762-ae2bb664de8a)|

* With a user that has both sites and domains, confirm that there have been no regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
