### PR TITLE
A4A: Fix Partner directory's expertise form validation with approved directories.

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form-validation.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form-validation.ts
@@ -33,6 +33,11 @@ const useExpertiseFormValidation = () => {
 				newValidationError.directories = translate( `Directories can't be empty` );
 			} else {
 				payload.directories.forEach( ( directory ) => {
+					if ( directory.status === 'approved' ) {
+						// If the directory has already been approved. We do not need to validate the URLs
+						return;
+					}
+
 					if ( directory.urls.length < 1 ) {
 						newValidationError.clientSites = translate( `Client sites can't be empty` );
 						return;

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/hooks/use-expertise-form.ts
@@ -92,8 +92,11 @@ export default function useExpertiseForm( { initialFormData }: Props ) {
 			formData.directories.length > 0 &&
 			formData.feedbackUrl.length > 0 &&
 			// Ensure that each directory request has 5 valid URLs
-			formData.directories.every( ( { urls } ) => {
-				return urls.every( ( url ) => url && isValidUrl( url ) ) && areURLsUnique( urls );
+			formData.directories.every( ( { status, urls } ) => {
+				return (
+					status === 'approved' ||
+					( urls.every( ( url ) => url && isValidUrl( url ) ) && areURLsUnique( urls ) )
+				);
 			} ),
 		[ formData ]
 	);

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -147,6 +147,8 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 
 	const directoryOptions = Object.keys( availableDirectories ) as DirectoryApplicationType[];
 
+	const pendingDirectories = directories.filter( ( { status } ) => status !== 'approved' );
+
 	return (
 		<Form
 			className="partner-directory-agency-expertise"
@@ -222,7 +224,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 					</div>
 				</FormField>
 
-				{ !! directories.length && (
+				{ !! pendingDirectories.length && (
 					<FormField
 						label={ translate( 'Client sites' ) }
 						sub={ translate(
@@ -232,7 +234,7 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 						isRequired
 					>
 						<div className="partner-directory-agency-expertise__directory-client-sites">
-							{ directories.map( ( { directory, urls } ) => (
+							{ pendingDirectories.map( ( { directory, urls } ) => (
 								<EnhancedDirectoryClientSamples
 									checks={ [ validateNonEmpty(), validateUniqueUrls() ] }
 									field={ urls }


### PR DESCRIPTION
We recently moved a few pre-approved Woo partners to A4A. These partners currently have incomplete PD forms, which cause PD form validation errors when they try to update their information in A4A with incomplete data.

To address this issue, this pull request updates the form to validate only pending partner directories for valid sample sites. 

![355915925-cfa412ec-c529-4121-8ce4-a26655d3dc11](https://github.com/user-attachments/assets/2eefcb29-db7c-44fe-9506-9c0eb0a8348a)

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/924

## Proposed Changes

* Update the PD's expertise form to only check for valid sample sites if the Directory is not yet approved. If the directory is approved, we skip the validation and allow the user to submit empty samples.
* To also avoid confusion in the UI, we now hide the sample sites input field for Directories that are approved.

## Why are these changes being made?

* The current form is blocking a few partners from updating their PD information.

## Testing Instructions

* To conduct testing, you will need an approved directory with a missing client site. You can use the PD MC tool to approve any directories on your account that have a missing client site, for example, as shown below.
   <img width="356" alt="Screenshot 2024-08-08 at 3 24 52 PM" src="https://github.com/user-attachments/assets/f10a4b88-81f6-4fef-822a-66fc5fd02b71">
* Use the A4A live link and go to `/partner-directory/agency-expertise` page.
* Confirm that all approved directories no longer show the input fields for sample sites.
* Confirm that you can also submit the form without some validation errors.



## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
