### PR TITLE
Launchpad: Experiment setup for Launchpad A/B test

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -25,6 +25,7 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 		hasStartWritingFlowQueryArg &&
 		'full' === launchpadScreen &&
 		currentPostType === 'post';
+	const postFlowUrl = getQueryArg( window.location.search, 'postFlowUrl' );
 
 	useEffect( () => {
 		if ( shouldShowMinimalUIAndRedirectToFullscreenLaunchpad ) {
@@ -63,7 +64,10 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 
 			dispatch( 'core/edit-post' ).closePublishSidebar();
 
-			window.location.href = `${ siteOrigin }/setup/${ intent }/launchpad?siteSlug=${ siteSlug }`;
+			// Redirect to the post flow URL if it's provided, otherwise redirect to the launchpad.
+			window.location.href =
+				`${ siteOrigin }${ postFlowUrl }` ||
+				`${ siteOrigin }/setup/${ intent }/launchpad?siteSlug=${ siteSlug }`;
 		}
 	} );
 }

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -65,9 +65,9 @@ export function RedirectOnboardingUserAfterPublishingPost() {
 			dispatch( 'core/edit-post' ).closePublishSidebar();
 
 			// Redirect to the post flow URL if it's provided, otherwise redirect to the launchpad.
-			window.location.href =
-				`${ siteOrigin }${ postFlowUrl }` ||
-				`${ siteOrigin }/setup/${ intent }/launchpad?siteSlug=${ siteSlug }`;
+			window.location.href = postFlowUrl
+				? `${ siteOrigin }${ postFlowUrl }`
+				: `${ siteOrigin }/setup/${ intent }/launchpad?siteSlug=${ siteSlug }`;
 		}
 	} );
 }

--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -1,9 +1,8 @@
 import { BUILD_FLOW } from '@automattic/onboarding';
