### PR TITLE
Newsletter settings: move "." to be part of setting label

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeModalSetting.tsx
@@ -55,10 +55,10 @@ export const SubscribeModalSetting = ( {
 				disabled={ disabled }
 				label={
 					<>
-						{ translate( 'Show subscription pop-up when scrolling a post' ) }
+						{ translate( 'Show subscription pop-up when scrolling a post.' ) }
 						{ subscribeModalEditorUrl && (
 							<>
-								{ '. ' }
+								{ ' ' }
 								<ExternalLink href={ subscribeModalEditorUrl } onClick={ onEditClick }>
 									{ translate( 'Preview and edit' ) }
 								</ExternalLink>

--- a/client/my-sites/site-settings/settings-newsletter/SubscribeOverlaySetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeOverlaySetting.tsx
@@ -47,10 +47,10 @@ export const SubscribeOverlaySetting = ( {
 			disabled={ disabled }
 			label={
 				<>
-					{ translate( 'Subscription overlay on homepage' ) }
+					{ translate( 'Subscription overlay on homepage.' ) }
 					{ subscribeOverlayEditorUrl && (
 						<>
-							{ '. ' }
+							{ ' ' }
 							<ExternalLink href={ subscribeOverlayEditorUrl } onClick={ onEditClick }>
 								{ translate( 'Preview and edit' ) }
 							</ExternalLink>

--- a/client/my-sites/site-settings/settings-newsletter/SubscribePostEndSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribePostEndSetting.tsx
@@ -48,10 +48,10 @@ export const SubscribePostEndSetting = ( {
 			disabled={ disabled }
 			label={
 				<>
-					{ translate( 'Add the Subscribe Block at the end of each post' ) }
+					{ translate( 'Add the Subscribe Block at the end of each post.' ) }
 					{ showEditLink && (
 						<>
-							{ '. ' }
+							{ ' ' }
 							<ExternalLink href={ getEditUrl() } onClick={ onEditClick }>
 								{ translate( 'Preview and edit' ) }
 							</ExternalLink>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Addresses feedback in https://github.com/Automattic/wp-calypso/pull/88518#discussion_r1703404221:

> Unfortunately, this dot (.) is incorrect for languages like Japanese and Chinese, where a (。) is used. See Automattic/i18n-issues#841 for more details. Unless there is a special reason for this, I'll go ahead and append the dot to the entire string.

## Proposed Changes

* Append the dot to the entire string.

<img width="751" alt="Screenshot 2024-08-05 at 15 43 55" src="https://github.com/user-attachments/assets/e9506a94-092e-443d-ba8d-79f968efcc20">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check http://calypso.localhost:3000/settings/newsletter

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
