### PR TITLE
Fix Logged out reader masterbar broken items

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -98,7 +98,9 @@ const LayoutLoggedOut = ( {
 	const isJetpackThankYou =
 		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/jetpack/thank-you' );
 
-	const isReaderTagPage = sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/tag/' );
+	const isReaderTagPage =
+		sectionName === 'reader' &&
+		( pathNameWithoutLocale.startsWith( '/tag/' ) || pathNameWithoutLocale.startsWith( '/tags' ) );
 	const isReaderTagEmbed = typeof window !== 'undefined' && isReaderTagEmbedPage( window.location );
 
 	const isReaderDiscoverPage =

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -171,6 +171,11 @@ class MasterbarLoggedOut extends Component {
 			signupUrl = addLocaleToPath( signupUrl, locale );
 		}
 
+		// Add referrer query parameter for tracking
+		if ( sectionName === 'reader' ) {
+			signupUrl = addQueryArgs( { ref: 'reader-lp' }, signupUrl );
+		}
+
 		return (
 			<Item url={ signupUrl }>
 				{ translate( 'Sign Up', {

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -215,7 +215,7 @@ class MasterbarLoggedOut extends Component {
 		return (
 			<Masterbar className="masterbar__loggedout">
 				{ this.renderWordPressItem() }
-				<Item className="masterbar__item-title">{ title }</Item>
+				{ title && <Item className="masterbar__item-title">{ title }</Item> }
 				<div className="masterbar__login-links">
 					{ this.renderDiscoverItem() }
 					{ this.renderTagsItem() }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -77,6 +77,18 @@ body.is-mobile-app-view {
 		.masterbar__item:last-child:hover .masterbar__item-content {
 			color: var(--color-sidebar-text);
 		}
+		@media only screen and (max-width: 781px) {
+			.masterbar__login-links {
+				.masterbar__item {
+					width: unset !important;
+					padding: 0 8px;
+
+					.masterbar__item-content {
+						display: block !important;
+					}
+				}
+			}
+		}
 	}
 
 	&.masterbar--is-checkout {
@@ -561,9 +573,11 @@ body.is-mobile-app-view {
 
 	@media only screen and (max-width: 781px) {
 		font-size: $masterbar-mobile-font-size;
-		width: 52px;
 		padding: 0;
 
+		&:not(.masterbar__item--always-show-content) {
+			width: 52px;
+		}
 		// Show gravatar content
 		&:not(.masterbar__item-howdy) .masterbar__item-content {
 			display: none;
@@ -571,6 +585,10 @@ body.is-mobile-app-view {
 
 		.masterbar__item-howdy-howdy {
 			display: none;
+		}
+
+		&.masterbar__item--always-show-content .masterbar__item-content {
+			display: block;
 		}
 
 		svg,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/93188

## Proposed Changes
Reader Logged-out header looks broken in all screen sizes.

- [x] Hide left white box
- [x] Show menu in all screen sizes
- [x] Show WordPress.com full logo when >480px
- [x] Make it loos like the last masterbar changes (like [here](https://web.archive.org/web/20240630041517/https://wordpress.com/discover/))
- [x] Add `ref=reader-lo` to the sign-up header button (pbmxuV-3Dp-p2#comment-4682)

Before:

[Screencast from 2024-08-01 18-20-53.webm](https://github.com/user-attachments/assets/cfa176fb-d35b-4744-90d8-73881c3b1b5c)

After:

[Screencast from 2024-08-01 18-15-42.webm](https://github.com/user-attachments/assets/58044041-6e52-4aea-a7f4-70101481d923)

- [X] Show the Reader header on logged-out `/tags` 

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/61ca5ba7-642a-4046-8d72-f77105130f32) | ![image](https://github.com/user-attachments/assets/7d7c032d-f0a2-4746-b24b-793cf4de13dd) |

## Why are these changes being made?
Check proposed changes

## Testing Instructions

* Logged out, go to `/discover` or other Reader pages (Except Tags)
* Check the header in all screen sizes