### PR TITLE
Masterbar: Fix layout at 782px

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -327,7 +327,7 @@ body.is-mobile-app-view {
 		padding-left: 7px;
 	}
 
-	@media only screen and (max-width: 782px) {
+	@media only screen and (max-width: 781px) {
 		&.masterbar__reader,
 		&.masterbar__item-my-site-actions {
 			padding: 0;
@@ -411,7 +411,7 @@ body.is-mobile-app-view {
 
 		}
 
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			position: fixed;
 			.masterbar__item-subitems-item {
 				padding: 8px 16px;
@@ -559,7 +559,7 @@ body.is-mobile-app-view {
 		margin-right: 0;
 	}
 
-	@media only screen and (max-width: 782px) {
+	@media only screen and (max-width: 781px) {
 		font-size: $masterbar-mobile-font-size;
 		width: 52px;
 		padding: 0;
@@ -654,7 +654,7 @@ body.is-mobile-app-view {
 
 	&.masterbar__item-sidebar-menu {
 		display: none;
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			display: inline-block;
 			margin-right: 2px;
 			margin-left: -1px;
@@ -666,14 +666,14 @@ body.is-mobile-app-view {
 	&.masterbar__item-no-sites {
 		padding: 0 7px 0 5px; // trying to match core's 35px width
 
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			padding: 0;
 		}
 
 		.gridicon {
 			width: 24px;
 			height: 24px;
-			@media only screen and (max-width: 782px) {
+			@media only screen and (max-width: 781px) {
 				width: 32px;
 				height: 32px;
 			}
@@ -797,7 +797,7 @@ body.is-mobile-app-view {
 	}
 }
 .masterbar__item-action-search {
-	@media only screen and (max-width: 782px) {
+	@media only screen and (max-width: 781px) {
 		display: none !important; //Mobile styles not yet handled
 	}
 
@@ -851,7 +851,7 @@ body.is-mobile-app-view {
 	transition: all 0.2s ease-out;
 	font-size: $masterbar-font-size;
 
-	@media only screen and (max-width: 782px) {
+	@media only screen and (max-width: 781px) {
 		height: 34px;
 		margin-top: 6px;
 		margin-right: 9px;
@@ -959,7 +959,7 @@ body.is-mobile-app-view {
 
 		border: 2px solid var(--color-border-inverted);
 
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			width: 22px;
 			height: 22px;
 		}
@@ -971,7 +971,7 @@ body.is-mobile-app-view {
 	}
 
 	.gridicon {
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			position: relative;
 			left: 4px;
 		}
@@ -980,7 +980,7 @@ body.is-mobile-app-view {
 			display: block;
 			padding: 0;
 
-			@media only screen and (max-width: 782px) {
+			@media only screen and (max-width: 781px) {
 				padding-left: 8px;
 			}
 		}
@@ -1007,7 +1007,7 @@ body.is-mobile-app-view {
 		border-radius: unset;
 		margin-left: 1px;
 
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			width: 26px;
 			height: 26px;
 			margin-left: 4px;
@@ -1043,7 +1043,7 @@ body.is-mobile-app-view {
 		max-height: 94px;
 		padding: 12px 0 0 0;
 
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			min-width: 100% !important;
 			max-height: 100%;
 		}
@@ -1059,7 +1059,7 @@ body.is-mobile-app-view {
 		}
 	}
 
-	@media only screen and (max-width: 782px) {
+	@media only screen and (max-width: 781px) {
 		.masterbar__item-howdy-howdy,
 		.masterbar__item-howdy-account-gravatar {
 			display: none;
@@ -1103,7 +1103,7 @@ body.is-mobile-app-view {
 }
 
 .masterbar__reader {
-	@media only screen and (max-width: 782px) {
+	@media only screen and (max-width: 781px) {
 		.gridicon + .masterbar__item-content {
 			padding-left: 6px;
 		}
@@ -1121,7 +1121,7 @@ body.is-mobile-app-view {
 		border-bottom: 1px solid #646970;
 	}
 
-	@media only screen and (max-width: 782px) {
+	@media only screen and (max-width: 781px) {
 		.masterbar__item-content {
 			padding-left: 6px;
 		}
@@ -1139,7 +1139,7 @@ body.is-mobile-app-view {
 	color: $masterbar-color-primary;
 	font-size: $masterbar-font-size;
 
-	@media only screen and (max-width: 782px) {
+	@media only screen and (max-width: 781px) {
 		height: 34px;
 		margin-top: 6px;
 		margin-right: 9px;
@@ -1225,7 +1225,7 @@ body.is-mobile-app-view {
 
 .masterbar-cart-button {
 	svg {
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			width: 32px;
 			height: 32px;
 		}
@@ -1243,7 +1243,7 @@ body.is-mobile-app-view {
 		width: 24px;
 		height: 24px;
 
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			width: 32px;
 			height: 32px;
 		}
@@ -1443,7 +1443,7 @@ a.masterbar__quick-language-switcher {
 		width: 22px;
 		height: 22px;
 
-		@media only screen and (max-width: 782px) {
+		@media only screen and (max-width: 781px) {
 			width: 30px;
 			height: 30px;
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/93184

## Proposed Changes

Fix Masterbar layout at 782px

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4c8fddb9-a834-4680-8bbd-3202c54e98e1) | ![image](https://github.com/user-attachments/assets/6948eba1-c174-46ce-93fd-08dd1a5bba68) |

### 781 to 783px

#### Before

[Screencast from 2024-08-01 11-25-02.webm](https://github.com/user-attachments/assets/1053e2b6-2267-4c04-a646-05da0a1944dd)

#### After

[Screencast from 2024-08-01 11-24-32.webm](https://github.com/user-attachments/assets/36bd8334-f2ce-4a0e-89dd-fdae777cc6d8)


## Why are these changes being made?
Masterbar layout looking bad only at 782px

## Testing Instructions
* Go to /sites with 782px screen width
* Check masterbar layout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
