### PR TITLE
I18N: Escape percent sign.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -173,7 +173,7 @@ const OneYearDiscountTimeFrame: React.FC< OneYearDiscountTimeFrameProps & A11yPr
 	if ( ! discountPercentage ) {
 		text = translate( 'per month, billed yearly' );
 	} else {
-		text = translate( 'per month, billed yearly. %(discount)d% off the first year.', {
+		text = translate( 'per month, billed yearly. %(discount)d%% off the first year.', {
 			args: {
 				discount: discountPercentage,
 			},


### PR DESCRIPTION
The percent sign in `per month, billed yearly. %(discount)d% off the first year.` is not escaped, resulting in the string being broken in locales where the next character after % is a valid `printf` placeholder:

![image](https://github.com/user-attachments/assets/987c7c0a-bdda-41b6-b629-dc2d5ffaa159)


## Proposed Changes

* This PR escapes the percent sign in `per month, billed yearly. %(discount)d% off the first year.`


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `cloud.jetpack.localhost:3000/pricing` and confirm the string is displayed correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
