### PR TITLE
Global sidebar - fix sidebar items alignment and sizing

### DIFF
--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -35,7 +35,7 @@ export default function globalSidebarMenu( { showP2s = false } = {} ) {
 		...( showP2s
 			? [
 					{
-						icon: <ReaderA8cIcon size={ 22 } />,
+						icon: <ReaderA8cIcon />,
 						slug: 'sites-p2',
 						title: translate( 'P2s' ),
 						navigationLabel: translate( 'Manage all my P2 sites' ),
@@ -53,7 +53,7 @@ export default function globalSidebarMenu( { showP2s = false } = {} ) {
 			url: '/domains/manage',
 		},
 		{
-			icon: <Icon icon={ brush } size={ 24 } className="sidebar__menu-icon" />,
+			icon: <Icon icon={ brush } size={ 24 } className="sidebar__menu-icon sidebar_svg-brush" />,
 			slug: 'themes',
 			title: translate( 'Themes' ),
 			navigationLabel: translate( 'Themes' ),

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -65,6 +65,22 @@ $brand-text: "SF Pro Text", $sans;
 	.is-global-sidebar-collapsed {
 		--sidebar-width-max: 69px;
 		--sidebar-width-min: 69px;
+
+		.sidebar {
+			.sidebar__menu-icon {
+				&.sidebar_svg-brush {
+					margin-left: 0;
+				}
+
+				&.sidebar_svg-a8c {
+					padding: 0 2px;
+				}
+
+				&.dashicons-admin-site-alt3 {
+					padding: 0 1px;
+				}
+			}
+		}
 	}
 
 	.is-unified-site-sidebar-visible {
@@ -257,7 +273,13 @@ $font-size: rem(14px);
 			color: var(--color-sidebar-gridicon-fill);
 			margin-right: 8px;
 
+			&.sidebar_svg-brush {
+				margin-left: -2px;
+			}
+
 			&.sidebar_svg-a8c {
+				margin-right: 10px;
+				margin-left: 0;
 				path {
 					stroke: var(--color-sidebar-gridicon-fill);
 					fill: none;
@@ -440,6 +462,7 @@ $font-size: rem(14px);
 			padding: 12px 10px;
 			margin: 0 12px;
 			border-radius: 4px;
+			max-height: 44px;
 		}
 
 		.sidebar__expandable-content .sidebar__menu-link {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8402

Tidies up the alignment and sizing of global sidebar items

## Proposed Changes

* Reduce size of Automattic icon for P2s
* Update the max-height of the sidebar items to 44px to make them consistent

## Before

**Sidebar** - misaligned with variable heights
 
<img width="296" alt="sidebar-misaligned" src="https://github.com/user-attachments/assets/cec63f9c-a7f2-4941-90ce-9cc3a56d636b">
<img width="296" alt="sidebar-variable-heights" src="https://github.com/user-attachments/assets/f27acf26-c99e-4d71-adc5-e4ffb6c815c9">

**Collapsed Sidebar** - misaligned with variable heights

<img width="68" alt="sidebar-collapsed-misaligned" src="https://github.com/user-attachments/assets/f6078138-ccd8-4ae8-91b0-094025967619">
<img width="68" alt="sidebar-collapsed-variable-heights" src="https://github.com/user-attachments/assets/de66a1e5-f23d-4c32-820f-1cee7e891f9e">

## After

**Sidebar** - Aligned with consistent heights

<img width="295" alt="sidebar-aligned" src="https://github.com/user-attachments/assets/0285bb74-14e5-4489-aba6-434055c40ae9">
<img width="295" alt="sidebar-same-heights" src="https://github.com/user-attachments/assets/a5adf6ba-ad13-4c4d-8ee6-2c81d995f64e">

**Collapsed Sidebar** - Aligned with consistent heights

<img width="69" alt="sidebar-collapsed-aligned" src="https://github.com/user-attachments/assets/24de61d6-b01f-4e24-b604-acda30d75538">
<img width="69" alt="sidebar-collapsed-same-heights" src="https://github.com/user-attachments/assets/3cde9a7d-8c9a-4f1a-8cfb-5210e0397107">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Clean up inconsistent styling on sites dashboard for better UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites` on calypso live and confirm alignment and sizing is fixed
* You may need to force the hover state on the `.sidebar__menu-link` class items in sidebar to see the selected state more clearly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
