### PR TITLE
Readymade Templates: Mark content generation step as complete

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
@@ -1,4 +1,5 @@
 import { FormLabel } from '@automattic/components';
+import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -16,7 +17,6 @@ import { ReadymadeTemplate } from 'calypso/my-sites/patterns/types';
 import generateAIContentForTemplate from './api/generate-content';
 import ReadymadeTemplatePreview from './components/readymade-template-preview';
 import TextProgressBar from './components/text-progress-bar';
-import type { OnboardSelect } from '@automattic/data-stores';
 import './style.scss';
 
 type ReadymadeTemplateGenerateContentProps = {
@@ -52,6 +52,11 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 					globalStyles: rt.globalStyles,
 					canReplaceContent: true,
 					siteSetupOption: 'readymade-template',
+				} )
+			)
+			.then( () =>
+				updateLaunchpadSettings( siteSlug, {
+					checklist_statuses: { generate_content: true },
 				} )
 			)
 			.then( () => setIsGeneratingContent( false ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/8594

## Proposed Changes

* We update the state of the task when generating content

I'm going to change when the task gets marked as complete on:
- https://github.com/Automattic/dotcom-forge/issues/8595

Because of that, the scope of this PR just includes marking the task as done and not the trigger.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link
* Go to the Readymade Template flow's Generate content step
* Generate content and go back
* You should see that the task is complete.

| Before | After |
| ----- | ----- |
|![Screenshot 2024-08-07 at 11 40 09](https://github.com/user-attachments/assets/47ca771f-1fac-4440-a99e-04199ceb9ab1)|![Screenshot 2024-08-07 at 11 39 14](https://github.com/user-attachments/assets/3807ca8c-523c-4514-9278-5d75c2193374)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
