### PR TITLE
Make mocking instructions better

### DIFF
--- a/bin/welcome.js
+++ b/bin/welcome.js
@@ -24,6 +24,7 @@ ${ chalk.greenBright( 'Press any key to continue...' ) }
 `
 	);
 
+	// Wait for user input to continue
 	process.stdin.setRawMode( true );
 	process.stdin.once( 'data', () => {
 		process.stdin.setRawMode( false );

--- a/bin/welcome.js
+++ b/bin/welcome.js
@@ -12,9 +12,22 @@ console.log( chalk.cyan( '               |___/|_|                \n' ) );
 
 if ( process.env.MOCK_WORDPRESSDOTCOM === '1' ) {
 	console.log(
-		`Mocking WordPress.com
+		`${ chalk.yellowBright.bold( 'Mocking WordPress.com' ) }
+		
 - Add ${ chalk.yellowBright( '127.0.0.1 wordpress.com' ) } to your hosts file.
+- If you want to sandbox authentication backend, sandbox ${ chalk.yellowBright(
+			'de.wordpress.com'
+		) } in your hosts file.
 - Type ${ chalk.white.bgBlue( ' thisisunsafe ' ) } in Chrome when you visit wordpress.com.
+
+${ chalk.greenBright( 'Press any key to continue...' ) }
 `
 	);
+
+	process.stdin.setRawMode( true );
+	process.stdin.once( 'data', () => {
+		process.stdin.setRawMode( false );
+		console.log( chalk.greenBright( 'Continuing...' ) );
+		process.exit( 0 );
+	} );
 }

--- a/bin/welcome.js
+++ b/bin/welcome.js
@@ -15,7 +15,7 @@ if ( process.env.MOCK_WORDPRESSDOTCOM === '1' ) {
 		`${ chalk.yellowBright.bold( 'Mocking WordPress.com' ) }
 		
 - Add ${ chalk.yellowBright( '127.0.0.1 wordpress.com' ) } to your hosts file.
-- If you want to sandbox authentication backend, sandbox ${ chalk.yellowBright(
+- If you want to sandbox the authentication backend, sandbox ${ chalk.yellowBright(
 			'de.wordpress.com'
 		) } in your hosts file.
 - Type ${ chalk.white.bgBlue( ' thisisunsafe ' ) } in Chrome when you visit wordpress.com.


### PR DESCRIPTION
Wait until the user reads the mocking instructions when the user runs `yarn start-mock-wordpress-com`

### Testing
1. Run `yarn start-mock-wordpress-com`.
2. The instructions should be clear and should wait for you to press enter. 

```bash
             _                           
    ___ __ _| |_   _ _ __  ___  ___      
   / __/ _` | | | | | '_ \/ __|/ _ \ 
  | (_| (_| | | |_| | |_) \__ \ (_) |  
   \___\__,_|_|\__, | .__/|___/\___/ 
               |___/|_|                

Mocking WordPress.com
		
- Add 127.0.0.1 wordpress.com to your hosts file.
- If you want to sandbox authentication backend, sandbox de.wordpress.com in your hosts file.
- Type  thisisunsafe  in Chrome when you visit wordpress.com.

Press any key to continue...
```