### PR TITLE
Stepper: Update `free-post-setup` flow to use framework tracking for step-submit

### DIFF
--- a/client/landing/stepper/declarative-flow/free-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/free-post-setup.ts
@@ -1,7 +1,10 @@
+import { Onboard } from '@automattic/data-stores';
 import { FREE_POST_SETUP_FLOW } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import { useSiteSlug } from '../hooks/use-site-slug';
-import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { ONBOARD_STORE } from '../stores';
 import { STEPS } from './internals/steps';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
@@ -12,17 +15,20 @@ const freePostSetup: Flow = {
 		return translate( 'Free' );
 	},
 	isSignupFlow: false,
+	useSideEffect() {
+		const { setIntent } = useDispatch( ONBOARD_STORE );
+		useEffect( () => {
+			setIntent( Onboard.SiteIntent.FreePostSetup );
+		}, [] );
+	},
+
 	useSteps() {
 		return [ STEPS.FREE_POST_SETUP ];
 	},
-
 	useStepNavigation( currentStep, navigate ) {
-		const flowName = this.name;
 		const siteSlug = useSiteSlug();
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, 'free-post-setup', flowName, currentStep );
-
 			switch ( currentStep ) {
 				case 'freePostSetup':
 					return window.location.assign(
@@ -45,6 +51,7 @@ const freePostSetup: Flow = {
 
 		return { goNext, goBack, goToStep, submit };
 	},
+	use__Temporary__ShouldTrackEvent: ( event ) => 'submit' === event,
 };
 
 export default freePostSetup;

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -24,4 +24,5 @@ export enum SiteIntent {
 	ReadyMadeTemplate = 'readymade-template',
 	AIAssembler = 'ai-assembler',
 	Newsletter = 'newsletter',
+	FreePostSetup = 'free-post-setup',
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91755

## Proposed Changes

- Follows up from https://github.com/Automattic/wp-calypso/pull/93100
- Updates the `free-post-setup` flow to opt-in for framework tracking on the step submit event
- Updates the flow to set the site intent in the side effect hook for use in the tracks call

### Questions/Caveats 

- Is this flow still in use? Going to `/setup/free-post-setup` will show the free-post-setup step, but the CTA is broken/non-responsive. I can see this has the `isSignupFlow: false` property, so presumably this isn't a signup flow per se - which leads to:
- If a site is not created through this flow, then should the `FreePostSetup ` constant be set on the `SiteIntent` type? This was previously hardcoded for passing into the Tracks event, so that may have been intentional. Left a comment below to confirm: https://github.com/Automattic/wp-calypso/pull/93178/files#r1699819153

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/91755

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- go to `/setup/free-post-setup?siteSlug=[site slug]`
- Confirm that calypso_signup_actions_submit_step is logged with correct values (in Netowrk tab, check for `.gif` request) when submitting the step/form
- Confirm that `intent` is logged with `free-post-setup`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
