### PR TITLE
A4A > Referrals: Remove the unused component from translations

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -93,7 +93,6 @@ export default function ConsolidatedViews( {
 								'Every 60 days, we pay out commissions. {{a}}Learn more about payouts and commissions{{/a}}.',
 								{
 									components: {
-										nbsp: <>&nbsp;</>,
 										a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
 									},
 								}
@@ -122,7 +121,6 @@ export default function ConsolidatedViews( {
 									' We estimate the commission based on the active use for the current month. {{a}}Learn more about payouts and commissions{{/a}}.',
 								{
 									components: {
-										nbsp: <>&nbsp;</>,
 										a: <a href={ link } target="_blank" rel="noreferrer noopener" />,
 									},
 									comment: 'This is a tooltip explaining how the commission is calculated',


### PR DESCRIPTION
## Proposed Changes

* This PR removes the unused component from translations in the Referrals page.

## Why are these changes being made?

* Remove the unused component from translations

## Testing Instructions

* Open the A4A live link
* Go to the Referral dashboard > Click the info icon next to the `All time commissions` & `Commissions expected in {month}` cards on the top and verify the tooltip text looks fine:

<img width="341" alt="Screenshot 2024-07-31 at 1 51 38 PM" src="https://github.com/user-attachments/assets/62638d5c-6a76-49e3-98bc-2bbc0cc54536">

<img width="451" alt="Screenshot 2024-07-31 at 1 51 48 PM" src="https://github.com/user-attachments/assets/44dde1da-a966-4070-8340-abb33e59b299">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
