### PR TITLE
A4A: update migration incentive end date

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
@@ -36,7 +36,7 @@ const MigrationOfferV2 = () => {
 					<div className="a4a-migration-offer-v2__body">
 						<p className="a4a-migration-offer-v2__description">
 							{ translate(
-								'Migrate your clients’ sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You’ll also receive an additional $100 for each migrated site—up to $3,000 until September 30, 2024. {{a}}See details{{/a}}',
+								'Migrate your clients’ sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You’ll also receive an additional $100 for each migrated site—up to $3,000 until October 31, 2024. {{a}}See details{{/a}}',
 								{
 									components: {
 										a: (

--- a/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/index.tsx
@@ -22,7 +22,7 @@ const MigrationOfferHeader = ( { withIcon }: { withIcon?: boolean } ) => {
 const MigrationOfferBody = () => {
 	const translate = useTranslate();
 	const description = translate(
-		"Migrate your clients' sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You'll also receive an additional $100 for each migrated site—up to $3,000 until September 30, 2024."
+		"Migrate your clients' sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You'll also receive an additional $100 for each migrated site—up to $3,000 until October 31, 2024."
 	);
 
 	return (

--- a/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/migrations-overview/index.tsx
@@ -61,7 +61,7 @@ export default function MigrationsOverview() {
 				</div>
 				<div className="migrations-overview__section-intro">
 					{ translate(
-						"Migrate your clients' sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You'll also receive an additional $100 for each migrated site—up to $3,000 until September 30, 2024."
+						"Migrate your clients' sites to WordPress.com or Pressable hosting and earn 50% revenue share until June 30, 2025. You'll also receive an additional $100 for each migrated site—up to $3,000 until October 31, 2024."
 					) }
 				</div>
 				<div className="migrations-overview__section-subtitle">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/898

## Proposed Changes

As migration offer got extended we need to update the wording. It should state `until October 31`

<img width="1332" alt="Screenshot 2024-08-01 at 2 44 07 PM" src="https://github.com/user-attachments/assets/e83851eb-112a-46c7-9462-08838075799b">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check all occurrences of the migration offer on pages:
- `/overview`
- `/marketplace/hosting`
- You might see new hosting design page, in that case also check without flag `/marketplace/hosting?flags=-a4a-hosting-page-redesign`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
