### PR TITLE
Jetpack: Link to instructions on how to activate a license key

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -7,6 +7,7 @@ import {
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from '@automattic/urls';
+import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
@@ -419,6 +420,9 @@ function PurchaseClipboardCard( {
 					</>
 				) }
 			</div>
+			<ExternalLink href="https://jetpack.com/support/activate-a-jetpack-product-via-license-key/">
+				{ translate( 'How to activate' ) }
+			</ExternalLink>
 		</Card>
 	);
 }

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -420,7 +420,10 @@ function PurchaseClipboardCard( {
 					</>
 				) }
 			</div>
-			<ExternalLink href="https://jetpack.com/support/activate-a-jetpack-product-via-license-key/">
+			<ExternalLink
+				className="manage-purchase__license-clipboard-link"
+				href="https://jetpack.com/support/activate-a-jetpack-product-via-license-key/"
+			>
 				{ translate( 'How to activate' ) }
 			</ExternalLink>
 		</Card>

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -467,9 +467,11 @@
 }
 
 .manage-purchase__license-clipboard-link {
+	margin-block-start: 8px;
 
 	@include breakpoint-deprecated(">480px") {
-		margin-left: 16px;
+		margin-block-start: 0;
+		margin-inline-start: 16px;
 	}
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -464,6 +464,13 @@
 		margin: 0 16px;
 		width: 200px;
 	}
+
+	.manage-purchase__license-clipboard-link {
+
+		@include breakpoint-deprecated(">480px") {
+			margin-left: 16px;
+		}
+	}
 }
 
 .manage-purchase__auto-renew-text button.is-link {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -464,12 +464,12 @@
 		margin: 0 16px;
 		width: 200px;
 	}
+}
 
-	.manage-purchase__license-clipboard-link {
+.manage-purchase__license-clipboard-link {
 
-		@include breakpoint-deprecated(">480px") {
-			margin-left: 16px;
-		}
+	@include breakpoint-deprecated(">480px") {
+		margin-left: 16px;
 	}
 }
 

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -116,7 +116,7 @@ class PurchaseItem extends Component {
 						TLDR: Don't display more than one primary button or action in a single card. (in which the card itself if a primary action/link in this case) */ }
 						<ExternalLink
 							className="purchase-item__link"
-							href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/#how-can-i-activate-my-license-key-in-my-jetpack-installation"
+							href="https://jetpack.com/support/activate-a-jetpack-product-via-license-key/"
 						>
 							{ translate( 'Learn more' ) }
 						</ExternalLink>


### PR DESCRIPTION
## Proposed Changes

Links to instructions on the Jetpack.com sire on how to activate an unassigned Jetpack license key.

* On the purchases table, it updates the link.
* On the purchased item page, it adds a new link.
* Both links send users to https://jetpack.com/support/activate-a-jetpack-product-via-license-key/

Reported in p1722601810633389-slack-C06PK2W8F42

## Why are these changes being made?

* On the purchases section of [WordPress.com](http://wordpress.com/) for a siteless purchase, we don’t link to any instructions about how to activate a license key.

## Testing Instructions

* Fire up this PR.
* Go to `/me/purchases` while having an unassigned Jetpack license.
* Ensure the “Learn more” link sends you to https://jetpack.com/support/activate-a-jetpack-product-via-license-key/
* Click on the unassigned license to jump into the page.
* Ensure you see the new “How to activate” link also sends you to https://jetpack.com/support/activate-a-jetpack-product-via-license-key/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?