### PR TITLE
A4A: Implement increment/decrement quantity functionality on the WPCOM hosting page.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-number-input/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-number-input/index.tsx
@@ -30,7 +30,7 @@ export default function A4ANumberInput( {
 	return (
 		<div className="a4a-number-input">
 			<Button onMouseDown={ onDecrement }>
-				<Icon className="gridicon" icon={ lineSolid } size={ 18 } />
+				<Icon icon={ lineSolid } size={ 18 } />
 			</Button>
 			<TextControl
 				value={ value }
@@ -38,7 +38,7 @@ export default function A4ANumberInput( {
 				type="number"
 			/>
 			<Button onMouseDown={ onIncrement }>
-				<Icon className="gridicon" icon={ plus } size={ 18 } />
+				<Icon icon={ plus } size={ 18 } />
 			</Button>
 		</div>
 	);

--- a/client/a8c-for-agencies/components/a4a-number-input/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-number-input/index.tsx
@@ -1,0 +1,45 @@
+import { Button, TextControl } from '@wordpress/components';
+import { Icon, lineSolid, plus } from '@wordpress/icons';
+import { useCallback } from 'react';
+
+import './style.scss';
+
+type Props = {
+	value: number;
+	onChange: ( value: number ) => void;
+	minimum?: number;
+	maximum?: number;
+	increment?: number;
+};
+
+export default function A4ANumberInput( {
+	value,
+	onChange,
+	minimum = 0,
+	maximum,
+	increment = 1,
+}: Props ) {
+	const onDecrement = useCallback( () => {
+		onChange( Math.min( value - increment, minimum ) );
+	}, [ increment, minimum, onChange, value ] );
+
+	const onIncrement = useCallback( () => {
+		onChange( maximum ? Math.max( value + increment, maximum ) : value + increment );
+	}, [ increment, maximum, onChange, value ] );
+
+	return (
+		<div className="a4a-number-input">
+			<Button onMouseDown={ onDecrement }>
+				<Icon className="gridicon" icon={ lineSolid } size={ 18 } />
+			</Button>
+			<TextControl
+				value={ value }
+				onChange={ ( newValue ) => onChange( parseInt( newValue, 10 ) ) }
+				type="number"
+			/>
+			<Button onMouseDown={ onIncrement }>
+				<Icon className="gridicon" icon={ plus } size={ 18 } />
+			</Button>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/a4a-number-input/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-number-input/index.tsx
@@ -15,16 +15,16 @@ type Props = {
 export default function A4ANumberInput( {
 	value,
 	onChange,
-	minimum = 0,
+	minimum = 1,
 	maximum,
 	increment = 1,
 }: Props ) {
 	const onDecrement = useCallback( () => {
-		onChange( Math.min( value - increment, minimum ) );
+		onChange( Math.max( value - increment, minimum ) );
 	}, [ increment, minimum, onChange, value ] );
 
 	const onIncrement = useCallback( () => {
-		onChange( maximum ? Math.max( value + increment, maximum ) : value + increment );
+		onChange( maximum ? Math.min( value + increment, maximum ) : value + increment );
 	}, [ increment, maximum, onChange, value ] );
 
 	return (

--- a/client/a8c-for-agencies/components/a4a-number-input/style.scss
+++ b/client/a8c-for-agencies/components/a4a-number-input/style.scss
@@ -1,0 +1,41 @@
+.theme-a8c-for-agencies .a4a-number-input {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+
+	align-items: center;
+	justify-content: center;
+
+	.components-button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 100%;
+		border: 1px solid var(--color-neutral-5);
+		padding: 0 6px;
+		max-height: 32px;
+	}
+
+	.components-text-control__input[type="number"] {
+		max-width: 80px;
+		text-align: center;
+		border-radius: 4px;
+		padding: 0;
+
+		-moz-appearance: textfield;
+
+		&:focus,
+		&:focus-visible {
+			border-color: var(--color-primary);
+			box-shadow: 0 0 0 0.5px var(--color-primary);
+			outline: 2px solid transparent;
+		}
+
+
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-wpcom-discount-tiers.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-wpcom-discount-tiers.tsx
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import { APIProductFamily } from 'calypso/state/partner-portal/types';
+import wpcomBulkOptions from '../../wpcom-overview/lib/wpcom-bulk-options';
+
+export default function useWPCOMDiscountTiers() {
+	const { data: products } = useProductsQuery( false, true );
+
+	const wpcomProducts = products
+		? ( products.find(
+				( product ) => product.slug === 'wpcom-hosting'
+		  ) as unknown as APIProductFamily )
+		: undefined;
+
+	return useMemo( () => {
+		return wpcomBulkOptions( wpcomProducts?.discounts?.tiers ?? [] );
+	}, [ wpcomProducts?.discounts?.tiers ] );
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -78,13 +78,15 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 	return (
 		<div className="wpcom-plan-selector">
 			<div className="wpcom-plan-selector__slider-container">
-				<WPCOMBulkSelector
-					selectedTier={ discountTiers[ 0 ] }
-					ownedPlans={ ownedPlans }
-					isLoading={ ! isLicenseCountsReady }
-					hideOwnedPlansBadge
-					readOnly
-				/>
+				{ ! referralMode && (
+					<WPCOMBulkSelector
+						selectedTier={ discountTiers[ 0 ] }
+						ownedPlans={ ownedPlans }
+						isLoading={ ! isLicenseCountsReady }
+						hideOwnedPlansBadge
+						readOnly
+					/>
+				) }
 			</div>
 
 			<div className="wpcom-plan-selector__card">
@@ -150,7 +152,7 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 								{ ctaLabel }
 							</Button>
 
-							<A4ANumberInput value={ quantity } onChange={ setQuantity } />
+							{ ! referralMode && <A4ANumberInput value={ quantity } onChange={ setQuantity } /> }
 						</div>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -2,16 +2,17 @@ import formatCurrency from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useMemo, useState } from 'react';
+import A4ANumberInput from 'calypso/a8c-for-agencies/components/a4a-number-input';
 import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
 import SimpleList from 'calypso/a8c-for-agencies/sections/marketplace/common/simple-list';
 import { MarketplaceTypeContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
 import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
 import WPCOMBulkSelector from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection';
-import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options';
-import { DiscountTier } from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
+import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
 import useWPCOMPlanDescription from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import useWPCOMDiscountTiers from '../../../hooks/use-wpcom-discount-tiers';
 
 import './style.scss';
 
@@ -24,6 +25,8 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 
 	const { data: licenseCounts, isSuccess: isLicenseCountsReady } = useFetchLicenseCounts();
 
+	const [ quantity, setQuantity ] = useState( 1 );
+
 	const { wpcomPlans } = useProductAndPlans( {} );
 
 	const plan = getWPCOMCreatorPlan( wpcomPlans ) ?? wpcomPlans[ 0 ];
@@ -35,20 +38,18 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 		}
 	}, [ isLicenseCountsReady, licenseCounts?.products, plan ] );
 
-	const options = wpcomBulkOptions( [] );
-
-	const [ selectedTier, setSelectedTier ] = useState< DiscountTier >( options[ 0 ] );
-
-	const onSelectTier = ( tier: DiscountTier ) => {
-		setSelectedTier( tier );
-	};
+	const discountTiers = useWPCOMDiscountTiers();
 
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const referralMode = marketplaceType === 'referral';
 
-	// For referral mode we only display 1 option.
-	const quantity = referralMode ? 1 : ( selectedTier.value as number ) - ownedPlans;
-	const discount = referralMode ? options[ 0 ].discount : selectedTier.discount;
+	const discount = useMemo( () => {
+		if ( referralMode ) {
+			return discountTiers[ 0 ].discount;
+		}
+
+		return calculateTier( discountTiers, quantity + ownedPlans ).discount;
+	}, [ discountTiers, ownedPlans, quantity, referralMode ] );
 
 	const originalPrice = Number( plan?.amount ?? 0 ) * quantity;
 	const actualPrice = originalPrice - originalPrice * discount;
@@ -77,10 +78,8 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 	return (
 		<div className="wpcom-plan-selector">
 			<div className="wpcom-plan-selector__slider-container">
-				{ /* TODO: We will later replace these with different one on a separate PR */ }
 				<WPCOMBulkSelector
-					selectedTier={ selectedTier }
-					onSelectTier={ onSelectTier }
+					selectedTier={ discountTiers[ 0 ] }
 					ownedPlans={ ownedPlans }
 					isLoading={ ! isLicenseCountsReady }
 					hideOwnedPlansBadge
@@ -141,13 +140,18 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 							{ translate( 'How many sites would you like to buy?' ) }
 						</div>
 
-						<Button
-							variant="primary"
-							onClick={ () => onSelect( plan, quantity ) }
-							disabled={ ! isLicenseCountsReady }
-						>
-							{ ctaLabel }
-						</Button>
+						<div className="wpcom-plan-selector__cta-component">
+							<Button
+								className="wpcom-plan-selector__cta-button"
+								variant="primary"
+								onClick={ () => onSelect( plan, quantity ) }
+								disabled={ ! isLicenseCountsReady }
+							>
+								{ ctaLabel }
+							</Button>
+
+							<A4ANumberInput value={ quantity } onChange={ setQuantity } />
+						</div>
 					</div>
 				</div>
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
@@ -94,3 +94,13 @@
 	border-radius: 16px;
 	margin-block-end: 8px;
 }
+
+.wpcom-plan-selector__cta-component {
+	display: flex;
+	flex-direction: row;
+	gap: 16px;
+}
+
+.wpcom-plan-selector__cta-button {
+	min-width: 260px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -9,7 +9,7 @@ import A4AWPCOMSlider from './wpcom-slider';
 
 type Props = {
 	selectedTier: DiscountTier;
-	onSelectTier: ( value: DiscountTier ) => void;
+	onSelectTier?: ( value: DiscountTier ) => void;
 	ownedPlans: number;
 	isLoading?: boolean;
 	hideOwnedPlansBadge?: boolean;
@@ -41,7 +41,7 @@ export default function WPCOMBulkSelector( {
 
 	const onSelectOption = useCallback(
 		( option: number ) => {
-			onSelectTier( calculateTier( options, option ) );
+			onSelectTier?.( calculateTier( options, option ) );
 		},
 		[ onSelectTier, options ]
 	);
@@ -53,7 +53,7 @@ export default function WPCOMBulkSelector( {
 	const minimumQuantity = ownedPlans + 1;
 
 	useEffect( () => {
-		onSelectTier( calculateTier( options, minimumQuantity ) );
+		onSelectTier?.( calculateTier( options, minimumQuantity ) );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ ownedPlans, options ] );
 


### PR DESCRIPTION
This PR implements the quantity incremented/decremented in the WPCOM plan page.

<img width="536" alt="Screenshot 2024-07-29 at 9 20 26 PM" src="https://github.com/user-attachments/assets/d3bf6fd2-626c-4eef-bdaf-39026c55d3f5">


Closes https://github.com/Automattic/jetpack-genesis/issues/441

## Proposed Changes

* Implement reusable `A4ANumberInput` component. We can use this in a couple of future use cases. One would be on the Products page.
* Update the `WPCOMBulkSelector` component so that the `onSelectTier` property is not required. This is necessary, as our current use case only utilizes this component as a presentational element.
* Update the WPCOM hosting page to use the new component. We now calculate the discount from (quantity + owned plans).

## Why are these changes being made?

* This allows agency users to purchase WPCOM plans in bulk.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting` page.
* Make sure you are in the Standard tab.
* Test the new component if it works correctly especially the discount calculation.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
