### PR TITLE
feat(hosting-overview-refinements): show hosting info for staging sites

### DIFF
--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -230,54 +230,52 @@ const PlanCard: FC = () => {
 						</>
 					) }
 				</div>
-				{ ! isStaging && (
-					<>
-						{ isAgencyPurchase && (
-							<div className="hosting-overview__plan-agency-purchase">
-								<p>
-									{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
-										components: {
-											a: isA4A ? (
-												<a
-													href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
-												></a>
-											) : (
-												<strong></strong>
-											),
-										},
-									} ) }
-								</p>
-							</div>
-						) }
-						{ ! isAgencyPurchase && <PricingSection /> }
-						{ ! isLoading && (
-							<PlanStorage
-								className="hosting-overview__plan-storage"
-								hideWhenNoStorage
-								siteId={ site?.ID }
-								StorageBarComponent={ PlanStorageBar }
-							>
-								{ storageAddons.length > 0 && ! isAgencyPurchase && (
-									<div className="hosting-overview__plan-storage-footer">
-										<Button
-											className="hosting-overview__link-button"
-											plain
-											href={ `/add-ons/${ site?.slug }` }
-										>
-											{ translate( 'Need more storage?' ) }
-										</Button>
-									</div>
-								) }
-							</PlanStorage>
-						) }
-						{ config.isEnabled( 'hosting-overview-refinements' ) && site && (
-							<PlanSiteVisits siteId={ site.ID } />
-						) }
-						{ config.isEnabled( 'hosting-overview-refinements' ) && isAtomic && site && (
-							<PlanBandwidth siteId={ site.ID } />
-						) }
-					</>
-				) }
+				<>
+					{ isAgencyPurchase && (
+						<div className="hosting-overview__plan-agency-purchase">
+							<p>
+								{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
+									components: {
+										a: isA4A ? (
+											<a
+												href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
+											></a>
+										) : (
+											<strong></strong>
+										),
+									},
+								} ) }
+							</p>
+						</div>
+					) }
+					{ ! isAgencyPurchase && ! isStaging && <PricingSection /> }
+					{ ! isLoading && (
+						<PlanStorage
+							className="hosting-overview__plan-storage"
+							hideWhenNoStorage
+							siteId={ site?.ID }
+							StorageBarComponent={ PlanStorageBar }
+						>
+							{ storageAddons.length > 0 && ! isAgencyPurchase && (
+								<div className="hosting-overview__plan-storage-footer">
+									<Button
+										className="hosting-overview__link-button"
+										plain
+										href={ `/add-ons/${ site?.slug }` }
+									>
+										{ translate( 'Need more storage?' ) }
+									</Button>
+								</div>
+							) }
+						</PlanStorage>
+					) }
+					{ config.isEnabled( 'hosting-overview-refinements' ) && site && (
+						<PlanSiteVisits siteId={ site.ID } />
+					) }
+					{ config.isEnabled( 'hosting-overview-refinements' ) && isAtomic && site && (
+						<PlanBandwidth siteId={ site.ID } />
+					) }
+				</>
 			</HostingCard>
 		</>
 	);

--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -214,6 +214,9 @@ const PlanCard: FC = () => {
 		}
 	};
 
+	const shouldRenderPlanData =
+		! isStaging || ( isStaging && config.isEnabled( 'hosting-overview-refinements' ) );
+
 	return (
 		<>
 			<QuerySitePlans siteId={ site?.ID } />
@@ -230,52 +233,54 @@ const PlanCard: FC = () => {
 						</>
 					) }
 				</div>
-				<>
-					{ isAgencyPurchase && (
-						<div className="hosting-overview__plan-agency-purchase">
-							<p>
-								{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
-									components: {
-										a: isA4A ? (
-											<a
-												href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
-											></a>
-										) : (
-											<strong></strong>
-										),
-									},
-								} ) }
-							</p>
-						</div>
-					) }
-					{ ! isAgencyPurchase && ! isStaging && <PricingSection /> }
-					{ ! isLoading && (
-						<PlanStorage
-							className="hosting-overview__plan-storage"
-							hideWhenNoStorage
-							siteId={ site?.ID }
-							StorageBarComponent={ PlanStorageBar }
-						>
-							{ storageAddons.length > 0 && ! isAgencyPurchase && (
-								<div className="hosting-overview__plan-storage-footer">
-									<Button
-										className="hosting-overview__link-button"
-										plain
-										href={ `/add-ons/${ site?.slug }` }
-									>
-										{ translate( 'Need more storage?' ) }
-									</Button>
-								</div>
-							) }
-						</PlanStorage>
-					) }
-					{ config.isEnabled( 'hosting-overview-refinements' ) && site && (
-						<PlanSiteVisits siteId={ site.ID } />
-					) }
-					{ config.isEnabled( 'hosting-overview-refinements' ) && isAtomic && site && (
-						<PlanBandwidth siteId={ site.ID } />
-					) }
-				</>
+				{ shouldRenderPlanData && (
+					<>
+						{ isAgencyPurchase && (
+							<div className="hosting-overview__plan-agency-purchase">
+								<p>
+									{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
+										components: {
+											a: isA4A ? (
+												<a
+													href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }
+												></a>
+											) : (
+												<strong></strong>
+											),
+										},
+									} ) }
+								</p>
+							</div>
+						) }
+						{ ! isAgencyPurchase && ! isStaging && <PricingSection /> }
+						{ ! isLoading && (
+							<PlanStorage
+								className="hosting-overview__plan-storage"
+								hideWhenNoStorage
+								siteId={ site?.ID }
+								StorageBarComponent={ PlanStorageBar }
+							>
+								{ storageAddons.length > 0 && ! isAgencyPurchase && (
+									<div className="hosting-overview__plan-storage-footer">
+										<Button
+											className="hosting-overview__link-button"
+											plain
+											href={ `/add-ons/${ site?.slug }` }
+										>
+											{ translate( 'Need more storage?' ) }
+										</Button>
+									</div>
+								) }
+							</PlanStorage>
+						) }
+						{ config.isEnabled( 'hosting-overview-refinements' ) && site && (
+							<PlanSiteVisits siteId={ site.ID } />
+						) }
+						{ config.isEnabled( 'hosting-overview-refinements' ) && isAtomic && site && (
+							<PlanBandwidth siteId={ site.ID } />
+						) }
+					</>
+				) }
 			</HostingCard>
 		</>
 	);


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8604



## Why are these changes being made?
ATM we render empty square block for Staging sites, instead of Bandwidth, Visits etc info.
After discussion (p9Jlb4-dgp-p2#comment-12672) we decided to render such info for them.

## Testing Instructions
1. Purchase Atomic site
2. Make it staging (Open `/sites` -> Select your site -> Open tab `Staging Site`)
3. Visit the site a few times to have some numbers
4. Assert that now it has the data like the next: <br /> <img width="471" alt="Screenshot 2024-08-07 at 14 18 47" src="https://github.com/user-attachments/assets/132b0951-1318-405a-b00e-8bf71f1df163">
