### PR TITLE
A4A > Marketplace: Minor text updates & enhancements the new hosting page

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/common-hosting-benefits.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/common-hosting-benefits.tsx
@@ -7,7 +7,7 @@ export default function CommonHostingBenefits() {
 	return (
 		<HostingBenefitsSection
 			heading={ translate( 'Improve your client relationships with our hosting' ) }
-			subheading={ translate( 'How can Automattic help' ) }
+			subheading={ translate( 'How Automattic can help' ) }
 			background={ BackgroundType3 }
 			items={ [
 				{

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useContext } from 'react';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v2';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import VIPLogo from 'calypso/assets/images/a8c-for-agencies/vip-full-logo.svg';
@@ -12,6 +12,7 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import { MarketplaceTypeContext } from '../../context';
 import EnterpriseAgencyHosting from './enterprise-agency-hosting';
 import PremierAgencyHosting from './premier-agency-hosting';
 import StandardAgencyHosting from './standard-agency-hosting';
@@ -67,6 +68,10 @@ export default function HostingV2( { onAddToCart, section }: Props ) {
 
 	const isLargeScreen = useBreakpoint( '>1280px' );
 
+	const { marketplaceType } = useContext( MarketplaceTypeContext );
+
+	const isReferMode = marketplaceType === 'referral';
+
 	const handleTabClick = useCallback(
 		( tab: string ) => {
 			page.show( `/marketplace/hosting/${ tab }` );
@@ -97,18 +102,22 @@ export default function HostingV2( { onAddToCart, section }: Props ) {
 					handleTabClick( 'pressable' );
 				},
 			},
-			{
-				key: 'vip',
-				label: translate( 'Enterprise' ),
-				subtitle: isLargeScreen && translate( 'WordPress for enterprise-level demands' ),
-				visible: true,
-				selected: section === 'vip',
-				onClick: () => {
-					handleTabClick( 'vip' );
-				},
-			},
+			...( isReferMode
+				? []
+				: [
+						{
+							key: 'vip',
+							label: translate( 'Enterprise' ),
+							subtitle: isLargeScreen && translate( 'WordPress for enterprise-level demands' ),
+							visible: true,
+							selected: section === 'vip',
+							onClick: () => {
+								handleTabClick( 'vip' );
+							},
+						},
+				  ] ),
 		],
-		[ handleTabClick, isLargeScreen, section, translate ]
+		[ handleTabClick, isLargeScreen, isReferMode, section, translate ]
 	);
 
 	const navItems = featureTabs.map( ( featureTab ) => {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -4,6 +4,10 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback, useContext, useEffect } from 'react';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v2';
+import {
+	A4A_MARKETPLACE_HOSTING_LINK,
+	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import VIPLogo from 'calypso/assets/images/a8c-for-agencies/vip-full-logo.svg';
 import WPCOMLogo from 'calypso/assets/images/a8c-for-agencies/wpcom-logo.svg';
@@ -74,7 +78,7 @@ export default function HostingV2( { onAddToCart, section }: Props ) {
 
 	const handleTabClick = useCallback(
 		( tab: string ) => {
-			page.show( `/marketplace/hosting/${ tab }` );
+			page.show( `${ A4A_MARKETPLACE_HOSTING_LINK }/${ tab }` );
 			dispatch( recordTracksEvent( 'calypso_a4a_marketplace_hosting_tab_click', { tab } ) );
 		},
 		[ dispatch ]
@@ -83,7 +87,7 @@ export default function HostingV2( { onAddToCart, section }: Props ) {
 	useEffect( () => {
 		// Redirect since the VIP section is not available in refer mode
 		if ( isReferMode && section === 'vip' ) {
-			page.show( `/marketplace/hosting/wpcom` );
+			page.show( A4A_MARKETPLACE_HOSTING_WPCOM_LINK );
 		}
 	}, [ isReferMode, section ] );
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useCallback, useContext } from 'react';
+import { useMemo, useCallback, useContext, useEffect } from 'react';
 import MigrationOffer from 'calypso/a8c-for-agencies/components/a4a-migration-offer-v2';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/pressable-logo.svg';
 import VIPLogo from 'calypso/assets/images/a8c-for-agencies/vip-full-logo.svg';
@@ -79,6 +79,13 @@ export default function HostingV2( { onAddToCart, section }: Props ) {
 		},
 		[ dispatch ]
 	);
+
+	useEffect( () => {
+		// Redirect since the VIP section is not available in refer mode
+		if ( isReferMode && section === 'vip' ) {
+			page.show( `/marketplace/hosting/wpcom` );
+		}
+	}, [ isReferMode, section ] );
 
 	const featureTabs = useMemo(
 		() => [

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -27,7 +27,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 				heading={ translate( 'Jetpack Complete included' ) }
 				subheading={ translate( "Supercharge your clients' sites" ) }
 				description={ translate(
-					'Every Pressable hosting plan comes with a Jetpack Security License for free - a $239/year/site value.'
+					'Every site built on Pressable comes with Jetpack Complete for free - a $599/year/site value.'
 				) }
 				background={ BackgroundType1 }
 				items={ [
@@ -115,7 +115,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 						profile: {
 							avatar: ProfileAvatar1,
 							name: 'Ben Giordano',
-							title: translate( 'Founder - %(companyName)s', {
+							title: translate( 'Founder, %(companyName)s', {
 								args: {
 									companyName: 'Freshy',
 								},
@@ -129,7 +129,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 					{
 						profile: {
 							name: 'Justin Barrett',
-							title: translate( 'Director of Technology - %(companyName)s', {
+							title: translate( 'Director of Technology, %(companyName)s', {
 								args: {
 									companyName: 'Autoshop Solutions',
 								},

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
@@ -120,7 +120,7 @@ export default function StandardAgencyHosting( { onAddToCart }: Props ) {
 					{
 						profile: {
 							name: 'Ajit Bohra',
-							title: translate( 'Founder - %(companyName)s', {
+							title: translate( 'Founder, %(companyName)s', {
 								args: {
 									companyName: 'LUBUS',
 								},
@@ -136,7 +136,7 @@ export default function StandardAgencyHosting( { onAddToCart }: Props ) {
 						profile: {
 							name: 'Brian Lalli',
 							avatar: ProfileAvatar1,
-							title: translate( 'President - %(companyName)s', {
+							title: translate( 'President, %(companyName)s', {
 								args: {
 									companyName: 'Moon Rooster LLC',
 								},

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -186,14 +186,16 @@ export default function PlanSelectionDetails( {
 										onClick={ onSelectPlan }
 										primary
 									>
-										{ translate( 'Select %(planName)s plan', {
-											args: {
-												planName: selectedPlan
-													? getPressableShortName( selectedPlan.name )
-													: customString,
-											},
-											comment: '%(planName)s is the name of the selected plan.',
-										} ) }
+										{ isNewHostingPage
+											? translate( 'Select this plan' )
+											: translate( 'Select %(planName)s plan', {
+													args: {
+														planName: selectedPlan
+															? getPressableShortName( selectedPlan.name )
+															: customString,
+													},
+													comment: '%(planName)s is the name of the selected plan.',
+											  } ) }
 									</Button>
 								) }
 							</>


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/467
Closes https://github.com/Automattic/jetpack-genesis/issues/470

## Proposed Changes

* This PR makes some text updates & enhances the new hosting page. 

## Why are these changes being made?

* To update the new hosting page with some text updates and enhancements. 

## Testing Instructions

* Open the A4A live link
* Go to Marketplace - Hosting > Verify the below points:

- The text here says, `How Automattic can help` instead of `How can Automattic help`

<img width="1390" alt="Screenshot 2024-08-07 at 1 14 53 PM" src="https://github.com/user-attachments/assets/9f1010c2-4a38-4e01-a16e-cfea511abfb3">

- There is a comma next to the role instead of a hyphen

<img width="1398" alt="Screenshot 2024-08-07 at 1 15 02 PM" src="https://github.com/user-attachments/assets/c9a14254-5341-46d4-9f3a-ec29e66eb5b4">

<img width="1397" alt="Screenshot 2024-08-07 at 1 15 12 PM" src="https://github.com/user-attachments/assets/3b188c4b-5949-412a-90a8-d151c70ec45c">

- The description here says, `Every site built on Pressable comes with Jetpack Complete for free - a $599/year/site value.`

<img width="1431" alt="Screenshot 2024-08-07 at 1 15 32 PM" src="https://github.com/user-attachments/assets/f435a000-012a-4f55-9e26-bdc29dc1ebb3">

- The button now says `Select this plan`

<img width="1287" alt="Screenshot 2024-08-07 at 1 15 45 PM" src="https://github.com/user-attachments/assets/6a7f3acc-930b-44da-9005-5559067dfc47">

- The Enterprise tab is hidden when the Refer Mode is on

<img width="1415" alt="Screenshot 2024-08-07 at 1 23 46 PM" src="https://github.com/user-attachments/assets/f2856795-859f-4027-b70e-f69097f8d945">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
