### PR TITLE
Revert "Stats: Fix translations for the purchase page"

### DIFF
--- a/apps/odyssey-stats/.size-limit.js
+++ b/apps/odyssey-stats/.size-limit.js
@@ -3,7 +3,7 @@ const path = require( 'path' );
 module.exports = [
 	{
 		path: path.join( __dirname, 'dist/build.min.js' ),
-		limit: '500 KiB',
+		limit: '400 KiB',
 	},
 	{
 		path: path.join( __dirname, 'dist/widget-loader.min.js' ),

--- a/client/my-sites/stats/pages/purchase/controller.tsx
+++ b/client/my-sites/stats/pages/purchase/controller.tsx
@@ -1,10 +1,15 @@
-import StatsPurchasePage from 'calypso/my-sites/stats/pages/purchase';
+import AsyncLoad from 'calypso/components/async-load';
+import PageLoading from '../shared/page-loading';
 import type { Context } from '@automattic/calypso-router';
 
 function purchase( context: Context, next: () => void ) {
 	context.primary = (
 		// DO NOT WRAP WITH <LoadStatsPage /> or you will get an infinite loop
-		<StatsPurchasePage query={ context.query } />
+		<AsyncLoad
+			require="calypso/my-sites/stats/pages/purchase"
+			placeholder={ PageLoading }
+			query={ context.query }
+		/>
 	);
 	next();
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#89672 since async bundles are now properly translated https://github.com/Automattic/wp-calypso/pull/92918

Related to: https://github.com/Automattic/red-team/issues/96