### PR TITLE
Automated Migrations: Add the Credentials collection placeholder step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -7,6 +7,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextArea from 'calypso/components/forms/form-textarea';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
@@ -70,32 +71,46 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									type="text"
 									id="site-address"
 									value={ siteAddress }
+									placeholder={ translate( 'Enter your WordPress site address.' ) }
 									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
 										setSiteAddress( e.target.value )
 									}
 								/>
+								<div className="site-migration-credentials__form-error">
+									{ translate( 'Enter the URL of your source site.' ) }
+								</div>
 							</div>
-							<div className="site-migration-credentials__form-field">
-								<FormLabel htmlFor="username">{ translate( 'Username' ) }</FormLabel>
-								<FormTextInput
-									type="text"
-									id="username"
-									value={ username }
-									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
-										setUsername( e.target.value )
-									}
-								/>
+
+							<div className="site-migration-credentials__form-fields-row">
+								<div className="site-migration-credentials__form-field">
+									<FormLabel htmlFor="username">
+										{ translate( 'WordPress admin username' ) }
+									</FormLabel>
+									<FormTextInput
+										type="text"
+										id="username"
+										value={ username }
+										placeholder={ translate( 'Username' ) }
+										onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
+											setUsername( e.target.value )
+										}
+									/>
+								</div>
+								<div className="site-migration-credentials__form-field">
+									<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
+									<FormTextInput
+										type="password"
+										id="password"
+										value={ password }
+										placeholder={ translate( 'Password' ) }
+										onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
+											setPassword( e.target.value )
+										}
+									/>
+								</div>
 							</div>
-							<div className="site-migration-credentials__form-field">
-								<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
-								<FormTextInput
-									type="password"
-									id="password"
-									value={ password }
-									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
-										setPassword( e.target.value )
-									}
-								/>
+							<div className="site-migration-credentials__form-error">
+								{ translate( 'Enter your WordPress admin username and password.' ) }
 							</div>
 						</div>
 					</div>
@@ -115,18 +130,36 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									placeholder={ translate( 'Enter your backup file location' ) }
 								/>
 							</div>
-							<div>
+							<div className="site-migration-credentials__form-note">
 								{ translate(
-									'Share a link to your backup file, hosted on a service like Dropbox or Google Drive, ensuring that anyone with the link has access to the file.'
+									"Upload your file to a service like Dropbox or Google Drive to get a link. Don't forget to make sure that anyone with the link can access it."
 								) }
 							</div>
 						</div>
 					</div>
 				) }
+
+				<div className="site-migration-credentials__form-field">
+					<FormLabel htmlFor="site-address">{ translate( 'Notes (optional)' ) }</FormLabel>
+					<FormTextArea
+						type="text"
+						id="site-address"
+						placeholder={ translate(
+							'Share any other details that will help us access your site for the migration.'
+						) }
+						value={ siteAddress }
+						onChange={ ( e: ChangeEvent< HTMLInputElement > ) => setSiteAddress( e.target.value ) }
+					/>
+				</div>
 				<div>
 					<NextButton type="submit">{ translate( 'Continue' ) }</NextButton>
 				</div>
 			</Card>
+			<div className="site-migration-credentials__skip">
+				<button className="button navigation-link step-container__navigation-link has-underline is-borderless">
+					{ translate( 'Skip, I need help providing access' ) }
+				</button>
+			</div>
 		</form>
 	);
 };
@@ -146,6 +179,7 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 				flowName="site-migration"
 				goBack={ navigation?.goBack }
 				goNext={ navigation?.submit }
