### PR TITLE
A4A > Marketplace: Minor text updates to the hosting page

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/index.tsx
@@ -55,7 +55,7 @@ const MigrationOfferV2 = () => {
 							className="a4a-migration-offer-v2__button"
 							href={ CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT }
 						>
-							{ translate( 'Contact us to start migrating' ) }
+							{ translate( 'Contact us to learn more' ) }
 							<Icon icon={ external } size={ 18 } />
 						</Button>
 					</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/index.tsx
@@ -163,11 +163,14 @@ export default function HostingV2( { onAddToCart, section }: Props ) {
 				>
 					<div className="hosting-v2__hero-content">
 						<div className="hosting-v2__heading">
-							{ translate( "Choose the hosting tailored{{br/}}for your client's needs.", {
-								components: {
-									br: <br />,
-								},
-							} ) }
+							{ translate(
+								'High Performance, Highly Secure{{br/}}Managed WordPress Hosting for Agencies',
+								{
+									components: {
+										br: <br />,
+									},
+								}
+							) }
 						</div>
 						<MigrationOffer />
 						<NavTabs enforceTabsView>{ navItems }</NavTabs>


### PR DESCRIPTION
## Proposed Changes

* This PR makes some text updates as mentioned here: pfunGA-21T-p2#comment-4506

## Why are these changes being made?

* To update the texts in the new hosting page

## Testing Instructions

* Open the A4A live link
* Go to Marketplace - Hosting: Verify the heading and the migration CTA is updated as shown below"

<img width="1426" alt="Screenshot 2024-08-08 at 12 59 12 PM" src="https://github.com/user-attachments/assets/e797e3a4-a654-4742-9e2b-d375023252ff">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?