### PR TITLE
Global sidebar - update top padding.

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -109,7 +109,7 @@ $brand-text: "SF Pro Text", $sans;
 		@include custom-scrollbars-on-hover(transparent, $gray-600);
 		flex: 1;
 		overflow-y: auto;
-		padding-top: 16px;
+		padding-top: 40px;
 
 		.sidebar,
 		.sidebar__menu:not(.is-togglable) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#8492

## Proposed Changes

Updates the top padding of the global sidebar to fit the design as laid out on the issue.

BEFORE

<img width="315" alt="Screenshot 2024-07-29 at 2 06 23 PM" src="https://github.com/user-attachments/assets/b1f87f2e-6f73-4d0e-bea8-ff1f086f7017">

<img width="344" alt="Screenshot 2024-07-29 at 2 12 49 PM" src="https://github.com/user-attachments/assets/9ee75064-7953-40ba-955c-e60947ac2d61">



AFTER
<img width="376" alt="Screenshot 2024-07-29 at 2 04 26 PM" src="https://github.com/user-attachments/assets/485e1351-400a-465d-a28d-643c8a1628ea">
<img width="367" alt="Screenshot 2024-07-29 at 2 12 41 PM" src="https://github.com/user-attachments/assets/4f71fe49-6d47-486b-a818-3b166c8dac62">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* per design request.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the /sites and /read and verify the sidebar has more top margin.
* smoke test & w/ mobile viewports

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
