### PR TITLE
feat(hosting-overview-refinements): render WP and PHP versions on Hosting-Overview page

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -60,7 +60,7 @@ export default function ItemPreviewPaneHeader( {
 	};
 
 	const handleWpVersionClick = () => {
-		page( `/hosting-config/${ selectedSite?.domain }#php` );
+		page( `/hosting-config/${ selectedSite?.domain }#wp` );
 	};
 
 	return (

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -117,7 +117,7 @@ export default function ItemPreviewPaneHeader( {
 												WordPress{ ' ' }
 												<Button
 													className="item-preview__header-env-data-item-link"
-													onClick={ handlePhpVersionClick }
+													onClick={ handleWpVersionClick }
 												>
 													{ wpVersion }
 												</Button>
@@ -128,7 +128,7 @@ export default function ItemPreviewPaneHeader( {
 												PHP{ ' ' }
 												<Button
 													className="item-preview__header-env-data-item-link"
-													onClick={ handleWpVersionClick }
+													onClick={ handlePhpVersionClick }
 												>
 													{ phpVersion }
 												</Button>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -1,3 +1,5 @@
+import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
@@ -5,6 +7,11 @@ import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
+import QuerySitePhpVersion from 'calypso/components/data/query-site-php-version';
+import { useSelector } from 'calypso/state';
+import { getAtomicHostingPhpVersion } from 'calypso/state/selectors/get-atomic-hosting-php-version';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import SiteFavicon from '../../site-favicon';
 import { ItemData, ItemPreviewPaneHeaderExtraProps } from '../types';
 
@@ -30,6 +37,11 @@ export default function ItemPreviewPaneHeader( {
 }: Props ) {
 	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
 	const size = isLargerThan960px ? 64 : 50;
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = selectedSite?.ID || 0;
+	const phpVersion = useSelector( ( state ) => getAtomicHostingPhpVersion( state, siteId ) );
+	const wpVersion = selectedSite?.options?.software_version;
+	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
 
 	const focusRef = useRef< HTMLButtonElement >( null );
 
@@ -43,73 +55,111 @@ export default function ItemPreviewPaneHeader( {
 	const siteIconFallback =
 		extraProps?.siteIconFallback ?? ( itemData.isDotcomSite ? 'wordpress-logo' : 'color' );
 
-	return (
-		<div className={ clsx( 'item-preview__header', className ) }>
-			<div className="item-preview__header-content">
-				{ !! itemData?.withIcon && (
-					<SiteFavicon
-						blogId={ itemData.blogId }
-						fallback={ siteIconFallback }
-						color={ itemData.color }
-						className="item-preview__header-favicon"
-						size={ size }
-					/>
-				) }
-				<div className="item-preview__header-info">
-					<div className="item-preview__header-title-summary">
-						<div className="item-preview__header-title">{ itemData.title }</div>
-						<div className="item-preview__header-summary">
-							{ itemData?.url ? (
-								<Button
-									variant="link"
-									className="item-preview__header-summary-link"
-									href={ itemData.url }
-									target="_blank"
-								>
-									<span>
-										{ itemData.subtitle }
-										<Icon
-											className="sidebar-v2__external-icon"
-											icon={ external }
-											size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
-										/>
-									</span>
-								</Button>
-							) : (
-								itemData.subtitle
-							) }
+	const handlePhpVersionClick = () => {
+		page( `/hosting-config/${ selectedSite?.domain }#php` );
+	};
 
-							{ extraProps && extraProps.subtitleExtra ? (
-								<span>
-									<extraProps.subtitleExtra />
-								</span>
-							) : (
-								''
-							) }
-						</div>
-					</div>
-					{ isPreviewLoaded && (
-						<div className="item-preview__header-actions">
-							{ extraProps?.headerButtons ? (
-								<extraProps.headerButtons
-									focusRef={ focusRef }
-									itemData={ itemData }
-									closeSitePreviewPane={ closeItemPreviewPane || ( () => {} ) }
-								/>
-							) : (
-								<Button
-									onClick={ closeItemPreviewPane }
-									className="item-preview__close-preview"
-									aria-label={ translate( 'Close Preview' ) }
-									ref={ focusRef }
-								>
-									<Gridicon icon="cross" size={ ICON_SIZE_REGULAR } />
-								</Button>
-							) }
-						</div>
+	const handleWpVersionClick = () => {
+		page( `/hosting-config/${ selectedSite?.domain }#php` );
+	};
+
+	return (
+		<>
+			{ isAtomic && <QuerySitePhpVersion siteId={ siteId } /> }
+			<div className={ clsx( 'item-preview__header', className ) }>
+				<div className="item-preview__header-content">
+					{ !! itemData?.withIcon && (
+						<SiteFavicon
+							blogId={ itemData.blogId }
+							fallback={ siteIconFallback }
+							color={ itemData.color }
+							className="item-preview__header-favicon"
+							size={ size }
+						/>
 					) }
+					<div className="item-preview__header-info">
+						<div className="item-preview__header-title-summary">
+							<div className="item-preview__header-title">{ itemData.title }</div>
+							<div className="item-preview__header-summary">
+								{ itemData?.url ? (
+									<Button
+										variant="link"
+										className="item-preview__header-summary-link"
+										href={ itemData.url }
+										target="_blank"
+									>
+										<span>
+											{ itemData.subtitle }
+											<Icon
+												className="sidebar-v2__external-icon"
+												icon={ external }
+												size={ extraProps?.externalIconSize || ICON_SIZE_SMALL }
+											/>
+										</span>
+									</Button>
+								) : (
+									itemData.subtitle
+								) }
+
+								{ extraProps && extraProps.subtitleExtra ? (
+									<span>
+										<extraProps.subtitleExtra />
+									</span>
+								) : (
+									''
+								) }
+							</div>
+							{ config.isEnabled( 'hosting-overview-refinements' ) &&
+								( wpVersion || phpVersion ) && (
+									<div className="item-preview__header-env-data">
+										{ wpVersion && (
+											<div className="item-preview__header-env-data-item">
+												WordPress{ ' ' }
+												<Button
+													className="item-preview__header-env-data-item-link"
+													onClick={ handlePhpVersionClick }
+												>
+													{ wpVersion }
+												</Button>
+											</div>
+										) }
+										{ phpVersion && (
+											<div className="item-preview__header-env-data-item">
+												PHP{ ' ' }
+												<Button
+													className="item-preview__header-env-data-item-link"
+													onClick={ handleWpVersionClick }
+												>
+													{ phpVersion }
+												</Button>
+											</div>
+										) }
+									</div>
+								) }
+						</div>
+						{ isPreviewLoaded && (
+							<div className="item-preview__header-actions">
+								{ extraProps?.headerButtons ? (
+									<extraProps.headerButtons
+										focusRef={ focusRef }
+										itemData={ itemData }
+										closeSitePreviewPane={ closeItemPreviewPane || ( () => {} ) }
+									/>
+								) : (
+									<Button
+										onClick={ closeItemPreviewPane }
+										className="item-preview__close-preview"
+										aria-label={ translate( 'Close Preview' ) }
+										ref={ focusRef }
+									>
+										<Gridicon icon="cross" size={ ICON_SIZE_REGULAR } />
+									</Button>
+								) }
+							</div>
+						) }
+					</div>
 				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -115,12 +115,16 @@ export default function ItemPreviewPaneHeader( {
 										{ wpVersion && (
 											<div className="item-preview__header-env-data-item">
 												WordPress{ ' ' }
-												<Button
-													className="item-preview__header-env-data-item-link"
-													onClick={ handleWpVersionClick }
-												>
-													{ wpVersion }
-												</Button>
+												{ isAtomic ? (
+													<Button
+														className="item-preview__header-env-data-item-link"
+														onClick={ handleWpVersionClick }
+													>
+														{ wpVersion }
+													</Button>
+												) : (
+													wpVersion
+												) }
 											</div>
 										) }
 										{ phpVersion && (

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -21,7 +21,7 @@ $blueberry-color: #3858e9;
 			}
 
 			.item-preview__header-env-data {
-				padding-top: 8px;
+				padding-top: 6px;
 				display: flex;
 				gap: 16px;
 				font-family: $font-sf-pro-text;
@@ -32,6 +32,7 @@ $blueberry-color: #3858e9;
 				.item-preview__header-env-data-item-link {
 					color: $blueberry-color;
 					padding: 0;
+					height: auto;
 				}
 			}
 		}
@@ -66,7 +67,7 @@ $blueberry-color: #3858e9;
 				.item-preview__header-title {
 					@include a4a-font-heading-xxl;
 					color: var(--color-text-black);
-					margin-bottom: 4px;
+					padding: 4px 0;
 				}
 
 				.item-preview__header-summary {
@@ -115,7 +116,7 @@ $blueberry-color: #3858e9;
 				.item-preview__header-title {
 					@include a4a-font-heading-md;
 					color: var(--color-text-black);
-					margin-bottom: 4px;
+					padding: 6px 0 4px 0;
 				}
 
 				.item-preview__header-summary {

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -1,4 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "@automattic/components/src/styles/typography.scss";
+
+$blueberry-color: #3858e9;
 
 .item-preview__header {
 
@@ -15,6 +18,21 @@
 
 			.item-preview__header-summary-link svg {
 				vertical-align: middle;
+			}
+
+			.item-preview__header-env-data {
+				padding-top: 8px;
+				display: flex;
+				gap: 16px;
+				font-family: $font-sf-pro-text;
+				font-size: rem(14px);
+				color: #101517;
+				letter-spacing: -0.15px;
+
+				.item-preview__header-env-data-item-link {
+					color: $blueberry-color;
+					padding: 0;
+				}
 			}
 		}
 
@@ -38,7 +56,7 @@
 		.item-preview__header-content {
 			padding: 48px 48px 24px 48px;
 			display: flex;
-			align-items: center;
+			align-items: top;
 
 			.item-preview__header-title-summary {
 				flex-grow: 1;

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -31,6 +31,7 @@ $blueberry-color: #3858e9;
 
 				.item-preview__header-env-data-item-link {
 					color: $blueberry-color;
+					font-size: inherit;
 					padding: 0;
 					height: auto;
 				}

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -4,6 +4,7 @@ import {
 	WPCOM_FEATURES_ATOMIC,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { useEffect } from '@wordpress/element';
 import { localize } from 'i18n-calypso';
 import { Fragment, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
@@ -137,6 +138,30 @@ const Hosting = ( props ) => {
 		isSiteAtomic,
 		transferState,
 	} = props;
+
+	useEffect( () => {
+		if ( [ '#php', '#wp' ].includes( window.location.hash ) ) {
+			let count = 0;
+			const interval = setInterval( () => {
+				let targetElement;
+				if ( window.location.hash === '#php' ) {
+					targetElement = document.querySelector( '[data-scroll-id="php-version-select"]' );
+				} else if ( window.location.hash === '#wp' ) {
+					targetElement = document.querySelector( '[data-scroll-id="wp-version-select"]' );
+				}
+
+				if ( targetElement ) {
+					targetElement.scrollIntoView( { behavior: 'smooth' } );
+					clearInterval( interval );
+				}
+
+				count++;
+				if ( count > 10 ) {
+					clearInterval( interval );
+				}
+			}, 500 );
+		}
+	}, [] );
 
 	const [ isTrialAcknowledgeModalOpen, setIsTrialAcknowledgeModalOpen ] = useState( false );
 	const [ hasTransfer, setHasTransferring ] = useState(

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -103,7 +103,9 @@ const WebServerSettingsCard = ( {
 
 		return (
 			<FormFieldset>
-				<FormLabel>{ translate( 'WordPress version' ) }</FormLabel>
+				<FormLabel data-scroll-id="wp-version-select">
+					{ translate( 'WordPress version' ) }
+				</FormLabel>
 				{ isWpcomStagingSite && (
 					<>
 						<FormSelect
@@ -202,7 +204,7 @@ const WebServerSettingsCard = ( {
 			selectedPhpVersion || phpVersion || ( disabled && recommendedValue );
 		return (
 			<FormFieldset>
-				<FormLabel>{ translate( 'PHP version' ) }</FormLabel>
+				<FormLabel data-scroll-id="php-version-select">{ translate( 'PHP version' ) }</FormLabel>
 				<FormSelect
 					disabled={ disabled || isUpdatingPhpVersion }
 					className="web-server-settings-card__php-version-select"


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8448


## Why are these changes being made?
We are rendering PHP and WP versions of a site on hosting-overview page, according to the design: R8yjT7mjG0Uw8h2GPyIY6R-fi-4041_65153

## Testing Instructions
1) Purchase Atomic website
2) Open `/sites`
3) Select the website (You should be landed on hosting overview page)
4) Assert that you see PHP and WP version: <br/><img width="604" alt="Screenshot 2024-08-02 at 19 42 49" src="https://github.com/user-attachments/assets/073f953f-ea4f-4878-acf1-caf976eb4a54">
5) Click on the number of WP version
6) Assert that you are landed on `Server Settings` and the page is auto-scrolled to the bottom (you should see "WordPress version" section)
7) Click on Overview tab
8) And this time click on the number of PHP version
9) Assert that you are landed on `Server Settings` and the page is auto-scrolled to the bottom (you should see "PHP version" section)
10) Assert that mobile version looks good and works also well
11) As a separate test case - assert that Simple websites don't have PHP and WP versions 
12) Optionally - assert that Staging websites work the same way as Atomic
