### PR TITLE
[Odie] Fix forwarding wording

### DIFF
--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -31,7 +31,7 @@ export const UserMessage = ( {
 	);
 
 	const supportHappinessWording = __(
-		'It sounds like you want to talk to a human. We’re here to help! Please provide more details about your issue so our Happiness Engineers can assist you:',
+		'It sounds like you want to talk to a human. We’re here to help! Use the option below to message our Happiness Engineers.',
 		__i18n_text_domain__
 	);
 

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -17,7 +17,7 @@ export const UserMessage = ( {
 	message: Message;
 	onDislike: () => void;
 } ) => {
-	const { extraContactOptions } = useOdieAssistantContext();
+	const { extraContactOptions, isUserElegible } = useOdieAssistantContext();
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support;
 	const hasFeedback = !! message?.rating_value;
 	const isUser = message.role === 'user';
@@ -30,6 +30,13 @@ export const UserMessage = ( {
 		__i18n_text_domain__
 	);
 
+	const supportHappinessWording = __(
+		'It sounds like you want to talk to a human. We’re here to help! Please provide more details about your issue so our Happiness Engineers can assist you:',
+		__i18n_text_domain__
+	);
+
+	const forwardMessage = isUserElegible ? supportHappinessWording : supportForumWording;
+
 	return (
 		<>
 			<Markdown
@@ -38,7 +45,7 @@ export const UserMessage = ( {
 					a: CustomALink,
 				} }
 			>
-				{ isRequestingHumanSupport ? supportForumWording : message.content }
+				{ isRequestingHumanSupport ? forwardMessage : message.content }
 			</Markdown>
 			{ showExtraContactOptions && extraContactOptions }
 			{ ! hasFeedback && ! isUser && (


### PR DESCRIPTION
## Proposed Changes

If user is elegible for Happiness Engineering support, we need to change the wording.

## Testing Instructions

Have a paid site (or free, but be assigned to the current experiment) and ask for human support. You should receive a message like this:

![image](https://github.com/user-attachments/assets/be1891c2-d386-4ccd-a1c8-d7114b9ff88c)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
