### PR TITLE
Masterbar: Fix out border & icon color on support-session

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -572,10 +572,16 @@ body.is-mobile-app-view {
 		background: var(--studio-orange-70);
 		--color-masterbar-icon: var(--studio-gray-5) !important;
 		--color-masterbar-text: var(--studio-gray-5) !important;
+		--color-masterbar-highlight: var(--studio-gray-5) !important;
 	}
 
 	.is-support-session &:hover {
 		background: var(--studio-orange-50);
+	}
+
+	.is-support-session &.is-active:hover {
+		background: var(--studio-orange-70);
+		color: var(--studio-gray-5);
 	}
 
 	&.masterbar__item-notifications {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -574,6 +574,10 @@ body.is-mobile-app-view {
 		--color-masterbar-text: var(--studio-gray-5) !important;
 	}
 
+	.is-support-session &:hover {
+		background: var(--studio-orange-50);
+	}
+
 	&.masterbar__item-notifications {
 		margin-right: 0;
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -570,6 +570,7 @@ body.is-mobile-app-view {
 
 	.is-support-session &.is-active {
 		background: var(--studio-orange-70);
+		--color-masterbar-icon: var(--studio-gray-5) !important;
 	}
 
 	&.masterbar__item-notifications {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -571,6 +571,7 @@ body.is-mobile-app-view {
 	.is-support-session &.is-active {
 		background: var(--studio-orange-70);
 		--color-masterbar-icon: var(--studio-gray-5) !important;
+		--color-masterbar-text: var(--studio-gray-5) !important;
 	}
 
 	&.masterbar__item-notifications {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -49,6 +49,11 @@ body.is-mobile-app-view {
 		// Use generic colors so that they override whatever theme colors the user has picked.
 		background: var(--studio-orange);
 		border-bottom: 1px solid var(--studio-orange-60);
+
+		.masterbar__item.has-global-border::before,
+		.masterbar__item.has-global-border::after {
+			background: var(--studio-orange-70);
+		}
 	}
 
 	&.masterbar__loggedout {


### PR DESCRIPTION
Slack: p1723039124414569-slack-C06DN6QQVAQ

## Proposed Changes

Fix masterbar out border color & icon color for support session.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/707a5db2-d217-4499-85b8-4f0dc7cdcb91) | ![image](https://github.com/user-attachments/assets/e21088a1-e09f-46ef-a380-cce1b0d10de9) |
| ![image](https://github.com/user-attachments/assets/df50f3fc-d645-4329-ae6e-a97e16c4ec9d) | ![image](https://github.com/user-attachments/assets/fd88012d-d17e-454b-ae56-b84d6ab4532a)|

## Testing Instructions

* Start a support session
* Go to `/sites` or `/read`
* Check the selected item border & icon color
