### PR TITLE
Fix padding issue for credits notice

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -21,6 +21,10 @@ $business-plan-color: #7f54b3;
 		}
 	}
 
+	.notice.is-reskinned {
+		padding-right: 16px;
+	}
+
 	.import__upgrade-plan-features-container {
 		background: #fff;
 		border: solid var(--studio-gray-5) 1px;


### PR DESCRIPTION
## Proposed Changes

This PR adds some padding to prevent the text in the plan credits notice from bumping up against the edge of the notice.

**Before**
<img width="1388" alt="image" src="https://github.com/user-attachments/assets/da0161fc-7a89-4d06-ab2f-ea514ef7a02b">


**After**
<img width="1504" alt="image" src="https://github.com/user-attachments/assets/cbfcc3e0-72fd-496d-a45b-ee765e2809ac">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site and pick the personal plan
* On the site goals step, pick an import
* Enter a url like `blog.ted.com` and make your way to the migrate offer screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
