### PR TITLE
Fix /themes sidebar between 600px & 780px

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1049,8 +1049,8 @@ $font-size: rem(14px);
 	// client/layout/sidebar/style.scss
 	.theme-default {
 		.focus-content .layout__content {
-			padding: 70px 24px 24px;
-			transition: padding 0.15s ease-in-out;
+			padding: 70px 24px 24px !important;
+			transition: padding 0.15s ease-in-out !important;
 		}
 
 		.sidebar {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1049,8 +1049,8 @@ $font-size: rem(14px);
 	// client/layout/sidebar/style.scss
 	.theme-default {
 		.focus-content .layout__content {
-			padding: 70px 24px 24px !important;
-			transition: padding 0.15s ease-in-out !important;
+			padding: 70px 24px 24px;
+			transition: padding 0.15s ease-in-out;
 		}
 
 		.sidebar {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -13,7 +13,9 @@
 
 		.layout__content {
 			min-height: 100vh;
-			padding: calc(var(--masterbar-height) + 16px) 16px 16px var(--sidebar-width-max);
+			@media screen and (min-width: 782px) {
+				padding: calc(var(--masterbar-height) + 16px) 16px 16px var(--sidebar-width-max);
+			}
 		}
 
 		.layout__primary > * {


### PR DESCRIPTION
Slack: p1722449070835639-slack-C06DN6QQVAQ

## Proposed Changes
When screen size is between 600 & 780px and you start in `/sites` and then changed to `/themes` the `#content` element keeps using the padding like the sidebar is opened.
This is caused by how the CSS is loaded. When loading /sites first, [this CSS](https://github.com/Automattic/wp-calypso/blob/e801441e373f2c2cd9a7575aec89404e31b606c1/client/my-sites/themes/theme-showcase.scss#L16) has priority over [this one](https://github.com/Automattic/wp-calypso/blob/8e5c872c40ef7f294f735d44c99d4beb360c9454/client/my-sites/sidebar/style.scss#L1052-L1053).

Fixed by making [this CSS](https://github.com/Automattic/wp-calypso/blob/e801441e373f2c2cd9a7575aec89404e31b606c1/client/my-sites/themes/theme-showcase.scss#L16) available when screen >781px

### Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/7028da50-3908-4e4c-98a1-2a2b54619925) | ![image](https://github.com/user-attachments/assets/df497a80-5c3a-46fb-b856-d0fe3872c2f6) |

### Video
Before:

[Screencast from 2024-07-31 22-45-25.webm](https://github.com/user-attachments/assets/7d090962-8891-4483-bdbd-d873b9cb33e3)

After:

[Screencast from 2024-07-31 22-51-15.webm](https://github.com/user-attachments/assets/d0189d68-c1d1-46bd-93aa-b6c08196b39d)

## Testing Instructions

* With screen size between 600 and 781px
* Go to /sites
* Click on menu, then Themes
* It should show as after screenshot.
