### PR TITLE
Plans: Refactor action button component into shared

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -30,10 +30,10 @@ import { useManageTooltipToggle } from '../../hooks/use-manage-tooltip-toggle';
 import filterUnusedFeaturesObject from '../../lib/filter-unused-features-object';
 import getPlanFeaturesObject from '../../lib/get-plan-features-object';
 import { sortPlans } from '../../lib/sort-plan-properties';
-import PlanFeatures2023GridActions from '../actions';
 import PlanTypeSelector from '../plan-type-selector';
 import { Plans2023Tooltip } from '../plans-2023-tooltip';
 import PopularBadge from '../popular-badge';
+import ActionButton from '../shared/action-button';
 import BillingTimeframe from '../shared/billing-timeframe';
 import HeaderPrice from '../shared/header-price';
 import { PlanStorage } from '../shared/storage';
@@ -439,7 +439,7 @@ const ComparisonGridHeaderCell = ( {
 			<div className="plan-comparison-grid__billing-info">
 				<BillingTimeframe planSlug={ planSlug } showRefundPeriod={ showRefundPeriod } />
 			</div>
-			<PlanFeatures2023GridActions
+			<ActionButton
 				currentSitePlanSlug={ currentSitePlanSlug }
 				availableForPurchase={ gridPlan.availableForPurchase }
 				isInSignup={ isInSignup }

--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -294,4 +294,12 @@
 			}
 		}
 	}
+
+	.plans-grid-next-action-button {
+		margin-bottom: auto;
+
+		.plans-grid-next-action-button__content {
+			min-height: 40px;
+		}
+	}
 }

--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -10,14 +10,6 @@
 		}
 	}
 
