### PR TITLE
Stepper: Provision for flows to override the default Tracks event props

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -14,3 +14,20 @@ export const HOW_TO_MIGRATE_OPTIONS = {
 	DO_IT_FOR_ME: 'difm',
 	DO_IT_MYSELF: 'myself',
 };
+
+/**
+ * All Tracks events related to Stepper.
+ * Prefixed with `STEPPER_TRACKS_EVENT_[scope]_[action]` to avoid conflicts with other Tracks events.
+ * Example: `STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT` -> scope = `STEP_NAV`, action = `SUBMIT`
+ */
+export const STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT = 'calypso_signup_actions_submit_step'; // TODO clk can be updated to match the constant name
+export const STEPPER_TRACKS_EVENT_STEP_NAV_BACK = 'calypso_signup_actions_step_nav_back';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_NEXT = 'calypso_signup_actions_step_nav_next';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW = 'calypso_signup_actions_step_nav_exit_flow';
+
+export const STEPPER_TRACKS_EVENTS_STEP_NAVIGATION = < const >[
+	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
+	STEPPER_TRACKS_EVENT_STEP_NAV_BACK,
+	STEPPER_TRACKS_EVENT_STEP_NAV_NEXT,
+	STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW,
+];

--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -20,8 +20,8 @@ export const HOW_TO_MIGRATE_OPTIONS = {
  * Prefixed with `STEPPER_TRACKS_EVENT_[scope]_[action]` to avoid conflicts with other Tracks events.
  * Example: `STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT` -> scope = `STEP_NAV`, action = `SUBMIT`
  */
-export const STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT = 'calypso_signup_actions_submit_step'; // TODO clk can be updated to match the constant name
+export const STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT = 'calypso_signup_actions_submit_step';
 
-export const STEPPER_TRACKS_EVENTS_STEP_NAVIGATION = < const >[
+export const STEPPER_TRACKS_EVENTS_STEP_NAV_SUBMIT = < const >[
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
 ];

--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -22,6 +22,4 @@ export const HOW_TO_MIGRATE_OPTIONS = {
  */
 export const STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT = 'calypso_signup_actions_submit_step';
 
-export const STEPPER_TRACKS_EVENTS_STEP_NAV_SUBMIT = < const >[
-	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
-];
+export const STEPPER_TRACKS_EVENTS = < const >[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ];

--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -21,13 +21,7 @@ export const HOW_TO_MIGRATE_OPTIONS = {
  * Example: `STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT` -> scope = `STEP_NAV`, action = `SUBMIT`
  */
 export const STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT = 'calypso_signup_actions_submit_step'; // TODO clk can be updated to match the constant name
-export const STEPPER_TRACKS_EVENT_STEP_NAV_BACK = 'calypso_signup_actions_step_nav_back';
-export const STEPPER_TRACKS_EVENT_STEP_NAV_NEXT = 'calypso_signup_actions_step_nav_next';
-export const STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW = 'calypso_signup_actions_step_nav_exit_flow';
 
 export const STEPPER_TRACKS_EVENTS_STEP_NAVIGATION = < const >[
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
-	STEPPER_TRACKS_EVENT_STEP_NAV_BACK,
-	STEPPER_TRACKS_EVENT_STEP_NAV_NEXT,
-	STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW,
 ];

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -11,10 +11,10 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
-import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../constants';
 import { useDomainParams } from '../hooks/use-domain-params';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { redirect } from './internals/steps-repository/import/util';
 import {
 	AssertConditionResult,
@@ -106,23 +106,18 @@ const connectDomain: Flow = {
 	useSteps() {
 		return CONNECT_DOMAIN_STEPS;
 	},
-	useTracksEventProps( event ) {
-		const { domain, provider } = useDomainParams();
-
-		if ( STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT === event ) {
-			return {
-				domain,
-				provider,
-			};
-		}
-	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
-		const { domain } = useDomainParams();
+		const { domain, provider } = useDomainParams();
 
 		triggerGuidesForStep( flowName, _currentStepSlug );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug, undefined, {
+				provider,
+				domain,
+			} );
+
 			switch ( _currentStepSlug ) {
 				case 'plans':
 					clearSignupDestinationCookie();
@@ -152,7 +147,6 @@ const connectDomain: Flow = {
 			submit,
 		};
 	},
-	use__Temporary__ShouldTrackEvent: ( event ) => 'submit' === event,
 };
 
 export default connectDomain;

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -11,10 +11,10 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../constants';
 import { useDomainParams } from '../hooks/use-domain-params';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
-import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { redirect } from './internals/steps-repository/import/util';
 import {
 	AssertConditionResult,
@@ -106,18 +106,23 @@ const connectDomain: Flow = {
 	useSteps() {
 		return CONNECT_DOMAIN_STEPS;
 	},
+	useTracksEventProps( event ) {
+		const { domain, provider } = useDomainParams();
+
+		if ( STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT === event ) {
+			return {
+				domain,
+				provider,
+			};
+		}
+	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
-		const { domain, provider } = useDomainParams();
+		const { domain } = useDomainParams();
 
 		triggerGuidesForStep( flowName, _currentStepSlug );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
-			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug, undefined, {
-				provider,
-				domain,
-			} );
-
 			switch ( _currentStepSlug ) {
 				case 'plans':
 					clearSignupDestinationCookie();
@@ -147,6 +152,7 @@ const connectDomain: Flow = {
 			submit,
 		};
 	},
+	use__Temporary__ShouldTrackEvent: ( event ) => 'submit' === event,
 };
 
 export default connectDomain;

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -1,5 +1,6 @@
 import { OnboardSelect } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
+import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from 'calypso/landing/stepper/constants';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordSubmitStep } from '../../analytics/record-submit-step';
 import type { Flow, Navigate, ProvidedDependencies, StepperStep } from '../../types';
@@ -36,7 +37,8 @@ export const useStepNavigationWithTracking = ( {
 					intent,
 					flow.name,
 					currentStepRoute,
-					flow.variantSlug
+					flow.variantSlug,
+					flow.useTracksEventProps?.( STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT )
 				);
 			stepNavigation.submit?.( providedDependencies, ...params );
 		},

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -38,7 +38,7 @@ export const useStepNavigationWithTracking = ( {
 					flowName,
 					currentStepRoute,
 					variantSlug,
-					tracksEventPropsFromFlow?.submit?.[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ]
+					tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ]
 				);
 				stepNavigation.submit?.( providedDependencies, ...params );
 			},

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -26,8 +26,7 @@ export const useStepNavigationWithTracking = ( {
 	);
 	const intent =
 		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(), [] ) ?? '';
-
-	const tracksEventPropsSubmit = useTracksEventProps?.( STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT );
+	const tracksEventPropsFromFlow = useTracksEventProps?.();
 
 	return useMemo(
 		() => ( {
@@ -39,11 +38,11 @@ export const useStepNavigationWithTracking = ( {
 					flowName,
 					currentStepRoute,
 					variantSlug,
-					tracksEventPropsSubmit
+					tracksEventPropsFromFlow?.submit?.[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ]
 				);
 				stepNavigation.submit?.( providedDependencies, ...params );
 			},
 		} ),
-		[ stepNavigation, intent, flowName, currentStepRoute, variantSlug, tracksEventPropsSubmit ]
+		[ stepNavigation, intent, flowName, currentStepRoute, variantSlug, tracksEventPropsFromFlow ]
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -19,7 +19,7 @@ export const useStepNavigationWithTracking = ( {
 	navigate,
 	steps,
 }: Params< ReturnType< Flow[ 'useSteps' ] > > ) => {
-	const stepNavigation = flow.useStepNavigation?.(
+	const stepNavigation = flow.useStepNavigation(
 		currentStepRoute,
 		navigate,
 		steps.map( ( step ) => step.slug )

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -14,19 +14,19 @@ interface Params< FlowSteps extends StepperStep[] > {
 }
 
 export const useStepNavigationWithTracking = ( {
-	flow: { useTracksEventProps, useStepNavigation, name: flowName, variantSlug },
+	flow,
 	currentStepRoute,
 	navigate,
 	steps,
 }: Params< ReturnType< Flow[ 'useSteps' ] > > ) => {
-	const stepNavigation = useStepNavigation(
+	const stepNavigation = flow.useStepNavigation?.(
 		currentStepRoute,
 		navigate,
 		steps.map( ( step ) => step.slug )
 	);
 	const intent =
 		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(), [] ) ?? '';
-	const tracksEventPropsFromFlow = useTracksEventProps?.();
+	const tracksEventPropsFromFlow = flow.useTracksEventProps?.();
 
 	return useMemo(
 		() => ( {
@@ -35,14 +35,14 @@ export const useStepNavigationWithTracking = ( {
 				recordSubmitStep(
 					providedDependencies,
 					intent,
-					flowName,
+					flow.name,
 					currentStepRoute,
-					variantSlug,
+					flow.variantSlug,
 					tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ]
 				);
 				stepNavigation.submit?.( providedDependencies, ...params );
 			},
 		} ),
-		[ stepNavigation, intent, flowName, currentStepRoute, variantSlug, tracksEventPropsFromFlow ]
+		[ stepNavigation, intent, flow, currentStepRoute, tracksEventPropsFromFlow ]
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -1,6 +1,6 @@
 import { StepperInternal } from '@automattic/data-stores';
 import React from 'react';
-import { StepperTracksEventStepNavigation } from '../../types';
+import { STEPPER_TRACKS_EVENTS_STEP_NAV_SUBMIT } from '../../constants';
 
 /**
  * This is the return type of useStepNavigation hook
@@ -107,9 +107,24 @@ export type UseSideEffectHook< FlowSteps extends StepperStep[] > = (
 	navigate: Navigate< FlowSteps >
 ) => void;
 
-export type UseTracksEventPropsHook = (
-	event: StepperTracksEventStepNavigation
-) => Record< string, string | number | null > | undefined;
+/**
+ * Used for overriding props recorded by the default Tracks event loggers.
+ * Can pass any properties that should be recorded for the respective events.
+ * Can be used to pass new Tracks events and their props to be logged on the respective flow control key.
+ *
+ * - Currently only applicable to `NavigationControls`, as per the signature.
+ * - Passing in new events to log needs only updating the respective event constant in `stepper/constants.ts`.
+ */
+export type UseTracksEventPropsHook = () => {
+	[ key in keyof NavigationControls ]?: key extends 'submit'
+		? {
+				[ key in ( typeof STEPPER_TRACKS_EVENTS_STEP_NAV_SUBMIT )[ number ] ]?: Record<
+					string,
+					string | number | null
+				>;
+		  }
+		: undefined;
+};
 
 export type Flow = {
 	name: string;
@@ -144,11 +159,6 @@ export type Flow = {
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
 	useSideEffect?: UseSideEffectHook< ReturnType< Flow[ 'useSteps' ] > >;
-	/**
-	 * Used for overriding the props recorded by the default/framework-handled Tracks event recorders.
-	 * Can pass any properties that should be recorded for the event.
-	 *   - Currently only applicable to step-navigation events.
-	 */
 	useTracksEventProps?: UseTracksEventPropsHook;
 	/**
 	 * Temporary hook to allow gradual migration of flows to the globalised/default event tracking.

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -1,6 +1,6 @@
 import { StepperInternal } from '@automattic/data-stores';
 import React from 'react';
-import { STEPPER_TRACKS_EVENTS_STEP_NAV_SUBMIT } from '../../constants';
+import { STEPPER_TRACKS_EVENTS } from '../../constants';
 
 /**
  * This is the return type of useStepNavigation hook
@@ -110,20 +110,9 @@ export type UseSideEffectHook< FlowSteps extends StepperStep[] > = (
 /**
  * Used for overriding props recorded by the default Tracks event loggers.
  * Can pass any properties that should be recorded for the respective events.
- * Can be used to pass new Tracks events and their props to be logged on the respective flow control key.
- *
- * - Currently only applicable to `NavigationControls`, as per the signature.
- * - Passing in new events to log needs only updating the respective event constant in `stepper/constants.ts`.
  */
 export type UseTracksEventPropsHook = () => {
-	[ key in keyof NavigationControls ]?: key extends 'submit'
-		? {
-				[ key in ( typeof STEPPER_TRACKS_EVENTS_STEP_NAV_SUBMIT )[ number ] ]?: Record<
-					string,
-					string | number | null
-				>;
-		  }
-		: undefined;
+	[ key in ( typeof STEPPER_TRACKS_EVENTS )[ number ] ]?: Record< string, string | number | null >;
 };
 
 export type Flow = {

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -141,7 +141,8 @@ export type Flow = {
 	 */
 	useSideEffect?: UseSideEffectHook< ReturnType< Flow[ 'useSteps' ] > >;
 	/**
-	 * Used for extending the default/framework-handled event tracking with custom properties.
+	 * Used for overriding the props recorded by the default/framework-handled Tracks event recorders.
+	 * Can pass any properties that should be recorded for the event.
 	 *   - Currently only applicable to step-navigation events.
 	 */
 	useTracksEventProps?: (

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -107,6 +107,10 @@ export type UseSideEffectHook< FlowSteps extends StepperStep[] > = (
 	navigate: Navigate< FlowSteps >
 ) => void;
 
+export type UseTracksEventPropsHook = (
+	event: StepperTracksEventStepNavigation
+) => Record< string, string | number | null > | undefined;
+
 export type Flow = {
 	name: string;
 	/**
@@ -145,9 +149,7 @@ export type Flow = {
 	 * Can pass any properties that should be recorded for the event.
 	 *   - Currently only applicable to step-navigation events.
 	 */
-	useTracksEventProps?: (
-		event: StepperTracksEventStepNavigation
-	) => Record< string, string | number | null > | undefined;
+	useTracksEventProps?: UseTracksEventPropsHook;
 	/**
 	 * Temporary hook to allow gradual migration of flows to the globalised/default event tracking.
 	 * IMPORTANT: This hook will be removed in the future.

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -1,5 +1,6 @@
 import { StepperInternal } from '@automattic/data-stores';
 import React from 'react';
+import { StepperTracksEventStepNavigation } from '../../types';
 
 /**
  * This is the return type of useStepNavigation hook
@@ -139,7 +140,13 @@ export type Flow = {
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
 	useSideEffect?: UseSideEffectHook< ReturnType< Flow[ 'useSteps' ] > >;
-
+	/**
+	 * Used for extending the default/framework-handled event tracking with custom properties.
+	 *   - Currently only applicable to step-navigation events.
+	 */
+	useTracksEventProps?: (
+		event: StepperTracksEventStepNavigation
+	) => Record< string, string | number | null > | undefined;
 	/**
 	 * Temporary hook to allow gradual migration of flows to the globalised/default event tracking.
 	 * IMPORTANT: This hook will be removed in the future.

--- a/client/landing/stepper/types.ts
+++ b/client/landing/stepper/types.ts
@@ -1,7 +1,4 @@
 /** Step */
-
-import { STEPPER_TRACKS_EVENTS_STEP_NAVIGATION } from './constants';
-
 export type StepOptions = Record< string, unknown >;
 
 export interface Step {
@@ -26,6 +23,3 @@ export interface Flow< P extends string > {
 		index: FlowStepIndex< P >;
 	} >;
 }
-
-export type StepperTracksEventStepNavigation =
-	( typeof STEPPER_TRACKS_EVENTS_STEP_NAVIGATION )[ number ];

--- a/client/landing/stepper/types.ts
+++ b/client/landing/stepper/types.ts
@@ -1,5 +1,7 @@
 /** Step */
 
+import { STEPPER_TRACKS_EVENTS_STEP_NAVIGATION } from './constants';
+
 export type StepOptions = Record< string, unknown >;
 
 export interface Step {
@@ -24,3 +26,6 @@ export interface Flow< P extends string > {
 		index: FlowStepIndex< P >;
 	} >;
 }
+
+export type StepperTracksEventStepNavigation =
+	( typeof STEPPER_TRACKS_EVENTS_STEP_NAVIGATION )[ number ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91755
Part of addressing https://github.com/Automattic/wp-calypso/issues/94108

## Proposed Changes

* Adds a system of constants and types for the relevant Stepper Tracks events
* Introduce a flow prop `useTracksEventProps` that flows can define to either override or pass new props into the respective Tracks loggers
* For a use case, see the `connect-domain` flow update: https://github.com/Automattic/wp-calypso/pull/93275 (although, subject to change)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/91755

This is one of the improvements outlined in the PT (pdDR7T-1BF-p2) as agreed on by several folks -> a provision for flows to locally override or include more properties in the event logging.

We technically do not have a particular use for this right now. There is a bit of YAGNI here in general. **EDIT**: I think I'm starting to spot usages already while investigating other events beyond "step-submit", so this observation may not be true.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- See https://github.com/Automattic/wp-calypso/pull/93275 for testing the `connect-domain` flow (that currently uses this mechanism - subject to change though)
- Confirm a previously-enabled flow tracks the submit event without failure. See https://github.com/Automattic/wp-calypso/pull/93136 for testing the `newsletter` flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?