### PR TITLE
Notifications: remove usage of ReactDOM.findDOMNode

### DIFF
--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
-import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import actions from '../state/actions';
 import getFilterName from '../state/selectors/get-filter-name';
@@ -51,11 +50,11 @@ export class NoteList extends Component {
 	}
 
 	componentDidMount() {
-		ReactDOM.findDOMNode( this.scrollableContainer ).addEventListener( 'scroll', this.onScroll );
+		this.scrollableContainer.addEventListener( 'scroll', this.onScroll );
 	}
 
 	componentWillUnmount() {
-		ReactDOM.findDOMNode( this.scrollableContainer ).removeEventListener( 'scroll', this.onScroll );
+		this.scrollableContainer.removeEventListener( 'scroll', this.onScroll );
 	}
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -68,7 +67,7 @@ export class NoteList extends Component {
 
 	componentDidUpdate( prevProps ) {
 		if ( this.noteList && ! this.props.isLoading ) {
-			const element = ReactDOM.findDOMNode( this.scrollableContainer );
+			const element = this.scrollableContainer;
 			if (
 				element.clientHeight > 0 &&
 				element.scrollTop + element.clientHeight >= this.noteList.clientHeight - 300
@@ -91,7 +90,7 @@ export class NoteList extends Component {
 
 		requestAnimationFrame( () => ( this.isScrolling = false ) );
 
-		const element = ReactDOM.findDOMNode( this.scrollableContainer );
+		const element = this.scrollableContainer;
 		if ( ! this.state.scrolling || this.state.scrollY !== element.scrollTop ) {
 			// only set state and trigger render if something has changed
 			this.setState( {
@@ -349,7 +348,6 @@ export class NoteList extends Component {
 
 		return (
 			<>
-				{ /* Keep the wpnc__note-list as the first child of the Fragment to ensure the ReactDOM.findDOMNode returns the list element */ }
 				<div className={ classes } id="wpnc__note-list" ref={ this.props.listElementRef }>
 					<FilterBar
 						controller={ this.props.filterController }


### PR DESCRIPTION
Removes `findDOMNode` usage from Notifications. The method is deprecated and logs warnings into console.

In our case `this.scrollableContainer` is already a DOM node, it's set by the `this.storeScrollableContainer` callback passed as a `ref` to a `div`. In distant past the `ref` used to point to a React component instance.

**How to test:**
The scroll listeners attached to the `scrollableContainer` trigger loading more notifications when you scroll down, so that's a specific feature to check.