### PR TITLE
A4A: Make the new Hosting pages mobile responsive.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
@@ -26,6 +26,10 @@ const MigrationOfferV2 = () => {
 			<div className="a4a-migration-offer-v2__main">
 				<h3 className="a4a-migration-offer-v2__title">
 					{ translate( 'Special limited time migration offer' ) }
+
+					<Button className="a4a-migration-offer-v2__view-toggle-mobile" onClick={ onToggleView }>
+						<Icon icon={ chevronDown } size={ 24 } />
+					</Button>
 				</h3>
 
 				{ isExpanded && (

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
@@ -25,7 +25,7 @@ const MigrationOfferV2 = () => {
 
 			<div className="a4a-migration-offer-v2__main">
 				<h3 className="a4a-migration-offer-v2__title">
-					{ translate( 'Special limited-time migration offer for our partners' ) }
+					{ translate( 'Special limited time migration offer' ) }
 				</h3>
 
 				{ isExpanded && (

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/style.scss
@@ -56,6 +56,7 @@
 	@include break-medium {
 		@include a4a-font-heading-lg;
 		margin-block-start: 10px;
+		margin-block-end: 8px;
 	}
 }
 

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/style.scss
@@ -10,7 +10,7 @@
 	border: 1px solid var(--color-primary-5);
 	background-color: var(--color-primary-0);
 	transition: padding 0.15s linear;
-	padding: 8px 16px 16px;
+	padding: 8px 16px;
 
 	@include break-medium {
 		padding: 20px 32px;
@@ -21,8 +21,12 @@
 }
 
 .a4a-migration-offer-v2__side {
-	display: none;
 	height: 48px;
+}
+
+.a4a-migration-offer-v2__side,
+.theme-a8c-for-agencies .components-button.a4a-migration-offer-v2__view-toggle {
+	display: none;
 
 	@include break-medium {
 		display: block;
@@ -35,7 +39,6 @@
 }
 
 .a4a-migration-offer-v2__main {
-	display: flex;
 	flex-direction: column;
 	gap: 8px;
 	flex-grow: 1;
@@ -43,13 +46,18 @@
 
 .a4a-migration-offer-v2__title {
 	@include a4a-font-heading-md;
-	margin-block-start: 10px;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+
+	margin-block-end: 0;
 
 	@include break-medium {
 		@include a4a-font-heading-lg;
+		margin-block-start: 10px;
 	}
 }
-
 
 .a4a-migration-offer-v2__body {
 	display: flex;
@@ -88,10 +96,16 @@
 	@include a4a-font-body-md;
 }
 
-.theme-a8c-for-agencies .components-button.a4a-migration-offer-v2__view-toggle {
-	position: absolute;
-	inset-inline-end: 24px;
+.theme-a8c-for-agencies .components-button.a4a-migration-offer-v2__view-toggle-mobile {
+	display: block;
 
+	@include break-medium {
+		display: none;
+	}
+}
+
+.theme-a8c-for-agencies .components-button.a4a-migration-offer-v2__view-toggle,
+.theme-a8c-for-agencies .components-button.a4a-migration-offer-v2__view-toggle-mobile {
 	&,
 	&:hover,
 	&:focus,
@@ -107,12 +121,11 @@
 	svg {
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
 	}
-
-	@include break-medium {
-		position: relative;
-	}
 }
 
-.a4a-migration-offer-v2.is-expanded .components-button.a4a-migration-offer-v2__view-toggle svg {
-	transform: rotate(180deg);
+.a4a-migration-offer-v2.is-expanded {
+	.components-button.a4a-migration-offer-v2__view-toggle svg,
+	.components-button.a4a-migration-offer-v2__view-toggle-mobile svg {
+		transform: rotate(180deg);
+	}
 }

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/style.scss
@@ -9,16 +9,24 @@
 	border-radius: 4px;
 	border: 1px solid var(--color-primary-5);
 	background-color: var(--color-primary-0);
-	padding: 20px 32px;
 	transition: padding 0.15s linear;
+	padding: 8px 16px 16px;
 
-	&.is-expanded {
-		padding: 20px 32px 24px;
+	@include break-medium {
+		padding: 20px 32px;
+		&.is-expanded {
+			padding: 20px 32px 24px;
+		}
 	}
 }
 
 .a4a-migration-offer-v2__side {
+	display: none;
 	height: 48px;
+
+	@include break-medium {
+		display: block;
+	}
 }
 
 .a4a-migration-offer-v2__icon {
@@ -34,29 +42,38 @@
 }
 
 .a4a-migration-offer-v2__title {
-	@include a4a-font-heading-lg;
-
+	@include a4a-font-heading-md;
 	margin-block-start: 10px;
+
+	@include break-medium {
+		@include a4a-font-heading-lg;
+	}
 }
 
 
 .a4a-migration-offer-v2__body {
 	display: flex;
-	gap: 40px;
+	gap: 16px;
 	align-content: center;
 	flex-direction: column;
 
-	@include break-large {
+	@include break-xlarge {
+		gap: 40px;
 		flex-direction: row;
 	}
 }
 
 .a4a-migration-offer-v2__description {
-	@include a4a-font-body-lg;
+	@include a4a-font-body-md;
+	margin: 0;
 
 	a {
 		color: var(--color-text);
 		text-decoration: underline;
+	}
+
+	@include break-medium {
+		@include a4a-font-body-lg;
 	}
 }
 
@@ -72,6 +89,9 @@
 }
 
 .theme-a8c-for-agencies .components-button.a4a-migration-offer-v2__view-toggle {
+	position: absolute;
+	inset-inline-end: 24px;
+
 	&,
 	&:hover,
 	&:focus,
@@ -86,6 +106,10 @@
 
 	svg {
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
+	}
+
+	@include break-medium {
+		position: relative;
 	}
 }
 

--- a/client/a8c-for-agencies/components/a4a-number-input/style.scss
+++ b/client/a8c-for-agencies/components/a4a-number-input/style.scss
@@ -17,7 +17,7 @@
 	}
 
 	.components-text-control__input[type="number"] {
-		max-width: 80px;
+		width: 80px;
 		text-align: center;
 		border-radius: 4px;
 		padding: 0;

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-additional-features-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-additional-features-section/style.scss
@@ -33,7 +33,10 @@ ul.hosting-additional-features {
 		display: flex;
 		align-content: center;
 		gap: 4px;
-		white-space: nowrap;
+
+		@include break-medium {
+			white-space: nowrap;
+		}
 	}
 
 	.gridicon {

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/style.scss
@@ -7,7 +7,7 @@
 	grid-template-rows: 1fr;
 	gap: 24px;
 
-	@include break-medium {
+	@include break-large {
 		grid-template-columns: repeat(2, 1fr);
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/style.scss
@@ -20,11 +20,16 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	gap: 24px;
-	padding: 32px;
 	border-radius: 4px;
 	border: 1px solid var(--color-neutral-5);
 	background-color: var(--color-surface);
+	gap: 16px;
+	padding: 16px;
+
+	@include break-medium {
+		gap: 24px;
+		padding: 32px;
+	}
 }
 
 .hosting-benefits-card__title {
@@ -34,6 +39,7 @@
 
 .hosting-benefits-card__description {
 	@include a4a-font-body-lg;
+	margin: 0;
 }
 
 .hosting-benefits-card__list {

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/style.scss
@@ -4,10 +4,11 @@
 .hosting-overview-features {
 	display: grid;
 	grid-template-columns: 1fr;
-	column-gap: 48px;
-	row-gap: 32px;
+	gap: 16px;
 
 	@include break-large {
+		column-gap: 48px;
+		row-gap: 32px;
 		grid-template-columns: 1fr 1fr;
 	}
 }
@@ -17,7 +18,6 @@
 	flex-direction: row;
 	gap: 32px;
 	align-items: center;
-
 }
 
 .hosting-overview-features__item-icon {

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-section/index.tsx
@@ -1,6 +1,8 @@
+import { useBreakpoint } from '@automattic/viewport-react';
 import { ReactNode } from 'react';
-import './style.scss';
 import { SectionBackground } from './backgrounds';
+
+import './style.scss';
 
 export type HostingSectionProps = {
 	children: ReactNode;
@@ -19,12 +21,14 @@ export default function HostingSection( {
 	children,
 	background,
 }: HostingSectionProps ) {
+	const isNarrowView = useBreakpoint( '<960px' );
+
 	return (
 		<section
 			className="hosting-section-wrapper"
 			style={ {
 				backgroundColor: background?.color,
-				backgroundImage: background?.image,
+				backgroundImage: isNarrowView ? undefined : background?.image,
 				backgroundSize: background?.size,
 			} }
 		>

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-section/style.scss
@@ -1,17 +1,24 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .hosting-section-wrapper {
 	margin-inline: 0;
 	background-repeat: no-repeat;
 	background-position: top right;
-	padding: 80px 0;
+	padding: 40px 0;
 
 	> * {
-		padding-inline: 0;
+		padding-inline: 16px;
 
-		@include breakpoint-deprecated( ">660px" ) {
+		@include break-medium {
 			max-width: 1500px;
 			margin-inline: auto !important;
 			padding-inline: 40px;
 		}
+	}
+
+	@include break-medium {
+		padding: 80px 0;
 	}
 }
 
@@ -30,14 +37,26 @@
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-	margin-block-end: 32px;
+	margin-block-end: 24px;
+
+	@include break-medium {
+		margin-block-end: 32px;
+	}
 }
 
 .hosting-section__header-title {
-	@include a4a-font-heading-xxl;
+	@include a4a-font-heading-xl;
+
+	@include break-medium {
+		@include a4a-font-heading-xxl;
+	}
 }
 
 .hosting-section__header-description {
-	@include a4a-font-body-lg;
+	@include a4a-font-body-md;
 	margin: 0;
+
+	@include break-medium {
+		@include a4a-font-body-lg;
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-testimonials-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-testimonials-section/style.scss
@@ -14,13 +14,19 @@
 .hosting-testimonials__item {
 	display: flex;
 	flex-direction: column;
-	gap: 24px;
+	gap: 16px;
 
 	border-radius: 4px;
 	border: 1px solid var(--color-neutral-5);
 	background-color: var(--color-neutral-0);
-	padding: 32px;
+	padding: 16px;
 	justify-content: space-between;
+
+
+	@include break-medium {
+		gap: 24px;
+		padding: 32px;
+	}
 }
 
 .hosting-testimonials__item-message {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/style.scss
@@ -1,16 +1,17 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-
 .enterprise-agency-hosting__top-container {
 	display: grid;
 	grid-template-columns: 1fr;
-	gap: 24px;
-	padding-inline: 8px;
-	padding-block-end: 48px;
+	gap: 16px;
+	padding: 0 16px 48px;
 
-	@include break-small {
+	@include break-medium {
+		max-width: 1500px;
+		margin-inline: auto;
 		padding-inline: 40px;
+		gap: 24px;
 	}
 
 	@include break-xlarge {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -11,6 +11,8 @@ import HostingTestimonialsSection from '../../../common/hosting-testimonials-sec
 import PressableOverviewPlanSelection from '../../../pressable-overview/plan-selection';
 import CommonHostingBenefits from '../common-hosting-benefits';
 
+import './style.scss';
+
 type Props = {
 	onAddToCart: ( plan: APIProductFamilyProduct ) => void;
 };
@@ -19,7 +21,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 	const translate = useTranslate();
 
 	return (
-		<div>
+		<div className="premier-agency-hosting">
 			<PressableOverviewPlanSelection onAddToCart={ onAddToCart } />
 			<HostingAdditionalFeaturesSection
 				icon={ <JetpackLogo size={ 16 } /> }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/style.scss
@@ -1,0 +1,34 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.premier-agency-hosting .pressable-overview-plan-selection {
+	padding: 0 16px;
+	box-sizing: border-box;
+	.pressable-overview-plan-selection__filter-owned-plan {
+		margin-block-start: 0;
+	}
+
+	.pressable-overview-plan-selection__details {
+		flex-direction: column;
+	}
+
+	.pressable-overview-plan-selection__details-card {
+		border: none;
+		padding: 0;
+	}
+
+	@include break-large {
+		max-width: 1000px;
+		width: 100%;
+
+
+		.pressable-overview-plan-selection__details {
+			flex-direction: row;
+		}
+
+		.pressable-overview-plan-selection__details-card {
+			border: 1px solid var(--color-neutral-5);
+			padding: 24px;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/style.scss
@@ -1,7 +1,10 @@
-.standard-agency-hosting__plan-selector-container {
-	padding: 0 0 48px;
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
-	@include breakpoint-deprecated( ">660px" ) {
+.standard-agency-hosting__plan-selector-container {
+	padding: 0 16px 48px;
+
+	@include break-medium {
 		max-width: 1500px;
 		margin-inline: auto;
 		padding-inline: 40px;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
@@ -20,18 +20,21 @@
 }
 
 .wpcom-plan-selector__card {
-	border: 1px solid var(--color-neutral-5);
-	border-radius: 4px;
-	padding: 32px;
-
 	display: flex;
 	flex-direction: column;
 	gap: 24px;
 
-	@include break-large {
+	@include break-medium {
+		border: 1px solid var(--color-neutral-5);
+		border-radius: 4px;
+		padding: 32px;
+	}
+
+	@include break-xlarge {
 		flex-direction: row;
 		gap: 108px;
 	}
+
 }
 
 .wpcom-plan-selector__plan-name {
@@ -62,7 +65,7 @@
 .wpcom-plan-selector__cta {
 	display: flex;
 	flex-direction: column;
-	align-items: flex-start;
+	align-items: stretch;
 	gap: 16px;
 	margin-block-start: 24px;
 }
@@ -97,12 +100,18 @@
 
 .wpcom-plan-selector__cta-component {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column-reverse;
+	align-items: flex-start;
 	gap: 16px;
+
+	@include break-huge {
+		flex-direction: row;
+	}
 }
 
 .wpcom-plan-selector__cta-button {
 	min-width: 260px;
+	width: 100%;
 }
 
 .wpcom-plan-selector__details.is-placeholder {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
@@ -80,9 +80,9 @@ $tab-background-color: #f4fbff;
 		> * {
 			position: relative;
 			z-index: 1;
-			padding-inline: 0;
+			padding-inline: 16px;
 
-			@include breakpoint-deprecated( ">660px" ) {
+			@include break-large {
 				max-width: 1500px;
 				margin-inline: auto !important;
 				padding-inline: 40px;
@@ -95,15 +95,32 @@ $tab-background-color: #f4fbff;
 			padding-block-start: 32px;
 		}
 
+		.hosting-v2__container {
+			padding-block-start: 24px;
+
+			@include break-medium {
+				padding-block-start: 32px;
+			}
+		}
+
 		.hosting-v2__heading {
-			@include a4a-font-heading-xxl;
-			margin-block-end: 32px;
+			@include a4a-font-heading-xl;
+			margin-block-end: 24px;
+
+			@include break-medium {
+				@include a4a-font-heading-xxl;
+				margin-block-end: 32px;
+			}
 		}
 
 		.section-nav-tabs {
 			width: auto;
-			margin: 39px 0 0;
 			box-shadow: none;
+			margin: 24px 0 0;
+
+			@include break-medium {
+				margin: 39px 0 0;
+			}
 		}
 
 		.section-nav-tabs__list {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
@@ -89,10 +89,14 @@ $tab-background-color: #f4fbff;
 			}
 		}
 
-
 		.hosting-v2__hero-content {
-			padding-inline: 64px;
-			padding-block-start: 32px;
+			padding: 16px 16px 0;
+
+			@include break-medium {
+				max-width: 1500px;
+				padding-inline: 40px;
+				padding-block-start: 32px;
+			}
 		}
 
 		.hosting-v2__container {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
@@ -154,23 +154,28 @@ $tab-background-color: #f4fbff;
 	}
 
 	.hosting-v2__content-header {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 16px;
-		padding: 0 0 48px;
+		display: none;
 
-		.hosting-v2__content-header-title {
-			@include a4a-font-body-md;
-		}
+		@include break-medium {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			text-align: center;
+			gap: 16px;
+			padding: 0 40px 48px;
 
-		.hosting-v2__content-logo {
-			.wordpress-vip-logo {
-				display: inline-flex;
+			.hosting-v2__content-header-title {
+				@include a4a-font-body-md;
 			}
 
-			img {
-				height: 32px;
+			.hosting-v2__content-logo {
+				.wordpress-vip-logo {
+					display: inline-flex;
+				}
+
+				img {
+					height: 32px;
+				}
 			}
 		}
 	}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
@@ -182,7 +182,11 @@ $tab-background-color: #f4fbff;
 
 	.hosting-overview-features__item {
 		align-items: flex-start;
-		gap: 16px;
+		gap: 4px;
+
+		@include break-medium {
+			gap: 16px;
+		}
 	}
 
 	.hosting-overview-features__item-icon {

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-slider/style.scss
@@ -4,14 +4,24 @@
 
 .a4a-slider {
 	display: flex;
-	flex-direction: row;
-	gap: 24px;
-	align-items: flex-end;
+	flex-direction: column;
+	gap: 16px;
+	align-items: stretch;
+
+	@include break-medium {
+		flex-direction: row;
+		gap: 24px;
+	}
 }
 
 .a4a-slider__input {
 	position: relative;
 	flex-grow: 1;
+	margin-block-start: -16px;
+
+	@include break-medium {
+		margin-block-start: 0;
+	}
 }
 
 .a4a-slider__input [type="range"] {
@@ -92,16 +102,24 @@
 }
 
 .a4a-slider__label-container {
-	display: none;
-	text-align: right;
+	display: flex;
+	flex-direction: row;
+	text-align: left;
+	align-content: center;
+	gap: 6px;
 
 	@include break-medium {
 		display: block;
+		text-align: right;
 	}
 }
 
 .a4a-slider__sub {
-	margin-block-start: 4px;
+	margin-block-start: 0;
+
+	@include break-medium {
+		margin-block-start: 4px;
+	}
 }
 
 .a4a-slider__label,


### PR DESCRIPTION
This PR updates CSS rules to make the new Hosting pages mobile responsive.

https://github.com/user-attachments/assets/aa806cfd-6e0e-4e8b-863f-496630b87506


Closes https://github.com/Automattic/jetpack-genesis/issues/455

## Proposed Changes

* Update a few CSS rules for the new page. **Please note that mobile responsiveness for the header, navigation button, and navigation background will be handled in a separate PR.**

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting` page.
* Test the page for mobile responsiveness. Make sure that the pages do not break on any screen sizes. Refer to the figma design for correct spacing and font sizes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
