### PR TITLE
Me sidebar - add link to help page.

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -209,7 +209,7 @@ class MeSidebar extends Component {
 					<SidebarItem
 						selected={ itemLinkMatches( '/help', path ) }
 						link="/help"
-						label={ translate( 'Get Help' ) }
+						label={ translate( 'Support' ) }
 						icon="help"
 						onNavigate={ this.onNavigate }
 					/>

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -205,6 +205,14 @@ class MeSidebar extends Component {
 						icon="plans"
 						onNavigate={ this.onNavigate }
 					/>
+
+					<SidebarItem
+						selected={ itemLinkMatches( '/help', path ) }
+						link="/help"
+						label={ translate( 'Get help' ) }
+						icon="help"
+						onNavigate={ this.onNavigate }
+					/>
 				</SidebarMenu>
 			</>
 		);

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -209,7 +209,7 @@ class MeSidebar extends Component {
 					<SidebarItem
 						selected={ itemLinkMatches( '/help', path ) }
 						link="/help"
-						label={ translate( 'Get help' ) }
+						label={ translate( 'Get Help' ) }
 						icon="help"
 						onNavigate={ this.onNavigate }
 					/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1722261407010809-slack-C03NLNTPZ2T

## Proposed Changes

* Adds a link to the help page in the me sidebar.

BEFORE (no menu item to the */help page)
<img width="855" alt="Screenshot 2024-07-29 at 11 04 57 AM" src="https://github.com/user-attachments/assets/d1cf8a12-fdec-40d3-9e1c-5a08ea46d64b">


AFTER (menu item at bottom of sidebar)
<img width="848" alt="Screenshot 2024-07-29 at 10 58 30 AM" src="https://github.com/user-attachments/assets/e6e1e359-ab7d-4049-8b44-76bf0aba463b">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* More access to help in the context of account settings was desired.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Load `*/help` or visit /me and select the help item at the very bottom of the sidebar.
* Verify the button works as expected, and shows selected while at /help.
* Smoke test /help logged out in an incognito tab (shouldn't be necessary but hey, why not?).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?