### PR TITLE
Make reauth modal fullscreen and keep the left hand Masterbar accessible

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -166,6 +166,7 @@ $z-layers: (
 		".popover.info-tooltip__container": 100300,
 		".popover.info-popover__tooltip.plugin-action__disabled-info": 100300,
 		"body .webui-popover": 100300,
+		".reauth-required__dialog-body .masterbar__section--left": 100300,
 		".fullscreen-fader": 200000,
 		".guided-tours__overlay": 200050,
 		".guided-tours__step": 201000,

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -272,7 +272,7 @@ class ReauthRequired extends Component {
 
 		return (
 			<Dialog
-				bodyOpenClassName="reauth-required__dialog-body"
+				bodyOpenClassName="ReactModal__Body--open reauth-required__dialog-body"
 				autoFocus={ false }
 				className="reauth-required__dialog"
 				isVisible={ this.props?.twoStepAuthorization.isReauthRequired() }

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -272,6 +272,7 @@ class ReauthRequired extends Component {
 
 		return (
 			<Dialog
+				bodyOpenClassName="reauth-required__dialog-body"
 				autoFocus={ false }
 				className="reauth-required__dialog"
 				isVisible={ this.props?.twoStepAuthorization.isReauthRequired() }

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -274,7 +274,6 @@ class ReauthRequired extends Component {
 			<Dialog
 				autoFocus={ false }
 				className="reauth-required__dialog"
-				isFullScreen={ false }
 				isVisible={ this.props?.twoStepAuthorization.isReauthRequired() }
 			>
 				{ isSecurityKeySupported && twoFactorAuthType === 'webauthn' ? (

--- a/client/me/reauth-required/style.scss
+++ b/client/me/reauth-required/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .reauth-required__send-sms-throttled {
 	margin-bottom: 1em;
 }
@@ -16,4 +18,31 @@
 
 .reauth-required__logout {
 	margin-top: 1em;
+}
+
+// Let the left section of the masterbar be on top of the dialog during reauth.
+.reauth-required__dialog-body {
+	.masterbar {
+		position: inherit;
+		transition: none;
+		margin-bottom: -46px;
+
+		@media (max-width: $break-small) {
+			margin-bottom: 0;
+		}
+
+		@media (min-width: $break-medium) {
+			margin-bottom: -32px;
+		}
+
+		.masterbar__section--left {
+			z-index: z-index("root", ".reauth-required__dialog-body .masterbar__section--left");
+		}
+	}
+	.layout__content {
+		@media (max-width: $break-small) {
+			padding-top: 16px !important;
+			transition: none !important;
+		}
+	}
 }

--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -83,7 +83,7 @@ const Dialog = ( {
 			role="dialog"
 			shouldCloseOnEsc={ shouldCloseOnEsc }
 			shouldCloseOnOverlayClick={ shouldCloseOnOverlayClick }
-			{ ...( bodyOpenClassName ? { bodyOpenClassName } : {} ) }
+			bodyOpenClassName={ bodyOpenClassName }
 		>
 			{ showCloseIcon && (
 				<button

--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -25,6 +25,7 @@ type Props = {
 	shouldCloseOnOverlayClick?: boolean;
 	labelledby?: string;
 	describedby?: string;
+	bodyOpenClassName?: string;
 };
 
 const Dialog = ( {
@@ -45,6 +46,7 @@ const Dialog = ( {
 	shouldCloseOnOverlayClick = true,
 	labelledby,
 	describedby,
+	bodyOpenClassName,
 }: PropsWithChildren< Props > ) => {
 	const close = useCallback( () => onClose?.(), [ onClose ] );
 	const onButtonClick = useCallback(
@@ -81,6 +83,7 @@ const Dialog = ( {
 			role="dialog"
 			shouldCloseOnEsc={ shouldCloseOnEsc }
 			shouldCloseOnOverlayClick={ shouldCloseOnOverlayClick }
+			bodyOpenClassName={ bodyOpenClassName }
 		>
 			{ showCloseIcon && (
 				<button

--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -83,7 +83,7 @@ const Dialog = ( {
 			role="dialog"
 			shouldCloseOnEsc={ shouldCloseOnEsc }
 			shouldCloseOnOverlayClick={ shouldCloseOnOverlayClick }
-			bodyOpenClassName={ bodyOpenClassName }
+			{ ...( bodyOpenClassName ? { bodyOpenClassName } : {} ) }
 		>
 			{ showCloseIcon && (
 				<button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8575

## Proposed Changes

* This PR has the reauth modal cover the full screen, including the masterbar. However, it keeps the lefthand of the Masterbar accessible so the user can navigate away from the reauth attempt.
* It exposes and makes use of the `bodyOpenClassName` property on the react-modal component.


Before | After
--|--
<img width="1298" alt="Screenshot 2024-08-06 at 5 21 35 PM" src="https://github.com/user-attachments/assets/5a23844d-c6f6-47e9-9bc0-7898b1ae5c7c">  |  <video src="https://github.com/user-attachments/assets/8408c56f-88bc-41dc-ae78-409e9052c4a8">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Having the Masterbar visible above the reauth modal _feels_ like a bug. Additionally, the submenu popups are not clickable when the modal is open. This PR corrects the _feel_ of the modal as well as makes the submenu popups on the left hand available to the user.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /me and remove the twostep_auth cookie from the browser console.
* View that the Masterbar is visible above the reauth modal.
* Load this PR 
* Navigate to /me and remove the twostep_auth cookie from the browser console.
* View that the Masterbar is below the reauth modal.
* The right-hand items should be under the modal and not clickable.
* The left-hand masterbar items should still be clickable and usable.
* Make sure the left-hand items are all functional in mobile and desktop.
* Try authenticating and make sure the masterbar is working correctly.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
