### PR TITLE
A4A > Referrals: Use invoice status to calculate the commissions 

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referral-invoices.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-fetch-referral-invoices.ts
@@ -26,10 +26,11 @@ const getReferralInvoices = ( data: {
 
 				let isPaid = false;
 				let isDue = false;
-				if ( invoice.amount_due > 0 ) {
-					isDue = true;
-				} else if ( invoice.amount_paid > 0 ) {
+
+				if ( invoice.status === 'paid' ) {
 					isPaid = true;
+				} else if ( invoice.status === 'open' ) {
+					isDue = true;
 				}
 
 				acc.push( {


### PR DESCRIPTION
## Proposed Changes

* This PR uses invoice status to calculate the commissions

## Why are these changes being made?

* To fix the all-time commissions for the referrals. 

## Testing Instructions

* Open the A4A live link
* Testing this is hard, and can be used only on the real customer account. Just making sure the the referral commissions on the Referral - Dashboard loads fine should be ok. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
