### PR TITLE
Track Migration Start for Reddit and Google Ads

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -9,6 +9,7 @@ import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-tri
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
+import { recordMigrationStart } from 'calypso/lib/analytics/ad-tracking/ad-track-migration-start';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { addQueryArgs } from 'calypso/lib/url';
 import { GUIDED_ONBOARDING_FLOW_REFERRER } from 'calypso/signup/steps/initial-intent/constants';
@@ -125,6 +126,9 @@ const siteMigration: Flow = {
 			window.location.assign( to );
 		};
 
+		if ( urlQueryParams.get( 'ref' ) === 'move-lp' ) {
+			recordMigrationStart();
+		}
 		// Call triggerGuidesForStep for the current step
 		useEffect( () => {
 			triggerGuidesForStep( flowName, currentStep, siteId );

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -56,7 +56,14 @@ const siteMigration: Flow = {
 
 		return stepsWithRequiredLogin( [ ...baseSteps, ...hostedVariantSteps ] );
 	},
-
+	useSideEffect() {
+		const urlQueryParams = useQuery();
+		useEffect( () => {
+			if ( urlQueryParams.get( 'ref' ) === 'move-lp' ) {
+				recordMigrationStart();
+			}
+		}, [ urlQueryParams ] );
+	},
 	useAssertConditions(): AssertConditionResult {
 		const { siteSlug, siteId } = useSiteData();
 		const { isAdmin } = useIsSiteAdmin();
@@ -125,10 +132,6 @@ const siteMigration: Flow = {
 		const exitFlow = ( to: string ) => {
 			window.location.assign( to );
 		};
-
-		useEffect( () => {
-			recordMigrationStart();
-		}, [ urlQueryParams ] );
 
 		// Call triggerGuidesForStep for the current step
 		useEffect( () => {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -126,9 +126,10 @@ const siteMigration: Flow = {
 			window.location.assign( to );
 		};
 
-		if ( urlQueryParams.get( 'ref' ) === 'move-lp' ) {
+		useEffect( () => {
 			recordMigrationStart();
-		}
+		}, [ urlQueryParams ] );
+
 		// Call triggerGuidesForStep for the current step
 		useEffect( () => {
 			triggerGuidesForStep( flowName, currentStep, siteId );

--- a/client/lib/analytics/ad-tracking/ad-track-migration-start.ts
+++ b/client/lib/analytics/ad-tracking/ad-track-migration-start.ts
@@ -25,6 +25,8 @@ const adTrackGoogleEvent = (): void => {
 };
 
 export const recordMigrationStart = (): void => {
-	adTrackRedditEvent();
-	adTrackGoogleEvent();
+	setTimeout( () => {
+		adTrackRedditEvent();
+		adTrackGoogleEvent();
+	}, 0 );
 };

--- a/client/lib/analytics/ad-tracking/ad-track-migration-start.ts
+++ b/client/lib/analytics/ad-tracking/ad-track-migration-start.ts
@@ -1,5 +1,5 @@
 import { mayWeTrackByTracker } from '../tracker-buckets';
-import { debug, TRACKING_IDS } from './constants';
+import { TRACKING_IDS, debug } from './constants';
 
 const adTrackRedditEvent = (): void => {
 	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
@@ -15,9 +15,9 @@ const adTrackGoogleEvent = (): void => {
 	}
 	const params = [
 		'event',
-		'migration-flow-start',
+		'conversion',
 		{
-			send_to: TRACKING_IDS.wpcomGoogleAdsGtag,
+			send_to: TRACKING_IDS.wpcomGoogleAdsGtagMigrationStart,
 		},
 	];
 	debug( 'adTrackMigrationStart: [Google Ads Gtag]', params );

--- a/client/lib/analytics/ad-tracking/ad-track-migration-start.ts
+++ b/client/lib/analytics/ad-tracking/ad-track-migration-start.ts
@@ -1,0 +1,30 @@
+import { mayWeTrackByTracker } from '../tracker-buckets';
+import { debug, TRACKING_IDS } from './constants';
+
+const adTrackRedditEvent = (): void => {
+	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
+		return;
+	}
+	debug( 'adTrackMigrationStart: [Reddit Ads Tag]' );
+	window.rdt( 'track', 'Search' );
+};
+
+const adTrackGoogleEvent = (): void => {
+	if ( ! mayWeTrackByTracker( 'googleAds' ) ) {
+		return;
+	}
+	const params = [
+		'event',
+		'migration-flow-start',
+		{
+			send_to: TRACKING_IDS.wpcomGoogleAdsGtag,
+		},
+	];
+	debug( 'adTrackMigrationStart: [Google Ads Gtag]', params );
+	window.gtag( ...params );
+};
+
+export const recordMigrationStart = (): void => {
+	adTrackRedditEvent();
+	adTrackGoogleEvent();
+};

--- a/client/lib/analytics/ad-tracking/ad-track-migration-start.ts
+++ b/client/lib/analytics/ad-tracking/ad-track-migration-start.ts
@@ -25,8 +25,6 @@ const adTrackGoogleEvent = (): void => {
 };
 
 export const recordMigrationStart = (): void => {
-	setTimeout( () => {
-		adTrackRedditEvent();
-		adTrackGoogleEvent();
-	}, 0 );
+	adTrackRedditEvent();
+	adTrackGoogleEvent();
 };

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -59,6 +59,7 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
 	wpcomGoogleAdsGtagDomainTransferPurchase: 'AW-946162814/8T2PCL3d7rsYEP6YlcMD',
+	wpcomGoogleAdsGtagMigrationStart: 'AW-946162814/0qOACLyvvccZEP6YlcMD',
 	wpcomGoogleGA4Gtag: 'G-1H4VG5F5JF',
 	jetpackGoogleTagManagerId: 'GTM-MWWK6WM',
 	jetpackGoogleGA4Gtag: 'G-K8CRH0LL00',

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -19,7 +19,6 @@ import {
 	GOOGLE_GTM_SCRIPT_URL,
 	WPCOM_CLARITY_URI,
 	REDDIT_TRACKING_SCRIPT_URL,
-	WPCOM_REDDIT_PIXEL_ID,
 } from './constants';
 import { setup } from './setup';
 
@@ -160,15 +159,6 @@ function initLoadedTrackingScripts() {
 		const currentUser = getCurrentUser();
 		const params = currentUser ? { em: currentUser.hashedPii.email } : {};
 		window.pintrk( 'load', TRACKING_IDS.pinterestInit, params );
-	}
-
-	if ( mayWeTrackByTracker( 'reddit' ) ) {
-		const params = {
-			optOut: false,
-			useDecimalCurrencyValues: true,
-		};
-
-		window.rdt( 'init', WPCOM_REDDIT_PIXEL_ID, params );
 	}
 
 	debug( 'loadTrackingScripts: init done' );

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -8,6 +8,7 @@ import {
 	ADROLL_PURCHASE_PIXEL_URL_1,
 	ADROLL_PURCHASE_PIXEL_URL_2,
 	TRACKING_IDS,
+	WPCOM_REDDIT_PIXEL_ID,
 } from './constants';
 
 export function setup() {
@@ -223,10 +224,14 @@ function setupRedditGlobal() {
 	window.rdt =
 		window.rdt ||
 		function ( ...args ) {
+			window.rdt.callQueue = window.rdt.callQueue || [];
 			window.rdt.sendEvent ? window.rdt.sendEvent( ...args ) : window.rdt.callQueue.push( args );
 		};
-
-	window.rdt.callQueue = [];
+	const params = {
+		optOut: false,
+		useDecimalCurrencyValues: true,
+	};
+	window.rdt( 'init', WPCOM_REDDIT_PIXEL_ID, params );
 }
 
 function setupGtag() {


### PR DESCRIPTION
Related to # https://github.com/Automattic/martech/issues/3206

Migrations focused campaigns will be started and we are adding event tracking for Google and Reddit.

## Proposed Changes
1. Create a Tracking File
    - Add a new file to contain tracking codes for migration starts. This file can include any third-party trackers.
2. Add Tracking Codes
   - Include Reddit and Google tracking codes in the newly created file.
3. Update Migration Flow
   - Modify the migration flow to trigger a tracking event based on the user's referrer. Ensure that the appropriate tracking event fires for each applicable referrer.


## Testing Instructions

1. Apply patch
3. Enable` ad-tracking` and `cookie-banner` in the development.json and spin up calypso locally.
4. Open chrome console and navigate to the network tab
5. Navigate to /setup/hosted-site-migration?ref=move-lp in the browser
6. Once the page loads, you should see:
    - Reddit: A call to Search tracking event. See the screenshot below (filer by Reddit)
    - Google: A conversion event should be fired with tracking label 0qOACLyvvccZEP6YlcMD (Filter by label: 0qOACLyvvccZEP6YlcMD)

Reddit
<img width="1226" alt="Screenshot 2024-07-26 at 3 15 30 PM" src="https://github.com/user-attachments/assets/e2020a4d-e4d5-4dd6-b8fd-212bfe7323b5">

Google
![image](https://github.com/user-attachments/assets/7c02c2cc-eb2e-4ed7-ba68-7e9039448bd0)