+				hideSkip
 				isFullLayout
 				formattedHeader={
 					<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,0 +1,169 @@
+import { FormLabel } from '@automattic/components';
+import Card from '@automattic/components/src/card';
+import { NextButton, StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent, useState, type FC } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+import './style.scss';
+
+interface CredentialsFormProps {
+	onSubmit: () => void;
+}
+
+export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
+	const translate = useTranslate();
+
+	const [ accessMethod, setAccessMethod ] = useState< string >( 'credentials' );
+	const [ siteAddress, setSiteAddress ] = useState< string >( '' );
+	const [ username, setUsername ] = useState< string >( '' );
+	const [ password, setPassword ] = useState< string >( '' );
+	const [ backupFileLocation, setBackupFileLocation ] = useState< string >( '' );
+
+	const handleAccessMethodChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		setAccessMethod( event.target.value );
+	};
+
+	const handleSubmit = () => {
+		// Handle form submission logic here
+		onSubmit();
+	};
+
+	return (
+		<form onSubmit={ handleSubmit }>
+			<Card>
+				<div>
+					<FormLabel>{ translate( 'How can we access your site?' ) }</FormLabel>
+					<div>
+						<FormRadio
+							label={ translate( 'WordPress credentials' ) }
+							value="credentials"
+							name="how-to-access-site"
+							checked={ accessMethod === 'credentials' }
+							onChange={ handleAccessMethodChange }
+							disabled={ false }
+						/>
+					</div>
+					<div>
+						<FormRadio
+							label={ translate( 'Backup file' ) }
+							value="backup"
+							name="how-to-access-site"
+							checked={ accessMethod === 'backup' }
+							onChange={ handleAccessMethodChange }
+							disabled={ false }
+						/>
+					</div>
+				</div>
+				<hr />
+				{ accessMethod === 'credentials' && (
+					<div className="site-migration-credentials">
+						<div className="site-migration-credentials__form">
+							<div className="site-migration-credentials__form-field">
+								<FormLabel htmlFor="site-address">{ translate( 'Site address' ) }</FormLabel>
+								<FormTextInput
+									type="text"
+									id="site-address"
+									value={ siteAddress }
+									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
+										setSiteAddress( e.target.value )
+									}
+								/>
+							</div>
+							<div className="site-migration-credentials__form-field">
+								<FormLabel htmlFor="username">{ translate( 'Username' ) }</FormLabel>
+								<FormTextInput
+									type="text"
+									id="username"
+									value={ username }
+									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
+										setUsername( e.target.value )
+									}
+								/>
+							</div>
+							<div className="site-migration-credentials__form-field">
+								<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
+								<FormTextInput
+									type="password"
+									id="password"
+									value={ password }
+									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
+										setPassword( e.target.value )
+									}
+								/>
+							</div>
+						</div>
+					</div>
+				) }
+				{ accessMethod === 'backup' && (
+					<div className="site-migration-credentials">
+						<div className="site-migration-credentials__form">
+							<div className="site-migration-credentials__form-field">
+								<FormLabel htmlFor="backup-file">{ translate( 'Backup file location' ) }</FormLabel>
+								<FormTextInput
+									type="text"
+									id="backup-file"
+									value={ backupFileLocation }
+									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
+										setBackupFileLocation( e.target.value )
+									}
+									placeholder={ translate( 'Enter your backup file location' ) }
+								/>
+							</div>
+							<div>
+								{ translate(
+									'Share a link to your backup file, hosted on a service like Dropbox or Google Drive, ensuring that anyone with the link has access to the file.'
+								) }
+							</div>
+						</div>
+					</div>
+				) }
+				<div>
+					<NextButton type="submit">{ translate( 'Continue' ) }</NextButton>
+				</div>
+			</Card>
+		</form>
+	);
+};
+
+export type SiteMigrationIdentifyAction = 'continue' | 'skip_platform_identification';
+
+const SiteMigrationCredentials: Step = function ( { navigation } ) {
+	const translate = useTranslate();
+
+	const handleSubmit = () => {
+		return navigation.submit?.();
+	};
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'Tell us about your site' ) } />
+			<StepContainer
+				stepName="site-migration-credentials"
+				flowName="site-migration"
+				goBack={ navigation?.goBack }
+				goNext={ navigation?.submit }
+				isFullLayout
+				formattedHeader={
+					<FormattedHeader
+						id="site-migration-credentials-header"
+						headerText={ translate( 'Tell us about your site' ) }
+						subHeaderText={ translate(
+							'Please share the following details to access your site and start your migration.'
+						) }
+						align="center"
+					/>
+				}
+				stepContent={ <CredentialsForm onSubmit={ handleSubmit } /> }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default SiteMigrationCredentials;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -39,7 +39,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 			<Card>
 				<div>
 					<FormLabel>{ translate( 'How can we access your site?' ) }</FormLabel>
-					<div>
+					<div className="site-migration-credentials__radio">
 						<FormRadio
 							label={ translate( 'WordPress credentials' ) }
 							value="credentials"
@@ -49,7 +49,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 							disabled={ false }
 						/>
 					</div>
-					<div>
+					<div className="site-migration-credentials__radio">
 						<FormRadio
 							label={ translate( 'Backup file' ) }
 							value="backup"
@@ -130,8 +130,6 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 		</form>
 	);
 };
