### PR TITLE
Masterbar: Use hover background color for dot stroke on hover

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1234,12 +1234,17 @@ body.is-mobile-app-view {
 		transform: translate(10%, 2%) scale(0.93);
 		stroke-width: 6%;
 		stroke: var(--color-masterbar-background);
+		transition: all 200ms ease-in-out;
+	}
+
+	&:hover .cart-circle {
+		stroke: var(--color-masterbar-item-hover-background);
 	}
 }
 
 .masterbar-notifications {
 	svg {
-		overflow: overlay;
+		overflow: visible;
 		width: 24px;
 		height: 24px;
 
@@ -1251,11 +1256,10 @@ body.is-mobile-app-view {
 
 	.notifications-bell-icon__bubble {
 		animation: bubble-unread-indication 0.5s linear both;
-		transition: all 150ms ease-in;
 		transform-origin: 20px 4px;
 
 		use {
-			transition: all 150ms ease-in;
+			transition: all 200ms ease-in-out;
 			transform-origin: 20px 4px;
 			transform: translate(-2%, 2%) scale(0.93);
 			stroke-width: 6%;
@@ -1263,9 +1267,8 @@ body.is-mobile-app-view {
 		}
 	}
 
-	&:hover use.border {
-		transition: all 150ms ease-in;
-		fill: var(--color-masterbar-item-active-background);
+	&:hover use {
+		stroke: var(--color-masterbar-item-hover-background);
 	}
 }
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1225,6 +1225,7 @@ body.is-mobile-app-view {
 
 .masterbar-cart-button {
 	svg {
+		overflow: visible;
 		@media only screen and (max-width: 782px) {
 			width: 32px;
 			height: 32px;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1239,7 +1239,9 @@ body.is-mobile-app-view {
 	}
 
 	&:hover .cart-circle {
-		stroke: var(--color-masterbar-item-hover-background);
+		@media only screen and (min-width: 481px) {
+			stroke: var(--color-masterbar-item-hover-background);
+		}
 	}
 }
 
@@ -1269,7 +1271,9 @@ body.is-mobile-app-view {
 	}
 
 	&:hover use {
-		stroke: var(--color-masterbar-item-hover-background);
+		@media only screen and (min-width: 481px) {
+			stroke: var(--color-masterbar-item-hover-background);
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8454

## Proposed Changes

* This PR fixes the stroke color of the notification dot when you hover over it.
* Noteably, the icon background hover color only changes when the width is > 480px, so our stroke color follows the same rule.

Before | After
--|--
<img width="901" alt="Screenshot 2024-08-01 at 3 53 45 PM" src="https://github.com/user-attachments/assets/c5b86262-e424-4808-89ad-6ac416bb03d5">  | <img width="893" alt="Screenshot 2024-08-01 at 4 01 02 PM" src="https://github.com/user-attachments/assets/baadf09d-b281-44e0-8eba-ffa83b1f1457">






## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Aesthetics

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live
* Go to a Calypso page like /plans/[site]
* Hover over the shopping cart and notification center icons and view that the "stroke" around the dot is the same color as the background when you hover over the icon and also when you don't.
* Try changing your profile color in /me and check the dot "stroke" hober color again on the /plans/[site]
* Test on a width < 480px
* Click the icons to be sure they work
* Check out the mobile view to be sure it works


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
