### PR TITLE
A4A: Update Hosting page v2 to use the existing Hosting URL scheme.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -6,6 +6,7 @@ import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';
 import HostingOverview from './hosting-overview';
+import { getValidHostingSection } from './lib/hosting';
 import { getValidBrand } from './lib/product-brand';
 import PressableOverview from './pressable-overview';
 import DownloadProducts from './primary/download-products';
@@ -41,11 +42,13 @@ export const marketplaceHostingContext: Callback = ( context, next ) => {
 	const { purchase_type } = context.query;
 	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
 
+	const section = getValidHostingSection( context.params.section );
+
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Hosting" path={ context.path } />
-			<HostingOverview defaultMarketplaceType={ purchaseType } />
+			<HostingOverview defaultMarketplaceType={ purchaseType } section={ section } />
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -1,7 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { type Callback } from '@automattic/calypso-router';
 import page from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
-import { A4A_MARKETPLACE_HOSTING_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_MARKETPLACE_HOSTING_LINK,
+	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import MarketplaceSidebar from '../../components/sidebar-menu/marketplace';
 import AssignLicense from './assign-license';
 import Checkout from './checkout';
@@ -39,6 +43,11 @@ export const marketplaceProductsContext: Callback = ( context, next ) => {
 };
 
 export const marketplaceHostingContext: Callback = ( context, next ) => {
+	if ( isEnabled( 'a4a-hosting-page-redesign' ) && ! context.params.section ) {
+		page.redirect( A4A_MARKETPLACE_HOSTING_WPCOM_LINK );
+		return;
+	}
+
 	const { purchase_type } = context.query;
 	const purchaseType = purchase_type === 'referral' ? 'referral' : undefined;
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -2,14 +2,13 @@ import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useLayoutEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v2';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import VIPLogo from 'calypso/assets/images/a8c-for-agencies/vip-full-logo.svg';
 import WPCOMLogo from 'calypso/assets/images/a8c-for-agencies/wpcom-logo.svg';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import { useURLQueryParams } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import EnterpriseAgencyHosting from './enterprise-agency-hosting';
 import PremierAgencyHosting from './premier-agency-hosting';
@@ -19,32 +18,30 @@ import './style.scss';
 
 type Props = {
 	onAddToCart: ( plan: APIProductFamilyProduct, quantity: number ) => void;
+	section: 'wpcom' | 'pressable' | 'vip';
 };
 
-const HostingContent = ( {
-	selectedFeatureId,
-	onAddToCart,
-}: Props & { selectedFeatureId: string } ) => {
+const HostingContent = ( { section, onAddToCart }: Props ) => {
 	const translate = useTranslate();
 
 	let content;
 	let logo;
 	let title;
-	if ( selectedFeatureId === 'standard' ) {
+	if ( section === 'wpcom' ) {
 		content = <StandardAgencyHosting onAddToCart={ onAddToCart } />;
 		logo = <img src={ WPCOMLogo } alt="WPCOM" />;
 		title = translate(
 			'Optimized and hassle-free hosting for business websites, local merchants, and small online retailers.'
 		);
 	}
-	if ( selectedFeatureId === 'premier' ) {
+	if ( section === 'pressable' ) {
 		content = <PremierAgencyHosting onAddToCart={ ( product ) => onAddToCart( product, 1 ) } />;
 		logo = <img src={ PressableLogo } alt="Pressable" />;
 		title = translate(
 			'Premier Agency hosting best for large-scale businesses and major eCommerce sites.'
 		);
 	}
-	if ( selectedFeatureId === 'enterprise' ) {
+	if ( section === 'vip' ) {
 		content = <EnterpriseAgencyHosting />;
 		logo = <img src={ VIPLogo } alt="VIP" />;
 		title = translate(
@@ -62,66 +59,45 @@ const HostingContent = ( {
 	);
 };
 
-export default function HostingV2( { onAddToCart }: Props ) {
+export default function HostingV2( { onAddToCart, section }: Props ) {
 	const translate = useTranslate();
 
 	const isLargeScreen = useBreakpoint( '>1280px' );
 
-	const { setParams, getParamValue } = useURLQueryParams();
-
-	const [ selectedFeatureId, setSelectedFeatureId ] = useState< string >(
-		getParamValue( 'hosting' )
-	);
-
-	useLayoutEffect( () => {
-		if ( ! selectedFeatureId ) {
-			setParams( [
-				{
-					key: 'hosting',
-					value: 'standard',
-				},
-			] );
-			setSelectedFeatureId( 'standard' );
-		}
-	}, [ selectedFeatureId, setParams ] );
-
 	const featureTabs = useMemo(
 		() => [
 			{
-				key: 'standard',
+				key: 'wpcom',
 				label: isLargeScreen ? translate( 'Standard Agency Hosting' ) : translate( 'Standard' ),
 				subtitle: isLargeScreen && translate( 'Optimized and hassle-free hosting' ),
 				visible: true,
-				selected: selectedFeatureId === 'standard',
+				selected: section === 'wpcom',
 				onClick: () => {
-					setSelectedFeatureId( 'standard' );
-					page.show( '/marketplace/hosting?hosting=standard' );
+					page.show( '/marketplace/hosting/wpcom' );
 				},
 			},
 			{
-				key: 'premier',
+				key: 'pressable',
 				label: isLargeScreen ? translate( 'Premier Agency Hosting' ) : translate( 'Premier' ),
 				subtitle: isLargeScreen && translate( 'Best for large-scale businesses' ),
 				visible: true,
-				selected: selectedFeatureId === 'premier',
+				selected: section === 'pressable',
 				onClick: () => {
-					setSelectedFeatureId( 'premier' );
-					page.show( '/marketplace/hosting?hosting=premier' );
+					page.show( '/marketplace/hosting/pressable' );
 				},
 			},
 			{
-				key: 'enterprise',
+				key: 'vip',
 				label: translate( 'Enterprise' ),
 				subtitle: isLargeScreen && translate( 'WordPress for enterprise-level demands' ),
 				visible: true,
-				selected: selectedFeatureId === 'enterprise',
+				selected: section === 'vip',
 				onClick: () => {
-					setSelectedFeatureId( 'enterprise' );
-					page.show( '/marketplace/hosting?hosting=enterprise' );
+					page.show( '/marketplace/hosting/vip' );
 				},
 			},
 		],
-		[ isLargeScreen, selectedFeatureId, translate ]
+		[ isLargeScreen, section, translate ]
 	);
 
 	const navItems = featureTabs.map( ( featureTab ) => {
@@ -149,9 +125,9 @@ export default function HostingV2( { onAddToCart }: Props ) {
 			<div className="hosting-v2__hero-container">
 				<div
 					className={ clsx( 'hosting-v2__hero', {
-						'is-standard': selectedFeatureId === 'standard',
-						'is-premier': selectedFeatureId === 'premier',
-						'is-enterprise': selectedFeatureId === 'enterprise',
+						'is-standard': section === 'wpcom',
+						'is-premier': section === 'pressable',
+						'is-enterprise': section === 'vip',
 					} ) }
 				>
 					<div className="hosting-v2__hero-content">
@@ -167,9 +143,7 @@ export default function HostingV2( { onAddToCart }: Props ) {
 					</div>
 				</div>
 			</div>
-			{ selectedFeatureId && (
-				<HostingContent selectedFeatureId={ selectedFeatureId } onAddToCart={ onAddToCart } />
-			) }
+			{ section && <HostingContent section={ section } onAddToCart={ onAddToCart } /> }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -25,7 +25,11 @@ import HostingV2 from './hosting-v2';
 
 import './style.scss';
 
-function Hosting() {
+type Props = {
+	section: 'wpcom' | 'pressable' | 'vip';
+};
+
+function Hosting( { section }: Props ) {
 	const translate = useTranslate();
 	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
@@ -93,7 +97,11 @@ function Hosting() {
 			</LayoutTop>
 
 			<LayoutBody className={ clsx( { 'is-full-width': isNewHostingPage } ) }>
-				{ isNewHostingPage ? <HostingV2 onAddToCart={ onAddToCart } /> : <HostingList /> }
+				{ isNewHostingPage ? (
+					<HostingV2 section={ section } onAddToCart={ onAddToCart } />
+				) : (
+					<HostingList />
+				) }
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import {
 	A4A_MARKETPLACE_ASSIGN_LICENSE_LINK,
@@ -23,6 +24,7 @@ import {
 } from './controller';
 
 export default function () {
+	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 	page( A4A_MARKETPLACE_LINK, requireAccessContext, marketplaceContext, makeLayout, clientRender );
 	page(
 		`${ A4A_MARKETPLACE_PRODUCTS_LINK }/:brand?`,
@@ -31,27 +33,32 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
 	page(
-		A4A_MARKETPLACE_HOSTING_LINK,
+		isNewHostingPage ? `${ A4A_MARKETPLACE_HOSTING_LINK }/:section?` : A4A_MARKETPLACE_HOSTING_LINK,
 		requireAccessContext,
 		marketplaceHostingContext,
 		makeLayout,
 		clientRender
 	);
-	page(
-		A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
-		requireAccessContext,
-		marketplacePressableContext,
-		makeLayout,
-		clientRender
-	);
-	page(
-		A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
-		requireAccessContext,
-		marketplaceWpcomContext,
-		makeLayout,
-		clientRender
-	);
+
+	if ( ! isNewHostingPage ) {
+		page(
+			A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+			requireAccessContext,
+			marketplacePressableContext,
+			makeLayout,
+			clientRender
+		);
+		page(
+			A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+			requireAccessContext,
+			marketplaceWpcomContext,
+			makeLayout,
+			clientRender
+		);
+	}
+
 	page(
 		A4A_MARKETPLACE_CHECKOUT_LINK,
 		requireAccessContext,

--- a/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/lib/hosting.tsx
@@ -96,3 +96,14 @@ export function isPressableHostingProduct( keyOrSlug: string ) {
 export function isWPCOMHostingProduct( keyOrSlug: string ) {
 	return keyOrSlug.startsWith( 'wpcom-hosting' );
 }
+
+/*
+ * Get valid hosting section. If not valid, default to 'wpcom'
+ * @param {string} section - Hosting section
+ * @returns {'wpcom' | 'pressable' | 'vip'} - Valid hosting section
+ */
+export function getValidHostingSection( section: string ) {
+	return [ 'wpcom', 'pressable', 'vip' ].includes( section )
+		? ( section as 'wpcom' | 'pressable' | 'vip' )
+		: 'wpcom';
+}


### PR DESCRIPTION
Currently, the new Hosting page uses the following URL scheme (`/marketplace/hosting?hosting=${hosting}`). To avoid updating existing references to the old Hosting page URLs, this PR modifies the Hosting V2 page to use the old format (e.g. `/marketplace/hosting/wpcom`, `/marketplace/hosting/pressable` & `/marketplace/hosting/vip`).

Closes https://github.com/Automattic/jetpack-genesis/issues/462

## Proposed Changes

* Instead of using the `hosting` query parameter to determine which tab is selected on the new Hosting page, we now use the URL parameter **'section'** (`/marketplace/hosting/:section?`). This aligns with the current Hosting URL scheme and allows the old URL to still work and point to the correct tab.

## Why are these changes being made?

* This prevents us from updating existing references to the old URL to point to a different hosting URL scheme.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting` page.
* Test all tabs are working correctly, and the URL is updated with the following format `/marketplace/hosting/:section?`.
* Now test the old Hosting page if it does not have any regression by appending `?flags=-a4a-hosting-page-redesign` in the URL and disabling the new feature.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
