### PR TITLE
Global sidebar - support themes and plugins with domain only account

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -271,6 +271,8 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 	}
 
 	const startsWithPaths = [
+		'/themes',
+		'/plugins',
 		'/checkout/',
 		`/me/purchases/${ slug }`,
 		`/purchases/add-payment-method/${ slug }`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8435
Follow up to https://github.com/Automattic/wp-calypso/pull/93068

This PR addresses the issues for a user account with no site but has a domain.

When a user clicks on either the `/themes` or `/plugins` global sidebar links, they were being redirected back to the domain manage site which appeared broken UX.

This PR will allow those links to work.

## Proposed Changes

* Adds `/themes` and '/plugins` to whitelist of routes that can be accessed with a domain-only account.

## Before

https://github.com/user-attachments/assets/17815095-4a49-4fda-a60f-234495d011f3

## After

https://github.com/user-attachments/assets/61ac5819-11f6-478a-8551-f7cce58c3874

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the UX for domain-only accounts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a test account but bail out of create account flow when asked to choose a domain - this will mean the WP account is created but no site has been added to your account.
* Go to `/domains/manage` and add a domain and complete the checkout purchase. I suggest you add a coupon for the domain registration (.blog domain) and purchase a .blog domain with this coupon.
* Go to `/sites` and confirm the `/themes` and `/plugins` links don't work.
* Apply the PR and confirm the sidebar works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
