### PR TITLE
Jetpack Backup: fix broken styles in the backup browser

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-browser-node.tsx
@@ -256,6 +256,7 @@ const FileBrowserNode: FunctionComponent< FileBrowserNodeProps > = ( {
 							onClick={ handleClick }
 							showTooltip={ isLabelTruncated }
 							label={ item.name }
+							variant="tertiary"
 						>
 							<FileTypeIcon type={ item.type } /> { label }
 						</Button>

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -269,8 +269,6 @@
 
 		svg.components-checkbox-control__checked,
 		svg.components-checkbox-control__indeterminate {
-			left: -2px;
-			top: -2px;
 			height: 20px;
 			width: 20px;
 		}

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -90,7 +90,9 @@
 		}
 
 		.components-button {
+			border: 0;
 			font-size: $font-body-small;
+			font-weight: normal;
 			height: 32px;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix backup browser item button and checkbox selected/indeterminated state

| Before | After |
|---|---|
| ![CleanShot 2024-07-30 at 15 26 15@2x](https://github.com/user-attachments/assets/46ed51a9-449f-419b-a81f-f414c1393a97) | ![CleanShot 2024-07-30 at 15 25 57@2x](https://github.com/user-attachments/assets/34222c83-073f-4128-b831-64d32143e025) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Backup browser UI looks a bit broken right now due to some recent CSS changes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jetpack Cloud live branch.
* Navigate to the backup browser.
* Ensure the UI looks like the screenshot shared above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
