### PR TITLE
Frictionless Email Subscriptions: Update account creation step to generate random username

### DIFF
--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -176,6 +176,7 @@ function SubscribeEmailStep( props ) {
 					extra: {
 						first_name: queryArguments.first_name,
 						...( includeLastName && { last_name: queryArguments.last_name } ),
+						generate_random_username: true,
 					},
 				},
 				flowName,


### PR DESCRIPTION
Related to https://github.com/Automattic/martech/issues/3232

## Proposed Changes

When creating a new passwordless account via `/users/new`, adds the `extra` property `generate_random_username` which instructs the backend to generate a username **without using the email address as a hint**.

Requires: D156892-code

## Why are these changes being made?

Privacy concerns with creating a username based on the email address were raised here: https://github.com/Automattic/wp-calypso/issues/92394

## Testing Instructions

- Navigate to the following URL with a new account value for `user_email`:
  - `/start/email-subscription/subscribe?user_email=test%40email.com&first_name=Test&last_name=&mailing_list=zzz&redirect_to=%2F&from=%2Fzzz%2F`
- Inspect the `/users/new` network request
  - Check that the `generate_random_username: true` property is included in the `extra` object
  - Check that a 200 response is received
- Visit the new account's `/me` page and check that a random username has been generated that IS NOT related to the email address eg. if the email is `bob.jones.90@gmail.com` the username should not include 'bob' or 'jones'

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?