### PR TITLE
Masterbar: Fix RTL border first/last item + external border

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -701,6 +701,20 @@ body.is-mobile-app-view {
 			pointer-events: none;
 		}
 
+		body.rtl & {
+			&::before {
+				left: auto;
+				right: calc(-1 * var(--masterbar-item-active-border-radius));
+				mask: radial-gradient(circle at 0 0, transparent var(--masterbar-item-active-border-radius), var(--color-sidebar-background) var(--masterbar-item-active-border-radius));
+			}
+
+			&::after {
+				right: auto;
+				left: calc(-1 * var(--masterbar-item-active-border-radius));
+				mask: radial-gradient(circle at 100% 0, transparent var(--masterbar-item-active-border-radius), var(--color-sidebar-background) var(--masterbar-item-active-border-radius));
+			}
+		}
+
 		&::before {
 			left: calc(-1 * var(--masterbar-item-active-border-radius));
 			mask: radial-gradient(circle at 0 0, transparent var(--masterbar-item-active-border-radius), var(--color-sidebar-background) var(--masterbar-item-active-border-radius));
@@ -718,6 +732,13 @@ body.is-mobile-app-view {
 			--color-masterbar-icon: var(--color-sidebar-menu-selected-text);
 			--color-masterbar-highlight: var(--color-sidebar-menu-selected-text);
 			--color-masterbar-item-active-background: var(--color-sidebar-background);
+
+			&.masterbar__item-my-sites {
+				border-top-left-radius: 0;
+			}
+			&.masterbar__item-howdy {
+				border-top-right-radius: 0;
+			}
 
 			&::before,
 			&::after {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -733,9 +733,6 @@ body.is-mobile-app-view {
 			--color-masterbar-highlight: var(--color-sidebar-menu-selected-text);
 			--color-masterbar-item-active-background: var(--color-sidebar-background);
 
-			&.masterbar__item-my-sites {
-				border-top-left-radius: 0;
-			}
 			&.masterbar__item-howdy {
 				border-top-right-radius: 0;
 			}
@@ -743,6 +740,12 @@ body.is-mobile-app-view {
 			&::before,
 			&::after {
 				opacity: 1;
+			}
+
+			@media only screen and (min-width: 781px) {
+				&.masterbar__item-my-sites {
+					border-top-left-radius: 0;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8532, https://github.com/Automattic/wp-calypso/issues/93190

## Proposed Changes
The "all sites" and "profile" links in the global masterbar should have no border radius in their outer corners when selected.
RTL external borders are inverted

- [X] W logo should not have top-left border radius.
- [X] Profile should not have top-right border radius.
- [X] External borders on selected items are inverted in RTL.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/0ae2e00e-b302-415c-9cad-f0f2454da778) | ![image](https://github.com/user-attachments/assets/3947e591-832b-4f90-9b7f-e4386777ce0a) |
| ![image](https://github.com/user-attachments/assets/83978f72-0fe7-4259-8482-28a39df58b85) | ![image](https://github.com/user-attachments/assets/0b3ee0ac-03fa-40be-a416-56b8730bcefd) |
| ![image](https://github.com/user-attachments/assets/c73de9ae-7e62-4d64-9532-40fef3b368c6) | ![image](https://github.com/user-attachments/assets/02112e6f-28e7-4e8d-8737-5b887759fa47) |
| ![image](https://github.com/user-attachments/assets/ee3e7c7e-5958-4a34-b17c-b0c0cee5bc02) |![image](https://github.com/user-attachments/assets/d261e57a-45ae-47b6-9a91-6deaffc610c0) |

## Testing Instructions

* Go to `/sites`
* Check the W logo top left border.
* With RTL locale, check the W logo top right border.
* Go to `/me`
* Check the profile top right border.
* With RTL locale, check the profile top left border.
* With RTL locale, check the external borders on the selected item.
