### PR TITLE
Temporarily disable the DPA CTA

### DIFF
--- a/client/me/privacy/dpa.jsx
+++ b/client/me/privacy/dpa.jsx
@@ -78,16 +78,21 @@ const DPA = () => {
 						) }
 					</strong>
 				</p>
-				<Button
-					className="privacy__dpa-request-button"
-					disabled={ isLoading }
-					onClick={ requestDpa }
-				>
+				<Button className="privacy__dpa-request-button" disabled onClick={ requestDpa }>
 					{ translate( 'Request a DPA', {
 						comment:
 							'A Data Processing Addendum (DPA) is a document to assure customers, vendors, and partners that their data handling complies with the law.',
 					} ) }
 				</Button>
+				<p>
+					<small>
+						<strong>
+							{ translate(
+								'Notice: The ability to request a DPA is temporarily on hold while updates are made to our Data Processing Addendum. We expect this feature to be restored on or before August 16.'
+							) }
+						</strong>
+					</small>
+				</p>
 			</Card>
 		</>
 	);

--- a/client/me/privacy/dpa.jsx
+++ b/client/me/privacy/dpa.jsx
@@ -1,6 +1,5 @@
 import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import SectionHeader from 'calypso/components/section-header';
 import wp from 'calypso/lib/wp';
@@ -9,13 +8,11 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 const NOTICE_ID = 'request-dpa-notice';
 
 const DPA = () => {
-	const [ isLoading, setLoading ] = useState( false );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const requestDpa = async () => {
 		try {
-			setLoading( true );
 			await wp.req.post( '/me/request-dpa', { apiNamespace: 'wpcom/v2' } );
 			dispatch(
 				successNotice(
@@ -38,8 +35,6 @@ const DPA = () => {
 					{ id: NOTICE_ID }
 				)
 			);
-		} finally {
-			setLoading( false );
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1723055054024199-slack-C02FMH4G8

## Proposed Changes

* Temporarily disable the DPA CTA at https://wordpress.com/me/privacy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure it's disabled:

![image](https://github.com/user-attachments/assets/3c649459-6356-4de1-a920-3231667f0ec4)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?