### PR TITLE
A4A > Partner Directory: Redirection to overview if the agency data is not already fetched

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/index.tsx
@@ -1,23 +1,11 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import {
-	A4A_OVERVIEW_LINK,
-	A4A_PARTNER_DIRECTORY_LINK,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { PARTNER_DIRECTORY_DASHBOARD_SLUG } from './constants';
 import { partnerDirectoryDashboardContext } from './controller';
 
 export default function () {
-	// Check if the Partner Directory is not enabled
-	if ( ! config.isEnabled( 'a4a-partner-directory' ) ) {
-		// Redirect user to the Overview page
-		page.redirect( A4A_OVERVIEW_LINK );
-		// And return now and don't config the Partner Directory routes.
-		return;
-	}
-
 	// Redirect to the Dashboard page: /partner-directory/dashboard
 	page( A4A_PARTNER_DIRECTORY_LINK, () => {
 		page.redirect( `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_DASHBOARD_SLUG }` );

--- a/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/partner-directory.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useMemo } from 'react';
@@ -9,10 +10,17 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_OVERVIEW_LINK,
+	A4A_PARTNER_DIRECTORY_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
 import { useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import {
+	getActiveAgency,
+	isFetchingAgency,
+	hasFetchedAgency,
+} from 'calypso/state/a8c-for-agencies/agency/selectors';
 import AgencyDetailsForm from './agency-details';
 import AgencyExpertise from './agency-expertise';
 import {
@@ -43,6 +51,8 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 	const title = translate( 'Partner Directory' );
 
 	const agency = useSelector( getActiveAgency );
+	const hasAgency = useSelector( hasFetchedAgency );
+	const isFetching = useSelector( isFetchingAgency );
 
 	const applicationData = useMemo( () => mapApplicationFormData( agency ), [ agency ] );
 	const agencyDetailsData = useMemo( () => mapAgencyDetailsFormData( agency ), [ agency ] );
@@ -86,6 +96,18 @@ export default function PartnerDirectory( { selectedSection }: Props ) {
 
 		return sections;
 	}, [ translate, agencyDetailsData, applicationData ] );
+
+	// Wait until the agency is fetched
+	if ( ! hasAgency || isFetching ) {
+		return null;
+	}
+
+	// Check if the Partner Directory is allowed for the agency
+	if ( ! agency?.partner_directory_allowed ) {
+		// Redirect user to the Overview page
+		page.redirect( A4A_OVERVIEW_LINK );
+		return;
+	}
 
 	// Set the selected section
 	const section: Section = sections[ selectedSection ];

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -40,7 +40,7 @@
 		"a4a/site-migration": true,
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
-		"a4a-partner-directory": true,
+		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": true,
 		"hosting-overview-refinements": false

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -33,7 +33,7 @@
 		"a4a/site-migration": true,
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
-		"a4a-partner-directory": true,
+		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": false,
 		"hosting-overview-refinements": false


### PR DESCRIPTION
Resolves: https://github.com/Automattic/automattic-for-agencies-dev/issues/878

## Proposed Changes

This PR fixes an issue that occurs when you try to access the Partner Directory URL directly, and the agency data is not fetched yet. At that moment, the PD is disabled because it doesn't have the agency data, redirecting users to the Overview section.

Moving the conditional to the Partner Directory component and checking if the agency is already checked, fixes the issue.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Check the code.
- Ensure that your testing agency is allowed to see the Partner Directory using the MC tool.
- Apply this change locally.
- Set to false the feature flag in `a8c-for-agencies-development.json` => `"a4a-partner-directory": false,`
- If you go directly to `/partner-directory/dashboard`:
   - In trunk: it will redirect you to the Overview section
   - In this branch: it'll wait for the agency data and show you the section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
