### PR TITLE
RT: Add premium badges

### DIFF
--- a/client/my-sites/patterns/components/readymade-template-details/index.tsx
+++ b/client/my-sites/patterns/components/readymade-template-details/index.tsx
@@ -1,3 +1,4 @@
+import { PremiumBadge } from '@automattic/components';
 import { addLocaleToPathLocaleInFront, useLocalizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -44,6 +45,7 @@ export const ReadymadeTemplateDetails: ReadymadeTemplateDetailsFC = ( { id, rend
 					</a>
 					<div className="readymade-template-details">
 						<div className="readymade-template-details-content">
+							<PremiumBadge shouldHideTooltip className="readymade-template-details-premium" />
 							<div className="readymade-template-details-header">
 								<h1 className="readymade-template-details-title">{ readymadeTemplate.title }</h1>
 								<div className="readymade-template-details-actions">

--- a/client/my-sites/patterns/components/readymade-template-details/style.scss
+++ b/client/my-sites/patterns/components/readymade-template-details/style.scss
@@ -58,6 +58,12 @@ a.readymade-template-details-back {
 	}
 }
 
+.readymade-template-details-premium.premium-badge {
+	margin-left: 0;
+	background-color: #50575e;
+	margin-bottom: 10px;
+}
+
 .readymade-template-details-preview {
 	width: 55%;
 

--- a/client/my-sites/patterns/components/readymade-templates/section.tsx
+++ b/client/my-sites/patterns/components/readymade-templates/section.tsx
@@ -80,6 +80,7 @@ export const ReadymadeTemplatesSection = ( {
 			id="readymade-templates-section"
 			theme="dark"
 			title={ translate( 'Ready-to-use site layouts' ) }
+			isPremium
 		>
 			<div className="readymade-templates" ref={ containerRef }>
 				{ readymadeTemplates.map( ( readymadeTemplate ) => (

--- a/client/my-sites/patterns/components/section/index.tsx
+++ b/client/my-sites/patterns/components/section/index.tsx
@@ -1,3 +1,4 @@
+import { PremiumBadge } from '@automattic/components';
 import clsx from 'clsx';
 import { RefObject } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -12,6 +13,7 @@ type PatternsSectionProps = {
 	theme?: 'blue' | 'dark' | 'gray';
 	bodyFullWidth?: boolean;
 	children: React.ReactNode;
+	isPremium?: boolean;
 };
 
 export const PatternsSection = ( {
@@ -22,6 +24,7 @@ export const PatternsSection = ( {
 	theme,
 	bodyFullWidth,
 	children,
+	isPremium,
 }: PatternsSectionProps ) => {
 	const sectionProps = id ? { id } : {};
 	return (
@@ -35,6 +38,11 @@ export const PatternsSection = ( {
 				'patterns-section--full-width-body': bodyFullWidth,
 			} ) }
 		>
+			{ isPremium && (
+				<div className="patterns-section__premium-badge">
+					<PremiumBadge shouldHideTooltip />
+				</div>
+			) }
 			<div className="patterns-section__header">
 				<h2>{ title }</h2>
 				<div className="patterns-section__header-description">{ preventWidows( description ) }</div>

--- a/client/my-sites/patterns/components/section/style.scss
+++ b/client/my-sites/patterns/components/section/style.scss
@@ -45,6 +45,15 @@
 	}
 }
 
+.patterns-section__premium-badge {
+	@include patterns-page-width;
+	margin-bottom: 10px;
+	.premium-badge {
+		margin-left: 0;
+		background-color: #50575e;
+	}
+}
+
 .patterns-section__header {
 	@include patterns-page-width;
 	padding-bottom: 48px;


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8616

## Proposed Changes

Add a "Premium" badge to the Readymade template sections on /patterns and also on the RT details page, above the RT name.



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These two badges will help foreshadow that Readymade Templates will require the premium plan by default - due to their dependency on global styles. This will make it less of a surprise when the user later enters the launchpad.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Use calypso live link
 2. Go to /patterns
 3. Scroll down down down until you find the "Ready-to-use site layouts" section
 4. Notice the premium badge
 5. Choose one of the layouts
 6. Notice the premium badge once again

Before | After
-------|------
 <img width="1032" alt="Screenshot 2024-08-07 at 21 10 18" src="https://github.com/user-attachments/assets/5a5c9fc0-0972-45e0-8251-f9ecc86ed2ad">| <img width="1032" alt="Screenshot 2024-08-07 at 21 08 36" src="https://github.com/user-attachments/assets/59c70b12-26ab-4045-8bcf-8c17f807a793">
 <img width="1032" alt="Screenshot 2024-08-07 at 21 09 28" src="https://github.com/user-attachments/assets/08a09d90-3443-4ed3-8035-72883bab5161"> | <img width="1032" alt="Screenshot 2024-08-07 at 21 09 03" src="https://github.com/user-attachments/assets/344e12f8-cf97-42a6-b145-e8c077f1d2b3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
