### PR TITLE
Stepper: Update `connect-domain` flow to use framework tracking for submit-step

### DIFF
--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -11,10 +11,10 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../constants';
 import { useDomainParams } from '../hooks/use-domain-params';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
-import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { redirect } from './internals/steps-repository/import/util';
 import {
 	AssertConditionResult,
@@ -106,18 +106,23 @@ const connectDomain: Flow = {
 	useSteps() {
 		return CONNECT_DOMAIN_STEPS;
 	},
+	useTracksEventProps( event ) {
+		const { domain, provider } = useDomainParams();
+
+		if ( STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT === event ) {
+			return {
+				domain,
+				provider,
+			};
+		}
+	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
-		const { domain, provider } = useDomainParams();
+		const { domain } = useDomainParams();
 
 		triggerGuidesForStep( flowName, _currentStepSlug );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
-			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug, undefined, {
-				provider,
-				domain,
-			} );
-
 			switch ( _currentStepSlug ) {
 				case 'plans':
 					clearSignupDestinationCookie();
@@ -147,6 +152,7 @@ const connectDomain: Flow = {
 			submit,
 		};
 	},
+	use__Temporary__ShouldTrackEvent: ( event ) => 'submit' === event,
 };
 
 export default connectDomain;

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -110,11 +110,9 @@ const connectDomain: Flow = {
 		const { domain, provider } = useDomainParams();
 
 		return {
-			submit: {
-				[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ]: {
-					domain,
-					provider,
-				},
+			[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ]: {
+				domain,
+				provider,
 			},
 		};
 	},

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -106,15 +106,17 @@ const connectDomain: Flow = {
 	useSteps() {
 		return CONNECT_DOMAIN_STEPS;
 	},
-	useTracksEventProps( event ) {
+	useTracksEventProps() {
 		const { domain, provider } = useDomainParams();
 
-		if ( STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT === event ) {
-			return {
-				domain,
-				provider,
-			};
-		}
+		return {
+			submit: {
+				[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ]: {
+					domain,
+					provider,
+				},
+			},
+		};
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91755
Part of addressing https://github.com/Automattic/wp-calypso/issues/94108

## Proposed Changes

- Updates the `connect-domain` flow to opt-in for framework tracking on submit-step nav event
- ~Updates the flow to set the site intent in the side effect hook for use in the Tracks call~
- Uses the event-override provision for passing in `domain` and `provider` as additional props (this is subject to change)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/91755

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- go through `/setup/connect-domain?domain=[foo]&provider=[bar]`
- confirm in Network tab `t.gif` requests tracking the correct values for `calypso_signup_actions_submit_step` (including `domain: foo`, `provider: bar`)
- the above should behave exactly like in production

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
