### PR TITLE
Domains: Include checkout terms for promotional pricing

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -7,6 +7,7 @@ import { Children, Fragment, ReactNode, isValidElement } from 'react';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { has100YearPlan, hasRenewableSubscription } from 'calypso/lib/cart-values/cart-items';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
+import DomainPromotionalPricingRestrictions from 'calypso/my-sites/checkout/src/components/domain-promotional-pricing-restrictions';
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -96,6 +97,7 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 			/>
 			<>
 				{ ! isGiftPurchase && <DomainRegistrationAgreement cart={ cart } /> }
+				{ ! isGiftPurchase && <DomainPromotionalPricingRestrictions cart={ cart } /> }
 				{ ! isGiftPurchase && <DomainRegistrationHsts cart={ cart } /> }
 				{ ! isGiftPurchase && <DomainRegistrationDotGay cart={ cart } /> }
 				{ ! isGiftPurchase && <DomainRegistrationFreeGravatarDomain cart={ cart } /> }

--- a/client/my-sites/checkout/src/components/domain-promotional-pricing-restrictions.tsx
+++ b/client/my-sites/checkout/src/components/domain-promotional-pricing-restrictions.tsx
@@ -60,7 +60,8 @@ class DomainPromotionalPricingRestrictions extends Component<
 	render() {
 		const { cart } = this.props;
 		if (
-			! ( hasDomainRegistration( cart ) || hasTransferProduct( cart ) ) &&
+			! hasDomainRegistration( cart ) &&
+			! hasTransferProduct( cart ) &&
 			! this.hasAnyDomainWithPromotionalPrice( cart )
 		) {
 			return null;

--- a/client/my-sites/checkout/src/components/domain-promotional-pricing-restrictions.tsx
+++ b/client/my-sites/checkout/src/components/domain-promotional-pricing-restrictions.tsx
@@ -1,0 +1,77 @@
+import { DOMAIN_PROMOTIONAL_PRICING_POLICY } from '@automattic/urls';
+import { localize } from 'i18n-calypso';
+import { Component } from 'react';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import {
+	getDomainMappings,
+	getDomainRegistrations,
+	getDomainTransfers,
+	hasDomainRegistration,
+	hasTransferProduct,
+} from 'calypso/lib/cart-values/cart-items';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/src/components/checkout-terms-item';
+import type { ResponseCart } from '@automattic/shopping-cart';
+import type { LocalizeProps } from 'i18n-calypso';
+
+export interface DomainPromotionalPricingRestrictionsProps {
+	cart: ResponseCart;
+}
+
+class DomainPromotionalPricingRestrictions extends Component<
+	DomainPromotionalPricingRestrictionsProps & LocalizeProps
+> {
+	recordPromotionalPricingPolicyClick = () => {
+		gaRecordEvent( 'Upgrades', 'Clicked Registration Agreement Link' );
+	};
+
+	hasAnyDomainWithPromotionalPrice( cart: ResponseCart ): boolean {
+		const domainProducts = [
+			...getDomainRegistrations( cart ),
+			...getDomainMappings( cart ),
+			...getDomainTransfers( cart ),
+		];
+		return domainProducts.some(
+			( product ) => product.item_subtotal_integer !== product.item_original_subtotal_integer
+		);
+	}
+
+	renderPromotionalPricingRestrictionsLink = () => {
+		return (
+			<p>
+				{ this.props.translate(
+					'{{promotionalPricingPolicyLink}}Restrictions apply{{/promotionalPricingPolicyLink}}.',
+					{
+						components: {
+							promotionalPricingPolicyLink: (
+								<a
+									href={ DOMAIN_PROMOTIONAL_PRICING_POLICY }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ this.recordPromotionalPricingPolicyClick }
+								/>
+							),
+						},
+					}
+				) }
+			</p>
+		);
+	};
+
+	render() {
+		const { cart } = this.props;
+		if (
+			! ( hasDomainRegistration( cart ) || hasTransferProduct( cart ) ) &&
+			! this.hasAnyDomainWithPromotionalPrice( cart )
+		) {
+			return null;
+		}
+
+		return (
+			<CheckoutTermsItem isPrewrappedChildren>
+				{ this.renderPromotionalPricingRestrictionsLink() }
+			</CheckoutTermsItem>
+		);
+	}
+}
+
+export default localize( DomainPromotionalPricingRestrictions );

--- a/client/my-sites/checkout/src/components/domain-promotional-pricing-restrictions.tsx
+++ b/client/my-sites/checkout/src/components/domain-promotional-pricing-restrictions.tsx
@@ -59,11 +59,8 @@ class DomainPromotionalPricingRestrictions extends Component<
 
 	render() {
 		const { cart } = this.props;
-		if (
-			! hasDomainRegistration( cart ) &&
-			! hasTransferProduct( cart ) &&
-			! this.hasAnyDomainWithPromotionalPrice( cart )
-		) {
+		const cartHasDomain = hasDomainRegistration( cart ) || hasTransferProduct( cart );
+		if ( ! cartHasDomain || ! this.hasAnyDomainWithPromotionalPrice( cart ) ) {
 			return null;
 		}
 

--- a/packages/urls/src/index.ts
+++ b/packages/urls/src/index.ts
@@ -20,6 +20,7 @@ export const DOMAIN_EXPIRATION_AUCTION = `${ root }/domains/domain-expiration/#e
 export const DOMAIN_EXPIRATION_REDEMPTION = `${ root }/domains/domain-expiration/#renewing-a-domain-in-the-redemption-period`;
 export const DOMAIN_RECENTLY_REGISTERED = `${ root }/domains/register-domain/#waiting-for-domain-changes`;
 export const DOMAIN_PRICING_AND_AVAILABLE_TLDS = `${ root }/domains/domain-pricing-and-available-tlds/`;
+export const DOMAIN_PROMOTIONAL_PRICING_POLICY = `${ root }/domains/domain-pricing-and-available-tlds/#domain-name-promotional-pricing-policy`;
 export const DNS_RECORDS_EDITING_OR_DELETING = `${ root }/domains/custom-dns/#editing-or-deleting-dns-records`;
 export const DNS_TXT_RECORD_CHAR_LIMIT = `${ root }/domains/custom-dns/#txt-record-character-limit`;
 export const ECOMMERCE = `${ root }/ecommerce/`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
## Proposed Changes
Adds checkout terms pointing to the domain support page for domain pricing, specifically on the "Promotional Pricing Policy" section. This only happens if there's a domain on sale in the cart.

## Testing Instructions
Add a domain (registration, transfer or mapping) on sale to the cart and ensure you see the checkout term as in the screenshot.

## Preview
![image](https://github.com/user-attachments/assets/c78d90da-150e-4e93-848a-1c0d34cb916c)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
