### PR TITLE
Overview: Add SSL cert column to domain list

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -203,7 +203,7 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						margin-inline: 26px;
 					}
 					table {
-						grid-template-columns: 75px 2fr 1fr 1fr auto auto auto auto;
+						grid-template-columns: 75px 2fr 1fr 1fr 1fr auto auto auto auto;
 
 						th:last-child,
 						td:last-child {

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -6,6 +6,7 @@ import { Icon, info } from '@wordpress/icons';
 import { removeQueryArgs } from '@wordpress/url';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import useUrlQueryParam from 'calypso/a8c-for-agencies/hooks/use-url-query-param';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Accordion from 'calypso/components/domains/accordion';
 import {
@@ -98,6 +99,7 @@ const Settings = ( {
 	const contactInformation = findRegistrantWhois( whoisData );
 
 	const queryParams = new URLSearchParams( window.location.search );
+	const shouldOpenSsl = useUrlQueryParam( 'ssl-open' );
 
 	useEffect( () => {
 		if ( ! contactInformation ) {
@@ -164,6 +166,7 @@ const Settings = ( {
 				subtitle={ getSslReadableStatus( domain ) }
 				key="security"
 				isDisabled={ domain.isMoveToNewSitePending }
+				expanded={ !! shouldOpenSsl }
 			>
 				<DomainSecurityDetails
 					domain={ domain }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -6,7 +6,6 @@ import { Icon, info } from '@wordpress/icons';
 import { removeQueryArgs } from '@wordpress/url';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import useUrlQueryParam from 'calypso/a8c-for-agencies/hooks/use-url-query-param';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Accordion from 'calypso/components/domains/accordion';
 import {
@@ -99,7 +98,6 @@ const Settings = ( {
 	const contactInformation = findRegistrantWhois( whoisData );
 
 	const queryParams = new URLSearchParams( window.location.search );
-	const shouldOpenSsl = useUrlQueryParam( 'ssl-open' );
 
 	useEffect( () => {
 		if ( ! contactInformation ) {
@@ -166,7 +164,7 @@ const Settings = ( {
 				subtitle={ getSslReadableStatus( domain ) }
 				key="security"
 				isDisabled={ domain.isMoveToNewSitePending }
-				expanded={ !! shouldOpenSsl }
+				expanded={ queryParams.get( 'ssl-open' ) === 'true' }
 			>
 				<DomainSecurityDetails
 					domain={ domain }

--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -75,7 +75,7 @@ export interface DomainData {
 	};
 	pending_whois_update: boolean;
 	tld_maintenance_end_time: 0;
-	ssl_status: 'active' | 'pending' | 'disabled' | null;
+	ssl_status: 'active' | 'pending' | 'newly_registered' | 'disabled' | null;
 	gdpr_consent_status: string;
 	supports_gdpr_consent_management: boolean;
 	supports_transfer_approval: boolean;

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -111,6 +111,13 @@ export const siteSpecificViewColumns = (
 		isSortable: false,
 	},
 	{
+		name: 'ssl',
+		label: __( 'SSL', __i18n_text_domain__ ),
+		isSortable: true,
+		initialSortDirection: 'asc',
+		supportsOrderSwitching: true,
+	},
+	{
 		name: 'expire_renew',
 		label: __( 'Expires / renews on', __i18n_text_domain__ ),
 		isSortable: true,

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -63,6 +63,7 @@ export const allSitesViewColumns = (
 		isSortable: true,
 		initialSortDirection: 'asc',
 		supportsOrderSwitching: true,
+		sortFunctions: [ getSimpleSortFunctionBy( 'ssl_status' ) ],
 	},
 	{
 		name: 'expire_renew',
@@ -123,6 +124,7 @@ export const siteSpecificViewColumns = (
 		isSortable: true,
 		initialSortDirection: 'asc',
 		supportsOrderSwitching: true,
+		sortFunctions: [ getSimpleSortFunctionBy( 'ssl_status' ) ],
 	},
 	{
 		name: 'expire_renew',

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { DomainData, PartialDomainData } from '@automattic/data-stores';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { I18N } from 'i18n-calypso';
@@ -31,127 +32,141 @@ const domainLabel = ( count: number, isBulkSelection: boolean, showCount: boolea
 export const allSitesViewColumns = (
 	translate: I18N[ 'translate' ],
 	domainStatusPurchaseActions?: DomainStatusPurchaseActions
-): DomainsTableColumn[] => [
-	{
-		name: 'domain',
-		label: domainLabel,
-		sortLabel: __( 'Domain', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'asc',
-		supportsOrderSwitching: true,
-		sortFunctions: [ getSimpleSortFunctionBy( 'domain' ) ],
-	},
-	{
-		name: 'owner',
-		label: __( 'Owner', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'asc',
-		supportsOrderSwitching: true,
-		sortFunctions: [ getSimpleSortFunctionBy( 'owner' ) ],
-	},
-	{
-		name: 'site',
-		label: __( 'Site', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'asc',
-		supportsOrderSwitching: true,
-		sortFunctions: [ getSimpleSortFunctionBy( 'blog_name' ) ],
-	},
-	{
-		name: 'ssl',
-		label: __( 'SSL', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'asc',
-		supportsOrderSwitching: true,
-		sortFunctions: [ getSimpleSortFunctionBy( 'ssl_status' ) ],
-	},
-	{
-		name: 'expire_renew',
-		label: __( 'Expires / renews on', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'asc',
-		supportsOrderSwitching: true,
-		sortFunctions: [ getSimpleSortFunctionBy( 'expiry' ) ],
-	},
-	{
-		name: 'status',
-		label: __( 'Status', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'desc',
-		supportsOrderSwitching: true,
-		sortFunctions: getStatusSortFunctions( translate, domainStatusPurchaseActions ),
-	},
-	{
-		name: 'status_action',
-		label: null,
-		isSortable: false,
-	},
-	{
-		name: 'action',
-		label: __( 'Actions', __i18n_text_domain__ ),
-	},
-];
+): DomainsTableColumn[] => {
+	const columns: DomainsTableColumn[] = [
+		{
+			name: 'domain',
+			label: domainLabel,
+			sortLabel: __( 'Domain', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'asc',
+			supportsOrderSwitching: true,
+			sortFunctions: [ getSimpleSortFunctionBy( 'domain' ) ],
+		},
+		{
+			name: 'owner',
+			label: __( 'Owner', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'asc',
+			supportsOrderSwitching: true,
+			sortFunctions: [ getSimpleSortFunctionBy( 'owner' ) ],
+		},
+		{
+			name: 'site',
+			label: __( 'Site', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'asc',
+			supportsOrderSwitching: true,
+			sortFunctions: [ getSimpleSortFunctionBy( 'blog_name' ) ],
+		},
+		{
+			name: 'expire_renew',
+			label: __( 'Expires / renews on', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'asc',
+			supportsOrderSwitching: true,
+			sortFunctions: [ getSimpleSortFunctionBy( 'expiry' ) ],
+		},
+		{
+			name: 'status',
+			label: __( 'Status', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'desc',
+			supportsOrderSwitching: true,
+			sortFunctions: getStatusSortFunctions( translate, domainStatusPurchaseActions ),
+		},
+		{
+			name: 'status_action',
+			label: null,
+			isSortable: false,
+		},
+		{
+			name: 'action',
+			label: __( 'Actions', __i18n_text_domain__ ),
+		},
+	];
+
+	if ( config.isEnabled( 'hosting-overview-refinements' ) ) {
+		columns.splice( 3, 0, {
+			name: 'ssl',
+			label: __( 'SSL', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'asc',
+			supportsOrderSwitching: true,
+			sortFunctions: [ getSimpleSortFunctionBy( 'ssl_status' ) ],
+		} );
+	}
+
+	return columns;
+};
 
 export const siteSpecificViewColumns = (
 	translate: I18N[ 'translate' ],
 	domainStatusPurchaseActions?: DomainStatusPurchaseActions
-): DomainsTableColumn[] => [
-	{
-		name: 'domain',
-		label: domainLabel,
-		sortLabel: __( 'Domain', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'asc',
-		supportsOrderSwitching: true,
-		sortFunctions: [ getSimpleSortFunctionBy( 'domain' ) ],
-	},
-	{
-		name: 'owner',
-		label: __( 'Owner', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'asc',
-		supportsOrderSwitching: true,
-		sortFunctions: [ getSimpleSortFunctionBy( 'owner' ) ],
-	},
-	{
-		name: 'email',
-		label: __( 'Email', __i18n_text_domain__ ),
-		isSortable: false,
-	},
-	{
-		name: 'ssl',
-		label: __( 'SSL', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'asc',
-		supportsOrderSwitching: true,
-		sortFunctions: [ getSimpleSortFunctionBy( 'ssl_status' ) ],
-	},
-	{
-		name: 'expire_renew',
-		label: __( 'Expires / renews on', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'asc',
-		supportsOrderSwitching: true,
-		sortFunctions: [ getSimpleSortFunctionBy( 'expiry' ) ],
-	},
-	{
-		name: 'status',
-		label: __( 'Status', __i18n_text_domain__ ),
-		isSortable: true,
-		initialSortDirection: 'desc',
-		supportsOrderSwitching: true,
-		sortFunctions: getStatusSortFunctions( translate, domainStatusPurchaseActions ),
-	},
-	{
-		name: 'status_action',
-		label: null,
-		isSortable: false,
-	},
-	{
-		name: 'action',
-		label: __( 'Actions', __i18n_text_domain__ ),
-	},
-];
+): DomainsTableColumn[] => {
+	const columns: DomainsTableColumn[] = [
+		{
+			name: 'domain',
+			label: domainLabel,
+			sortLabel: __( 'Domain', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'asc',
+			supportsOrderSwitching: true,
+			sortFunctions: [ getSimpleSortFunctionBy( 'domain' ) ],
+		},
+		{
+			name: 'owner',
+			label: __( 'Owner', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'asc',
+			supportsOrderSwitching: true,
+			sortFunctions: [ getSimpleSortFunctionBy( 'owner' ) ],
+		},
+		{
+			name: 'email',
+			label: __( 'Email', __i18n_text_domain__ ),
+			isSortable: false,
+		},
+		{
+			name: 'expire_renew',
+			label: __( 'Expires / renews on', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'asc',
+			supportsOrderSwitching: true,
+			sortFunctions: [ getSimpleSortFunctionBy( 'expiry' ) ],
+		},
+		{
+			name: 'status',
+			label: __( 'Status', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'desc',
+			supportsOrderSwitching: true,
+			sortFunctions: getStatusSortFunctions( translate, domainStatusPurchaseActions ),
+		},
+		{
+			name: 'status_action',
+			label: null,
+			isSortable: false,
+		},
+		{
+			name: 'action',
+			label: __( 'Actions', __i18n_text_domain__ ),
+		},
+	];
+
+	if ( config.isEnabled( 'hosting-overview-refinements' ) ) {
+		columns.splice( 3, 0, {
+			name: 'ssl',
+			label: __( 'SSL', __i18n_text_domain__ ),
+			isSortable: true,
+			initialSortDirection: 'asc',
+			supportsOrderSwitching: true,
+			sortFunctions: [ getSimpleSortFunctionBy( 'ssl_status' ) ],
+		} );
+	}
+
+	return columns;
+};
 export const applyColumnSort = (
 	domains: PartialDomainData[],
 	domainData: Record< number, DomainData[] >,

--- a/packages/domains-table/src/domains-table-header/columns.ts
+++ b/packages/domains-table/src/domains-table-header/columns.ts
@@ -58,6 +58,13 @@ export const allSitesViewColumns = (
 		sortFunctions: [ getSimpleSortFunctionBy( 'blog_name' ) ],
 	},
 	{
+		name: 'ssl',
+		label: __( 'SSL', __i18n_text_domain__ ),
+		isSortable: true,
+		initialSortDirection: 'asc',
+		supportsOrderSwitching: true,
+	},
+	{
 		name: 'expire_renew',
 		label: __( 'Expires / renews on', __i18n_text_domain__ ),
 		isSortable: true,

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -437,14 +437,13 @@ describe( 'expires or renew on cell', () => {
 			has_registration: false,
 		} );
 
-		const { container } = render( <DomainsTableRow domain={ partialDomain } />, {
+		render( <DomainsTableRow domain={ partialDomain } />, {
 			domains: [ partialDomain ],
 			isAllSitesView: true,
 		} );
 
-		const renewNowCells = container.querySelectorAll( '.domains-table-row__renews-on-cell' );
-		expect( renewNowCells ).toHaveLength( 1 );
-		expect( renewNowCells[ 0 ] ).toHaveTextContent( '-' );
+		const expiresRenewsOnCell = screen.getByTestId( 'expires-renews-on' );
+		expect( expiresRenewsOnCell ).toHaveTextContent( '-' );
 	} );
 } );
 

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -437,12 +437,14 @@ describe( 'expires or renew on cell', () => {
 			has_registration: false,
 		} );
 
-		render( <DomainsTableRow domain={ partialDomain } />, {
+		const { container } = render( <DomainsTableRow domain={ partialDomain } />, {
 			domains: [ partialDomain ],
 			isAllSitesView: true,
 		} );
 
-		expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		const renewNowCells = container.querySelectorAll( '.domains-table-row__renews-on-cell' );
+		expect( renewNowCells ).toHaveLength( 1 );
+		expect( renewNowCells[ 0 ] ).toHaveTextContent( '-' );
 	} );
 } );
 

--- a/packages/domains-table/src/domains-table/domains-table-expires-renews-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-expires-renews-cell.tsx
@@ -65,7 +65,7 @@ export const DomainsTableExpiresRenewsOnCell = ( {
 	);
 
 	return (
-		<Element className="domains-table-row__renews-on-cell">
+		<Element data-testid="expires-renews-on" className="domains-table-row__renews-on-cell">
 			{ expiryDate ? (
 				<>
 					{ ! isCompact && (

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -15,6 +15,7 @@ import { DomainsTableExpiresRenewsOnCell } from './domains-table-expires-renews-
 import { DomainsTablePlaceholder } from './domains-table-placeholder';
 import { DomainsTableRowActions } from './domains-table-row-actions';
 import { DomainsTableSiteCell } from './domains-table-site-cell';
+import DomainsTableSSLCell from './domains-table-ssl-cell';
 import { DomainsTableStatusCell } from './domains-table-status-cell';
 import { DomainsTableStatusCTA } from './domains-table-status-cta';
 import type { MouseEvent } from 'react';
@@ -43,6 +44,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 		isAllSitesView,
 		domainStatus,
 		pendingUpdates,
+		sslStatus,
 	} = useDomainRow( domain );
 	const { canSelectAnyDomains, domainsTableColumns, isCompact } = useDomainsTable();
 
@@ -193,6 +195,14 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 					return (
 						<td key={ domain.domain + column.name }>
 							<DomainsTableEmailIndicator domain={ domain } siteSlug={ siteSlug } />
+						</td>
+					);
+				}
+
+				if ( column.name === 'ssl' ) {
+					return (
+						<td key={ domain.domain + column.name }>
+							<DomainsTableSSLCell sslStatus={ sslStatus } />
 						</td>
 					);
 				}

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
@@ -200,14 +199,13 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 					);
 				}
 
-				if ( column.name === 'ssl' && config.isEnabled( 'hosting-overview-refinements' ) ) {
+				if ( column.name === 'ssl' ) {
 					return (
-						<td key={ domain.domain + column.name }>
-							<DomainsTableSSLCell
-								domainManagementLink={ domainManagementLink }
-								sslStatus={ sslStatus }
-							/>
-						</td>
+						<DomainsTableSSLCell
+							key={ domain.domain + column.name }
+							domainManagementLink={ domainManagementLink }
+							sslStatus={ sslStatus }
+						/>
 					);
 				}
 

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { PartialDomainData } from '@automattic/data-stores';
 import { CheckboxControl } from '@wordpress/components';
@@ -199,7 +200,7 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 					);
 				}
 
-				if ( column.name === 'ssl' ) {
+				if ( column.name === 'ssl' && config.isEnabled( 'hosting-overview-refinements' ) ) {
 					return (
 						<td key={ domain.domain + column.name }>
 							<DomainsTableSSLCell

--- a/packages/domains-table/src/domains-table/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row.tsx
@@ -202,7 +202,10 @@ export function DomainsTableRow( { domain }: DomainsTableRowProps ) {
 				if ( column.name === 'ssl' ) {
 					return (
 						<td key={ domain.domain + column.name }>
-							<DomainsTableSSLCell sslStatus={ sslStatus } />
+							<DomainsTableSSLCell
+								domainManagementLink={ domainManagementLink }
+								sslStatus={ sslStatus }
+							/>
 						</td>
 					);
 				}

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '@wordpress/components';
+import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
 
 interface DomainsTableSSLCellProps {
@@ -13,6 +15,16 @@ export default function DomainsTableSSLCell( { sslStatus }: DomainsTableSSLCellP
 				[ 'domains-table-row__ssl-cell__disabled' ]: sslStatus === 'disabled',
 			} ) }
 		>
+			{ sslStatus && (
+				<Icon
+					className={ clsx( 'domains-table-row__ssl-icon', {
+						[ 'domains-table-row__ssl-icon__active' ]: sslStatus === 'active',
+						[ 'domains-table-row__ssl-icon__pending' ]: sslStatus === 'pending',
+						[ 'domains-table-row__ssl-icon__disabled' ]: sslStatus === 'disabled',
+					} ) }
+					icon={ lock }
+				/>
+			) }
 			{ sslStatus === null ? '-' : sslStatus.charAt( 0 ).toUpperCase() + sslStatus.slice( 1 ) }
 		</div>
 	);

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -1,8 +1,9 @@
 import { DomainData } from '@automattic/data-stores';
-import { Button, Icon } from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import type { MouseEvent } from 'react';
 
 interface DomainsTableSSLCellProps {
 	domainManagementLink: string;
@@ -27,11 +28,6 @@ export default function DomainsTableSSLCell( {
 		}
 	};
 
-	const handleClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
-		event.stopPropagation();
-		window.location.href = `${ domainManagementLink }?ssl-open=true`;
-	};
-
 	return (
 		<div className="domains-table-row__ssl-cell">
 			{ sslStatus && (
@@ -45,17 +41,17 @@ export default function DomainsTableSSLCell( {
 				/>
 			) }
 			{ sslStatus !== null ? (
-				<Button
+				<a
 					className={ clsx( 'domains-table-row__ssl-status-button', {
 						[ 'domains-table-row__ssl-status-button__active' ]: sslStatus === 'active',
 						[ 'domains-table-row__ssl-status-button__pending' ]: sslStatus === 'pending',
 						[ 'domains-table-row__ssl-status-button__disabled' ]: sslStatus === 'disabled',
 					} ) }
-					variant="link"
-					onClick={ handleClick }
+					href={ `${ domainManagementLink }?ssl-open=true` }
+					onClick={ ( e: MouseEvent ) => e.stopPropagation() }
 				>
 					{ getSSLStatusText() }
-				</Button>
+				</a>
 			) : (
 				<>-</>
 			) }

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -1,12 +1,28 @@
 import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 
 interface DomainsTableSSLCellProps {
 	sslStatus: 'active' | 'pending' | 'disabled' | null;
 }
 
 export default function DomainsTableSSLCell( { sslStatus }: DomainsTableSSLCellProps ) {
+	const translate = useTranslate();
+
+	const getSSLStatusText = () => {
+		if ( sslStatus === 'active' ) {
+			return translate( 'Active' );
+		}
+		if ( sslStatus === 'pending' ) {
+			return translate( 'Pending' );
+		}
+		if ( sslStatus === 'disabled' ) {
+			return translate( 'Disabled' );
+		}
+		return '-';
+	};
+
 	return (
 		<div
 			className={ clsx( 'domains-table-row__ssl-cell', {
@@ -25,7 +41,7 @@ export default function DomainsTableSSLCell( { sslStatus }: DomainsTableSSLCellP
 					icon={ lock }
 				/>
 			) }
-			{ sslStatus === null ? '-' : sslStatus.charAt( 0 ).toUpperCase() + sslStatus.slice( 1 ) }
+			{ getSSLStatusText() }
 		</div>
 	);
 }

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -46,9 +46,9 @@ export default function DomainsTableSSLCell( {
 			{ sslStatus !== null ? (
 				<Button
 					className={ clsx( 'domains-table-row__ssl-status-button', {
-						[ 'is-active' ]: sslStatus === 'active',
-						[ 'is-pending' ]: sslStatus === 'pending',
-						[ 'is-disabled' ]: sslStatus === 'disabled',
+						[ 'domains-table-row__ssl-status-button__active' ]: sslStatus === 'active',
+						[ 'domains-table-row__ssl-status-button__pending' ]: sslStatus === 'pending',
+						[ 'domains-table-row__ssl-status-button__disabled' ]: sslStatus === 'disabled',
 					} ) }
 					variant="link"
 					onClick={ handleClick }

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -15,15 +15,17 @@ export default function DomainsTableSSLCell( {
 }: DomainsTableSSLCellProps ) {
 	const translate = useTranslate();
 
+	const isPendingSSL = sslStatus === 'pending' || sslStatus === 'newly_registered';
+
 	const getSSLStatusText = () => {
 		if ( sslStatus === 'active' ) {
 			return translate( 'Active' );
 		}
-		if ( sslStatus === 'pending' ) {
+		if ( isPendingSSL ) {
 			return translate( 'Pending' );
 		}
 		if ( sslStatus === 'disabled' ) {
-			return translate( 'Error' );
+			return translate( 'Disabled' );
 		}
 	};
 
@@ -33,7 +35,7 @@ export default function DomainsTableSSLCell( {
 				<Icon
 					className={ clsx( 'domains-table-row__ssl-icon', {
 						[ 'domains-table-row__ssl-icon__active' ]: sslStatus === 'active',
-						[ 'domains-table-row__ssl-icon__pending' ]: sslStatus === 'pending',
+						[ 'domains-table-row__ssl-icon__pending' ]: isPendingSSL,
 						[ 'domains-table-row__ssl-icon__disabled' ]: sslStatus === 'disabled',
 					} ) }
 					icon={ lock }
@@ -44,7 +46,7 @@ export default function DomainsTableSSLCell( {
 				<a
 					className={ clsx( 'domains-table-row__ssl-status-button', {
 						[ 'domains-table-row__ssl-status-button__active' ]: sslStatus === 'active',
-						[ 'domains-table-row__ssl-status-button__pending' ]: sslStatus === 'pending',
+						[ 'domains-table-row__ssl-status-button__pending' ]: isPendingSSL,
 						[ 'domains-table-row__ssl-status-button__disabled' ]: sslStatus === 'disabled',
 					} ) }
 					href={ `${ domainManagementLink }?ssl-open=true` }

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -1,0 +1,19 @@
+import clsx from 'clsx';
+
+interface DomainsTableSSLCellProps {
+	sslStatus: 'active' | 'pending' | 'disabled' | null;
+}
+
+export default function DomainsTableSSLCell( { sslStatus }: DomainsTableSSLCellProps ) {
+	return (
+		<div
+			className={ clsx( 'domains-table-row__ssl-cell', {
+				[ 'domains-table-row__ssl-cell__active' ]: sslStatus === 'active',
+				[ 'domains-table-row__ssl-cell__pending' ]: sslStatus === 'pending',
+				[ 'domains-table-row__ssl-cell__disabled' ]: sslStatus === 'disabled',
+			} ) }
+		>
+			{ sslStatus === null ? '-' : sslStatus.charAt( 0 ).toUpperCase() + sslStatus.slice( 1 ) }
+		</div>
+	);
+}

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -3,7 +3,6 @@ import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import type { MouseEvent } from 'react';
 
 interface DomainsTableSSLCellProps {
 	domainManagementLink: string;
@@ -49,7 +48,7 @@ export default function DomainsTableSSLCell( {
 						[ 'domains-table-row__ssl-status-button__disabled' ]: sslStatus === 'disabled',
 					} ) }
 					href={ `${ domainManagementLink }?ssl-open=true` }
-					onClick={ ( e: MouseEvent ) => e.stopPropagation() }
+					onClick={ ( event ) => event.stopPropagation() }
 				>
 					{ getSSLStatusText() }
 				</a>

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -1,13 +1,17 @@
-import { Icon } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 
 interface DomainsTableSSLCellProps {
+	domainManagementLink: string;
 	sslStatus: 'active' | 'pending' | 'disabled' | null;
 }
 
-export default function DomainsTableSSLCell( { sslStatus }: DomainsTableSSLCellProps ) {
+export default function DomainsTableSSLCell( {
+	domainManagementLink,
+	sslStatus,
+}: DomainsTableSSLCellProps ) {
 	const translate = useTranslate();
 
 	const getSSLStatusText = () => {
@@ -20,17 +24,15 @@ export default function DomainsTableSSLCell( { sslStatus }: DomainsTableSSLCellP
 		if ( sslStatus === 'disabled' ) {
 			return translate( 'Disabled' );
 		}
-		return '-';
+	};
+
+	const handleClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
+		event.stopPropagation();
+		window.location.href = `${ domainManagementLink }?ssl-open=true`;
 	};
 
 	return (
-		<div
-			className={ clsx( 'domains-table-row__ssl-cell', {
-				[ 'domains-table-row__ssl-cell__active' ]: sslStatus === 'active',
-				[ 'domains-table-row__ssl-cell__pending' ]: sslStatus === 'pending',
-				[ 'domains-table-row__ssl-cell__disabled' ]: sslStatus === 'disabled',
-			} ) }
-		>
+		<div className="domains-table-row__ssl-cell">
 			{ sslStatus && (
 				<Icon
 					className={ clsx( 'domains-table-row__ssl-icon', {
@@ -41,7 +43,21 @@ export default function DomainsTableSSLCell( { sslStatus }: DomainsTableSSLCellP
 					icon={ lock }
 				/>
 			) }
-			{ getSSLStatusText() }
+			{ sslStatus !== null ? (
+				<Button
+					className={ clsx( 'domains-table-row__ssl-status-button', {
+						[ 'is-active' ]: sslStatus === 'active',
+						[ 'is-pending' ]: sslStatus === 'pending',
+						[ 'is-disabled' ]: sslStatus === 'disabled',
+					} ) }
+					variant="link"
+					onClick={ handleClick }
+				>
+					{ getSSLStatusText() }
+				</Button>
+			) : (
+				<>-</>
+			) }
 		</div>
 	);
 }

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -1,3 +1,4 @@
+import { DomainData } from '@automattic/data-stores';
 import { Button, Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -29,7 +29,7 @@ export default function DomainsTableSSLCell( {
 	};
 
 	return (
-		<div className="domains-table-row__ssl-cell">
+		<td className="domains-table-row__ssl-cell">
 			{ sslStatus && (
 				<Icon
 					className={ clsx( 'domains-table-row__ssl-icon', {
@@ -38,6 +38,7 @@ export default function DomainsTableSSLCell( {
 						[ 'domains-table-row__ssl-icon__disabled' ]: sslStatus === 'disabled',
 					} ) }
 					icon={ lock }
+					size={ 18 }
 				/>
 			) }
 			{ sslStatus !== null ? (
@@ -55,6 +56,6 @@ export default function DomainsTableSSLCell( {
 			) : (
 				<>-</>
 			) }
-		</div>
+		</td>
 	);
 }

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -5,7 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 
 interface DomainsTableSSLCellProps {
 	domainManagementLink: string;
-	sslStatus: 'active' | 'pending' | 'disabled' | null;
+	sslStatus: DomainData[ 'ssl_status' ];
 }
 
 export default function DomainsTableSSLCell( {

--- a/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-ssl-cell.tsx
@@ -23,7 +23,7 @@ export default function DomainsTableSSLCell( {
 			return translate( 'Pending' );
 		}
 		if ( sslStatus === 'disabled' ) {
-			return translate( 'Disabled' );
+			return translate( 'Error' );
 		}
 	};
 

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -142,7 +142,7 @@
 		}
 	}
 
-	.domains-table-row__ssl-status-button {
+	.domains-table-row__ssl-cell .domains-table-row__ssl-status-button {
 		text-decoration: none;
 		margin-left: -6px;
 
@@ -150,14 +150,14 @@
 			box-shadow: none;
 		}
 
-		&.is-active,
-		&.is-active :hover {
+		&__active,
+		&__active :hover {
 			color: var(--studio-green-50);
 		}
-		&.is-pending,
-		&.is-pending :hover,
-		&.is-disabled,
-		&.is-disabled :hover {
+		&__pending,
+		&__pending :hover,
+		&__disabled,
+		&__disabled :hover {
 			color: var(--studio-orange-50);
 		}
 	}

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -144,11 +144,6 @@
 
 	.domains-table-row__ssl-cell .domains-table-row__ssl-status-button {
 		text-decoration: none;
-		margin-left: -6px;
-
-		&:focus {
-			box-shadow: none;
-		}
 
 		&__active,
 		&__active :hover {
@@ -166,7 +161,7 @@
 		height: 16px;
 		position: relative;
 		top: 3px;
-		margin-left: -8px;
+		margin-right: -6px;
 
 		&__active {
 			fill: var(--studio-green-50);

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -161,7 +161,7 @@
 		height: 16px;
 		position: relative;
 		top: 3px;
-		margin-right: -6px;
+		margin-right: -5px;
 
 		&__active {
 			fill: var(--studio-green-50);

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -153,10 +153,10 @@
 		&.is-active :hover {
 			color: var(--studio-green-50);
 		}
-		&__pending,
-		&__pending :hover,
-		&__disabled,
-		&__disabled :hover {
+		&.is-pending,
+		&.is-pending :hover,
+		&.is-disabled,
+		&.is-disabled :hover {
 			color: var(--studio-orange-50);
 		}
 	}

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -143,7 +143,7 @@
 	}
 
 	.domains-table-row__ssl-cell {
-		gap: 4px;
+		gap: 2px;
 	}
 
 	.domains-table-row__ssl-cell .domains-table-row__ssl-status-button {

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -142,6 +142,10 @@
 		}
 	}
 
+	.domains-table-row__ssl-cell {
+		gap: 4px;
+	}
+
 	.domains-table-row__ssl-cell .domains-table-row__ssl-status-button {
 		text-decoration: none;
 
@@ -158,11 +162,6 @@
 	}
 
 	.domains-table-row__ssl-icon {
-		height: 16px;
-		position: relative;
-		top: 3px;
-		margin-right: -5px;
-
 		&__active {
 			fill: var(--studio-green-50);
 		}

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -34,7 +34,12 @@
 		}
 
 		// Note: The checkbox does not count for column counting purposes
-
+		&.is-8-column {
+			grid-template-columns: 20px 2fr 1fr 1fr 1fr auto auto auto auto;
+		}
+		&.is-8-column:not(.has-checkbox) {
+			grid-template-columns: 2fr 1fr 1fr 1fr auto auto auto auto;
+		}
 		&.is-7-column {
 			grid-template-columns: 20px 2fr 1fr 1fr auto auto auto auto;
 		}

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -144,6 +144,7 @@
 
 	.domains-table-row__ssl-status-button {
 		text-decoration: none;
+		margin-left: -6px;
 
 		&:focus {
 			box-shadow: none;
@@ -165,7 +166,7 @@
 		height: 16px;
 		position: relative;
 		top: 3px;
-		margin-right: -4px;
+		margin-left: -8px;
 
 		&__active {
 			fill: var(--studio-green-50);

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -137,6 +137,21 @@
 		}
 	}
 
+	.domains-table-row__ssl-cell {
+
+		&__active {
+			color: var(--studio-green-50);
+		}
+
+		&__pending {
+			color: var(--studio-orange-50);
+		}
+
+		&__disabled {
+			color: var(--studio-gray-50);
+		}
+	}
+
 	.domains-table-checkbox-td {
 		input[type="checkbox"][disabled] {
 			cursor: no-drop;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -137,19 +137,30 @@
 		}
 	}
 
-	.domains-table-row__ssl-cell {
+	.domains-table-row__ssl-cell,
+	.domains-table-row__ssl-icon {
 
 		&__active {
 			color: var(--studio-green-50);
+			fill: var(--studio-green-50);
 		}
 
 		&__pending {
 			color: var(--studio-orange-50);
+			fill: var(--studio-orange-50);
 		}
 
 		&__disabled {
 			color: var(--studio-gray-50);
+			fill: var(--studio-gray-50);
 		}
+	}
+
+	.domains-table-row__ssl-icon {
+		height: 16px;
+		position: relative;
+		top: 3px;
+		margin-right: -4px;
 	}
 
 	.domains-table-checkbox-td {
@@ -157,6 +168,7 @@
 			cursor: no-drop;
 		}
 	}
+
 
 	.domains-table-row__domain {
 		flex-direction: column;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -142,18 +142,22 @@
 		}
 	}
 
-	.domains-table-row__ssl-cell,
-	.domains-table-row__ssl-icon {
+	.domains-table-row__ssl-status-button {
+		text-decoration: none;
 
-		&__active {
-			color: var(--studio-green-50);
-			fill: var(--studio-green-50);
+		&:focus {
+			box-shadow: none;
 		}
 
+		&.is-active,
+		&.is-active :hover {
+			color: var(--studio-green-50);
+		}
 		&__pending,
-		&__disabled {
+		&__pending :hover,
+		&__disabled,
+		&__disabled :hover {
 			color: var(--studio-orange-50);
-			fill: var(--studio-orange-50);
 		}
 	}
 
@@ -162,6 +166,15 @@
 		position: relative;
 		top: 3px;
 		margin-right: -4px;
+
+		&__active {
+			fill: var(--studio-green-50);
+		}
+
+		&__pending,
+		&__disabled {
+			fill: var(--studio-orange-50);
+		}
 	}
 
 	.domains-table-checkbox-td {

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -145,14 +145,10 @@
 			fill: var(--studio-green-50);
 		}
 
-		&__pending {
+		&__pending,
+		&__disabled {
 			color: var(--studio-orange-50);
 			fill: var(--studio-orange-50);
-		}
-
-		&__disabled {
-			color: var(--studio-gray-50);
-			fill: var(--studio-gray-50);
 		}
 	}
 

--- a/packages/domains-table/src/use-domain-row.ts
+++ b/packages/domains-table/src/use-domain-row.ts
@@ -142,6 +142,8 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		  } )
 		: null;
 
+	const sslStatus = currentDomainData?.sslStatus ?? null;
+
 	return {
 		ref,
 		site,
@@ -162,5 +164,6 @@ export const useDomainRow = ( domain: PartialDomainData ) => {
 		pendingUpdates,
 		currentDomainData,
 		showBulkActions,
+		sslStatus,
 	};
 };

--- a/packages/domains-table/src/utils/types.ts
+++ b/packages/domains-table/src/utils/types.ts
@@ -131,7 +131,7 @@ export type ResponseDomain = {
 	registrationDate: string;
 	registryExpiryDate: string;
 	renewableUntil: string;
-	sslStatus: 'active' | 'pending' | 'disabled' | null;
+	sslStatus: 'active' | 'pending' | 'newly_registered' | 'disabled' | null;
 	subdomainPart?: string;
 	subscriptionId: string | null;
 	supportsDomainConnect: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8398-gh-Automattic/dotcom-forge

## Proposed Changes

Adds an SSL column to the Domains table. While the target was specifically the Hosting Overview, this table is used in other locations as well. After testing each, I've included the SSL column across the board, but am open to feedback if it makes anything feel too cluttered.

Design doc: R8yjT7mjG0Uw8h2GPyIY6R-fi-4041_65153

### Screenshot:

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/f9ead0b7-baad-4ed7-9f45-32512a29924e">


> [!NOTE]
> I applied the suggestion from the design feedback post to also add the green/orange treatment to the text (instead of just the icon) because I'm pretty sure we'll end up wanting to go that way. If we don't, it'll be an easy change.

## Why are these changes being made?

SSL status is an essential site metric that is currently buried behind different screens/settings. Making this more visible solves a customer pain point and brings our product more in line with our competitors.

## Testing Instructions
- Visit the [Calypso Live link for this branch](https://calypso.live/?image=registry.a8c.com/calypso/app:build-116088)
- Open `/overview` for any of your sites by clicking on the Hosting Overview button
- Append `?flags=hosting-overview-refinements` to the end of the url
- Confirm that the SSL column is present and reporting accurately
- Click on the SSL title to confirm the sorting order can be reversed (note: if your list of domains has only one status and then a `null` value (represented as `-` for free WPCOM provided domains) the sort will probably only work the first time. As far as I can tell, the sorting utility doesn't resort those `null` values after the initial click.
- Use the back button on your browser to return to `/overview`.
- Click on the `Domains` button in the left-hand sidebar to view the global domain list
- confirm that SSL values are being reported, and different states are styled correctly
- Test the sorting again. This time, because you're an a11n, you probably have enough variety to see the full sort effect.
- Locate or search for a site in the list that you know has a custom domain name, then select that domain
- In the sidebar, select `Upgrades > Domains` to view the domains list for this site.
- Confirm that SSL data is listed for each of the domains on the site, once again with `-` displayed for free domains that aren't eligible for SSL
- Finally, register a new domain, for your test site. Preferably a `.blog` because `.com`s resolve SSL certificates faster than I resolve an ice cream cone on a hot August day (which, for clarity, is _really_ fast).
- Once the new domain is registered, reload the Hosting Overview and find your new domain in the domains table. Confirm that it's reporting the `newly_registered` domain's SSL status as `pending`. 