### PR TITLE
[Odie] Force navigation for non elegible users to forums

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -132,8 +132,12 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const setOdieStorage = useSetOdieStorage( 'chat_id' );
 
 	const navigateToContactOptions = useCallback( () => {
-		navigate( '/contact-options' );
-	}, [ navigate ] );
+		if ( isUserElegible ) {
+			navigate( '/contact-options' );
+		} else {
+			navigate( '/contact-form?mode=FORUM' );
+		}
+	}, [ navigate, isUserElegible ] );
 
 	return (
 		<CardBody ref={ containerRef } className="help-center__container-content">


### PR DESCRIPTION
Related to #

## Proposed Changes

If user is not elegible for requesting HE's support it will be redirected to forums.

## Why are these changes being made?
Providing better free user flows.

## Testing Instructions

Same as https://github.com/Automattic/wp-calypso/pull/93212