### PR TITLE
Plans: Relocate header price component into shared

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -31,11 +31,11 @@ import filterUnusedFeaturesObject from '../../lib/filter-unused-features-object'
 import getPlanFeaturesObject from '../../lib/get-plan-features-object';
 import { sortPlans } from '../../lib/sort-plan-properties';
 import PlanFeatures2023GridActions from '../actions';
-import PlanFeatures2023GridHeaderPrice from '../header-price';
 import PlanTypeSelector from '../plan-type-selector';
 import { Plans2023Tooltip } from '../plans-2023-tooltip';
 import PopularBadge from '../popular-badge';
 import BillingTimeframe from '../shared/billing-timeframe';
+import HeaderPrice from '../shared/header-price';
 import { PlanStorage } from '../shared/storage';
 import { StickyContainer } from '../sticky-container';
 import type {
@@ -431,7 +431,7 @@ const ComparisonGridHeaderCell = ( {
 					</select>
 				) }
 			</PlanSelector>
-			<PlanFeatures2023GridHeaderPrice
+			<HeaderPrice
 				planSlug={ planSlug }
 				currentSitePlanSlug={ currentSitePlanSlug }
 				visibleGridPlans={ visibleGridPlans }

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -20,7 +20,7 @@ import MobileFreeDomain from './mobile-free-domain';
 import PlanFeaturesList from './plan-features-list';
 import PlanHeaders from './plan-headers';
 import PlanLogos from './plan-logos';
-import PlanPrice from './plan-price';
+import PlanPrices from './plan-prices';
 import PlanTagline from './plan-tagline';
 import PreviousFeaturesIncludedTitle from './previous-features-included-title';
 import SpotlightPlan from './spotlight-plan';
@@ -113,7 +113,7 @@ const MobileView = ( {
 					<PlanHeaders renderedGridPlans={ [ gridPlan ] } />
 					{ isNotFreePlan && isInSignup && <PlanTagline renderedGridPlans={ [ gridPlan ] } /> }
 					{ isNotFreePlan && (
-						<PlanPrice
+						<PlanPrices
 							renderedGridPlans={ [ gridPlan ] }
 							currentSitePlanSlug={ currentSitePlanSlug }
 						/>

--- a/packages/plans-grid-next/src/components/features-grid/plan-prices.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-prices.tsx
@@ -1,8 +1,8 @@
 import { GridPlan } from '../../types';
-import PlanFeatures2023GridHeaderPrice from '../header-price';
 import PlanDivOrTdContainer from '../plan-div-td-container';
+import HeaderPrice from '../shared/header-price';
 
-type PlanPriceProps = {
+type PlanPricesProps = {
 	currentSitePlanSlug?: string | null;
 	renderedGridPlans: GridPlan[];
 	options?: {
@@ -10,7 +10,7 @@ type PlanPriceProps = {
 	};
 };
 
-const PlanPrice = ( { currentSitePlanSlug, options, renderedGridPlans }: PlanPriceProps ) => {
+const PlanPrices = ( { currentSitePlanSlug, options, renderedGridPlans }: PlanPricesProps ) => {
 	return renderedGridPlans.map( ( { planSlug } ) => {
 		return (
 			<PlanDivOrTdContainer
@@ -19,7 +19,7 @@ const PlanPrice = ( { currentSitePlanSlug, options, renderedGridPlans }: PlanPri
 				className="plan-features-2023-grid__table-item plan-price"
 				isTableCell={ options?.isTableCell }
 			>
-				<PlanFeatures2023GridHeaderPrice
+				<HeaderPrice
 					planSlug={ planSlug }
 					currentSitePlanSlug={ currentSitePlanSlug }
 					visibleGridPlans={ renderedGridPlans }
@@ -29,4 +29,4 @@ const PlanPrice = ( { currentSitePlanSlug, options, renderedGridPlans }: PlanPri
 	} );
 };
 
-export default PlanPrice;
+export default PlanPrices;

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -6,7 +6,7 @@ import BillingTimeframes from './billing-timeframes';
 import PlanFeaturesList from './plan-features-list';
 import PlanHeaders from './plan-headers';
 import PlanLogos from './plan-logos';
-import PlanPrice from './plan-price';
+import PlanPrices from './plan-prices';
 import PlanTagline from './plan-tagline';
 import TopButtons from './top-buttons';
 
@@ -47,7 +47,7 @@ const SpotlightPlan = ( {
 			<PlanHeaders renderedGridPlans={ [ gridPlanForSpotlight ] } />
 			{ isNotFreePlan && <PlanTagline renderedGridPlans={ [ gridPlanForSpotlight ] } /> }
 			{ isNotFreePlan && (
-				<PlanPrice
+				<PlanPrices
 					renderedGridPlans={ [ gridPlanForSpotlight ] }
 					currentSitePlanSlug={ currentSitePlanSlug }
 				/>

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -10,7 +10,7 @@ import EnterpriseFeatures from './enterprise-features';
 import PlanFeaturesList from './plan-features-list';
 import PlanHeaders from './plan-headers';
 import PlanLogos from './plan-logos';
-import PlanPrice from './plan-price';
+import PlanPrices from './plan-prices';
 import PlanTagline from './plan-tagline';
 import PreviousFeaturesIncludedTitle from './previous-features-included-title';
 import TopButtons from './top-buttons';
@@ -106,7 +106,7 @@ const Table = ( {
 					/>
 				</tr>
 				<tr>
-					<PlanPrice
+					<PlanPrices
 						renderedGridPlans={ gridPlansWithoutSpotlight }
 						options={ { isTableCell: true } }
 						currentSitePlanSlug={ currentSitePlanSlug }

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -2,12 +2,12 @@ import { isWpcomEnterpriseGridPlan, type PlanSlug } from '@automattic/calypso-pr
 import { PlanPrice } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { usePlansGridContext } from '../grid-context';
-import useIsLargeCurrency from '../hooks/use-is-large-currency';
-import { usePlanPricingInfoFromGridPlans } from '../hooks/use-plan-pricing-info-from-grid-plans';
-import type { GridPlan } from '../types';
+import { usePlansGridContext } from '../../../grid-context';
+import useIsLargeCurrency from '../../../hooks/use-is-large-currency';
+import { usePlanPricingInfoFromGridPlans } from '../../../hooks/use-plan-pricing-info-from-grid-plans';
+import type { GridPlan } from '../../../types';
 
-interface PlanFeatures2023GridHeaderPriceProps {
+interface HeaderPriceProps {
 	planSlug: PlanSlug;
 	currentSitePlanSlug?: string | null;
 	visibleGridPlans: GridPlan[];
@@ -130,10 +130,7 @@ const HeaderPriceContainer = styled.div`
 	}
 `;
 
-const PlanFeatures2023GridHeaderPrice = ( {
-	planSlug,
-	visibleGridPlans,
-}: PlanFeatures2023GridHeaderPriceProps ) => {
+const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
 	const {
@@ -177,12 +174,12 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					</Badge>
 				) }
 				{ isLargeCurrency ? (
-					<PricesGroup isLargeCurrency={ isLargeCurrency }>
+					<PricesGroup isLargeCurrency>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ 0 }
 							displayPerMonthNotation={ false }
-							isLargeCurrency={ isLargeCurrency }
+							isLargeCurrency
 							isSmallestUnit
 							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 							className="is-placeholder-price" // This is a placeholder price to keep the layout consistent
@@ -192,7 +189,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							currencyCode={ currencyCode }
 							rawPrice={ introOfferPrice }
 							displayPerMonthNotation={ false }
-							isLargeCurrency={ isLargeCurrency }
+							isLargeCurrency
 							isSmallestUnit={ false }
 							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 							discounted
@@ -203,7 +200,6 @@ const PlanFeatures2023GridHeaderPrice = ( {
 						currencyCode={ currencyCode }
 						rawPrice={ introOfferPrice }
 						displayPerMonthNotation={ false }
-						isLargeCurrency={ isLargeCurrency }
 						isSmallestUnit={ false }
 						priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 					/>
@@ -249,12 +245,12 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					' '
 				</Badge>
 				{ isLargeCurrency ? (
-					<PricesGroup isLargeCurrency={ isLargeCurrency }>
+					<PricesGroup isLargeCurrency>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ 0 }
 							displayPerMonthNotation={ false }
-							isLargeCurrency={ isLargeCurrency }
+							isLargeCurrency
 							isSmallestUnit
 							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 							className="is-placeholder-price" // This is a placeholder price to keep the layout consistent
@@ -264,7 +260,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							currencyCode={ currencyCode }
 							rawPrice={ originalPrice.monthly }
 							displayPerMonthNotation={ false }
-							isLargeCurrency={ isLargeCurrency }
+							isLargeCurrency
 							isSmallestUnit
 							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 							discounted
@@ -275,7 +271,6 @@ const PlanFeatures2023GridHeaderPrice = ( {
 						currencyCode={ currencyCode }
 						rawPrice={ originalPrice.monthly }
 						displayPerMonthNotation={ false }
-						isLargeCurrency={ isLargeCurrency }
 						isSmallestUnit
 						priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 					/>
@@ -298,4 +293,4 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	);
 };
 
-export default PlanFeatures2023GridHeaderPrice;
+export default HeaderPrice;

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -14,13 +14,18 @@ jest.mock( 'react-redux', () => ( {
 } ) );
 jest.mock( '../../grid-context', () => ( { usePlansGridContext: jest.fn() } ) );
 
-import { type PlanSlug, PLAN_ANNUAL_PERIOD, PLAN_PERSONAL } from '@automattic/calypso-products';
+import {
+	type PlanSlug,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_ENTERPRISE_GRID_WPCOM,
+	PLAN_PERSONAL,
+} from '@automattic/calypso-products';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { usePlansGridContext } from '../../grid-context';
-import PlanFeatures2023GridHeaderPrice from '../header-price';
+import HeaderPrice from '../shared/header-price';
 
-describe( 'PlanFeatures2023GridHeaderPrice', () => {
+describe( 'HeaderPrice', () => {
 	const defaultProps = {
 		isLargeCurrency: false,
 		planSlug: PLAN_PERSONAL as PlanSlug,
@@ -48,7 +53,7 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 			},
 		} ) );
 
-		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
+		const { container } = render( <HeaderPrice { ...defaultProps } /> );
 		const rawPrice = container.querySelector( '.plan-price.is-original' );
 		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
 
@@ -73,11 +78,88 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 			},
 		} ) );
 
-		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
+		const { container } = render( <HeaderPrice { ...defaultProps } /> );
 		const rawPrice = container.querySelector( '.plan-price' );
 		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
 
 		expect( rawPrice ).toHaveTextContent( '10' );
 		expect( discountedPrice ).toBeNull();
+	} );
+
+	test( 'should render empty for the enterprise plan', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_ENTERPRISE_GRID_WPCOM ]: {
+					isMonthlyPlan: true,
+					pricing,
+				},
+			},
+		} ) );
+
+		const { container } = render(
+			<HeaderPrice { ...defaultProps } planSlug={ PLAN_ENTERPRISE_GRID_WPCOM } />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'should display "Limited Time Offer" badge when intro offer exists and offer is not complete', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+			introOffer: {
+				formattedPrice: '$5.00',
+				rawPrice: 5,
+				intervalUnit: 'month',
+				intervalCount: 1,
+				isOfferComplete: false,
+			},
+		};
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					isMonthlyPlan: true,
+					pricing,
+				},
+			},
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } /> );
+		const badge = container.querySelector( '.plan-features-2023-grid__badge' );
+
+		expect( badge ).toHaveTextContent( 'Limited Time Offer' );
+	} );
+
+	test( 'should display "One time discount" badge when there is a monthly discounted price', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: 60, monthly: 5 },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					isMonthlyPlan: true,
+					pricing,
+				},
+			},
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } /> );
+		const badge = container.querySelector( '.plan-features-2023-grid__badge' );
+
+		expect( badge ).toHaveTextContent( 'One time discount' );
 	} );
 } );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/86936

## Proposed Changes

- Renames the `PlanFeatures2023GridHeaderPrice ` component to `HeaderPrice`
- Relocates the `HeaderPrice` component into `components/shared/header-price`
- Adds additional tests for the `HeaderPrice` component

## Why are these changes being made?

- `HeaderPrice` is a component that is shared by both `FeaturesGrid` and `ComparisonGrid`. Part of a broader effort to move any shared components into `components/shared`

## Testing Instructions

- No functional changes
- Tests should pass
- Smoke test `/plans/:site` to check that instances of the `HeaderPrice` component appear as they do on production

![CleanShot 2024-08-06 at 15 33 02@2x](https://github.com/user-attachments/assets/d11e6b21-5b20-4e47-ab76-8c5167c6a03a)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
