### PR TITLE
Remove duplicate Substack importer config

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -340,18 +340,6 @@ function getConfig( {
 		weight: 0,
 	};
 
-	importerConfig.substack = {
-		engine: 'substack',
-		key: 'importer-type-substack',
-		type: 'url',
-		priority: 'secondary',
-		title: 'Substack',
-		icon: 'substack',
-		description: '',
-		uploadDescription: '',
-		weight: 0,
-	};
-
 	importerConfig.tumblr = {
 		engine: 'tumblr',
 		key: 'importer-type-tumblr',


### PR DESCRIPTION
It was causing the Substack importer to break.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1722000826457569-slack-C052XEUUBL4

## Proposed Changes

This removes a duplicate Substack importer-config that was labelled as 'secondary'.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This caused the description to be missing from the Substack importer and the importer didn't function.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch or use the calypso.live url.
* Visit `/import` and pick a site. 
* Click on the Substack option and verify it looks like this:
![CleanShot 2024-07-29 at 17 18 23](https://github.com/user-attachments/assets/ca1e9cff-ebf4-4efb-ba98-d740cc922b2d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?