### PR TITLE
feat(hosting-overview-refinements): add Site Visits block to Hosting Overview page

### DIFF
--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	getPlan,
 	PlanSlug,
@@ -16,6 +17,7 @@ import PlanStorage from 'calypso/blocks/plan-storage';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import { HostingCard, HostingCardLinkButton } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { PlanSiteVisits } from 'calypso/hosting-overview/components/plan-site-visits';
 import PlanStorageBar from 'calypso/hosting-overview/components/plan-storage-bar';
 import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
@@ -263,6 +265,9 @@ const PlanCard: FC = () => {
 									</div>
 								) }
 							</PlanStorage>
+						) }
+						{ config.isEnabled( 'hosting-overview-refinements' ) && site && (
+							<PlanSiteVisits siteId={ site.ID } />
 						) }
 					</>
 				) }

--- a/client/hosting-overview/components/plan-site-visits.tsx
+++ b/client/hosting-overview/components/plan-site-visits.tsx
@@ -1,0 +1,74 @@
+import moment from 'moment';
+import { useEffect, useState } from 'react'; // eslint-disable-line no-unused-vars -- used in the jsdoc types
+import wpcom from 'calypso/lib/wp';
+import './style.scss';
+
+interface PlanSiteVisitsProps {
+	siteId: number;
+}
+
+interface VisitResponse {
+	data: [ string, number ][];
+}
+
+export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
+	const [ visitsNumber, setVisitsNumber ] = useState< number | null >( null );
+
+	useEffect( () => {
+		// It's possible to go with `unit: month` and `quantity: 1` to get the last month's data
+		// but I tested thoroughly - it doesn't work for this case, since looks like it doesn't include the current (today) day,
+		// and additionally it provides extra info about previous month, if, for example, `date` is the first day of the month (e.g. "2024-07-01")
+		// so I decided that it worth to make extra calculations (get specific days and sum them) to be explicit and ensure that rendered data is correct
+		// -----------------
+		// Also, I considered option to use getHighlights[ PAST_THIRTY_DAYS ], but according to my investigation - it totally doesn't work for our case:
+		// 1) It doesn't include current day
+		// 2) It counts not calendar month, but 30 days from the "yesterday"
+		const todayDate = moment().format( 'YYYY-MM-DD' );
+		const numberOfDays = todayDate.split( '-' ).pop();
+		wpcom.req
+			.get( `/sites/${ siteId }/stats/visits`, {
+				unit: 'day',
+
+				quantity: numberOfDays,
+				date: todayDate,
+				stat_fields: 'views',
+			} )
+			.then( ( result: VisitResponse ) => {
+				const views = result.data.reduce(
+					( acc: number, [ , curr ]: [ string, number ] ) => acc + curr,
+					0
+				);
+
+				setVisitsNumber( views );
+			} );
+	}, [ siteId ] );
+
+	if ( ! visitsNumber ) {
+		return;
+	}
+
+	return (
+		<div>
+			<div
+				style={ {
+					display: 'flex',
+					justifyContent: 'space-between',
+					padding: '20px 0',
+				} }
+			>
+				<div>Unlimited Site visits</div>
+				<div
+					title={
+						'From ' +
+						moment().startOf( 'month' ).format( 'DD/MM/YYYY' ) +
+						' to ' +
+						moment().format( 'DD/MM/YYYY' )
+					}
+				>
+					{ visitsNumber } views this month
+				</div>
+			</div>
+			Go to Stats page
+		</div>
+	);
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8400

## Proposed Changes
With this PR we are adding the number of visits to a site since the start of the month (into the "Hosting Overview" page).

## Testing Instructions
1. Create `Atomic` website (After finishing all steps - repeat them for Simple website)
2. Launch it
3. Visit it a few times
4. Waiut a bit
5. Open Hosting overview page
6. Assert that you see the number of visits for Atomic<br /><img width="697" alt="Screenshot 2024-07-29 at 17 18 16" src="https://github.com/user-attachments/assets/60e0162b-0662-4f37-9f89-19b1887cf480">
7. Assert that you see for Simple website<br /><img width="492" alt="Screenshot 2024-07-29 at 17 24 01" src="https://github.com/user-attachments/assets/a83fbee2-7cc7-478a-95a2-690e8099635a">

