### PR TITLE
Jetpack Backup: add `has_credentials` event prop to restore Tracks events

### DIFF
--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -5,7 +5,10 @@ import Button from 'calypso/components/forms/form-button';
 import { backupDownloadPath, backupRestorePath } from 'calypso/my-sites/backup/paths';
 import { rewindRequestBackup } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
+import {
+	areJetpackCredentialsInvalid,
+	hasJetpackCredentials,
+} from 'calypso/state/jetpack/credentials/selectors';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -44,6 +47,7 @@ const RestoreButton = ( { disabled, rewindId, primary } ) => {
 
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const hasCredentials = useSelector( ( state ) => hasJetpackCredentials( state, siteId ) );
 	const needsCredentials = useSelector( ( state ) =>
 		getDoesRewindNeedCredentials( state, siteId )
 	);
@@ -60,7 +64,12 @@ const RestoreButton = ( { disabled, rewindId, primary } ) => {
 		disabled || needsCredentials || isRestoreInProgress || ( ! isAtomic && areCredentialsInvalid );
 	const href = ! isRestoreDisabled ? backupRestorePath( siteSlug, rewindId ) : undefined;
 	const onRestore = () =>
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore', { rewind_id: rewindId } ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_restore', {
+				rewind_id: rewindId,
+				has_credentials: hasCredentials,
+			} )
+		);
 
 	return (
 		<Button

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-header.tsx
@@ -8,6 +8,7 @@ import { backupDownloadPath } from 'calypso/my-sites/backup/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { rewindRequestGranularBackup } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { hasJetpackCredentials } from 'calypso/state/jetpack/credentials/selectors';
 import { setNodeCheckState } from 'calypso/state/rewind/browser/actions';
 import canRestoreSite from 'calypso/state/rewind/selectors/can-restore-site';
 import getBackupBrowserCheckList from 'calypso/state/rewind/selectors/get-backup-browser-check-list';
@@ -29,6 +30,7 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( { rewin
 	const browserCheckList = useSelector( ( state ) => getBackupBrowserCheckList( state, siteId ) );
 	const isRestoreDisabled = useSelector( ( state ) => ! canRestoreSite( state, siteId ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
+	const hasCredentials = useSelector( ( state ) => hasJetpackCredentials( state, siteId ) );
 
 	const onDownloadClick = () => {
 		const includePaths = browserCheckList.includeList.map( ( item ) => item.id ).join( ',' );
@@ -39,7 +41,11 @@ const FileBrowserHeader: FunctionComponent< FileBrowserHeaderProps > = ( { rewin
 		page.redirect( backupDownloadPath( siteSlug, rewindId as unknown as string ) );
 	};
 	const onRestoreClick = () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_browser_restore_multiple_files' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_browser_restore_multiple_files', {
+				has_credentials: hasCredentials,
+			} )
+		);
 		page.redirect( backupGranularRestorePath( siteSlug, rewindId as unknown as string ) );
 	};
 	// When the checkbox is clicked, we'll update the check state in the state

--- a/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-info-card.tsx
@@ -7,6 +7,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import wp from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { hasJetpackCredentials } from 'calypso/state/jetpack/credentials/selectors';
 import { setNodeCheckState } from 'calypso/state/rewind/browser/actions';
 import canRestoreSite from 'calypso/state/rewind/selectors/can-restore-site';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -57,6 +58,7 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
 
 	const isRestoreDisabled = useSelector( ( state ) => ! canRestoreSite( state, siteId ) );
+	const hasCredentials = useSelector( ( state ) => hasJetpackCredentials( state, siteId ) );
 
 	// Dispatch an error notice if the download could not be prepared
 	const handlePrepareDownloadError = useCallback( () => {
@@ -199,9 +201,10 @@ const FileInfoCard: FunctionComponent< FileInfoCardProps > = ( {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_backup_browser_restore_single_file', {
 				file_type: item.type,
+				has_credentials: hasCredentials,
 			} )
 		);
-	}, [ dispatch, item.type, path, rewindId, siteId, siteSlug ] );
+	}, [ dispatch, hasCredentials, item.type, path, rewindId, siteId, siteSlug ] );
 
 	useEffect( () => {
 		if ( prepareDownloadStatus === PREPARE_DOWNLOAD_STATUS.PREPARING ) {

--- a/client/my-sites/backup/rewind-flow/error.tsx
+++ b/client/my-sites/backup/rewind-flow/error.tsx
@@ -3,8 +3,9 @@ import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent, useEffect } from 'react';
 import downloadFailureImage from 'calypso/assets/images/illustrations/jetpack-cloud-download-failure.svg';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { hasJetpackCredentials } from 'calypso/state/jetpack/credentials/selectors';
 
 interface Props {
 	imgSrc?: string;
@@ -23,13 +24,22 @@ const RewindFlowError: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const hasCredentials = useSelector( ( state ) => hasJetpackCredentials( state, siteId ) );
 
 	useEffect( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_failed' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_restore_failed', {
+				has_credentials: hasCredentials,
+			} )
+		);
+	}, [ dispatch, hasCredentials ] );
 
 	const handleContactSupportClick = () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_failed_contact_support_click' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_restore_failed_contact_support_click', {
+				has_credentials: hasCredentials,
+			} )
+		);
 	};
 
 	return (

--- a/client/my-sites/backup/rewind-flow/error.tsx
+++ b/client/my-sites/backup/rewind-flow/error.tsx
@@ -6,6 +6,7 @@ import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { hasJetpackCredentials } from 'calypso/state/jetpack/credentials/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 interface Props {
 	imgSrc?: string;
@@ -24,6 +25,7 @@ const RewindFlowError: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
 	const hasCredentials = useSelector( ( state ) => hasJetpackCredentials( state, siteId ) );
 
 	useEffect( () => {

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -235,23 +235,44 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 		setUserHasRequestedRestore( true );
 
 		// Track the restore confirmation event.
-		dispatch( recordTracksEvent( 'calypso_jetpack_granular_restore_confirm' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_granular_restore_confirm', {
+				has_credentials: hasCredentials,
+			} )
+		);
 	}, [
 		isPreflightEnabled,
 		credentialsAreValid,
 		dispatch,
+		hasCredentials,
 		preflightCheck,
 		siteId,
 		refetchPreflightStatus,
 	] );
 
 	const onCancel = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_granular_restore_cancel' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_granular_restore_cancel', {
+				has_credentials: hasCredentials,
+			} )
+		);
+	}, [ dispatch, hasCredentials ] );
 
 	const onGoBack = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_granular_restore_goback' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_granular_restore_goback', {
+				has_credentials: hasCredentials,
+			} )
+		);
+	}, [ dispatch, hasCredentials ] );
+
+	const onViewSiteClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_granular_restore_complete_view_site', {
+				has_credentials: hasCredentials,
+			} )
+		);
+	}, [ dispatch, hasCredentials ] );
 
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
@@ -520,11 +541,7 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 				target="_blank"
 				href={ siteUrl }
 				className="rewind-flow__primary-button"
