### PR TITLE
Notifications: Fix standalone locale

### DIFF
--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -36,6 +36,7 @@ export class Notifications extends PureComponent {
 		locale: PropTypes.string,
 		receiveMessage: PropTypes.func,
 		wpcom: PropTypes.object.isRequired,
+		forceLocale: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -87,6 +88,10 @@ export class Notifications extends PureComponent {
 		client = new RestClient();
 		client.global = globalData;
 		client.sendMessage = receiveMessage;
+
+		if ( this.props.forceLocale ) {
+			client.locale = this.props.locale;
+		}
 
 		/**
 		 * Initialize store with actions that need to occur on

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -27,6 +27,7 @@ export function Client() {
 	this.subscribing = false;
 	this.subscribed = false;
 	this.firstRender = true;
+	this.locale = null;
 	this.inbox = [];
 
 	window.addEventListener( 'storage', handleStorageEvent.bind( this ) );
@@ -166,6 +167,7 @@ function getNotes() {
 	const parameters = {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash',
 		number: this.noteRequestLimit,
+		locale: this.locale,
 	};
 
 	const notes = getAllNotes( store.getState() );

--- a/apps/notifications/src/standalone/index.jsx
+++ b/apps/notifications/src/standalone/index.jsx
@@ -1,4 +1,5 @@
 import '@automattic/calypso-polyfills';
+import { setLocale } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import Notifications, { refreshNotes } from '../panel/Notifications';
@@ -11,6 +12,24 @@ import '../panel/boot/stylesheets/style.scss';
 const localePattern = /[&?]locale=([\w_-]+)/;
 const match = localePattern.exec( document.location.search );
 const locale = match ? match[ 1 ] : 'en';
+
+const fetchLocale = ( localeSlug ) => {
+	const xhr = new XMLHttpRequest();
+
+	xhr.open( 'GET', `https://widgets.wp.com/languages/notifications/${ localeSlug }.json`, true );
+
+	xhr.onload = ( { target } ) => {
+		if ( 200 !== target.status ) {
+			return;
+		}
+
+		try {
+			setLocale( JSON.parse( xhr.response ) );
+		} catch ( e ) {}
+	};
+
+	xhr.send();
+};
 
 let store = { dispatch: () => {}, getState: () => {} };
 const customEnhancer = ( next ) => ( reducer, initialState ) =>
@@ -76,6 +95,10 @@ const NotesWrapper = ( { wpcom } ) => {
 	const [ isShowing, setIsShowing ] = useState( false );
 	const [ isVisible, setIsVisible ] = useState( document.visibilityState === 'visible' );
 	const [ isShortcutsPopoverVisible, setShortcutsPopoverVisible ] = useState( false );
+
+	if ( locale && 'en' !== locale ) {
+		fetchLocale( locale );
+	}
 
 	debug( 'wrapper state update', { isShowing, isVisible } );
 

--- a/apps/notifications/src/standalone/index.jsx
+++ b/apps/notifications/src/standalone/index.jsx
@@ -13,22 +13,20 @@ const localePattern = /[&?]locale=([\w_-]+)/;
 const match = localePattern.exec( document.location.search );
 const locale = match ? match[ 1 ] : 'en';
 
-const fetchLocale = ( localeSlug ) => {
-	const xhr = new XMLHttpRequest();
+const fetchLocale = async ( localeSlug ) => {
+	try {
+		const response = await fetch(
+			`https://widgets.wp.com/languages/notifications/${ localeSlug }.json`
+		);
 
-	xhr.open( 'GET', `https://widgets.wp.com/languages/notifications/${ localeSlug }.json`, true );
-
-	xhr.onload = ( { target } ) => {
-		if ( 200 !== target.status ) {
+		// Fall back to English if the locale is not available
+		if ( ! response.ok ) {
 			return;
 		}
 
-		try {
-			setLocale( JSON.parse( xhr.response ) );
-		} catch ( e ) {}
-	};
-
-	xhr.send();
+		// Set the locale for the i18n-calypso library
+		setLocale( await response.json() );
+	} catch {}
 };
 
 let store = { dispatch: () => {}, getState: () => {} };

--- a/apps/notifications/src/standalone/index.jsx
+++ b/apps/notifications/src/standalone/index.jsx
@@ -172,6 +172,7 @@ const NotesWrapper = ( { wpcom } ) => {
 			receiveMessage={ sendMessage }
 			redirectPath="/"
 			wpcom={ wpcom }
+			forceLocale
 		/>
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8531

## Proposed Changes

On `wp-admin`, the notifications are showing using an iframe but the top menu and days separators are not using the locale passed in the query param.

Site locale: DE
User's site profile locale: DE
WP profile locale: PT

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4e7cd43f-ddc4-4fec-a75f-aac4b22b62a3) | ![image](https://github.com/user-attachments/assets/399d7feb-4389-4084-9ad6-89922e1c7fbb) |

## Why are these changes being made?
Notifications are not using the correct locale

#### To Do
- [ ] Compile, deploy, and use languages from `/notifications/language` instead of getting from `widgets.wp.com/languages/notifications`
- [x] The notifications use the user locale instead of the selected one.

## Testing Instructions

* Run `yarn build --sync` in `/apps/notifications`
* Sandbox `widgets.wp.com`
* Go to `/wp-admin` on one of your sites
* The top buttons should use the selected locale
* Same for the "days separators" (Today | Yesterday | 2 Days ago )
