### PR TITLE
Masterbar: Update Help admin-bar icon to the solid version

### DIFF
--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -13,10 +13,6 @@ function AdminHelpCenterContent() {
 	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
 	const show = useSelect( ( select ) => select( 'automattic/help-center' ).isHelpCenterShown() );
 	const button = document.getElementById( 'wp-admin-bar-help-center' );
-	const child = button.querySelector( '.ab-item' );
-	if ( child ) {
-		child.classList.add( 'ab-icon' );
-	}
 
 	useEffect( () => {
 		if ( show ) {

--- a/apps/help-center/help-center-wp-admin.js
+++ b/apps/help-center/help-center-wp-admin.js
@@ -13,6 +13,10 @@ function AdminHelpCenterContent() {
 	const { setShowHelpCenter } = useDispatch( 'automattic/help-center' );
 	const show = useSelect( ( select ) => select( 'automattic/help-center' ).isHelpCenterShown() );
 	const button = document.getElementById( 'wp-admin-bar-help-center' );
+	const child = button.querySelector( '.ab-item' );
+	if ( child ) {
+		child.classList.add( 'ab-icon' );
+	}
 
 	useEffect( () => {
 		if ( show ) {

--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -30,23 +30,6 @@
 /**
  * WP-ADMIN Masterbar Styling
  */
-.admin-color-light {
-	#help-center-icon,
-	#help-center-icon-with-notification {
-		path {
-			fill: #333;
-		}
-	}
-}
-
-.active {
-	#help-center-icon,
-	#help-center-icon-with-notification {
-		path {
-			fill: #333;
-		}
-	}
-}
 
 body.is-nav-unification {
 	#wpadminbar #wp-toolbar #wp-admin-bar-help-center {
@@ -57,7 +40,7 @@ body.is-nav-unification {
 #wpadminbar #wp-toolbar {
 	#wp-admin-bar-help-center {
 		padding: 0;
-		width: 36px;
+		width: 38px;
 		display: none;
 
 		@include breakpoint-deprecated( ">960px" ) {
@@ -70,13 +53,21 @@ body.is-nav-unification {
 
 		svg {
 			position: absolute;
-			height: 24px;
-			width: 24px;
-			top: 0;
+			height: 22px;
+			width: 22px;
+			top: 1px;
 			left: 0;
 			right: 0;
 			bottom: 0;
 			padding: 4px 6px;
+		}
+
+		@media (max-width: 782px) {
+			svg {
+				height: 30px !important;
+				padding: 7px 8px !important;
+				width: 30px !important;
+			}
 		}
 
 		&.unseen-notification {
@@ -88,23 +79,16 @@ body.is-nav-unification {
 			}
 		}
 
+		.ab-icon {
+			width: 18px;
+		}
+
 		.ab-item.ab-empty-item {
 			transition: 250ms ease;
 		}
 
 		.ab-item:hover {
 			cursor: pointer;
-		}
-
-		&.active,
-		&.active:hover {
-			.ab-item.ab-empty-item {
-				background: #fff !important;
-
-				svg {
-					fill: var(--wp-admin-theme-color-darker-20);
-				}
-			}
 		}
 	}
 

--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -30,17 +30,10 @@
 /**
  * WP-ADMIN Masterbar Styling
  */
-
-body.is-nav-unification {
-	#wpadminbar #wp-toolbar #wp-admin-bar-help-center {
-		margin-right: 5px;
-	}
-}
-
 #wpadminbar #wp-toolbar {
 	#wp-admin-bar-help-center {
 		padding: 0;
-		width: 38px;
+		width: 43px;
 		display: none;
 
 		@include breakpoint-deprecated( ">960px" ) {
@@ -59,7 +52,7 @@ body.is-nav-unification {
 			left: 0;
 			right: 0;
 			bottom: 0;
-			padding: 4px 6px;
+			padding: 4px 11px;
 		}
 
 		@media (max-width: 782px) {
@@ -79,10 +72,6 @@ body.is-nav-unification {
 			}
 		}
 
-		.ab-icon {
-			width: 18px;
-		}
-
 		.ab-item.ab-empty-item {
 			transition: 250ms ease;
 		}
@@ -90,6 +79,10 @@ body.is-nav-unification {
 		.ab-item:hover {
 			cursor: pointer;
 		}
+	}
+
+	.ab-icon:hover {
+		color: inherit;
 	}
 
 

--- a/apps/help-center/help-icon.svg
+++ b/apps/help-center/help-icon.svg
@@ -1,8 +1,8 @@
-<svg id="help-center-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<svg id="help-center-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 	<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
 </svg>
 
-<svg id="help-center-icon-with-notification" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg id="help-center-icon-with-notification" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 	<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
 	<circle cx="18.5" cy="6.5" r="3" fill="var( --color-masterbar-unread-dot-background, #e26f56 )" stroke="white"/>
 </svg>

--- a/apps/help-center/help-icon.svg
+++ b/apps/help-center/help-icon.svg
@@ -1,10 +1,8 @@
-<svg id="help-center-icon"  width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-	<path d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0zM12 8.75a1.5 1.5 0 01.167 2.99c-.465.052-.917.44-.917 1.01V14h1.5v-.845A3 3 0 109 10.25h1.5a1.5 1.5 0 011.5-1.5zM11.25 15v1.5h1.5V15h-1.5z"
-	fill="white"/>
+<svg id="help-center-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+	<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
 </svg>
 
 <svg id="help-center-icon-with-notification" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<path d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0zM12 8.75a1.5 1.5 0 01.167 2.99c-.465.052-.917.44-.917 1.01V14h1.5v-.845A3 3 0 109 10.25h1.5a1.5 1.5 0 011.5-1.5zM11.25 15v1.5h1.5V15h-1.5z"
-	fill="white"/>
+	<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
 	<circle cx="18.5" cy="6.5" r="3" fill="var( --color-masterbar-unread-dot-background, #e26f56 )" stroke="white"/>
 </svg>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8454

## Proposed Changes

* Change the Help icon in the Masterbar to the solid version, similar to the one in Calypso.

Before | After
--|--
<img width="448" alt="Screenshot 2024-07-30 at 5 55 06 PM" src="https://github.com/user-attachments/assets/3511a0e3-6e05-4d3d-872f-1dacf86c52fc">  |  <img width="447" alt="Screenshot 2024-07-30 at 5 53 23 PM" src="https://github.com/user-attachments/assets/704ef5c7-2e74-4efd-b2af-ca3af8143509">

Before | After
--|--
<img width="972" alt="Screenshot 2024-07-30 at 5 54 16 PM" src="https://github.com/user-attachments/assets/bdd6c489-d4ce-4020-a419-b01c26fa6bbb">  | <img width="971" alt="Screenshot 2024-07-30 at 5 53 02 PM" src="https://github.com/user-attachments/assets/a7647521-8d4a-41c8-ad61-f8189efcdaa7">






## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency in branding and design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- cd into apps/help-center in you local Calypso clone
- run yarn dev --sync (you may need a terminal connection to your sandbox open)
- Sandbox your Simple test site and widgets.wp.com.
- Go to any wp-admin page on your test site and view the solid help center icon
- Test the mobile and desktop versions
- Be sure to click the icon to be sure the help center works.

I'm not sure how to test on Atomic sites. 🤔 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
