### PR TITLE
A4A Payment method: only create setup intent ID just before using it

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-save-card.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-save-card.ts
@@ -7,19 +7,17 @@ import { isClientView } from '../lib/is-client-view';
 
 type Props = {
 	useAsPrimaryPaymentMethod?: boolean;
-	stripeSetupIntentId?: string;
 };
 
 export function useSaveCard( {
 	useAsPrimaryPaymentMethod,
-	stripeSetupIntentId,
 }: Props ): ( token: string ) => Promise< unknown > {
 	const dispatch = useDispatch();
 	const agencyId = useSelector( getActiveAgencyId );
 	const isClient = isClientView();
 
 	return useCallback(
-		async ( token: string ) => {
+		async ( token: string, stripeSetupIntentId?: string ) => {
 			const response = await wpcom.req.post(
 				{
 					apiNamespace: 'wpcom/v2',
@@ -43,6 +41,6 @@ export function useSaveCard( {
 			dispatch( recordTracksEvent( 'calypso_a4a_add_new_credit_card' ) );
 			return response;
 		},
-		[ agencyId, dispatch, isClient, stripeSetupIntentId, useAsPrimaryPaymentMethod ]
+		[ agencyId, dispatch, isClient, useAsPrimaryPaymentMethod ]
 	);
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/lib/fetch-stripe-setup-intent-id.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/lib/fetch-stripe-setup-intent-id.ts
@@ -1,0 +1,18 @@
+import { StripeSetupIntentId } from '@automattic/calypso-stripe';
+import { getStripeConfiguration } from './get-stripe-configuration';
+
+async function fetchStripeSetupIntentId(): Promise< StripeSetupIntentId > {
+	const configuration = await getStripeConfiguration( { needs_intent: true } );
+	const intentId: string | undefined =
+		configuration?.setup_intent_id && typeof configuration.setup_intent_id === 'string'
+			? configuration.setup_intent_id
+			: undefined;
+	if ( ! intentId ) {
+		throw new Error(
+			'Error loading new payment method intent. Received invalid data from the server.'
+		);
+	}
+	return intentId;
+}
+
+export default fetchStripeSetupIntentId;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/570

## Proposed Changes

This PR addresses vulnerability when setting up new payment method in stripe. This added in the same manner as in original integration here: https://github.com/Automattic/wp-calypso/pull/79881

Instead of having Setup intent in advance, we will retrieve it right before adding Payment method. Thus, we are removing `StripeSetupIntentIdProvider` and all related code. And use `fetch` right before registering new payment method.

Note: this PR only addresses A4A platfrom and not code in Jetpack cloud.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Description from original issue:
> In order to add a new credit card without a (paid) purchase, we must create a Stripe Setup Intent. To do this requires first fetching an intent ID from our endpoint. Because of the implementation details when this was originally implemented, we fetched this ID when the "Add new payment method" form (originally the only place that used a Setup Intent) loaded. This was fine because it was very likely that the user would add a new card on that form. However, now that we accept new credit cards for free purchases in checkout, this means we are creating far more setup intent IDs than we need.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link, navigate to `/purchases/payment-methods`.
- If you have payment method, delete it.
- Try adding new Payment method, all should work as expected.
- You can also try to delete payment method, navigate to `/marketplace/products` and try to checkout. You will be redirected again to Add payment method and all should work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
