### PR TITLE
Reader follow: Fix subscription url

### DIFF
--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -76,7 +76,7 @@ export default function ReaderFeedHeaderFollow( props ) {
 				{ siteUrl && (
 					<div className="reader-feed-header__follow-button">
 						<ReaderFollowButton
-							siteUrl={ siteUrl }
+							siteUrl={ feed.feed_URL || siteUrl }
 							hasButtonStyle
 							iconSize={ 24 }
 							onFollowToggle={ openSuggestedFollowsModal }

--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -62,7 +62,7 @@ class SearchFollowButton extends Component {
 		// If we find a feed then set the feed object
 		let feed;
 		if ( resemblesUrl( query ) ) {
-			feed = feeds?.find( ( f ) => f?.feed_URL.includes( urlToDomainAndPath( query ) ) );
+			feed = feeds?.find( ( f ) => f?.feed_URL?.includes( urlToDomainAndPath( query ) ) );
 		}
 
 		// If no feed found, then don't show the follow button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

In the `ReaderFeedHeaderFollow` we should use `feed_URL` and fallback to `siteUrl`.
Otherwise, the following request will use the wrong feed URL and fail to subscribe/unsubscribe for RSS feeds.

In the original issue the follow button for the site poststatus.com was broken. I wasn't able to reproduce this but I noticed a js error when searching for the site:
<img width="588" alt="Screenshot 2024-07-26 at 17 20 47" src="https://github.com/user-attachments/assets/056fbc94-34c9-40bd-b767-8e5d364f74a7">
This PR adds a safety check for this case.

Fixes https://github.com/Automattic/wp-calypso/issues/86304

## Proposed Changes

*  `ReaderFeedHeaderFollow` we should use `feed_URL` and fallback to `siteUrl`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use PR link
* Visit `read/feeds/1218003`. You should be able to subscribe/unsubscribe
* Visit `/read/feeds/1218003/posts/5321298255`. You should be able to subscribe/unsubscribe

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
