### PR TITLE
e2e: Improve preview menu selector

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -20,6 +20,8 @@ const selectors = {
 	// Post status
 	postStatusButton: `.editor-post-status > button`,
 
+	desktopPreviewMenuItem: ( target: EditorPreviewOptions ) =>
+		`button[role*="menuitem"] span:text("${ target }")`,
 	previewPane: `.edit-post-visual-editor`,
 
 	// Publish
@@ -194,7 +196,10 @@ export class EditorToolbarComponent {
 
 		// Locate and click on the intended preview target.
 		const editorParent = await this.editor.parent();
-		await editorParent.getByRole( 'menuitem', { name: target } ).click();
+		const desktopPreviewMenuItemLocator = editorParent.locator(
+			selectors.desktopPreviewMenuItem( target )
+		);
+		await desktopPreviewMenuItemLocator.click();
 
 		// Verify the editor panel is resized and stable.
 		const desktopPreviewPaneLocator = editorParent.locator( selectors.previewPane );


### PR DESCRIPTION
The preview button selector needs to be updated to work for roles `menuitem` and `menuitemradio` to improve the e2e tests. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
https://github.com/Automattic/wp-calypso/issues/92945

## Proposed Changes

* Update preview button selector

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To have a fix for the nightly build e2e tests

## Testing Instructions
Running these should pass:
```
VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__post-basic-flow.ts
```

```
TEST_ON_ATOMIC=true GUTENBERG_NIGHTLY=true yarn workspace wp-e2e-tests debug test/e2e/specs/editor/editor__post-basic-flow.ts
```

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
