### PR TITLE
RT: Add continue button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
@@ -104,7 +104,7 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 						<FormTextarea
 							name="tagline"
 							id="tagline"
-							disabled={ isGeneratingContent }
+							disabled={ isGeneratingContent || isSaving }
 							placeholder={ translate(
 								"Write an amazing description of your site, like: The Beachcomber Bistro is a cafe offering amazing food, delicious coffee and local beers. It's located next to the beach at Harlyn Bay, offering a stunning view from our deck."
 							) }
@@ -116,7 +116,9 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 						<Button
 							className="checklist-item__checklist-secondary-button"
 							onClick={ generateContent }
-							disabled={ isPromptEmpty || numberOfGenerations >= 5 || isGeneratingContent }
+							disabled={
+								isPromptEmpty || numberOfGenerations >= 5 || isGeneratingContent || isSaving
+							}
 						>
 							{ isGeneratingContent
 								? translate( 'Generating content' )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/style.scss
@@ -26,6 +26,14 @@
 		margin-left: 10px;
 	}
 
+	.checklist-item__checklist-primary-button.components-button {
+		transition: opacity 1s;
+
+		&.hidden {
+			opacity: 0;
+		}
+	}
+
 	.step-container__header {
 		margin-bottom: 32px;
 	}

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -296,3 +296,37 @@
 		margin: 12px 0;
 	}
 }
+
+.checklist-item__checklist-secondary-button.components-button {
+	width: 100%;
+	font-weight: 500;
+	padding: 11px;
+	margin-top: 12px;
+	background-color: var(--color-neutral-10);
+	border-color: var(--color-neutral-30);
+	border-radius: 4px;
+	color: var(--color-text);
+	justify-content: center;
+	font-size: $font-body-small;
+	height: auto;
+	line-height: 22px;
+
+	&:hover:not([disabled]) {
+		background-color: var(--color-neutral-20);
+		border-color: var(--color-neutral-40);
+		color: var(--color-text);
+	}
+
+	&[disabled] {
+		background-color: var(--color-neutral-5);
+		border-color: var(--color-neutral-20);
+		color: var(--color-neutral-40);
+	}
+
+	&:disabled {
+		opacity: 1;
+		&:hover {
+			color: var(--color-neutral-40);
+		}
+	}
+}

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -302,8 +302,8 @@
 	font-weight: 500;
 	padding: 11px;
 	margin-top: 12px;
-	background-color: var(--color-neutral-10);
-	border-color: var(--color-neutral-30);
+	background-color: var(--studio-white);
+	border: 1px solid var(--studio-gray-100);
 	border-radius: 4px;
 	color: var(--color-text);
 	justify-content: center;
@@ -312,14 +312,14 @@
 	line-height: 22px;
 
 	&:hover:not([disabled]) {
-		background-color: var(--color-neutral-20);
+		background-color: var(--studio-gray-0);
 		border-color: var(--color-neutral-40);
 		color: var(--color-text);
 	}
 
 	&[disabled] {
-		background-color: var(--color-neutral-5);
-		border-color: var(--color-neutral-20);
+		background-color: var(--studio-gray-0);
+		border: none;
 		color: var(--color-neutral-40);
 	}
 


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/8595

## Proposed Changes

* Added a continue button
* Improved the generate content button by updating the message while it's disabled.
* We now only save the generated content when the user presses the continue button.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to the generate content step of the readymade template flow
* Input text and press the generate content button.
* Once the content is generated, the continue button should appear.
* Check that the buttons are always in the correct states.
* Check that if you do not continue the content isn't persisted.
* Check that when persisted the content loads correctly.


https://github.com/user-attachments/assets/b4de2f10-02fd-403a-856b-3c3b412f1f81



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
