### PR TITLE
A4A > Marketplace: Use tabs view for all screen sizes on the new hosting page

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -163,7 +163,7 @@ export default function HostingV2( { onAddToCart }: Props ) {
 							} ) }
 						</div>
 						<MigrationOffer />
-						<NavTabs>{ navItems }</NavTabs>
+						<NavTabs enforceTabsView>{ navItems }</NavTabs>
 					</div>
 				</div>
 			</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
@@ -13,6 +13,7 @@ $tab-background-color: #f4fbff;
 	.hosting-v2__hero {
 		position: relative;
 		overflow: hidden;
+		inset-block-start: 1px;
 
 		&::before {
 			background: url(calypso/assets/images/a8c-for-agencies/hosting-illustration.svg) no-repeat center/contain;
@@ -108,8 +109,6 @@ $tab-background-color: #f4fbff;
 		.section-nav-tabs__list {
 			justify-content: space-between;
 			gap: 4px;
-			position: relative;
-			inset-block-start: 1px;
 		}
 
 		.section-nav-tab {
@@ -127,8 +126,9 @@ $tab-background-color: #f4fbff;
 				border-block-end: none;
 				background: var(--color-light-backdrop);
 
+				.section-nav-tab__link,
 				.section-nav-tab__link:hover {
-					background: none;
+					background: unset;
 				}
 			}
 
@@ -139,7 +139,11 @@ $tab-background-color: #f4fbff;
 
 		.hosting-v2__nav-item-label {
 			color: var(--color-accent-90);
-			@include a4a-font-heading-md($font-weight: 600);
+			@include a4a-font-body-sm($font-weight: 600);
+
+			@include break-mobile {
+				@include a4a-font-heading-md($font-weight: 600);
+			}
 		}
 
 		.hosting-v2__nav-item-subtitle {
@@ -185,5 +189,14 @@ $tab-background-color: #f4fbff;
 		min-width: 32px;
 		max-width: 32px;
 		height: 32px;
+	}
+
+	.section-nav-tab__link {
+		padding: 16px 8px;
+		text-align: center;
+
+		@include break-mobile {
+			padding: 16px;
+		}
 	}
 }

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -22,10 +22,12 @@ class NavTabs extends Component {
 		label: PropTypes.string,
 		hasSiblingControls: PropTypes.bool,
 		hasHorizontalScroll: PropTypes.bool,
+		enforceTabsView: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		hasSiblingControls: false,
+		enforceTabsView: false,
 	};
 
 	state = {
@@ -68,8 +70,10 @@ class NavTabs extends Component {
 			return child && cloneElement( child, { ref: this.storeTabRefs( index ) } );
 		} );
 
+		const isDropdownEnabled = ! this.props.enforceTabsView && this.state.isDropdown;
+
 		const tabsClassName = clsx( 'section-nav-tabs', {
-			'is-dropdown': this.state.isDropdown,
+			'is-dropdown': isDropdownEnabled,
 			'has-siblings': this.props.hasSiblingControls,
 		} );
 
@@ -82,6 +86,7 @@ class NavTabs extends Component {
 					'section-nav-group': true,
 					'has-horizontal-scroll':
 						this.props.hasHorizontalScroll && innerWidth > MOBILE_PANEL_THRESHOLD,
+					'enforce-tabs-view': this.props.enforceTabsView,
 				} ) }
 				ref={ this.navGroupRef }
 			>
@@ -91,7 +96,7 @@ class NavTabs extends Component {
 						{ tabs }
 					</ul>
 
-					{ this.state.isDropdown && innerWidth > MOBILE_PANEL_THRESHOLD && this.getDropdown() }
+					{ isDropdownEnabled && innerWidth > MOBILE_PANEL_THRESHOLD && this.getDropdown() }
 				</div>
 			</div>
 			/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/components/section-nav/tabs.scss
+++ b/client/components/section-nav/tabs.scss
@@ -26,3 +26,15 @@
 		}
 	}
 }
+
+.enforce-tabs-view {
+	&.section-nav-group {
+		display: block;
+		border-top: none;
+		margin-block-start: 0;
+	}
+
+	.section-nav-tabs__list {
+		display: flex;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/459

## Proposed Changes

* This PR 

- Updates the NavTabs to enforce tabs view.
- Does minor CSS fixes to match the design 

NOTE: This PR only deals with tabs, not other areas

## Why are these changes being made?

* We want to use the tabs view always for the new hosting page instead of a dropdown on small screens. 

## Testing Instructions

* Open the A4A live link
* Go to Referrals > Open any detailed view > Verify the tabs view switches to mobile view on small screen sizes.
* Go to Marketplace - Hosting > Verify the tabs view is always shown irrespective of the screen sizes, starting from 320px. Please note the tabs might break on small screens, but this will be fine when we have the mobile UI ready.

<img width="1728" alt="Screenshot 2024-07-31 at 10 08 42 AM" src="https://github.com/user-attachments/assets/8280d935-98da-4687-952c-022eaacde12b">

<img width="767" alt="Screenshot 2024-07-31 at 10 11 34 AM" src="https://github.com/user-attachments/assets/dfb3c014-10dd-4751-ae3e-bc443647567e">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
