### PR TITLE
A4A: Disable the 'Premier Agency Hosting' tab when on Referral mode. 

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -1,6 +1,9 @@
+import page from '@automattic/calypso-router';
 import { JetpackLogo } from '@automattic/components';
 import { layout, blockMeta, shuffle, help, keyboardReturn, tip } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useContext, useEffect } from 'react';
+import { A4A_MARKETPLACE_HOSTING_WPCOM_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-1.png';
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/premier-testimonial-2.png';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -8,6 +11,7 @@ import HostingAdditionalFeaturesSection from '../../../common/hosting-additional
 import HostingFeaturesSection from '../../../common/hosting-features-section';
 import { BackgroundType1, BackgroundType2 } from '../../../common/hosting-section/backgrounds';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
+import { MarketplaceTypeContext } from '../../../context';
 import PressableOverviewPlanSelection from '../../../pressable-overview/plan-selection';
 import CommonHostingBenefits from '../common-hosting-benefits';
 
@@ -19,6 +23,15 @@ type Props = {
 
 export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 	const translate = useTranslate();
+
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+
+	useEffect( () => {
+		// If on 'Referral mode', we redirect page to WPCOM section as this is Pressable is not available for Referrals.
+		if ( marketplaceType === 'referral' ) {
+			page( A4A_MARKETPLACE_HOSTING_WPCOM_LINK );
+		}
+	}, [ marketplaceType ] );
 
 	return (
 		<div className="premier-agency-hosting">

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/style.scss
@@ -156,6 +156,10 @@ $tab-background-color: #f4fbff;
 			.section-nav-tab__link:hover {
 				background-color: $tab-background-color;
 			}
+
+			.section-nav-tab__link[disabled] {
+				opacity: 0.3;
+			}
 		}
 
 		.hosting-v2__nav-item-label {
@@ -168,8 +172,13 @@ $tab-background-color: #f4fbff;
 		}
 
 		.hosting-v2__nav-item-subtitle {
+			display: none;
 			color: var(--color-accent-90);
 			@include a4a-font-body-md;
+
+			@include break-wide {
+				display: block;
+			}
 		}
 
 	}


### PR DESCRIPTION
Pressable plans are currently not available for referrals. This PR ensures that the Premier Hosting tab is inaccessible in Referral mode.

<img width="1576" alt="Screenshot 2024-08-01 at 7 26 28 PM" src="https://github.com/user-attachments/assets/90eafa82-918f-4148-aa66-b3a077bb4a73">

Closes https://github.com/Automattic/jetpack-genesis/issues/458

## Proposed Changes

* Update the Hosting tab components to allow for disabling and displaying a tooltip message on hover.
* When in Referral mode, disable the 'Premier Agency Hosting' tab and ensure the user is redirected to the 'Standard Agency Hosting' tab when already in the Premier tab while switching the Referral toggle.

## Why are these changes being made?

* This is a safeguard for broken Pressable referral flow that is not currently supported.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting` page.
* Toggle the Referral mode and confirm that the Premier Agency Hosting tab is not accessible. Hovering the tab should render a tooltip explaining why it is disabled.
* Confirm that when toggling the Referral mode while in the Premier tab, the page is redirected to the Standard tab.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
