### PR TITLE
A4A: Implement the 'Add to cart' button in the new Pressable hosting page.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -65,7 +65,7 @@ export default function HostingV2( { onAddToCart }: Props ) {
 					setSelectedFeatureId( 'premier' );
 					page.show( '/marketplace/hosting?hosting=premier' );
 				},
-				content: <PremierAgencyHosting />,
+				content: <PremierAgencyHosting onAddToCart={ ( product ) => onAddToCart( product, 1 ) } />,
 			},
 			{
 				key: 'enterprise',

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -3,6 +3,7 @@ import { layout, blockMeta, shuffle, help, keyboardReturn, tip } from '@wordpres
 import { useTranslate } from 'i18n-calypso';
 import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-1.png';
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-2.png';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import HostingAdditionalFeaturesSection from '../../../common/hosting-additional-features-section';
 import HostingFeaturesSection from '../../../common/hosting-features-section';
 import { BackgroundType1, BackgroundType2 } from '../../../common/hosting-section/backgrounds';
@@ -10,12 +11,12 @@ import HostingTestimonialsSection from '../../../common/hosting-testimonials-sec
 import PressableOverviewPlanSelection from '../../../pressable-overview/plan-selection';
 import CommonHostingBenefits from '../common-hosting-benefits';
 
-export default function PremierAgencyHosting() {
-	const translate = useTranslate();
+type Props = {
+	onAddToCart: ( plan: APIProductFamilyProduct ) => void;
+};
 
-	const onAddToCart = () => {
-		// TODO: Implement this function
-	};
+export default function PremierAgencyHosting( { onAddToCart }: Props ) {
+	const translate = useTranslate();
 
 	return (
 		<div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -41,9 +41,10 @@ function Hosting() {
 	const onAddToCart = useCallback(
 		( plan: APIProductFamilyProduct, quantity: number ) => {
 			if ( plan ) {
-				const items = selectedCartItems?.filter(
-					( cartItem ) => cartItem.family_slug !== 'wpcom-hosting'
-				);
+				const items =
+					plan.family_slug === 'wpcom-hosting' || plan.family_slug === 'pressable-hosting'
+						? selectedCartItems?.filter( ( cartItem ) => cartItem.family_slug !== plan.family_slug )
+						: selectedCartItems;
 
 				setSelectedCartItems( [ ...items, { ...plan, quantity } ] );
 				setShowCart( true );


### PR DESCRIPTION
This pull request adds the 'Add to cart' functionality to the Pressable hosting page. **It's important to note that handling for the referral mode in the Pressable plan will be addressed in a separate pull request.**

<img width="1775" alt="Screenshot 2024-07-29 at 10 16 42 PM" src="https://github.com/user-attachments/assets/b0a9e6a2-a3e3-4dc5-a4b6-7278e29dc6a1">


Closes https://github.com/Automattic/jetpack-genesis/issues/457

## Proposed Changes

* Implement the 'Add to cart' onClick handler in the Pressable hosting page.

## Testing Instructions

* Use the A4A live link below and go to the `/marketplace/hosting` page.
* Confirm that you can add a portable plan to the cart.
* Confirm that you can only add 1 WPCOM plan at a time.
* Confirm that you can only add 1 Pressabnle plan at a time.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
