### PR TITLE
Global sidebar - remove check that hides sidebar if no sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -916,7 +916,7 @@ export function hideNavigationIfLoggedInWithNoSites( context, next ) {
 
 export function addNavigationIfLoggedIn( context, next ) {
 	const state = context.store.getState();
-	if ( isUserLoggedIn( state ) && getCurrentUserSiteCount( state ) > 0 ) {
+	if ( isUserLoggedIn( state ) ) {
 		navigation( context, next );
 	}
 	next();

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -8,7 +8,6 @@ import {
 } from 'calypso/controller';
 import {
 	addNavigationIfLoggedIn,
-	hideNavigationIfLoggedInWithNoSites,
 	navigation,
 	noSite,
 	selectSiteOrSkipIfLoggedInWithMultipleSites,
@@ -77,7 +76,6 @@ export default function ( router ) {
 		selectSiteOrSkipIfLoggedInWithMultipleSites,
 		noSite,
 		renderThemes,
-		hideNavigationIfLoggedInWithNoSites,
 		addNavigationIfLoggedIn,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8435

This PR just addresses the bug for a user account with no sites.

## Proposed Changes

* Removes check for `/themes` to hide sidebar if user has no sites.
* Loading the global sidebar updates a toplevel CSS classes that fixes other CSS issues like the masterbar highlight color bleeding.


## Before

<img width="974" alt="Screenshot 2024-07-29 at 11 22 26" src="https://github.com/user-attachments/assets/0cf99d7d-11e1-41cc-8331-5698e686b8ee">

## After

https://github.com/user-attachments/assets/bff7a4d4-4214-4eea-af1f-24897cabcc17


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* More consistent UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a test account but bail out of create account flow when asked to choose a domain - this will mean the WP account is created but no site has been added to your account.
* Go to `/themes` and confirm sidebar loads the same as it does on `/sites` and `/plugins`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
