### PR TITLE
Paid Impoter: connect stripe add notices

### DIFF
--- a/client/my-sites/importer/newsletter/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/connect-stripe.tsx
@@ -2,7 +2,6 @@ import { Card } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import StripeLogo from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
-import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getConnectUrlForSiteId } from 'calypso/state/memberships/settings/selectors';
@@ -42,9 +41,6 @@ export default function ConnectStripe( { nextStepUrl, fromSite }: Props ) {
 
 	return (
 		<Card>
-			{ site?.ID && (
-				<QueryMembershipsSettings siteId={ site.ID } source="import-paid-subscribers" />
-			) }
 			<h2>Finish importing paid subscribers</h2>
 			<p>
 				To your migrate <strong>17 paid subscribers</strong> to WordPress.com, make sure you're

--- a/client/my-sites/importer/newsletter/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/map-plans.tsx
@@ -1,0 +1,24 @@
+import { Card } from '@automattic/components';
+import { Button } from '@wordpress/components';
+
+type Props = {
+	nextStepUrl: string;
+};
+
+export default function MapPlans( { nextStepUrl }: Props ) {
+	return (
+		<Card>
+			<h2>Paid newsletter offering</h2>
+			<p>
+				<strong>
+					Review the plans retieved from Stripe and create euqivalent plans in WordPress.com
+				</strong>{ ' ' }
+				to prevent disruption to your current paid subscribers.
+			</p>
+			<Button variant="primary">Continue</Button>{ ' ' }
+			<Button variant="secondary" href={ nextStepUrl }>
+				Skip for now
+			</Button>
+		</Card>
+	);
+}

--- a/client/my-sites/importer/newsletter/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/map-plans.tsx
@@ -3,6 +3,7 @@ import { Button } from '@wordpress/components';
 
 type Props = {
 	nextStepUrl: string;
+	fromSite: string;
 };
 
 export default function MapPlans( { nextStepUrl }: Props ) {

--- a/client/my-sites/importer/newsletter/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/map-plans.tsx
@@ -3,7 +3,6 @@ import { Button } from '@wordpress/components';
 
 type Props = {
 	nextStepUrl: string;
-	fromSite: string;
 };
 
 export default function MapPlans( { nextStepUrl }: Props ) {

--- a/client/my-sites/importer/newsletter/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers.tsx
@@ -40,7 +40,7 @@ export default function PaidSubscribers( { nextStepUrl, fromSite }: Props ) {
 			{ ! hasConnectedAccount && (
 				<ConnectStripe nextStepUrl={ nextStepUrl } fromSite={ fromSite } />
 			) }
-			{ hasConnectedAccount && <MapPlans nextStepUrl={ nextStepUrl } fromSite={ fromSite } /> }
+			{ hasConnectedAccount && <MapPlans nextStepUrl={ nextStepUrl } /> }
 		</>
 	);
 }


### PR DESCRIPTION
This is a follow up PR to https://github.com/Automattic/wp-calypso/pull/93198

Related to https://github.com/Automattic/wp-calypso/issues/93154 


## Proposed Changes
This PR refactors some of the code unify it a bit as well as adds notices that show up after we connect stripe or the flow has been cancedl. 

Create a new MapPlans component that gets rendered after the user is connected. 

The new notices: 
<img width="400" alt="Screenshot 2024-08-02 at 12 22 48 PM" src="https://github.com/user-attachments/assets/21d06a39-4b67-494e-bf2d-ce77a811991d">
<img width="400" alt="Screenshot 2024-08-02 at 12 22 37 PM" src="https://github.com/user-attachments/assets/0bc62af1-8e95-41a1-97bc-642bc3c0bf4e">


* See notice 

## Why are these changes being made?

* So that we show the user that they have successfully connected the 

## Testing Instructions

Visit the following URLs. ( Which would be generated by the stripe redirect )
/import/newsletter/substack/example.com/paid-subscribers?from=example.com&stripe_connect_cancelled=1

and 
/import/newsletter/substack/example.com/paid-subscribers?from=example.com&stripe_connect_success=1

You should see the notification as expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
