### PR TITLE
Revert "A4A > Marketplace:  Implement Schedule Demo for Pressable hosting"

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -5,29 +5,15 @@ import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/premi
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-2.png';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
 import HostingFeaturesSection from '../../../common/hosting-features-section';
-import HostingOverview from '../../../common/hosting-overview';
 import { BackgroundType1, BackgroundType2 } from '../../../common/hosting-section/backgrounds';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
-import PressableOverviewPlanSelection from '../../../pressable-overview/plan-selection';
 import CommonHostingBenefits from '../common-hosting-benefits';
 
 export default function PremierAgencyHosting() {
 	const translate = useTranslate();
 
-	const onAddToCart = () => {
-		// TODO: Implement this function
-	};
-
 	return (
 		<div>
-			<HostingOverview
-				title=""
-				slug="pressable-hosting"
-				subtitle={ translate(
-					'Premier Agency hosting best for large-scale businesses and major eCommerce sites.'
-				) }
-			/>
-			<PressableOverviewPlanSelection onAddToCart={ onAddToCart } />
 			<HostingAdditionalFeaturesSection
 				icon={ <JetpackLogo size={ 16 } /> }
 				heading={ translate( "Supercharge your clients' sites" ) }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -1,7 +1,6 @@
-import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
-import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -23,8 +22,6 @@ type Props = {
 export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLoading }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-
-	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
 	const info = selectedPlan?.slug ? getPressablePlan( selectedPlan?.slug ) : null;
 
@@ -56,7 +53,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 		<section className="pressable-overview-plan-selection__details">
 			<div className="pressable-overview-plan-selection__details-card">
 				<div className="pressable-overview-plan-selection__details-card-header">
-					<h3 className="pressable-overview-plan-selection__details-card-header-title plan-name">
+					<h3 className="pressable-overview-plan-selection__details-card-header-title">
 						{ translate( '%(planName)s plan', {
 							args: {
 								planName: selectedPlan ? getPressableShortName( selectedPlan.name ) : customString,
@@ -108,10 +105,6 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 							components: { b: <b /> },
 							comment: '%(size)s is the amount of storage in gigabytes.',
 						} ),
-						isNewHostingPage &&
-							translate( '{{b}}Unmetered{{/b}} bandwidth', {
-								components: { b: <b /> },
-							} ),
 					] }
 				/>
 
@@ -119,7 +112,7 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 					<Button
 						className="pressable-overview-plan-selection__details-card-cta-button"
 						onClick={ onSelectPlan }
-						variant="primary"
+						primary
 					>
 						{ translate( 'Select %(planName)s plan', {
 							args: {
@@ -136,58 +129,27 @@ export default function PlanSelectionDetails( { selectedPlan, onSelectPlan, isLo
 						onClick={ onContactUs }
 						href={ PRESSABLE_CONTACT_LINK }
 						target="_blank"
-						variant="primary"
+						primary
 					>
 						{ translate( 'Contact us' ) } <Icon icon={ external } size={ 16 } />
 					</Button>
 				) }
 			</div>
 
-			{ isNewHostingPage ? (
-				<div className="pressable-overview-plan-selection__details-card is-aside">
-					<h3 className="pressable-overview-plan-selection__details-card-header-title">
-						{ translate( 'Schedule a demo and personal consultation' ) }
-					</h3>
-					<div className="pressable-overview-plan-selection__details-card-header-subtitle">
-						{ translate(
-							'One of our friendly experts would be happy to give you a one-on-one tour of our platform and discuss:'
-						) }
-					</div>
+			<div className="pressable-overview-plan-selection__details-card is-aside">
+				<h3 className="pressable-overview-plan-selection__details-card-header-title">
+					{ translate( 'All plans include:' ) }{ ' ' }
+				</h3>
 
-					<SimpleList
-						items={ [
-							translate( 'Our support, service, and pricing flexibility' ),
-							translate( 'The best hosting plan for your needs' ),
-							translate( 'How to launch and manage WordPress sites' ),
-							translate( 'The free perks that come with Pressable' ),
-						] }
-					/>
-					<Button
-						className="pressable-overview-plan-selection__details-card-cta-button"
-						onClick={ onContactUs }
-						href={ PRESSABLE_CONTACT_LINK }
-						target="_blank"
-						variant="secondary"
-					>
-						{ translate( 'Schedule a Demo' ) } <Icon icon={ external } size={ 18 } />
-					</Button>
-				</div>
-			) : (
-				<div className="pressable-overview-plan-selection__details-card is-aside">
-					<h3 className="pressable-overview-plan-selection__details-card-header-title">
-						{ translate( 'All plans include:' ) }
-					</h3>
-
-					<SimpleList
-						items={ [
-							translate( '24/7 WordPress hosting support' ),
-							translate( 'WP Cloud platform' ),
-							translate( 'Jetpack Security (optional)' ),
-							translate( 'Free site migrations' ),
-						] }
-					/>
-				</div>
-			) }
+				<SimpleList
+					items={ [
+						translate( '24/7 WordPress hosting support' ),
+						translate( 'WP Cloud platform' ),
+						translate( 'Jetpack Security (optional)' ),
+						translate( 'Free site migrations' ),
+					] }
+				/>
+			</div>
 		</section>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/index.tsx
@@ -1,5 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
-import clsx from 'clsx';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -19,8 +17,6 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 	const dispatch = useDispatch();
 
 	const [ selectedPlan, setSelectedPlan ] = useState< APIProductFamilyProduct | null >( null );
-
-	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
 	const onSelectPlan = useCallback(
 		( plan: APIProductFamilyProduct | null ) => {
@@ -56,11 +52,7 @@ export default function PressableOverviewPlanSelection( { onAddToCart }: Props )
 	}, [ dispatch, onAddToCart, selectedPlan ] );
 
 	return (
-		<div
-			className={ clsx( 'pressable-overview-plan-selection', {
-				'is-new-hosting-page': isNewHostingPage,
-			} ) }
-		>
+		<div className="pressable-overview-plan-selection">
 			<PlanSelectionFilter
 				selectedPlan={ selectedPlan }
 				plans={ pressablePlans }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -54,10 +54,6 @@
 	font-weight: 600;
 }
 
-.pressable-overview-plan-selection__details-card-header-subtitle {
-	@include a4a-font-body-md;
-}
-
 .pressable-overview-plan-selection__details-card-header-price {
 	display: flex;
 	flex-direction: column;
@@ -222,43 +218,5 @@
 		border-radius: 4px;
 		max-width: 350px;
 		height: 256px;
-	}
-}
-
-.is-new-hosting-page.pressable-overview-plan-selection {
-
-	@include break-huge {
-		width: 1000px;
-	}
-
-	.pressable-overview-plan-selection__filter-owned-plan {
-		margin-block-start: 32px;
-	}
-
-	.pressable-overview-plan-selection__details-card {
-		flex: 1;
-		border: 1px solid var(--color-neutral-5);
-		justify-content: space-between;
-	}
-
-	.pressable-overview-plan-selection__details-card-header-title {
-		@include a4a-font-heading-lg;
-
-		&.plan-name {
-			margin-block-end: 8px;
-			@include a4a-font-heading-xl;
-		}
-	}
-
-	.pressable-overview-plan-selection__details-card-header-price {
-		gap: 8px;
-	}
-
-	.pressable-overview-plan-selection__details-card-header-price-value {
-		@include a4a-font-heading-xl;
-	}
-
-	.pressable-overview-plan-selection__details > * {
-		gap: 24px;
 	}
 }


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2024-07-26 at 2 43 29 PM" src="https://github.com/user-attachments/assets/8ad36a7f-dd97-496b-9d7b-103ca6a8beeb">


Reverts Automattic/wp-calypso#93006