### PR TITLE
A4A Dev Sites: Submit dev site from configuration modal

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -6,7 +6,10 @@ import { check, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
-import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
+import useCreateWPCOMDevSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-dev-site';
+import useCreateWPCOMSiteMutation, {
+	CreateSiteParams,
+} from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
@@ -40,6 +43,7 @@ export default function SiteConfigurationsModal( {
 	const { phpVersions } = usePhpVersions();
 	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading );
 	const { mutate: createWPCOMSite } = useCreateWPCOMSiteMutation();
+	const { mutate: createWPCOMDevSite } = useCreateWPCOMDevSiteMutation();
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>
 		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );
@@ -72,10 +76,6 @@ export default function SiteConfigurationsModal( {
 
 	const onSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
-		if ( ! siteId ) {
-			// Creating a dev site scenario.
-			return;
-		}
 
 		setIsSubmitting( true );
 		const formData = new FormData( event.currentTarget );
@@ -94,17 +94,33 @@ export default function SiteConfigurationsModal( {
 
 		recordTracksEvent( 'calypso_a4a_create_site_config_submit', trackingParams );
 
-		createWPCOMSite( params, {
-			onSuccess: () => {
-				onCreateSiteSuccess( siteId );
-			},
-			onError: async ( error ) => {
-				if ( error.status === 400 ) {
-					await siteName.revalidateCurrentSiteName();
-					setIsSubmitting( false );
-				}
-			},
-		} );
+		if ( isDevSite ) {
+			createWPCOMDevSite( params, {
+				onSuccess: ( response ) => {
+					onCreateSiteSuccess( response.site.id );
+					closeModal();
+				},
+				onError: async ( error ) => {
+					if ( error.status === 400 ) {
+						await siteName.revalidateCurrentSiteName();
+						setIsSubmitting( false );
+					}
+				},
+			} );
+		} else {
+			params.id = siteId;
+			createWPCOMSite( params as CreateSiteParams, {
+				onSuccess: () => {
+					onCreateSiteSuccess( siteId );
+				},
+				onError: async ( error ) => {
+					if ( error.status === 400 ) {
+						await siteName.revalidateCurrentSiteName();
+						setIsSubmitting( false );
+					}
+				},
+			} );
+		}
 	};
 
 	const onRequestCloseModal = () => {

--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -7,9 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import useCreateWPCOMDevSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-dev-site';
-import useCreateWPCOMSiteMutation, {
-	CreateSiteParams,
-} from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
+import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import { useDataCenterOptions } from 'calypso/data/data-center/use-data-center-options';
@@ -108,18 +106,20 @@ export default function SiteConfigurationsModal( {
 				},
 			} );
 		} else {
-			params.id = siteId;
-			createWPCOMSite( params as CreateSiteParams, {
-				onSuccess: () => {
-					onCreateSiteSuccess( siteId );
-				},
-				onError: async ( error ) => {
-					if ( error.status === 400 ) {
-						await siteName.revalidateCurrentSiteName();
-						setIsSubmitting( false );
-					}
-				},
-			} );
+			createWPCOMSite(
+				{ ...params, id: siteId },
+				{
+					onSuccess: () => {
+						onCreateSiteSuccess( siteId );
+					},
+					onError: async ( error ) => {
+						if ( error.status === 400 ) {
+							await siteName.revalidateCurrentSiteName();
+							setIsSubmitting( false );
+						}
+					},
+				}
+			);
 		}
 	};
 

--- a/client/a8c-for-agencies/data/sites/use-create-wpcom-dev-site.ts
+++ b/client/a8c-for-agencies/data/sites/use-create-wpcom-dev-site.ts
@@ -1,0 +1,52 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export interface APIError {
+	status: number;
+}
+
+export interface CreateDevSiteParams {
+	site_name?: string;
+	php_version?: string;
+	primary_data_center?: string;
+	is_fully_managed_agency_site?: boolean;
+}
+
+interface APIResponse {
+	site: {
+		id: number;
+		title: string;
+		url: string;
+		features: object;
+	};
+	license: object;
+	provision: object;
+}
+
+function createWPCOMDevSiteMutation(
+	params: CreateDevSiteParams,
+	agencyId?: number
+): Promise< APIResponse > {
+	if ( ! agencyId ) {
+		throw new Error( 'Agency ID is required to create a dev site' );
+	}
+
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/agency/${ agencyId }/sites/provision-dev-site`,
+		body: params,
+	} );
+}
+
+export default function useCreateWPCOMDevSiteMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, CreateDevSiteParams, TContext >
+): UseMutationResult< APIResponse, APIError, CreateDevSiteParams, TContext > {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation< APIResponse, APIError, CreateDevSiteParams, TContext >( {
+		...options,
+		mutationFn: ( args ) => createWPCOMDevSiteMutation( args, agencyId ),
+	} );
+}

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -1,14 +1,20 @@
 import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
-import { A4A_MARKETPLACE_PRODUCTS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_SITES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
+import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
@@ -22,6 +28,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
 	const { randomSiteName, isRandomSiteNameLoading } = useRandomSiteName();
+	const { refetch: refetchPendingSites } = useFetchPendingSites();
 
 	const [ tourStepRef, setTourStepRef ] = useState< HTMLElement | null >( null );
 	const [ showConfigurationModal, setShowConfigurationModal ] = useState( false );
@@ -30,6 +37,14 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 		setShowConfigurationModal( ! showConfigurationModal );
 	};
 
+	const onCreateSiteSuccess = useCallback(
+		( id: number ) => {
+			refetchPendingSites();
+			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
+		},
+		[ refetchPendingSites ]
+	);
+
 	return (
 		<div className="sites-header__actions">
 			{ showConfigurationModal && (
@@ -37,7 +52,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 					closeModal={ toggleSiteConfigurationsModal }
 					randomSiteName={ randomSiteName }
 					isRandomSiteNameLoading={ isRandomSiteNameLoading }
-					onCreateSiteSuccess={ () => {} }
+					onCreateSiteSuccess={ onCreateSiteSuccess }
 				/>
 			) }
 			{ config.isEnabled( 'a4a-dev-sites' ) && (


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/8351.

## Proposed Changes

Follow up of https://github.com/Automattic/wp-calypso/pull/93193, for Add dev site configuration modal.

It submits the form and calls the `/agency/${ agencyId }/sites/provision-dev-site` endpoint.


## Testing Instructions
- Open the sites page on A4A client.
- Open `Start developing for free` on the header and click to create a new site.
- You should see the site configuration modal.
- The `Allow clients to use the WordPress.com Help Center and hosting features.` checkbox and label should be disabled.
- Click on Create site.
- It should close the modal, return to the sites page and display a yellow banner.
- After a few seconds or minute, the banner should turn green, with the site ready:
![image](https://github.com/user-attachments/assets/a00268a3-e4d7-417a-aa96-4c46791f85eb)


Make a regression test.
Create a new site on A4A by issuing a license and clicking on `Create new site` at the `Needs setup` page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
