### PR TITLE
Performance Profiler: Add route and page

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -192,6 +192,7 @@ const LayoutLoggedOut = ( {
 	} else if (
 		[
 			'patterns',
+			'performance-profiler',
 			'plugins',
 			'reader',
 			'site-profiler',

--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -8,19 +8,17 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { PerformanceProfilerDashboard } from './pages/dashboard';
 
 export function PerformanceProfilerDashboardContext( context: Context, next: () => void ): void {
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+
 	if ( ! config.isEnabled( 'performance-profiler' ) ) {
 		page.redirect( '/' );
 		return;
 	}
 
-	const isLoggedIn = isUserLoggedIn( context.store.getState() );
-	const pathName = context.pathname || '';
-	const routerDomain = pathName.split( '/speed-test-tool/' )[ 1 ]?.trim() || '';
-
 	context.primary = (
 		<>
 			<Main fullWidthLayout>
-				<PerformanceProfilerDashboard domain={ routerDomain } />
+				<PerformanceProfilerDashboard url={ context.query?.url ?? '' } />
 			</Main>
 
 			<UniversalNavbarFooter isLoggedIn={ isLoggedIn } />

--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -1,0 +1,46 @@
+import config from '@automattic/calypso-config';
+import page, { Context } from '@automattic/calypso-router';
+import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
+import { translate } from 'i18n-calypso';
+import EmptyContent from 'calypso/components/empty-content';
+import Main from 'calypso/components/main';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { PerformanceProfilerDashboard } from './pages/dashboard';
+
+export function PerformanceProfilerDashboardContext( context: Context, next: () => void ): void {
+	if ( ! config.isEnabled( 'performance-profiler' ) ) {
+		page.redirect( '/' );
+		return;
+	}
+
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+	const pathName = context.pathname || '';
+	const routerDomain = pathName.split( '/speed-test-tool/' )[ 1 ]?.trim() || '';
+
+	context.primary = (
+		<>
+			<Main fullWidthLayout>
+				<PerformanceProfilerDashboard domain={ routerDomain } />
+			</Main>
+
+			<UniversalNavbarFooter isLoggedIn={ isLoggedIn } />
+		</>
+	);
+
+	next();
+}
+
+export const notFound = ( context: Context, next: () => void ) => {
+	context.primary = (
+		<EmptyContent
+			className="content-404"
+			illustration="/calypso/images/illustrations/illustration-404.svg"
+			title={ translate( 'Uh oh. Page not found.' ) }
+			line={ translate( "Sorry, the page you were looking for doesn't exist or has been moved." ) }
+			action={ translate( 'Return Home' ) }
+			actionURL="/"
+		/>
+	);
+
+	next();
+};

--- a/client/performance-profiler/index.node.ts
+++ b/client/performance-profiler/index.node.ts
@@ -1,0 +1,18 @@
+import { getLanguageRouteParam } from '@automattic/i18n-utils';
+import { makeLayout, setLocaleMiddleware } from 'calypso/controller';
+import { serverRouter } from 'calypso/server/isomorphic-routing';
+
+/**
+ * Using the server routing for this section has the sole purpose of defining
+ * a named route parameter for the language, that is used to set `context.lang`
+ * via the `setLocaleMiddleware()`.
+ *
+ * The `context.lang` value is then used in the server renderer to properly
+ * attach the translation files to the page.
+ * @see https://github.com/Automattic/wp-calypso/blob/trunk/client/server/render/index.js#L171.
+ */
+export default ( router: ReturnType< typeof serverRouter > ) => {
+	const lang = getLanguageRouteParam();
+
+	router( [ `/${ lang }/speed-test-tool(/*)?` ], setLocaleMiddleware(), makeLayout );
+};

--- a/client/performance-profiler/index.web.ts
+++ b/client/performance-profiler/index.web.ts
@@ -1,0 +1,14 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
+import { PerformanceProfilerDashboardContext, notFound } from './controller';
+
+export default function () {
+	page( '/speed-test-tool/:domain', PerformanceProfilerDashboardContext, makeLayout, clientRender );
+	page(
+		'/speed-test-tool/:domain/*',
+		PerformanceProfilerDashboardContext,
+		makeLayout,
+		clientRender
+	);
+	page( '/speed-test-tool*', notFound, makeLayout, clientRender );
+}

--- a/client/performance-profiler/index.web.ts
+++ b/client/performance-profiler/index.web.ts
@@ -3,12 +3,6 @@ import { makeLayout, render as clientRender } from 'calypso/controller/index.web
 import { PerformanceProfilerDashboardContext, notFound } from './controller';
 
 export default function () {
-	page( '/speed-test-tool/:domain', PerformanceProfilerDashboardContext, makeLayout, clientRender );
-	page(
-		'/speed-test-tool/:domain/*',
-		PerformanceProfilerDashboardContext,
-		makeLayout,
-		clientRender
-	);
+	page( '/speed-test-tool/', PerformanceProfilerDashboardContext, makeLayout, clientRender );
 	page( '/speed-test-tool*', notFound, makeLayout, clientRender );
 }

--- a/client/performance-profiler/package.json
+++ b/client/performance-profiler/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.node.ts",
+	"browser": "index.web.ts"
+}

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -1,0 +1,22 @@
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import './style.scss';
+import DocumentHead from 'calypso/components/data/document-head';
+
+type PerformanceProfilerDashboardProps = {
+	domain: string;
+};
+
+export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboardProps ) => {
+	const translate = useTranslate();
+	const { domain } = props;
+
+	return (
+		<div className="container">
+			<DocumentHead title={ translate( 'Speed Test' ) } />
+
+			<div className="top-section"> Top section - { domain } </div>
+			<div className="dahsboard-content">Dashboard content</div>
+		</div>
+	);
+};

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -4,18 +4,18 @@ import './style.scss';
 import DocumentHead from 'calypso/components/data/document-head';
 
 type PerformanceProfilerDashboardProps = {
-	domain: string;
+	url: string;
 };
 
 export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboardProps ) => {
 	const translate = useTranslate();
-	const { domain } = props;
+	const { url } = props;
 
 	return (
 		<div className="container">
 			<DocumentHead title={ translate( 'Speed Test' ) } />
 
-			<div className="top-section"> Top section - { domain } </div>
+			<div className="top-section"> Top section - { url } </div>
 			<div className="dahsboard-content">Dashboard content</div>
 		</div>
 	);

--- a/client/performance-profiler/pages/dashboard/style.scss
+++ b/client/performance-profiler/pages/dashboard/style.scss
@@ -1,0 +1,14 @@
+.is-group-performance-profiler .layout__content {
+	padding: 0;
+}
+
+.top-section {
+	color: #fff;
+	min-height: 200px;
+	padding-top: 40px;
+	background: linear-gradient(180deg, var(--studio-gray-100) 25.44%, rgba(16, 21, 23, 0) 100%), url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iOCIgY3k9IjgiIHI9IjEiIGZpbGw9IndoaXRlIiBmaWxsLW9wYWNpdHk9IjAuMjUiLz4KPC9zdmc+Cg==) repeat, var(--studio-gray-100);
+}
+
+.dahsboard-content {
+	min-height: 600px;
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -320,6 +320,16 @@ const sections = [
 		trackLoadPerformance: true,
 	},
 	{
+		name: 'performance-profiler',
+		paths: [ '/speed-test-tool', `/([a-z]{2,3}|[a-z]{2}-[a-z]{2})/speed-test-tool` ],
+		module: 'calypso/performance-profiler',
+		enableLoggedOut: true,
+		group: 'performance-profiler',
+		isomorphic: true,
+		title: 'Speed Test',
+		trackLoadPerformance: true,
+	},
+	{
 		name: 'domains',
 		paths: [ '/domains' ],
 		module: 'calypso/my-sites/domains',

--- a/config/development.json
+++ b/config/development.json
@@ -167,6 +167,7 @@
 		"p2-enabled": false,
 		"page/export": true,
 		"pattern-assembler/v2": true,
+		"performance-profiler": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -137,6 +137,7 @@
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"pattern-assembler/v2": true,
+		"performance-profiler": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,6 +133,7 @@
 		"p2-enabled": true,
 		"page/export": true,
 		"pattern-assembler/v2": true,
+		"performance-profiler": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -132,6 +132,7 @@
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"pattern-assembler/v2": true,
+		"performance-profiler": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
Fixes [Create the Performance Profiler page sctructure in Calypso](https://github.com/Automattic/dotcom-forge/issues/8622)

## Proposed Changes

Add the structure for the new Performance Profiler page with:
* The feature flag `"performance-profiler"` enabled on `dev` and `wpcalypso`
* The new route `/speed-test-tool` showing the main menu when logged out
* The page separated in a top section, content and footer with some styling already applied
* The controller that passes the domain from the URL

## Why are these changes being made?
To add a page for the new Performance Profiler 

## Testing Instructions

* Go to `/speed-test-tool?url=:url`. Ex: `/speed-test-tool?url=wordpress.com`
* You should see the skeleton of the page as below
* Go to a route that don't fit this pattern. Ex: `/speed-test-tool/wordpress.com`
* You should see the not found page

| Skeleton  | Not found |
| ------------- | ------------- |
|![CleanShot 2024-08-07 at 14 14 37@2x](https://github.com/user-attachments/assets/4bc807ed-eef3-47f1-80fb-780e7d965a98)|![CleanShot 2024-08-07 at 14 14 46@2x](https://github.com/user-attachments/assets/ae57fcb2-e1f3-4d88-a878-4878d91c1bcb)|




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
