### PR TITLE
RT: Place CTA to the right

### DIFF
--- a/client/my-sites/patterns/components/readymade-template-details/style.scss
+++ b/client/my-sites/patterns/components/readymade-template-details/style.scss
@@ -85,12 +85,16 @@ a.readymade-template-details-back {
 	margin-bottom: 40px;
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
 	gap: 8px;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
 
 	@media (max-width: $break-wide) {
 		margin-bottom: 24px;
+	}
+
+	@media (max-width: $break-mobile) {
+		align-items: center;
+		flex-wrap: wrap;
 	}
 }
 
@@ -105,6 +109,7 @@ a.readymade-template-details-back {
 .readymade-template-details-actions {
 	display: flex;
 	gap: 16px;
+	margin-top: 6px;
 
 	.components-button {
 		box-shadow: none;


### PR DESCRIPTION
## Proposed Changes

Prevents the "Pick this layout" button from moving to a new line by allowing the RT title to wrap into multiple lines if needed

Before | After
--- | ---
<img width="1121" alt="Screenshot 2024-08-08 at 15 28 53" src="https://github.com/user-attachments/assets/ace1acd3-5349-4e12-879e-66540fc08acd"> | <img width="1117" alt="Screenshot 2024-08-08 at 15 28 35" src="https://github.com/user-attachments/assets/65d00e07-ffa8-40b0-9e81-20186fbf27c3">


## Why are these changes being made?

To ensure that the CTA is always placed on the right regardless of the RT title

## Testing Instructions
- Use the Calypso live link below
- Go to `/patterns`
- Scroll down to the RT section
- Select a RT with a long title (e.g. Wedding Photographer)
- Make sure the "Pick his layout button" is always on the right (except mobile)
- Make sure the RT title wraps into two lines if there is not enough space (except mobile)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
