### PR TITLE
Move recommended sites below subscriptions in subscription management

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -7,7 +7,7 @@
 
 
 .site-subscriptions-list {
-	margin: 0;
+	margin: 0 0 32px 0;
 
 	.row {
 		@extend %site-subscriptions-list-site-row;

--- a/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
@@ -74,8 +74,8 @@ const ReaderSiteSubscriptions = () => {
 	return (
 		<>
 			<SiteSubscriptionsListActionsBar />
-			{ ! searchTerm && <RecommendedSites /> }
 			<SiteSubscriptionsList notFoundComponent={ NotFoundSiteSubscriptions } />
+			{ ! searchTerm && <RecommendedSites /> }
 
 			{ hasSomeSubscriptions && hasSomeUnsubscribedSearchResults ? (
 				<div className="site-subscriptions__search-recommendations-label">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Move recommended sites below subscriptions in subscription management. This way sites with no subscriptions will see the recommendations and have a chance to subscribe. Sites with lots of subscriptions will only see them if they reach the bottom

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Subscription management on a 13" laptop doesn't show the subscription management above the fold

## Testing Instructions

* On any site, go to /read/subscriptions
* Before:
<img width="1426" alt="Screenshot 2024-08-07 at 11 50 54" src="https://github.com/user-attachments/assets/cbfded02-5f91-4d52-9feb-ce86588aa7a0">
* After:
* 
<img width="1424" alt="Screenshot 2024-08-07 at 11 51 13" src="https://github.com/user-attachments/assets/4420ca7d-f8f4-43c0-9615-8aa0d807a144">
<img width="1424" alt="Screenshot 2024-08-07 at 11 51 17" src="https://github.com/user-attachments/assets/9ab4d3f5-ba6c-4ecc-af13-4cbdd441f3e8">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
