### PR TITLE
Reader follow: Fix the fatal error because the feed is undefined

### DIFF
--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -76,7 +76,7 @@ export default function ReaderFeedHeaderFollow( props ) {
 				{ siteUrl && (
 					<div className="reader-feed-header__follow-button">
 						<ReaderFollowButton
-							siteUrl={ feed.feed_URL || siteUrl }
+							siteUrl={ feed?.feed_URL || siteUrl }
 							hasButtonStyle
 							iconSize={ 24 }
 							onFollowToggle={ openSuggestedFollowsModal }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1722778653928909/1722478880.511299-slack-C02FMH4G8

## Proposed Changes

* Fix the fatal error because the feed is undefined. The issue was introduced by https://github.com/Automattic/wp-calypso/pull/93030
  ![image](https://github.com/user-attachments/assets/9a076dae-9fac-42a2-8378-dbdd7b4d5f7f)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It causes the fatal error

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the notification
* Select “OOO and X liked your post ...”
* Click the site link under the user name
   ![image](https://github.com/user-attachments/assets/9a03573b-91d7-497a-83ed-b4b848e4018a)
* Make sure it opens `/read/blogs/:site_id` correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?