-import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
+import { useExitFlow } from '../hooks/use-exit-flow';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { useLaunchpadDecider } from './internals/hooks/use-launchpad-decider';
@@ -28,19 +27,9 @@ const build: Flow = {
 		const flowName = this.name;
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
-		const { setPendingAction } = useDispatch( ONBOARD_STORE );
+		const { exitFlow } = useExitFlow( { navigate, processing: true } );
 
 		triggerGuidesForStep( flowName, _currentStep );
-
-		const exitFlow = ( to: string ) => {
-			setPendingAction( () => {
-				return new Promise( () => {
-					window.location.assign( to );
-				} );
-			} );
-
-			return navigate( 'processing' );
-		};
 
 		const { postFlowNavigator, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -16,6 +16,7 @@ import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
+import { useLaunchpadDecider } from './internals/hooks/use-launchpad-decider';
 import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import { Flow, ProvidedDependencies } from './internals/types';
@@ -66,6 +67,11 @@ const free: Flow = {
 			return navigate( 'processing' );
 		};
 
+		const { getPostFlowUrl, postFlowNavigator, initializeLaunchpadState } = useLaunchpadDecider( {
+			exitFlow,
+			navigate,
+		} );
+
 		const submit = ( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) => {
 			switch ( _currentStep ) {
 				case 'freeSetup':
@@ -98,20 +104,25 @@ const free: Flow = {
 					}
 
 					if ( selectedDesign ) {
-						return navigate( `launchpad?siteSlug=${ siteSlug }` );
+						return postFlowNavigator( { siteId, siteSlug } );
 					}
 
 					return navigate( `designSetup?siteSlug=${ providedDependencies?.siteSlug }` );
 
 				case 'designSetup':
 					if ( providedDependencies?.goToCheckout ) {
-						const destination = `/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;
+						const destination = getPostFlowUrl( {
+							flow: flowName,
+							siteSlug: providedDependencies.siteSlug as string,
+						} );
 						persistSignupDestination( destination );
 						setSignupCompleteSlug( providedDependencies?.siteSlug );
 						setSignupCompleteFlowName( flowName );
-						const returnUrl = encodeURIComponent(
-							`/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies?.siteSlug }`
-						);
+						initializeLaunchpadState( {
+							siteId,
+							siteSlug: providedDependencies.siteSlug as string,
+						} );
+						const returnUrl = encodeURIComponent( destination );
 
 						return window.location.assign(
 							`/checkout/${ encodeURIComponent(

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -113,6 +113,7 @@ const free: Flow = {
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = getPostFlowUrl( {
 							flow: flowName,
+							siteId,
 							siteSlug: providedDependencies.siteSlug as string,
 						} );
 						persistSignupDestination( destination );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -1,0 +1,73 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { useExperiment } from 'calypso/lib/explat';
+
+export const LAUNCHPAD_EXPERIMENT_NAME = 'launchpad-decider-example';
+
+interface Props {
+	exitFlow: ( path: string ) => void;
+	navigate: ( path: string ) => void;
+}
+
+interface PostFlowUrlProps {
+	flow: string;
+	siteId: string | number | null;
+	siteSlug: string;
+}
+
+interface SiteProps {
+	siteId: string | number | null;
+	siteSlug: string | null;
+}
+
+export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( LAUNCHPAD_EXPERIMENT_NAME );
+
+	const variationsToSkipLaunchpad = [ 'treatment_no_launchpad', 'treatment_home_launchpad' ];
+	const shouldByPassLaunchpad =
+		! isLoadingExperiment ||
+		variationsToSkipLaunchpad.includes( experimentAssignment?.variationName ?? '' ) ||
+		true;
+
+	let launchpadStateOnSkip: null | 'skipped' | 'off' = null;
+	if ( shouldByPassLaunchpad ) {
+		launchpadStateOnSkip =
+			experimentAssignment?.variationName === 'treatment_no_launchpad' ? 'off' : 'skipped';
+	}
+
+	const setLaunchpadSkipState = ( siteIdOrSlug: string | number | null ) => {
+		if ( siteIdOrSlug && launchpadStateOnSkip ) {
+			updateLaunchpadSettings( siteIdOrSlug, { launchpad_screen: launchpadStateOnSkip } );
+		}
+	};
+
+	return {
+		getPostFlowUrl: ( { flow, siteId, siteSlug }: PostFlowUrlProps ) => {
+			if ( shouldByPassLaunchpad ) {
+				return '/home/' + siteSlug;
+			}
+
+			if ( siteId ) {
+				return `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }&siteId=${ siteId }`;
+			}
+
+			return `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`;
+		},
+		postFlowNavigator: ( { siteId, siteSlug }: SiteProps ) => {
+			if ( shouldByPassLaunchpad ) {
+				setLaunchpadSkipState( siteId || siteSlug );
+
+				exitFlow( '/home/' + siteSlug );
+				return;
+			}
+
+			navigate( `launchpad?siteSlug=${ siteSlug }&siteId=${ siteId }` );
+			return;
+		},
+		initializeLaunchpadState: ( { siteId, siteSlug }: SiteProps ) => {
+			if ( shouldByPassLaunchpad ) {
+				setLaunchpadSkipState( siteId || siteSlug );
+				return;
+			}
+		},
+	};
+};

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -1,7 +1,7 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useExperiment } from 'calypso/lib/explat';
 
-export const LAUNCHPAD_EXPERIMENT_NAME = 'launchpad-decider-example';
+export const LAUNCHPAD_EXPERIMENT_NAME = 'calypso_onboarding_launchpad_removal_test_2024_08';
 
 interface Props {
 	exitFlow: ( path: string ) => void;

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -22,16 +22,12 @@ interface SiteProps {
 export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( LAUNCHPAD_EXPERIMENT_NAME );
 
-	const variationsToSkipLaunchpad = [ 'treatment_no_launchpad', 'treatment_home_launchpad' ];
-	const shouldByPassLaunchpad =
-		! isLoadingExperiment ||
-		variationsToSkipLaunchpad.includes( experimentAssignment?.variationName ?? '' ) ||
-		true;
+	const shouldShowCustomerHome =
+		! isLoadingExperiment && 'treatment' === experimentAssignment?.variationName;
 
-	let launchpadStateOnSkip: null | 'skipped' | 'off' = null;
-	if ( shouldByPassLaunchpad ) {
-		launchpadStateOnSkip =
-			experimentAssignment?.variationName === 'treatment_no_launchpad' ? 'off' : 'skipped';
+	let launchpadStateOnSkip: null | 'skipped' = null;
+	if ( shouldShowCustomerHome ) {
+		launchpadStateOnSkip = 'skipped';
 	}
 
 	const setLaunchpadSkipState = ( siteIdOrSlug: string | number | null ) => {
@@ -42,7 +38,7 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 
 	return {
 		getPostFlowUrl: ( { flow, siteId, siteSlug }: PostFlowUrlProps ) => {
-			if ( shouldByPassLaunchpad ) {
+			if ( shouldShowCustomerHome ) {
 				return '/home/' + siteSlug;
 			}
 
@@ -53,7 +49,7 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 			return `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`;
 		},
 		postFlowNavigator: ( { siteId, siteSlug }: SiteProps ) => {
-			if ( shouldByPassLaunchpad ) {
+			if ( shouldShowCustomerHome ) {
 				setLaunchpadSkipState( siteId || siteSlug );
 
 				exitFlow( '/home/' + siteSlug );
@@ -64,7 +60,7 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 			return;
 		},
 		initializeLaunchpadState: ( { siteId, siteSlug }: SiteProps ) => {
-			if ( shouldByPassLaunchpad ) {
+			if ( shouldShowCustomerHome ) {
 				setLaunchpadSkipState( siteId || siteSlug );
 				return;
 			}

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -1,4 +1,5 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { ExperimentAssignment } from '@automattic/explat-client';
 import { useExperiment } from 'calypso/lib/explat';
 
 export const LAUNCHPAD_EXPERIMENT_NAME = 'calypso_onboarding_launchpad_removal_test_2024_08';
@@ -70,4 +71,32 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 			}
 		},
 	};
+};
+
+/**
+ * Get the launchpad state based on the experiment assignment
+ * @param expLoading
+ * @param experimentAssigment
+ * @param shouldSkip
+ */
+export const getLaunchpadStateBasedOnExperiment = (
+	expLoading: boolean,
+	experimentAssigment: ExperimentAssignment | null,
+	shouldSkip: boolean
+) => {
+	if (
+		expLoading ||
+		! experimentAssigment?.variationName ||
+		experimentAssigment.variationName === 'control'
+	) {
+		if ( shouldSkip ) {
+			return 'skipped';
+		}
+
+		return 'full';
+	}
+
+	if ( experimentAssigment.variationName === 'treatment' ) {
+		return 'skipped';
+	}
 };

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -23,7 +23,10 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( LAUNCHPAD_EXPERIMENT_NAME );
 
 	const shouldShowCustomerHome =
-		! isLoadingExperiment && 'treatment' === experimentAssignment?.variationName;
+		! isLoadingExperiment &&
+		( 'treatment' === experimentAssignment?.variationName ||
+			// for testing/development purposes we can use sessionStorage to force the treatment
+			'treatment' === window.sessionStorage.getItem( 'launchpad_experiment_variation' ) );
 
 	let launchpadStateOnSkip: null | 'skipped' = null;
 	if ( shouldShowCustomerHome ) {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -22,16 +22,10 @@ interface SiteProps {
 
 export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( LAUNCHPAD_EXPERIMENT_NAME );
-
-	const shouldShowCustomerHome =
-		! isLoadingExperiment &&
-		( 'treatment' === experimentAssignment?.variationName ||
-			// for testing/development purposes we can use sessionStorage to force the treatment
-			'treatment' ===
-				window.sessionStorage.getItem( 'launchpad_removal_2024_experiment_variation' ) );
+	const showCustomerHome = shouldShowCustomerHome( isLoadingExperiment, experimentAssignment );
 
 	let launchpadStateOnSkip: null | 'skipped' = null;
-	if ( shouldShowCustomerHome ) {
+	if ( showCustomerHome ) {
 		launchpadStateOnSkip = 'skipped';
 	}
 
@@ -43,7 +37,7 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 
 	return {
 		getPostFlowUrl: ( { flow, siteId, siteSlug }: PostFlowUrlProps ) => {
-			if ( shouldShowCustomerHome ) {
+			if ( showCustomerHome ) {
 				return '/home/' + siteSlug;
 			}
 
@@ -54,7 +48,7 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 			return `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`;
 		},
 		postFlowNavigator: ( { siteId, siteSlug }: SiteProps ) => {
-			if ( shouldShowCustomerHome ) {
+			if ( showCustomerHome ) {
 				setLaunchpadSkipState( siteId || siteSlug );
 
 				exitFlow( '/home/' + siteSlug );
@@ -65,7 +59,7 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 			return;
 		},
 		initializeLaunchpadState: ( { siteId, siteSlug }: SiteProps ) => {
-			if ( shouldShowCustomerHome ) {
+			if ( showCustomerHome ) {
 				setLaunchpadSkipState( siteId || siteSlug );
 				return;
 			}
@@ -74,16 +68,34 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 };
 
 /**
+ * Determine if the customer home should be shown
+ * @param isLoadingExperiment
+ * @param experimentAssignment
+ */
+export function shouldShowCustomerHome(
+	isLoadingExperiment: boolean,
+	experimentAssignment: ExperimentAssignment | null
+): boolean {
+	return (
+		! isLoadingExperiment &&
+		( 'treatment' === experimentAssignment?.variationName ||
+			// for testing/development purposes we can use sessionStorage to force the treatment
+			'treatment' ===
+				window.sessionStorage.getItem( 'launchpad_removal_2024_experiment_variation' ) )
+	);
+}
+
+/**
  * Get the launchpad state based on the experiment assignment
  * @param expLoading
  * @param experimentAssigment
  * @param shouldSkip
  */
-export const getLaunchpadStateBasedOnExperiment = (
+export function getLaunchpadStateBasedOnExperiment(
 	expLoading: boolean,
 	experimentAssigment: ExperimentAssignment | null,
 	shouldSkip: boolean
-) => {
+) {
 	if (
 		expLoading ||
 		! experimentAssigment?.variationName ||
@@ -99,4 +111,4 @@ export const getLaunchpadStateBasedOnExperiment = (
 	if ( experimentAssigment.variationName === 'treatment' ) {
 		return 'skipped';
 	}
-};
+}

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -26,7 +26,8 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 		! isLoadingExperiment &&
 		( 'treatment' === experimentAssignment?.variationName ||
 			// for testing/development purposes we can use sessionStorage to force the treatment
-			'treatment' === window.sessionStorage.getItem( 'launchpad_experiment_variation' ) );
+			'treatment' ===
+				window.sessionStorage.getItem( 'launchpad_removal_2024_experiment_variation' ) );
 
 	let launchpadStateOnSkip: null | 'skipped' = null;
 	if ( shouldShowCustomerHome ) {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -56,12 +56,10 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 			}
 
 			navigate( `launchpad?siteSlug=${ siteSlug }&siteId=${ siteId }` );
-			return;
 		},
 		initializeLaunchpadState: ( { siteId, siteSlug }: SiteProps ) => {
 			if ( showCustomerHome ) {
 				setLaunchpadSkipState( siteId || siteSlug );
-				return;
 			}
 		},
 	};

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -14,6 +14,7 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { useExitFlow } from '../hooks/use-exit-flow';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
@@ -83,16 +84,8 @@ const newsletter: Flow = {
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
 		const query = useQuery();
-		const { setPendingAction } = useDispatch( ONBOARD_STORE );
+		const { exitFlow } = useExitFlow();
 		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
-
-		const exitFlow = ( to: string ) => {
-			setPendingAction( () => {
-				return new Promise( () => {
-					window.location.assign( to );
-				} );
-			} );
-		};
 
 		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -22,6 +22,7 @@ import { ONBOARD_STORE, SITE_STORE, USER_STORE, STEPPER_INTERNAL_STORE } from '.
 import { shouldRedirectToSiteMigration } from './helpers';
 import {
 	useLaunchpadDecider,
+	getLaunchpadStateBasedOnExperiment,
 	LAUNCHPAD_EXPERIMENT_NAME,
 } from './internals/hooks/use-launchpad-decider';
 import { STEPS } from './internals/steps';
@@ -177,20 +178,14 @@ const siteSetupFlow: Flow = {
 				return 'off';
 			}
 
-			if (
-				isLoadingLaunchpadExperiment ||
-				! launchpadExperimentAssigment?.variationName ||
-				launchpadExperimentAssigment.variationName === 'control'
-			) {
-				if ( shouldSkip ) {
-					return 'skipped';
-				}
+			const launchpadState = getLaunchpadStateBasedOnExperiment(
+				isLoadingLaunchpadExperiment,
+				launchpadExperimentAssigment,
+				shouldSkip
+			);
 
-				return 'full';
-			}
-
-			if ( launchpadExperimentAssigment.variationName === 'treatment' ) {
-				return 'skipped';
+			if ( launchpadState ) {
+				return launchpadState;
 			}
 
 			// We shouldn't get here, but match the default/existing behaviour

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -7,7 +7,6 @@ import wpcomRequest from 'wpcom-proxy-request';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
-import { LAUNCHPAD_EXPERIMENT_NAME } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useExperiment } from 'calypso/lib/explat';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
@@ -21,7 +20,10 @@ import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE, STEPPER_INTERNAL_STORE } from '../stores';
 import { shouldRedirectToSiteMigration } from './helpers';
-import { useLaunchpadDecider } from './internals/hooks/use-launchpad-decider';
+import {
+	useLaunchpadDecider,
+	LAUNCHPAD_EXPERIMENT_NAME,
+} from './internals/hooks/use-launchpad-decider';
 import { STEPS } from './internals/steps';
 import { redirect } from './internals/steps-repository/import/util';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -7,7 +7,9 @@ import wpcomRequest from 'wpcom-proxy-request';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
+import { LAUNCHPAD_EXPERIMENT_NAME } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useExperiment } from 'calypso/lib/explat';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/route';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
@@ -19,6 +21,7 @@ import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE, STEPPER_INTERNAL_STORE } from '../stores';
 import { shouldRedirectToSiteMigration } from './helpers';
+import { useLaunchpadDecider } from './internals/hooks/use-launchpad-decider';
 import { STEPS } from './internals/steps';
 import { redirect } from './internals/steps-repository/import/util';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
@@ -161,6 +164,45 @@ const siteSetupFlow: Flow = {
 		const { setDesignOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 
+		const [ isLoadingLaunchpadExperiment, launchpadExperimentAssigment ] =
+			useExperiment( LAUNCHPAD_EXPERIMENT_NAME );
+
+		const getLaunchpadScreenValue = (
+			intent: string,
+			shouldSkip: boolean
+		): 'full' | 'skipped' | 'off' => {
+			if ( ! isLaunchpadIntent( intent ) || isLaunched ) {
+				return 'off';
+			}
+
+			if (
+				isLoadingLaunchpadExperiment ||
+				! launchpadExperimentAssigment?.variationName ||
+				launchpadExperimentAssigment.variationName === 'control'
+			) {
+				if ( shouldSkip ) {
+					return 'skipped';
+				}
+
+				return 'full';
+			}
+
+			if ( launchpadExperimentAssigment.variationName === 'treatment_no_launchpad' ) {
+				return 'off';
+			}
+
+			if ( launchpadExperimentAssigment.variationName === 'treatment_skip_launchpad' ) {
+				return 'skipped';
+			}
+
+			// We shouldn't get here, but match the default/existing behaviour
+			if ( shouldSkip ) {
+				return 'skipped';
+			}
+
+			return 'full';
+		};
+
 		const goToFlow = ( fullStepPath: string ) => {
 			const path = `/setup/${ fullStepPath }`.replace( /([^:])(\/\/+)/g, '$1/' );
 
@@ -201,14 +243,10 @@ const siteSetupFlow: Flow = {
 
 					// Update Launchpad option based on site intent
 					if ( typeof siteId === 'number' ) {
-						let launchpadScreen;
-						if ( ! options.skipLaunchpad ) {
-							launchpadScreen = isLaunchpadIntent( siteIntent ) && ! isLaunched ? 'full' : 'off';
-						} else {
-							launchpadScreen = 'skipped';
-						}
-
-						settings.launchpad_screen = launchpadScreen;
+						settings.launchpad_screen = getLaunchpadScreenValue(
+							siteIntent,
+							options.skipLaunchpad ?? false
+						);
 					}
 
 					let redirectionUrl = to;
@@ -245,6 +283,11 @@ const siteSetupFlow: Flow = {
 			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
 			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent' ] );
 		};
+
+		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
+			exitFlow,
+			navigate,
+		} );
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
 			switch ( currentStep ) {
@@ -317,11 +360,11 @@ const siteSetupFlow: Flow = {
 					}
 
 					if ( isLaunchpadIntent( intent ) ) {
-						const url = siteId
-							? `/setup/${ intent }/launchpad?siteSlug=${ siteSlug }&siteId=${ siteId }`
-							: `/setup/${ intent }/launchpad?siteSlug=${ siteSlug }`;
+						initializeLaunchpadState( { siteId, siteSlug } );
+						const url = getPostFlowUrl( { flow: intent, siteId, siteSlug } );
 						return exitFlow( url );
 					}
+
 					return exitFlow( `/home/${ siteId ?? siteSlug }` );
 				}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -189,11 +189,7 @@ const siteSetupFlow: Flow = {
 				return 'full';
 			}
 
-			if ( launchpadExperimentAssigment.variationName === 'treatment_no_launchpad' ) {
-				return 'off';
-			}
-
-			if ( launchpadExperimentAssigment.variationName === 'treatment_skip_launchpad' ) {
+			if ( launchpadExperimentAssigment.variationName === 'treatment' ) {
 				return 'skipped';
 			}
 

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -15,6 +15,7 @@ import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useExitFlow } from '../hooks/use-exit-flow';
 import { useSiteData } from '../hooks/use-site-data';
 import { stepsWithRequiredLogin } from '../utils/steps-with-required-login';
 
@@ -77,8 +78,9 @@ const startWriting: Flow = {
 
 	useStepNavigation( currentStep, navigate ) {
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
-		const { setSelectedSite, setPendingAction } = useDispatch( ONBOARD_STORE );
+		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
 		const { site, siteSlug, siteId } = useSiteData();
+		const { exitFlow } = useExitFlow();
 
 		// This flow clear the site_intent when flow is completed.
 		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
@@ -89,14 +91,6 @@ const startWriting: Flow = {
 				setIntentOnSite( siteSlug, '' );
 			}
 		}, [ siteSlug, setIntentOnSite, isSiteLaunched ] );
-
-		const exitFlow = ( to: string ) => {
-			setPendingAction( () => {
-				return new Promise( () => {
-					window.location.assign( to );
-				} );
-			} );
-		};
 
 		const { getPostFlowUrl, postFlowNavigator, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -122,11 +122,6 @@ const startWriting: Flow = {
 							} ),
 						] );
 
-						initializeLaunchpadState( {
-							siteId: providedDependencies?.siteId as number,
-							siteSlug: providedDependencies?.siteSlug as string,
-						} );
-
 						const siteOrigin = window.location.origin;
 
 						return redirect(

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -1,5 +1,6 @@
 import { Onboard, useLaunchpad } from '@automattic/data-stores';
 import { isAssemblerDesign } from '@automattic/design-picker';
+import { FREE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
@@ -38,7 +39,7 @@ const updateDesign: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
-		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || 'free';
+		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || FREE_FLOW;
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 		const selectedDesign = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -3,12 +3,14 @@ import { isAssemblerDesign } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
+import { useLaunchpadDecider } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
 import { useQuery } from '../hooks/use-query';
+import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { STEPS } from './internals/steps';
@@ -34,6 +36,7 @@ const updateDesign: Flow = {
 		}, [] );
 	},
 	useStepNavigation( currentStep, navigate ) {
+		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
 		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || 'free';
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
@@ -53,9 +56,19 @@ const updateDesign: Flow = {
 			return navigate( 'processing' );
 		};
 
+		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
+			exitFlow,
+			navigate,
+		} );
+
 		function submit( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) {
 			switch ( currentStep ) {
 				case 'processing':
+					initializeLaunchpadState( {
+						siteId,
+						siteSlug: ( providedDependencies?.siteSlug ?? siteSlug ) as string,
+					} );
+
 					if ( results.some( ( result ) => result === ProcessingResult.FAILURE ) ) {
 						return navigate( 'error' );
 					}
@@ -74,7 +87,11 @@ const updateDesign: Flow = {
 					}
 
 					return window.location.assign(
-						`/setup/${ flowToReturnTo }/launchpad?siteSlug=${ siteSlug }`
+						getPostFlowUrl( {
+							flow: flowToReturnTo,
+							siteId,
+							siteSlug: siteSlug as string,
+						} )
 					);
 
 				case 'designSetup':

--- a/client/landing/stepper/hooks/use-exit-flow.ts
+++ b/client/landing/stepper/hooks/use-exit-flow.ts
@@ -1,0 +1,22 @@
+import { useDispatch } from '@wordpress/data';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+
+/**
+ * The useExitFlow hook provides a function to handle exiting a flow
+ * by setting a pending action that redirects the browser to a specified URL.
+ */
+export const useExitFlow = () => {
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+
+	const exitFlow = ( to: string ) => {
+		setPendingAction( () => {
+			return new Promise( () => {
+				window.location.assign( to );
+			} );
+		} );
+	};
+
+	return {
+		exitFlow,
+	};
+};

--- a/client/landing/stepper/hooks/use-exit-flow.ts
+++ b/client/landing/stepper/hooks/use-exit-flow.ts
@@ -1,11 +1,17 @@
 import { useDispatch } from '@wordpress/data';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 
+type UseExitFlowParams =
+	| { processing: true; navigate: ( to: string ) => void }
+	| { processing?: false; navigate?: ( to: string ) => void }
+	| undefined;
+
 /**
  * The useExitFlow hook provides a function to handle exiting a flow
- * by setting a pending action that redirects the browser to a specified URL.
+ * by setting a pending action that redirects the browser to a specified URL,
+ * with an optional navigation step if processing is required.
  */
-export const useExitFlow = () => {
+export const useExitFlow = ( params?: UseExitFlowParams ) => {
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	const exitFlow = ( to: string ) => {
@@ -14,6 +20,10 @@ export const useExitFlow = () => {
 				window.location.assign( to );
 			} );
 		} );
+
+		if ( params?.processing && params?.navigate ) {
+			return params.navigate( 'processing' );
+		}
 	};
 
 	return {

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -72,7 +72,10 @@ export async function maybeRedirect( context, next ) {
 			'calypso_onboarding_launchpad_removal_test_2024_08'
 		);
 
-		const shouldShowLaunchpad = 'treatment' !== experimentAssignment?.variationName;
+		const shouldShowLaunchpad =
+			'treatment' !== experimentAssignment?.variationName &&
+			// for testing/development purposes we can use sessionStorage to force the treatment
+			'treatment' !== window.sessionStorage.getItem( 'launchpad_experiment_variation' );
 
 		if (
 			shouldShowLaunchpad &&

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -75,7 +75,8 @@ export async function maybeRedirect( context, next ) {
 		const shouldShowLaunchpad =
 			'treatment' !== experimentAssignment?.variationName &&
 			// for testing/development purposes we can use sessionStorage to force the treatment
-			'treatment' !== window.sessionStorage.getItem( 'launchpad_experiment_variation' );
+			'treatment' !==
+				window.sessionStorage.getItem( 'launchpad_removal_2024_experiment_variation' );
 
 		if (
 			shouldShowLaunchpad &&

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -67,7 +68,14 @@ export async function maybeRedirect( context, next ) {
 			checklist: launchpadChecklist,
 		} = await fetchLaunchpad( slug );
 
+		const experimentAssignment = await loadExperimentAssignment(
+			'calypso_onboarding_launchpad_removal_test_2024_08'
+		);
+
+		const shouldShowLaunchpad = 'treatment' !== experimentAssignment?.variationName;
+
 		if (
+			shouldShowLaunchpad &&
 			launchpadScreenOption === 'full' &&
 			! areLaunchpadTasksCompleted( launchpadChecklist, isSiteLaunched )
 		) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8541

## Proposed Changes

* This exploratory PR looks at how complicated it might be to put together a PR that would allow us to create an A/B/C test around the fullscreen Launchpad. The idea for the test would be that we'd want to compare three behaviours:
   1. The current experience, where users see the fullscreen launchpad, and need to Skip it to get to Customer Home
   2. Instead of showing the fullscreen launchpad, we mark the launchpad as skipped, which should show it less obtrusively in Customer Home
   3. We always disable the fullscreen launchpad, so it's not displayed in the flow or Customer Home.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make the experiment possible: pbxNRc-3Yh-p2

## Testing Instructions

**Prerequisite**
- Run your sandbox and apply changes from https://github.com/Automattic/jetpack/pull/39237
- Proxy the {SITE_SLUG} you choose for testing
- Since we made changes on `apps/wpcom-block-editor/` we should follow:
  - Proxy `widgets.wp.com`
  - From the path `apps/wpcom-block-editor/` run the command `yarn dev --sync `
  - More info about syncing widget app with sandbox, find [here](https://github.com/Automattic/wp-calypso/blob/382b78199f323b152fbfa38a8c34af3e41d84166/apps/wpcom-block-editor/README.md). 
- In the active tab, open your developer tool and set the experiment variation as a session item. `window.sessionStorage.setItem( 'launchpad_removal_2024_experiment_variation', 'treatment' );`


### BUILD flow

**Scenario 1:**
* go to `/setup/site-setup?siteSlug={SITE_SLUG}`
* choose "Promote myself or business"
* select "Choose a theme"
* select a theme
* press "continue" button
* check if there is a home screen instead of the full-screen launchpad

**Scenario 2:**
- go to `/setup/site-setup?siteSlug={SITE_SLUG}`
- without goal selection, press "continue" button
- select "Design your own"
- select accordingly styles, pages, add additional content
- press WP icon button (top left corner)
- from the left sidebar navigation, click on the "Go to dashboard" back button
- check if there is a home screen instead of a full-screen launchpad

**Scenario 3:**
- make everything from scenario 2, but instead of WP icon
- make any change
- and press "Save"
- from the "Great progress" modal, click on the "Next Steps" button
- check if there is a home screen instead of a full-screen launchpad

---

### DESIGN FIRST flow

- go to `/setup/design-first/new-or-existing-site`
- select your site
- pick a design and press "continue"
- check if there is a home screen instead of a full-screen launchpad

---

### START WRITING flow

- go to `/setup/start-writing`
- select or create a site
- enter any content and "publish" the post
- from the "Great progress" modal, click on the "Next Steps" button
- check if there is a home screen instead of a full-screen launchpad

---

### NEWSLETTER flow
- go to `/setup/newsletter`
- select the site title, plan, and domain
- check if there is a home screen instead of a full-screen launchpad

---

### WRITE flow
- go to `/setup/site-setup?siteSlug={SITE_SLUG}`
- choose "Write & publish"
- select "Start writing" (Draft your first post)
- edit post content and "Publish"
- from the "Great progress" modal, click on the "Next Steps" button
- check if there is a home screen instead of a full-screen launchpad
<img width="1006" alt="Screenshot 2024-09-06 at 17 43 23" src="https://github.com/user-attachments/assets/b659be18-b3bb-4332-bc9a-a28ceef53d8e">

---

### FREE flow
- go to `/setup/free`
- enter a site name
- select theme and styles
- check if there is a home screen instead of a full-screen launchpad

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?