### PR TITLE
Masterbar: Update icon dot size and placement

### DIFF
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-icon.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-icon.tsx
@@ -9,9 +9,15 @@ export const CartIcon: React.FC< Props > = ( { newItems } ) => (
 			<g>
 				<path
 					fill="var( --color-masterbar-icon )"
-					d="M14.1,5c0.5,2.7,2.8,4.9,5.6,5l-0.4,1.4   c-0.2,0.9-1,1.6-2,1.6H7v2h10c1.1,0,2,0.9,2,2H7c-1.1,0-2-0.9-2-2v-2V5V4H3V2h2c1.1,0,2,0.9,2,2v1H14.1z M7,22c1.1,0,2-0.9,2-2   s-0.9-2-2-2s-2,0.9-2,2S5.9,22,7,22z M15,20c0-1.1,0.9-2,2-2s2,0.9,2,2s-0.9,2-2,2S15,21.1,15,20z"
+					d="M9,20c0,1.1-0.9,2-2,2s-2-0.9-2-2s0.9-2,2-2   S9,18.9,9,20z M17,18c-1.1,0-2,0.9-2,2s0.9,2,2,2s2-0.9,2-2S18.1,18,17,18z M17.4,13c0.9,0,1.7-0.7,2-1.6L21,5H7V4c0-1.1-0.9-2-2-2   H3v2h2v1v8v2c0,1.1,0.9,2,2,2h12c0-1.1-0.9-2-2-2H7v-2H17.4z"
 				/>
-				<circle cx="20" cy="4" r="4" fill="var( --color-masterbar-unread-dot-background )" />
+				<circle
+					className="cart-circle"
+					cx="20"
+					cy="4"
+					r="4"
+					fill="var( --color-masterbar-unread-dot-background )"
+				/>
 			</g>
 		) : (
 			<g>

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1180,6 +1180,11 @@ body.is-mobile-app-view {
 			height: 32px;
 		}
 	}
+	.cart-circle {
+		transform: translate(10%, 2%) scale(0.93);
+		stroke-width: 6%;
+		stroke: var(--color-masterbar-background);
+	}
 }
 
 .masterbar-notifications {
@@ -1202,6 +1207,9 @@ body.is-mobile-app-view {
 		use {
 			transition: all 150ms ease-in;
 			transform-origin: 20px 4px;
+			transform: translate(-2%, 2%) scale(0.93);
+			stroke-width: 6%;
+			stroke: var(--color-masterbar-background);
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8454

## Proposed Changes

* This PR updates the dot size on the shopping cart and bell icons so that the size and placement match that of wp-admin

NOTE: The shopping cart does not appear on wp-admin, this PR does not address that.
NOTE: The dot icons may be different colors from wp-admin and Calypso depending on your color scheme. This PR does not address that.

Before | After
--|--
<img width="1006" alt="Screenshot 2024-07-30 at 7 34 00 PM" src="https://github.com/user-attachments/assets/1033ab11-6f25-40d0-90b8-10a5a1420c23">  | <img width="1007" alt="Screenshot 2024-07-30 at 7 34 07 PM" src="https://github.com/user-attachments/assets/52809e10-5894-4a20-ba85-d66651f116b9">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Consistency in design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live and go to a Hosting page like /plans/[site]
* Load an item in your shopping cart and trigger a notification (you can comment on your site to do this)
* View that the dots on the shopping cart and bell icon are the same size and approximate placement as a /wp-admin page for the same site. NOTE: The shopping cart does not appear on /wp-admin and the dot colors may be different between Calypso and wp-admin (this PR does not address those issues).
* View the icon dots on mobile and ensure they look ok.
* Ensure the icons are clickable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
