### PR TITLE
Fix twitter selectors to work with edge

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -29,8 +29,7 @@ export class TwitterBlockFlow implements BlockFlow {
 		this.configurationData = configurationData;
 	}
 
-	// @todo Change to "YouTube Embed" once Gutenberg v18.9.0 is deployed everywhere.
-	blockSidebarName = /(Twitter Embed|Twitter)/;
+	blockSidebarName = 'Twitter';
 	blockEditorSelector = blockParentSelector;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -5,7 +5,7 @@ interface ConfigurationData {
 	expectedTweetText: string;
 }
 
-const blockParentSelector = '[aria-label="Block: Twitter"]:has-text("Twitter URL")';
+const blockParentSelector = '[aria-label*="Block: Twitter"]:has-text("Twitter")';
 const selectors = {
 	embedUrlInput: `${ blockParentSelector } input`,
 	embedButton: `${ blockParentSelector } button:has-text("Embed")`,
@@ -29,7 +29,8 @@ export class TwitterBlockFlow implements BlockFlow {
 		this.configurationData = configurationData;
 	}
 
-	blockSidebarName = 'Twitter';
+	// @todo Change to "YouTube Embed" once Gutenberg v18.9.0 is deployed everywhere.
+	blockSidebarName = /(Twitter Embed|Twitter)/;
 	blockEditorSelector = blockParentSelector;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
@@ -5,7 +5,7 @@ import { EditorPage } from '../../pages';
  * An interface for block-based flows to enable iterating the same smoke test cases for a set of blocks.
  */
 export interface BlockFlow {
-	blockSidebarName: string | RegExp;
+	blockSidebarName: string;
 	blockTestName?: string;
 	blockEditorSelector: string;
 	configure?( context: EditorContext ): Promise< void >;

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
@@ -5,7 +5,7 @@ import { EditorPage } from '../../pages';
  * An interface for block-based flows to enable iterating the same smoke test cases for a set of blocks.
  */
 export interface BlockFlow {
-	blockSidebarName: string;
+	blockSidebarName: string | RegExp;
 	blockTestName?: string;
 	blockEditorSelector: string;
 	configure?( context: EditorContext ): Promise< void >;

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
@@ -29,7 +29,6 @@ export class YouTubeBlockFlow implements BlockFlow {
 	}
 
 	blockSidebarName = 'YouTube';
-
 	blockEditorSelector = blockParentSelector;
 
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to Gutenberg rotation related to this change: https://github.com/WordPress/gutenberg/pull/63371
Task: #[92543](https://github.com/Automattic/wp-calypso/issues/92945)

Testing instructions
- Atomic (Jetpack edge): `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core.ts`
- Simple: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core.ts`
- Gutenberg edge: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core.ts`


Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
