### PR TITLE
Overview: Remove refinements feature flag indicator

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import React, { useState } from 'react';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
@@ -80,10 +79,7 @@ export default function ItemPreviewPane( {
 		);
 	} );
 
-	const shouldHideNav =
-		hideNavIfSingleTab &&
-		featureTabs.length <= 1 &&
-		! config.isEnabled( 'hosting-overview-refinements' );
+	const shouldHideNav = hideNavIfSingleTab && featureTabs.length <= 1;
 
 	return (
 		<div className={ clsx( 'item-preview__pane', className ) }>

--- a/client/hosting/overview/components/hosting-overview.tsx
+++ b/client/hosting/overview/components/hosting-overview.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -22,15 +21,6 @@ const HostingOverview: FC = () => {
 
 	return (
 		<div className="hosting-overview">
-			<p
-				className="hosting-overview-refinement-flag-test"
-				style={ {
-					display: config.isEnabled( 'hosting-overview-refinements' ) ? 'auto' : 'none',
-					gridArea: '1 / 2',
-				} }
-			>
-				Hello World
-			</p>
 			<NavigationHeader
 				className="hosting-overview__navigation-header"
 				title={ translate( 'Overview' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8613-gh-Automattic/dotcom-forge

## Proposed Changes

Remove "Hello World" indicator that the `hosting-overview-refinements` feature flag is active

**Before:**
![image](https://github.com/user-attachments/assets/871e5289-b1d3-44e8-ba9a-c655e90c992d)

**After**
![image](https://github.com/user-attachments/assets/81a62509-e4aa-4f4c-924a-f7eaf4157782)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When this flag was created, we added a "Hello world" so we could easily confirm it was functioning and activated properly during the earlier stages of the project. As work nears completion, this helper is no longer needed.

## Testing Instructions

- Visit the [Calypso Live link for this branch](https://calypso.live/?image=registry.a8c.com/calypso/app:build-116004)
- Open `/overview` for any of your sites by clicking on the Hosting Overview button
- append `?flags=hosting-overview-refinements` to the end of the url
- Confirm that "Hello World" does not appear to the right of the "Overview" page title (see screenshots above)