### PR TITLE
Stepper: Track `variant` slug with submit-step event. Update site-migration flow to use framework tracking

### DIFF
--- a/client/landing/stepper/declarative-flow/free-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/free-post-setup.ts
@@ -21,7 +21,6 @@ const freePostSetup: Flow = {
 			setIntent( Onboard.SiteIntent.FreePostSetup );
 		}, [] );
 	},
-
 	useSteps() {
 		return [ STEPS.FREE_POST_SETUP ];
 	},

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -31,7 +31,13 @@ export const useStepNavigationWithTracking = ( {
 		...stepNavigation,
 		submit: ( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) => {
 			shouldTrackSubmit &&
-				recordSubmitStep( providedDependencies, intent, flow.name, currentStepRoute );
+				recordSubmitStep(
+					providedDependencies,
+					intent,
+					flow.name,
+					currentStepRoute,
+					flow.variantSlug
+				);
 			stepNavigation.submit?.( providedDependencies, ...params );
 		},
 	};

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -460,6 +460,7 @@ const siteMigration: Flow = {
 
 		return { goBack, submit, exitFlow };
 	},
+	use__Temporary__ShouldTrackEvent: ( event ) => 'submit' === event,
 };
 
 export default siteMigration;

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -15,15 +15,14 @@ import { HOW_TO_MIGRATE_OPTIONS } from '../constants';
 import { useIsSiteAdmin } from '../hooks/use-is-site-admin';
 import { useSiteData } from '../hooks/use-site-data';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
-import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
+import { USER_STORE, SITE_STORE } from '../stores';
 import { goToCheckout } from '../utils/checkout';
-import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { getSiteIdParam } from './internals/steps-repository/import/util';
 import { type SiteMigrationIdentifyAction } from './internals/steps-repository/site-migration-identify';
 import { AssertConditionState } from './internals/types';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
-import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
+import type { SiteSelect, UserSelect } from '@automattic/data-stores';
 
 const FLOW_NAME = 'site-migration';
 
@@ -102,11 +101,6 @@ const siteMigration: Flow = {
 		const siteCount =
 			useSelect( ( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(), [] )
 				?.site_count ?? 0;
-
-		const intent = useSelect(
-			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
-			[]
-		);
 		const siteSlugParam = useSiteSlugParam();
 		const urlQueryParams = useQuery();
 		const fromQueryParam = urlQueryParams.get( 'from' );
@@ -128,7 +122,6 @@ const siteMigration: Flow = {
 
 		// TODO - We may need to add `...params: string[]` back once we start adding more steps.
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, intent, flowName, currentStep, variantSlug );
 			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
 			const siteId = getSiteIdBySlug( siteSlug ) || getSiteIdParam( urlQueryParams );
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -1,8 +1,9 @@
 import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { Onboard, type SiteSelect, type UserSelect } from '@automattic/data-stores';
 import { isHostedSiteMigrationFlow } from '@automattic/onboarding';
 import { SiteExcerptData } from '@automattic/sites';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
@@ -15,20 +16,26 @@ import { HOW_TO_MIGRATE_OPTIONS } from '../constants';
 import { useIsSiteAdmin } from '../hooks/use-is-site-admin';
 import { useSiteData } from '../hooks/use-site-data';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
-import { USER_STORE, SITE_STORE } from '../stores';
+import { USER_STORE, SITE_STORE, ONBOARD_STORE } from '../stores';
 import { goToCheckout } from '../utils/checkout';
 import { STEPS } from './internals/steps';
 import { getSiteIdParam } from './internals/steps-repository/import/util';
 import { type SiteMigrationIdentifyAction } from './internals/steps-repository/site-migration-identify';
 import { AssertConditionState } from './internals/types';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
-import type { SiteSelect, UserSelect } from '@automattic/data-stores';
 
 const FLOW_NAME = 'site-migration';
 
 const siteMigration: Flow = {
 	name: FLOW_NAME,
 	isSignupFlow: false,
+
+	useSideEffect() {
+		const { setIntent } = useDispatch( ONBOARD_STORE );
+		useEffect( () => {
+			setIntent( Onboard.SiteIntent.SiteMigration );
+		}, [] );
+	},
 
 	useSteps() {
 		const baseSteps = [

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -25,4 +25,5 @@ export enum SiteIntent {
 	AIAssembler = 'ai-assembler',
 	Newsletter = 'newsletter',
 	FreePostSetup = 'free-post-setup',
+	SiteMigration = 'site-migration',
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91755

## Proposed Changes

- Logs the flow's `variant` slug that's added on child flows for the submit-step nav event
- Updates the `site-migration` flow to opt-in for framework tracking on submit-step nav event
- Updates the flow to set the site intent in the side effect hook for use in the tracks call

### Questions/Caveats

Similar questions/caveats mentioned in https://github.com/Automattic/wp-calypso/pull/93178 and https://github.com/Automattic/wp-calypso/pull/93178#discussion_r1699819153

- basically whether `site-migration` is a correct value for `SiteIntent` / whether it maps and should map to the [recorded site's intent](https://github.com/Automattic/wp-calypso/blob/trunk/packages/data-stores/src/queries/use-site-intent.ts)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/91755

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Main/parent flow:

- go to `/setup/site-migration/site-migration-identify?siteSlug=[site slug]`
- fill out the form and click to continue
- confirm in Network tab a `t.gif` request exists tracking the correct values for `calypso_signup_actions_submit_step`
- it should track the intent `site-migration` (TBD whether correct/wrong)
- it shouldn't track any variant slug as it's undefined. that part to be confirmed in a child flow like `hosted-site-migration`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
