### PR TITLE
100 year plan fix padding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -215,6 +215,14 @@ button {
 
 }
 
+.hundred-year-plan.step-route {
+	@include break-small {
+		&.setup {
+			margin-top: -60px;
+		}
+	}
+}
+
 .import-focused .step-container.site-picker,
 .import-hosted-site .step-container.site-picker {
 	max-width: 1280px;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -215,14 +215,6 @@ button {
 
 }
 
-.hundred-year-plan.step-route {
-	@include break-small {
-		&.setup {
-			margin-top: -60px;
-		}
-	}
-}
-
 .import-focused .step-container.site-picker,
 .import-hosted-site .step-container.site-picker {
 	max-width: 1280px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/styles.scss
@@ -2,6 +2,12 @@
 @import "@wordpress/base-styles/mixins";
 @import "../hundred-year-plan-step-wrapper/mixins";
 
+.hundred-year-plan.step-route {
+	@include break-small {
+		margin-top: -60px;
+	}
+}
+
 .hundred-year-plan-setup {
 	.step-container__content {
 		.components-button.setup-form__submit.is-primary {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Add a negative margin when in the setup step of the 100 year plan flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Context: pdDR7T-1Mk-p2#comment-2250
`setup` step in the 100 year plan flow has a wrong top padding.

![image](https://github.com/user-attachments/assets/9ebc8675-062e-4316-a69a-1415120f74d9)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live link
* Visit /setup/hundred-year-plan/setup
* There should be no strange top padding

