### PR TITLE
A4A: Remove mention of "Creator" within the WordPress license revoke dialog

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { useTranslate } from 'i18n-calypso';
 import { PropsWithChildren, useContext, useCallback } from 'react';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
@@ -33,12 +34,8 @@ const LicenseTransition = ( props: PropsWithChildren< LicenseTransitionProps > )
 	<CSSTransition { ...props } classNames="license-list__license-transition" timeout={ 150 } />
 );
 
-const getProductName = ( name: string ): string => {
-	// For WordPress plans, we don't want to mention the specific plan.
-	return name.startsWith( 'WordPress.com' ) ? 'WordPress.com' : name;
-};
-
 export default function LicenseList() {
+	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { filter, search, sortField, sortDirection, currentPage } =
 		useContext( LicensesOverviewContext );
@@ -68,6 +65,11 @@ export default function LicenseList() {
 		},
 		[ dispatch ]
 	);
+
+	const getProductName = ( name: string ): string => {
+		// For WordPress plans, we don't want to mention the specific plan.
+		return name.startsWith( 'WordPress.com' ) ? translate( 'WordPress.com site' ) : name;
+	};
 
 	return (
 		<div className="license-list">

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -33,6 +33,11 @@ const LicenseTransition = ( props: PropsWithChildren< LicenseTransitionProps > )
 	<CSSTransition { ...props } classNames="license-list__license-transition" timeout={ 150 } />
 );
 
+const getProductName = ( name: string ): string => {
+	// For WordPress plans, we don't want to mention the specific plan.
+	return name.startsWith( 'WordPress.com' ) ? 'WordPress.com' : name;
+};
+
 export default function LicenseList() {
 	const dispatch = useDispatch();
 	const { filter, search, sortField, sortDirection, currentPage } =
@@ -79,7 +84,7 @@ export default function LicenseList() {
 							<LicensePreview
 								parentLicenseId={ license.licenseId }
 								licenseKey={ license.licenseKey }
-								product={ license.product }
+								product={ getProductName( license.product ) }
 								blogId={ license.blogId }
 								siteUrl={ license.siteUrl }
 								hasDownloads={ license.hasDownloads }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -68,7 +68,7 @@ export default function LicenseList() {
 
 	const getProductName = ( name: string ): string => {
 		// For WordPress plans, we don't want to mention the specific plan.
-		return name.startsWith( 'WordPress.com' ) ? translate( 'WordPress.com site' ) : name;
+		return name.startsWith( 'WordPress.com' ) ? translate( 'WordPress.com Site' ) : name;
 	};
 
 	return (


### PR DESCRIPTION
Since we do not market the WordPress.com Creator plan in A4A and do not mention this on the purchase flow, we also need to update the revoke dialog to be consistent.

| Before | After |
|--------|--------|
| <img width="706" alt="Screenshot 2024-08-08 at 5 47 24 PM" src="https://github.com/user-attachments/assets/85231406-dbb2-45ab-b88f-ec6ac90d6094"> |  <img width="712" alt="Screenshot 2024-08-09 at 4 18 11 PM" src="https://github.com/user-attachments/assets/22287652-b548-4a52-a603-a29203a1ea35"> | 


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/498

## Proposed Changes

* Update the License Preview component to replace any WordPress.com product name with 'WordPress.com'.

## Testing Instructions

* Purchase a new WPCOM plan in the marketplace. (Do not create a site).
* Use the A4A live link and go to the `/purchases/licenses` page.
* Look for the WPCOM license and revoke it.
* Confirm that the Revoke license dialog only shows 'WordPress.com' as the product name.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