-				onClick={ () =>
-					dispatch(
-						recordTracksEvent( 'calypso_jetpack_backup_granular_restore_complete_view_site' )
-					)
-				}
+				onClick={ onViewSiteClick }
 			>
 				{ translate( 'View your website {{externalIcon/}}', {
 					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
@@ -568,10 +585,21 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 		}
 
 		if ( isFinished && userHasRequestedRestore ) {
-			dispatch( recordTracksEvent( 'calypso_jetpack_backup_granular_restore_completed' ) );
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_backup_granular_restore_completed', {
+					has_credentials: hasCredentials,
+				} )
+			);
 			setUserHasRequestedRestore( false );
 		}
-	}, [ dispatch, inProgressRewindStatus, isFinished, isInProgress, userHasRequestedRestore ] );
+	}, [
+		dispatch,
+		hasCredentials,
+		inProgressRewindStatus,
+		isFinished,
+		isInProgress,
+		userHasRequestedRestore,
+	] );
 
 	const render = () => {
 		if ( loading ) {

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -206,6 +206,14 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		);
 	}, [ dispatch, hasCredentials ] );
 
+	const onViewSiteClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_restore_completed_view_site', {
+				has_credentials: hasCredentials,
+			} )
+		);
+	}, [ dispatch, hasCredentials ] );
+
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	const loading = rewindState.state === 'uninitialized';
@@ -333,13 +341,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				href={ siteUrl }
 				target="_blank"
 				className="rewind-flow__primary-button"
