### PR TITLE
A4A Dev Sites: Require payment method when creating a new dev site.

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -33,14 +33,14 @@ type Props = {
 	onWPCOMImport?: ( blogIds: number[] ) => void;
 	showMainButtonLabel: boolean;
 	devSite?: boolean;
-	toggleSiteConfigurationsModal?: () => void;
+	toggleDevSiteConfigurationsModal?: () => void;
 };
 
 export default function AddNewSiteButton( {
 	showMainButtonLabel,
 	onWPCOMImport,
 	devSite,
-	toggleSiteConfigurationsModal,
+	toggleDevSiteConfigurationsModal,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -215,7 +215,7 @@ export default function AddNewSiteButton( {
 									`${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_SITES_LINK }?add_new_dev_site=true`
 								);
 							} else {
-								toggleSiteConfigurationsModal?.();
+								toggleDevSiteConfigurationsModal?.();
 							}
 						},
 					},

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -1,10 +1,9 @@
 import page from '@automattic/calypso-router';
 import { Popover, Gridicon, Button, WordPressLogo, JetpackLogo } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
-import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
@@ -51,14 +50,6 @@ export default function AddNewSiteButton( {
 	const [ showA4AConnectionModal, setShowA4AConnectionModal ] = useState( false );
 	const [ showJetpackConnectionModal, setShowJetpackConnectionModal ] = useState( false );
 	const [ showImportFromWPCOMModal, setShowImportFromWPCOMModal ] = useState( false );
-
-	const paymentMethodAdded = getQueryArg( window.location.href, 'add_new_dev_site' );
-
-	useEffect( () => {
-		if ( devSite && paymentMethodAdded ) {
-			toggleSiteConfigurationsModal?.();
-		}
-	}, [ paymentMethodAdded, devSite, toggleSiteConfigurationsModal ] );
 
 	const toggleMenu = () => {
 		setMenuVisible( ( isVisible ) => ! isVisible );

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -1,11 +1,14 @@
+import page from '@automattic/calypso-router';
 import { Popover, Gridicon, Button, WordPressLogo, JetpackLogo } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
+import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
+import usePaymentMethod from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/hooks/use-payment-method';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -13,6 +16,8 @@ import A4ALogo from '../a4a-logo';
 import {
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
+	A4A_PAYMENT_METHODS_ADD_LINK,
+	A4A_SITES_LINK,
 	A4A_SITES_LINK_NEEDS_SETUP,
 } from '../sidebar-menu/lib/constants';
 import A4AConnectionModal from './a4a-connection-modal';
@@ -40,11 +45,20 @@ export default function AddNewSiteButton( {
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { paymentMethodRequired } = usePaymentMethod();
 
 	const [ isMenuVisible, setMenuVisible ] = useState( false );
 	const [ showA4AConnectionModal, setShowA4AConnectionModal ] = useState( false );
 	const [ showJetpackConnectionModal, setShowJetpackConnectionModal ] = useState( false );
 	const [ showImportFromWPCOMModal, setShowImportFromWPCOMModal ] = useState( false );
+
+	const paymentMethodAdded = getQueryArg( window.location.href, 'add_new_dev_site' );
+
+	useEffect( () => {
+		if ( devSite && paymentMethodAdded ) {
+			toggleSiteConfigurationsModal?.();
+		}
+	}, [ paymentMethodAdded, devSite, toggleSiteConfigurationsModal ] );
 
 	const toggleMenu = () => {
 		setMenuVisible( ( isVisible ) => ! isVisible );
@@ -204,7 +218,15 @@ export default function AddNewSiteButton( {
 					heading: translate( 'WordPress.com' ),
 					description: translate( 'Create a site and try our hosting features for free' ),
 					buttonProps: {
-						onClick: toggleSiteConfigurationsModal,
+						onClick: () => {
+							if ( paymentMethodRequired ) {
+								page(
+									`${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_SITES_LINK }?add_new_dev_site=true`
+								);
+							} else {
+								toggleSiteConfigurationsModal?.();
+							}
+						},
 					},
 					extraContent: hasAvailableDevSites ? (
 						<div className="site-selector-and-importer__popover-site-count">

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -192,7 +192,7 @@ function PaymentMethodForm() {
 						returnQueryArg
 					)
 				);
-			} else if ( returnQueryArg?.includes( 'new_dev_site' ) ) {
+			} else if ( returnQueryArg?.includes( 'add_new_dev_site' ) ) {
 				const params = {
 					add_new_dev_site: true,
 				};

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -192,6 +192,11 @@ function PaymentMethodForm() {
 						returnQueryArg
 					)
 				);
+			} else if ( returnQueryArg?.includes( 'new_dev_site' ) ) {
+				const params = {
+					add_new_dev_site: true,
+				};
+				page( addQueryArgs( params, returnQueryArg ) );
 			}
 		} else {
 			page( isClientView() ? A4A_CLIENT_PAYMENT_METHODS_LINK : A4A_PAYMENT_METHODS_LINK );

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -33,7 +33,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 	const [ tourStepRef, setTourStepRef ] = useState< HTMLElement | null >( null );
 	const [ showConfigurationModal, setShowConfigurationModal ] = useState( false );
 
-	const toggleSiteConfigurationsModal = useCallback( () => {
+	const toggleDevSiteConfigurationsModal = useCallback( () => {
 		setShowConfigurationModal( ! showConfigurationModal );
 	}, [ showConfigurationModal ] );
 
@@ -47,19 +47,19 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 
 	const devSite = config.isEnabled( 'a4a-dev-sites' );
 
-	const paymentMethodAdded = getQueryArg( window.location.href, 'add_new_dev_site' );
+	const addNewDevSite = getQueryArg( window.location.href, 'add_new_dev_site' );
 
 	useEffect( () => {
-		if ( devSite && paymentMethodAdded ) {
-			toggleSiteConfigurationsModal?.();
+		if ( devSite && addNewDevSite ) {
+			toggleDevSiteConfigurationsModal?.();
 		}
-	}, [ paymentMethodAdded, devSite, toggleSiteConfigurationsModal ] );
+	}, [ addNewDevSite, devSite, toggleDevSiteConfigurationsModal ] );
 
 	return (
 		<div className="sites-header__actions">
 			{ showConfigurationModal && (
 				<SiteConfigurationsModal
-					closeModal={ toggleSiteConfigurationsModal }
+					closeModal={ toggleDevSiteConfigurationsModal }
 					randomSiteName={ randomSiteName }
 					isRandomSiteNameLoading={ isRandomSiteNameLoading }
 					onCreateSiteSuccess={ onCreateSiteSuccess }
@@ -69,7 +69,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 				<AddNewSiteButton
 					showMainButtonLabel={ ! isMobile }
 					devSite
-					toggleSiteConfigurationsModal={ toggleSiteConfigurationsModal }
+					toggleDevSiteConfigurationsModal={ toggleDevSiteConfigurationsModal }
 				/>
 			) }
 			<div ref={ ( ref ) => setTourStepRef( ref ) }>

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -45,15 +45,15 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 		[ refetchPendingSites ]
 	);
 
-	const devSite = config.isEnabled( 'a4a-dev-sites' );
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	const addNewDevSite = getQueryArg( window.location.href, 'add_new_dev_site' );
 
 	useEffect( () => {
-		if ( devSite && addNewDevSite ) {
+		if ( devSitesEnabled && addNewDevSite ) {
 			toggleDevSiteConfigurationsModal?.();
 		}
-	}, [ addNewDevSite, devSite, toggleDevSiteConfigurationsModal ] );
+	}, [ addNewDevSite, devSitesEnabled, toggleDevSiteConfigurationsModal ] );
 
 	return (
 		<div className="sites-header__actions">
@@ -65,7 +65,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 					onCreateSiteSuccess={ onCreateSiteSuccess }
 				/>
 			) }
-			{ devSite && (
+			{ devSitesEnabled && (
 				<AddNewSiteButton
 					showMainButtonLabel={ ! isMobile }
 					devSite

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -2,9 +2,9 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { addQueryArgs } from '@wordpress/url';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
@@ -33,9 +33,9 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 	const [ tourStepRef, setTourStepRef ] = useState< HTMLElement | null >( null );
 	const [ showConfigurationModal, setShowConfigurationModal ] = useState( false );
 
-	const toggleSiteConfigurationsModal = () => {
+	const toggleSiteConfigurationsModal = useCallback( () => {
 		setShowConfigurationModal( ! showConfigurationModal );
-	};
+	}, [ showConfigurationModal ] );
 
 	const onCreateSiteSuccess = useCallback(
 		( id: number ) => {
@@ -44,6 +44,16 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 		},
 		[ refetchPendingSites ]
 	);
+
+	const devSite = config.isEnabled( 'a4a-dev-sites' );
+
+	const paymentMethodAdded = getQueryArg( window.location.href, 'add_new_dev_site' );
+
+	useEffect( () => {
+		if ( devSite && paymentMethodAdded ) {
+			toggleSiteConfigurationsModal?.();
+		}
+	}, [ paymentMethodAdded, devSite, toggleSiteConfigurationsModal ] );
 
 	return (
 		<div className="sites-header__actions">
@@ -55,7 +65,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 					onCreateSiteSuccess={ onCreateSiteSuccess }
 				/>
 			) }
-			{ config.isEnabled( 'a4a-dev-sites' ) && (
+			{ devSite && (
 				<AddNewSiteButton
 					showMainButtonLabel={ ! isMobile }
 					devSite


### PR DESCRIPTION
## Proposed Changes
![image](https://github.com/user-attachments/assets/42acfb16-abf5-422d-bf6f-9f655191eb15)

Requires payment method (credit card) when creating a new dev site.

## Testing Instructions

Use an account that has no credit card attached.

You can delete previews registered credit card on http://agencies.localhost:3000/purchases/payment-methods

Try to create a new dev site under `ADD A NEW DEVELOPMENT SITE`

You should be redirected to the new credit card page.

After adding a new valid credit card (I used Ramp), you should be redirected to the `/sites` page. The new dev page modal should open automatically.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
