### PR TITLE
Replace VideoPress upsell with plan upsell in the 'Videos' stats module

### DIFF
--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -83,6 +83,7 @@ const paidStats = [
 	STAT_TYPE_CLICKS,
 	STAT_TYPE_TOP_AUTHORS,
 	STAT_TYPE_SEARCH_TERMS,
+	STAT_TYPE_VIDEO_PLAYS,
 ];
 
 // Gated controls for WPCOM sites without the FEATURE_STATS_PAID feature.

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
@@ -8,6 +8,7 @@ import {
 	STAT_TYPE_REFERRERS,
 	STAT_TYPE_SEARCH_TERMS,
 	STAT_TYPE_TOP_AUTHORS,
+	STAT_TYPE_VIDEO_PLAYS,
 } from '../constants';
 import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
 import { Props } from '.';
@@ -30,6 +31,10 @@ const getUpsellCopy = ( statType: string ) => {
 			return translate( 'Identify your audience’s favorite writers and perspectives.' );
 		case STATS_FEATURE_DATE_CONTROL:
 			return translate( 'Compare different time periods to analyze your site’s growth.' );
+		case STAT_TYPE_VIDEO_PLAYS:
+			return translate(
+				'Discover your most popular videos to better understand how they performed.'
+			);
 		default:
 			return translate( 'Upgrade your plan to unlock Jetpack Stats.' );
 	}

--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
@@ -32,9 +32,7 @@ const getUpsellCopy = ( statType: string ) => {
 		case STATS_FEATURE_DATE_CONTROL:
 			return translate( 'Compare different time periods to analyze your site’s growth.' );
 		case STAT_TYPE_VIDEO_PLAYS:
-			return translate(
-				'Discover your most popular videos to better understand how they performed.'
-			);
+			return translate( 'Discover your most popular videos and find out how they performed.' );
 		default:
 			return translate( 'Upgrade your plan to unlock Jetpack Stats.' );
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/92887

## Proposed Changes

For a site on a plan that doesn't have access to VideoPress, this updates the 'Videos' stats module on the `/stats/day/:site` page to display a plan upsell instead of the VideoPress upsell.

| Before | After |
| -- | -- |
|![CleanShot 2024-08-01 at 14 03 45@2x](https://github.com/user-attachments/assets/a5d88172-8921-4ae0-a874-bcd139336095)|![CleanShot 2024-08-01 at 14 04 39@2x](https://github.com/user-attachments/assets/cfcaf5ce-6a77-451e-801c-24328985eb5e)|


## Why are these changes being made?

It doesn’t make sense for a wp.com site to purchase VideoPress instead of upgrading to the Explorer plan or higher. 

## Testing Instructions

- Visit `/stats/day/:site` for a site that **doesn't** have access to VideoPress eg. free plan
  - Check that the 'Upgrade plan' CTA is displayed (as per the 'After' screenshot above)
  - Clicking the 'Upgrade plan' link should open an upgrade modal
- Visit `/stats/day/:site` for a site that **does** have access to VideoPress eg. explorer plan
  - Check that the existing CTA remains which links to VideoPress (as per the 'Before' screenshot above)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
