### PR TITLE
Site selected flow: show ecommerce plan

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -37,7 +37,9 @@ export function useModalResolutionCallback( {
 				if (
 					paidDomainName &&
 					( ( flowName && [ ONBOARDING_GUIDED_FLOW, 'onboarding' ].includes( flowName ) ) ||
-						intent === 'plans-jetpack-app-site-creation' )
+						[ 'plans-jetpack-app-site-creation', 'plans-site-selected-legacy' ].includes(
+							intent || ''
+						) )
 				) {
 					return PAID_PLAN_IS_REQUIRED_DIALOG;
 				}

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -60,6 +60,7 @@ import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import isDomainOnlySiteSelector from 'calypso/state/selectors/is-domain-only-site';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -375,6 +376,10 @@ const PlansFeaturesMain = ( {
 		withDiscount,
 	} );
 
+	const isDomainOnlySite = useSelector( ( state: IAppState ) =>
+		siteId ? !! isDomainOnlySiteSelector( state, siteId ) : false
+	);
+
 	const hiddenPlans = {
 		hideFreePlan,
 		hidePersonalPlan,
@@ -402,6 +407,7 @@ const PlansFeaturesMain = ( {
 		term,
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
+		isDomainOnlySite,
 	} );
 
 	// we need only the visible ones for features grid (these should extend into plans-ui data store selectors)
@@ -423,6 +429,7 @@ const PlansFeaturesMain = ( {
 		term,
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
+		isDomainOnlySite,
 	} );
 
 	// when `deemphasizeFreePlan` is enabled, the Free plan will be presented as a CTA link instead of a plan card in the features grid.

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -108,6 +108,7 @@ export function generateSteps( {
 			optionalDependencies: [ 'themeSlugWithRepo' ],
 			props: {
 				intent: 'plans-site-selected-legacy',
+				deemphasizeFreePlan: true,
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -107,7 +107,7 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],
 			optionalDependencies: [ 'themeSlugWithRepo' ],
 			props: {
-				hideEcommercePlan: true,
+				intent: 'plans-site-selected-legacy',
 			},
 		},
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -30,6 +30,7 @@ import { getStepUrl } from 'calypso/signup/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
+import isDomainOnlySiteSelector from 'calypso/state/selectors/is-domain-only-site';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getIntervalType, shouldBasePlansOnSegment } from './util';
@@ -112,6 +113,7 @@ export class PlansStep extends Component {
 			flowName,
 			initialContext,
 			intervalType,
+			isDomainOnlySite,
 		} = this.props;
 
 		const intervalTypeValue = intervalType || getIntervalType( this.props.path );
@@ -141,7 +143,17 @@ export class PlansStep extends Component {
 			? segmentSlug
 			: undefined;
 
-		const paidDomainName = domainItem?.meta;
+		let paidDomainName = domainItem?.meta;
+
+		/**
+		 * Domain-only sites have a paid domain but are on the free plan.
+		 * For flows showing plans for domain-only sites, we need to set
+		 * `paidDomainName` to the value of the domain-only site's domain.
+		 */
+		if ( ! paidDomainName && isDomainOnlySite && selectedSite.URL ) {
+			paidDomainName = selectedSite.URL;
+		}
+
 		let freeWPComSubdomain;
 		if ( typeof siteUrl === 'string' && siteUrl.includes( '.wordpress.com' ) ) {
 			freeWPComSubdomain = siteUrl;
@@ -412,6 +424,7 @@ export default connect(
 		// some descendants of this component may display discounted prices if
 		// they apply to the given site.
 		selectedSite: siteSlug ? getSiteBySlug( state, siteSlug ) : null,
+		isDomainOnlySite: siteSlug ? isDomainOnlySiteSelector( state, siteSlug ) : false,
 		customerType: parseQs( path.split( '?' ).pop() ).customerType,
 		hasInitializedSitesBackUrl: getCurrentUserSiteCount( state ) ? '/sites/' : false,
 	} ),

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -27,6 +27,7 @@ import { getSegmentedIntent } from 'calypso/my-sites/plans/utils/get-segmented-i
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import StartStepWrapper from 'calypso/signup/step-wrapper';
 import { getStepUrl } from 'calypso/signup/utils';
+import { getDomainFromUrl } from 'calypso/site-profiler/utils/get-valid-url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -151,7 +152,7 @@ export class PlansStep extends Component {
 		 * `paidDomainName` to the value of the domain-only site's domain.
 		 */
 		if ( ! paidDomainName && isDomainOnlySite && selectedSite.URL ) {
-			paidDomainName = selectedSite.URL;
+			paidDomainName = getDomainFromUrl( selectedSite.URL );
 		}
 
 		let freeWPComSubdomain;
@@ -430,7 +431,7 @@ export const isDotBlogDomainRegistration = ( domainItem ) => {
 };
 
 export default connect(
-	( state, { path, signupDependencies: { siteSlug, domainItem } } ) => ( {
+	( state, { path, signupDependencies: { siteSlug, siteId, domainItem } } ) => ( {
 		// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 		disableBloggerPlanWithNonBlogDomain:
 			domainItem && ! isSubdomain( domainItem.meta ) && ! isDotBlogDomainRegistration( domainItem ),
@@ -438,7 +439,8 @@ export default connect(
 		// some descendants of this component may display discounted prices if
 		// they apply to the given site.
 		selectedSite: siteSlug ? getSiteBySlug( state, siteSlug ) : null,
-		isDomainOnlySite: siteSlug ? isDomainOnlySiteSelector( state, siteSlug ) : false,
+		isDomainOnlySite:
+			siteId || siteSlug ? isDomainOnlySiteSelector( state, siteId || siteSlug ) : false,
 		customerType: parseQs( path.split( '?' ).pop() ).customerType,
 		hasInitializedSitesBackUrl: getCurrentUserSiteCount( state ) ? '/sites/' : false,
 	} ),

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -220,7 +220,13 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderText() {
-		const { translate, useEmailOnboardingSubheader, signupDependencies, flowName } = this.props;
+		const {
+			translate,
+			useEmailOnboardingSubheader,
+			signupDependencies,
+			flowName,
+			deemphasizeFreePlan,
+		} = this.props;
 
 		const { segmentationSurveyAnswers } = signupDependencies;
 		const { segmentSlug } = getSegmentedIntent( segmentationSurveyAnswers );
@@ -256,6 +262,14 @@ export class PlansStep extends Component {
 				'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.',
 				{ components: { link: freePlanButton } }
 			);
+		}
+
+		/**
+		 * If deemphasizeFreePlan is shown, we already show a subheader.
+		 * Returning null here hides the default subheader and prevents two subheaders from being shown.
+		 */
+		if ( deemphasizeFreePlan ) {
+			return null;
 		}
 	}
 

--- a/packages/plans-grid-next/src/hooks/data-store/types.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/types.ts
@@ -26,6 +26,10 @@ export interface UseGridPlansParams {
 	 * Provide a map of plan slug keyed strings to display as the highlight label on top of each plan.
 	 */
 	highlightLabelOverrides?: { [ K in PlanSlug ]?: TranslateResult };
+	/**
+	 * Used to hide the "Your Plan" label for domain-only sites
+	 */
+	isDomainOnlySite?: boolean;
 }
 
 export type UseGridPlansType = (

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
@@ -27,6 +27,7 @@ const useGridPlansForComparisonGrid = ( {
 	term,
 	useCheckPlanAvailabilityForPurchase,
 	useFreeTrialPlanSlugs,
+	isDomainOnlySite,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
 		allFeaturesList,
@@ -44,6 +45,7 @@ const useGridPlansForComparisonGrid = ( {
 		term,
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
+		isDomainOnlySite,
 	} );
 
 	const planFeaturesForComparisonGrid = useRestructuredPlanFeaturesForComparisonGrid( {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
@@ -23,6 +23,7 @@ const useGridPlansForFeaturesGrid = ( {
 	useCheckPlanAvailabilityForPurchase,
 	useFreeTrialPlanSlugs,
 	highlightLabelOverrides,
+	isDomainOnlySite,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
 		allFeaturesList,
@@ -42,6 +43,7 @@ const useGridPlansForFeaturesGrid = ( {
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
 		highlightLabelOverrides,
+		isDomainOnlySite,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -233,6 +233,7 @@ const useGridPlans: UseGridPlansType = ( {
 	siteId,
 	isDisplayingPlansNeededForFeature,
 	highlightLabelOverrides,
+	isDomainOnlySite,
 } ) => {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs?.( {
 		intent: intent ?? 'default',
@@ -278,6 +279,7 @@ const useGridPlans: UseGridPlansType = ( {
 		selectedPlan,
 		plansAvailabilityForPurchase,
 		highlightLabelOverrides,
+		isDomainOnlySite,
 	} );
 
 	// TODO: pricedAPIPlans to be queried from data-store package

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -279,7 +279,7 @@ const useGridPlans: UseGridPlansType = ( {
 		selectedPlan,
 		plansAvailabilityForPurchase,
 		highlightLabelOverrides,
-		isDomainOnlySite,
+		isDomainOnlySite: isDomainOnlySite || false,
 	} );
 
 	// TODO: pricedAPIPlans to be queried from data-store package

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -200,6 +200,7 @@ const usePlanTypesWithIntent = ( {
 			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;
 		case 'plans-affiliate':
+		case 'plans-site-selected-legacy':
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		default:

--- a/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
@@ -20,6 +20,7 @@ interface Props {
 		[ key: string ]: boolean;
 	};
 	highlightLabelOverrides?: { [ K in PlanSlug ]?: TranslateResult };
+	isDomainOnlySite: boolean;
 }
 
 // TODO clk: move to plans data store
@@ -30,6 +31,7 @@ const useHighlightLabels = ( {
 	selectedPlan,
 	plansAvailabilityForPurchase,
 	highlightLabelOverrides,
+	isDomainOnlySite,
 }: Props ) => {
 	const translate = useTranslate();
 
@@ -43,7 +45,7 @@ const useHighlightLabels = ( {
 			}
 
 			const isCurrentPlan = currentSitePlanSlug
-				? isSamePlan( currentSitePlanSlug, planSlug )
+				? isSamePlan( currentSitePlanSlug, planSlug ) && ! isDomainOnlySite
 				: false;
 			const isPlanAvailableForPurchase = plansAvailabilityForPurchase?.[ planSlug ];
 			const isSuggestedPlan =

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -74,6 +74,7 @@ export type PlansIntent =
 	| 'plans-guided-segment-blogger'
 	| 'plans-guided-segment-nonprofit'
 	| 'plans-guided-segment-consumer-or-business'
+	| 'plans-site-selected-legacy'
 	| 'default';
 
 export interface PlanActionOverrides {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/3262

## Proposed Changes

* Shows the e-commerce plan and hides the enterprise plan for the `plans-site-selected-legacy` step. This is done using the intent mechanism.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Please see https://github.com/Automattic/martech/issues/3262

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go through the domain-only signup flow.
2. Click "Just buy a domain" in the flow and complete checkout of only a domain.
3. In the 'Thank You" page, click "Create a new site".
4. Confirm that the Ecommerce plan is present and the Enterprise plan is hidden.
5. Confirm that the free plan does not have the "Your plan" label.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
