### PR TITLE
gt-e2e: always click close after inserting block on mobile

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -39,16 +39,7 @@ export class EditorSidebarBlockInserterComponent {
 		}
 
 		const editorParent = await this.editor.parent();
-		const blockInserterPanelLocator = editorParent.locator( selectors.closeBlockInserterButton );
-
-		try {
-			// The panel is expected to auto-close. Let's possibly wait for that
-			// detach event
-			await blockInserterPanelLocator.waitFor( { state: 'detached' } );
-		} catch {
-			// If not auto-closed, trigger a close
-			await blockInserterPanelLocator.click();
-		}
+		await editorParent.locator( selectors.closeBlockInserterButton ).click();
 
 		await this.page.locator( sidebarParentSelector ).waitFor( { state: 'detached' } );
 	}


### PR DESCRIPTION
For mobile viewports we are always waiting for the block inserter to automatically close before we click on the close icon.
Since we need to explicitly close the block inserter after adding a block, this check adds a lot of extra execution time to our e2e tests.

Related to #
https://github.com/Automattic/wp-calypso/issues/92945

## Proposed Changes

* Avoid waiting to the inserter to automatically close

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid unnecessary waiting in our e2e tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
`$VIEWPORT_NAME="mobile"  TEST_ON_ATOMIC="true" GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test --group=gutenberg --maxWorkers=1 --workerIdleMemoryLimit=1GB`
*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
