### PR TITLE
Site Level User Profile: add banner and restructure /me[/account]

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -677,21 +677,23 @@ class Account extends Component {
 					{ this.renderPrimarySite() }
 				</FormFieldset>
 
-				<FormFieldset>
-					<FormLabel htmlFor="user_URL">{ translate( 'Web address' ) }</FormLabel>
-					<FormTextInput
-						disabled={ this.getDisabledState( ACCOUNT_FORM_NAME ) }
-						id="user_URL"
-						name="user_URL"
-						type="url"
-						onFocus={ this.getFocusHandler( 'Web Address Field' ) }
-						value={ this.getUserSetting( 'user_URL' ) || '' }
-						onChange={ this.updateUserSettingInput }
-					/>
-					<FormSettingExplanation>
-						{ translate( 'Shown publicly when you comment on blogs.' ) }
-					</FormSettingExplanation>
-				</FormFieldset>
+				{ ! config.isEnabled( 'layout/site-level-user-profile' ) && (
+					<FormFieldset>
+						<FormLabel htmlFor="user_URL">{ translate( 'Web address' ) }</FormLabel>
+						<FormTextInput
+							disabled={ this.getDisabledState( ACCOUNT_FORM_NAME ) }
+							id="user_URL"
+							name="user_URL"
+							type="url"
+							onFocus={ this.getFocusHandler( 'Web Address Field' ) }
+							value={ this.getUserSetting( 'user_URL' ) || '' }
+							onChange={ this.updateUserSettingInput }
+						/>
+						<FormSettingExplanation>
+							{ translate( 'Shown publicly when you comment on blogs.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+				) }
 
 				<FormButton
 					isSubmitting={ this.isSubmittingForm( ACCOUNT_FORM_NAME ) }

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, FormLabel } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import clsx from 'clsx';
@@ -23,6 +24,7 @@ import ProfileLinks from 'calypso/me/profile-links';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
+import SiteLevelProfileBanner from './site-level-profile-banner';
 import UpdatedGravatarString from './updated-gravatar-string';
 
 import './style.scss';
@@ -65,6 +67,8 @@ class Profile extends Component {
 						}
 					) }
 				/>
+
+				{ isEnabled( 'layout/site-level-user-profile' ) && <SiteLevelProfileBanner /> }
 
 				<SectionHeader label={ this.props.translate( 'Profile' ) } />
 				<Card className="profile__settings">
@@ -120,6 +124,21 @@ class Profile extends Component {
 								value={ this.props.getSetting( 'description' ) }
 							/>
 						</FormFieldset>
+
+						{ isEnabled( 'layout/site-level-user-profile' ) && (
+							<FormFieldset>
+								<FormLabel htmlFor="user_URL">{ this.props.translate( 'Web address' ) }</FormLabel>
+								<FormTextInput
+									disabled={ this.props.getDisabledState() }
+									id="user_URL"
+									name="user_URL"
+									type="url"
+									onChange={ this.props.updateSetting }
+									onFocus={ this.getFocusHandler( 'Web Address Field' ) }
+									value={ this.props.getSetting( 'user_URL' ) }
+								/>
+							</FormFieldset>
+						) }
 
 						<FormFieldset
 							className={ clsx( {

--- a/client/me/profile/site-level-profile-banner/index.tsx
+++ b/client/me/profile/site-level-profile-banner/index.tsx
@@ -1,0 +1,51 @@
+import { useTranslate } from 'i18n-calypso';
+import Banner from 'calypso/components/banner';
+import InfoPopover from 'calypso/components/info-popover';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import SiteLevelProfileModal from '../site-level-profile-modal';
+
+import './style.scss';
+
+export default function SiteLevelProfileBanner() {
+	const translate = useTranslate();
+	const siteCount = useSelector( ( state ) => getCurrentUserSiteCount( state ) );
+
+	if ( siteCount === 0 ) {
+		return null;
+	}
+
+	return (
+		<Banner
+			className="site-level-profile-banner"
+			icon="info-outline"
+			title={ translate(
+				'The following sections are your public WordPress.com profile.{{infoPopover/}}',
+				{
+					components: {
+						infoPopover: (
+							<InfoPopover className="site-level-profile-banner__popover">
+								{ translate(
+									'This is your profile that will be shown publicly when you comment on another WordPress.com blog.'
+								) }
+							</InfoPopover>
+						),
+					},
+				}
+			) }
+			description={
+				<>
+					{ translate(
+						'To manage your profile on a specific site instead, {{modal}}click here{{/modal}}.',
+						{
+							components: {
+								br: <br />,
+								modal: <SiteLevelProfileModal />,
+							},
+						}
+					) }
+				</>
+			}
+		/>
+	);
+}

--- a/client/me/profile/site-level-profile-banner/index.tsx
+++ b/client/me/profile/site-level-profile-banner/index.tsx
@@ -36,7 +36,7 @@ export default function SiteLevelProfileBanner() {
 			description={
 				<>
 					{ translate(
-						'To manage your profile on a specific site instead, {{modal}}click here{{/modal}}.',
+						"To manage your profile on a specific site instead, {{modal}}click here{{/modal}} to visit the site's profile page.",
 						{
 							components: {
 								br: <br />,

--- a/client/me/profile/site-level-profile-banner/index.tsx
+++ b/client/me/profile/site-level-profile-banner/index.tsx
@@ -20,7 +20,7 @@ export default function SiteLevelProfileBanner() {
 			className="site-level-profile-banner"
 			icon="info-outline"
 			title={ translate(
-				'The following sections are your public WordPress.com profile.{{infoPopover/}}',
+				'The following settings are your public WordPress.com profile.{{infoPopover/}}',
 				{
 					components: {
 						infoPopover: (

--- a/client/me/profile/site-level-profile-banner/style.scss
+++ b/client/me/profile/site-level-profile-banner/style.scss
@@ -1,0 +1,5 @@
+.site-level-profile-banner {
+	&__popover svg {
+		margin-bottom: -3px;
+	}
+}

--- a/client/me/profile/site-level-profile-modal/index.jsx
+++ b/client/me/profile/site-level-profile-modal/index.jsx
@@ -1,0 +1,45 @@
+import { Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import SiteSelector from 'calypso/components/site-selector';
+import { navigate } from 'calypso/lib/navigate';
+import { useStore } from 'calypso/state';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+
+export default function SiteLevelProfileModal( props ) {
+	const store = useStore();
+	const translate = useTranslate();
+
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const onSiteSelect = ( siteId ) => {
+		const state = store.getState();
+		const profileUrl = getSiteAdminUrl( state, siteId, 'profile.php' );
+		navigate( profileUrl );
+	};
+
+	const onClose = () => {
+		setIsOpen( false );
+	};
+
+	const renderModal = () => {
+		if ( ! isOpen ) {
+			return null;
+		}
+		return (
+			<Modal onRequestClose={ onClose } size="medium" title={ translate( 'Select a site' ) }>
+				{ /* eslint-disable-next-line jsx-a11y/no-autofocus */ }
+				<SiteSelector autoFocus onSiteSelect={ onSiteSelect } isReskinned />
+			</Modal>
+		);
+	};
+
+	return (
+		<>
+			<a href="/me" onClick={ setIsOpen }>
+				{ props.children }
+			</a>
+			{ renderModal() }
+		</>
+	);
+}

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -95,7 +95,7 @@
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
-		"layout/site-level-user-profile": false,
+		"layout/site-level-user-profile": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/dotcom-forge/issues/8486
- https://github.com/Automattic/dotcom-forge/issues/8485

## Proposed Changes

Under the `layout/site-level-user-profile` flag, enabled on wpcalypso, this PR does the following:

### In /me:
- Added a notice saying that this is the WordPress.com public profile.
- Added a link to manage site-level user profile.
   - When clicked, it opens a site selector.
   - When a site is selected, it navigates to that site's `profile.php`.
- Added Web address field from `/me/account`.

### In /me/account:
- Removed Web address field.
- Removed Admin color scheme field.

|Screen|Before|After|
|-|-|-|
|/me|<img width="500" alt="image" src="https://github.com/user-attachments/assets/4a5a0e6e-d2fb-4b79-950e-2752a6c86ccb"><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>.|<img width="448" alt="image" src="https://github.com/user-attachments/assets/89d6407c-2899-4fea-96bc-923883f73021"><br><br>Tooltip:<br> <img width="295" alt="image" src="https://github.com/user-attachments/assets/3f532a1c-62dc-4ce9-94c7-c5bd2105a5e7"><br><br>Site selector: <br><img width="798" alt="image" src="https://github.com/user-attachments/assets/9a160621-71fe-4804-b340-0a2320c41fe3">|
|/me/account|<img width="596" alt="image" src="https://github.com/user-attachments/assets/6ea8db5b-53e6-483c-8e60-93afc3f9e136">|<img width="691" alt="image" src="https://github.com/user-attachments/assets/537597d2-0f84-43fe-a1ab-b0f98a6d7a8a">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make it clear that the /me page is the public WordPress.com profile, and to provide an easy way to edit the profile on individual site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the Calypso live URL to go to /me.
2. Test if you understand that the page is for public WordPress.com profile.
2. Test if you manage to go to a site's profile.php if you want to manage your profile on that specific site.
3. Test saving the fields and make sure that the fields are updated.
4. Check /me/account as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
