### PR TITLE
feat(hosting-overview-refinements): display WP version name in Hosting header

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -124,11 +124,21 @@ export default function ItemPreviewPaneHeader( {
 														className="item-preview__header-env-data-item-link"
 														onClick={ handleWpVersionClick }
 													>
-														{ wpVersion } { wpVersionName && `(${ wpVersionName })` }
+														{ wpVersion }{ ' ' }
+														{ wpVersionName && (
+															<span className="item-preview__header-env-data-item-link-capitalize">
+																({ wpVersionName })
+															</span>
+														) }
 													</Button>
 												) : (
 													<>
-														{ wpVersion } { wpVersionName && `(${ wpVersionName })` }
+														{ wpVersion }{ ' ' }
+														{ wpVersionName && (
+															<span className="item-preview__header-env-data-item-link-capitalize">
+																({ wpVersionName })
+															</span>
+														) }
 													</>
 												) }
 											</div>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -8,8 +8,10 @@ import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
 import QuerySitePhpVersion from 'calypso/components/data/query-site-php-version';
+import QuerySiteWpVersion from 'calypso/components/data/query-site-wp-version';
 import { useSelector } from 'calypso/state';
 import { getAtomicHostingPhpVersion } from 'calypso/state/selectors/get-atomic-hosting-php-version';
+import { getAtomicHostingWpVersion } from 'calypso/state/selectors/get-atomic-hosting-wp-version';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import SiteFavicon from '../../site-favicon';
@@ -40,6 +42,7 @@ export default function ItemPreviewPaneHeader( {
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = selectedSite?.ID || 0;
 	const phpVersion = useSelector( ( state ) => getAtomicHostingPhpVersion( state, siteId ) );
+	const wpVersionName = useSelector( ( state ) => getAtomicHostingWpVersion( state, siteId ) );
 	const wpVersion = selectedSite?.options?.software_version;
 	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
 
@@ -66,6 +69,7 @@ export default function ItemPreviewPaneHeader( {
 	return (
 		<>
 			{ isAtomic && <QuerySitePhpVersion siteId={ siteId } /> }
+			{ isAtomic && <QuerySiteWpVersion siteId={ siteId } /> }
 			<div className={ clsx( 'item-preview__header', className ) }>
 				<div className="item-preview__header-content">
 					{ !! itemData?.withIcon && (
@@ -120,10 +124,12 @@ export default function ItemPreviewPaneHeader( {
 														className="item-preview__header-env-data-item-link"
 														onClick={ handleWpVersionClick }
 													>
-														{ wpVersion }
+														{ wpVersion } { wpVersionName && `(${ wpVersionName })` }
 													</Button>
 												) : (
-													wpVersion
+													<>
+														{ wpVersion } { wpVersionName && `(${ wpVersionName })` }
+													</>
 												) }
 											</div>
 										) }

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -34,6 +34,9 @@ $blueberry-color: #3858e9;
 					font-size: inherit;
 					padding: 0;
 					height: auto;
+					.item-preview__header-env-data-item-link-capitalize {
+						text-transform: capitalize;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8403

## Proposed Changes
We were going to display WP version number in `Server Settings` tab, but there is a lot of effort. To speed up things, we decided to render `latest/beta` after the version number in the header
<img width="541" alt="Screenshot 2024-08-07 at 17 34 36" src="https://github.com/user-attachments/assets/482bec46-7151-4932-a519-624943a19e2f">


## Testing Instructions
1. Create Atomic website
2. Open Hosting page (`/sites` -> Click on any site)
3. Assert that you see `(latest)` after the version name
4. Make Staging website (`/sites` -> `Staging Site`)
5. Select the Staging site
6. Assert that you see `(latest)` after the version name
7. Open `Server Settings` and update the WP version to `beta`
8. Assert that you see `(beta)` after the version name
<img width="541" alt="Screenshot 2024-08-07 at 17 34 36" src="https://github.com/user-attachments/assets/482bec46-7151-4932-a519-624943a19e2f">
<img width="654" alt="Screenshot 2024-08-07 at 17 36 50" src="https://github.com/user-attachments/assets/f8cde80f-6840-4aa0-a3e2-3f7807801432">
