### PR TITLE
A4A > Marketplace: Enable hosting page redesign on production

### DIFF
--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -34,6 +34,7 @@
 		"a4a-logged-out-signup": true,
 		"a4a-automated-referrals": true,
 		"a4a-partner-directory": false,
+		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": false,
 		"hosting-overview-refinements": false
 	},


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/426

## Proposed Changes

* This PR enables the new hosting page on production.

## Why are these changes being made?

* To enable the new hosting page on the production environment.

## Testing Instructions

* Verify the feature flag `a4a-hosting-page-redesign` for the new hosting page is enabled only on the production config file.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
