### PR TITLE
feat(hosting-overview-refinements): add spinner for activation hosting-features

### DIFF
--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -189,9 +189,7 @@ const HostingFeatures = () => {
 	let buttons;
 	if ( isTransferInProgress && config.isEnabled( 'hosting-overview-refinements' ) ) {
 		title = translate( 'Activating hosting features' );
-		description = translate(
-			'Stay tuned, as we activate the following features included in your plan'
-		);
+		description = translate( 'This place will refresh once the activation is completed.' );
 	} else if ( showActivationButton ) {
 		title = activateTitle;
 		description = activateDescription;

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -3,7 +3,7 @@ import { FEATURE_SFTP, getPlan, PLAN_BUSINESS } from '@automattic/calypso-produc
 import page from '@automattic/calypso-router';
 import { Dialog } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
 import { AnyAction } from 'redux';
@@ -248,6 +248,7 @@ const HostingFeatures = () => {
 	return (
 		<div className="hosting-features">
 			<div className="hosting-features__hero">
+				{ isTransferInProgress && <Spinner className="hosting-features__content-spinner" /> }
 				<h1>{ title }</h1>
 				<p>{ description }</p>
 				{ buttons }

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -189,7 +189,12 @@ const HostingFeatures = () => {
 	let buttons;
 	if ( isTransferInProgress && config.isEnabled( 'hosting-overview-refinements' ) ) {
 		title = translate( 'Activating hosting features' );
-		description = translate( 'This place will refresh once the activation is completed.' );
+		description = translate(
+			"The hosting features will appear here automatically when they're ready!",
+			{
+				comment: 'Description of the hosting features page when the features are being activated.',
+			}
+		);
 	} else if ( showActivationButton ) {
 		title = activateTitle;
 		description = activateDescription;

--- a/client/hosting/hosting-features/components/style.scss
+++ b/client/hosting/hosting-features/components/style.scss
@@ -25,6 +25,13 @@
 		font-size: rem(14px);
 		height: 40px;
 	}
+
+	.hosting-features__content-spinner {
+		margin-top: 16px;
+		& + h1 {
+			margin-top: 0;
+		}
+	}
 }
 
 .hosting-features__cards {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8450

## Proposed Changes
With this PR we are just adding spinner on the "Hosting Features" tab, when it's in the state of transferring to Atomic.

## Testing Instructions
Apply the next diff
```
diff --git a/client/hosting/hosting-features/components/hosting-features.tsx b/client/hosting/hosting-features/components/hosting-features.tsx
index dfaafa3d981..ef65bb92a7d 100644
--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -59,11 +59,7 @@ const HostingFeatures = () => {
        const hasEnTranslation = useHasEnTranslation();

        const transfer = useSelector( ( state ) => getAtomicTransfer( state, siteId ) );
-       const isTransferInProgress = [
-               transferStates.PENDING,
-               transferStates.ACTIVE,
-               transferStates.PROVISIONED,
-       ].includes( transfer.status );
+       const isTransferInProgress = true;

        useEffect( () => {
                if ( ! siteId ) {
```

1. Open `/sites`
2. Select any Simple site
3. Select "Hosting Features" tab
4. Assert that you see the spinner<br /><img width="1021" alt="Screenshot 2024-08-08 at 16 14 51" src="https://github.com/user-attachments/assets/0761fd7c-b372-4b5c-91f6-99d5286a5f05">
