### PR TITLE
Site Restore: Limit deleted sites access to only the sites dashboard

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -81,6 +81,10 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const isAdmin = useSelector( ( state ) => canCurrentUser( state, site.ID, 'manage_options' ) );
 
 	const onSiteClick = ( event: React.MouseEvent ) => {
+		if ( site.is_deleted ) {
+			return;
+		}
+
 		if ( isAdmin && ! isP2Site && ! isNotAtomicJetpack( site ) ) {
 			openSitePreviewPane && openSitePreviewPane( site );
 		} else {

--- a/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
+++ b/client/hosting/sites/components/sites-dataviews/dataviews-fields/site-field.tsx
@@ -81,10 +81,6 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 	const isAdmin = useSelector( ( state ) => canCurrentUser( state, site.ID, 'manage_options' ) );
 
 	const onSiteClick = ( event: React.MouseEvent ) => {
-		if ( site.is_deleted ) {
-			return;
-		}
-
 		if ( isAdmin && ! isP2Site && ! isNotAtomicJetpack( site ) ) {
 			openSitePreviewPane && openSitePreviewPane( site );
 		} else {
@@ -104,7 +100,12 @@ const SiteField = ( { site, openSitePreviewPane }: Props ) => {
 					`
 				) }
 				leading={
-					<Button className="sites-dataviews__preview-trigger" onClick={ onSiteClick } borderless>
+					<Button
+						className="sites-dataviews__preview-trigger"
+						onClick={ onSiteClick }
+						borderless
+						disabled={ site.is_deleted }
+					>
 						<ListTileLeading title={ title }>
 							<SiteFavicon
 								className="sites-site-favicon"

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -602,12 +602,12 @@ export function siteSelection( context, next ) {
 
 	const siteId = getSiteId( getState(), siteFragment );
 
-	const site = getSite( getState(), siteId );
+	// const site = getSite( getState(), siteId );
 
-	if ( site && site.is_deleted ) {
-		dispatch( setSelectedSiteId( null ) );
-		return next();
-	}
+	// if ( site && site.is_deleted ) {
+	// 	dispatch( setSelectedSiteId( null ) );
+	// 	return next();
+	// }
 
 	if ( siteId && ! isUnlinkedCheckout ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
@@ -870,7 +870,19 @@ export function selectSite( context ) {
 	// Logged in: Terminate the regular handler path by not calling next()
 	// and render the site selection screen, redirecting the user if they
 	// only have one site.
-	composeHandlers( siteSelection, sites, makeLayout, render )( context );
+	composeHandlers( siteSelection, selectSiteIfNotDeleted, sites, makeLayout, render )( context );
+}
+
+export function selectSiteIfNotDeleted( context, next ) {
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	if ( selectedSite && selectedSite.is_deleted ) {
+		context.store.dispatch( setSelectedSiteId( null ) );
+		return;
+	}
+
+	return next();
 }
 
 export function selectSiteIfLoggedIn( context, next ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -602,13 +602,6 @@ export function siteSelection( context, next ) {
 
 	const siteId = getSiteId( getState(), siteFragment );
 
-	// const site = getSite( getState(), siteId );
-
-	// if ( site && site.is_deleted ) {
-	// 	dispatch( setSelectedSiteId( null ) );
-	// 	return next();
-	// }
-
 	if ( siteId && ! isUnlinkedCheckout ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 		// to wp-admin. In that case, don't continue handling the route.

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -602,6 +602,13 @@ export function siteSelection( context, next ) {
 
 	const siteId = getSiteId( getState(), siteFragment );
 
+	const site = getSite( getState(), siteId );
+
+	if ( site && site.is_deleted ) {
+		dispatch( setSelectedSiteId( null ) );
+		return next();
+	}
+
 	if ( siteId && ! isUnlinkedCheckout ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 		// to wp-admin. In that case, don't continue handling the route.

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -53,6 +53,11 @@ class Sites extends Component {
 		if ( hasJetpackActivePlugins( site ) && ! isJetpackSiteOrJetpackCloud( site ) ) {
 			return false;
 		}
+
+		if ( site.is_deleted ) {
+			return false;
+		}
+
 		const path = this.props.siteBasePath;
 
 		// Domains can be managed on Simple and Atomic sites.


### PR DESCRIPTION
This draft PR limits deleted sites access to other parts of the UI by redirecting them to the site selection dropdown and filtering them out from being selected. Accessing the site from different urls will redirect to that page.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8149

## Proposed Changes

* Show site selection menu when a url to a deleted site as accessed
* Filter out deleted sites from site selection list so that it cannot be selected
* Prevent deleted sites from opening the site preview pane on the `/sites` page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To facilitate site restore we are returning deleted sites to the `/sites` page. We keep the user associated with the deleted site so it can be easily restored, however we need to prevent the user from performing any actions on the site. Although interactions to the backend will fail, to prevent the experience from being broken we want to make deleted sites only accessible from the `/sites` page to be restored.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Pre-req: 
Following diff should be applied to sandbox D156148-code

* Delete a site using `settings/delete-site/siteSlug`
* Try to browse `/home/deletedSite`
* Verify it redirects to site selection page and the deleted site is not available to select
* Go to `/sites?status=deleted`
* Verify the deleted site is there and cannot be selected.


<img width="530" alt="image" src="https://github.com/user-attachments/assets/79c0c8a8-d692-457d-ad0c-7e1208bb4a0f">

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/f656d2f1-39de-4575-bf97-e9406dbfb6ae">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?