### PR TITLE
Stats: Use localized "upgrade_deadline_date" from API for the paywall notice

### DIFF
--- a/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/commercial-site-upgrade-notice.tsx
@@ -5,7 +5,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
@@ -28,10 +27,9 @@ const CommercialSiteUpgradeNotice = ( {
 
 	// Determine when the paywall will go into effect (if applicable).
 	// The upgrade_deadline_date is the actual date the paywall will be applied.
-	const moment = useLocalizedMoment();
 	const { data } = usePlanUsageQuery( siteId );
 	// Guard against empty value in the API response.
-	const paywallMoment = data?.upgrade_deadline_date ? moment( data.upgrade_deadline_date ) : null;
+	const paywallUpgradeDeadlineDate = data?.upgrade_deadline_date;
 
 	const gotoJetpackStatsProduct = () => {
 		isOdysseyStats
@@ -93,7 +91,7 @@ const CommercialSiteUpgradeNotice = ( {
 				components: sharedTranslationComponents,
 			}
 		);
-	} else if ( paywallMoment === null ) {
+	} else if ( ! paywallUpgradeDeadlineDate ) {
 		bannerBody = translate(
 			'{{p}}To ensure uninterrupted access to core Stats features, please upgrade to a Jetpack Stats Commercial license using the button below. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
 			{
@@ -104,7 +102,7 @@ const CommercialSiteUpgradeNotice = ( {
 		bannerBody = translate(
 			'{{p}}To ensure uninterrupted access to core Stats features, please upgrade to a Jetpack Stats Commercial license using the button below by {{b}}%(date)s{{/b}}. {{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}}{{commercialUpgradeLink}}{{commercialUpgradeLinkText}}Learn more{{/commercialUpgradeLinkText}}{{externalIcon /}}{{/commercialUpgradeLink}}{{/p}}',
 			{
-				args: { date: paywallMoment.format( 'LL' ) },
+				args: { date: paywallUpgradeDeadlineDate },
 				components: sharedTranslationComponents,
 			}
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/93003

## Proposed Changes

* Use localized `upgrade_deadline_date` from API instead.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A missed commit to fix the paywall `upgrade_deadline_date` string from https://github.com/Automattic/wp-calypso/pull/93003#pullrequestreview-2205264594.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As per the testing instructions of https://github.com/Automattic/wp-calypso/pull/93003.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
