### PR TITLE
A4A: Fix Scan column redirect to work with WPCOM sites.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
@@ -219,8 +219,8 @@ describe( 'useRowMetadata', () => {
 
 		const expected = {
 			eventName: 'calypso_jetpack_agency_dashboard_scan_threats_click_large_screen',
-			isExternalLink: false,
-			link: '',
+			isExternalLink: true,
+			link: `https://wordpress.com/scan/history/${ FAKE_SITE.url }`,
 			isSupported: true,
 			row: rows.scan,
 			siteDown: false,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -46,9 +46,11 @@ const getLinks = (
 			break;
 		}
 		case 'scan': {
-			// Scan link should not be available for Atomic sites.
-			if ( status !== 'inactive' && ! isAtomicSite ) {
-				link = `/scan/${ siteUrlWithMultiSiteSupport }`;
+			if ( status !== 'inactive' ) {
+				link = isAtomicSite
+					? `https://wordpress.com/scan/history/${ siteUrlWithMultiSiteSupport }`
+					: `/scan/${ siteUrlWithMultiSiteSupport }`;
+				isExternalLink = isAtomicSite;
 			}
 			break;
 		}


### PR DESCRIPTION
This updates the Site column redirect on the Site dashboard for both A4A and Jetpack manage to work with WPCOM sites. Note that clicking the column for Jetpack and A4A client sites will only show the preview pane. 

<img width="1348" alt="Screenshot 2024-08-07 at 5 09 16 PM" src="https://github.com/user-attachments/assets/43f593b8-5a2d-4700-b2bc-3dc5f8715e88">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/730

## Proposed Changes

* Update the Scan column so when that it redirects to `https://wordpress.com/scan/history/${ WPCOM_SITE }`.

## Why are these changes being made?

* Improves user experience.

## Testing Instructions

* Use the A4A live link and go to `/sites` or use the Jetpack Cloud live link and go to `/dashboard`.
* Look for WPCOM sites in the table.
* Confirm that the Scan column is clickable and redirects to the correct WPCOM page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
