### PR TITLE
Stepper new-hosted-site: Fix coupon discounted price display

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -62,6 +62,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		hideFreePlan: reduxHideFreePlan,
 		domainCartItem,
 		hidePlansFeatureComparison,
+		couponCode,
 	} = useSelect( ( select ) => {
 		return {
 			hideFreePlan: ( select( ONBOARD_STORE ) as OnboardSelect ).getHideFreePlan(),
@@ -69,6 +70,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			hidePlansFeatureComparison: (
 				select( ONBOARD_STORE ) as OnboardSelect
 			 ).getHidePlansFeatureComparison(),
+			couponCode: ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
 		};
 	}, [] );
 	const { flowName } = props;
@@ -177,6 +179,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					renderSiblingWhenLoaded={ () => props.shouldIncludeFAQ && <PlanFAQ /> }
 					showPlanTypeSelectorDropdown={ config.isEnabled( 'onboarding/interval-dropdown' ) }
 					onPlanIntervalUpdate={ onPlanIntervalUpdate }
+					coupon={ couponCode }
 				/>
 			</div>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Based on the request made in p1721758148684499-slack-CV1BNGVCH, we want to enable auto-applying coupon discounts in the `/setup/new-hosted-site` Stepper signup flow.
* https://github.com/Automattic/wp-calypso/pull/92978 enabled coupon application for this flow but it does not show coupon-discounted price in the plans step.
* This PR now enables showing coupon discounted price in the plans step.

### BEFORE
<img width="815" alt="Screenshot 2024-07-29 at 12 36 50 PM" src="https://github.com/user-attachments/assets/cbfae8fa-be10-4dea-8534-dc2d6e99a5ff">



### AFTER

<img width="847" alt="Screenshot 2024-07-29 at 12 36 28 PM" src="https://github.com/user-attachments/assets/597d76c7-941c-4a4b-ae53-23467906dabd">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Take the coupon code from 352ea-pb. Let's call it COUPON_CODE.
* Visit `/setup/new-hosted-site/?coupon=COUPON_CODE and verify that the plans step shows the coupon discounted price.
* Visit the same flow without the coupon parameter and verify that the plans step shows the regular plan price.

