### PR TITLE
Reader: Fix margins for Logged Out + Fix margin on < back

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -24,9 +24,6 @@
 	.layout__content {
 		background: var(--studio-white);
 	}
-	.main.search-stream {
-		padding-inline: 0;
-	}
 }
 
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -51,7 +51,7 @@ body.is-section-reader {
 .is-reader-page .search-stream__with-sites.main {
 	margin: 0 auto;
 	@include breakpoint-deprecated( "<660px" ) {
-		margin: 16px 0;
+		margin: 16px auto;
 	}
 }
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -97,7 +97,7 @@
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
-		margin: 32px 16px;
+		margin: 0 16px 16px;
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8529

## Proposed Changes

Fix logged-out reader margins when screen < 660px, and fix top margin on `< back` button when a tag is selected

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/1ed26d47-8140-481d-92f0-8ffbec2d0e50) | ![image](https://github.com/user-attachments/assets/a713e962-4516-4aaf-9ac1-424d58473dad) |
| ![image](https://github.com/user-attachments/assets/2613df01-7a4b-4d76-8ab3-edaafdcc36f6) | ![image](https://github.com/user-attachments/assets/118159f9-7eb5-436a-bfa4-9f96c233178c) |
| ![image](https://github.com/user-attachments/assets/a0ef1a5d-1be0-4e42-a289-76489097cef6) | ![image](https://github.com/user-attachments/assets/6160277b-560a-4c7e-8d37-a750f61a8473) |
## Why are these changes being made?
Fix design

## Testing Instructions

#### Logged out
* Go to `/discovery`
* Check the margin of the reader in screen sizes < 600px.
* Check also in `/read/search`
* Go to `/tags`
* Click on a tag from the list.
* Check the Back button does not have a big margin on the top.

#### Logged in
* Go to `/tags`
* Click on a tag from the list.
* Check the Back button does not have a big margin on the top.
* Check `/discovery` and `/read/search` for regressions.
