### PR TITLE
A4A Dev Sites: Add `Development` badge for free development sites

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -20,7 +20,7 @@
 	font-weight: 500;
 	font-size: rem(14px);
 
-	.migration-badge {
+	.status-badge {
 		border-radius: 2px;
 	}
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -17,7 +17,7 @@ const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProp
 
 	const migrationInProgress = site.sticker?.includes( 'migration-in-progress' );
 	// TODO: Replace with actual dev site check
-	const devSite = false;
+	const isDevSite = false;
 
 	return (
 		<Button
@@ -33,7 +33,7 @@ const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProp
 			<div className="sites-dataviews__site-name">
 				<div>{ site.blogname }</div>
 				{ ! migrationInProgress && <div className="sites-dataviews__site-url">{ site.url }</div> }
-				{ ( migrationInProgress || devSite ) && (
+				{ ( migrationInProgress || isDevSite ) && (
 					<Badge
 						className="status-badge"
 						type={ migrationInProgress ? 'info-blue' : 'info-purple' }

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -16,6 +16,8 @@ const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProp
 	}
 
 	const migrationInProgress = site.sticker?.includes( 'migration-in-progress' );
+	// TODO: Replace with actual dev site check
+	const devSite = false;
 
 	return (
 		<Button
@@ -31,9 +33,14 @@ const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProp
 			<div className="sites-dataviews__site-name">
 				<div>{ site.blogname }</div>
 				{ ! migrationInProgress && <div className="sites-dataviews__site-url">{ site.url }</div> }
-				{ migrationInProgress && (
-					<Badge className="migration-badge" type="info-blue">
-						{ translate( 'Migration in progress' ) }
+				{ ( migrationInProgress || devSite ) && (
+					<Badge
+						className="status-badge"
+						type={ migrationInProgress ? 'info-blue' : 'info-purple' }
+					>
+						{ migrationInProgress
+							? translate( 'Migration in progress' )
+							: translate( 'Development' ) }
 					</Badge>
 				) }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8527.

## Proposed Changes

* add `Development` badge for free development sites - by reusing the existing component that has been used for sites in the `Migration in progress` state

Since we don't have actual data whether certain site is a free dev site available yet, the PR relies on placeholder `isDevSite` constant. We can either merge this PR as-is - or - wait until the data on dev sites is available and adjust the PR further.

![Markup on 2024-08-01 at 17:02:51](https://github.com/user-attachments/assets/2989219a-3942-4739-a528-58086be4eb30)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR locally and change `isDevSite` constant to `true` in `client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx`.
2. Build the app with `yarn start-a8c-for-agencies`.
3. Head over to Sites section at http://agencies.localhost:3000/sites/ (or any other section that displays list of sites).
4. Take a look at the `Development` badge displayed (currently on all sites).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
