### PR TITLE
Design Picker: fixes partner thumbnails.

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -50,21 +50,23 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 		const themeImgSrcDoubleDpi = photon( design.screenshot, { fit, zoom: 2 } ) || design.screenshot;
 
 		if ( oldHighResImageLoading ) {
-			<img
-				src={ themeImgSrc }
-				srcSet={ `${ themeImgSrcDoubleDpi } 2x` }
-				alt={ design.description }
-			/>;
-		} else {
 			return (
 				<img
-					loading="lazy"
 					src={ themeImgSrc }
-					srcSet={ `${ themeImgSrc }` }
+					srcSet={ `${ themeImgSrcDoubleDpi } 2x` }
 					alt={ design.description }
 				/>
 			);
 		}
+
+		return (
+			<img
+				loading="lazy"
+				src={ themeImgSrc }
+				srcSet={ `${ themeImgSrc }` }
+				alt={ design.description }
+			/>
+		);
 	}
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8085

## Proposed Changes

* properly returns `<img>` tag

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|![CleanShot 2024-08-08 at 13 43 25@2x](https://github.com/user-attachments/assets/ec97d773-2a13-49c4-9c11-f27c768957f2)|![CleanShot 2024-08-08 at 13 43 53@2x](https://github.com/user-attachments/assets/ddf8c2bb-149a-48b8-81cf-e1a84853cac5)|

Seems that this experiment pbxNRc-3N2-p2 is the culprit for not showing the partner images.
To reproduce

- Assign yourself to the treatment variation
- Load https://wordpress.com/setup/site-setup-wg/design-choices?siteSlug=papazogloucharalampos26.wordpress.com&siteId=235830263&notice=purchase-success
- Check that partner theme images don't load
- Then load the same page from this branch
- Check that partner theme images load

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?