### PR TITLE
Site Migrations: Check for a `from` param on the identification step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -80,18 +80,11 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		isFetched,
 	} = useAnalyzeUrlQuery( siteURL, siteURL !== '' );
 
-	const urlQueryParams = useQuery();
-	const from = urlQueryParams.get( 'from' );
-
 	useEffect( () => {
-		// If we have a URL in the query params, set it as the site URL.
-		if ( from ) {
-			setSiteURL( from );
-		}
 		if ( siteInfo ) {
 			onComplete( siteInfo );
 		}
-	}, [ from, onComplete, siteInfo ] );
+	}, [ onComplete, siteInfo ] );
 
 	if ( isFetching || ( isFetched && ! hasError ) ) {
 		return <ScanningStep />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -80,11 +80,18 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 		isFetched,
 	} = useAnalyzeUrlQuery( siteURL, siteURL !== '' );
 
+	const urlQueryParams = useQuery();
+	const from = urlQueryParams.get( 'from' );
+
 	useEffect( () => {
+		// If we have a URL in the query params, set it as the site URL.
+		if ( from ) {
+			setSiteURL( from );
+		}
 		if ( siteInfo ) {
 			onComplete( siteInfo );
 		}
-	}, [ onComplete, siteInfo ] );
+	}, [ from, onComplete, siteInfo ] );
 
 	if ( isFetching || ( isFetched && ! hasError ) ) {
 		return <ScanningStep />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -131,12 +131,6 @@ describe( 'SiteMigrationIdentify', () => {
 		);
 	} );
 
-	it( 'sets the input value to the site url when the "from" param is set', () => {
-		render( {}, { initialEntry: '/some-path?from=existent-site.com' } );
-
-		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'existent-site.com' );
-	} );
-
 	it( 'sends again the same value set on the url', async () => {
 		const submit = jest.fn();
 		render(
@@ -149,7 +143,7 @@ describe( 'SiteMigrationIdentify', () => {
 			.query( { site_url: 'https://existent-site.com' } )
 			.reply( 200, API_RESPONSE_WITH_OTHER_PLATFORM );
 
-		await userEvent.click( screen.getByRole( 'button', { name: /Check my site/ } ) );
+		await userEvent.click( screen.getByRole( 'heading', { name: /Scanning your site/ } ) );
 		await waitFor( () =>
 			expect( submit ).toHaveBeenCalledWith( expect.objectContaining( { platform: 'unknown' } ) )
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to paYKcK-59M-p2

## Proposed Changes

* On the site identification step, check to see if we already have a `from` URL and a unique value to skip identification in the query params. If so, proceed to the next step.
* This allows us to skip this step if a URL has already been provided from another source (ie the Move landing page, which will be updated in D157710-code) but still fires the `calypso_signup_start` Tracks event to indicate we've started signup.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
* Bug report here: paYKcK-59M-p2
* We're missing the `calypso_signup_start` event from the `/move` landing page because the landing page goes directly to the second step in the hosted-site-migration flow. The start event is only fired on the first step of the flow, so it gets skipped in this case.
* This is the first part of fixing this issue; we also need to update the landing page to point to the first step rather than the site picker step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this branch
* Go to `/setup/hosted-site-migration?from=https://yoururlofchoice.com&skipIdentification=yes`
* This presumes we've already run URL validation from the source of the `from` param before landing in Stepper. You'll be forwarded to the next step (site picker if you have multiple sites already, site creation if not)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?