### PR TITLE
Stepper: Update `newsletter` flow to use framework tracking for step-submit

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -1,3 +1,6 @@
+import { OnboardSelect } from '@automattic/data-stores';
+import { useSelect } from '@wordpress/data';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordSubmitStep } from '../../analytics/record-submit-step';
 import type { Flow, Navigate, ProvidedDependencies, StepperStep } from '../../types';
 
@@ -19,6 +22,8 @@ export const useStepNavigationWithTracking = ( {
 		navigate,
 		steps.map( ( step ) => step.slug )
 	);
+	const intent =
+		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(), [] ) ?? '';
 
 	const shouldTrackSubmit = flow.use__Temporary__ShouldTrackEvent?.( 'submit' ) ?? false;
 
@@ -26,7 +31,7 @@ export const useStepNavigationWithTracking = ( {
 		...stepNavigation,
 		submit: ( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) => {
 			shouldTrackSubmit &&
-				recordSubmitStep( providedDependencies, '', flow.name, currentStepRoute );
+				recordSubmitStep( providedDependencies, intent, flow.name, currentStepRoute );
 			stepNavigation.submit?.( providedDependencies, ...params );
 		},
 	};

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,4 +1,4 @@
-import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
 import { NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -70,10 +70,11 @@ const newsletter: Flow = {
 		return [ ...publicSteps, ...privateSteps ];
 	},
 	useSideEffect() {
-		const { setHidePlansFeatureComparison } = useDispatch( ONBOARD_STORE );
+		const { setHidePlansFeatureComparison, setIntent } = useDispatch( ONBOARD_STORE );
 		useEffect( () => {
 			setHidePlansFeatureComparison( true );
 			clearSignupDestinationCookie();
+			setIntent( Onboard.SiteIntent.Newsletter );
 		}, [] );
 	},
 	useStepNavigation( _currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -17,7 +17,6 @@ import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
-import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
 
@@ -95,8 +94,6 @@ const newsletter: Flow = {
 		triggerGuidesForStep( flowName, _currentStep );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
-
 			const launchpadUrl = `/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;
 
 			switch ( _currentStep ) {
@@ -175,6 +172,7 @@ const newsletter: Flow = {
 
 		return { goNext, goBack, goToStep, submit };
 	},
+	use__Temporary__ShouldTrackEvent: ( event ) => 'submit' === event,
 };
 
 export default newsletter;

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -23,4 +23,5 @@ export enum SiteIntent {
 	AssemblerFirst = 'assembler-first',
 	ReadyMadeTemplate = 'readymade-template',
 	AIAssembler = 'ai-assembler',
+	Newsletter = 'newsletter',
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91755

## Proposed Changes

* Follows up from https://github.com/Automattic/wp-calypso/pull/93100
* Updates the Newsletter flow to opt-in for framework tracking on the step `submit` event
* Updates the flow to set the site intent in a the side effect hook for use in the tracks call

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/91755

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/newsletter`
* Go through the flow until checkout
* Confirm in the Network tab that requests to `t.gif` with `calypso_signup_actions_submit_step` fire correctly and on each step progression. 
  * Confirm the properties logged are identical to production, with the exception of `intent` that is new to this PR

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
