### PR TITLE
Readymade Templates: Disable "generate content" button when there is no prompt

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
@@ -74,6 +74,7 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 						<FormTextarea
 							name="tagline"
 							id="tagline"
+							disabled={ isGeneratingContent }
 							placeholder={ translate(
 								"Write an amazing description of your site, like: The Beachcomber Bistro is a cafe offering amazing food, delicious coffee and local beers. It's located next to the beach at Harlyn Bay, offering a stunning view from our deck."
 							) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
@@ -35,6 +35,8 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 	const [ isGeneratingContent, setIsGeneratingContent ] = useState( false );
 	const { assembleSite } = useDispatch( SITE_STORE );
 
+	const isPromptEmpty = ! aiContext.trim();
+
 	const handleTextareaChange = ( event: { target: { value: string } } ) => {
 		setAiContext( event.target.value );
 	};
@@ -83,7 +85,7 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 						<Button
 							className="checklist-item__checklist-primary-button"
 							onClick={ generateContent }
-							disabled={ numberOfGenerations >= 5 || isGeneratingContent }
+							disabled={ isPromptEmpty || numberOfGenerations >= 5 || isGeneratingContent }
 						>
 							{ translate( 'Generate content' ) }
 						</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8590

## Proposed Changes

* Disable the "generate content" button when there is no prompt
* Disable the textarea when the AI content is loading

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/patterns`
* Scroll down to the site layouts
* Pick one of the layouts
* Click on `Customize content with AI`
* Wait until loading is done
* Check that the "generate content" button is disabled when there is no prompt
* Check that the textarea is disabled when the AI content is loading

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/238a4969-95ea-408e-8ea7-87fce57bfad5)|![image](https://github.com/user-attachments/assets/3bb3cb2a-57ea-455d-aa09-925efd3fbb80)|
|![image](https://github.com/user-attachments/assets/9938f284-7806-467d-9b93-9c5a36ec3a34)|![image](https://github.com/user-attachments/assets/58e93554-2c41-46ad-b1f4-f471851c96e6)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
