### PR TITLE
A4A > Marketplace: Update the standard hosting slider to support input values

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
@@ -56,6 +56,7 @@
 .wpcom-plan-selector__price-discount {
 	@include a4a-font-body-md;
 	color: var(--color-success);
+	text-wrap: nowrap;
 }
 
 .wpcom-plan-selector__price-interval {

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection.tsx
@@ -13,7 +13,8 @@ type Props = {
 	ownedPlans: number;
 	isLoading?: boolean;
 	hideOwnedPlansBadge?: boolean;
-	readOnly?: boolean;
+	hideNumberInput?: boolean;
+	quantity?: number;
 };
 
 export default function WPCOMBulkSelector( {
@@ -22,7 +23,8 @@ export default function WPCOMBulkSelector( {
 	ownedPlans,
 	isLoading,
 	hideOwnedPlansBadge,
-	readOnly,
+	hideNumberInput,
+	quantity,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -53,9 +55,11 @@ export default function WPCOMBulkSelector( {
 	const minimumQuantity = ownedPlans + 1;
 
 	useEffect( () => {
-		onSelectTier?.( calculateTier( options, minimumQuantity ) );
+		if ( ! hideNumberInput ) {
+			onSelectTier?.( calculateTier( options, minimumQuantity ) );
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ ownedPlans, options ] );
+	}, [ ownedPlans, options, hideNumberInput ] );
 
 	if ( isLoading ) {
 		return (
@@ -94,10 +98,11 @@ export default function WPCOMBulkSelector( {
 				label={ translate( 'Total sites' ) }
 				sub={ translate( 'Total discount' ) }
 				value={ selectedOption }
+				quantity={ quantity }
 				onChange={ onSelectOption }
 				options={ options }
 				minimum={ minimumQuantity }
-				readOnly={ readOnly }
+				hideNumberInput={ hideNumberInput }
 			/>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options.ts
@@ -1,9 +1,13 @@
+import { isEnabled } from '@automattic/calypso-config';
+
 const wpcomBulkOptions = (
 	discountOptions?: {
 		quantity: number;
 		discount_percent: number;
 	}[]
 ) => {
+	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
+
 	if ( ! discountOptions || discountOptions.length === 0 ) {
 		return [
 			{
@@ -24,12 +28,15 @@ const wpcomBulkOptions = (
 
 	if ( options[ 0 ].value !== 1 ) {
 		// We need to make sure that the first option is always 1 to allow user to purchase a single site.
-		options.unshift( {
-			value: 1,
-			label: '1',
-			discount: 0,
-			sub: '',
-		} );
+		options.unshift(
+			{
+				value: 1,
+				label: '1',
+				discount: 0,
+				sub: '',
+			},
+			...( isNewHostingPage ? [ { value: 2, label: '2', discount: 0, sub: '' } ] : [] )
+		);
 	}
 
 	return options;


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/465

## Proposed Changes

* This PR updates the standard agency hosting slider to support input values.

## Why are these changes being made?

* To allow users to interact with the slider and update the slider according to the input values and vice-versa. 

## Testing Instructions

* Open the A4A live link
* Go to Marketplace - Hosting - Standard agency hosting > Interact with the slider at various scenarios and verify it works as expected. Interacting with both slider and input box should update the values accordingly.

1) When the user has 0 plans


https://github.com/user-attachments/assets/30ca7931-a953-4cb8-b1e8-e41ffc4625ae


2) When the user has 1-9 plans

https://github.com/user-attachments/assets/9725cac5-97ba-4f8c-bf6c-dd02d6550433


3) When the user has > 10 plans 

https://github.com/user-attachments/assets/d60a7472-6d6b-4172-98c2-413c2347f84a


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
