### PR TITLE
feat(hosting-overview-refinements): add Bandwidth block to Hosting Overview page

### DIFF
--- a/client/hosting-overview/components/plan-bandwidth.tsx
+++ b/client/hosting-overview/components/plan-bandwidth.tsx
@@ -1,0 +1,67 @@
+import { convertBytes } from 'calypso/my-sites/backup/backup-contents-page/file-browser/util';
+import { useSiteMetricsQuery } from 'calypso/my-sites/site-monitoring/use-metrics-query';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+interface PlanBandwidthProps {
+	siteId: number;
+}
+
+const getCurrentMonthRangeTimestamps = () => {
+	const now = new Date();
+	const firstDayOfMonth = new Date( now.getFullYear(), now.getMonth(), 1 );
+	const startInSeconds = Math.floor( firstDayOfMonth.getTime() / 1000 );
+
+	const today = new Date();
+	const endInSeconds = Math.floor( today.getTime() / 1000 );
+
+	return {
+		startInSeconds,
+		endInSeconds,
+	};
+};
+
+export function PlanBandwidth( { siteId }: PlanBandwidthProps ) {
+	const selectedSiteData = useSelector( getSelectedSite );
+	const selectedSiteDomain = selectedSiteData?.domain;
+
+	const { startInSeconds, endInSeconds } = getCurrentMonthRangeTimestamps();
+
+	const { data } = useSiteMetricsQuery( siteId, {
+		start: startInSeconds,
+		end: endInSeconds,
+		metric: 'response_bytes_persec',
+	} );
+
+	if ( ! data || ! selectedSiteDomain ) {
+		return;
+	}
+
+	const valueInBytes = data.data.periods.reduce(
+		( acc, curr ) => acc + ( curr.dimension[ selectedSiteDomain ] || 0 ),
+		0
+	);
+
+	const { unitAmount, unit } = convertBytes( valueInBytes );
+
+	const startFormatted = new Date( startInSeconds * 1000 ).toLocaleDateString();
+	const endFormatted = new Date( endInSeconds * 1000 ).toLocaleDateString();
+
+	return (
+		<div>
+			<div
+				style={ {
+					display: 'flex',
+					justifyContent: 'space-between',
+					padding: '20px 0',
+				} }
+			>
+				<div>Unlimited Bandwidth</div>
+				<div title={ 'From ' + startFormatted + ' to ' + endFormatted }>
+					{ unitAmount } { unit } used this month
+				</div>
+			</div>
+			Links
+		</div>
+	);
+}

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -32,6 +32,7 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
+import { AppState } from 'calypso/types';
 
 const PricingSection: FC = () => {
 	const translate = useTranslate();
@@ -170,7 +171,7 @@ const PlanCard: FC = () => {
 		isJetpackSite( state, site?.ID, { treatAtomicAsJetpackSite: false } )
 	);
 	const isStaging = isStagingSite( site ?? undefined );
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, site.ID ?? 0 ) );
+	const isAtomic = useSelector( ( state: AppState ) => isAtomicSite( state, site?.ID ?? 0 ) );
 	const isOwner = planDetails?.user_is_owner;
 	const planPurchaseId = useSelector( ( state: IAppState ) =>
 		getCurrentPlanPurchaseId( state, site?.ID ?? 0 )

--- a/client/hosting-overview/components/plan-card.tsx
+++ b/client/hosting-overview/components/plan-card.tsx
@@ -17,6 +17,7 @@ import PlanStorage from 'calypso/blocks/plan-storage';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import { HostingCard, HostingCardLinkButton } from 'calypso/components/hosting-card';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { PlanBandwidth } from 'calypso/hosting-overview/components/plan-bandwidth';
 import { PlanSiteVisits } from 'calypso/hosting-overview/components/plan-site-visits';
 import PlanStorageBar from 'calypso/hosting-overview/components/plan-storage-bar';
 import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
@@ -26,6 +27,7 @@ import { isStagingSite } from 'calypso/sites-dashboard/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isA4AUser } from 'calypso/state/partner-portal/partner/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
+import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
@@ -168,6 +170,7 @@ const PlanCard: FC = () => {
 		isJetpackSite( state, site?.ID, { treatAtomicAsJetpackSite: false } )
 	);
 	const isStaging = isStagingSite( site ?? undefined );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, site.ID ?? 0 ) );
 	const isOwner = planDetails?.user_is_owner;
 	const planPurchaseId = useSelector( ( state: IAppState ) =>
 		getCurrentPlanPurchaseId( state, site?.ID ?? 0 )
@@ -268,6 +271,9 @@ const PlanCard: FC = () => {
 						) }
 						{ config.isEnabled( 'hosting-overview-refinements' ) && site && (
 							<PlanSiteVisits siteId={ site.ID } />
+						) }
+						{ config.isEnabled( 'hosting-overview-refinements' ) && isAtomic && site && (
+							<PlanBandwidth siteId={ site.ID } />
 						) }
 					</>
 				) }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8399

## Proposed Changes
With this PR we are adding the used bandwidth of a site since the start of the month (into the "Hosting Overview" page).

## Testing Instructions
1. Create Atomic website (Bandwidth is not allowed for Simple websites website)
2. Launch it
3. Visit it a few times
4. Wait a bit
5. Open Hosting overview page
6. Assert that you see Bandwidth:<br /><img width="438" alt="Screenshot 2024-07-29 at 18 01 28" src="https://github.com/user-attachments/assets/247db4eb-c9e1-487c-a6d8-9c2920a24c16">
