### PR TITLE
Jetpack Backup: Enable credential-less restores on all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -54,6 +54,7 @@
 		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -39,6 +39,7 @@
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/card-addition-improvements": true,
 		"jetpack/golden-token": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -42,6 +42,7 @@
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/card-addition-improvements": true,
 		"jetpack/golden-token": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -42,6 +42,7 @@
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/card-addition-improvements": true,
 		"jetpack/golden-token": true,

--- a/config/production.json
+++ b/config/production.json
@@ -67,6 +67,7 @@
 		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": false,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -63,6 +63,7 @@
 		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,

--- a/config/test.json
+++ b/config/test.json
@@ -48,6 +48,7 @@
 		"importers/substack": true,
 		"individual-subscriber-stats": false,
 		"jetpack/agency-dashboard": true,
+		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -71,6 +71,7 @@
 		"jetpack/ai-assistant-request-limit": true,
 		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": true,
+		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/405

## Proposed Changes

* Enable `jetpack/backup-restore-preflight-checks` feature flag on all staging, test and production environments.
  * We will monitor the feature for a few weeks before deciding to get rid of the feature flag.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Credential-less restores release: peaFOp-2mO-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure `Restore to this point` button is enabled when navigating to the backup page using a site without credentials configured.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?