### PR TITLE
Frictionless Email Subscriptions: Update subscribe email flow page load logic

### DIFF
--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -24,7 +24,6 @@ function SubscribeEmailStepContent( props ) {
 
 	return (
 		<SignupForm
-			// recaptchaClientId={ this.state.recaptchaClientId }
 			displayUsernameInput={ false }
 			email={ email || '' }
 			flowName={ flowName }

--- a/client/signup/steps/subscribe-email/content.jsx
+++ b/client/signup/steps/subscribe-email/content.jsx
@@ -2,6 +2,7 @@ import { localize } from 'i18n-calypso';
 import SignupForm from 'calypso/blocks/signup-form';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 
+// TODO: This component is not needed. Migrate logic into the subscribe-email index file
 function SubscribeEmailStepContent( props ) {
 	const {
 		email,

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import DOMPurify from 'dompurify';
 import emailValidator from 'email-validator';
@@ -71,47 +71,33 @@ function SubscribeEmailStep( props ) {
 
 	const { mutate: subscribeEmail, isPending: isSubscribingEmail } = useSubscribeEmail();
 
-	const subscribeEmailAndCompleteFlow = useCallback(
-		( { email_address } = { email_address: email } ) => {
-			return subscribeEmail(
-				{
-					email_address,
-					mailing_list_category: queryArguments.mailing_list,
-					from: queryArguments.from,
+	const subscribeEmailAndSubmitStep = ( { email_address } = { email_address: email } ) => {
+		return subscribeEmail(
+			{
+				email_address,
+				mailing_list_category: queryArguments.mailing_list,
+				from: queryArguments.from,
+			},
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_signup_email_subscription_success', {
+						mailing_list: queryArguments.mailing_list,
+					} );
+
+					props.submitSignupStep( { stepName: 'subscribe' }, { redirect: redirectUrl } );
+					goToNextStep();
 				},
-				{
-					onSuccess: () => {
-						recordTracksEvent( 'calypso_signup_email_subscription_success', {
-							mailing_list: queryArguments.mailing_list,
-						} );
+			}
+		);
+	};
 
-						props.submitSignupStep( { stepName: 'subscribe' }, { redirect: redirectUrl } );
-						goToNextStep();
-					},
-				}
-			);
-		},
-		[
-			email,
-			queryArguments.from,
-			queryArguments.mailing_list,
-			subscribeEmail,
-			goToNextStep,
-			redirectUrl,
-			props.submitSignupStep,
-		]
-	);
-
-	const handleRecordRegistration = useCallback(
-		( userData ) => {
-			recordRegistration( {
-				userData,
-				flow: flowName,
-				type: 'passwordless',
-			} );
-		},
-		[ flowName ]
-	);
+	const recordPasswordlessRegistration = ( userData ) => {
+		recordRegistration( {
+			userData,
+			flow: flowName,
+			type: 'passwordless',
+		} );
+	};
 
 	const { mutate: createNewAccount, isPending: isCreatingNewAccount } = useCreateNewAccountMutation(
 		{
@@ -122,12 +108,12 @@ function SubscribeEmailStep( props ) {
 					email,
 				};
 
-				handleRecordRegistration( userData );
+				recordPasswordlessRegistration( userData );
 
 				/**
-				 * User data is stale now that a new account has been created. We need to
-				 * refresh user data because we log them out after email subscription, which
-				 * requires an updated logout nonce.
+				 * We want to log out new users out after we subscribe their email. This will
+				 * require an updated logout nonce. User data in the store, however, is stale
+				 * because we just created a new account. We need to refresh the user data.
 				 */
 				wpcom.loadToken( response.bearer_token );
 				await props.fetchCurrentUser();
@@ -142,10 +128,11 @@ function SubscribeEmailStep( props ) {
 						onSuccess: () => {
 							setIsRedirectingToLogout( true );
 							/**
-							 * Logged in users will see an "Is it you?" page. Logged out users will skip the page.
-							 * To make email capture more seamless at conferences we keep users logged out after
-							 * new user creation. This allows us to capture multiple signups on one device without
-							 * showing the "Is it you?" page to each subsequent person.
+							 * Logged in users will see an "Is it you?" page. Logged out users will
+							 * skip the page. To make email capture more seamless at conferences we
+							 * keep users logged out after new user creation. This allows us to
+							 * capture multiple signups on one device without showing the "Is it you?"
+							 * page to each subsequent person.
 							 */
 							props.redirectToLogout( redirectUrl );
 						},
@@ -154,15 +141,28 @@ function SubscribeEmailStep( props ) {
 			},
 			onError: ( error ) => {
 				if ( isExistingAccountError( error.error ) ) {
-					subscribeEmailAndCompleteFlow();
+					subscribeEmailAndSubmitStep();
 				}
 			},
 		}
 	);
 
+	// On page load, attempt to subscribe the submitted email to the mailing list
 	useEffect( () => {
-		// 1. Handle subscription if user is logged out and email is valid
-		if ( ! currentUser && emailValidator.validate( email ) ) {
+		if ( ! emailValidator.validate( email ) ) {
+			return;
+		}
+
+		if ( currentUser ) {
+			if ( currentUser.email === email ) {
+				subscribeEmailAndSubmitStep();
+			}
+
+			// Otherwise show the "Is this you?" page
+			return;
+		}
+
+		if ( ! currentUser ) {
 			/**
 			 * Last name is an optional field in the subscription form, and an empty value may be
 			 * submitted. However the API will deem an empty last name invalid and return an error,
@@ -182,11 +182,6 @@ function SubscribeEmailStep( props ) {
 				flowName,
 				isPasswordless: true,
 			} );
-		}
-
-		// 2. Handle subscription if user is logged in and account email matches the submitted email
-		if ( currentUser?.email === email && ! isCreatingNewAccount && ! isSubscribingEmail ) {
-			subscribeEmailAndCompleteFlow();
 		}
 	}, [ email ] );
 
@@ -210,12 +205,12 @@ function SubscribeEmailStep( props ) {
 						redirectUrl={ redirectUrl }
 						handleCreateAccountError={ ( error, submittedEmail ) => {
 							if ( isExistingAccountError( error.error ) ) {
-								subscribeEmail( { email_address: submittedEmail } );
+								subscribeEmailAndSubmitStep( { email_address: submittedEmail } );
 							}
 						} }
 						handleCreateAccountSuccess={ ( userData ) => {
-							handleRecordRegistration( userData );
-							subscribeEmail( { email_address: userData.email } );
+							recordPasswordlessRegistration( userData );
+							subscribeEmailAndSubmitStep( { email_address: userData.email } );
 						} }
 						notYouText={ translate(
 							'Not you?{{br/}}Log out and {{link}}subscribe with %(email)s{{/link}}',
@@ -229,6 +224,11 @@ function SubscribeEmailStep( props ) {
 											className="continue-as-user__change-user-link"
 											onClick={ () => {
 												recordTracksEvent( 'calypso_signup_click_on_change_account' );
+
+												/**
+												 * Redirect to the current URL after logout. The current URL includes
+												 * query params like email, name, etc. which we parse on page load.
+												 */
 												props.redirectToLogout( window.location.href );
 											} }
 										/>

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -224,11 +224,6 @@ function SubscribeEmailStep( props ) {
 											className="continue-as-user__change-user-link"
 											onClick={ () => {
 												recordTracksEvent( 'calypso_signup_click_on_change_account' );
-
-												/**
-												 * Redirect to the current URL after logout. The current URL includes
-												 * query params like email, name, etc. which we parse on page load.
-												 */
 												props.redirectToLogout( window.location.href );
 											} }
 										/>

--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -111,7 +111,7 @@ function SubscribeEmailStep( props ) {
 				recordPasswordlessRegistration( userData );
 
 				/**
-				 * We want to log out new users out after we subscribe their email. This will
+				 * We want to log out new users after we subscribe their email. This will
 				 * require an updated logout nonce. User data in the store, however, is stale
 				 * because we just created a new account. We need to refresh the user data.
 				 */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Refactors page load logic and inline comments to improve readability
* There should be no change to user facing functionality

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There were comments and conditional logic that obscured helpful knowledge about business use cases for anyone reading the code
* We've now organized page load logic to explicitly handle concerns between logged in users vs. logged out users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test subscribe email flow logic
 
**Logged in user**
- Log into wordpress.com
- With these PR changes, navigate to `/start/email-subscription/subscribe?user_email={NEW_USER_EMAIL_HERE}&first_name=edna&last_name=mode&mailing_list=learn&redirect_to=%2Flearn&from=%2F`
- Verify that you see the continue as user page
- Verify that clicking continue subscribes the current user to the email subscription ( see browser dev console pigeon request ). Also confirm that the user is redirected to wordpress.com/learn
- Navigate to the same url as linked above with the same new user email
- Verify that clicking on the "another account" anchor tag logs out the current user and subscribes the original user_email query param to /pigeon. Also confirm that the user is redirected to wordpress.com/learn. And finally, confirm that the new user that has been created is not logged into wordpress.com by visiting WordPress.com ( should see the logged out home page )

**Logged out user**
- Smoke test experience
- Revisit the email-subscription flow by submitting both an existing email and a non-existent email in the user_email url query params. Confirm that the user is redirected to wordpress.com/learn once user is subscribed to mailing list.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
