### PR TITLE
Refactor/a4a/site dashboard preview pane

### DIFF
--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -18,7 +18,6 @@ function configureSitesContext( context: Context ) {
 	const category = context.params.category || A4A_SITES_DASHBOARD_DEFAULT_CATEGORY;
 	const siteUrl = context.params.siteUrl;
 	const siteFeature = context.params.feature || A4A_SITES_DASHBOARD_DEFAULT_FEATURE;
-	const hideListingInitialState = !! siteUrl;
 
 	const {
 		s: search,
@@ -40,7 +39,6 @@ function configureSitesContext( context: Context ) {
 			categoryInitialState={ category }
 			siteUrlInitialState={ siteUrl }
 			siteFeatureInitialState={ siteFeature }
-			hideListingInitialState={ hideListingInitialState }
 			showOnlyFavoritesInitialState={
 				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
 			}

--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import ItemPreviewPane, {
 	createFeaturePreview,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/item-preview-pane';
@@ -19,7 +19,6 @@ import {
 	HOSTING_OVERVIEW_ID,
 } from 'calypso/a8c-for-agencies/sections/sites/features/features';
 import { PreviewPaneProps } from 'calypso/a8c-for-agencies/sections/sites/site-preview-pane/types';
-import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { useJetpackAgencyDashboardRecordTrackEvent } from 'calypso/jetpack-cloud/sections/agency-dashboard/hooks';
 import { A4A_SITES_DASHBOARD_DEFAULT_FEATURE } from '../../constants';
 import { useFetchTestConnections } from '../../hooks/use-fetch-test-connection';
@@ -44,6 +43,8 @@ export function OverviewPreviewPane( {
 	isSmallScreen = false,
 	hasError = false,
 	onRefetchSite,
+	selectedSiteFeature = A4A_SITES_DASHBOARD_DEFAULT_FEATURE,
+	setSelectedSiteFeature,
 }: PreviewPaneProps ) {
 	const translate = useTranslate();
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
@@ -60,17 +61,6 @@ export function OverviewPreviewPane( {
 
 	// Show error pane if there is an error
 	const showErrorPane = formattedSite?.[ 0 ].site.error ?? false;
-
-	const { selectedSiteFeature, setSelectedSiteFeature } = useContext( SitesDashboardContext );
-
-	useEffect( () => {
-		if ( selectedSiteFeature === undefined ) {
-			setSelectedSiteFeature( A4A_SITES_DASHBOARD_DEFAULT_FEATURE );
-		}
-		return () => {
-			setSelectedSiteFeature( undefined );
-		};
-	}, [] );
 
 	const errorFeatures = useMemo(
 		() => [

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -4,7 +4,6 @@ import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useContext, useMemo, useState, ReactNode } from 'react';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
-import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import {
 	DataViewsColumn,
@@ -80,8 +79,7 @@ export const JetpackSitesDataViews = ( {
 
 			setDataViewsState( ( prevState: DataViewsState ) => ( {
 				...prevState,
-				selectedItem: site,
-				type: DATAVIEWS_LIST,
+				selectedItem: site.url,
 			} ) );
 		},
 		[ isNotProduction, setDataViewsState ]

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/types.ts
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/types.ts
@@ -20,7 +20,8 @@ export interface FeatureTabInterface {
 export interface PreviewPaneProps {
 	site: Site;
 	closeSitePreviewPane?: () => void;
-	selectedFeatureId?: string;
+	selectedSiteFeature?: string;
+	setSelectedSiteFeature: ( id: string ) => void;
 	features?: FeaturePreviewInterface[];
 	className?: string;
 	isSmallScreen?: boolean;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -15,7 +15,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	dataViewsState: initialDataViewsState,
 	setDataViewsState: () => {},
 
-	initialSelectedSiteUrl: '',
 	currentPage: 1,
 	path: '',
 	featurePreview: null,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -9,9 +9,6 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	selectedSiteFeature: undefined,
 	setSelectedSiteFeature: () => {},
 
-	hideListing: undefined,
-	setHideListing: () => {},
-
 	showOnlyFavorites: undefined,
 	setShowOnlyFavorites: () => {},
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -14,7 +14,6 @@ import SitesDashboardContext from './sites-dashboard-context';
 
 interface Props {
 	showOnlyFavoritesInitialState?: boolean;
-	hideListingInitialState?: boolean;
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
 	siteFeatureInitialState?: string;
@@ -42,7 +41,6 @@ const buildFilters = ( { issueTypes }: { issueTypes: string } ) => {
 };
 
 export const SitesDashboardProvider = ( {
-	hideListingInitialState = false,
 	showOnlyFavoritesInitialState = false,
 	categoryInitialState,
 	siteUrlInitialState,
@@ -55,7 +53,6 @@ export const SitesDashboardProvider = ( {
 	sort,
 	featurePreview,
 }: Props ) => {
-	const [ hideListing, setHideListing ] = useState( hideListingInitialState );
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
 	const [ showOnlyFavorites, setShowOnlyFavorites ] = useState( showOnlyFavoritesInitialState );
@@ -97,7 +94,6 @@ export const SitesDashboardProvider = ( {
 		setInitialSelectedSiteUrl( siteUrlInitialState );
 		if ( ! siteUrlInitialState ) {
 			setShowOnlyFavorites( showOnlyFavoritesInitialState );
-			setHideListing( false );
 		}
 
 		setDataViewsState( ( previousState ) => ( {
@@ -127,8 +123,6 @@ export const SitesDashboardProvider = ( {
 		setSelectedCategory: setSelectedCategory,
 		selectedSiteFeature: selectedSiteFeature,
 		setSelectedSiteFeature: setSelectedSiteFeature,
-		hideListing: hideListing,
-		setHideListing: setHideListing,
 		showOnlyFavorites: showOnlyFavorites,
 		setShowOnlyFavorites: setShowOnlyFavorites,
 		path,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useState } from 'react';
 import {
+	DATAVIEWS_LIST,
 	DATAVIEWS_TABLE,
 	initialDataViewsState,
 } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
@@ -61,7 +62,6 @@ export const SitesDashboardProvider = ( {
 	const [ currentLicenseInfo, setCurrentLicenseInfo ] = useState< string | null >( null );
 	const [ mostRecentConnectedSite, setMostRecentConnectedSite ] = useState< string | null >( null );
 	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
-	const [ initialSelectedSiteUrl, setInitialSelectedSiteUrl ] = useState( siteUrlInitialState );
 
 	const handleSetBulkManagementActive = ( isActive: boolean ) => {
 		setIsBulkManagementActive( isActive );
@@ -91,7 +91,6 @@ export const SitesDashboardProvider = ( {
 	} );
 
 	useEffect( () => {
-		setInitialSelectedSiteUrl( siteUrlInitialState );
 		if ( ! siteUrlInitialState ) {
 			setShowOnlyFavorites( showOnlyFavoritesInitialState );
 		}
@@ -99,14 +98,14 @@ export const SitesDashboardProvider = ( {
 		setDataViewsState( ( previousState ) => ( {
 			...previousState,
 			...( siteUrlInitialState
-				? {}
+				? { selectedItem: siteUrlInitialState, type: DATAVIEWS_LIST }
 				: {
 						filters: buildFilters( { issueTypes } ),
+						search: searchQuery,
+						sort,
+						selectedItem: undefined,
+						type: DATAVIEWS_TABLE,
 				  } ),
-			...( siteUrlInitialState ? {} : { search: searchQuery } ),
-			...( siteUrlInitialState ? {} : { sort } ),
-			...( siteUrlInitialState ? {} : { selectedItem: undefined } ),
-			...( siteUrlInitialState ? {} : { type: DATAVIEWS_TABLE } ),
 		} ) );
 	}, [
 		setDataViewsState,
@@ -115,7 +114,6 @@ export const SitesDashboardProvider = ( {
 		sort,
 		issueTypes,
 		siteUrlInitialState,
-		setInitialSelectedSiteUrl,
 	] );
 
 	const sitesDashboardContextValue: SitesDashboardContextInterface = {
@@ -128,7 +126,6 @@ export const SitesDashboardProvider = ( {
 		path,
 		currentPage,
 		isBulkManagementActive,
-		initialSelectedSiteUrl: initialSelectedSiteUrl,
 		setIsBulkManagementActive: handleSetBulkManagementActive,
 		selectedSites,
 		setSelectedSites,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -61,6 +61,7 @@ export default function SitesDashboard() {
 		setDataViewsState,
 		initialSelectedSiteUrl,
 		selectedSiteFeature,
+		setSelectedSiteFeature,
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
 		showOnlyFavorites,
@@ -282,6 +283,8 @@ export default function SitesDashboard() {
 				<LayoutColumn className="site-preview-pane" wide>
 					<OverviewPreviewPane
 						site={ dataViewsState.selectedItem }
+						selectedSiteFeature={ selectedSiteFeature }
+						setSelectedSiteFeature={ setSelectedSiteFeature }
 						closeSitePreviewPane={ closeSitePreviewPane }
 						isSmallScreen={ ! isLargeScreen }
 						hasError={ isError }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -65,8 +65,6 @@ export default function SitesDashboard() {
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
 		showOnlyFavorites,
-		hideListing,
-		setHideListing,
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
@@ -108,7 +106,6 @@ export default function SitesDashboard() {
 	useEffect( () => {
 		if ( dataViewsState.selectedItem && ! initialSelectedSiteUrl ) {
 			setDataViewsState( { ...dataViewsState, type: DATAVIEWS_TABLE, selectedItem: undefined } );
-			setHideListing( false );
 			return;
 		}
 
@@ -130,11 +127,11 @@ export default function SitesDashboard() {
 		}
 		// Omitting sitesViewState to prevent infinite loop
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ data, isError, isLoading, initialSelectedSiteUrl, setDataViewsState, setHideListing ] );
+	}, [ data, isError, isLoading, initialSelectedSiteUrl, setDataViewsState ] );
 
 	useEffect( () => {
 		// If there isn't a selected site and we are showing only the preview pane we should wait for the selected site to load from the endpoint
-		if ( hideListing && ! dataViewsState.selectedItem ) {
+		if ( ! dataViewsState.selectedItem ) {
 			return;
 		}
 
@@ -167,15 +164,13 @@ export default function SitesDashboard() {
 		dataViewsState.page,
 		showOnlyFavorites,
 		dataViewsState.sort,
-		hideListing,
 	] );
 
 	const closeSitePreviewPane = useCallback( () => {
 		if ( dataViewsState.selectedItem ) {
 			setDataViewsState( { ...dataViewsState, type: DATAVIEWS_TABLE, selectedItem: undefined } );
-			setHideListing( false );
 		}
-	}, [ dataViewsState, setDataViewsState, setHideListing ] );
+	}, [ dataViewsState, setDataViewsState ] );
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {
@@ -221,63 +216,61 @@ export default function SitesDashboard() {
 			wide
 			title={ dataViewsState.selectedItem ? null : translate( 'Sites' ) }
 		>
-			{ ! hideListing && (
-				<LayoutColumn className="sites-overview" wide>
-					<LayoutTop withNavigation={ navItems.length > 1 }>
-						{ recentlyCreatedSite && (
-							<ProvisioningSiteNotification
-								siteId={ Number( recentlyCreatedSite ) }
-								migrationIntent={ !! migrationIntent }
-							/>
-						) }
-
-						<LayoutHeader>
-							<Title>{ translate( 'Sites' ) }</Title>
-							<Actions>
-								<MobileSidebarNavigation />
-								<SitesHeaderActions onWPCOMImport={ () => refetch() } />
-							</Actions>
-						</LayoutHeader>
-						{ navItems.length > 1 && (
-							<LayoutNavigation { ...selectedItemProps }>
-								<NavigationTabs { ...selectedItemProps } items={ navItems } />
-							</LayoutNavigation>
-						) }
-					</LayoutTop>
-
-					<SiteNotifications />
-					{ tourId && <GuidedTour defaultTourId={ tourId } /> }
-					<QueryReaderTeams />
-					<DashboardDataContext.Provider
-						value={ {
-							verifiedContacts: {
-								emails: verifiedContacts?.emails ?? [],
-								phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
-								refetchIfFailed: () => {
-									if ( fetchContactFailed ) {
-										refetchContacts();
-									}
-									return;
-								},
-							},
-							products: products ?? [],
-							isLargeScreen: isLargeScreen || false,
-						} }
-					>
-						<JetpackSitesDataViews
-							className={ clsx( 'sites-overview__content', {
-								'is-hiding-navigation': navItems.length <= 1,
-							} ) }
-							data={ data }
-							isLoading={ isLoading }
-							isLargeScreen={ isLargeScreen || false }
-							setDataViewsState={ setDataViewsState }
-							dataViewsState={ dataViewsState }
-							onRefetchSite={ refetch }
+			<LayoutColumn className="sites-overview" wide>
+				<LayoutTop withNavigation={ navItems.length > 1 }>
+					{ recentlyCreatedSite && (
+						<ProvisioningSiteNotification
+							siteId={ Number( recentlyCreatedSite ) }
+							migrationIntent={ !! migrationIntent }
 						/>
-					</DashboardDataContext.Provider>
-				</LayoutColumn>
-			) }
+					) }
+
+					<LayoutHeader>
+						<Title>{ translate( 'Sites' ) }</Title>
+						<Actions>
+							<MobileSidebarNavigation />
+							<SitesHeaderActions onWPCOMImport={ () => refetch() } />
+						</Actions>
+					</LayoutHeader>
+					{ navItems.length > 1 && (
+						<LayoutNavigation { ...selectedItemProps }>
+							<NavigationTabs { ...selectedItemProps } items={ navItems } />
+						</LayoutNavigation>
+					) }
+				</LayoutTop>
+
+				<SiteNotifications />
+				{ tourId && <GuidedTour defaultTourId={ tourId } /> }
+				<QueryReaderTeams />
+				<DashboardDataContext.Provider
+					value={ {
+						verifiedContacts: {
+							emails: verifiedContacts?.emails ?? [],
+							phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
+							refetchIfFailed: () => {
+								if ( fetchContactFailed ) {
+									refetchContacts();
+								}
+								return;
+							},
+						},
+						products: products ?? [],
+						isLargeScreen: isLargeScreen || false,
+					} }
+				>
+					<JetpackSitesDataViews
+						className={ clsx( 'sites-overview__content', {
+							'is-hiding-navigation': navItems.length <= 1,
+						} ) }
+						data={ data }
+						isLoading={ isLoading }
+						isLargeScreen={ isLargeScreen || false }
+						setDataViewsState={ setDataViewsState }
+						dataViewsState={ dataViewsState }
+						onRefetchSite={ refetch }
+					/>
+				</DashboardDataContext.Provider>
+			</LayoutColumn>
 
 			{ dataViewsState.selectedItem && (
 				<LayoutColumn className="site-preview-pane" wide>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -6,7 +6,7 @@ import {
 	DEFAULT_SORT_DIRECTION,
 	DEFAULT_SORT_FIELD,
 } from '../constants';
-import { DashboardSortInterface, Site } from '../types';
+import { DashboardSortInterface } from '../types';
 import { getSelectedFilters } from './get-selected-filters';
 
 const buildQueryString = ( {
@@ -69,7 +69,7 @@ export const updateSitesDashboardUrl = ( {
 	category?: string;
 	setCategory: ( category: string ) => void;
 	filters: DataViewsFilter[];
-	selectedSite?: Site;
+	selectedSite?: string;
 	selectedSiteFeature?: string;
 	search: string;
 	currentPage: number;
@@ -101,10 +101,10 @@ export const updateSitesDashboardUrl = ( {
 		selectedSiteFeature !== A4A_SITES_DASHBOARD_DEFAULT_FEATURE
 	) {
 		// If the selected feature is the default one, we can leave the url a little cleaner, that's why we are comparing to the default feature in the condition above.
-		url = `${ baseUrl }/${ category }/${ selectedSite.url }/${ selectedSiteFeature }`;
+		url = `${ baseUrl }/${ category }/${ selectedSite }/${ selectedSiteFeature }`;
 		shouldAddQueryArgs = false;
 	} else if ( category && selectedSite ) {
-		url = `${ baseUrl }/${ category }/${ selectedSite.url }`;
+		url = `${ baseUrl }/${ category }/${ selectedSite }`;
 		shouldAddQueryArgs = false;
 	} else if ( category && category !== A4A_SITES_DASHBOARD_DEFAULT_CATEGORY ) {
 		// If the selected category is the default one, we can leave the url a little cleaner, that's why we are comparing to the default category in the condition above.

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -14,9 +14,6 @@ export interface SitesDashboardContextInterface {
 	dataViewsState: DataViewsState;
 	setDataViewsState: React.Dispatch< React.SetStateAction< DataViewsState > >;
 
-	hideListing?: boolean;
-	setHideListing: ( hideListing: boolean ) => void;
-
 	showOnlyFavorites?: boolean;
 	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
 

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -17,7 +17,6 @@ export interface SitesDashboardContextInterface {
 	showOnlyFavorites?: boolean;
 	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
 
-	initialSelectedSiteUrl?: string;
 	path: string;
 	currentPage: number;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
