### PR TITLE
Update: Pass fromSite URL to the Substack importer

### DIFF
--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -52,6 +52,7 @@ class FileImporter extends PureComponent {
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
 		} ),
+		fromSite: PropTypes.string,
 	};
 
 	handleClick = ( shouldStartImport ) => {
@@ -73,7 +74,7 @@ class FileImporter extends PureComponent {
 	render() {
 		const { title, icon, description, overrideDestination, uploadDescription, optionalUrl } =
 			this.props.importerData;
-		const { importerStatus, site } = this.props;
+		const { importerStatus, site, fromSite } = this.props;
 		const { errorData, importerState } = importerStatus;
 		const isEnabled = appStates.DISABLED !== importerState;
 		const showStart = includes( compactStates, importerState );
@@ -128,6 +129,7 @@ class FileImporter extends PureComponent {
 						importerStatus={ importerStatus }
 						site={ site }
 						optionalUrl={ optionalUrl }
+						fromSite={ fromSite }
 					/>
 				) }
 			</Card>

--- a/client/my-sites/importer/importer-substack.jsx
+++ b/client/my-sites/importer/importer-substack.jsx
@@ -21,6 +21,7 @@ class ImporterSubstack extends PureComponent {
 			} ),
 			statusMessage: PropTypes.string,
 		} ),
