### PR TITLE
Site Level User Profile: improve banner and web address field UI

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import EditGravatar from 'calypso/blocks/edit-gravatar';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -103,7 +104,32 @@ class Profile extends Component {
 								onFocus={ this.getFocusHandler( 'Display Name Field' ) }
 								value={ this.props.getSetting( 'display_name' ) }
 							/>
+							{ isEnabled( 'layout/site-level-user-profile' ) && (
+								<FormSettingExplanation>
+									{ this.props.translate( 'Shown publicly when you comment on other sites.' ) }
+								</FormSettingExplanation>
+							) }
 						</FormFieldset>
+
+						{ isEnabled( 'layout/site-level-user-profile' ) && (
+							<FormFieldset>
+								<FormLabel htmlFor="user_URL">
+									{ this.props.translate( 'Public web address' ) }
+								</FormLabel>
+								<FormTextInput
+									disabled={ this.props.getDisabledState() }
+									id="user_URL"
+									name="user_URL"
+									type="url"
+									onChange={ this.props.updateSetting }
+									onFocus={ this.getFocusHandler( 'Web Address Field' ) }
+									value={ this.props.getSetting( 'user_URL' ) }
+								/>
+								<FormSettingExplanation>
+									{ this.props.translate( 'Shown publicly when you comment on other sites.' ) }
+								</FormSettingExplanation>
+							</FormFieldset>
+						) }
 
 						<FormFieldset>
 							<FormLabel htmlFor="description">{ this.props.translate( 'About me' ) }</FormLabel>
@@ -116,21 +142,6 @@ class Profile extends Component {
 								value={ this.props.getSetting( 'description' ) }
 							/>
 						</FormFieldset>
-
-						{ isEnabled( 'layout/site-level-user-profile' ) && (
-							<FormFieldset>
-								<FormLabel htmlFor="user_URL">{ this.props.translate( 'Web address' ) }</FormLabel>
-								<FormTextInput
-									disabled={ this.props.getDisabledState() }
-									id="user_URL"
-									name="user_URL"
-									type="url"
-									onChange={ this.props.updateSetting }
-									onFocus={ this.getFocusHandler( 'Web Address Field' ) }
-									value={ this.props.getSetting( 'user_URL' ) }
-								/>
-							</FormFieldset>
-						) }
 
 						<p className="profile__gravatar-profile-description">
 							<span>

--- a/client/me/profile/site-level-profile-banner/index.tsx
+++ b/client/me/profile/site-level-profile-banner/index.tsx
@@ -36,10 +36,9 @@ export default function SiteLevelProfileBanner() {
 			description={
 				<>
 					{ translate(
-						"To manage your profile on a specific site instead, {{modal}}click here{{/modal}} to visit the site's profile page.",
+						'To manage your profile on a specific site instead, {{modal}}visit the site’s profile page{{/modal}}.',
 						{
 							components: {
-								br: <br />,
 								modal: <SiteLevelProfileModal />,
 							},
 						}


### PR DESCRIPTION
Related to p1723087602699649-slack-CRWCHQGUB

## Proposed Changes

This PR improves the UI of the banner and the web address field on /me as follows:

|Before|After|
|-|-|
|<img width="580" alt="Screenshot 2024-08-08 at 13 31 34" src="https://github.com/user-attachments/assets/12a32fab-4902-420f-a118-a57d0901dafc">|<img width="508" alt="image" src="https://github.com/user-attachments/assets/edf4e40c-355b-4e06-bea5-eaf7acd0d47b"><br>- Reworded the CTA to match with Gravatar's new notice CTA at the end of the form) (see below)|
|<img width="860" alt="image" src="https://github.com/user-attachments/assets/1a352212-9ee9-4a6a-b4e3-e374a81d8e8f">|<img width="864" alt="image" src="https://github.com/user-attachments/assets/b7a548ad-f021-4aad-a934-de9748419c41"><br>- Moved the field right next to `Public display name`<br>- Renamed it to `Public web address`<br>- Added subtitle for explicity clarity|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Trying to improve clarity.

## Testing Instructions

1. Go to live URL's `/me`.
2. Verify the screen as shown in the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?