### PR TITLE
Help center: update styles to work on front end of site

### DIFF
--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -43,6 +43,7 @@
 
 			input.search__input {
 				font-size: $font-body-small;
+				min-height: 40px;
 			}
 		}
 

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -10,7 +10,7 @@ $head-foot-height: 50px;
 		position: fixed;
 		background-color: #fff;
 		color: #000;
-		z-index: 9999;
+		z-index: 99998;
 		cursor: default;
 		transition: max-height 0.5s;
 

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -21,6 +21,7 @@ $z-index: 99999;
 		}
 
 		.button {
+			text-decoration: none;
 			font-size: $font-body-small;
 		}
 

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -4,13 +4,14 @@
 @import "@automattic/typography/styles/variables";
 
 $head-foot-height: 50px;
+$z-index: 99999;
 
 .help-center {
 	.components-card.help-center__container {
 		position: fixed;
 		background-color: #fff;
 		color: #000;
-		z-index: 99998;
+		z-index: $z-index;
 		cursor: default;
 		transition: max-height 0.5s;
 
@@ -557,7 +558,7 @@ $head-foot-height: 50px;
 }
 
 .help-center__container-header-menu {
-	z-index: 99999;
+	z-index: $z-index;
 
 	.popover__menu {
 		.help-center__container-header-menu-item {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8466

We are going to show the help center on the front end of the site. Sites that haven't upgraded show an upgrade banner. The help center is partially hidden behind this banner for these sites.

This PR just updates the z-index to be more than the marketing banner so it can be seen when toggled in admin bar.

This also fixes an issue on atomic where the search text field is picking up a `min-height` style from Jetpack.

This PR also fixes issue with button text having an underline decoration.

## Proposed Changes

* Updates the help center container z-index so it is not hidden behind marketing banner on front end of site
* Adds a `min-height` style to help center `search__input` component.
* Adds a `text-decoration:none` on buttons in help center to avoid text decorations leaking from other styles.

## Before
<img width="973" alt="Screenshot 2024-07-31 at 19 42 55" src="https://github.com/user-attachments/assets/0768a020-1401-4e05-a676-37e1a346373b">

## After
<img width="928" alt="Screenshot 2024-07-31 at 19 43 30" src="https://github.com/user-attachments/assets/a39b53b0-fe6e-4eb8-a630-8d5d5d8a7cc9">

## Before
<img width="799" alt="Screenshot 2024-08-01 at 23 10 27" src="https://github.com/user-attachments/assets/a38e6b92-1b51-4d91-89a6-2a6c60560f22">

## After
<img width="696" alt="Screenshot 2024-08-02 at 10 57 53" src="https://github.com/user-attachments/assets/89b6608e-17b6-4d00-abde-8f08468ca547">

## Before
<img width="404" alt="Screenshot 2024-08-02 at 15 08 48" src="https://github.com/user-attachments/assets/39560b03-f2df-49a6-9dd6-c1c6bc1867a2">

## After
<img width="392" alt="Screenshot 2024-08-02 at 15 11 27" src="https://github.com/user-attachments/assets/be346397-4e4e-42ef-8b50-8de3b9b34a97">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Tidy up UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow test instructions from https://github.com/Automattic/jetpack/pull/38651 to show the help center on the front end of your (non-P2) test site.
* cd into `apps/help-center`
* run `yarn dev --sync`.
* Sandbox your test site and `widgets.wp.com`.
* Your changes should be reflected on the site live.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
