### PR TITLE
A4A: Validate site address without `siteId` dependency

### DIFF
--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/index.tsx
@@ -35,7 +35,7 @@ export default function SiteConfigurationsModal( {
 	const translate = useTranslate();
 	const dataCenterOptions = useDataCenterOptions();
 	const { phpVersions } = usePhpVersions();
-	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading, siteId );
+	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading );
 	const { mutate: createWPCOMSite } = useCreateWPCOMSiteMutation();
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/site-configurations-modal/use-site-name.tsx
@@ -13,10 +13,10 @@ import './style.scss';
 const SUBDOMAIN_LENGTH_MINIMUM = 4;
 const SUBDOMAIN_LENGTH_MAXIMUM = 50;
 
-const checkSiteAvailability = async ( agencyId: number, siteId: number, siteName: string ) => {
+const checkSiteAvailability = async ( agencyId: number, siteName: string ) => {
 	const response = await wpcom.req.post(
 		{
-			path: `/agency/${ agencyId }/sites/${ siteId }/provision/validate`,
+			path: `/agency/${ agencyId }/validate-site-address`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{ site_name: siteName, domain: 'wordpress.com', type: freeSiteAddressType.BLOG }
@@ -30,11 +30,7 @@ const checkSiteAvailability = async ( agencyId: number, siteId: number, siteName
 	return response;
 };
 
-const useCheckSiteAvailability = (
-	siteId: number,
-	siteName: string,
-	skipAvailability: boolean
-) => {
+const useCheckSiteAvailability = ( siteName: string, skipAvailability: boolean ) => {
 	const agencyId = useSelector( getActiveAgencyId );
 	const siteNameRef = useRef( '' );
 	const [ availabilityState, setAvailabilityState ] = useState( {
@@ -63,7 +59,7 @@ const useCheckSiteAvailability = (
 			siteNameSuggestion: '',
 		} );
 
-		checkSiteAvailability( agencyId, siteId, siteName ).then( ( result ) => {
+		checkSiteAvailability( agencyId, siteName ).then( ( result ) => {
 			if ( siteName === siteNameRef.current ) {
 				setAvailabilityState( {
 					isSiteNameAvailiable: result.valid,
@@ -73,7 +69,7 @@ const useCheckSiteAvailability = (
 			}
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ agencyId, siteId, siteName, skipAvailability ] );
+	}, [ agencyId, siteName, skipAvailability ] );
 
 	const revalidateCurrentSiteName = async () => {
 		setAvailabilityState( {
@@ -86,11 +82,7 @@ const useCheckSiteAvailability = (
 	return { ...availabilityState, revalidateCurrentSiteName };
 };
 
-export const useSiteName = (
-	randomSiteName: string,
-	isRandomSiteNameLoading: boolean,
-	siteId: number
-) => {
+export const useSiteName = ( randomSiteName: string, isRandomSiteNameLoading: boolean ) => {
 	const translate = useTranslate();
 	const [ siteName, setSiteName ] = useState( randomSiteName );
 	const [ debouncedSiteName ] = useDebounce( siteName, 500 );
@@ -136,7 +128,7 @@ export const useSiteName = (
 		isSiteNameAvailiable,
 		siteNameSuggestion,
 		revalidateCurrentSiteName,
-	} = useCheckSiteAvailability( siteId, debouncedSiteName, !! skipAvailability );
+	} = useCheckSiteAvailability( debouncedSiteName, !! skipAvailability );
 
 	if ( ! isSiteNameAvailiable && ! isCheckingSiteAvailability && ! isDebouncingSiteName ) {
 		if ( siteNameSuggestion ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8500.

## Proposed Changes

* use `/agency/${ agencyId }/validate-site-address` instead of `/agency/${ agencyId }/sites/${ siteId }/provision/validate` endpoint
* remove `siteId` from all related props / params

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* related task: https://github.com/Automattic/dotcom-forge/issues/8500
* related project thread: pdDOJh-3Cl-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build it (or use the Calypso Live link).
2. Head over to http://agencies.localhost:3000/marketplace/hosting and add new license(s) to your Agency account.
3. Go to http://agencies.localhost:3000/sites/need-setup and click on the "Create new site" link.
4. Open the browser console → Network tab.
5. While in the "Configure your new site" modal, try to make changes to the site address.
6. The new `https://public-api.wordpress.com/wpcom/v2/agency/<agency-id>/validate-site-address` endpoint should get triggered and validation itself should work correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?