### PR TITLE
Masterbar: Show help icon on all browser widths

### DIFF
--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -34,11 +34,6 @@
 	#wp-admin-bar-help-center {
 		padding: 0;
 		width: 43px;
-		display: none;
-
-		@include breakpoint-deprecated( ">960px" ) {
-			display: block;
-		}
 
 		#help-center-icon-with-notification {
 			display: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8605

## Proposed Changes

* The Help icon is missing in the Masterbar at > 782px and <= 960px browser widths. This PR ensures the Help icon is visible at all widths.

Before | After
--|--
<img width="800" alt="Screenshot 2024-08-07 at 11 00 02 AM" src="https://github.com/user-attachments/assets/32830811-f760-4e09-85dc-1dba0f0bbaba">  | <img width="801" alt="Screenshot 2024-08-07 at 11 00 40 AM" src="https://github.com/user-attachments/assets/d6840291-a6fd-4661-8e2f-8600734e2585">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Creating a consistent UI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open up a wp-admin test site and confirm the original problem exists
* Load this PR locally
* Open a connection to your sandbox
* In your local terminal in this PR `cd` to `/apps/help-center`
* Run `yarn build --sync`
* Sandbox your site and widgets.wp.com
* Open up a wp-admin test site and confirm the Help icon is visible at all widths

You can read more on testing the Help center changes in the [Readme](https://github.com/Automattic/wp-calypso/blob/a718e9de802ecbbf3e1cb8e5e6d69c93d8e10f0c/apps/help-center/README.md).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
