### PR TITLE
A4A: Fix incorrect WPCOM-owned plan calculation.

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
@@ -16,9 +16,10 @@ export const getFetchLicensesQueryKey = (
 	sortField: LicenseSortField,
 	sortDirection: LicenseSortDirection,
 	page: number,
+	perPage: number,
 	agencyId?: number
 ) => {
-	return [ 'a4a-licenses', filter, search, sortField, sortDirection, page, agencyId ];
+	return [ 'a4a-licenses', filter, search, sortField, sortDirection, page, perPage, agencyId ];
 };
 
 export default function useFetchLicenses(
@@ -26,12 +27,21 @@ export default function useFetchLicenses(
 	search: string,
 	sortField: LicenseSortField,
 	sortDirection: LicenseSortDirection,
-	page: number
+	page: number,
+	perPage: number = LICENSES_PER_PAGE
 ) {
 	const agencyId = useSelector( getActiveAgencyId );
 
 	return useQuery( {
-		queryKey: getFetchLicensesQueryKey( filter, search, sortField, sortDirection, page, agencyId ),
+		queryKey: getFetchLicensesQueryKey(
+			filter,
+			search,
+			sortField,
+			sortDirection,
+			page,
+			perPage,
+			agencyId
+		),
 		queryFn: () =>
 			wpcom.req.get(
 				{
@@ -45,7 +55,7 @@ export default function useFetchLicenses(
 					page: page,
 					sort_field: sortField,
 					sort_direction: sortDirection,
-					per_page: LICENSES_PER_PAGE,
+					per_page: perPage,
 				}
 			),
 		select: ( data ) => {

--- a/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
+++ b/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
@@ -9,7 +9,7 @@ import useFetchLicenses from '../data/purchases/use-fetch-licenses';
 import useProductAndPlans from '../sections/marketplace/hooks/use-product-and-plans';
 import { getWPCOMCreatorPlan } from '../sections/marketplace/lib/hosting';
 
-export default function useWpcomOwnedSites() {
+export default function useWPCOMOwnedSites() {
 	// We will have to loop to all License pages to get all licenses and get correct calculation.
 	const [ currentPage, setCurrentPage ] = useState( 1 );
 	const [ licenses, setLicenses ] = useState< License[] >( [] );

--- a/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
+++ b/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
@@ -31,10 +31,12 @@ export default function useWPCOMOwnedSites() {
 
 	useEffect( () => {
 		if ( data ) {
-			setLicenses( ( prevLicenses ) => [ ...prevLicenses, ...data.items ] );
+			setLicenses( ( prevLicenses ) =>
+				currentPage === 1 ? data.items : [ ...prevLicenses, ...data.items ]
+			);
 			setTotalLicenses( data.total );
 		}
-	}, [ data ] );
+	}, [ currentPage, data ] );
 
 	useEffect( () => {
 		if ( licenses.length < totalLicenses ) {

--- a/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
+++ b/client/a8c-for-agencies/hooks/use-wpcom-owned-sites.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { License } from 'calypso/state/partner-portal/types';
+import useFetchLicenses from '../data/purchases/use-fetch-licenses';
+import useProductAndPlans from '../sections/marketplace/hooks/use-product-and-plans';
+import { getWPCOMCreatorPlan } from '../sections/marketplace/lib/hosting';
+
+export default function useWpcomOwnedSites() {
+	// We will have to loop to all License pages to get all licenses and get correct calculation.
+	const [ currentPage, setCurrentPage ] = useState( 1 );
+	const [ licenses, setLicenses ] = useState< License[] >( [] );
+	const [ totalLicenses, setTotalLicenses ] = useState( 0 );
+	const [ isReady, setIsReady ] = useState( false );
+
+	const { wpcomPlans } = useProductAndPlans( {} );
+
+	const creatorPlan = getWPCOMCreatorPlan( wpcomPlans );
+
+	const { data } = useFetchLicenses(
+		LicenseFilter.NotRevoked,
+		'',
+		LicenseSortField.IssuedAt,
+		LicenseSortDirection.Descending,
+		currentPage,
+		100
+	);
+
+	useEffect( () => {
+		if ( data ) {
+			setLicenses( ( prevLicenses ) => [ ...prevLicenses, ...data.items ] );
+			setTotalLicenses( data.total );
+		}
+	}, [ data ] );
+
+	useEffect( () => {
+		if ( licenses.length < totalLicenses ) {
+			setCurrentPage( ( prevPage ) => prevPage + 1 );
+		} else {
+			// if we have all licenses, then we are ready to calculate the count
+			setIsReady( true );
+		}
+	}, [ licenses.length, totalLicenses ] );
+
+	return {
+		count: isReady
+			? licenses.filter(
+					( license ) => license.productId === creatorPlan?.product_id && ! license.referral // We make sure we do not count referrals
+			  ).length
+			: 0,
+		isReady,
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -1,7 +1,7 @@
 import formatCurrency from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import A4ANumberInput from 'calypso/a8c-for-agencies/components/a4a-number-input';
 import useWPCOMOwnedSites from 'calypso/a8c-for-agencies/hooks/use-wpcom-owned-sites';
 import SimpleList from 'calypso/a8c-for-agencies/sections/marketplace/common/simple-list';
@@ -199,6 +199,14 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 			}
 		}
 	};
+
+	useEffect( () => {
+		if ( isLicenseCountsReady ) {
+			setQuantity(
+				ownedPlans ? Number( selectedTier.value ) - ownedPlans : Number( selectedTier.value )
+			);
+		}
+	}, [ isLicenseCountsReady, ownedPlans, selectedTier.value ] );
 
 	if ( ! plan ) {
 		return;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -1,7 +1,7 @@
 import formatCurrency from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import A4ANumberInput from 'calypso/a8c-for-agencies/components/a4a-number-input';
 import useWPCOMOwnedSites from 'calypso/a8c-for-agencies/hooks/use-wpcom-owned-sites';
 import SimpleList from 'calypso/a8c-for-agencies/sections/marketplace/common/simple-list';
@@ -199,14 +199,6 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 			}
 		}
 	};
-
-	useEffect( () => {
-		if ( isLicenseCountsReady ) {
-			setQuantity(
-				ownedPlans ? Number( selectedTier.value ) - ownedPlans : Number( selectedTier.value )
-			);
-		}
-	}, [ isLicenseCountsReady, ownedPlans, selectedTier.value ] );
 
 	if ( ! plan ) {
 		return;

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/hooks/use-total-invoice-value.ts
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/hooks/use-total-invoice-value.ts
@@ -1,8 +1,6 @@
 import { useContext, useMemo } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
-import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
-import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
-import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import useWPCOMOwnedSites from 'calypso/a8c-for-agencies/hooks/use-wpcom-owned-sites';
 import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options';
 import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
 import { isWooCommerceProduct } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/woocommerce-product-slug-mapping';
@@ -20,20 +18,16 @@ export const useGetProductPricingInfo = () => {
 		() => wpcomBulkOptions( wpcomProducts?.discounts?.tiers ),
 		[ wpcomProducts?.discounts?.tiers ]
 	);
-	const { data: licenseCounts, isSuccess: isLicenseCountsReady } = useFetchLicenseCounts();
+	const { count } = useWPCOMOwnedSites();
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
-	const { wpcomPlans } = useProductAndPlans( {} );
-	const creatorPlan = getWPCOMCreatorPlan( wpcomPlans );
 	const ownedPlans = useMemo( () => {
 		// We don't count ownded plans when referring products
 		if ( marketplaceType === 'referral' ) {
 			return 0;
 		}
-		if ( isLicenseCountsReady && creatorPlan ) {
-			const productStats = licenseCounts?.products?.[ creatorPlan.slug ];
-			return productStats?.not_revoked || 0;
-		}
-	}, [ creatorPlan, isLicenseCountsReady, licenseCounts?.products, marketplaceType ] );
+
+		return count;
+	}, [ count, marketplaceType ] );
 
 	const getProductPricingInfo = (
 		userProducts: Record< string, ProductListItem >,

--- a/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/wpcom-overview/index.tsx
@@ -13,7 +13,7 @@ import {
 	external,
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
@@ -27,7 +27,7 @@ import {
 	A4A_MARKETPLACE_HOSTING_LINK,
 	A4A_MARKETPLACE_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
+import useWPCOMOwnedSites from 'calypso/a8c-for-agencies/hooks/use-wpcom-owned-sites';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -63,7 +63,7 @@ function WpcomOverview() {
 		toggleCart,
 	} = useShoppingCart();
 
-	const { data: licenseCounts, isSuccess: isLicenseCountsReady } = useFetchLicenseCounts();
+	const { count: ownedPlans, isReady: isLicenseCountsReady } = useWPCOMOwnedSites();
 
 	const options = wpcomBulkOptions( [] );
 
@@ -76,13 +76,6 @@ function WpcomOverview() {
 	const { wpcomPlans } = useProductAndPlans( {} );
 
 	const creatorPlan = getWPCOMCreatorPlan( wpcomPlans );
-
-	const ownedPlans = useMemo( () => {
-		if ( isLicenseCountsReady && creatorPlan ) {
-			const productStats = licenseCounts?.products?.[ creatorPlan.slug ];
-			return productStats?.not_revoked || 0;
-		}
-	}, [ creatorPlan, isLicenseCountsReady, licenseCounts?.products ] );
 
 	// For referral mode we only display 1 option.
 	const displayQuantity = referralMode ? 1 : ( selectedTier.value as number ) - ownedPlans;

--- a/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-refetch-licenses.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/hooks/use-refetch-licenses.ts
@@ -5,6 +5,7 @@ import { getFetchLicensesQueryKey } from 'calypso/a8c-for-agencies/data/purchase
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { LicenseListContext } from 'calypso/state/partner-portal/types';
+import { LICENSES_PER_PAGE } from '../../lib/constants';
 
 export default function useRefetchLicenses( context: Context< LicenseListContext > ) {
 	const agencyId = useSelector( getActiveAgencyId );
@@ -25,6 +26,7 @@ export default function useRefetchLicenses( context: Context< LicenseListContext
 				sortField,
 				sortDirection,
 				currentPage,
+				LICENSES_PER_PAGE,
 				agencyId
 			),
 		} );


### PR DESCRIPTION
Currently, when calculating the number of WPCOM plans the user owns, we use the licenses count, which does not account for referral licenses. This PR resolves this issue.

**Note that there is a slight issue with the new WPCOM hosting page after introducing the hook. The disabled area on the Slider is not redrawn after the calculation. I will fix it in a separate PR.**

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/913

## Proposed Changes

* To resolve the issue, we will need to use the licenses REST endpoint to determine the number of WPCOM licenses linked to the current user that are referrals. The licenses/count endpoint does not provide the necessary referral details, so it cannot be used. This pull request introduces a new hook that retrieves all licenses from the Licenses endpoint and then filters out all WPCOM creator licenses that are not referrals.

## Why are these changes being made?

* We should not count referrals as WPCOM owned plans for volume discount calculation.

## Testing Instructions

* Use the A4A live link and go to `/marketplace/hosting/wpcom?flags=-a4a-hosting-page-redesign`.
* Create some WPCOM referrals.
* After creating some referrals, confirm that WPCOM plans that are referrals do not count as owned.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
