### PR TITLE
A4A: Show a placeholder on the WPCOM plan card when product data is fetching.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -90,26 +90,35 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 			</div>
 
 			<div className="wpcom-plan-selector__card">
-				<div className="wpcom-plan-selector__details">
-					{ ownedPlans && (
-						<div className="wpcom-plan-selector__owned-plan">
-							{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
-								args: {
-									count: ownedPlans,
-								},
-								count: ownedPlans,
-								comment: '%(count)s is the number of WordPress.com sites owned by the user',
-							} ) }
+				{ ! isLicenseCountsReady && (
+					<div className="wpcom-plan-selector__details is-placeholder">
+						{ ownedPlans && <div className="wpcom-plan-selector__owned-plan"></div> }
+						<div className="wpcom-plan-selector__plan-name"></div>
+						<div className="wpcom-plan-selector__price"></div>
+						<div className="wpcom-plan-selector__price-interval"></div>
+						<div className="wpcom-plan-selector__cta">
+							<div className="wpcom-plan-selector__cta-label"></div>
+							<div className="wpcom-plan-selector__cta-component"></div>
 						</div>
-					) }
+					</div>
+				) }
 
-					<h2 className="wpcom-plan-selector__plan-name">{ planName }</h2>
+				{ isLicenseCountsReady && (
+					<div className="wpcom-plan-selector__details">
+						{ ownedPlans && (
+							<div className="wpcom-plan-selector__owned-plan">
+								{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
+									args: {
+										count: ownedPlans,
+									},
+									count: ownedPlans,
+									comment: '%(count)s is the number of WordPress.com sites owned by the user',
+								} ) }
+							</div>
+						) }
 
-					{ ! isLicenseCountsReady && (
-						<div className="wpcom-plan-selector__price is-placeholder"></div>
-					) }
+						<h2 className="wpcom-plan-selector__plan-name">{ planName }</h2>
 
-					{ isLicenseCountsReady && (
 						<div className="wpcom-plan-selector__price">
 							<b className="wpcom-plan-selector__price-actual-value">
 								{ formatCurrency( actualPrice, plan.currency ) }
@@ -135,27 +144,27 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 								{ plan.price_interval === 'month' && translate( 'per month' ) }
 							</div>
 						</div>
-					) }
 
-					<div className="wpcom-plan-selector__cta">
-						<div className="wpcom-plan-selector__cta-label">
-							{ translate( 'How many sites would you like to buy?' ) }
-						</div>
+						<div className="wpcom-plan-selector__cta">
+							<div className="wpcom-plan-selector__cta-label">
+								{ translate( 'How many sites would you like to buy?' ) }
+							</div>
 
-						<div className="wpcom-plan-selector__cta-component">
-							<Button
-								className="wpcom-plan-selector__cta-button"
-								variant="primary"
-								onClick={ () => onSelect( plan, quantity ) }
-								disabled={ ! isLicenseCountsReady }
-							>
-								{ ctaLabel }
-							</Button>
+							<div className="wpcom-plan-selector__cta-component">
+								<Button
+									className="wpcom-plan-selector__cta-button"
+									variant="primary"
+									onClick={ () => onSelect( plan, quantity ) }
+									disabled={ ! isLicenseCountsReady }
+								>
+									{ ctaLabel }
+								</Button>
 
-							{ ! referralMode && <A4ANumberInput value={ quantity } onChange={ setQuantity } /> }
+								{ ! referralMode && <A4ANumberInput value={ quantity } onChange={ setQuantity } /> }
+							</div>
 						</div>
 					</div>
-				</div>
+				) }
 
 				<div className="wpcom-plan-selector__features">
 					<SimpleList

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -16,32 +16,19 @@ import useWPCOMDiscountTiers from '../../../hooks/use-wpcom-discount-tiers';
 
 import './style.scss';
 
