### PR TITLE
Site Migration: Improve site preparation for migration logs

### DIFF
--- a/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
+++ b/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
@@ -23,7 +23,9 @@ const TRANSFER_COMPLETED = ( siteId: number ) => ( {
 const errorCaptureMigrationKey = replyWithError( {
 	error: 'anyError',
 } );
+
 jest.mock( 'calypso/lib/analytics/tracks' );
+jest.mock( 'calypso/lib/logstash' );
 
 describe( 'usePrepareSiteForMigration', () => {
 	beforeAll( () => nock.disableNetConnect() );


### PR DESCRIPTION
## Proposed Changes

* Introduce logs to track the start/complete/error site preparation for migration flow.

## Why are these changes being made?
* It will enable us to create a dashboard to analyze the success rate. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the `/setup/migration-signup` flow
* When you arrive on the instructions page, check the network connection and look for calls to /logstash endpoint
* The logstash request body should contain the property.type`calypso_prepare_site_for_migration` 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
