### PR TITLE
Site Migration: Ensure we add the source site URL as a query arg

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -4,7 +4,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Icon, globe, group, shield, backup } from '@wordpress/icons';
 import { createElement, useEffect } from 'react';
-import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -25,8 +24,6 @@ const ImporterMigrateMessage: Step = () => {
 	const siteSlugParam = useSiteSlugParam();
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const siteSlug = siteSlugParam ?? '';
-	const { getSiteSetting } = useSiteSettings( siteSlug );
-	const sourceSiteUrl = getSiteSetting( 'migration_source_site_domain' ) ?? fromUrl ?? '';
 	const { isPending, sendTicket } = useSubmitMigrationTicket();
 
 	useEffect( () => {
@@ -35,7 +32,7 @@ const ImporterMigrateMessage: Step = () => {
 		} );
 		sendTicket( {
 			locale,
-			from_url: sourceSiteUrl,
+			from_url: fromUrl,
 			blog_url: siteSlug,
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -60,7 +57,7 @@ const ImporterMigrateMessage: Step = () => {
 									),
 									{
 										email: user?.email,
-										webSite: sourceSiteUrl,
+										webSite: fromUrl,
 									}
 								),
 								{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
@@ -71,9 +71,9 @@ const SiteMigrationSourceUrl: Step = function ( { navigation } ) {
 	const translate = useTranslate();
 
 	const handleSubmit = useCallback(
-		async ( action: string, data?: { from: string } ) => {
+		async ( action: string, data: { from: string } ) => {
 			// If we have a site and URL, record the migration source domain.
-			if ( siteSlug && data?.from ) {
+			if ( siteSlug && data.from ) {
 				await saveSiteSettings( siteSlug, { migration_source_site_domain: data.from } );
 			}
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -381,8 +381,15 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_MIGRATION_SOURCE_URL.slug: {
+					const { from } = providedDependencies as {
+						from: string;
+					};
+					const nextStepUrl = addQueryArgs(
+						{ from, siteSlug, siteId },
+						STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
+					);
 					// Navigate to the assisted migration step.
-					return navigate( STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug, {
+					return navigate( nextStepUrl, {
 						siteId,
 						siteSlug,
 					} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1722270910584999-slack-C06PZC1RR5F and https://github.com/Automattic/wp-calypso/pull/92944

## Proposed Changes

* Fix bug where we were sending an empty source site URL to the ticket even though we were recording it in the site settings. The source site URL might not have been populated on the front end yet.
* Set the `from` URL in the source site URL request step as a query arg so it can be immediately available to the ticket hook rather than waiting for it to be fetched from site settings.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug originally raised here p1722270910584999-slack-C06PZC1RR5F

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please note, testing these flows will cause tickets to be sent to the WP.com Migrations queue in ZenDesk.

**Test with a source site provided:**

* Switch to this branch, navigate to `/start`
* Select import at the site intention step
* Enter your URL
* Select Migrate Site
* Select Do it for me
* Check out
* You should be brought to the final assisted migration screen with the URL filled out

<img width="1448" alt="Screenshot 2024-07-24 at 2 36 46 PM" src="https://github.com/user-attachments/assets/9d1ff4d7-0a15-4f7b-ba7e-81d9d9029658">

* Check the corresponding ticket in ZenDesk and ensure it includes the source site URL you filled out.

**Test without a source site provided:**

* Switch to this branch, navigate to `/start`
* Select import at the site intention step
* Do not enter a URL; instead, select Pick your current platform from a list
* Choose WordPress
* Select Migrate Site
* Select Do it for me
* Check out
* You should be shown the source site URL collection screen:

<img width="1450" alt="Screenshot 2024-07-24 at 2 39 21 PM" src="https://github.com/user-attachments/assets/f60eedbc-fda4-46ee-824c-4506b43833e1">

* Upon putting in a valid URL, you should be brought to the final assisted migration screen with the URL filled out:

<img width="1448" alt="Screenshot 2024-07-24 at 2 36 46 PM" src="https://github.com/user-attachments/assets/9d1ff4d7-0a15-4f7b-ba7e-81d9d9029658">

* Check the corresponding ticket in ZenDesk and ensure it includes the source site URL you filled out.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?