### PR TITLE
A4A: Update the new WPCOM hosting page to use the simpler A4A slider.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -8,14 +8,11 @@ import SimpleList from 'calypso/a8c-for-agencies/sections/marketplace/common/sim
 import { MarketplaceTypeContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
 import useProductAndPlans from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans';
 import { getWPCOMCreatorPlan } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
-import WPCOMBulkSelector from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/bulk-selection';
-import {
-	DiscountTier,
-	calculateTier,
-} from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
+import { calculateTier } from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-values-utils';
 import useWPCOMPlanDescription from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/wpcom-card/hooks/use-wpcom-plan-description';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import useWPCOMDiscountTiers from '../../../hooks/use-wpcom-discount-tiers';
+import WPCOMPlanSlider from './slider';
 
 import './style.scss';
 
@@ -170,35 +167,7 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 		return count;
 	}, [ count, referralMode ] );
 
-	const discountTiers = useWPCOMDiscountTiers();
-
-	const [ selectedTier, setSelectedTier ] = useState< DiscountTier >( discountTiers[ 0 ] );
-
-	const [ quantity, setQuantity ] = useState(
-		selectedTier.value ? Number( selectedTier.value ) : 1
-	);
-
-	const handleSetSelectedTier = ( tier: DiscountTier ) => {
-		setSelectedTier( tier );
-		// If the user already owns plans, set the quantity to the difference between the selected tier and the owned plans
-		setQuantity( ownedPlans ? Number( tier.value ) - ownedPlans : Number( tier.value ) );
-	};
-
-	const handleSetQuantity = ( value: number ) => {
-		if ( value ) {
-			setQuantity( value );
-			const tier = discountTiers.find( ( tier ) => tier.value === value );
-			if ( tier ) {
-				if ( tier.value < 10 ) {
-					setSelectedTier( tier );
-				} else {
-					setSelectedTier(
-						discountTiers.find( ( { value } ) => value === 10 ) ?? discountTiers[ 0 ]
-					);
-				}
-			}
-		}
-	};
+	const [ quantity, setQuantity ] = useState( 1 );
 
 	if ( ! plan ) {
 		return;
@@ -208,14 +177,10 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 		<div className="wpcom-plan-selector">
 			<div className="wpcom-plan-selector__slider-container">
 				{ ! referralMode && (
-					<WPCOMBulkSelector
-						selectedTier={ selectedTier }
-						onSelectTier={ handleSetSelectedTier }
+					<WPCOMPlanSlider
 						quantity={ quantity }
+						onChange={ setQuantity }
 						ownedPlans={ ownedPlans }
-						isLoading={ ! isLicenseCountsReady }
-						hideOwnedPlansBadge
-						hideNumberInput
 					/>
 				) }
 			</div>
@@ -228,7 +193,7 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 						ownedPlans={ ownedPlans }
 						referralMode={ referralMode }
 						quantity={ quantity }
-						setQuantity={ handleSetQuantity }
+						setQuantity={ setQuantity }
 					/>
 				) : (
 					<PlanDetailsPlaceholder />

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/slider.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/slider.tsx
@@ -1,0 +1,61 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import A4ASlider, { Option } from 'calypso/a8c-for-agencies/components/slider';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import wpcomBulkOptions from 'calypso/a8c-for-agencies/sections/marketplace/wpcom-overview/lib/wpcom-bulk-options';
+import { APIProductFamily } from 'calypso/state/partner-portal/types';
+
+type Props = {
+	ownedPlans: number;
+	quantity: number;
+	onChange: ( quantity: number ) => void;
+};
+
+export default function WPCOMPlanSlider( { quantity, ownedPlans, onChange }: Props ) {
+	const translate = useTranslate();
+
+	const { data } = useProductsQuery( false, true );
+
+	const wpcomProducts = data
+		? ( data.find(
+				( product ) => product.slug === 'wpcom-hosting'
+		  ) as unknown as APIProductFamily )
+		: undefined;
+
+	const options = useMemo( () => {
+		const options = wpcomBulkOptions( wpcomProducts?.discounts?.tiers );
+
+		// Override the last option label to include '+' symbol.
+		options[ options.length - 1 ].label = options[ options.length - 1 ].label + '+';
+		return options;
+	}, [ wpcomProducts?.discounts?.tiers ] );
+
+	const MaxValue = options[ options.length - 1 ].value;
+
+	const isOverMaxValue = quantity + ownedPlans > MaxValue;
+
+	const onSelectOption = ( option: Option ) => {
+		if ( option ) {
+			if ( option.value === MaxValue && isOverMaxValue ) {
+				return;
+			}
+
+			onChange( ( option.value as number ) - ownedPlans );
+		}
+	};
+
+	const value = isOverMaxValue
+		? MaxValue
+		: options.findIndex( ( option ) => option.value === ownedPlans + quantity );
+
+	return (
+		<A4ASlider
+			label={ translate( 'Total sites' ) }
+			sub={ translate( 'Total discount' ) }
+			value={ value }
+			onChange={ onSelectOption }
+			options={ options }
+			minimum={ ownedPlans }
+		/>
+	);
+}


### PR DESCRIPTION
The new WPCOM Hosting page currently uses a ported A4A slider that was originally designed to handle more complex requirements. However, the slider has some alignment and pointer bugs, as it was originally meant to handle a larger volume of quantity 100+. Since the current options are much simpler, it would be best to use the basic A4A slider this time to avoid inheriting those bugs.

Depends on https://github.com/Automattic/wp-calypso/pull/93326
Closes https://github.com/Automattic/jetpack-genesis/issues/466
Closes https://github.com/Automattic/jetpack-genesis/issues/468
Follow Up https://github.com/Automattic/wp-calypso/pull/93239#issuecomment-2270912463

## Proposed Changes

* Update the WPCOM Hosting page to use the base A4A slider.

## Why are these changes being made?

* The current WPCOM slider has some UI bugs inherited from an overly complicated slider. This approach avoids those issues.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting/wpcom` page.
* Confirm that the WPCOM slider is working and does not have misalignment and pointer issues.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
