### PR TITLE
Add document referrer in blazepro login

### DIFF
--- a/client/layout/masterbar/blaze-pro.tsx
+++ b/client/layout/masterbar/blaze-pro.tsx
@@ -10,7 +10,11 @@ import './blaze-pro.scss';
 
 const BlazeProOauthMasterbar = () => {
 	function onClick() {
-		window.history.back();
+		if ( document.referrer ) {
+			window.location.href = document.referrer;
+		} else {
+			window.history.back();
+		}
 	}
 
 	const backNav = (


### PR DESCRIPTION
Related to # (dsp repo)

## Proposed Changes

- Change the back button to use document.referrer when possible in BlazePro login page

## Why are these changes being made?
Sometimes, when the user clicks in the "back" button it gets redirected to a wrong destination or sometimes it just goes blank. This PR aims to use window.referrer when possible so the user lands in a ideal place.-

## Testing Instructions

- Follow steps in this [PR](https://github.com/Automattic/wp-calypso/pull/91095) to create a javascript file that you can run in node to create login links.
- Create a link with your javascript file
- Copy that link in a href in codesandbox or some webpage created in your local environment
- open that URL, with calypso running. Click on "Back" button. It should just send you back

loom: https://www.loom.com/share/458cec11a75a4e129d8ef60a7941b20f

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
