### PR TITLE
Help Center: Fix `navigateToRoute`

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -134,7 +134,6 @@ export const setShowSupportDoc = function* ( link: string, postId: number, blogI
 		link,
 		postId: String( postId ),
 		...( blogId && { blogId: String( blogId ) } ), // Conditionally add blogId if it exists, the default is support blog
-		cacheBuster: String( Date.now() ),
 	} );
 
 	yield setNavigateToRoute( `/post/?${ params }` );

--- a/packages/help-center/src/components/help-center-article.tsx
+++ b/packages/help-center/src/components/help-center-article.tsx
@@ -2,19 +2,16 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Flex, FlexItem } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { Icon, external } from '@wordpress/icons';
-import React from 'react';
-import { useSearchParams, useLocation, useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { usePostByUrl } from '../hooks';
 import { BackButton } from './back-button';
 import { BackToTopButton } from './back-to-top-button';
 import ArticleContent from './help-center-article-content';
 
-export const HelpCenterArticle = ( { navigateToRoute }: { navigateToRoute: string } ) => {
+export const HelpCenterArticle = () => {
 	const [ searchParams ] = useSearchParams();
 	const { sectionName } = useHelpCenterContext();
-	const { pathname, search, hash } = useLocation();
-	const navigate = useNavigate();
 
 	const postUrl = searchParams.get( 'link' ) || '';
 	const query = searchParams.get( 'query' );
@@ -35,13 +32,6 @@ export const HelpCenterArticle = ( { navigateToRoute }: { navigateToRoute: strin
 			}, 0 );
 		}
 	}, [ postUrl, post ] );
-
-	// Handle redirecting to new routes
-	useEffect( () => {
-		if ( navigateToRoute && navigateToRoute !== pathname + search + hash ) {
-			navigate( navigateToRoute );
-		}
-	}, [ navigateToRoute, pathname, search, hash, navigate ] );
 
 	useEffect( () => {
 		if ( post ) {

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -39,12 +39,11 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	currentRoute,
 	openingCoordinates,
 } ) => {
-	const { show, isMinimized, navigateToRoute } = useSelect( ( select ) => {
+	const { show, isMinimized } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
 			show: store.isHelpCenterShown(),
 			isMinimized: store.getIsMinimized(),
-			navigateToRoute: store.getNavigateToRoute(),
 		};
 	}, [] );
 
@@ -109,7 +108,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	}
 
 	return (
-		<MemoryRouter initialEntries={ navigateToRoute ? [ navigateToRoute ] : undefined }>
+		<MemoryRouter>
 			<FeatureFlagProvider>
 				<OptionalDraggable
 					draggable={ ! isMobile && ! isMinimized }

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -97,8 +97,12 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	);
 
 	useEffect( () => {
-		if ( navigateToRoute && location.pathname !== navigateToRoute ) {
-			navigate( navigateToRoute );
+		if ( navigateToRoute ) {
+			const fullLocation = `${ location.pathname }${ location.search }`;
+			// On navigate once to keep the back button responsive.
+			if ( fullLocation !== navigateToRoute ) {
+				navigate( navigateToRoute );
+			}
 			setNavigateToRoute( null );
 		}
 	}, [ navigate, navigateToRoute, setNavigateToRoute, location ] );
@@ -134,10 +138,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 							<HelpCenterSearch onSearchChange={ setSearchTerm } currentRoute={ currentRoute } />
 						}
 					/>
-					<Route
-						path="/post"
-						element={ <HelpCenterArticle navigateToRoute={ navigateToRoute ?? '' } /> }
-					/>
+					<Route path="/post" element={ <HelpCenterArticle /> } />
 					<Route path="/contact-options" element={ <HelpCenterContactPage /> } />
 					<Route
 						path="/contact-form"

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -11,7 +11,7 @@ import { CardBody, Disabled } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import React, { useCallback, useState } from 'react';
-import { Route, Routes, useLocation, Navigate, useNavigate } from 'react-router-dom';
+import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 /**
  * Internal Dependencies
  */
@@ -98,6 +98,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 
 	useEffect( () => {
 		if ( navigateToRoute ) {
+			navigate( navigateToRoute );
 			setNavigateToRoute( null );
 		}
 	}, [ navigate, navigateToRoute, setNavigateToRoute ] );
@@ -130,11 +131,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 					<Route
 						path="/"
 						element={
-							navigateToRoute ? (
-								<Navigate to={ navigateToRoute } />
-							) : (
-								<HelpCenterSearch onSearchChange={ setSearchTerm } currentRoute={ currentRoute } />
-							)
+							<HelpCenterSearch onSearchChange={ setSearchTerm } currentRoute={ currentRoute } />
 						}
 					/>
 					<Route

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -97,11 +97,11 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	);
 
 	useEffect( () => {
-		if ( navigateToRoute ) {
+		if ( navigateToRoute && location.pathname !== navigateToRoute ) {
 			navigate( navigateToRoute );
 			setNavigateToRoute( null );
 		}
-	}, [ navigate, navigateToRoute, setNavigateToRoute ] );
+	}, [ navigate, navigateToRoute, setNavigateToRoute, location ] );
 
 	// reset the scroll location on navigation, TODO: unless there's an anchor
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -98,7 +98,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 
 	useEffect( () => {
 		if ( navigateToRoute ) {
-			const fullLocation = `${ location.pathname }${ location.search }`;
+			const fullLocation = [ location.pathname, location.search, location.hash ].join( '' );
 			// On navigate once to keep the back button responsive.
 			if ( fullLocation !== navigateToRoute ) {
 				navigate( navigateToRoute );


### PR DESCRIPTION
Fixed https://github.com/Automattic/wp-calypso/issues/93189

See: https://github.com/Automattic/wp-calypso/pull/92899#pullrequestreview-2214049777

## Proposed Changes

Fixed `navigateToRoute` in the Help Center.

## Testing Instructions

Make sure you can't reproduce https://github.com/Automattic/wp-calypso/issues/93189

cc @arcangelini, does this break your logic?