### PR TITLE
Help Center: Action hook to open home

### DIFF
--- a/apps/happy-blocks/block-library/support-content-links/index.php
+++ b/apps/happy-blocks/block-library/support-content-links/index.php
@@ -11,8 +11,8 @@
 <div class="support-content-links">
 	<p>
 		<?php esc_html_e( 'Questions?', 'happy-blocks' ); ?>
-		<a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/help?help-center=wapuu' ) ); ?>" target="_blank" rel="noreferrer noopener">
-			<?php esc_html_e( 'Contact our Happiness Engineers.', 'happy-blocks' ); ?>
+		<a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/help?help-center=home' ) ); ?>" target="_blank" rel="noreferrer noopener">
+			<?php esc_html_e( 'Get help.', 'happy-blocks' ); ?>
 		</a>
 	</p>
 	<p>

--- a/packages/help-center/src/hooks/use-action-hooks.ts
+++ b/packages/help-center/src/hooks/use-action-hooks.ts
@@ -27,6 +27,17 @@ export const useActionHooks = () => {
 			},
 		},
 		/**
+		 * Open Help Center.
+		 */
+		{
+			condition() {
+				return queryParams.get( 'help-center' ) === 'home';
+			},
+			action() {
+				setShowHelpCenter( true );
+			},
+		},
+		/**
 		 * Open to Wapuu chat.
 		 */
 		{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/93181

## Proposed Changes

- A new action hook that open the Help Center in the homepage when the url has `help-center=home` query param.
- Changed the text at the bottom of /support to `Get Help`

![image](https://github.com/user-attachments/assets/8b90f3a9-ab4d-491a-a0f6-c7bef1c1e26b)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to be able to juts open the Help Center, while now it is only possible to open Wapuu.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Live link
- Go to `/help?help-center=home` => It should open the Help Center home
- Go to `/help?help-center=wapuu` => It should open the Help Center with Wapuu
- `yarn dev --sync` from `apps/happy-blocks`
- Sandbox support
- Check that the text has changed and it opens /help with the Help Center open