### PR TITLE
Readymade Templates: Header and Footers are persisted correctly when generating content with AI

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
@@ -44,7 +44,7 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 		setNumberOfGenerations( numberOfGenerations + 1 );
 		generateAIContentForTemplate( readymadeTemplate, aiContext )
 			.then( ( rt: ReadymadeTemplate ) =>
-				assembleSite( siteId, 'assembler', {
+				assembleSite( siteId, 'pub/assembler', {
 					homeHtml: rt.home.content,
 					headerHtml: rt.home.header,
 					footerHtml: rt.home.footer,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/8591

## Proposed Changes

* We now send the correct theme so that the site editor and preview can retrieve the correct header and footer.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to the Generate Content with AI step of the Readymade template flow.
* Generate content
* The preview should show the header and footer.
* The site should also show the header and footer as expected.

| Before | After |
|-----|-----|
| ![Screenshot 2024-08-06 at 14 08 54](https://github.com/user-attachments/assets/fbcd54d0-8264-49d5-ba1f-0b015725551c)| ![Screenshot 2024-08-06 at 14 12 14](https://github.com/user-attachments/assets/f586c06c-e02b-43ff-8b4f-333f28355fad)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
