### PR TITLE
NPM dependencies: update `core-bundle-js` and import Iterator helper polyfills

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -120,7 +120,7 @@
 		"component-file-picker": "^0.2.1",
 		"cookie": "^0.4.1",
 		"cookie-parser": "^1.4.6",
-		"core-js-bundle": "^3.6.4",
+		"core-js-bundle": "^3.37.1",
 		"cpf_cnpj": "^0.2.0",
 		"creditcards": "^3.1.0",
 		"csv-parse": "^5.1.0",

--- a/packages/calypso-polyfills/browser.js
+++ b/packages/calypso-polyfills/browser.js
@@ -5,3 +5,4 @@
 // browsers.
 
 import 'core-js/stable';
+import 'core-js/proposals/iterator-helpers-stage-3';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/WordPress/gutenberg/pull/64123

## Proposed Changes

Following a [tip](https://github.com/WordPress/gutenberg/pull/64123#issuecomment-2259946774) from @jsnajdr 

I'm not sure if this is needed - I haven't been around this repo for a while.

This PR:

- updates the core-js-bundle npm package to the latest version
- imports proposed Iterator helper polyfills into `browser.js`

## Why are these changes being made?

So that [Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) methods are available for use in the Calypso code base.

These methods, for example [Iterator.prototype.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find) are experimental and don't yet have wide browser support.

For example, Gutenberg was using `Iterator.prototype.find()`, which [broke functionality in the site editor](https://github.com/WordPress/gutenberg/pull/64123). 

Gutenberg and Core relies on widely supported standards with little polyfilling, but it doesn't mean Calypso has to 😄 

## Testing Instructions

Pretty crude, but I've just been checking to see if an Iterator method works in Chrome, Firefox and Safari, e.g., pasting some iterators in a component and checking the output at http://calypso.localhost:3000/log-in

```diff
diff --git a/client/blocks/login/index.jsx b/client/blocks/login/index.jsx
index d76f8d1718..7038e261cb 100644
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -140,6 +140,12 @@ class Login extends Component {
 		}
 
 		window.scrollTo( 0, 0 );
+
+		const myMap = new Map( [
+			[1, "one"],
+			[2, "two"],
+			[3, "three"],
+		] ).values().find( ( [ num, label ] ) => console.log( `${ num } is ${ label }` ) );
 	}
 
 	componentDidUpdate( prevProps ) {
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
