### PR TITLE
Passwordless Auth - Enable passwordless sign up for the core profiler flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -127,6 +127,7 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		disableTosText: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -1045,7 +1046,7 @@ class SignupForm extends Component {
 
 		return (
 			<LoggedOutFormFooter isBlended={ this.props.isSocialSignupEnabled }>
-				{ this.termsOfServiceLink() }
+				{ ! this.props.disableTosText && this.termsOfServiceLink() }
 				<FormButton
 					className={ clsx(
 						'signup-form__submit',
@@ -1332,6 +1333,7 @@ class SignupForm extends Component {
 						flowName={ this.props.flowName }
 						goToNextStep={ this.props.goToNextStep }
 						renderTerms={ this.termsOfServiceLink }
+						disableTosText={ this.props.disableTosText }
 						submitForm={ this.handlePasswordlessSubmit }
 						logInUrl={ logInUrl }
 						disabled={ this.props.disabled }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -32,6 +32,7 @@ class PasswordlessSignupForm extends Component {
 		onInputChange: PropTypes.func,
 		onCreateAccountError: PropTypes.func,
 		onCreateAccountSuccess: PropTypes.func,
+		disableTosText: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -328,7 +329,7 @@ class PasswordlessSignupForm extends Component {
 						/>
 						{ this.props.children }
 					</ValidationFieldset>
-					{ this.props.renderTerms?.() }
+					{ ! this.props.disableTosText && this.props.renderTerms?.() }
 					{ this.formFooter() }
 				</LoggedOutForm>
 			</div>

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -27,7 +27,7 @@ export class AuthFormHeader extends Component {
 		// Connected props
 		translate: PropTypes.func.isRequired,
 		user: PropTypes.object,
-		hideSiteCard: PropTypes.bool,
+		disableSiteCard: PropTypes.bool,
 	};
 
 	getState() {
@@ -300,7 +300,7 @@ export class AuthFormHeader extends Component {
 					headerText={ this.getHeaderText() }
 					subHeaderText={ this.getSubHeaderText() }
 				/>
-				{ ! this.props.hideSiteCard && this.getSiteCard() }
+				{ ! this.props.disableSiteCard && this.getSiteCard() }
 			</div>
 		);
 	}

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -192,7 +192,7 @@ export class AuthFormHeader extends Component {
 			switch ( currentState ) {
 				case 'logged-out':
 					return translate(
-						"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to connect your store to your WordPress.com account. {{br/}} Already have one? {{a}}Log in{{/a}}",
+						"We'll make it quick – promise. In order to take advantage of the benefits offered by %(pluginName)s, you'll need to create a WordPress account. {{br/}} Already have one? {{a}}Log in{{/a}}",
 						translateParams
 					);
 				default:

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -514,6 +514,7 @@ export class JetpackSignup extends Component {
 					/>
 					<SignupForm
 						disabled={ isCreatingAccount }
+						isPasswordless={ isWooCoreProfiler }
 						email={ this.props.authQuery.userEmail }
 						footerLink={ this.renderFooterLink() }
 						handleSocialResponse={ this.handleSocialResponse }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -516,6 +516,7 @@ export class JetpackSignup extends Component {
 						disabled={ isCreatingAccount }
 						isPasswordless={ isWooCoreProfiler }
 						disableTosText={ isWooCoreProfiler }
+						labelText={ isWooCoreProfiler ? this.props.translate( 'Your Email' ) : null }
 						email={ this.props.authQuery.userEmail }
 						footerLink={ this.renderFooterLink() }
 						handleSocialResponse={ this.handleSocialResponse }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -510,7 +510,7 @@ export class JetpackSignup extends Component {
 						isWooOnboarding={ this.isWooOnboarding() }
 						isWooCoreProfiler={ this.isWooCoreProfiler() }
 						isFromAutomatticForAgenciesPlugin={ this.isFromAutomatticForAgenciesPlugin() }
-						hideSiteCard={ isWooCoreProfiler }
+						disableSiteCard={ isWooCoreProfiler }
 					/>
 					<SignupForm
 						disabled={ isCreatingAccount }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -515,6 +515,7 @@ export class JetpackSignup extends Component {
 					<SignupForm
 						disabled={ isCreatingAccount }
 						isPasswordless={ isWooCoreProfiler }
+						disableTosText={ isWooCoreProfiler }
 						email={ this.props.authQuery.userEmail }
 						footerLink={ this.renderFooterLink() }
 						handleSocialResponse={ this.handleSocialResponse }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1120,6 +1120,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.signup-form {
+		max-width: 327px;
 		padding-top: 48px;
 		.signup-form__passwordless-form-wrapper {
 			button.is-primary {
@@ -1134,10 +1135,13 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			}
 		}
 
+		input.signup-form__passwordless-email {
+			margin-bottom: 0;
+		}
+
 		.auth-form__social {
 			padding-top: 0;
 			.auth-form__social-buttons {
-				margin-top: 38px;
 				width: 100%;
 				.social-buttons__button {
 					width: 100%;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1767,4 +1767,68 @@ $breakpoint-mobile: 660px;
 			}
 		}
 	}
+
+	&.is-woocommerce-core-profiler-flow.is-woo-passwordless {
+		.login__lost-password-link {
+			color: var(--wp-admin-theme-color);
+		}
+
+		button.button.is-primary {
+			background-color: var(--wp-admin-theme-color);
+			font-family: inherit;
+			&:hover {
+				background-color: var(--wp-admin-theme-color);
+			}
+		}
+
+		.login__form-header-wrapper {
+			max-width: 615px;
+			text-align: center;
+		}
+
+		.jetpack-connect__main-logo {
+			@media (max-width: $break-mobile) {
+				padding-top: 0;
+			}
+		}
+
+		.formatted-header__subtitle,
+		.login__header-subtitle {
+			color: #757575;
+			text-align: center;
+			font-size: 1rem;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 24px; /* 150% */
+			a {
+				font-weight: inherit;
+				font-size: inherit;
+			}
+			@media (max-width: $break-mobile) {
+				text-align: start;
+			}
+		}
+		input[type="text"].form-text-input,
+		input[type="email"].form-text-input,
+		input[type="password"].form-text-input,
+		input[type="tel"].form-text-input {
+			border-radius: 2px;
+			border: 1px solid var(--Gutenberg-Gray-500, #bbb);
+			background: var(--Gutenberg-White, #fff);
+			&:hover,
+			&:focus {
+				border: 2px solid var(--Gutenberg-Gray-500, #bbb);
+			}
+		}
+
+		.auth-form__social .auth-form__social-buttons .social-buttons__button.button {
+			border-radius: 2px;
+			border: 1px solid var(--Gray-Gray-20, #a7aaad) !important;
+			background: var(--black-white-white, #fff);
+			span {
+				font-size: 0.875rem;
+				letter-spacing: 0.32px;
+			}
+		}
+	}
 }

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1803,6 +1803,7 @@ $breakpoint-mobile: 660px;
 			a {
 				font-weight: inherit;
 				font-size: inherit;
+				color: var(--wp-admin-theme-color);
 			}
 			@media (max-width: $break-mobile) {
 				text-align: start;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1786,6 +1786,16 @@ $breakpoint-mobile: 660px;
 			text-align: center;
 		}
 
+		.signup-form {
+			margin-top: 0;
+			label.form-label {
+				font-size: rem(11px);
+			}
+			input {
+				font-size: rem(13px);
+			}
+		}
+
 		.jetpack-connect__main-logo {
 			@media (max-width: $break-mobile) {
 				padding-top: 0;

--- a/client/state/jetpack-connect/actions/create-account.js
+++ b/client/state/jetpack-connect/actions/create-account.js
@@ -27,6 +27,8 @@ export function createAccount( userData ) {
 				client_id: config( 'wpcom_signup_id' ),
 				client_secret: config( 'wpcom_signup_key' ),
 			} );
+			// Preserve the original username in case the user's username is not available in userData
+			const username = data.username;
 			const bearerToken = makeJsonSchemaParser(
 				{
 					type: 'object',
@@ -39,7 +41,7 @@ export function createAccount( userData ) {
 			)( data );
 
 			dispatch( recordTracksEvent( 'calypso_jpc_create_account_success' ) );
-			return { username: userData.username, bearerToken };
+			return { username: userData.username ?? username, bearerToken };
 		} catch ( error ) {
 			dispatch(
 				recordTracksEvent( 'calypso_jpc_create_account_error', {

--- a/client/state/selectors/get-is-woo-passwordless.ts
+++ b/client/state/selectors/get-is-woo-passwordless.ts
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getCurrentOAuth2Client } from '../oauth2-clients/ui/selectors';
 import getWccomFrom from './get-wccom-from';
+import { isWooCommerceCoreProfilerFlow } from './is-woocommerce-core-profiler-flow';
 import type { AppState } from 'calypso/types';
 
 /**
@@ -15,7 +16,7 @@ export default function getIsWooPasswordless( state: AppState ): boolean {
 	}
 
 	// Enable Woo Passwordless if user is from WooCommerce Core Profiler.
-	if ( state?.route?.query?.initial?.from === 'woocommerce-core-profiler' ) {
+	if ( isWooCommerceCoreProfilerFlow( state ) ) {
 		return true;
 	}
 

--- a/client/state/selectors/get-is-woo-passwordless.ts
+++ b/client/state/selectors/get-is-woo-passwordless.ts
@@ -14,6 +14,11 @@ export default function getIsWooPasswordless( state: AppState ): boolean {
 		return false;
 	}
 
+	// Enable Woo Passwordless if user is from WooCommerce Core Profiler.
+	if ( state?.route?.query?.initial?.from === 'woocommerce-core-profiler' ) {
+		return true;
+	}
+
 	// Enable Woo Passwordless only if user is from WooCommerce.com. Not enable for other flows such as "Core Profiler" for now.
 	return isWooOAuth2Client( getCurrentOAuth2Client( state ) ) && getWccomFrom( state ) !== null;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #92104 

## Proposed Changes

* Enable passwordless sign up
* Applies new design changes
* Email template change is not implemented yet (Image 3)

## Why are these changes being made?

* To enable new design changes and enable passwordless signup

## Testing Instructions

This PR requires https://github.com/woocommerce/woocommerce-start-dev-env environment as it requires sign up process.

1. Setup https://github.com/woocommerce/woocommerce-start-dev-env 
2. Once https://github.com/woocommerce/woocommerce-start-dev-env is ready, run `yarn start` in `wp-calypso`
3. Open a new incognito window
4. Create a new JN site with the latest WooCommerce
5. Go through the core profiler and make sure to select Jetpack on the plugins page.
6. Once you get to the jetpack connect page, confirm the new design (Image 1)
7. Enter an email address and click on the `Continue` button.
8. You should logged-in and see `continue as` design (Image 2)

Image 1:
![Screenshot 2024-08-02 at 5 32 29 PM](https://github.com/user-attachments/assets/a0391245-7c33-4a88-987d-67228e92cff6)

Image 2:
![Screenshot 2024-08-02 at 5 30 55 PM](https://github.com/user-attachments/assets/bb4cf562-e778-4ef2-81f9-4f678c99a210)

Image 3:
![image](https://github.com/user-attachments/assets/0edb55e1-17f0-4d71-822f-d687e5539013)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
