### PR TITLE
A4A > Marketplace: Fix the products page overlapping issues

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/style.scss
@@ -31,6 +31,8 @@ p.product-listing__description {
 	gap: 16px;
 	margin: 16px 0 32px;
 	justify-content: space-between;
+	position: relative;
+	z-index: 1;
 }
 
 .select-dropdown.is-compact.product-listing__product-filter-select {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/style.scss
@@ -71,4 +71,17 @@
 	.a4a-layout__top-wrapper {
 		z-index: 10;
 	}
+
+	.select-dropdown__item-text {
+		.content svg {
+			position: relative;
+			top: 5px;
+			margin-inline-end: 4px;
+		}
+	}
+
+	.section-nav.a4a-layout__navigation .select-dropdown__header .count {
+		top: 8.5px;
+		margin-inline-end: 8px;
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/873

## Proposed Changes

* This PR fixes the overlapping issues on the products page on small-screen devices.

## Why are these changes being made?

* To make the dropdown responsive on all the devices

## Testing Instructions

* Open the A4A live link
* Go to Marketplace - Products > Switch to any small screen size > 661px and verify the dropdown doesn't have any overlapping issues:

| Before | After |
|--------|--------|
| <img width="748" alt="Screenshot 2024-08-06 at 11 17 24 AM" src="https://github.com/user-attachments/assets/a5a9b38d-824f-4080-9f62-b54d9f580110"> | <img width="748" alt="Screenshot 2024-08-06 at 11 17 30 AM" src="https://github.com/user-attachments/assets/885b9e24-e588-49ab-97b3-0fbf7a9d3951"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
