### PR TITLE
Substack importer: update copy and font hierarchy

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -223,9 +223,9 @@ function getConfig( {
 			</>
 		),
 		optionalUrl: {
-			title: translate( 'Substack Newsletter URL' ),
+			title: translate( 'Substack URL' ),
 			description: translate(
-				'Recommended: A Substack Newsletter URL to import comments and author information.'
+				'Recommended: Include the Substack URL to import comments and author information.'
 			),
 			invalidDescription: translate( 'Enter a valid Substack Newsletter URL (%(exampleUrl)s).', {
 				args: { exampleUrl: 'https://example-newsletter.substack.com/' },

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -185,7 +185,7 @@ function getConfig( {
 			<>
 				<p>
 					{ translate(
-						'Import posts and images, podcasts and public comments from a Substack export file to {{b}}%(siteTitle)s{{/b}}.',
+						'Import posts and images, podcasts and public comments from Substack to {{b}}%(siteTitle)s{{/b}}.',
 						{
 							args: {
 								siteTitle,
@@ -210,10 +210,15 @@ function getConfig( {
 		uploadDescription: (
 			<>
 				{ translate(
-					'A Substack export file is a ZIP file containing a CSV file with all posts.'
+					"To generate a ZIP file of all your Substack posts, go to your Substack {{b}}Settings > Exports{{/b}} and click 'Create a new export.' Once the ZIP file is downloaded, upload it below.",
+					{
+						components: {
+							b: <strong />,
+						},
+					}
 				) }{ ' ' }
 				<InlineSupportLink supportContext="importers-substack" showIcon={ false }>
-					{ translate( 'See how to get your export file.' ) }
+					{ translate( 'Need help?' ) }
 				</InlineSupportLink>
 			</>
 		),

--- a/client/my-sites/importer/importer-header/style.scss
+++ b/client/my-sites/importer/importer-header/style.scss
@@ -1,11 +1,11 @@
 .importer-header {
-	border-bottom: 1px solid var( --color-border-subtle );
+	border-bottom: 1px solid var(--color-border-subtle);
 	display: flex;
 	flex-flow: row nowrap;
 	margin-bottom: 1.25em;
 	gap: 1em;
 
-	@include breakpoint-deprecated( '>960px' ) {
+	@include breakpoint-deprecated(">960px") {
 		gap: 1.75em;
 	}
 
@@ -20,7 +20,7 @@
 	.importer-header__service-title {
 		line-height: 40px;
 
-		@include breakpoint-deprecated( '>960px' ) {
+		@include breakpoint-deprecated(">960px") {
 			line-height: 56px;
 		}
 	}
@@ -33,9 +33,9 @@
 
 .importer-header__service-title {
 	font-size: $font-title-small;
-	color: var( --color-text-subtle );
+	color: var(--color-text-subtle);
 
-	@include breakpoint-deprecated( '<660px' ) {
+	@include breakpoint-deprecated("<660px") {
 		line-height: 1;
 		margin-bottom: 0.25em;
 	}

--- a/client/my-sites/importer/importer-header/style.scss
+++ b/client/my-sites/importer/importer-header/style.scss
@@ -1,11 +1,11 @@
 .importer-header {
-	border-bottom: 1px solid var(--color-border-subtle);
+	border-bottom: 1px solid var( --color-border-subtle );
 	display: flex;
 	flex-flow: row nowrap;
 	margin-bottom: 1.25em;
 	gap: 1em;
 
-	@include breakpoint-deprecated( ">960px" ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		gap: 1.75em;
 	}
 
@@ -20,7 +20,7 @@
 	.importer-header__service-title {
 		line-height: 40px;
 
-		@include breakpoint-deprecated( ">960px" ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			line-height: 56px;
 		}
 	}
@@ -28,13 +28,14 @@
 
 .importer-header__service-info p {
 	margin-bottom: 1em;
+	font-size: $font-body-small;
 }
 
 .importer-header__service-title {
 	font-size: $font-title-small;
-	color: var(--color-text-subtle);
+	color: var( --color-text-subtle );
 
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		line-height: 1;
 		margin-bottom: 0.25em;
 	}

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -4,12 +4,14 @@
 	height: 180px;
 	margin-bottom: 1.5em;
 
-	background-color: var(--color-neutral-0);
-	border: 2px dashed var(--color-neutral-light);
-	transition: all 200ms ease-out, color 100ms ease-out;
-	fill: var(--color-neutral-20);
+	background-color: var( --color-neutral-0 );
+	border: 2px dashed var( --color-neutral-light );
+	transition:
+		all 200ms ease-out,
+		color 100ms ease-out;
+	fill: var( --color-neutral-20 );
 	font-size: $font-body;
-	color: var(--color-neutral-70);
+	color: var( --color-neutral-70 );
 	text-align: center;
 
 	input {
@@ -17,13 +19,13 @@
 	}
 
 	.accessible-focus &:focus {
-		border-color: var(--color-neutral-20);
+		border-color: var( --color-neutral-20 );
 	}
 
 	&:hover {
-		border-color: var(--color-neutral-70);
-		transform: translate3d(0, -1px, 0);
-		box-shadow: 0 2px 4px var(--color-neutral-10);
+		border-color: var( --color-neutral-70 );
+		transform: translate3d( 0, -1px, 0 );
+		box-shadow: 0 2px 4px var( --color-neutral-10 );
 	}
 
 	p {
@@ -31,16 +33,16 @@
 	}
 
 	.importer__upload-icon {
-		color: var(--color-neutral-light);
+		color: var( --color-neutral-light );
 	}
 }
 
 .importer__uploading-pane:hover .importer__upload-content .importer__upload-icon {
-	color: var(--color-neutral-70);
+	color: var( --color-neutral-70 );
 }
 
 .importer__uploading-pane-description {
-	font-size: $font-body-small;
+	font-size: $font-body;
 }
 
 .importer__upload-content {
@@ -49,18 +51,18 @@
 	left: 0;
 	right: 0;
 	text-align: center;
-	transform: translateY(-50%);
+	transform: translateY( -50% );
 
 	&.importer-upload-success {
-		color: var(--color-success);
+		color: var( --color-success );
 	}
 
 	&.importer-upload-failure {
-		color: var(--color-error);
+		color: var( --color-error );
 	}
 
 	.importer-upload-warning {
-		color: var(--studio-gray-90);
+		color: var( --studio-gray-90 );
 
 		a {
 			color: inherit;
@@ -75,16 +77,22 @@
 
 		&.is-pulsing {
 			.progress-bar__progress {
-				background-image: linear-gradient(-45deg, var(--color-accent) 28%, var(--color-accent-light) 28%, var(--color-accent-light) 72%, var(--color-accent) 72%);
+				background-image: linear-gradient(
+					-45deg,
+					var( --color-accent ) 28%,
+					var( --color-accent-light ) 28%,
+					var( --color-accent-light ) 72%,
+					var( --color-accent ) 72%
+				);
 			}
 		}
 	}
 
 	.progress-bar__progress {
-		background-color: var(--color-accent);
+		background-color: var( --color-accent );
 	}
 
 	&.is-complete .progress-bar__progress {
-		background-color: var(--color-success);
+		background-color: var( --color-success );
 	}
 }

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -4,14 +4,14 @@
 	height: 180px;
 	margin-bottom: 1.5em;
 
-	background-color: var( --color-neutral-0 );
-	border: 2px dashed var( --color-neutral-light );
+	background-color: var(--color-neutral-0);
+	border: 2px dashed var(--color-neutral-light);
 	transition:
 		all 200ms ease-out,
 		color 100ms ease-out;
-	fill: var( --color-neutral-20 );
+	fill: var(--color-neutral-20);
 	font-size: $font-body;
-	color: var( --color-neutral-70 );
+	color: var(--color-neutral-70);
 	text-align: center;
 
 	input {
@@ -19,13 +19,13 @@
 	}
 
 	.accessible-focus &:focus {
-		border-color: var( --color-neutral-20 );
+		border-color: var(--color-neutral-20);
 	}
 
 	&:hover {
-		border-color: var( --color-neutral-70 );
-		transform: translate3d( 0, -1px, 0 );
-		box-shadow: 0 2px 4px var( --color-neutral-10 );
+		border-color: var(--color-neutral-70);
+		transform: translate3d(0, -1px, 0);
+		box-shadow: 0 2px 4px var(--color-neutral-10);
 	}
 
 	p {
@@ -33,12 +33,12 @@
 	}
 
 	.importer__upload-icon {
-		color: var( --color-neutral-light );
+		color: var(--color-neutral-light);
 	}
 }
 
 .importer__uploading-pane:hover .importer__upload-content .importer__upload-icon {
-	color: var( --color-neutral-70 );
+	color: var(--color-neutral-70);
 }
 
 .importer__uploading-pane-description {
@@ -51,18 +51,18 @@
 	left: 0;
 	right: 0;
 	text-align: center;
-	transform: translateY( -50% );
+	transform: translateY(-50%);
 
 	&.importer-upload-success {
-		color: var( --color-success );
+		color: var(--color-success);
 	}
 
 	&.importer-upload-failure {
-		color: var( --color-error );
+		color: var(--color-error);
 	}
 
 	.importer-upload-warning {
-		color: var( --studio-gray-90 );
+		color: var(--studio-gray-90);
 
 		a {
 			color: inherit;
@@ -77,22 +77,16 @@
 
 		&.is-pulsing {
 			.progress-bar__progress {
-				background-image: linear-gradient(
-					-45deg,
-					var( --color-accent ) 28%,
-					var( --color-accent-light ) 28%,
-					var( --color-accent-light ) 72%,
-					var( --color-accent ) 72%
-				);
+				background-image: linear-gradient(-45deg, var(--color-accent) 28%, var(--color-accent-light) 28%, var(--color-accent-light) 72%, var(--color-accent) 72%);
 			}
 		}
 	}
 
 	.progress-bar__progress {
-		background-color: var( --color-accent );
+		background-color: var(--color-accent);
 	}
 
 	&.is-complete .progress-bar__progress {
-		background-color: var( --color-success );
+		background-color: var(--color-success);
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Improved font hierarchy to ensure the instructions have more visual than the intro text.
* In the case of Substack import, I've added detailed instructions and removed unnecessary words.

|Before|After|
|---|---|
|<img width="771" alt="Screenshot 2024-07-31 at 11 24 47" src="https://github.com/user-attachments/assets/680cac6b-3066-422b-85fc-1b1ef6ed26f4">|<img width="772" alt="Screenshot 2024-07-31 at 11 41 42" src="https://github.com/user-attachments/assets/8131de91-8874-4596-aa96-0c0d1f734d93">|

## Why are these changes being made?
The hypothesis is that providing more information with a better hierarchy will reduce the amount of users who upload a wrong file.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Tools > Import
* Ensure all importers have the same font-hierarchy as the `After` screenshot
* Ensure the Substack importer works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
