### PR TITLE
Global masterbar - fix gravatar outline color.

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -959,7 +959,7 @@ body.is-mobile-app-view {
 	}
 
 	.gravatar {
-		border: 1px solid var(--theme-submenu-background-color, --color-sidebar-submenu-background);
+		border: 1px solid var(--color-masterbar-border);
 		border-radius: unset;
 		margin-left: 1px;
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -959,7 +959,7 @@ body.is-mobile-app-view {
 	}
 
 	.gravatar {
-		border: 1px solid var(--color-sidebar-submenu-background);
+		border: 1px solid var(--theme-submenu-background-color, --color-sidebar-submenu-background);
 		border-radius: unset;
 		margin-left: 1px;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#8463

## Proposed Changes

Fixes issue with the white outline on the masterbar gravatar at global levels.

* uses `--color-masterbar-border` for the gravatars outline color instead of `--color-sidebar-submenu-background`  
   * These are both populated by the same initial variable: `--theme-submenu-background-color`, however the `--color-sidebar-submenu-background` is redefined at global levels to accommodate the unique color scheme of the global sidebar (this is the background color for submenu groups, like tags, lists, and a8c sections in the reader).
    * Using the masterbar variable seems more fitting here, since we are in the masterbar.


BEFORE
<img width="211" alt="Screenshot 2024-07-26 at 1 16 07 PM" src="https://github.com/user-attachments/assets/54993e29-95e3-4c8e-bbab-f0ee2bb6cc46">


AFTER
<img width="226" alt="Screenshot 2024-07-26 at 1 16 10 PM" src="https://github.com/user-attachments/assets/f22f30ca-2278-4cd0-9bba-1c45156c7c87">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The outline is inconsistent compared to the modern color scheme and undesirable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Visit global areas, verify the white outline around the gravatar is gone.
* visit your site's "my home" and verify the outline there is unchanged.
* swap a couple color schemes and repeat the above bullet comparing to production, there should be no differences at the site level.
* if you have the "modern" color scheme set, you should see no visible difference between the outline at site and global levels of calypso.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
