### PR TITLE
A4A Dev Sites: Introduce `useFetchDevLicenses` hook and use it to display available dev sites count

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
+import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
@@ -91,6 +92,7 @@ export default function AddNewSiteButton( {
 	const pressableOwnership = usePressableOwnershipType();
 
 	const { data: pendingSites } = useFetchPendingSites();
+	const { data: devLicenses } = useFetchDevLicenses();
 
 	const allAvailableSites =
 		pendingSites?.filter(
@@ -100,9 +102,8 @@ export default function AddNewSiteButton( {
 
 	const hasPendingWPCOMSites = allAvailableSites.length > 0;
 
-	// TODO: Replace with actual available dev sites count logic, similar to allAvailableSites above
-	const availableDevSites = [ 'site1', 'site2', 'site3' ];
-	const hasAvailableDevSites = allAvailableSites.length > 0;
+	const availableDevSites = devLicenses?.available;
+	const hasAvailableDevSites = devLicenses?.available > 0;
 
 	const mainButtonLabel = devSite
 		? translate( 'Start developing for free' )
@@ -209,9 +210,9 @@ export default function AddNewSiteButton( {
 						<div className="site-selector-and-importer__popover-site-count">
 							{ translate( '%(pendingSites)d site available', '%(pendingSites)d sites available', {
 								args: {
-									pendingSites: availableDevSites.length,
+									pendingSites: availableDevSites,
 								},
-								count: availableDevSites.length,
+								count: availableDevSites,
 								comment: '%(pendingSites)s is the number of sites available.',
 							} ) }
 						</div>

--- a/client/a8c-for-agencies/data/purchases/use-fetch-dev-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-dev-licenses.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function useFetchDevLicenses() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: [ 'a4a-dev-licenses', agencyId ],
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: '/jetpack-licensing/dev-licenses',
+				},
+				{
+					...( agencyId && { agency_id: agencyId } ),
+				}
+			),
+		select: ( data ) => {
+			return {
+				licenses: data?.licenses,
+				available: data?.available,
+			};
+		},
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/8551.

## Proposed Changes

* introduce `useFetchDevLicenses` hook and use it to display available dev sites count

![Markup on 2024-08-06 at 17:12:16](https://github.com/user-attachments/assets/aa540b39-f8c0-4dc7-9d13-fa9439745a2e)

ℹ️ Please note that this PR doesn't handle the case when there are no dev licenses left anymore. In that case, the `X sites available` text will not display at all. We will need to further explore how to update the UI and communicate this case to the user. Here's a separate task: https://github.com/Automattic/dotcom-forge/issues/8601.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR locally and build the app with `yarn start-a8c-for-agencies`.
2. Head over to the Sites section at http://agencies.localhost:3000/sites/need-setup?flags=a4a-dev-sites and click on the "Start developing for free" CTA button.
3. The number in the `X sites available` text should reflect the actual number of available free dev licenses you have.
4. If you would like to issue and / or revoke some of your free dev licenses, please follow the test instructions in this patch: D157648-code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?