### PR TITLE
RT: Adjust header of "Generate content" step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -104,7 +104,8 @@ button {
 .update-options,
 .hundred-year-plan,
 .link-in-bio-tld,
-.entrepreneur {
+.entrepreneur,
+.generate-content {
 	box-sizing: border-box;
 
 	&.step-route {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8589
Fixes https://github.com/Automattic/dotcom-forge/issues/8615

## Proposed Changes

Adjust the styles of the "Generate content with AI" step so the header is consistent with other launchpad steps:
- The WordPress logo is now visible
- The title is now displayed below the header

Before | After
--- | ---
<img width="1266" alt="Screenshot 2024-08-07 at 13 07 41" src="https://github.com/user-attachments/assets/85aafb9d-3f8c-402f-a486-4b380b581ca0"> | <img width="1265" alt="Screenshot 2024-08-07 at 13 08 08" src="https://github.com/user-attachments/assets/63ae0281-a7c7-4fd2-8b08-2931d93aa791">



## Why are these changes being made?

To have consistency across the different launchpad steps

## Testing Instructions
- Use the Calypso live link below
- Go to `/patterns`
- Scroll down to the RT section
- Pick and layout
- Once you're in the launchpad, select the "Generate content with AI" step
- Make sure the W logo is visible
- Make sure the title is placed below the header/nav

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