-type Props = {
+type PlanDetailsProps = {
+	plan: APIProductFamilyProduct;
 	onSelect: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+	ownedPlans: number;
+	referralMode?: boolean;
 };
 
-export default function WPCOMPlanSelector( { onSelect }: Props ) {
+function PlanDetails( { plan, onSelect, ownedPlans, referralMode }: PlanDetailsProps ) {
 	const translate = useTranslate();
-
-	const { data: licenseCounts, isSuccess: isLicenseCountsReady } = useFetchLicenseCounts();
 
 	const [ quantity, setQuantity ] = useState( 1 );
 
-	const { wpcomPlans } = useProductAndPlans( {} );
-
-	const plan = getWPCOMCreatorPlan( wpcomPlans ) ?? wpcomPlans[ 0 ];
-
-	const ownedPlans = useMemo( () => {
-		if ( isLicenseCountsReady && plan ) {
-			const productStats = licenseCounts?.products?.[ plan.slug ];
-			return productStats?.not_revoked || 0;
-		}
-	}, [ isLicenseCountsReady, licenseCounts?.products, plan ] );
-
 	const discountTiers = useWPCOMDiscountTiers();
-
-	const { marketplaceType } = useContext( MarketplaceTypeContext );
-	const referralMode = marketplaceType === 'referral';
 
 	const discount = useMemo( () => {
 		if ( referralMode ) {
@@ -71,6 +58,109 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 		} );
 	}, [ planName, quantity, referralMode, translate ] );
 
+	return (
+		<div className="wpcom-plan-selector__details">
+			{ ownedPlans && (
+				<div className="wpcom-plan-selector__owned-plan">
+					{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
+						args: {
+							count: ownedPlans,
+						},
+						count: ownedPlans,
+						comment: '%(count)s is the number of WordPress.com sites owned by the user',
+					} ) }
+				</div>
+			) }
+
+			<h2 className="wpcom-plan-selector__plan-name">{ planName }</h2>
+
+			<div className="wpcom-plan-selector__price">
+				<b className="wpcom-plan-selector__price-actual-value">
+					{ formatCurrency( actualPrice, plan.currency ) }
+				</b>
+				{ !! discount && (
+					<>
+						<b className="wpcom-plan-selector__price-original-value">
+							{ formatCurrency( originalPrice, plan.currency ) }
+						</b>
+
+						<span className="wpcom-plan-selector__price-discount">
+							{ translate( 'You save %(discount)s%', {
+								args: {
+									discount: Math.floor( discount * 100 ),
+								},
+								comment: '%(discount)s is the discount percentage.',
+							} ) }
+						</span>
+					</>
+				) }
+				<div className="wpcom-plan-selector__price-interval">
+					{ plan.price_interval === 'day' && translate( 'per day' ) }
+					{ plan.price_interval === 'month' && translate( 'per month' ) }
+				</div>
+			</div>
+
+			<div className="wpcom-plan-selector__cta">
+				<div className="wpcom-plan-selector__cta-label">
+					{ translate( 'How many sites would you like to buy?' ) }
+				</div>
+
+				<div className="wpcom-plan-selector__cta-component">
+					<Button
+						className="wpcom-plan-selector__cta-button"
+						variant="primary"
+						onClick={ () => onSelect( plan, quantity ) }
+					>
+						{ ctaLabel }
+					</Button>
+
+					{ ! referralMode && <A4ANumberInput value={ quantity } onChange={ setQuantity } /> }
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function PlanDetailsPlaceholder() {
+	return (
+		<div className="wpcom-plan-selector__details is-placeholder">
+			<div className="wpcom-plan-selector__owned-plan"></div>
+			<div className="wpcom-plan-selector__plan-name"></div>
+			<div className="wpcom-plan-selector__price"></div>
+			<div className="wpcom-plan-selector__price-interval"></div>
+			<div className="wpcom-plan-selector__cta">
+				<div className="wpcom-plan-selector__cta-label"></div>
+				<div className="wpcom-plan-selector__cta-component"></div>
+			</div>
+		</div>
+	);
+}
+
+type WPCOMPlanSelectorProps = {
+	onSelect: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+};
+
+export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps ) {
+	const translate = useTranslate();
+
+	const { data: licenseCounts, isSuccess: isLicenseCountsReady } = useFetchLicenseCounts();
+
+	const { wpcomPlans } = useProductAndPlans( {} );
+
+	const plan = getWPCOMCreatorPlan( wpcomPlans ) ?? wpcomPlans[ 0 ];
+
+	const ownedPlans = useMemo( () => {
+		if ( isLicenseCountsReady && plan ) {
+			const productStats = licenseCounts?.products?.[ plan.slug ];
+			return productStats?.not_revoked || 0;
+		}
+	}, [ isLicenseCountsReady, licenseCounts?.products, plan ] );
+
+	const discountTiers = useWPCOMDiscountTiers();
+
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+	const referralMode = marketplaceType === 'referral';
+
 	if ( ! plan ) {
 		return;
 	}
@@ -90,80 +180,15 @@ export default function WPCOMPlanSelector( { onSelect }: Props ) {
 			</div>
 
 			<div className="wpcom-plan-selector__card">
-				{ ! isLicenseCountsReady && (
-					<div className="wpcom-plan-selector__details is-placeholder">
-						{ ownedPlans && <div className="wpcom-plan-selector__owned-plan"></div> }
-						<div className="wpcom-plan-selector__plan-name"></div>
-						<div className="wpcom-plan-selector__price"></div>
-						<div className="wpcom-plan-selector__price-interval"></div>
-						<div className="wpcom-plan-selector__cta">
-							<div className="wpcom-plan-selector__cta-label"></div>
-							<div className="wpcom-plan-selector__cta-component"></div>
-						</div>
-					</div>
-				) }
-
-				{ isLicenseCountsReady && (
-					<div className="wpcom-plan-selector__details">
-						{ ownedPlans && (
-							<div className="wpcom-plan-selector__owned-plan">
-								{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
-									args: {
-										count: ownedPlans,
-									},
-									count: ownedPlans,
-									comment: '%(count)s is the number of WordPress.com sites owned by the user',
-								} ) }
-							</div>
-						) }
-
-						<h2 className="wpcom-plan-selector__plan-name">{ planName }</h2>
-
-						<div className="wpcom-plan-selector__price">
-							<b className="wpcom-plan-selector__price-actual-value">
-								{ formatCurrency( actualPrice, plan.currency ) }
-							</b>
-							{ !! discount && (
-								<>
-									<b className="wpcom-plan-selector__price-original-value">
-										{ formatCurrency( originalPrice, plan.currency ) }
-									</b>
-
-									<span className="wpcom-plan-selector__price-discount">
-										{ translate( 'You save %(discount)s%', {
-											args: {
-												discount: Math.floor( discount * 100 ),
-											},
-											comment: '%(discount)s is the discount percentage.',
-										} ) }
-									</span>
-								</>
-							) }
-							<div className="wpcom-plan-selector__price-interval">
-								{ plan.price_interval === 'day' && translate( 'per day' ) }
-								{ plan.price_interval === 'month' && translate( 'per month' ) }
-							</div>
-						</div>
-
-						<div className="wpcom-plan-selector__cta">
-							<div className="wpcom-plan-selector__cta-label">
-								{ translate( 'How many sites would you like to buy?' ) }
-							</div>
-
-							<div className="wpcom-plan-selector__cta-component">
-								<Button
-									className="wpcom-plan-selector__cta-button"
-									variant="primary"
-									onClick={ () => onSelect( plan, quantity ) }
-									disabled={ ! isLicenseCountsReady }
-								>
-									{ ctaLabel }
-								</Button>
-
-								{ ! referralMode && <A4ANumberInput value={ quantity } onChange={ setQuantity } /> }
-							</div>
-						</div>
-					</div>
+				{ isLicenseCountsReady ? (
+					<PlanDetails
+						plan={ plan }
+						onSelect={ onSelect }
+						ownedPlans={ ownedPlans }
+						referralMode={ referralMode }
+					/>
+				) : (
+					<PlanDetailsPlaceholder />
 				) }
 
 				<div className="wpcom-plan-selector__features">

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
@@ -104,3 +104,53 @@
 .wpcom-plan-selector__cta-button {
 	min-width: 260px;
 }
+
+.wpcom-plan-selector__details.is-placeholder {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+
+	.wpcom-plan-selector__owned-plan,
+	.wpcom-plan-selector__plan-name,
+	.wpcom-plan-selector__price,
+	.wpcom-plan-selector__price-interval,
+	.wpcom-plan-selector__cta-label,
+	.wpcom-plan-selector__cta-component {
+		@include placeholder( --color-neutral-10 );
+		border-radius: 4px;
+		box-sizing: border-box;
+	}
+
+	.wpcom-plan-selector__owned-plan {
+		width: 150px;
+	}
+
+	.wpcom-plan-selector__plan-name {
+		height: 30px;
+		margin-block-end: 4px;
+		width: 200px;
+	}
+
+	.wpcom-plan-selector__price {
+		width: 260px;
+		margin-block-end: 2px;
+	}
+
+	.wpcom-plan-selector__price-interval {
+		width: 50px;
+		height: 14px;
+	}
+
+	.wpcom-plan-selector__cta {
+		gap: 16px;
+	}
+
+	.wpcom-plan-selector__cta-label {
+		width: 250px;
+	}
+
+	.wpcom-plan-selector__cta-component {
+		width: 436px;
+		height: 36px;
+	}
+}


### PR DESCRIPTION
This pull request adds a minor UI improvement when fetching WPCOM product data. A placeholder will now be shown to avoid displaying an empty WPCOM plan card.

<img width="825" alt="Screenshot 2024-07-30 at 4 09 45 PM" src="https://github.com/user-attachments/assets/de1f9221-bc58-424c-9c49-3fa3cdcad18e">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/867

## Proposed Changes

* Implement the `wpcom-plan-selector__details` div placeholder and show it while `isLicenseCountsReady` is false. This ensures that all product data is ready before showing the content.

## Why are these changes being made?

* Improve User experience.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting` page.
* Confirm that the placeholder is displayed during the first fetch. (If you have trouble retesting, you can spin this branch locally and manually set `isLicenseCountsReady` to always false.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
