### PR TITLE
A4A: Fix the dark button styles

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
@@ -70,7 +70,7 @@ const ReferralToggle = () => {
 								'Please confirm your details before referring products to your clients.'
 							) }
 						</div>
-						<Button href="/referrals/payment-settings">
+						<Button className="is-dark" href="/referrals/payment-settings">
 							{ translate( 'Go to payment settings' ) }
 						</Button>
 					</A4APopover>

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/style.scss
@@ -23,14 +23,4 @@
 	.referral-toggle__notice-description {
 		@include a4a-font-body-md;
 	}
-
-	.button {
-		background-color: var(--color-accent-100);
-		color: var(--color-surface);
-
-		&:hover,
-		&:focus-visible {
-			background-color: var(--color-accent-100);
-		}
-	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/filter.tsx
@@ -125,7 +125,7 @@ export default function PlanSelectionFilter( {
 				<div className="pressable-overview-plan-selection__filter-buttons">
 					<Button
 						className={ clsx( 'pressable-overview-plan-selection__filter-button', {
-							'is-selected': filterType === FILTER_TYPE_INSTALL,
+							'is-dark': filterType === FILTER_TYPE_INSTALL,
 						} ) }
 						onClick={ onSelectInstallFilterType }
 					>
@@ -134,7 +134,7 @@ export default function PlanSelectionFilter( {
 
 					<Button
 						className={ clsx( 'pressable-overview-plan-selection__filter-button', {
-							'is-selected': filterType === FILTER_TYPE_VISITS,
+							'is-dark': filterType === FILTER_TYPE_VISITS,
 						} ) }
 						onClick={ onSelectVisitFilterType }
 					>

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -144,7 +144,7 @@
 	}
 }
 
-.components-button.pressable-overview-plan-selection__filter-button {
+.theme-a8c-for-agencies .components-button.pressable-overview-plan-selection__filter-button {
 	border: 1.5px solid var(--color-surface-backdrop);
 	font-size: 0.875rem;
 	font-weight: 600;
@@ -153,11 +153,6 @@
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 29px;
 	padding: 6px 12px;
-
-	&.is-selected {
-		background: var(--color-surface-backdrop);
-		color: var(--color-text-inverted);
-	}
 
 	&:focus {
 		box-shadow: none;

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -118,7 +118,7 @@ export default function ReferralsOverview( {
 									) }
 								</div>
 								<Button
-									className="referrals-overview__notice-button"
+									className="referrals-overview__notice-button is-dark"
 									href="/referrals/payment-settings"
 								>
 									{ translate( 'Go to payment settings' ) }
@@ -163,7 +163,7 @@ export default function ReferralsOverview( {
 												) }
 											</div>
 											<Button
-												className="referrals-overview__notice-button"
+												className="referrals-overview__notice-button is-dark"
 												href="/referrals/payment-settings"
 											>
 												{ translate( 'Go to payment settings' ) }

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -7,16 +7,6 @@ $data-view-border-color: #f1f1f1;
 	margin-block-end: 48px;
 }
 
-.theme-a8c-for-agencies .button.referrals-overview__notice-button {
-	background-color: var(--color-accent-100);
-	color: var(--color-surface);
-
-	&:hover,
-	&:focus-visible {
-		background-color: var(--color-accent-100);
-	}
-}
-
 .referrals-overview__notice {
 	.button.referrals-overview__notice-button {
 		margin-block-start: 1rem;

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -222,6 +222,17 @@
 		}
 	}
 
+	.button.is-dark,
+	.components-button.is-dark {
+		background-color: var(--color-accent-100);
+		color: var(--color-surface);
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--color-accent-100);
+		}
+	}
+
 	.split-button .button {
 		@include a4a-font-label-button;
 		height: 40px;


### PR DESCRIPTION
## Proposed Changes

This PR 
 
- Resolves the issues with the dark buttons by creating a new class, `is-dark`
- Resolves the problem with Pressable filter buttons where styles were not being applied correctly upon page refresh.

## Why are these changes being made?

* To fix the issues with the dark buttons & the Pressable filter buttons.

## Testing Instructions

- Open the A4A live link
- Go to Referrals and verify the dark buttons look good:

<img width="1373" alt="Screenshot 2024-07-29 at 8 06 47 AM" src="https://github.com/user-attachments/assets/20629769-71a5-4b63-8771-a8f599898ea3">

- Go to Marketplace and verify the button doesn't change the color on-hover after refreshing the page.

<img width="425" alt="Screenshot 2024-07-29 at 8 06 23 AM" src="https://github.com/user-attachments/assets/d3a71513-aca2-4959-883f-825aa23cf1b8">

- Go to /hosting/pressable and verify the filter button styles stay as-is even after refreshing the page

<img width="924" alt="Screenshot 2024-07-29 at 8 05 52 AM" src="https://github.com/user-attachments/assets/e8929227-2b69-48c5-85ee-a3d4a3fa585f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
