### PR TITLE
Site Migration: Refresh jetpack connection when the plugin list is not available

### DIFF
--- a/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
+++ b/client/landing/stepper/hooks/test/use-plugin-auto-installation.tsx
@@ -18,6 +18,9 @@ const PLUGIN = { name: 'migrate-guru/migrateguru', slug: 'migrate-guru' };
 const getSitePluginsEndpoint = ( siteId: number ) =>
 	`/rest/v1.2/sites/${ siteId }/plugins?http_envelope=1`;
 
+const getJetpackReconnectionEndpoint = ( siteId: number ) =>
+	`/rest/v1.2/sites/${ siteId }/migration-force-reconnection`;
+
 const getPluginInstallationEndpoint = ( siteId: number ) =>
 	`/rest/v1.2/sites/${ siteId }/plugins/migrate-guru/install?http_envelope=1`;
 
@@ -45,7 +48,9 @@ const installationWithSuccess = replyWithEnvelope( 200 );
 const installationWithGenericError = replyWithEnvelope( 400, { error: 'any error' } );
 
 describe( 'usePluginAutoInstallation', () => {
-	beforeAll( () => nock.disableNetConnect() );
+	beforeAll( () => {
+		nock.disableNetConnect();
+	} );
 	beforeEach( () => nock.cleanAll() );
 
 	it( 'returns success when the plugin is already installed and activated', async () => {
@@ -163,6 +168,11 @@ describe( 'usePluginAutoInstallation', () => {
 			.times( 2 )
 			.reply( 500, new Error( 'Error fetching plugins list' ) );
 
+		nock( 'https://public-api.wordpress.com:443' )
+			.post( getJetpackReconnectionEndpoint( SITE_ID ) )
+			.reply( 200 )
+			.persist();
+
 		const { result } = render( { retry: 1 } );
 
 		await waitFor(
@@ -171,6 +181,37 @@ describe( 'usePluginAutoInstallation', () => {
 					status: 'error',
 					error: expect.any( Error ),
 					completed: false,
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'refresh the jetpack connnection after all plugin list retries', async () => {
+		// First 3 calls to get the plugins list will fail
+		// The reconnection endpoint will be called after the 3rd failure
+		// The 4th call to get the plugins list will succeed
+		nock( 'https://public-api.wordpress.com:443' )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.times( 3 )
+			.reply( 500, new Error( 'Error fetching plugins list' ) )
+			.get( getSitePluginsEndpoint( SITE_ID ) )
+			.reply( 200, { plugins: [ { ...PLUGIN, active: true } ] } );
+
+		const refreshtokenCall = nock( 'https://public-api.wordpress.com:443' )
+			.post( getJetpackReconnectionEndpoint( SITE_ID ) )
+			.once()
+			.reply( 200 );
+
+		const { result } = render( { retry: 2 } );
+
+		await waitFor(
+			() => {
+				expect( refreshtokenCall.isDone() ).toBe( true );
+				expect( result.current ).toEqual( {
+					status: 'success',
+					error: null,
+					completed: true,
 				} );
 			},
 			{ timeout: 3000 }

--- a/client/landing/stepper/hooks/use-plugin-auto-installation.ts
+++ b/client/landing/stepper/hooks/use-plugin-auto-installation.ts
@@ -150,7 +150,7 @@ export const usePluginAutoInstallation = (
 	} = usePluginInstallation( plugin.slug, siteId, options );
 
 	const {
-		mutate: activatePlugin,
+		mutate: activate,
 		status: activationRequestStatus,
 		error: activationError,
 		isSuccess: isActivated,
@@ -185,8 +185,8 @@ export const usePluginAutoInstallation = (
 			return;
 		}
 
-		activatePlugin();
-	}, [ activatePlugin, shouldActivate ] );
+		activate();
+	}, [ activate, shouldActivate ] );
 
 	const getStatus = (): Status => {
 		if ( completed ) {

--- a/client/landing/stepper/hooks/use-plugin-auto-installation.ts
+++ b/client/landing/stepper/hooks/use-plugin-auto-installation.ts
@@ -70,6 +70,7 @@ const safeLogToLogstash = ( message: string, properties: Record< string, unknown
 const usePluginStatus = ( pluginSlug: string, siteId?: number, options?: Options ) => {
 	const queryClient = useQueryClient();
 	const remainingAttempts = useRef( REFRESH_JETPACK_TOTAL_ATTEMPTS );
+	const hasSuccessLogged = useRef( false );
 
 	const response = useQuery( {
 		queryKey: [ 'onboarding-site-plugin-status', siteId, pluginSlug ],
@@ -116,7 +117,11 @@ const usePluginStatus = ( pluginSlug: string, siteId?: number, options?: Options
 	}
 
 	if ( response.isSuccess && remainingAttempts.current < REFRESH_JETPACK_TOTAL_ATTEMPTS ) {
-		safeLogToLogstash( 'jetpack connection restored', { site: siteId } );
+		//Temporary fix for the issue where the success message is logged multiple times
+		if ( ! hasSuccessLogged.current ) {
+			hasSuccessLogged.current = true;
+			safeLogToLogstash( 'jetpack connection restored', { site: siteId } );
+		}
 	}
 
 	return response;

--- a/client/landing/stepper/hooks/use-plugin-auto-installation.ts
+++ b/client/landing/stepper/hooks/use-plugin-auto-installation.ts
@@ -19,7 +19,7 @@ interface SiteMigrationStatus {
 }
 
 export type Options = Pick< UseQueryOptions, 'enabled' | 'retry' >;
-export const DEFAULT_RETRY = process.env.NODE_ENV === 'test' ? 1 : 20;
+export const DEFAULT_RETRY = process.env.NODE_ENV === 'test' ? 1 : 10;
 const DEFAULT_RETRY_DELAY = process.env.NODE_ENV === 'test' ? 300 : 5000;
 
 const REFRESH_JETPACK_TOTAL_ATTEMPTS = process.env.NODE_ENV === 'test' ? 1 : 3;


### PR DESCRIPTION
Closes #93177
## Proposed Changes
* Force jetpack reconnection if the migration flow cannot fetch the plugin list due to jetpack connection issues.

## Why are these changes being made?
* We are facing a case where, after the site transfer, the UI is not able to fetch the plugin list to install the required plugin. The root cause is an issue with the jetpack connection.  It is a temporary solution until we properly fix the postmigration tasks.  More details on p1722437334246959-slack-C0Q664T29



## Testing Instructions
* Run the migration signup flow in staging or production `wordpress.com/setup` until you find a site where we are not able to install the plugins
* Run the branch code (local or calypso live) and access the same instructions page (same siteId and siteSlug)
* Check if, after a certain number of attempts the UI calls the new `migration-force-reconnection` endpoint
* Check if the plugin list fetchings started again.
* Check if the plugin installation/activation happened with success. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?