### PR TITLE
Odyssey Stats: Fix the view all link of Subscriber Stats

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -135,7 +135,7 @@ export default function SubscribersChartSection( {
 
 	const subscribersUrl = isOdysseyStats
 		? `https://cloud.jetpack.com/subscribers/${ slug }`
-		: `/people/subscribers/${ slug }`;
+		: `/subscribers/${ slug }`;
 
 	return (
 		<div className="subscribers-section">

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -6,8 +6,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 import { useSelector } from 'calypso/state';
-import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsPeriodHeader from '../stats-period-header';
 import { hideFractionNumber } from './chart-utils';
@@ -102,9 +100,6 @@ export default function SubscribersChartSection( {
 		queryDate
 	) as UseQueryResult< SubscribersDataResult >;
 
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId || 0 ) );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-
 	const handleDateChange = useCallback(
 		( newDate: Date ) => setQueryDate( new Date( newDate.getTime() ) ), // unless new Date is created, the component won't rerender
 		[ setQueryDate ]
@@ -138,23 +133,21 @@ export default function SubscribersChartSection( {
 	const slugPath = slug ? `/${ slug }` : '';
 	const pathTemplate = `${ subscribers.path }{{ interval }}${ slugPath }`;
 
-	const subscribersUrl =
-		isAtomic || isJetpack
-			? `https://cloud.jetpack.com/subscribers/${ slug }`
-			: `/people/subscribers/${ slug }`;
+	const subscribersUrl = isOdysseyStats
+		? `https://cloud.jetpack.com/subscribers/${ slug }`
+		: `/people/subscribers/${ slug }`;
+
 	return (
 		<div className="subscribers-section">
 			{ /* TODO: Remove highlight-cards class and use a highlight cards heading component instead. */ }
 			<div className="subscribers-section-heading highlight-cards">
 				<h1 className="highlight-cards-heading">
 					{ translate( 'Subscribers' ) }{ ' ' }
-					{ isOdysseyStats ? null : (
-						<small>
-							<a className="highlight-cards-heading-wrapper" href={ subscribersUrl }>
-								{ translate( 'View all subscribers' ) }
-							</a>
-						</small>
-					) }
+					<small>
+						<a className="highlight-cards-heading-wrapper" href={ subscribersUrl }>
+							{ translate( 'View all subscribers' ) }
+						</a>
+					</small>
 				</h1>
 				<div className="subscribers-section-heading__chart-controls">
 					<SubscribersNavigationArrows


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87865 

## Proposed Changes

* Determine the `View all subscribers` link based on platform rather than site type.
* Update the WPCOM subscriber page link since the route was changed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `View all subscribers` link of Subscriber Stats should work for Calypso and Odyssey Stats with different links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Calypso Stats
* Spin this change up with the Calypso Live link.
* Navigate to Stats > Subscribers for a WPCOM site.
* Ensure the `View all subscribers` link works as previously navigating to `/subscribers/{site-slug}`.

#### Odyssey Stats
* Spin this change on a local Jetpack site: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=/path-to-jetpack/projects/packages/stats-admin yarn dev`.
* Navigate to Stats > Subscribers.
* Ensure the `View all subscribers` link shows and navigate to `https://cloud.jetpack.com/subscribers/{site-slug}`.

|Before|After|
|-|-|
|<img width="1278" alt="截圖 2024-08-02 下午10 56 44" src="https://github.com/user-attachments/assets/b0e8d66e-d966-4088-ad2b-3d9d0b7147f7">|<img width="1296" alt="截圖 2024-08-02 下午10 55 26" src="https://github.com/user-attachments/assets/dd367c26-8a03-4a83-9df3-b059d4b9b84b">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
