### PR TITLE
feat(hosting-overview-refinements): render actual copy and hide activate button on hosting-features tab

### DIFF
--- a/client/hosting-features/components/hosting-features.tsx
+++ b/client/hosting-features/components/hosting-features.tsx
@@ -75,18 +75,14 @@ const HostingFeatures = () => {
 			return;
 		}
 
-		// console.log( 'useEffect' );
-		// console.log( transfer.status );
 		dispatch( fetchAtomicTransfer( siteId ) as unknown as AnyAction );
 		// A user can keep one tab open and start transfer in the second tab
 		// se we always run interval to check the status, to avoid case with rendering "Activate" button on old tabs of a browser
 		const interval = setInterval( () => {
-			// console.log( 'interval' );
 			dispatch( fetchAtomicTransfer( siteId ) as unknown as AnyAction );
 		}, 10000 );
 
 		return () => {
-			// console.log( 'clear' );
 			clearInterval( interval );
 		};
 	}, [ siteSlug, siteId, transfer.status, dispatch ] );
@@ -190,75 +186,71 @@ const HostingFeatures = () => {
 
 	let title;
 	let description;
-	let showActivateButton = true;
+	let buttons;
 	if ( isTransferInProgress && config.isEnabled( 'hosting-overview-refinements' ) ) {
 		title = translate( 'Activating hosting features' );
 		description = translate(
 			'Stay tuned, as we activate the following features included in your plan'
 		);
-		showActivateButton = true;
 	} else if ( showActivationButton ) {
 		title = activateTitle;
 		description = activateDescription;
+		buttons = (
+			<>
+				<Button
+					variant="primary"
+					className="hosting-features__button"
+					onClick={ () => {
+						if ( showActivationButton ) {
+							dispatch( recordTracksEvent( 'calypso_hosting_features_activate_click' ) );
+							return setShowEligibility( true );
+						}
+					} }
+				>
+					{ translate( 'Activate now' ) }
+				</Button>
+
+				<Dialog
+					additionalClassNames="plugin-details-cta__dialog-content"
+					additionalOverlayClassNames="plugin-details-cta__modal-overlay"
+					isVisible={ showEligibility }
+					onClose={ () => setShowEligibility( false ) }
+					showCloseIcon
+				>
+					<EligibilityWarnings
+						className="hosting__activating-warnings"
+						onProceed={ handleTransfer }
+						backUrl={ redirectUrl.current }
+						showDataCenterPicker
+						standaloneProceed
+						currentContext="hosting-features"
+					/>
+				</Dialog>
+			</>
+		);
 	} else {
 		title = unlockTitle;
 		description = unlockDescription;
+		buttons = (
+			<Button
+				variant="primary"
+				className="hosting-features__button"
+				href={ upgradeLink }
+				onClick={ () =>
+					dispatch( recordTracksEvent( 'calypso_hosting_features_upgrade_plan_click' ) )
+				}
+			>
+				{ translate( 'Upgrade now' ) }
+			</Button>
+		);
 	}
 
 	return (
 		<div className="hosting-features">
 			<div className="hosting-features__hero">
-				{ isTransferInProgress && <h1>transfer in progress</h1> }
 				<h1>{ title }</h1>
 				<p>{ description }</p>
-				{ showActivationButton ? (
-					<>
-						{ showActivateButton && (
-							<Button
-								variant="primary"
-								className="hosting-features__button"
-								onClick={ () => {
-									if ( showActivationButton ) {
-										dispatch( recordTracksEvent( 'calypso_hosting_features_activate_click' ) );
-										return setShowEligibility( true );
-									}
-								} }
-							>
-								{ translate( 'Activate now' ) }
-							</Button>
-						) }
-
-						<Dialog
-							additionalClassNames="plugin-details-cta__dialog-content"
-							additionalOverlayClassNames="plugin-details-cta__modal-overlay"
-							isVisible={ showEligibility }
-							onClose={ () => setShowEligibility( false ) }
-							showCloseIcon
-						>
-							<EligibilityWarnings
-								className="hosting__activating-warnings"
-								onProceed={ handleTransfer }
-								backUrl={ redirectUrl.current }
-								showDataCenterPicker
-								standaloneProceed
-								currentContext="hosting-features"
-							/>
-						</Dialog>
-					</>
-				) : (
-					<>
-						<Button
-							variant="primary"
-							className="hosting-features__button"
-							href={ upgradeLink }
-							onClick={ () =>
-								dispatch( recordTracksEvent( 'calypso_hosting_features_upgrade_plan_click' ) )
-							}
-						>
-							{ translate( 'Upgrade now' ) }
-						</Button>
-					</>
-				) }
+				{ buttons }
 			</div>
 			<div className="hosting-features__cards">
 				{ promoCards.map( ( card ) => (

--- a/client/hosting-features/components/hosting-features.tsx
+++ b/client/hosting-features/components/hosting-features.tsx
@@ -1,15 +1,20 @@
+import config from '@automattic/calypso-config';
 import { FEATURE_SFTP, getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Dialog } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
+import { AnyAction } from 'redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { HostingCard } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
+import { transferStates } from 'calypso/state/atomic-transfer/constants';
+import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -52,6 +57,39 @@ const HostingFeatures = () => {
 			: `/overview/${ siteId }`
 	);
 	const hasEnTranslation = useHasEnTranslation();
+
+	const transfer = useSelector( ( state ) => getAtomicTransfer( state, siteId ) );
+	const isTransferInProgress = [
+		transferStates.PENDING,
+		transferStates.ACTIVE,
+		transferStates.PROVISIONED,
+	].includes( transfer.status );
+
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		if ( transfer.status === transferStates.COMPLETED ) {
+			window.location.href = `/overview/${ siteSlug }`;
+			return;
+		}
+
+		// console.log( 'useEffect' );
+		// console.log( transfer.status );
+		dispatch( fetchAtomicTransfer( siteId ) as unknown as AnyAction );
+		// A user can keep one tab open and start transfer in the second tab
+		// se we always run interval to check the status, to avoid case with rendering "Activate" button on old tabs of a browser
+		const interval = setInterval( () => {
+			// console.log( 'interval' );
+			dispatch( fetchAtomicTransfer( siteId ) as unknown as AnyAction );
+		}, 10000 );
+
+		return () => {
+			// console.log( 'clear' );
+			clearInterval( interval );
+		};
+	}, [ siteSlug, siteId, transfer.status, dispatch ] );
 
 	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
 	const promoCards = [
@@ -150,25 +188,45 @@ const HostingFeatures = () => {
 				}
 		  );
 
+	let title;
+	let description;
+	let showActivateButton = true;
+	if ( isTransferInProgress && config.isEnabled( 'hosting-overview-refinements' ) ) {
+		title = translate( 'Activating hosting features' );
+		description = translate(
+			'Stay tuned, as we activate the following features included in your plan'
+		);
+		showActivateButton = true;
+	} else if ( showActivationButton ) {
+		title = activateTitle;
+		description = activateDescription;
+	} else {
+		title = unlockTitle;
+		description = unlockDescription;
+	}
+
 	return (
 		<div className="hosting-features">
 			<div className="hosting-features__hero">
-				<h1>{ showActivationButton ? activateTitle : unlockTitle }</h1>
-				<p>{ showActivationButton ? activateDescription : unlockDescription }</p>
+				{ isTransferInProgress && <h1>transfer in progress</h1> }
+				<h1>{ title }</h1>
+				<p>{ description }</p>
 				{ showActivationButton ? (
 					<>
-						<Button
-							variant="primary"
-							className="hosting-features__button"
-							onClick={ () => {
-								if ( showActivationButton ) {
-									dispatch( recordTracksEvent( 'calypso_hosting_features_activate_click' ) );
-									return setShowEligibility( true );
-								}
-							} }
-						>
-							{ translate( 'Activate now' ) }
-						</Button>
+						{ showActivateButton && (
+							<Button
+								variant="primary"
+								className="hosting-features__button"
+								onClick={ () => {
+									if ( showActivationButton ) {
+										dispatch( recordTracksEvent( 'calypso_hosting_features_activate_click' ) );
+										return setShowEligibility( true );
+									}
+								} }
+							>
+								{ translate( 'Activate now' ) }
+							</Button>
+						) }
 
 						<Dialog
 							additionalClassNames="plugin-details-cta__dialog-content"

--- a/client/state/atomic-transfer/constants.js
+++ b/client/state/atomic-transfer/constants.js
@@ -4,4 +4,5 @@ export const transferStates = {
 	COMPLETED: 'completed',
 	ERROR: 'error',
 	REVERTED: 'reverted',
+	PROVISIONED: 'provisioned',
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8407

## Proposed Changes
We want to render `Hosting features` tab in activation state (transfer from Simpel to Atomic). So that we will hide CTA buttons and change copy.

## Why are these changes being made?
If we don't do it - a user can click "Activate now" button and mess up a site (if activation takes a lot of time). Additionally - we don't render any data in UI regarding the "activation is in progress" state, so we should provide such info to users.

## Testing Instructions
0. Add `.env` file to the root of Calypso with `ACTIVE_FEATURE_FLAGS='hosting-overview-refinements'`
1. Purchase domain with `Starter` plan
2. Open "Hosting features" tab on "Sites" page (Let's call this tab as `A` during testing)
3. Copy the URL and open a separate tab (Let's call this tab as `B` during testing, we will use it in the end for testing)
4. In tab A, click `Upgrade now` and proceed with upgrading
5. Now let's repeat the 3-rd step to open one more separate tab (Let's call this tab as `C` during testing, we will use it in the end for testing), so that you will have the next tabs `B` and `C`:<br /><img width="2296" alt="Screenshot 2024-07-29 at 16 12 45" src="https://github.com/user-attachments/assets/7ee4bc76-a06c-43dd-b64f-1b8c9c295a7c">
6. Now, in tab `A` click `Activate now` and proceed
7. During activating process, the copy on tabs B and C should be changed to the next (with CTA buttons hidden)<br /><img width="2293" alt="Screenshot 2024-07-29 at 16 15 28" src="https://github.com/user-attachments/assets/00b3e02f-cf04-482e-8ad8-eebbee3d8528">
