### PR TITLE
Truncate site title in Masterbar using JS to match wp-admin

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -433,7 +433,7 @@ class MasterbarLoggedIn extends Component {
 				tipTarget="visit-site"
 				subItems={ [ { label: translate( 'Visit Site' ), url: siteUrl }, siteHomeOrAdminItem ] }
 			>
-				{ siteTitle }
+				{ siteTitle.length > 40 ? `${ siteTitle.substring( 0, 40 ) }\u2026` : siteTitle }
 			</Item>
 		);
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -715,12 +715,6 @@ body.is-mobile-app-view {
 		}
 	}
 
-	&.masterbar__item-my-site .masterbar__item-content {
-		max-width: 258px;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-
 	&.masterbar__item-help {
 		cursor: pointer;
 		// todo may need flex: unset

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -715,6 +715,12 @@ body.is-mobile-app-view {
 		}
 	}
 
+	&.masterbar__item-my-site .masterbar__item-content {
+		max-width: 258px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
 	&.masterbar__item-help {
 		cursor: pointer;
 		// todo may need flex: unset


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8639

## Proposed Changes

* Truncate long site titles in the Masterbar to 40 characters, just like in wp-admin.

Before | After
--|--
<img width="675" alt="Screenshot 2024-08-08 at 5 27 54 PM" src="https://github.com/user-attachments/assets/aee76f97-098b-43c8-bfc2-100eb35b256b">  | <img width="568" alt="Screenshot 2024-08-08 at 5 28 04 PM" src="https://github.com/user-attachments/assets/48327d78-c20f-4433-a394-43aa28f9ccdb">




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Aesthetics and consistency between Calypso and wp-admin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Update a test site so it has a really long site title.
* View the masterbar in production vs this PR to see that the title is properly truncated.
* Compare it to wp-admin to see the titles are truncated at about the same length.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
