### PR TITLE
Imports: Fix mShots UA string

### DIFF
--- a/client/lib/mshots/index.js
+++ b/client/lib/mshots/index.js
@@ -12,7 +12,7 @@ export async function loadmShotsPreview( options = {} ) {
 
 	const mShotsEndpointUrl = addQueryArgs(
 		rest,
-		`http://localhost:8000/mshots/v1/${ encodeURIComponent( url ) }`
+		`https://s0.wp.com/mshots/v1/${ encodeURIComponent( url ) }`
 	);
 
 	for ( let retries = 0; ; retries++ ) {

--- a/client/lib/mshots/index.js
+++ b/client/lib/mshots/index.js
@@ -1,15 +1,19 @@
+import { addQueryArgs } from '../url';
+
 const noop = () => {};
 
 export async function loadmShotsPreview( options = {} ) {
-	const { maxRetries = 1, retryTimeout = 1000 } = options;
-	const url = options.url || '';
+	const { url = '', maxRetries = 1, retryTimeout = 1000, ...rest } = options;
 
 	if ( ! url ) {
 		// TODO translate
 		throw new Error( 'You must specify a site URL to be able to generate a preview of the site' );
 	}
 
-	const mShotsEndpointUrl = `https://s0.wp.com/mshots/v1/${ url }`;
+	const mShotsEndpointUrl = addQueryArgs(
+		rest,
+		`http://localhost:8000/mshots/v1/${ encodeURIComponent( url ) }`
+	);
 
 	for ( let retries = 0; ; retries++ ) {
 		const response = await fetch( mShotsEndpointUrl, { method: 'GET' } );

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.jsx
@@ -42,6 +42,8 @@ class SiteImporterSitePreview extends Component {
 			url: this.props.siteURL,
 			maxRetries: 30,
 			retryTimeout: 1000,
+			// Forward the user agent to mShots so that it can render the site the same way as the user's browser.
+			forward_user_agent: true,
 		} )
 			.then( ( imageBlob ) => {
 				this.setState( {

--- a/packages/components/src/site-thumbnail/use-mshots-img.tsx
+++ b/packages/components/src/site-thumbnail/use-mshots-img.tsx
@@ -22,6 +22,10 @@ export type MShotsOptions = {
 	h?: number;
 	screen_height?: number;
 	requeue?: boolean;
+	/**
+	 * If true, the current user agent will be forwarded to the target site to mimic the user themselves viewing the site.
+	 */
+	forward_user_agent?: boolean;
 };
 
 function getRetinaSize( multiply: number, { w, h }: MShotsOptions ) {


### PR DESCRIPTION
Blocked by: https://github.com/Automattic/mShots/pull/97
Fixes: https://github.com/Automattic/wp-calypso/issues/45586

## Proposed Changes

This configured mShots URL to forward the current user agent to the site being screenshot. This unblocks fetching screenshots from Wix and fixes https://github.com/Automattic/wp-calypso/issues/45586.

## Why are these changes being made?
Wix blocks `HeadlessChrome` UA from viewing their sites.

## Testing Instructions

1. Go to /import/
2. Pick a site.
3. Pick Wix
4. Use my site https://yi1bgd.wixsite.com/owner (**please don't import it as this prevents further testing**).
5. The screenshot should show and not a 403 error.
