### PR TITLE
A4A: Use 'Free' word for products with zero prices in marketplace

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/multi-product-card/index.tsx
@@ -14,9 +14,9 @@ import getProductShortTitle from 'calypso/jetpack-cloud/sections/partner-portal/
 import getProductVariantShortTitle from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-product-variant-short-title';
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
 import LicenseLightboxLink from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox-link';
-import ProductPriceWithDiscount from 'calypso/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import ProductPriceWithDiscount from '../product-card/product-price-with-discount-info';
 
 import '../product-card/style.scss';
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/index.tsx
@@ -12,9 +12,9 @@ import { LICENSE_INFO_MODAL_ID } from 'calypso/jetpack-cloud/sections/partner-po
 import getProductShortTitle from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-product-short-title';
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
 import LicenseLightboxLink from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox-link';
-import ProductPriceWithDiscount from 'calypso/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from '../../../../../state/partner-portal/types';
+import ProductPriceWithDiscount from './product-price-with-discount-info';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
@@ -1,10 +1,11 @@
 import formatCurrency from '@automattic/format-currency';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { getProductPricingInfo } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
 import { useSelector } from 'calypso/state';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-import { getProductsList } from 'calypso/state/products-list/selectors';
+import { isProductsListFetching, getProductsList } from 'calypso/state/products-list/selectors';
 
 import './style.scss';
 
@@ -24,6 +25,7 @@ export default function ProductPriceWithDiscount( {
 	const translate = useTranslate();
 
 	const userProducts = useSelector( getProductsList );
+	const isFetching = useSelector( isProductsListFetching );
 	const isDailyPricing = product.price_interval === 'day';
 
 	const isBundle = quantity > 1;
@@ -39,7 +41,11 @@ export default function ProductPriceWithDiscount( {
 	if ( isFree ) {
 		return (
 			<div className={ clsx( 'product-price-with-discount__price', { 'is-compact': compact } ) }>
-				<p className="product-price-with-discount__free">{ translate( 'Free' ) }</p>
+				{ isFetching ? (
+					<TextPlaceholder />
+				) : (
+					<p className="product-price-with-discount__free">{ translate( 'Free' ) }</p>
+				) }
 			</div>
 		);
 	}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/index.tsx
@@ -1,0 +1,90 @@
+import formatCurrency from '@automattic/format-currency';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { getProductPricingInfo } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing';
+import { useSelector } from 'calypso/state';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { getProductsList } from 'calypso/state/products-list/selectors';
+
+import './style.scss';
+
+interface Props {
+	product: APIProductFamilyProduct;
+	hideDiscount?: boolean;
+	quantity?: number;
+	compact?: boolean;
+}
+
+export default function ProductPriceWithDiscount( {
+	product,
+	hideDiscount,
+	quantity = 1,
+	compact,
+}: Props ) {
+	const translate = useTranslate();
+
+	const userProducts = useSelector( getProductsList );
+	const isDailyPricing = product.price_interval === 'day';
+
+	const isBundle = quantity > 1;
+
+	const { actualCost, discountedCost, discountPercentage } = getProductPricingInfo(
+		userProducts,
+		product,
+		quantity
+	);
+
+	const isFree = actualCost === 0;
+
+	if ( isFree ) {
+		return (
+			<div className={ clsx( 'product-price-with-discount__price', { 'is-compact': compact } ) }>
+				<p className="product-price-with-discount__free">{ translate( 'Free' ) }</p>
+			</div>
+		);
+	}
+
+	return (
+		<div>
+			<div className={ clsx( 'product-price-with-discount__price', { 'is-compact': compact } ) }>
+				{ formatCurrency( discountedCost, product.currency ) }
+				{
+					// Display discount info only if there is a discount
+					discountPercentage > 0 && ! hideDiscount && (
+						<>
+							{ compact && (
+								<span className="product-price-with-discount__price-old">
+									{ formatCurrency( actualCost, product.currency ) }
+								</span>
+							) }
+
+							<span className="product-price-with-discount__price-discount">
+								{ translate( 'Save %(discountPercentage)s%%', {
+									args: {
+										discountPercentage,
+									},
+								} ) }
+							</span>
+
+							{ ! compact && (
+								<div>
+									<span className="product-price-with-discount__price-old">
+										{ formatCurrency( actualCost, product.currency ) }
+									</span>
+								</div>
+							) }
+						</>
+					)
+				}
+			</div>
+			<div className="product-price-with-discount__price-interval">
+				{ isDailyPricing &&
+					( isBundle ? translate( 'per bundle per day' ) : translate( 'per license per day' ) ) }
+				{ product.price_interval === 'month' &&
+					( isBundle
+						? translate( 'per bundle per month' )
+						: translate( 'per license per month' ) ) }
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/style.scss
@@ -7,6 +7,10 @@
 	color: var(--studio-gray-80);
 	line-height: 1;
 
+	.a4a-text-placeholder {
+		width: 5rem;
+	}
+
 	.product-price-with-discount__price-old {
 		text-decoration: line-through;
 		font-weight: 400;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/style.scss
@@ -19,7 +19,7 @@
 	}
 
 	.product-price-with-discount__free {
-		margin-block-end: 1rem;
+		margin-block-end: 1.5rem;
 		font-size: 1.5rem;
 		font-weight: 700;
 		color: var(--studio-black);

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-card/product-price-with-discount-info/style.scss
@@ -1,0 +1,48 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.product-price-with-discount__price {
+	font-size: 1.25rem;
+	font-weight: 600;
+	color: var(--studio-gray-80);
+	line-height: 1;
+
+	.product-price-with-discount__price-old {
+		text-decoration: line-through;
+		font-weight: 400;
+		font-size: 1rem;
+		text-wrap: nowrap;
+	}
+
+	.product-price-with-discount__free {
+		margin-block-end: 1rem;
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: var(--studio-black);
+	}
+
+	.product-price-with-discount__price-discount {
+		margin-inline-start: 8px;
+		font-size: 1rem;
+		font-weight: 500;
+		color: var(--color-link);
+		text-wrap: nowrap;
+	}
+
+	@include break-xlarge {
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: var(--studio-black);
+	}
+}
+
+.product-price-with-discount__price-interval {
+	font-size: 0.75rem;
+	font-weight: 400;
+	color: var(--studio-gray-60);
+	line-height: 2;
+}
+
+.product-price-with-discount__price.is-compact .product-price-with-discount__price-old {
+	margin-inline-start: 8px;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/555

## Proposed Changes

For better user experience we want to replace $0.00 prices in our marketplace with 'Free` word. 

This PR moves the related (`ProductPriceWithDiscount`) code into a4a codebase. Checks wether the price is 0, and, if it is displays only 'Free' word.

| Before | After |
| ---- | ---- |
| <img width="475" alt="Screenshot 2024-08-02 at 11 21 22 AM" src="https://github.com/user-attachments/assets/a095b2be-d52d-46b6-8e69-5bf84b43ef2f"> | <img width="478" alt="Screenshot 2024-08-02 at 11 21 15 AM" src="https://github.com/user-attachments/assets/03f0ff72-4289-4408-9010-262f823097ac"> |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link navigate to `/marketplace/products` and check prices.
- Particularly: WooCommerce Shipping, WooCommerce Accommodations bookings, WooCommerce Tax, WooPayments should state 'Free'

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