-	.plan-features-2023-gridrison__actions {
-		margin-bottom: auto;
-	}
-
-	.plan-features-2023-gridrison__actions-buttons {
-		min-height: 40px;
-	}
-
 	.plan-comparison-grid__header-cell {
 		display: flex;
 		flex-direction: column;

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.scss
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.scss
@@ -1,0 +1,5 @@
+.plan-features-2023-grid__plan-spotlight {
+	.plans-grid-next-action-button {
+		width: 200px;
+	}
+}

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -9,6 +9,7 @@ import PlanLogos from './plan-logos';
 import PlanPrices from './plan-prices';
 import PlanTagline from './plan-tagline';
 import TopButtons from './top-buttons';
+import './spotlight-plan.scss';
 
 type SpotlightPlanProps = {
 	currentSitePlanSlug?: string | null;

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -64,6 +64,7 @@ const SpotlightPlan = ( {
 				isInSignup={ isInSignup }
 				currentSitePlanSlug={ currentSitePlanSlug }
 				planActionOverrides={ planActionOverrides }
+				options={ { isFixedWidthActionButton: true } }
 			/>
 		</div>
 	);

--- a/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/spotlight-plan.tsx
@@ -64,7 +64,6 @@ const SpotlightPlan = ( {
 				isInSignup={ isInSignup }
 				currentSitePlanSlug={ currentSitePlanSlug }
 				planActionOverrides={ planActionOverrides }
-				options={ { isFixedWidthActionButton: true } }
 			/>
 		</div>
 	);

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -233,13 +233,6 @@
 		font-weight: 600;
 	}
 
-	.plan-features-2023-grid__actions-post-button-text {
-		text-align: center;
-		font-size: 0.75rem;
-		display: block;
-		margin-top: 10px;
-	}
-
 	&.is-top-buttons {
 		padding: 0 20px;
 		@include plans-grid-medium-large {
@@ -305,10 +298,6 @@
 		.plan-features-2023-grid__header-logo {
 			display: none;
 		}
-
-		.plan-features-2023-gridrison__actions {
-			width: 200px;
-		}
 	}
 }
 
@@ -373,12 +362,6 @@
 			margin-top: 8px;
 		}
 	}
-}
-
-.plan-features-2023-grid__multiple-actions-container {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
 }
 
 .plan-features-2023-grid__row:last-of-type .plan-features-2023-grid__table-item {

--- a/packages/plans-grid-next/src/components/features-grid/top-buttons.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/top-buttons.tsx
@@ -11,7 +11,6 @@ type TopButtonsProps = {
 	options?: {
 		isTableCell?: boolean;
 		isStuck?: boolean;
-		isFixedWidthActionButton?: boolean;
 	};
 };
 
@@ -41,7 +40,6 @@ const TopButtons = ( {
 					showMonthlyPrice
 					isStuck={ options?.isStuck || false }
 					visibleGridPlans={ renderedGridPlans }
-					isFixedWidth={ options?.isFixedWidthActionButton }
 				/>
 			</PlanDivOrTdContainer>
 		);

--- a/packages/plans-grid-next/src/components/features-grid/top-buttons.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/top-buttons.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { GridPlan, PlanActionOverrides } from '../../types';
-import PlanFeatures2023GridActions from '../actions';
 import PlanDivOrTdContainer from '../plan-div-td-container';
+import ActionButton from '../shared/action-button';
 
 type TopButtonsProps = {
 	currentSitePlanSlug?: string | null;
@@ -11,6 +11,7 @@ type TopButtonsProps = {
 	options?: {
 		isTableCell?: boolean;
 		isStuck?: boolean;
+		isFixedWidthActionButton?: boolean;
 	};
 };
 
@@ -30,7 +31,7 @@ const TopButtons = ( {
 				className={ classes }
 				isTableCell={ options?.isTableCell }
 			>
-				<PlanFeatures2023GridActions
+				<ActionButton
 					availableForPurchase={ availableForPurchase }
 					isInSignup={ isInSignup }
 					isMonthlyPlan={ isMonthlyPlan }
@@ -40,6 +41,7 @@ const TopButtons = ( {
 					showMonthlyPrice
 					isStuck={ options?.isStuck || false }
 					visibleGridPlans={ renderedGridPlans }
+					isFixedWidth={ options?.isFixedWidthActionButton }
 				/>
 			</PlanDivOrTdContainer>
 		);

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -170,7 +170,7 @@ const ActionButton = ( {
 		} else {
 			const hasFreeTrialPlan = isInSignup ? !! freeTrialPlanSlug : false;
 			actionButton = hasFreeTrialPlan ? (
-				<div className="plans-grid-next__action-button-multi">
+				<div className="plans-grid-next-action-button__multi">
 					<PlanButton planSlug={ planSlug } onClick={ () => freeTrialCallback() } busy={ busy }>
 						{ freeTrialText }
 					</PlanButton>
@@ -192,7 +192,7 @@ const ActionButton = ( {
 						{ text }
 					</PlanButton>
 					{ postButtonText && (
-						<span className="plans-grid-next__action-button-label">{ postButtonText }</span>
+						<span className="plans-grid-next-action-button__label">{ postButtonText }</span>
 					) }
 				</>
 			);
@@ -201,11 +201,11 @@ const ActionButton = ( {
 
 	return (
 		<div
-			className={ clsx( 'plans-grid-next__action-button', {
+			className={ clsx( 'plans-grid-next-action-button', {
 				'is-fixed-width': isFixedWidth,
 			} ) }
 		>
-			<div className="plans-grid-next__action-button-content">{ actionButton }</div>
+			<div className="plans-grid-next-action-button__content">{ actionButton }</div>
 		</div>
 	);
 };

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -202,7 +202,7 @@ const ActionButton = ( {
 	return (
 		<div
 			className={ clsx( 'plans-grid-next__action-button', {
-				'plans-grid-next__action-button--fixed-width': isFixedWidth,
+				'is-fixed-width': isFixedWidth,
 			} ) }
 		>
 			<div className="plans-grid-next__action-button-content">{ actionButton }</div>

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -8,19 +8,22 @@ import {
 import { AddOns, WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { useSelect } from '@wordpress/data';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { usePlansGridContext } from '../grid-context';
-import useIsLargeCurrency from '../hooks/use-is-large-currency';
-import { usePlanPricingInfoFromGridPlans } from '../hooks/use-plan-pricing-info-from-grid-plans';
-import PlanButton from './plan-button';
-import { useDefaultStorageOption } from './shared/storage';
-import type { GridPlan, PlanActionOverrides } from '../types';
+import { usePlansGridContext } from '../../../grid-context';
+import useIsLargeCurrency from '../../../hooks/use-is-large-currency';
+import { usePlanPricingInfoFromGridPlans } from '../../../hooks/use-plan-pricing-info-from-grid-plans';
+import PlanButton from '../../plan-button';
+import { useDefaultStorageOption } from '../../shared/storage';
+import type { GridPlan, PlanActionOverrides } from '../../../types';
+import './style.scss';
 
-type PlanFeaturesActionsButtonProps = {
+type ActionButtonProps = {
 	availableForPurchase: boolean;
 	currentSitePlanSlug?: string | null;
 	isPopular?: boolean;
 	isInSignup?: boolean;
+	isFixedWidth?: boolean;
 	isMonthlyPlan?: boolean;
 	planSlug: PlanSlug;
 	buttonText?: string;
@@ -30,7 +33,7 @@ type PlanFeaturesActionsButtonProps = {
 	visibleGridPlans: GridPlan[];
 };
 
-const PlanFeatures2023GridActions = ( {
+const ActionButton = ( {
 	planSlug,
 	currentSitePlanSlug,
 	visibleGridPlans,
@@ -38,7 +41,8 @@ const PlanFeatures2023GridActions = ( {
 	isStuck,
 	isInSignup,
 	isMonthlyPlan,
-}: PlanFeaturesActionsButtonProps ) => {
+	isFixedWidth,
+}: ActionButtonProps ) => {
 	const translate = useTranslate();
 	const {
 		gridPlansIndex,
@@ -166,7 +170,7 @@ const PlanFeatures2023GridActions = ( {
 		} else {
 			const hasFreeTrialPlan = isInSignup ? !! freeTrialPlanSlug : false;
 			actionButton = hasFreeTrialPlan ? (
-				<div className="plan-features-2023-grid__multiple-actions-container">
+				<div className="plans-grid-next__action-button-multi">
 					<PlanButton planSlug={ planSlug } onClick={ () => freeTrialCallback() } busy={ busy }>
 						{ freeTrialText }
 					</PlanButton>
@@ -188,9 +192,7 @@ const PlanFeatures2023GridActions = ( {
 						{ text }
 					</PlanButton>
 					{ postButtonText && (
-						<span className="plan-features-2023-grid__actions-post-button-text">
-							{ postButtonText }
-						</span>
+						<span className="plans-grid-next__action-button-label">{ postButtonText }</span>
 					) }
 				</>
 			);
@@ -198,10 +200,14 @@ const PlanFeatures2023GridActions = ( {
 	}
 
 	return (
-		<div className="plan-features-2023-gridrison__actions">
-			<div className="plan-features-2023-gridrison__actions-buttons">{ actionButton }</div>
+		<div
+			className={ clsx( 'plans-grid-next__action-button', {
+				'plans-grid-next__action-button--fixed-width': isFixedWidth,
+			} ) }
+		>
+			<div className="plans-grid-next__action-button-content">{ actionButton }</div>
 		</div>
 	);
 };
 
-export default PlanFeatures2023GridActions;
+export default ActionButton;

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -8,7 +8,6 @@ import {
 import { AddOns, WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { useSelect } from '@wordpress/data';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
 import useIsLargeCurrency from '../../../hooks/use-is-large-currency';
@@ -23,7 +22,6 @@ type ActionButtonProps = {
 	currentSitePlanSlug?: string | null;
 	isPopular?: boolean;
 	isInSignup?: boolean;
-	isFixedWidth?: boolean;
 	isMonthlyPlan?: boolean;
 	planSlug: PlanSlug;
 	buttonText?: string;
@@ -41,7 +39,6 @@ const ActionButton = ( {
 	isStuck,
 	isInSignup,
 	isMonthlyPlan,
-	isFixedWidth,
 }: ActionButtonProps ) => {
 	const translate = useTranslate();
 	const {
@@ -200,11 +197,7 @@ const ActionButton = ( {
 	}
 
 	return (
-		<div
-			className={ clsx( 'plans-grid-next-action-button', {
-				'is-fixed-width': isFixedWidth,
-			} ) }
-		>
+		<div className="plans-grid-next-action-button">
 			<div className="plans-grid-next-action-button__content">{ actionButton }</div>
 		</div>
 	);

--- a/packages/plans-grid-next/src/components/shared/action-button/style.scss
+++ b/packages/plans-grid-next/src/components/shared/action-button/style.scss
@@ -1,17 +1,3 @@
-.plans-grid-next-action-button {
-	.plans-grid-next-comparison-grid & {
-		margin-bottom: auto;
-
-		.plans-grid-next-action-button__content {
-			min-height: 40px;
-		}
-	}
-
-	.plan-features-2023-grid__plan-spotlight & {
-		width: 200px;
-	}
-}
-
 .plans-grid-next-action-button__label {
 	text-align: center;
 	font-size: 0.75rem;

--- a/packages/plans-grid-next/src/components/shared/action-button/style.scss
+++ b/packages/plans-grid-next/src/components/shared/action-button/style.scss
@@ -1,8 +1,8 @@
-.plans-grid-next__action-button {
+.plans-grid-next-action-button {
 	.plans-grid-next-comparison-grid & {
 		margin-bottom: auto;
 
-		.plans-grid-next__action-button-content {
+		.plans-grid-next-action-button__content {
 			min-height: 40px;
 		}
 	}
@@ -12,14 +12,14 @@
 	}
 }
 
-.plans-grid-next__action-button-label {
+.plans-grid-next-action-button__label {
 	text-align: center;
 	font-size: 0.75rem;
 	display: block;
 	margin-top: 10px;
 }
 
-.plans-grid-next__action-button-multi {
+.plans-grid-next-action-button__multi {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;

--- a/packages/plans-grid-next/src/components/shared/action-button/style.scss
+++ b/packages/plans-grid-next/src/components/shared/action-button/style.scss
@@ -1,21 +1,4 @@
 .plans-grid-next__action-button {
-	&-multi {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-
-	&-label {
-		text-align: center;
-		font-size: 0.75rem;
-		display: block;
-		margin-top: 10px;
-	}
-
-	&--fixed-width {
-		width: 200px;
-	}
-
 	.plans-grid-next-comparison-grid & {
 		margin-bottom: auto;
 
@@ -23,4 +6,21 @@
 			min-height: 40px;
 		}
 	}
+}
+
+.plans-grid-next__action-button-label {
+	text-align: center;
+	font-size: 0.75rem;
+	display: block;
+	margin-top: 10px;
+}
+
+.plans-grid-next__action-button-multi {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.plans-grid-next__action-button--fixed-width {
+	width: 200px;
 }

--- a/packages/plans-grid-next/src/components/shared/action-button/style.scss
+++ b/packages/plans-grid-next/src/components/shared/action-button/style.scss
@@ -1,0 +1,26 @@
+.plans-grid-next__action-button {
+	&-multi {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	&-label {
+		text-align: center;
+		font-size: 0.75rem;
+		display: block;
+		margin-top: 10px;
+	}
+
+	&--fixed-width {
+		width: 200px;
+	}
+
+	.plans-grid-next-comparison-grid & {
+		margin-bottom: auto;
+
+		.plans-grid-next__action-button-content {
+			min-height: 40px;
+		}
+	}
+}

--- a/packages/plans-grid-next/src/components/shared/action-button/style.scss
+++ b/packages/plans-grid-next/src/components/shared/action-button/style.scss
@@ -6,10 +6,10 @@
 			min-height: 40px;
 		}
 	}
-}
 
-.plans-grid-next__action-button.is-fixed-width {
-	width: 200px;
+	.plan-features-2023-grid__plan-spotlight & {
+		width: 200px;
+	}
 }
 
 .plans-grid-next__action-button-label {

--- a/packages/plans-grid-next/src/components/shared/action-button/style.scss
+++ b/packages/plans-grid-next/src/components/shared/action-button/style.scss
@@ -8,6 +8,10 @@
 	}
 }
 
+.plans-grid-next__action-button.is-fixed-width {
+	width: 200px;
+}
+
 .plans-grid-next__action-button-label {
 	text-align: center;
 	font-size: 0.75rem;
@@ -19,8 +23,4 @@
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-}
-
-.plans-grid-next__action-button--fixed-width {
-	width: 200px;
 }

--- a/packages/plans-grid-next/src/components/test/actions-button.tsx
+++ b/packages/plans-grid-next/src/components/test/actions-button.tsx
@@ -50,9 +50,9 @@ import { render, screen } from '@testing-library/react';
 import { useDispatch } from '@wordpress/data';
 import React from 'react';
 import { usePlansGridContext } from '../../grid-context';
-import PlanFeatures2023GridActions from '../actions';
+import ActionButton from '../shared/action-button';
 
-describe( 'PlanFeatures2023GridActions', () => {
+describe( 'ActionButton', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		useDispatch.mockImplementation( jest.fn( () => ( { setShowDomainUpsellDialog: jest.fn() } ) ) );
@@ -71,7 +71,6 @@ describe( 'PlanFeatures2023GridActions', () => {
 			freePlan: false,
 			isInSignup: false,
 			onUpgradeClick: jest.fn(),
-			isWpcomEnterpriseGridPlan: false,
 			isStuck: false,
 			showMonthlyPrice: true,
 			visibleGridPlans: [],
@@ -116,7 +115,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 			} ) );
 
 			render(
-				<PlanFeatures2023GridActions
+				<ActionButton
 					{ ...defaultProps }
 					currentSitePlanSlug={ PLAN_PREMIUM_2_YEARS }
 					planSlug={ PLAN_BUSINESS }
@@ -162,7 +161,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 			} ) );
 
 			render(
-				<PlanFeatures2023GridActions
+				<ActionButton
 					{ ...defaultProps }
 					currentSitePlanSlug={ PLAN_PREMIUM }
 					planSlug={ PLAN_BUSINESS }
@@ -207,7 +206,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 					},
 				} ) );
 				render(
-					<PlanFeatures2023GridActions
+					<ActionButton
 						{ ...defaultProps }
 						currentSitePlanSlug={ PLAN_BUSINESS_MONTHLY }
 						planSlug={ PLAN_BUSINESS }
@@ -266,7 +265,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 				} ) );
 
 				render(
-					<PlanFeatures2023GridActions
+					<ActionButton
 						{ ...defaultProps }
 						currentSitePlanSlug={ PLAN_BUSINESS_MONTHLY }
 						planSlug={ PLAN_BUSINESS_2_YEARS }
@@ -309,7 +308,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 					},
 				} ) );
 				render(
-					<PlanFeatures2023GridActions
+					<ActionButton
 						{ ...defaultProps }
 						currentSitePlanSlug={ PLAN_BUSINESS_MONTHLY }
 						planSlug={ PLAN_BUSINESS_3_YEARS }
@@ -344,13 +343,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 						} ),
 					},
 				} ) );
-				render(
-					<PlanFeatures2023GridActions
-						{ ...defaultProps }
-						planSlug={ PLAN_BUSINESS_3_YEARS }
-						isStuck
-					/>
-				);
+				render( <ActionButton { ...defaultProps } planSlug={ PLAN_BUSINESS_3_YEARS } isStuck /> );
 				const upgradeButton = screen.getByRole( 'button', { name: 'Upgrade – $20' } );
 
 				expect( upgradeButton ).toHaveTextContent( 'Upgrade – $20' );
@@ -384,7 +377,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 					},
 				} ) );
 				render(
-					<PlanFeatures2023GridActions
+					<ActionButton
 						{ ...defaultProps }
 						isInSignup
 						planSlug={ PLAN_BUSINESS }


### PR DESCRIPTION
Related to #87293

## Proposed Changes

* Renames the`PlanFeatures2023GridActions` component to `ActionButton`
* Relocates the `ActionButton` component into `components/shared/action-button`
* Cleanup and consolidation of related styles

## Why are these changes being made?

Part of a broader effort to move any shared components for the `plans-grid-next` package into `components/shared`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* No functional changes
* Tests should pass
* Smoke test `/plans/:site` to check that instances of `ActionButton` appear as per production

![CleanShot 2024-08-07 at 20 15 58@2x](https://github.com/user-attachments/assets/aec01785-090f-4f0b-aa0c-647190b19d32)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
