### PR TITLE
Checkout: add 3-year plan to sidebar upsell

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -22,7 +22,7 @@ import './style.scss';
 const debug = debugFactory( 'calypso:checkout-sidebar-plan-upsell' );
 
 function getUpsellVariant( currentVariant: WPCOMProductVariant, variants: WPCOMProductVariant[] ) {
-	// Return the binennial plan if the plan in cart is a monthly or annual plan
+	// Return the biennial plan if the plan in cart is a monthly or annual plan
 	if (
 		currentVariant.productBillingTermInMonths === 1 ||
 		currentVariant.productBillingTermInMonths === 12
@@ -30,7 +30,7 @@ function getUpsellVariant( currentVariant: WPCOMProductVariant, variants: WPCOMP
 		return variants?.find( ( product ) => product.termIntervalInMonths === 24 );
 	}
 
-	// Return the triennial plan if the plan in cart is a binennial plan
+	// Return the triennial plan if the plan in cart is a biennial plan
 	if ( currentVariant.productBillingTermInMonths === 24 ) {
 		return variants?.find( ( product ) => product.termIntervalInMonths === 36 );
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/3264

## Proposed Changes

* On the checkout page, the sidebar upsell will now show the 3-year plan when a 2-year plan is in the cart.
* This PR also includes a small refactor so that it is easy to add other upsells in the future (5-year plans, 10-year plans, etc.)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Customer feedback: pekYwv-4t6-p2#comment-3960

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add any monthly plan to the cart.
* Confirm that you see the sidebar upsell for the annual plan.
* <img width="374" alt="image" src="https://github.com/user-attachments/assets/e50c98b1-ff47-4ed4-b210-afebe4c779a1">
* Confirm that clicking on the CTA in the upsell switches to an annual plan in the cart.
* When an annual plan is in the cart, confirm that you see the sidebar upsell for the 2-year plan. (same as production)
* <img width="401" alt="image" src="https://github.com/user-attachments/assets/c5902224-4bc9-4995-9211-17c4332f7382">
* Confirm that clicking on the CTA in the upsell switches to a 2-year plan in the cart.
* When a 2-year plan is in the cart, confirm that you see the sidebar upsell for the 3-year plan.
* <img width="376" alt="image" src="https://github.com/user-attachments/assets/86be42e5-c3fb-4e59-857b-e8381c6d840d">
* Confirm that clicking on the CTA in the upsell switches to a 3-year plan in the cart.
* When a 3-year plan is in the cart, confirm that you do not see the sidebar upsell.
* <img width="1158" alt="image" src="https://github.com/user-attachments/assets/3887fb75-69c9-4043-aa93-299c5970546f">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?