+		fromSite: PropTypes.string,
 	};
 
 	render() {

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -12,15 +12,10 @@ type ContentProps = {
 	nextStepUrl: string;
 	selectedSite?: SiteDetails;
 	siteSlug: string;
-	newsletterUrl: QueryArgParsed;
+	fromSite: QueryArgParsed;
 };
 
-export default function Content( {
-	nextStepUrl,
-	selectedSite,
-	siteSlug,
-	newsletterUrl,
-}: ContentProps ) {
+export default function Content( { nextStepUrl, selectedSite, siteSlug, fromSite }: ContentProps ) {
 	const siteTitle = selectedSite?.title;
 	const siteId = selectedSite?.ID;
 
@@ -55,7 +50,7 @@ export default function Content( {
 				To generate a ZIP file of all your Substack posts, go to Settings { '>' } Exports and click
 				'Create a new export.' Once the ZIP file is downloaded, upload it in the next step.
 			</p>
-			<Button href={ `https://${ newsletterUrl }/publish/settings#exports` }>Export content</Button>
+			<Button href={ `https://${ fromSite }/publish/settings#exports` }>Export content</Button>
 			<hr />
 			<h2>Step 2: Import your content to WordPress.com</h2>
 			{ importerStatus && (
@@ -64,6 +59,7 @@ export default function Content( {
 					siteSlug={ siteSlug }
 					siteTitle={ siteTitle }
 					importerStatus={ importerStatus }
+					fromSite={ fromSite }
 				/>
 			) }
 			<Button href={ nextStepUrl } primary>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -54,9 +54,9 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
 		}
 	} );
-	const newsletterUrl = getQueryArg( window.location.href, 'newsletter' ) ?? null;
+	const fromSite = getQueryArg( window.location.href, 'from' ) ?? null;
 	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {
-		newsletter: newsletterUrl,
+		from: fromSite,
 	} );
 	const Step = steps[ stepIndex ] || steps[ 0 ];
 	return (
@@ -69,14 +69,14 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 			/>
 
 			<FormattedHeader headerText="Import your newsletter" />
-			{ ( ! step || ! newsletterUrl ) && <SelectNewsletterForm nextStepUrl={ nextStepUrl } /> }
-			{ step && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
-			{ step && newsletterUrl && (
+			{ ( ! step || ! fromSite ) && <SelectNewsletterForm nextStepUrl={ nextStepUrl } /> }
+			{ step && fromSite && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
+			{ step && fromSite && (
 				<Step
 					siteSlug={ siteSlug }
 					nextStepUrl={ nextStepUrl }
 					selectedSite={ selectedSite }
-					newsletterUrl={ newsletterUrl }
+					fromSite={ fromSite }
 				/>
 			) }
 		</div>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -46,15 +46,23 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 
 	const stepsProgress = [ 'Content', 'Subscribers', 'Paid Subscribers', 'Summary' ];
 
+	const fromSite = getQueryArg( window.location.href, 'from' ) ?? null;
+
+	if ( fromSite && ! step ) {
+		step = stepSlugs[ 0 ];
+	}
+
 	let stepIndex = 0;
 	let nextStep = stepSlugs[ 0 ];
+
 	stepSlugs.forEach( ( stepName, index ) => {
 		if ( stepName === step ) {
 			stepIndex = index;
 			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
 		}
 	} );
-	const fromSite = getQueryArg( window.location.href, 'from' ) ?? null;
+
+	const stepUrl = `/import/newsletter/${ engine }/${ siteSlug }/${ stepSlugs[ stepIndex ] }`;
 	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {
 		from: fromSite,
 	} );
@@ -69,9 +77,9 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 			/>
 
 			<FormattedHeader headerText="Import your newsletter" />
-			{ ( ! step || ! fromSite ) && <SelectNewsletterForm nextStepUrl={ nextStepUrl } /> }
-			{ step && fromSite && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
-			{ step && fromSite && (
+			{ ! fromSite && <SelectNewsletterForm stepUrl={ stepUrl } /> }
+			{ fromSite && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
+			{ fromSite && (
 				<Step
 					siteSlug={ siteSlug }
 					nextStepUrl={ nextStepUrl }

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -18,7 +18,7 @@ export default function SelectNewsletterForm( { nextStepUrl }: Props ) {
 		}
 
 		const { hostname } = parseUrl( fromSite );
-		page( addQueryArgs( nextStepUrl, { newsletter: hostname } ) );
+		page( addQueryArgs( nextStepUrl, { from: hostname } ) );
 		return;
 	};
 
@@ -27,7 +27,7 @@ export default function SelectNewsletterForm( { nextStepUrl }: Props ) {
 			<div className="select-newsletter-form">
 				<FormTextInputWithAction
 					onAction={ handleAction }
-					placeholder="http://example.substack.com"
+					placeholder="https://example.substack.com"
 					action="Continue"
 					isError={ hasError }
 				/>

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -6,9 +6,9 @@ import FormTextInputWithAction from 'calypso/components/forms/form-text-input-wi
 import { isValidUrl, parseUrl } from 'calypso/lib/importer/url-validation';
 
 type Props = {
-	nextStepUrl: string;
+	stepUrl: string;
 };
-export default function SelectNewsletterForm( { nextStepUrl }: Props ) {
+export default function SelectNewsletterForm( { stepUrl }: Props ) {
 	const [ hasError, setHasError ] = useState( false );
 
 	const handleAction = ( fromSite: string ) => {
@@ -18,7 +18,7 @@ export default function SelectNewsletterForm( { nextStepUrl }: Props ) {
 		}
 
 		const { hostname } = parseUrl( fromSite );
-		page( addQueryArgs( nextStepUrl, { from: hostname } ) );
+		page( addQueryArgs( stepUrl, { from: hostname } ) );
 		return;
 	};
 

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -11,13 +11,13 @@ type Props = {
 export default function SelectNewsletterForm( { nextStepUrl }: Props ) {
 	const [ hasError, setHasError ] = useState( false );
 
-	const handleAction = ( newsletterUrl: string ) => {
-		if ( ! isValidUrl( newsletterUrl ) ) {
+	const handleAction = ( fromSite: string ) => {
+		if ( ! isValidUrl( fromSite ) ) {
 			setHasError( true );
 			return;
 		}
 
-		const { hostname } = parseUrl( newsletterUrl );
+		const { hostname } = parseUrl( fromSite );
 		page( addQueryArgs( nextStepUrl, { newsletter: hostname } ) );
 		return;
 	};

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -7,10 +7,10 @@ import type { SiteDetails } from '@automattic/data-stores';
 type Props = {
 	nextStepUrl: string;
 	selectedSite?: SiteDetails;
-	newsletterUrl: QueryArgParsed;
+	fromSite: QueryArgParsed;
 };
 
-export default function Subscribers( { nextStepUrl, selectedSite, newsletterUrl }: Props ) {
+export default function Subscribers( { nextStepUrl, selectedSite, fromSite }: Props ) {
 	const isUserEligibleForSubscriberImporter = useIsEligibleSubscriberImporter();
 
 	if ( ! selectedSite ) {
@@ -23,7 +23,7 @@ export default function Subscribers( { nextStepUrl, selectedSite, newsletterUrl 
 				To generate a CSV file of all your Substack subscribers, go to the Subscribers tab and click
 				'Export.' Once the CSV file is downloaded, upload it in the next step.
 			</p>
-			<Button href={ `https://${ newsletterUrl }/publish/subscribers` }>Export subscribers</Button>
+			<Button href={ `https://${ fromSite }/publish/subscribers` }>Export subscribers</Button>
 			<hr />
 			<h2>Step 2: Import your subscribers to WordPress.com</h2>
 			<AddSubscriberForm

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -211,6 +211,7 @@ class SectionImport extends Component {
 					importerStatus={ importerStatus }
 					isAtomic={ site.options?.is_wpcom_atomic }
 					isJetpack={ site.jetpack }
+					fromSite={ this.props.fromSite }
 				/>
 			);
 		} );

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -170,10 +170,11 @@ export class UploadingPane extends PureComponent {
 	};
 
 	initiateFromUploadButton = () => {
+		let url = this.state.urlInput;
 		if ( this.props.optionalUrl && this.props.fromSite ) {
-			this.setState( { urlInput: this.props.fromSite } );
+			url = this.props.fromSite;
 		}
-		this.startUpload( this.state.fileToBeUploaded, this.state.urlInput );
+		this.startUpload( this.state.fileToBeUploaded, url );
 	};
 
 	setupUpload = ( file ) => {

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -48,6 +48,7 @@ export class UploadingPane extends PureComponent {
 			invalidDescription: PropTypes.string,
 			validate: PropTypes.func,
 		} ),
+		fromSite: PropTypes.string,
 	};
 
 	static defaultProps = { description: null, optionalUrl: null };
@@ -169,6 +170,9 @@ export class UploadingPane extends PureComponent {
 	};
 
 	initiateFromUploadButton = () => {
+		if ( this.props.optionalUrl && this.props.fromSite ) {
+			this.setState( { urlInput: this.props.fromSite } );
+		}
 		this.startUpload( this.state.fileToBeUploaded, this.state.urlInput );
 	};
 
@@ -236,7 +240,7 @@ export class UploadingPane extends PureComponent {
 	};
 
 	render() {
-		const { importerStatus, site, isEnabled } = this.props;
+		const { importerStatus, site, isEnabled, fromSite } = this.props;
 		const isReadyForImport = this.isReadyForImport();
 		const importerStatusClasses = clsx(
 			'importer__upload-content',
@@ -284,7 +288,7 @@ export class UploadingPane extends PureComponent {
 					) }
 					<DropZone onFilesDrop={ isReadyForImport ? this.initiateFromDrop : noop } />
 				</div>
-				{ this.props.optionalUrl && (
+				{ this.props.optionalUrl && ! fromSite && (
 					<div className="importer__uploading-pane-url-input">
 						<FormLabel>
 							{ this.props.optionalUrl.title }


### PR DESCRIPTION
This PR updates the Substack importer so that you can passed in `from-site` query parameter to it

This make it so that you don't have to type in Substack URL again if you already done that.

<table>
<tr>
<td>
Before:

<img width="400" alt="Screenshot 2024-07-30 at 3 40 56 PM" src="https://github.com/user-attachments/assets/a82cbb4d-4013-42ca-a018-45a0ca7e8db0">
</td>

<td>
After:

<img width="400" alt="Screenshot 2024-07-30 at 3 41 36 PM" src="https://github.com/user-attachments/assets/1e581282-f53a-4274-a42b-afa66cc18c3c">
</td>
</tr>
</table>

## Proposed Changes

* Set the From url via the URL if it contains one via the URL. 
So that the user doesn't have to enter it twice. 

Ideally we would verify that the URL is indeed a Substack site but that will be done after  D157008-code is merged which adds support for substack.

## Why are these changes being made?
* We are making the changes here to improve/simplify the importer flow. 


## Testing Instructions

* Navigate to /tools/importer the notice that you are able to navigate to substack and it asks you to for the substack url like before. 
* Add a ?from-site= into the URL with a valid substack site. 
The importer UI shouldn't ask you for a substack URL any more.
* Notice that when you import the substack content that performing the same action as when you import with the URL. 
You can notice this by looking at the substack url in the importer log. 


## Pre-merge Checklist



- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?