### PR TITLE
A4A > Marketplace: Implement new migration support form

### DIFF
--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
@@ -1,18 +1,19 @@
-import { useTranslate } from 'i18n-calypso';
+import { isEnabled } from '@automattic/calypso-config';
 import { useCallback, useState } from 'react';
+import MigrationContactSupportForm from '../a4a-migration-offer-v2/migration-contact-support-form';
 import UserContactSupportModalForm from '../user-contact-support-modal-form';
 
 export const CONTACT_URL_HASH_FRAGMENT = '#contact-support';
 export const CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT = '#contact-support-migration-offer';
 
 export default function A4AContactSupportWidget() {
-	const translate = useTranslate();
-
 	const hashSupportFormHash =
 		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
 		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
 
 	const [ showUserSupportForm, setShowUserSupportForm ] = useState( hashSupportFormHash );
+
+	const isNewHostingPage = isEnabled( 'a4a-hosting-page-redesign' );
 
 	const onCloseUserSupportForm = useCallback( () => {
 		// Remove any hash from the URL.
@@ -25,20 +26,10 @@ export default function A4AContactSupportWidget() {
 		setShowUserSupportForm( true );
 	}
 
-	const migrationOfferDefaultMessage =
-		translate( "I'd like to chat more about the migration offer." ) +
-		'\n\n' +
-		translate( '[your message here]' );
-
-	return (
-		<UserContactSupportModalForm
-			show={ showUserSupportForm }
-			onClose={ onCloseUserSupportForm }
-			defaultMessage={
-				window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT
-					? migrationOfferDefaultMessage
-					: undefined
-			}
-		/>
+	return isNewHostingPage &&
+		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT ? (
+		<MigrationContactSupportForm show={ showUserSupportForm } onClose={ onCloseUserSupportForm } />
+	) : (
+		<UserContactSupportModalForm show={ showUserSupportForm } onClose={ onCloseUserSupportForm } />
 	);
 }

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/index.tsx
@@ -1,0 +1,248 @@
+import { Button, FormLabel } from '@automattic/components';
+import { Modal, TextControl } from '@wordpress/components';
+import { Icon, close } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent, FormEventHandler, useCallback, useEffect, useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSelect from 'calypso/components/forms/form-select';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { successNotice } from 'calypso/state/notices/actions';
+import useSubmitContactSupport from '../../user-contact-support-modal-form/use-submit-contact-support';
+
+import './style.scss';
+
+type Props = {
+	show: boolean;
+	onClose?: () => void;
+	defaultMessage?: string;
+};
+
+const DEFAULT_PRODUCT_VALUE = 'wpcom';
+
+export default function MigrationContactSupportForm( { show, onClose }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const defaultMessage =
+		translate( "I'd like to chat more about the migration offer." ) +
+		'\n\n' +
+		translate( '[your message here]' );
+
+	const user = useSelector( getCurrentUser );
+
+	const [ name, setName ] = useState( user?.display_name );
+	const [ email, setEmail ] = useState( user?.email );
+	const [ product, setProduct ] = useState( DEFAULT_PRODUCT_VALUE );
+	const [ site, setSite ] = useState( 1 );
+	const [ message, setMessage ] = useState( defaultMessage );
+
+	const isPressableSelected = product === 'pressable';
+	const hasCompletedForm = !! message && !! name && !! email && !! product && ! isPressableSelected;
+
+	const { isSubmitting, submit, isSubmissionSuccessful } = useSubmitContactSupport();
+
+	const resetForm = useCallback( () => {
+		setMessage( defaultMessage );
+		setProduct( DEFAULT_PRODUCT_VALUE );
+	}, [ defaultMessage ] );
+
+	const onModalClose = useCallback( () => {
+		onClose?.();
+
+		dispatch( recordTracksEvent( 'calypso_a4a_migration_contact_support_form_close' ) );
+	}, [ dispatch, onClose ] );
+
+	useEffect( () => {
+		if ( isSubmissionSuccessful ) {
+			dispatch(
+				successNotice( translate( 'Thanks! Our migration team will get back to you shortly!' ), {
+					id: 'submit-migration-contact-support-success',
+					duration: 5000,
+				} )
+			);
+			onModalClose();
+		}
+	}, [ dispatch, isSubmissionSuccessful, onModalClose, translate ] );
+
+	useEffect( () => {
+		if ( show ) {
+			resetForm();
+		}
+	}, [ defaultMessage, resetForm, show ] );
+
+	const onNameChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
+		setName( event.currentTarget.value );
+	}, [] );
+
+	const onEmailChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
+		setEmail( event.currentTarget.value );
+	}, [] );
+
+	const onSiteChange = useCallback( ( value: number ) => {
+		setSite( value );
+	}, [] );
+
+	const onProductChange: FormEventHandler = useCallback(
+		( event: ChangeEvent< HTMLSelectElement > ) => {
+			setProduct( event.currentTarget.value );
+		},
+		[]
+	);
+
+	const onMessageChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
+		setMessage( event.currentTarget.value );
+	}, [] );
+
+	const onSubmit = useCallback( () => {
+		if ( ! hasCompletedForm ) {
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_migration_contact_support_form_submit', {
+				message,
+			} )
+		);
+
+		submit( { message, name, email, product, no_of_sites: site } );
+	}, [ hasCompletedForm, dispatch, message, submit, name, email, product, site ] );
+
+	useEffect( () => {
+		if ( show ) {
+			dispatch( recordTracksEvent( 'calypso_a4a_migration_contact_support_form_open' ) );
+		}
+	}, [ dispatch, show ] );
+
+	if ( ! show ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className="migration-contact-support-form"
+			onRequestClose={ onModalClose }
+			__experimentalHideHeader
+		>
+			<div className="migration-contact-support-form__main">
+				<Button
+					className="migration-contact-support-form__close-button"
+					plain
+					onClick={ onModalClose }
+					aria-label={ translate( 'Close' ) }
+				>
+					<Icon size={ 24 } icon={ close } />
+				</Button>
+
+				<h1 className="migration-contact-support-form__title">
+					{ translate( 'Contact support' ) }
+				</h1>
+
+				<FormFieldset>
+					<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
+					<FormTextInput
+						name="name"
+						id="name"
+						placeholder={ translate( 'Your name' ) }
+						value={ name }
+						onChange={ onNameChange }
+						onClick={ () =>
+							dispatch(
+								recordTracksEvent( 'calypso_a4a_migration_contact_support_form_name_click' )
+							)
+						}
+					/>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
+					<FormTextInput
+						name="email"
+						id="email"
+						placeholder={ translate( 'Your email' ) }
+						value={ email }
+						onChange={ onEmailChange }
+						onClick={ () =>
+							dispatch(
+								recordTracksEvent( 'calypso_a4a_migration_contact_support_form_email_click' )
+							)
+						}
+					/>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel htmlFor="site">{ translate( 'Number of sites' ) }</FormLabel>
+					<TextControl
+						value={ site }
+						onChange={ ( newValue ) => onSiteChange( parseInt( newValue, 10 ) ) }
+						type="number"
+						min="1"
+					/>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel htmlFor="product">
+						{ translate( 'What Automattic hosting product are you considering?' ) }
+					</FormLabel>
+					<FormSelect name="product" id="product" value={ product } onChange={ onProductChange }>
+						<option value="wpcom">{ translate( 'WordPress.com' ) }</option>
+						<option value="pressable">{ translate( 'Pressable' ) }</option>
+						<option value="dont-know">{ translate( "Don't know" ) }</option>
+					</FormSelect>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel htmlFor="message">
+						{ translate( 'Is there anything else you would like to share?' ) }
+					</FormLabel>
+					{ ! isPressableSelected ? (
+						<FormTextarea
+							name="message"
+							id="message"
+							placeholder={ translate( 'Add your message here' ) }
+							value={ message }
+							onChange={ onMessageChange }
+							onClick={ () =>
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_migration_contact_support_form_message_click' )
+								)
+							}
+						/>
+					) : (
+						<p>
+							{ translate(
+								'For help with Pressable, please {{a}}login to your Pressable account{{/a}} and request help using the chat widget on the bottom right of the page.',
+								{
+									components: {
+										a: (
+											<a
+												href="https://my.pressable.com/login"
+												target="_blank"
+												rel="noreferrer noopener"
+											/>
+										),
+									},
+								}
+							) }
+						</p>
+					) }
+				</FormFieldset>
+			</div>
+
+			<div className="migration-contact-support-form__footer">
+				<Button
+					busy={ isSubmitting }
+					className="migration-contact-support-form__footer-submit"
+					primary
+					disabled={ ! hasCompletedForm }
+					onClick={ onSubmit }
+				>
+					{ translate( 'Submit' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/style.scss
@@ -1,0 +1,93 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.migration-contact-support-form {
+	width: 827px;
+	max-height: 100%;
+	margin: 0;
+	@include a4a-font-body-lg;
+	color: var(--color-neutral-100);
+
+	@include breakpoint-deprecated( "<660px" ) {
+		width: 100%;
+	}
+
+	.components-modal__content {
+		padding: 0;
+
+		> div {
+			display: flex;
+			flex-direction: column;
+			justify-content: space-between;
+			height: 100%;
+		}
+	}
+
+	.components-text-control__input {
+		padding: 7px 14px;
+	}
+
+	.reviews-ratings-stars__star:focus {
+		outline: none;
+	}
+
+	.reviews-ratings-stars__star:focus-within {
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+		border-radius: 4px;
+	}
+
+	@include break-medium {
+		margin: auto;
+	}
+}
+
+.migration-contact-support-form .form-fieldset {
+	margin: 0;
+}
+
+.migration-contact-support-form__main {
+	padding: 40px;
+	gap: 24px;
+	display: flex;
+	flex-direction: column;
+}
+
+.migration-contact-support-form__title {
+	@include a4a-font-heading-xl;
+	margin: 0;
+	padding: 0;
+}
+
+.migration-contact-support-form__footer {
+	padding: 24px 40px;
+	text-align: right;
+	background-color: var(--color-neutral-0);
+	border-radius: 4px;
+}
+
+.migration-contact-support-form__close-button {
+	position: absolute;
+	inset-inline-end: 1rem;
+	inset-block-start: 1rem;
+	cursor: pointer;
+	transition: scale 0.2s ease-in;
+	max-height: 24px;
+
+	&:hover {
+		scale: 1.2;
+	}
+
+	&:focus-visible {
+		border-color: var(--color-primary);
+		outline: none;
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+		border-radius: 4px;
+	}
+}
+
+.button.is-primary.migration-contact-support-form__footer-submit:disabled {
+	color: var(--color-neutral-20);
+	background-color: var(--color-surface);
+	border-color: var(--color-neutral-5);
+}

--- a/client/a8c-for-agencies/data/support/types.ts
+++ b/client/a8c-for-agencies/data/support/types.ts
@@ -11,4 +11,5 @@ export interface SubmitContactSupportParams {
 	message: string;
 	product: string;
 	site?: string;
+	no_of_sites?: number;
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/471

## Proposed Changes

* This PR adds a new migration support form for A4A

Note: 

- This will be visible only if the hosting page feature flag is enabled. So please test it without the feature flag by appending the URL with `?flags=-a4a-hosting-page-redesign ` and verify that a ticket is created on ZD

## Testing Instructions

* Open the A4A live link
* Go to Marketplace - Hosting > Click on the `Contact us to learn more` button on the migration banner  > Verify that you can see the new form as shown below. Go ahead and submit the details > Verify that a ticket is created on ZD

<img width="957" alt="Screenshot 2024-08-08 at 4 30 47 PM" src="https://github.com/user-attachments/assets/0f234421-3519-4170-9bf6-97100e0dac68">

@jeffgolenski: I have kept the same experience of Pressable; please let me know if they can contact Pressable directly, and I'll change it.

<img width="806" alt="Screenshot 2024-08-08 at 4 40 54 PM" src="https://github.com/user-attachments/assets/82939d6b-4dba-4bcb-8fe8-2fb0a0b564bf">

<img width="1413" alt="Screenshot 2024-08-09 at 8 25 13 AM" src="https://github.com/user-attachments/assets/3a88080b-13e5-442a-841d-f446977e3609">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
