### PR TITLE
Provide a fallback for the plan upgrade copy

### DIFF
--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
@@ -1,4 +1,5 @@
-import { translate } from 'i18n-calypso';
+import { hasTranslation } from '@wordpress/i18n';
+import { translate, getLocaleSlug } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
@@ -16,6 +17,8 @@ import { Props } from '.';
 import './style.scss';
 
 const getUpsellCopy = ( statType: string ) => {
+	const defaultCopy = translate( 'Upgrade your plan to unlock Jetpack Stats.' );
+
 	switch ( statType ) {
 		case STAT_TYPE_REFERRERS:
 			return translate(
@@ -32,9 +35,12 @@ const getUpsellCopy = ( statType: string ) => {
 		case STATS_FEATURE_DATE_CONTROL:
 			return translate( 'Compare different time periods to analyze your site’s growth.' );
 		case STAT_TYPE_VIDEO_PLAYS:
-			return translate( 'Discover your most popular videos and find out how they performed.' );
+			return getLocaleSlug()?.startsWith( 'en' ) ||
+				hasTranslation( 'Discover your most popular videos and find out how they performed.' )
+				? translate( 'Discover your most popular videos and find out how they performed.' )
+				: defaultCopy;
 		default:
-			return translate( 'Upgrade your plan to unlock Jetpack Stats.' );
+			return defaultCopy;
 	}
 };
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/92887

## Proposed Changes

Followup to https://github.com/Automattic/wp-calypso/pull/93174 to provide a fallback for the new string.

## Why are these changes being made?

As @niranjan-uma-shankar [noted](https://github.com/Automattic/wp-calypso/pull/93174#discussion_r1703508924), the new string doesn't have a translation and will appear in English for non-EN locales.

## Testing Instructions

1. Visit `/me/account` and change the 'Interface Language' to something other than English
2. Visit `/stats/day/:site` and confirm that the translated fallback text is displayed:

Eg. after changing the interface language to French:

<img src="https://github.com/user-attachments/assets/c880682b-d7c1-4c9a-94e1-6be52bd7fcde" width=400 />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