-
-export type SiteMigrationIdentifyAction = 'continue' | 'skip_platform_identification';
 
 const SiteMigrationCredentials: Step = function ( { navigation } ) {
 	const translate = useTranslate();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -23,7 +23,10 @@
 			display: flex;
 			align-items: center;
 			.form-radio__label {
-				margin-left: 0;
+				margin-left: 0.5em;
+			}
+			.form-radio {
+				margin: 0;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -1,0 +1,22 @@
+.site-migration-credentials {
+	#site-migration-credentials-header {
+		.formatted-header__subtitle {
+			text-align: center;
+		}
+	}
+
+	.card {
+		max-width: 450px;
+		padding: 2em;
+		hr {
+			margin-top: 1em;
+		}
+		.action-buttons__next {
+			width: 100%;
+			margin-top: 1em;
+		}
+		.site-migration-credentials__form__field {
+			margin-top: 1em;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -6,7 +6,7 @@
 	}
 
 	.card {
-		max-width: 450px;
+		max-width: 500px;
 		padding: 2em;
 		hr {
 			margin-top: 1em;
@@ -15,6 +15,11 @@
 		.action-buttons__next {
 			width: 100%;
 			margin-top: 1em;
+		}
+		.site-migration-credentials__form-fields-row {
+			display: flex;
+			flex-direction: row;
+			gap: 1em;
 		}
 		.site-migration-credentials__form-field {
 			margin-top: 1em;
@@ -29,5 +34,17 @@
 				margin: 0;
 			}
 		}
+		.site-migration-credentials__form-note {
+			margin-top: 1em;
+			color: var(--color-text-subtle);
+		}
+		.site-migration-credentials__form-error {
+			color: var(--color-error);
+			font-size: 0.875rem;
+		}
+	}
+	.site-migration-credentials__skip {
+		margin-top: 1em;
+		text-align: center;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -10,13 +10,21 @@
 		padding: 2em;
 		hr {
 			margin-top: 1em;
+			background: var(--color-border-subtle);
 		}
 		.action-buttons__next {
 			width: 100%;
 			margin-top: 1em;
 		}
-		.site-migration-credentials__form__field {
+		.site-migration-credentials__form-field {
 			margin-top: 1em;
+		}
+		.site-migration-credentials__radio {
+			display: flex;
+			align-items: center;
+			.form-radio__label {
+				margin-left: 0;
+			}
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -245,6 +245,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/importer-migrate-message' ),
 	},
 
+	SITE_MIGRATION_CREDENTIALS: {
+		slug: 'site-migration-credentials',
+		asyncComponent: () => import( './steps-repository/site-migration-credentials' ),
+	},
+
 	SITE_MIGRATION_IDENTIFY: {
 		slug: 'site-migration-identify',
 		asyncComponent: () => import( './steps-repository/site-migration-identify' ),

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -43,6 +43,7 @@ const siteMigration: Flow = {
 			STEPS.ERROR,
 			STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
 			STEPS.SITE_MIGRATION_SOURCE_URL,
+			STEPS.SITE_MIGRATION_CREDENTIALS,
 		];
 
 		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME )
@@ -342,8 +343,10 @@ const siteMigration: Flow = {
 							providedDependencies?.userAcceptedDeal ||
 							urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME
 						) {
-							// If the user selected "Do it for me" but has not given us a source site, we should take them to the source URL step.
-							if ( ! fromQueryParam ) {
+							if ( config.isEnabled( 'automated-migration/collect-credentials' ) ) {
+								redirectAfterCheckout = STEPS.SITE_MIGRATION_CREDENTIALS.slug;
+							} else if ( ! fromQueryParam ) {
+								// If the user selected "Do it for me" but has not given us a source site, we should take them to the source URL step.
 								redirectAfterCheckout = STEPS.SITE_MIGRATION_SOURCE_URL.slug;
 							} else {
 								redirectAfterCheckout = STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug;
@@ -403,6 +406,13 @@ const siteMigration: Flow = {
 						siteSlug,
 					} );
 				}
+
+				case STEPS.SITE_MIGRATION_CREDENTIALS.slug: {
+					return navigate( STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug, {
+						siteId,
+						siteSlug,
+					} );
+				}
 			}
 		}
 
@@ -454,6 +464,10 @@ const siteMigration: Flow = {
 					}
 
 					return navigate( `site-migration-upgrade-plan?${ urlQueryParams.toString() }` );
+				}
+
+				case STEPS.SITE_MIGRATION_CREDENTIALS.slug: {
+					return navigate( `${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?${ urlQueryParams }` );
 				}
 			}
 		};

--- a/config/development.json
+++ b/config/development.json
@@ -31,6 +31,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/collect-credentials": false,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-assembler": true,
 		"calypso/big-sky": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -11,6 +11,7 @@
 	"facebook_api_key": "249643311490",
 	"features": {
 		"ad-tracking": false,
+		"automated-migration/collect-credentials": false,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,
 		"calypso/big-sky": true,

--- a/config/production.json
+++ b/config/production.json
@@ -22,6 +22,7 @@
 	"features": {
 		"ad-tracking": true,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/collect-credentials": false,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": false,
 		"calypso/big-sky": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,6 +20,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/collect-credentials": false,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,
 		"calypso/big-sky": true,

--- a/config/test.json
+++ b/config/test.json
@@ -23,6 +23,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/collect-credentials": false,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,6 +19,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
+		"automated-migration/collect-credentials": false,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-assembler": true,
 		"calypso/big-sky": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93251

## Proposed Changes

* Adds the new Credentials collection step behind a feature flag. 
* Adds the feature flag to all environment files: `automated-migration/collect-credentials`

<img width="706" alt="Captura de Tela 2024-08-12 às 17 38 59" src="https://github.com/user-attachments/assets/abaf51a2-7454-42f5-b4c1-0b16254fb861">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are introducing this new step to serve as a basis for testing the functionalities related to Automated Migration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch to your local environment or add use the Calypso Live link below.
* Open the dev console and activate the feature flag by running the following command:
```
window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')
```
* Now go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * The step doesn't do any actions yet
  * Clicking on `Continue` should take you to the `Instructions` step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
