### PR TITLE
Update: validate substack url

### DIFF
--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/mixins";
+
 .newsletter-importer {
 	margin: 24px auto 0;
 	max-width: 720px;
@@ -90,4 +92,8 @@
 	&.is-error {
 		color: var(--color-error);
 	}
+}
+
+.select-newsletter-form .is-loading {
+	@include placeholder( --color-neutral-10 );
 }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -80,6 +80,12 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 		from: fromSite,
 	} );
 	const Step = steps[ stepIndex ] || steps[ 0 ];
+
+	let title = 'Import your newsletter';
+	if ( urlData?.meta?.title ) {
+		title = `Import ${ urlData?.meta?.title }`;
+	}
+
 	return (
 		<div className="newsletter-importer">
 			<LogoChain
@@ -88,7 +94,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					{ name: 'wordpress', color: '#3858E9' },
 				] }
 			/>
-			<FormattedHeader headerText="Import your newsletter" />
+			<FormattedHeader headerText={ title } />
 			{ ! validFromSite && (
 				<SelectNewsletterForm
 					stepUrl={ stepUrl }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -1,6 +1,8 @@
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { useState, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import StepProgress from 'calypso/components/step-progress';
+import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ImporterLogo from '../importer-logo';
@@ -44,10 +46,20 @@ type NewsletterImporterProps = {
 export default function NewsletterImporter( { siteSlug, engine, step }: NewsletterImporterProps ) {
 	const selectedSite = useSelector( getSelectedSite ) ?? undefined;
 
+	const [ validFromSite, setValidFromSite ] = useState( false );
+
 	const stepsProgress = [ 'Content', 'Subscribers', 'Paid Subscribers', 'Summary' ];
 
 	let fromSite = getQueryArg( window.location.href, 'from' ) as string | string[];
 	fromSite = Array.isArray( fromSite ) ? fromSite[ 0 ] : fromSite;
+
+	const { data: urlData, isFetching } = useAnalyzeUrlQuery( fromSite );
+
+	useEffect( () => {
+		if ( urlData?.platform === engine ) {
+			setValidFromSite( true );
+		}
+	}, [ urlData, fromSite, engine ] );
 
 	if ( fromSite && ! step ) {
 		step = stepSlugs[ 0 ];
@@ -76,11 +88,17 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					{ name: 'wordpress', color: '#3858E9' },
 				] }
 			/>
-
 			<FormattedHeader headerText="Import your newsletter" />
-			{ ! fromSite && <SelectNewsletterForm stepUrl={ stepUrl } /> }
-			{ fromSite && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
-			{ fromSite && (
+			{ ! validFromSite && (
+				<SelectNewsletterForm
+					stepUrl={ stepUrl }
+					urlData={ urlData }
+					isLoading={ isFetching }
+					validFromSite={ validFromSite }
+				/>
+			) }
+			{ validFromSite && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
+			{ validFromSite && (
 				<Step
 					siteSlug={ siteSlug }
 					nextStepUrl={ nextStepUrl }

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -7,9 +7,17 @@ import { isValidUrl, parseUrl } from 'calypso/lib/importer/url-validation';
 
 type Props = {
 	stepUrl: string;
+	urlData?: UrlData;
+	isLoading: boolean;
+	validFromSite: boolean;
 };
-export default function SelectNewsletterForm( { stepUrl }: Props ) {
-	const [ hasError, setHasError ] = useState( false );
+export default function SelectNewsletterForm( {
+	stepUrl,
+	urlData,
+	isLoading,
+	validFromSite,
+}: Props ) {
+	const [ hasError, setHasError ] = useState( ! validFromSite );
 
 	const handleAction = ( fromSite: string ) => {
 		if ( ! isValidUrl( fromSite ) ) {
@@ -22,6 +30,16 @@ export default function SelectNewsletterForm( { stepUrl }: Props ) {
 		return;
 	};
 
+	if ( isLoading ) {
+		return (
+			<Card>
+				<div className="select-newsletter-form">
+					<p className="is-loading"></p>
+				</div>
+			</Card>
+		);
+	}
+
 	return (
 		<Card>
 			<div className="select-newsletter-form">
@@ -30,9 +48,12 @@ export default function SelectNewsletterForm( { stepUrl }: Props ) {
 					placeholder="https://example.substack.com"
 					action="Continue"
 					isError={ hasError }
+					defaultValue={ urlData?.url }
 				/>
 				{ hasError && (
-					<p className="select-newsletter-form__help is-error">Please enter a valid URL.</p>
+					<p className="select-newsletter-form__help is-error">
+						Please enter a valid substack URL.
+					</p>
 				) }
 				{ ! hasError && (
 					<p className="select-newsletter-form__help">

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -2,6 +2,7 @@ import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
+import { UrlData } from 'calypso/blocks/import/types';
 import FormTextInputWithAction from 'calypso/components/forms/form-text-input-with-action';
 import { isValidUrl, parseUrl } from 'calypso/lib/importer/url-validation';
 


### PR DESCRIPTION
Add substack verification step. 

Related to https://github.com/Automattic/wp-calypso/issues/93153

This helps to ensure that we are actually trying to import a substack site and can provide some links. 

After:

Placeholder ( while we validate the URL )
<img width="905" alt="Screenshot 2024-08-08 at 1 10 29 PM" src="https://github.com/user-attachments/assets/8be7c776-b27c-4dd4-85f7-f0674fce44ad">

If a valid url is provided. ( note the site title) 
<img width="848" alt="Screenshot 2024-08-08 at 1 10 17 PM" src="https://github.com/user-attachments/assets/68b32b4f-fb10-40b7-a866-99c99bef9570">

If a user enters an invalid URL. (Note that enej0i77.substack.com even though it is a substack.com subdomain it is not a valid site) 
<img width="873" alt="Screenshot 2024-08-08 at 1 12 47 PM" src="https://github.com/user-attachments/assets/ebfc28b1-cb14-42ce-b990-34345052580f">

## Proposed Changes

*

## Why are these changes being made?

* So that we can provide a more tailor experience for the site's user. 

## Testing Instructions
* Does it work as expected for you? 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
