### PR TITLE
ETK: track whether the dotcom fse feature is loaded

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -50,6 +50,26 @@ require_once __DIR__ . '/dotcom-fse/helpers.php';
 // Enqueues the shared JS data stores and defines shared helper functions.
 require_once __DIR__ . '/common/index.php';
 
+function wpcom_track_load_full_site_editing() {
+	// Avoid sending the track event every time.
+	if ( get_option( 'wpcom_dotcom_fse_log', false ) ) {
+		return;
+	}
+
+	add_option( 'wpcom_dotcom_fse_log', true );
+	$event_props = array(
+		'theme' => get_stylesheet(),
+	);
+
+	// Invoke the correct function based on the underlying infrastructure.
+	if ( function_exists( 'wpcomsh_record_tracks_event' ) ) {
+		wpcomsh_record_tracks_event( 'wpcom_dotcom_fse_load', $event_props );
+	} elseif ( function_exists( 'require_lib' ) && function_exists( 'tracks_record_event' ) ) {
+		require_lib( 'tracks/client' );
+		tracks_record_event( get_current_user_id(), 'wpcom_dotcom_fse_load', $event_props );
+	}
+}
+
 /**
  * Load dotcom-FSE.
  */
@@ -59,6 +79,9 @@ function load_full_site_editing() {
 	if ( ! is_full_site_editing_active() ) {
 		return;
 	}
+
+	wpcom_track_load_full_site_editing();
+
 	// Not dangerous here since we have already checked for eligibility.
 	dangerously_load_full_site_editing_files();
 	Full_Site_Editing::get_instance();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8208

## Proposed Changes

* Send the track event, `wpcom_dotcom_fse_load`, to see whether the legacy dotcom fse feature is still in use.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Measure whether to remove the legacy dotcom fse feature entirely instead of migration

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Manually move the log function to the front of `is_full_site_editing_active` function
* Go to Tracks Live View to see whether the event is logged as expected
  ![image](https://github.com/user-attachments/assets/d719fa84-8669-4da7-9662-eb3bf1d738a5)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
