### PR TITLE
Support: Change link to help

### DIFF
--- a/apps/happy-blocks/block-library/support-content-links/index.php
+++ b/apps/happy-blocks/block-library/support-content-links/index.php
@@ -11,7 +11,7 @@
 <div class="support-content-links">
 	<p>
 		<?php esc_html_e( 'Questions?', 'happy-blocks' ); ?>
-		<a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/help/contact/' ) ); ?>" target="_blank" rel="noreferrer noopener">
+		<a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/help?help-center=wapuu' ) ); ?>" target="_blank" rel="noreferrer noopener">
 			<?php esc_html_e( 'Contact our Happiness Engineers.', 'happy-blocks' ); ?>
 		</a>
 	</p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93152

## Proposed Changes

![image](https://github.com/user-attachments/assets/174fb373-f5e4-4595-8aaf-c023ef5ddf50)

Change the first link to land in the /help page with the Help Center open on Wapuu

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to simplify contacting our support

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Sync happy-blocks
- Go to /support and check the link in the image


