### PR TITLE
RT: The content generation step doesn't get blocked when generation limit is reached.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/api/generate-content/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/api/generate-content/index.ts
@@ -25,16 +25,19 @@ const generateAIContentForTemplate = async (
 		} )
 	);
 
-	const responses = await Promise.all( requests );
-
-	return {
-		...readymadeTemplate,
-		home: {
-			header: responses[ 0 ],
-			content: responses[ 1 ],
-			footer: responses[ 2 ],
-		},
-	};
+	try {
+		const responses = await Promise.all( requests );
+		return {
+			...readymadeTemplate,
+			home: {
+				header: responses[ 0 ],
+				content: responses[ 1 ],
+				footer: responses[ 2 ],
+			},
+		};
+	} catch ( error ) {
+		return readymadeTemplate;
+	}
 };
 
 export default generateAIContentForTemplate;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/8609

## Proposed Changes

* We re-use the previous RT if we get an API error.
* These changes prevent the UI from being unresponsive.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the D157884 code if it hasn't been released yet.
* You might need to tune the API to trigger the case you're interested in.
* Open the Calypso live link and go to the content generation step.
* Generate content until you reach the limit, once the limit is reached you should see that the content isn't updated anymore.

Note: The UI isn't blocked once the limit is reached, it will be very difficult for users to reach the limit, they would need to generate content 33 times. Therefore I don't think we need to invest more into handling when the limit is reached than what is in this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?