### PR TITLE
Add configurable block fallback name

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/twitter.ts
@@ -29,7 +29,8 @@ export class TwitterBlockFlow implements BlockFlow {
 		this.configurationData = configurationData;
 	}
 
-	blockSidebarName = 'Twitter';
+	blockSidebarName = 'Twitter Embed';
+	blockTestFallBackName = 'Twitter';
 	blockEditorSelector = blockParentSelector;
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
@@ -7,6 +7,7 @@ import { EditorPage } from '../../pages';
 export interface BlockFlow {
 	blockSidebarName: string;
 	blockTestName?: string;
+	blockTestFallBackName?: string;
 	blockEditorSelector: string;
 	configure?( context: EditorContext ): Promise< void >;
 	validateAfterPublish?( context: PublishedPostContext ): Promise< void >;

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/youtube.ts
@@ -28,7 +28,8 @@ export class YouTubeBlockFlow implements BlockFlow {
 		this.configurationData = configurationData;
 	}
 
-	blockSidebarName = 'YouTube';
+	blockSidebarName = 'YouTube Embed';
+	blockTestFallBackName = 'YouTube';
 	blockEditorSelector = blockParentSelector;
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -76,7 +76,10 @@ export class EditorSidebarBlockInserterComponent {
 	 */
 	async selectBlockInserterResult(
 		name: string,
-		{ type = 'block' }: { type?: 'block' | 'pattern' } = {}
+		{
+			type = 'block',
+			blockFallBackName = '',
+		}: { type?: 'block' | 'pattern'; blockFallBackName?: string } = {}
 	): Promise< void > {
 		const editorParent = await this.editor.parent();
 		let locator;
@@ -92,13 +95,12 @@ export class EditorSidebarBlockInserterComponent {
 				.getByRole( 'option', { name, exact: true } )
 				.first();
 
-			const isExactMatchVisible = await locator.isVisible();
+			const isResultVisible = await locator.isVisible();
 
-			// If exact match is not found, use non-exact match
-			if ( ! isExactMatchVisible ) {
+			if ( ! isResultVisible && blockFallBackName ) {
 				locator = editorParent
 					.locator( `.block-editor-inserter__block-list,.block-editor-block-types-list` )
-					.getByRole( 'option', { name, exact: false } )
+					.getByRole( 'option', { name: blockFallBackName, exact: true } )
 					.first();
 			}
 		}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -304,12 +304,13 @@ export class EditorPage {
 	async addBlockFromSidebar(
 		blockName: string,
 		blockEditorSelector: string,
-		{ noSearch }: { noSearch?: boolean } = {}
+		{ noSearch, blockFallBackName }: { noSearch?: boolean; blockFallBackName?: string } = {}
 	): Promise< ElementHandle > {
 		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent, {
 			noSearch: noSearch,
+			blockFallBackName: blockFallBackName,
 		} );
 
 		const blockHandle =
@@ -378,12 +379,12 @@ export class EditorPage {
 	private async addBlockFromInserter(
 		blockName: string,
 		inserter: BlockInserter,
-		{ noSearch }: { noSearch?: boolean } = {}
+		{ noSearch, blockFallBackName }: { noSearch?: boolean; blockFallBackName?: string } = {}
 	): Promise< void > {
 		if ( ! noSearch ) {
 			await inserter.searchBlockInserter( blockName );
 		}
-		await inserter.selectBlockInserterResult( blockName );
+		await inserter.selectBlockInserterResult( blockName, { blockFallBackName } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/shared-types/editor-types.ts
+++ b/packages/calypso-e2e/src/lib/pages/shared-types/editor-types.ts
@@ -5,6 +5,6 @@ export interface BlockInserter {
 	searchBlockInserter( blockName: string ): Promise< void >;
 	selectBlockInserterResult(
 		name: string,
-		options?: { type?: 'block' | 'pattern' }
+		options?: { type?: 'block' | 'pattern'; blockFallBackName?: string }
 	): Promise< void >;
 }

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -68,7 +68,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 					const blockHandle = await editorPage.addBlockFromSidebar(
 						blockFlow.blockSidebarName,
 						blockFlow.blockEditorSelector,
-						{ noSearch: true }
+						{ noSearch: true, blockFallBackName: blockFlow.blockTestFallBackName }
 					);
 					const id = await blockHandle.getAttribute( 'id' );
 					const editorCanvas = await editorPage.getEditorCanvas();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to Gutenberg rotation related to this change: https://github.com/WordPress/gutenberg/pull/63371
Task: #[92543](https://github.com/Automattic/wp-calypso/issues/92945)

Testing instructions
- Atomic (Jetpack edge): `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core.ts`
- Simple: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core.ts`
- Gutenberg edge: `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__core.ts`


Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
