### PR TITLE
Design Picker: fix thumbs not loading.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -108,7 +108,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		'calypso_design_picker_image_optimization_202406'
 	);
 	const variantName = experimentAssignment?.variationName;
-	const oldHighResImageLoading = ! isLoadingExperiment && variantName === 'treatment';
+	const oldHighResImageLoading = true || ( ! isLoadingExperiment && variantName === 'treatment' );
 
 	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -26,7 +26,7 @@ export const getMShotOptions = ( {
 	let w = 500;
 	let screen_height = 1100;
 	if ( oldHighResImageLoading ) {
-		w = highRes ? 1199 : 600;
+		w = highRes ? 600 : 600;
 		screen_height = 3600;
 	}
 	return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

pekYwv-4t6-p2#comment-3958

Probably related: https://github.com/Automattic/wp-calypso/issues/87166

## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/91625 introduced an experiment that sets `oldHighResImageLoading` to [true](https://github.com/Automattic/wp-calypso/pull/93373/files#diff-a539d272b24cf98cb319fb27637a06c9faf52cfea40d0af87cf1b7c2fec0915cL111). I have set it to `true` in this PR for demonstrations purposes.

**ONLY IN SAFARI**
When setting the `w` to 1199 ( I also tried 700, 800, 1200 ) the mshots request ( eg  `https://s0.wp.com/mshots/v1/https%3A%2F%2Fpublic-api.wordpress.com%2Fwpcom%2Fv2%2Fblock-previews%2Fsite%3Fstylesheet%3Dpub%252Fgoodskin%26language%3Den%26viewport_height%3D1040%26use_screenshot_overrides%3Dtrue%26site_title%3DGoodskin?vpw=1600&vph=1040&w=1199&screen_height=3600&oldHighResImageLoading=true&count=0` ) doesn't return in Calypso. Using it directly works. I still haven't found why 🧐.

@danluu can you also take a look?

![CleanShot 2024-08-08 at 15 32 43@2x](https://github.com/user-attachments/assets/056619db-19b9-4619-8061-4957e5c72d0e)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the wpcalypso branch in Safari
* Visit the design picker ( eg `https://wordpress.com/setup/site-setup-wg/designSetup?siteSlug=papazogloucharalampos26.wordpress.com&siteId=235830263&notice=purchase-success` )
* Navigate around, make sure all thumbnails load

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?