### PR TITLE
Site Migration: Redirect user to the customer home import screen when they start the flow from there

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -251,6 +251,15 @@ const siteMigration: Flow = {
 				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {
 					// Switch to the normal Import flow.
 					if ( providedDependencies?.destination === 'import' ) {
+						if ( urlQueryParams.get( 'ref' ) === 'calypso-importer' ) {
+							return exitFlow(
+								addQueryArgs(
+									{ engine: 'wordpress', ref: 'site-migration' },
+									`/import/${ siteSlug }`
+								)
+							);
+						}
+
 						return exitFlow(
 							addQueryArgs(
 								{

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -391,8 +391,12 @@ const siteMigration: Flow = {
 		}
 
 		const goBack = () => {
+			const siteSlug = urlQueryParams.get( 'siteSlug' ) || '';
 			switch ( currentStep ) {
 				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {
+					if ( urlQueryParams.get( 'ref' ) === 'calypso-importer' ) {
+						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/import/${ siteSlug }` ) );
+					}
 					return navigate( STEPS.SITE_MIGRATION_IDENTIFY.slug );
 				}
 				case STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug: {
@@ -402,6 +406,7 @@ const siteMigration: Flow = {
 					if ( urlQueryParams.get( 'ref' ) === GUIDED_ONBOARDING_FLOW_REFERRER ) {
 						return exitFlow( '/start/initial-intent' );
 					}
+
 					return exitFlow( `/setup/site-setup/goals?${ urlQueryParams }` );
 				}
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -298,7 +298,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'redirects the user to the internal import flow if they are comming from the customer home', () => {
+		it( 'redirects the user to the calypso import page when they come from there', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
@@ -397,7 +397,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'redirect the user back to the customer home when the flow is started from there', async () => {
+		it( 'redirects the user back the calypso import page when they come from there', async () => {
 			const { runUseStepNavigationGoBack } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationGoBack( {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -298,7 +298,23 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'Uses the siteId param fallback', async () => {
+		it( 'redirects the user to the internal import flow if they are comming from the customer home', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug,
+				currentURL: `/setup/site-migration/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?ref=calypso-importer&siteSlug=site-to-be-migrated.com`,
+				dependencies: {
+					destination: 'import',
+				},
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'/import/site-to-be-migrated.com?engine=wordpress&ref=site-migration'
+			);
+		} );
+
+		it( 'uses the siteId param fallback', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -384,7 +384,33 @@ describe( 'Site Migration Flow', () => {
 	} );
 
 	describe( 'goBack', () => {
-		it( 'backs to the identify step', async () => {
+		it( 'redirect the user back to the identify step from how to migrate', async () => {
+			const { runUseStepNavigationGoBack } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationGoBack( {
+				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?siteSlug=example.wordpress.com`,
+				state: null,
+			} );
+		} );
+
+		it( 'redirect the user back to the customer home when the flow is started from there', async () => {
+			const { runUseStepNavigationGoBack } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationGoBack( {
+				currentStep: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug,
+				currentURL: `/setup/site-migration/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?ref=calypso-importer&siteSlug=site-to-be-migrated.com`,
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				`/import/site-to-be-migrated.com?ref=site-migration`
+			);
+		} );
+
+		it( 'redirects the user back to the internal import list selection from migrate or import screen when they come from', async () => {
 			const { runUseStepNavigationGoBack } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationGoBack( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

closes #93129

## Proposed Changes
* Update the site-migration flow to the customer home > import file page  (`/import/:siteSlug`) instead of the site-migration import flow.
*  Fix the back button to redirect the user back to the customer home

## Why are these changes being made?
Based on the p1722417079166989-slack-C0Q664T29, we want to have the user using in-product tools when they start flows from there.  Ideally,  we should have an  "import or migrate" question directly on `/import/:siteSlug,` but it will require a new design in more time, so it is a temporary fix. 


## Testing Instructions
**Scenario 1:  User wants to import a file**
 - Create a simple site
 - Go to the Tools > Import > WordPress
 - Check if you were redirected to the `/setup/site-migration` flow
 - Click on the `Import content only` option
 -  Check if you have been redirected `/import/:siteSlug`
 - Check if you can see the import file screen


**Scenario 2:  User cancels the importing flow**
 - Create a simple site
 - Go to the Tools > Import > WordPress
 - Check if you were redirected to the `/setup/site-migration` flow
 - Click on the back button. 
 - Check if you have been redirected  `/import/:siteSlug.`
 - Check if you can see the list of available importers.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?