### PR TITLE
Stats: Adding empty states for summary pages

### DIFF
--- a/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
+++ b/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
@@ -26,6 +26,8 @@ const StatAuthors: React.FC< StatsDefaultModuleProps > = ( {
 	moduleStrings,
 	className,
 	summaryUrl,
+	summary,
+	listItemClassName,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -79,8 +81,10 @@ const StatAuthors: React.FC< StatsDefaultModuleProps > = ( {
 					period={ period }
 					query={ query }
 					statType={ statType }
-					showSummaryLink
+					showSummaryLink={ !! summary }
 					className={ className }
+					summary={ summary }
+					listItemClassName={ listItemClassName }
 					skipQuery
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
+++ b/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
@@ -26,6 +26,8 @@ const StatsClicks: React.FC< StatsDefaultModuleProps > = ( {
 	moduleStrings,
 	className,
 	summaryUrl,
+	summary,
+	listItemClassName,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -78,8 +80,10 @@ const StatsClicks: React.FC< StatsDefaultModuleProps > = ( {
 					period={ period }
 					query={ query }
 					statType={ statType }
-					showSummaryLink
+					showSummaryLink={ !! summary }
 					className={ className }
+					summary={ summary }
+					listItemClassName={ listItemClassName }
 					skipQuery
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
+++ b/client/my-sites/stats/features/modules/stats-countries/stats-countries.tsx
@@ -26,6 +26,8 @@ const StatsCountries: React.FC< StatsDefaultModuleProps > = ( {
 	moduleStrings,
 	className,
 	summaryUrl,
+	summary,
+	listItemClassName,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -76,8 +78,10 @@ const StatsCountries: React.FC< StatsDefaultModuleProps > = ( {
 					period={ period }
 					query={ query }
 					statType={ statType }
-					showSummaryLink
+					showSummaryLink={ !! summary }
 					className={ className }
+					summary={ summary }
+					listItemClassName={ listItemClassName }
 					skipQuery
 				>
 					<Geochart query={ query } skipQuery />

--- a/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
+++ b/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
@@ -28,6 +28,8 @@ const StatsDownloads: React.FC< StatsDefaultModuleProps > = ( {
 	moduleStrings,
 	className,
 	summaryUrl,
+	summary,
+	listItemClassName,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -77,8 +79,10 @@ const StatsDownloads: React.FC< StatsDefaultModuleProps > = ( {
 					period={ period }
 					query={ query }
 					statType={ statType }
-					showSummaryLink
+					showSummaryLink={ !! summary }
 					className={ className }
+					summary={ summary }
+					listItemClassName={ listItemClassName }
 					skipQuery
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -26,6 +26,8 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 	moduleStrings,
 	className,
 	summaryUrl,
+	summary,
+	listItemClassName,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -78,8 +80,10 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 					period={ period }
 					query={ query }
 					statType={ statType }
-					showSummaryLink
+					showSummaryLink={ !! summary }
 					className={ className }
+					summary={ summary }
+					listItemClassName={ listItemClassName }
 					skipQuery
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
+++ b/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
@@ -26,6 +26,8 @@ const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
 	moduleStrings,
 	className,
 	summaryUrl,
+	summary,
+	listItemClassName,
 }: StatsDefaultModuleProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -76,8 +78,10 @@ const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
 					period={ period }
 					query={ query }
 					statType={ statType }
-					showSummaryLink
+					showSummaryLink={ !! summary }
 					className={ className }
+					summary={ summary }
+					listItemClassName={ listItemClassName }
 					skipQuery
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -26,6 +26,8 @@ const StatsTopPosts: React.FC< StatsDefaultModuleProps > = ( {
 	moduleStrings,
 	className,
 	summaryUrl,
+	summary,
+	listItemClassName,
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -81,8 +83,10 @@ const StatsTopPosts: React.FC< StatsDefaultModuleProps > = ( {
 					period={ period }
 					query={ query }
 					statType={ statType }
-					showSummaryLink
+					showSummaryLink={ !! summary }
 					className={ className }
+					summary={ summary }
+					listItemClassName={ listItemClassName }
 					skipQuery
 				/>
 			) }

--- a/client/my-sites/stats/features/modules/types.d.ts
+++ b/client/my-sites/stats/features/modules/types.d.ts
@@ -11,6 +11,14 @@ type StatsDefaultModuleProps = {
 		empty: string;
 	};
 	summaryUrl?: string;
+	/**
+	 * @property {boolean} summary Render page elements specific for a summary page, e.g. a download button.
+	 */
+	summary?: boolean;
+	/**
+	 * @property {string} listItemClassName Custom class name for list items (used on a summary page).
+	 */
+	listItemClassName?: string;
 };
 
 type StatsAdvancedModuleWrapperProps = {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -767,7 +767,6 @@ class StatsSite extends Component {
 											'stats__flexible-grid-item--one-third--two-spaces':
 												! this.isModuleHidden( 'videos' ),
 										},
-
 										{
 											// Avoid 1/3 on smaller screen if Videos is visible
 											'stats__flexible-grid-item--full--large': ! this.isModuleHidden( 'videos' ),

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -76,7 +76,8 @@ class StatsDownloadCsv extends Component {
 	};
 
 	render() {
-		const { data, siteId, statType, query, translate, isLoading, borderless } = this.props;
+		const { data, siteId, statType, query, translate, isLoading, borderless, skipQuery } =
+			this.props;
 		try {
 			new Blob(); // eslint-disable-line no-new
 		} catch ( e ) {
@@ -92,7 +93,7 @@ class StatsDownloadCsv extends Component {
 				disabled={ disabled }
 				borderless={ borderless }
 			>
-				{ siteId && statType && query && (
+				{ ! skipQuery && siteId && statType && query && (
 					<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 				) }
 				<Gridicon icon="cloud-download" />{ ' ' }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -212,6 +212,7 @@ class StatsModule extends Component {
 								path={ path }
 								borderless
 								period={ period }
+								skipQuery={ skipQuery }
 							/>
 						) }
 					</div>

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -11,15 +11,20 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import AnnualSiteStats from 'calypso/my-sites/stats/annual-site-stats';
+import StatsModuleAuthors from 'calypso/my-sites/stats/features/modules/stats-authors';
+import StatsModuleClicks from 'calypso/my-sites/stats/features/modules/stats-clicks';
+import StatsModuleCountries from 'calypso/my-sites/stats/features/modules/stats-countries';
+import StatsModuleDownloads from 'calypso/my-sites/stats/features/modules/stats-downloads';
+import StatsModuleReferrers from 'calypso/my-sites/stats/features/modules/stats-referrers';
+import StatsModuleSearch from 'calypso/my-sites/stats/features/modules/stats-search';
+import StatsModuleTopPosts from 'calypso/my-sites/stats/features/modules/stats-top-posts';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
-import Countries from '../stats-countries';
 import DownloadCsv from '../stats-download-csv';
-import StatsModule from '../stats-module';
 import AllTimeNav from '../stats-module/all-time-nav';
 import PageViewTracker from '../stats-page-view-tracker';
 import statsStringsFactory from '../stats-strings';
@@ -96,12 +101,10 @@ class StatsSummary extends Component {
 				summaryView = (
 					<Fragment key="referrers-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
-						<StatsModule
-							path={ path }
+						<StatsModuleReferrers
 							moduleStrings={ StatsStrings.referrers }
 							period={ this.props.period }
 							query={ moduleQuery }
-							statType={ statType }
 							summary
 							listItemClassName={ listItemClassName }
 						/>
@@ -117,12 +120,10 @@ class StatsSummary extends Component {
 				summaryView = (
 					<Fragment key="clicks-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
-						<StatsModule
-							path={ path }
+						<StatsModuleClicks
 							moduleStrings={ StatsStrings.clicks }
 							period={ this.props.period }
 							query={ moduleQuery }
-							statType={ statType }
 							summary
 							listItemClassName={ listItemClassName }
 						/>
@@ -138,8 +139,8 @@ class StatsSummary extends Component {
 				summaryView = (
 					<Fragment key="countries-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
-						<Countries
-							path={ path }
+						<StatsModuleCountries
+							moduleStrings={ StatsStrings.countries }
 							period={ this.props.period }
 							query={ moduleQuery }
 							summary
@@ -172,12 +173,10 @@ class StatsSummary extends Component {
 				summaryView = (
 					<Fragment key="posts-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
-						<StatsModule
-							path={ path }
+						<StatsModuleTopPosts
 							moduleStrings={ StatsStrings.posts }
 							period={ this.props.period }
 							query={ moduleQuery }
-							statType={ statType }
 							summary
 							listItemClassName={ listItemClassName }
 						/>
@@ -195,12 +194,10 @@ class StatsSummary extends Component {
 				summaryView = (
 					<Fragment key="authors-summary">
 						{ this.renderSummaryHeader( path, statType, true, query ) }
-						<StatsModule
-							path={ path }
+						<StatsModuleAuthors
 							moduleStrings={ StatsStrings.authors }
 							period={ this.props.period }
 							query={ query }
-							statType={ statType }
 							className="stats__author-views"
 							summary
 							listItemClassName={ listItemClassName }
@@ -240,12 +237,10 @@ class StatsSummary extends Component {
 				summaryView = (
 					<Fragment key="filedownloads-summary">
 						{ this.renderSummaryHeader( path, statType, true, query ) }
-						<StatsModule
-							path={ path }
+						<StatsModuleDownloads
 							moduleStrings={ StatsStrings.filedownloads }
 							period={ this.props.period }
 							query={ query }
-							statType={ statType }
 							summary
 							listItemClassName={ listItemClassName }
 						/>
@@ -302,12 +297,10 @@ class StatsSummary extends Component {
 				summaryView = (
 					<Fragment key="search-terms-summary">
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
-						<StatsModule
-							path={ path }
+						<StatsModuleSearch
 							moduleStrings={ StatsStrings.search }
 							period={ this.props.period }
 							query={ moduleQuery }
-							statType={ statType }
 							summary
 							listItemClassName={ listItemClassName }
 						/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/100

## Proposed Changes

* update empty states on the summary pages to use the new modules (excluding Emails and Video)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* aligning empty states with the traffic page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the live branch
* go to each summary page on the Traffic page (excluding Emails and Video)
* verify that the empty state has an icon and matches empty states from the main page
* verify that the CSV download button works when it's available

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?