### PR TITLE
Stepper: Fix `calypso_stepper_flow_start` tracking param names

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-analytics/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-analytics/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { recordFlowStart } from '../../analytics/record-flow-start';
 
@@ -63,25 +63,30 @@ export const useFlowAnalytics = ( params: Params ) => {
 	const siteId = search.get( 'siteId' );
 	const siteSlug = search.get( 'siteSlug' );
 
-	const sessionKeys = {
-		flow,
-		variant,
-		site: siteId || siteSlug,
-	};
+	const sessionKeys = useMemo(
+		() => ( {
+			flow,
+			variant,
+			site: siteId || siteSlug,
+		} ),
+		[ flow, siteId, siteSlug, variant ]
+	);
 
 	const flowStarted = isTheFlowAlreadyStarted( sessionKeys );
-
-	const extraTrackingParams = {
-		ref,
-		step,
-		siteId,
-		siteSlug,
-		variant,
-	};
+	const extraTrackingParams = useMemo(
+		() => ( {
+			ref,
+			step,
+			site_id: siteId,
+			site_slug: siteSlug,
+			variant,
+		} ),
+		[ ref, siteId, siteSlug, step, variant ]
+	);
 
 	useEffect( () => {
 		if ( ! flowStarted && flow ) {
 			startSession( sessionKeys, extraTrackingParams );
 		}
-	}, [ flow ] );
+	}, [ extraTrackingParams, flow, flowStarted, sessionKeys ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-analytics/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-analytics/test/index.tsx
@@ -37,8 +37,8 @@ describe( 'useFlowAnalytics', () => {
 
 		expect( recordFlowStart ).toHaveBeenCalledWith( 'flow', {
 			ref: null,
-			siteId: null,
-			siteSlug: null,
+			site_id: null,
+			site_slug: null,
 			step: 'step',
 			variant: 'variant',
 		} );
@@ -50,8 +50,8 @@ describe( 'useFlowAnalytics', () => {
 		expect( recordFlowStart ).toHaveBeenCalledWith( 'flow', {
 			ref: 'previous-flow',
 			step: 'step',
-			siteId: null,
-			siteSlug: null,
+			site_id: null,
+			site_slug: null,
 			variant: 'variant',
 		} );
 	} );
@@ -62,8 +62,8 @@ describe( 'useFlowAnalytics', () => {
 		expect( recordFlowStart ).toHaveBeenCalledWith( 'flow', {
 			ref: null,
 			step: 'step',
-			siteId: '123',
-			siteSlug: 'somesite.example.com',
+			site_id: '123',
+			site_slug: 'somesite.example.com',
 			variant: 'variant',
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93061

## Proposed Changes

* Update update tracking param names to use snake_case instead of camelCase

## Why are these changes being made?
The camelCase triggers errors on the tracking lib

## Testing Instructions
- Access any flow `/setup/migration-signup` 
- Check if there is no error like this one:

```
Tracks: Event `calypso_stepper_flow_start` will be rejected because property name `siteSlug` does not match /^[a-z_][a-z0-9_]*$/. Please use a compliant property name.
```

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
