### PR TITLE
Adds a new variable to the promote post widget

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -53,6 +53,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	const previousRoute = useSelector( getPreviousRoute );
 	const selectedSite = useSelector( getSelectedSite );
 	const jetpackVersion = selectedSite?.options?.jetpack_version;
+	const blazeAdsVersion = selectedSite?.options?.blaze_ads_version;
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, selectedSite?.ID ) );
 	const { closeModal } = useRouteModal( 'blazepress-widget', keyValue );
 	const queryClient = useQueryClient();
@@ -120,6 +121,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 						handleShowTopBar,
 						localeSlug,
 						jetpackVersion,
+						blazeAdsVersion,
 						dispatch,
 						dspOriginProps
 					);

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -68,6 +68,7 @@ declare global {
 					headerNonce: string;
 				};
 				jetpackVersion?: string;
+				blazeAdsVersion?: string;
 				hotjarSiteSettings?: object;
 				recordDSPEvent?: ( name: string, props?: any ) => void;
 				options?: object;
@@ -156,6 +157,7 @@ export async function showDSP(
 	setShowTopBar?: ( show: boolean ) => void,
 	locale?: string,
 	jetpackVersion?: string,
+	blazeAdsVersion?: string,
 	dispatch?: Dispatch,
 	dspOriginProps?: DSPOriginProps
 ): Promise< boolean > {
@@ -215,6 +217,7 @@ export async function showDSP(
 					  }
 					: undefined,
 				jetpackVersion,
+				blazeAdsVersion,
 				hotjarSiteSettings: { ...getHotjarSiteSettings(), isEnabled: mayWeLoadHotJarScript() },
 				recordDSPEvent: dispatch ? getRecordDSPEventHandler( dispatch, dspOriginProps ) : undefined,
 				options: getWidgetOptions(),

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -292,6 +292,7 @@ export interface SiteDetailsOptions {
 	wpcom_production_blog_id?: number;
 	wpcom_staging_blog_ids?: number[];
 	can_blaze?: boolean;
+	blaze_ads_version?: string;
 	is_commercial?: boolean | null;
 	is_commercial_reasons?: string[];
 	wpcom_admin_interface?: string;


### PR DESCRIPTION
## Proposed Changes

* We are sending a new variable to the Promote Post widget, that will hold the Blaze Ads plugin version. 

## Why are these changes being made?

* We need this new version variable to be able to correctly segment features in the DSP API. We won't have the jetpack version if the self-hosted site is not running jetpack.

## Testing Instructions

Until we have the changes of the Blaze plugin and the DSP Widget, we won't be able to fully test this change. We can check that all works fine.

* Open the live preview
* Go to Tools->Advertising
* Click on the Promote Button
* Verify that the Promote post widget is loaded correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
