### PR TITLE
RT: Improve layout of details page

### DIFF
--- a/client/my-sites/patterns/components/readymade-template-details/index.tsx
+++ b/client/my-sites/patterns/components/readymade-template-details/index.tsx
@@ -75,7 +75,7 @@ export const ReadymadeTemplateDetails: ReadymadeTemplateDetailsFC = ( { id, rend
 									) }
 								</p>
 								<a href={ localizeUrl( 'https://wordpress.com/support/site-editor/' ) }>
-									{ translate( 'Learn more about how the block editor works.' ) }
+									{ translate( 'Learn more about how the site editor works.' ) }
 								</a>
 							</div>
 						</div>

--- a/client/my-sites/patterns/components/readymade-template-details/index.tsx
+++ b/client/my-sites/patterns/components/readymade-template-details/index.tsx
@@ -71,7 +71,7 @@ export const ReadymadeTemplateDetails: ReadymadeTemplateDetailsFC = ( { id, rend
 								<h4>{ translate( 'Need full control?' ) }</h4>
 								<p>
 									{ translate(
-										'If you want even more control, our powerful site editing tools are always at your disposal, allowing you tu customize every single detail of this beautiful layout.'
+										'If you want even more control, our powerful site editing tools are always at your disposal, allowing you to customize every single detail of this beautiful layout.'
 									) }
 								</p>
 								<a href={ localizeUrl( 'https://wordpress.com/support/site-editor/' ) }>

--- a/client/my-sites/patterns/components/readymade-template-details/index.tsx
+++ b/client/my-sites/patterns/components/readymade-template-details/index.tsx
@@ -65,7 +65,7 @@ export const ReadymadeTemplateDetails: ReadymadeTemplateDetailsFC = ( { id, rend
 								</p>
 								<p>
 									{ translate(
-										'Just describe your site in a few sentences, and our AI tool will customize the content for your'
+										'Just describe your site in a few sentences, and our AI tool will customize the content for you.'
 									) }
 								</p>
 								<h4>{ translate( 'Need full control?' ) }</h4>

--- a/client/my-sites/patterns/components/readymade-template-details/index.tsx
+++ b/client/my-sites/patterns/components/readymade-template-details/index.tsx
@@ -1,8 +1,8 @@
-import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
+import { addLocaleToPathLocaleInFront, useLocalizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
-import { Icon, arrowLeft, check, copy } from '@wordpress/icons';
+import { Icon, arrowLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { PatternsGetStarted } from 'calypso/my-sites/patterns/components/get-started';
 import { useReadymadeTemplates } from 'calypso/my-sites/patterns/hooks/use-readymade-templates';
 import { ReadymadeTemplateDetailsFC } from 'calypso/my-sites/patterns/types';
@@ -11,7 +11,7 @@ import './style.scss';
 
 export const ReadymadeTemplateDetails: ReadymadeTemplateDetailsFC = ( { id, renderPreview } ) => {
 	const translate = useTranslate();
-	const [ isCopied, setIsCopied ] = useState( false );
+	const localizeUrl = useLocalizeUrl();
 
 	useEffect( () => {
 		window.scroll( 0, 0 );
@@ -26,13 +26,6 @@ export const ReadymadeTemplateDetails: ReadymadeTemplateDetailsFC = ( { id, rend
 	if ( ! readymadeTemplate ) {
 		return null;
 	}
-
-	const copyLayout = () => {
-		navigator.clipboard.writeText(
-			readymadeTemplate.home.header + readymadeTemplate.home.content + readymadeTemplate.home.footer
-		);
-		setIsCopied( true );
-	};
 
 	return (
 		<>
@@ -50,13 +43,6 @@ export const ReadymadeTemplateDetails: ReadymadeTemplateDetailsFC = ( { id, rend
 								<h1 className="readymade-template-details-title">{ readymadeTemplate.title }</h1>
 								<div className="readymade-template-details-actions">
 									<Button
-										variant="secondary"
-										icon={ isCopied ? check : copy }
-										onClick={ copyLayout }
-									>
-										{ isCopied ? translate( 'Copied' ) : translate( 'Copy layout' ) }
-									</Button>
-									<Button
 										variant="primary"
 										href={ `/setup/readymade-template?readymadeTemplateId=${ readymadeTemplate.template_id }` }
 									>
@@ -67,11 +53,31 @@ export const ReadymadeTemplateDetails: ReadymadeTemplateDetailsFC = ( { id, rend
 							<div className="readymade-template-details-preview-mobile">
 								{ renderPreview?.( readymadeTemplate ) }
 							</div>
-							<div
-								className="readymade-template-details-description"
-								// eslint-disable-next-line react/no-danger
-								dangerouslySetInnerHTML={ { __html: readymadeTemplate.description } }
-							/>
+							<div className="readymade-template-details-description">
+								<div // eslint-disable-next-line react/no-danger
+									dangerouslySetInnerHTML={ { __html: readymadeTemplate.description } }
+								/>
+								<h4>{ translate( 'Customize it with AI' ) }</h4>
+								<p>
+									{ translate(
+										'Start with this layout and use our AI assistant to create the website of your dreams without breaking a sweat.'
+									) }
+								</p>
+								<p>
+									{ translate(
+										'Just describe your site in a few sentences, and our AI tool will customize the content for your'
+									) }
+								</p>
+								<h4>{ translate( 'Need full control?' ) }</h4>
+								<p>
+									{ translate(
+										'If you want even more control, our powerful site editing tools are always at your disposal, allowing you tu customize every single detail of this beautiful layout.'
+									) }
+								</p>
+								<a href={ localizeUrl( 'https://wordpress.com/support/site-editor/' ) }>
+									{ translate( 'Learn more about how the block editor works.' ) }
+								</a>
+							</div>
 						</div>
 						<div className="readymade-template-details-preview">
 							{ renderPreview?.( readymadeTemplate ) }

--- a/client/my-sites/patterns/components/readymade-template-details/style.scss
+++ b/client/my-sites/patterns/components/readymade-template-details/style.scss
@@ -143,6 +143,7 @@ a.readymade-template-details-back {
 		font-weight: 400;
 		line-height: 26px;
 		text-decoration: underline;
+		text-underline-offset: 4px;
 	}
 
 	p {

--- a/client/my-sites/patterns/components/readymade-template-details/style.scss
+++ b/client/my-sites/patterns/components/readymade-template-details/style.scss
@@ -86,16 +86,11 @@ a.readymade-template-details-back {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	gap: 16px;
+	gap: 8px;
+	flex-wrap: wrap;
 
 	@media (max-width: $break-wide) {
 		margin-bottom: 24px;
-	}
-
-	@media (max-width: $break-xlarge) {
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 8px;
 	}
 }
 
@@ -105,9 +100,6 @@ a.readymade-template-details-back {
 	line-height: 1.2;
 	letter-spacing: 0.185px;
 	margin-bottom: 0;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
 }
 
 .readymade-template-details-actions {
@@ -145,5 +137,26 @@ a.readymade-template-details-back {
 				border-color: var(--studio-gray-5);
 			}
 		}
+	}
+}
+
+.readymade-template-details-description {
+	h4 {
+		color: var(--studio-white);
+		font-size: 1rem;
+		font-weight: 700;
+		line-height: 24px;
+		margin-bottom: 8px;
+	}
+
+	a {
+		color: var(--studio-white);
+		font-weight: 400;
+		line-height: 26px;
+		text-decoration: underline;
+	}
+
+	p {
+		color: var(--studio-gray-20);
 	}
 }

--- a/client/my-sites/patterns/components/readymade-template-details/style.scss
+++ b/client/my-sites/patterns/components/readymade-template-details/style.scss
@@ -126,17 +126,6 @@ a.readymade-template-details-back {
 				color: var(--studio-gray-90);
 			}
 		}
-
-		&.is-secondary {
-			background-color: transparent;
-			border: 1px solid var(--studio-white);
-			color: var(--studio-white);
-
-			&:hover:not(:disabled) {
-				color: var(--studio-gray-5);
-				border-color: var(--studio-gray-5);
-			}
-		}
 	}
 }
 

--- a/client/my-sites/patterns/hooks/use-readymade-templates.ts
+++ b/client/my-sites/patterns/hooks/use-readymade-templates.ts
@@ -4,7 +4,7 @@ import type { ReadymadeTemplate } from 'calypso/my-sites/patterns/types';
 
 export const useReadymadeTemplates = () =>
 	useQuery< ReadymadeTemplate[] >( {
-		queryKey: [ 'pattern-library', 'readymade-templates-4' ],
+		queryKey: [ 'pattern-library', 'readymade-templates' ],
 		queryFn() {
 			return wpcom.req.get( {
 				path: '/themes/readymade-templates',

--- a/client/my-sites/patterns/hooks/use-readymade-templates.ts
+++ b/client/my-sites/patterns/hooks/use-readymade-templates.ts
@@ -4,7 +4,7 @@ import type { ReadymadeTemplate } from 'calypso/my-sites/patterns/types';
 
 export const useReadymadeTemplates = () =>
 	useQuery< ReadymadeTemplate[] >( {
-		queryKey: [ 'pattern-library', 'readymade-templates' ],
+		queryKey: [ 'pattern-library', 'readymade-templates-4' ],
 		queryFn() {
 			return wpcom.req.get( {
 				path: '/themes/readymade-templates',


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8587
Fixes https://github.com/Automattic/dotcom-forge/issues/8599

## Proposed Changes

- Removes the "Copy layout" button since it is more confusing than helpful
- Prevents the title from being truncated
- Enforces a generic description to inform that layouts can be customized with AI and with the site editor
- Also updated all the descriptions in the source site with some fancy description generated by ChatGPT

Before | After
--- | ---
<img width="1267" alt="Screenshot 2024-08-06 at 11 37 54" src="https://github.com/user-attachments/assets/628c5435-9967-4fa2-a688-60b3b9f7d3cb"> | <img width="1261" alt="Screenshot 2024-08-06 at 16 03 23" src="https://github.com/user-attachments/assets/da5f2062-ec91-4b6a-88b2-3bb77bda70ab">


## Why are these changes being made?

Because the details page felt empty

## Testing Instructions

- Use the Calypso live link below
- Go to `/patterns`
- Scroll down and select a RT
- Make sure the "Copy layout" button is gone
- Make the description looks good
- Try different viewport sizes and confirm that the title and the main CTA button have good responsiveness

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
