### PR TITLE
A4A: UX improvement on the A4A number input.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-number-input/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-number-input/index.tsx
@@ -1,6 +1,6 @@
 import { Button, TextControl } from '@wordpress/components';
 import { Icon, lineSolid, plus } from '@wordpress/icons';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import './style.scss';
 
@@ -19,6 +19,8 @@ export default function A4ANumberInput( {
 	maximum,
 	increment = 1,
 }: Props ) {
+	const [ dirtyValue, setDirtyValue ] = useState( '' );
+
 	const onDecrement = useCallback( () => {
 		onChange( Math.max( value - increment, minimum ) );
 	}, [ increment, minimum, onChange, value ] );
@@ -27,14 +29,28 @@ export default function A4ANumberInput( {
 		onChange( maximum ? Math.min( value + increment, maximum ) : value + increment );
 	}, [ increment, maximum, onChange, value ] );
 
+	const onBlur = useCallback( () => {
+		const next = Number( dirtyValue );
+		if ( ! isNaN( next ) && next >= minimum && ( ! maximum || next <= maximum ) ) {
+			onChange( next );
+		} else {
+			setDirtyValue( `${ value }` );
+		}
+	}, [ dirtyValue, maximum, minimum, onChange, value ] );
+
+	useEffect( () => {
+		setDirtyValue( `${ value }` );
+	}, [ value ] );
+
 	return (
 		<div className="a4a-number-input">
 			<Button onMouseDown={ onDecrement }>
 				<Icon icon={ lineSolid } size={ 18 } />
 			</Button>
 			<TextControl
-				value={ value }
-				onChange={ ( newValue ) => onChange( parseInt( newValue, 10 ) ) }
+				value={ dirtyValue }
+				onChange={ ( newValue ) => setDirtyValue( newValue ) }
+				onBlur={ onBlur }
 				type="number"
 			/>
 			<Button onMouseDown={ onIncrement }>

--- a/client/a8c-for-agencies/components/a4a-number-input/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-number-input/index.tsx
@@ -1,6 +1,6 @@
 import { Button, TextControl } from '@wordpress/components';
 import { Icon, lineSolid, plus } from '@wordpress/icons';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import './style.scss';
 
@@ -19,6 +19,7 @@ export default function A4ANumberInput( {
 	maximum,
 	increment = 1,
 }: Props ) {
+	const inputRef = useRef< HTMLInputElement >( null );
 	const [ dirtyValue, setDirtyValue ] = useState( '' );
 
 	const onDecrement = useCallback( () => {
@@ -48,9 +49,11 @@ export default function A4ANumberInput( {
 				<Icon icon={ lineSolid } size={ 18 } />
 			</Button>
 			<TextControl
+				ref={ inputRef }
 				value={ dirtyValue }
 				onChange={ ( newValue ) => setDirtyValue( newValue ) }
 				onBlur={ onBlur }
+				onFocus={ () => inputRef.current?.select() }
 				type="number"
 			/>
 			<Button onMouseDown={ onIncrement }>


### PR DESCRIPTION
This PR adds some minor UX improvement on how the A4A number input behaves.



https://github.com/user-attachments/assets/f8292eff-0ad9-47c4-aa86-69a48d6d05a6


Follow up https://github.com/Automattic/wp-calypso/pull/93331

## Proposed Changes

* Update the component so that it only triggers the onChange event when the input loses focus. This will prevent the `onChange` event from firing prematurely and disrupting user input.
* When in focus, the input should auto-select the value, reducing the number of clicks and button presses when replacing the value.

## Why are these changes being made?

* Improves user experience.

## Testing Instructions

* Use the A4A live link and go to `/marketplace/hosting/wpcom`.
* Test the manual input and confirm the expected improvements are applied.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
