### PR TITLE
Change viewer removal confirmation copy

### DIFF
--- a/client/my-sites/people/viewer-details/index.tsx
+++ b/client/my-sites/people/viewer-details/index.tsx
@@ -84,9 +84,7 @@ export default function ViewerDetails( props: Props ) {
 		accept(
 			<div>
 				<p>
-					{ translate(
-						'If you remove this viewer, he or she will not be able to visit this site.'
-					) }
+					{ translate( 'If you remove this viewer, they will not be able to visit this site.' ) }
 				</p>
 				<p>{ translate( 'Would you still like to remove this viewer?' ) }</p>
 			</div>,

--- a/client/my-sites/people/viewer-details/index.tsx
+++ b/client/my-sites/people/viewer-details/index.tsx
@@ -86,7 +86,7 @@ export default function ViewerDetails( props: Props ) {
 				<p>
 					{ translate( 'If you remove this viewer, they will not be able to visit this site.' ) }
 				</p>
-				<p>{ translate( 'Would you still like to remove this viewer?' ) }</p>
+				<p>{ translate( 'Would you still like to remove them?' ) }</p>
 			</div>,
 			( accepted: boolean ) => {
 				if ( accepted ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93226

## Proposed Changes

* Change "he or she" to "they."
* Change second line to "Would you still like to remove them?"

Before | After
----- | ----
<img width="570" alt="Screen Shot 2024-08-08 at 12 03 29 PM" src="https://github.com/user-attachments/assets/c0694553-43f6-4a4b-8770-809fe1cfab92"> | <img width="543" alt="Screen Shot 2024-08-08 at 2 54 35 PM" src="https://github.com/user-attachments/assets/8bff7fcb-1c07-4dd7-ab01-136e52c61136">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I noticed while fixing a related issue that this copy doesn't align with other language on WordPress.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a private site with viewers, go to /people/team.
* Click on a viewer.
* Click to remove the viewer.
* You should see the confirmation overlay.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
