### PR TITLE
A4A > Marketplace: update translations for enterprise hosting testimonials

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/enterprise-agency-hosting/index.tsx
@@ -102,30 +102,40 @@ export default function EnterpriseAgencyHosting() {
 						profile: {
 							avatar: ProfileAvatar1,
 							name: 'David Rousseau',
-							title: 'Vice President, Kaiser Family Foundation',
+							title: translate( 'Vice President, %(companyName)s', {
+								args: {
+									companyName: 'Kaiser Family Foundation',
+								},
+								comment: '%(companyName)s is the name of the company the testimonial is about.',
+							} ),
 							site: translate( 'Read the case study' ),
 							siteLink:
 								'https://wpvip.com/case-studies/evolving-the-kaiser-family-foundations-data-rich-platforms/',
 						},
-						testimonial:
-							// TODO: Change this to a real testimonial
+						testimonial: translate(
 							"In the past, the staff didn't touch the CMS. They wrote things in Word, sent it to the production team, and they put it online. With WordPress, that workflow is changing slowly and dramatically." +
-							" We've trained many of our content creators in the CMS. And, the closer the content creators are to it, the more creatively they are able to think about it.",
+								" We've trained many of our content creators in the CMS. And, the closer the content creators are to it, the more creatively they are able to think about it."
+						),
 					},
 
 					{
 						profile: {
 							avatar: ProfileAvatar2,
 							name: 'Joel Davies',
-							title: 'Head of Editorial Operations, News UK',
+							title: translate( 'Head of Editorial Operations, %(companyName)s', {
+								args: {
+									companyName: 'News UK',
+								},
+								comment: '%(companyName)s is the name of the company the testimonial is about.',
+							} ),
 							site: translate( 'Read the case study' ),
 							siteLink:
 								'https://wpvip.com/case-studies/behind-the-scenes-of-news-uks-rampant-speed-to-value-with-gutenberg/',
 						},
-						testimonial:
-							// TODO: Change this to a real testimonial
+						testimonial: translate(
 							'With Gutenberg, we were able to publish a breaking news story in two minutes versus five minutes in Classic [WordPress].' +
-							" The main reason for this is the reusable blocks which have been renamed 'The Game Changer.'",
+								" The main reason for this is the reusable blocks which have been renamed 'The Game Changer.'"
+						),
 					},
 				] }
 				itemBackgroundColor="#F5F2F1"


### PR DESCRIPTION
## Proposed Changes

* This PR adds translations to the Enterprise hosting testimonials 

## Why are these changes being made?

* To translate the texts

## Testing Instructions

* Open the A4A live link
* Go to Marketplace - Hosting - Enterprise and verify the testimonials are appearing correctly. You can compare it here if you would like: https://wpvip.com/wordpress-gutenberg/

<img width="1728" alt="Screenshot 2024-08-06 at 3 51 31 PM" src="https://github.com/user-attachments/assets/3618bfbc-09c6-40ad-94bf-d7212167e093">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
