### PR TITLE
Frictionless Email Subscriptions: Default to loading screen on initial page render

### DIFF
--- a/client/signup/steps/subscribe-email/index.jsx
+++ b/client/signup/steps/subscribe-email/index.jsx
@@ -73,7 +73,7 @@ function SubscribeEmailStep( props ) {
 		? addQueryArgs( window.location.href, { user_email: currentUser?.email } )
 		: '';
 
-	const [ isRedirectingToLogout, setIsRedirectingToLogout ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState( true );
 
 	const { mutate: subscribeEmail, isPending: isSubscribingEmail } = useSubscribeEmail();
 
@@ -129,7 +129,7 @@ function SubscribeEmailStep( props ) {
 					},
 					{
 						onSuccess: () => {
-							setIsRedirectingToLogout( true );
+							setIsLoading( true );
 							/**
 							 * Logged in users will see an "Is it you?" page. Logged out users will
 							 * skip the page. To make email capture more seamless at conferences we
@@ -153,6 +153,7 @@ function SubscribeEmailStep( props ) {
 	// On page load, attempt to subscribe the submitted email to the mailing list
 	useEffect( () => {
 		if ( ! emailValidator.validate( email ) ) {
+			setIsLoading( false );
 			return;
 		}
 
@@ -162,6 +163,7 @@ function SubscribeEmailStep( props ) {
 			}
 
 			// Otherwise show the "Is this you?" page
+			setIsLoading( false );
 			return;
 		}
 
@@ -188,7 +190,7 @@ function SubscribeEmailStep( props ) {
 		}
 	}, [ email ] );
 
-	const isPending = isCreatingNewAccount || isSubscribingEmail || isRedirectingToLogout;
+	const isPending = isCreatingNewAccount || isSubscribingEmail || isLoading;
 
 	return (
 		<div className="subscribe-email">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3239

## Proposed Changes

* Subscribe email step renders loading screen by default

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There are times when the page might flash rendered content before showing a loading screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To replicate, visit https://h4tests.wordpress.com/landing-page-test, submit the form, and then you should see the content appear and then disappear very quickly.
* With this patch, the only the loading screen should be displayed initially

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
