### PR TITLE
Fix domains table actions on site overview

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -40,6 +40,7 @@ export class SiteAddressChanger extends Component {
 		recordTracksEvent: PropTypes.func.isRequired,
 		onSiteAddressChanged: PropTypes.func,
 		hasNonWpcomDomains: PropTypes.bool,
+		skipRedirection: PropTypes.bool,
 
 		// `connect`ed
 		isSiteAddressChangeRequesting: PropTypes.bool,
@@ -77,7 +78,10 @@ export class SiteAddressChanger extends Component {
 			domainFieldValue,
 			newDomainSuffix.substr( 1 ),
 			oldDomain,
-			type
+			type,
+			true,
+			true,
+			this.props.skipRedirection
 		);
 
 		this.props.onSiteAddressChanged?.();

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -46,7 +46,6 @@ const ActiveDomainsCard: FC = () => {
 	if ( isJetpackNotAtomic ) {
 		return null;
 	}
-
 	return (
 		<HostingCard className="hosting-overview__active-domains">
 			<HostingCardHeading title={ translate( 'Active domains' ) }>
@@ -99,7 +98,14 @@ const ActiveDomainsCard: FC = () => {
 					currentDomainSuffix={ changeSiteAddressSourceDomain.name.match( /\.\w+\.\w+$/ )?.[ 0 ] }
 					isDialogVisible
 					onClose={ () => setChangeSiteAddressSourceDomain( null ) }
-					onSiteAddressChanged={ () => refetch() }
+					onSiteAddressChanged={ async () => {
+						await refetch();
+						setChangeSiteAddressSourceDomain( null );
+						if ( site?.slug ) {
+							page.replace( `/overview/${ site?.slug }` );
+						}
+					} }
+					skipRedirection
 				/>
 			) }
 		</HostingCard>

--- a/client/hosting-overview/components/active-domains-card.tsx
+++ b/client/hosting-overview/components/active-domains-card.tsx
@@ -1,26 +1,46 @@
+import page from '@automattic/calypso-router';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
-import { DomainsTable } from '@automattic/domains-table';
+import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
+import { FC, useMemo, useState } from 'react';
+import SiteAddressChanger from 'calypso/blocks/site-address-changer';
 import {
 	HostingCard,
 	HostingCardHeading,
 	HostingCardLinkButton,
 } from 'calypso/components/hosting-card';
 import { fetchSiteDomains } from 'calypso/my-sites/domains/domain-management/domains-table-fetch-functions';
+import { filterOutWpcomDomains } from 'calypso/my-sites/domains/domain-management/list/utils';
 import { isNotAtomicJetpack } from 'calypso/sites-dashboard/utils';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
+import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
+import {
+	showUpdatePrimaryDomainErrorNotice,
+	showUpdatePrimaryDomainSuccessNotice,
+} from 'calypso/state/domains/management/actions';
+import { setPrimaryDomain } from 'calypso/state/sites/domains/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const ActiveDomainsCard: FC = () => {
 	const forceMobile = useBreakpoint( '<660px' );
 	const site = useSelector( getSelectedSite );
 	const isJetpackNotAtomic = site && isNotAtomicJetpack( site );
-	const { data, isLoading } = useSiteDomainsQuery( site?.ID, {
+	const { data, isLoading, refetch } = useSiteDomainsQuery( site?.ID, {
 		queryFn: () => fetchSiteDomains( site?.ID ),
 	} );
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ changeSiteAddressSourceDomain, setChangeSiteAddressSourceDomain ] =
+		useState< ResponseDomain | null >( null );
+	const userCanSetPrimaryDomains = useSelector(
+		( state ) => ! currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+	);
+
+	const hasNonWpcomDomains = useMemo( () => {
+		return filterOutWpcomDomains( data?.domains ?? [] ).length > 0;
+	}, [ data ] );
 
 	// Do not render for self hosted jetpack sites, since they cannot manage domains with us.
 	if ( isJetpackNotAtomic ) {
@@ -49,7 +69,39 @@ const ActiveDomainsCard: FC = () => {
 				isAllSitesView={ false }
 				useMobileCards={ forceMobile }
 				siteSlug={ site?.slug ?? null }
+				userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
+				onDomainAction={ ( action, domain ) => {
+					if ( action === 'set-primary-address' && site ) {
+						return {
+							message: translate( 'Set domain as the primary site address' ),
+							action: async () => {
+								try {
+									await dispatch( setPrimaryDomain( site.ID, domain.domain ) );
+									dispatch( showUpdatePrimaryDomainSuccessNotice( domain.name ) );
+									page.replace( `/overview/${ domain.domain }` );
+									await refetch();
+								} catch ( error ) {
+									dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );
+								}
+							},
+						};
+					}
+
+					if ( action === 'change-site-address' ) {
+						setChangeSiteAddressSourceDomain( domain );
+					}
+				} }
 			/>
+			{ changeSiteAddressSourceDomain && (
+				<SiteAddressChanger
+					hasNonWpcomDomains={ hasNonWpcomDomains }
+					currentDomain={ changeSiteAddressSourceDomain }
+					currentDomainSuffix={ changeSiteAddressSourceDomain.name.match( /\.\w+\.\w+$/ )?.[ 0 ] }
+					isDialogVisible
+					onClose={ () => setChangeSiteAddressSourceDomain( null ) }
+					onSiteAddressChanged={ () => refetch() }
+				/>
+			) }
 		</HostingCard>
 	);
 };

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -188,6 +188,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 						isDialogVisible
 						onClose={ () => setChangeSiteAddressSourceDomain( null ) }
 						onSiteAddressChanged={ () => refetch() }
+						skipRedirection={ false }
 					/>
 				) }
 			</Main>

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -75,12 +75,16 @@ export const DomainsTableRowActions = ( {
 	const getActions = ( onClose?: () => void ) => {
 		return [
 			canViewDetails && (
-				<MenuItemLink href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }>
+				<MenuItemLink
+					key="actionDetails"
+					href={ domainManagementLink( domain, siteSlug, isAllSitesView ) }
+				>
 					{ domain.type === domainTypes.TRANSFER ? __( 'View transfer' ) : __( 'View settings' ) }
 				</MenuItemLink>
 			),
 			canManageDNS && (
 				<MenuItemLink
+					key="manageDNS"
 					onClick={ () => onDomainAction?.( 'manage-dns-settings', domain ) }
 					href={ domainMagementDNS( siteSlug, domain.name ) }
 				>
@@ -88,12 +92,16 @@ export const DomainsTableRowActions = ( {
 				</MenuItemLink>
 			),
 			canManageContactInfo && (
-				<MenuItemLink href={ domainManagementEditContactInfo( siteSlug, domain.name ) }>
+				<MenuItemLink
+					key="manageContactInfo"
+					href={ domainManagementEditContactInfo( siteSlug, domain.name ) }
+				>
 					{ __( 'Manage contact information' ) }
 				</MenuItemLink>
 			),
 			canMakePrimarySiteAddress && (
 				<MenuItemLink
+					key="makePrimarySiteAddress"
 					onClick={ () => {
 						onDomainAction?.( 'set-primary-address', domain );
 						onClose?.();
@@ -105,18 +113,23 @@ export const DomainsTableRowActions = ( {
 			),
 			canTransferToWPCOM && (
 				<MenuItemLink
+					key="transferToWPCOM"
 					href={ domainUseMyDomain( siteSlug, domain.name, useMyDomainInputMode.transferDomain ) }
 				>
 					{ __( 'Transfer to WordPress.com' ) }
 				</MenuItemLink>
 			),
 			canConnectDomainToASite && (
-				<MenuItemLink href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }>
+				<MenuItemLink
+					key="connectToSite"
+					href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }
+				>
 					{ __( 'Attach to an existing site' ) }
 				</MenuItemLink>
 			),
 			canChangeSiteAddress && (
 				<MenuItemLink
+					key="changeSiteAddress"
 					onClick={ () => {
 						onDomainAction?.( 'change-site-address', domain );
 						onClose?.();


### PR DESCRIPTION
Domains table's actions "_Change site address_" and "_Make primary site address_"  didn't work properly when the table was rendered in site overview page.

This PR addresses the issue.

## Testing Instructions
Apply this patch locally or use the Calypso link below and visit the overview page for a site that has at least a custom domain (`/overview/your-site-slug`).

### Test set primary domain
**If the site uses a custom domain name**
- Verify that you can set the free WordPress.com subdomain as a primary address
![domains-table-3](https://github.com/user-attachments/assets/fc753260-b19d-4f34-8e69-f6afa0c4a8cc)

**If the site uses the default free WordPress.com subdomain**
- Verify that you can set the a custom domain as a primary address
![domains-table-1](https://github.com/user-attachments/assets/83874a2b-df77-4578-9279-3ac68eda37f5)

In both cases, verify that the page url is correctly updated after the update.

### Test change site address
- Verify that you can change the free WordPress.com url.
![domains-table-2](https://github.com/user-attachments/assets/a6e26063-99c8-40e0-a2a3-4585dc7a1a19)

If the the free subdomain had been use as primary site address, verify that the page url is correctly updated after the update.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