-				onClick={ () =>
-					dispatch(
-						recordTracksEvent( 'calypso_jetpack_restore_completed_view_site', {
-							has_credentials: hasCredentials,
-						} )
-					)
-				}
+				onClick={ onViewSiteClick }
 			>
 				{ translate( 'View your website {{externalIcon/}}', {
 					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -150,11 +150,16 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		setShowConfirm( false );
 
 		// Track the restore confirmation event.
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_confirm' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_restore_confirm', {
+				has_credentials: hasCredentials,
+			} )
+		);
 	}, [
 		isPreflightEnabled,
 		credentialsAreValid,
 		dispatch,
+		hasCredentials,
 		preflightCheck,
 		siteId,
 		refetchPreflightStatus,
@@ -170,20 +175,36 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		setShowConfirm( true );
 
 		// Track the restore retry event.
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_failed_retry' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_restore_failed_retry', {
+				has_credentials: hasCredentials,
+			} )
+		);
 	}, [ dispatch ] );
 
 	const onGoBack = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_goback' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_restore_goback', {
+				has_credentials: hasCredentials,
+			} )
+		);
+	}, [ dispatch, hasCredentials ] );
 
 	const onAddingCredentialsClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_adding_credentials' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_restore_adding_credentials', {
+				has_credentials: hasCredentials,
+			} )
+		);
+	}, [ dispatch, hasCredentials ] );
 
 	const onLearnAddingCredentialsClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_learn_adding_credentials' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_restore_learn_adding_credentials', {
+				has_credentials: hasCredentials,
+			} )
+		);
+	}, [ dispatch, hasCredentials ] );
 
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
@@ -313,7 +334,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				target="_blank"
 				className="rewind-flow__primary-button"
 				onClick={ () =>
-					dispatch( recordTracksEvent( 'calypso_jetpack_restore_completed_view_site' ) )
+					dispatch(
+						recordTracksEvent( 'calypso_jetpack_restore_completed_view_site', {
+							has_credentials: hasCredentials,
+						} )
+					)
 				}
 			>
 				{ translate( 'View your website {{externalIcon/}}', {
@@ -400,7 +425,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 
 	useEffect( () => {
 		if ( isFinished ) {
-			dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore_completed' ) );
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_backup_restore_completed', {
+					has_credentials: hasCredentials,
+				} )
+			);
 			setRestoreInitiated( false );
 			setUserHasRequestedRestore( false );
 			setRestoreFailed( false );
@@ -413,6 +442,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 		}
 	}, [
 		dispatch,
+		hasCredentials,
 		inProgressRewindStatus,
 		isFinished,
 		isRestoreInProgress,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/591

## Proposed Changes

* Add `has_credentials` event prop to restore Tracks events, using the [hasJetpackCredentials selector](https://github.com/Automattic/wp-calypso/blob/e5b49b40406c4a8adc844e3fbab8c57d13e9e462/client/state/jetpack/credentials/selectors.js#L18).
  * calypso_jetpack_backup_restore
  * calypso_jetpack_backup_restore_failed
  * calypso_jetpack_backup_restore_failed_contact_support_click
  * calypso_jetpack_granular_restore_confirm
  * calypso_jetpack_granular_restore_cancel
  * calypso_jetpack_granular_restore_goback
  * calypso_jetpack_backup_granular_restore_complete_view_site
  * calypso_jetpack_backup_granular_restore_completed
  * calypso_jetpack_backup_restore_confirm
  * calypso_jetpack_backup_restore_failed_retry
  * calypso_jetpack_backup_restore_goback
  * calypso_jetpack_backup_restore_adding_credentials
  * calypso_jetpack_backup_restore_learn_adding_credentials
  * calypso_jetpack_restore_completed_view_site
  * calypso_jetpack_backup_restore_completed
  * calypso_jetpack_backup_browser_restore_multiple_files
  * calypso_jetpack_backup_browser_restore_single_file

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to track our new credential-less restore feature usage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!TIP]
> You could use this extension to make it easier: p7H4VZ-4cf-p2

You could try testing regular and granular restores using a site with credentials and a site without credentials.
Ensure Tracks events includes the `has_credentials` prop:

![CleanShot 2024-07-30 at 15 04 37@2x](https://github.com/user-attachments/assets/d26c7837-3360-4699-be23-6e4fd6c57e35)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
