### PR TITLE
RT: Center generating content message on mobile

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/components/readymade-template-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/components/readymade-template-preview/index.tsx
@@ -4,6 +4,7 @@ import {
 	RenderedContent,
 } from '@automattic/block-renderer';
 import { Spinner } from '@wordpress/components';
+import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import React from 'react';
 import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/constants';
@@ -23,7 +24,7 @@ const ReadymadeTemplatePreview: React.FC< RTPreviewProps > = ( {
 } ) => {
 	if ( isLoading ) {
 		return (
-			<div className="readymade-template-preview">
+			<div className={ clsx( 'readymade-template-preview', 'is-loading' ) }>
 				<Spinner />
 				<strong>{ translate( 'Generating content for your site.' ) }</strong>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/components/readymade-template-preview/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/components/readymade-template-preview/style.scss
@@ -6,14 +6,15 @@
 	.components-spinner {
 		width: 16px;
 		height: 16px;
-		padding-top: 120px;
 	}
 
 	&.is-loading {
+		display: flex;
+		margin-top: 120px;
+
 		@media (max-width: #{ ($break-medium) }) {
 			margin-top: 24px;
 			width: unset;
-			display: flex;
 			justify-content: center;
 
 			.components-spinner {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/components/readymade-template-preview/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/components/readymade-template-preview/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .readymade-template-preview {
 	width: 50%;
 
@@ -5,6 +7,19 @@
 		width: 16px;
 		height: 16px;
 		padding-top: 120px;
+	}
+
+	&.is-loading {
+		@media (max-width: #{ ($break-medium) }) {
+			margin-top: 24px;
+			width: unset;
+			display: flex;
+			justify-content: center;
+
+			.components-spinner {
+				padding-top: 0;
+			}
+		}
 	}
 
 	circle {


### PR DESCRIPTION
## Proposed Changes

* Center the `Generating content for your site` message on mobile:

|Before|After|
|---|---|
|![Screenshot from 2024-08-07 17-44-27](https://github.com/user-attachments/assets/1dd94f8e-2771-44b7-b468-710a54f56c7c)|![image](https://github.com/user-attachments/assets/09cb8203-0586-4eaf-8293-25f9bc33eb23)|

* Also, vertically align the spinner with the text on desktop, you can see on the first image that it's a little bit off:

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/6af4a937-8e0d-4e87-abf4-9fe4b1239970)|![image](https://github.com/user-attachments/assets/e3b6961a-d307-4252-9a5d-1ff520cf10b7)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/patterns`
* Scroll down to the site layouts
* Pick one of the layouts
* Click on Customize content with AI
* Wait until loading is done
* Enter a prompt and click on generate content
* Check that the Generating content for your site. message is properly aligned both on desktop and mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
