### PR TITLE
Fix Help Center search card

### DIFF
--- a/apps/help-center/webpack.config.js
+++ b/apps/help-center/webpack.config.js
@@ -50,6 +50,14 @@ function getWebpackConfig( env = { source: '' }, argv = {} ) {
 			// disable module concatenation so that instances of `__()` are not renamed
 			concatenateModules: false,
 		},
+		resolve: {
+			...webpackConfig.resolve,
+			alias: {
+				'../../components/search/style.scss': path.resolve(
+					'../../client/components/search/style-v2.scss'
+				),
+			},
+		},
 		plugins: [
 			...webpackConfig.plugins.filter(
 				( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -10,8 +10,8 @@ import { v4 as uuid } from 'uuid';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
-
-import './style.scss';
+// Don't change me. I'm used by the webpack alias in help-center/webpack.config.js
+import '../../components/search/style.scss';
 
 /**
  * Internal variables
@@ -343,7 +343,7 @@ class Search extends Component {
 			spellCheck: 'false',
 		};
 
-		const searchClass = clsx( this.props.additionalClasses, this.props.dir, {
+		const searchClass = clsx( 'calypso-search-bar', this.props.additionalClasses, this.props.dir, {
 			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,

--- a/client/components/search/style-v2.scss
+++ b/client/components/search/style-v2.scss
@@ -1,0 +1,236 @@
+@import "@automattic/typography/styles/variables";
+@import "../../assets/stylesheets/shared/mixins/long-content-fade";
+
+/**
+ * @component Search - THIS FILE IS ONLY USED IN THE HELP CENTER BECAUSE THE ORIGINAL HAS TOO GENERIC CLASS NAMES.
+ */
+
+.is-section-purchases .search {
+	z-index: z-index("root", ".is-section-purchases .search");
+}
+
+.calypso-search-bar {
+	border-radius: 2px;
+	display: flex;
+	flex: 1 1 auto;
+	margin-bottom: 24px;
+	width: 60px;
+	height: 51px;
+	position: relative;
+	align-items: center;
+	// places search above filters
+	z-index: z-index("root", ".search");
+	transition: all 0.15s ease-in-out;
+
+	.search__icon-navigation {
+		flex: 0 0 auto;
+		display: flex;
+		align-items: center;
+		background-color: var(--color-surface);
+		height: 100%;
+
+		.accessible-focus &:focus {
+			box-shadow: inset 0 0 0 2px var(--color-primary-light);
+			position: relative;
+			z-index: 9999;
+		}
+	}
+
+	.search__open-icon,
+	.search__close-icon {
+		flex: 0 0 auto;
+		width: 50px;
+		z-index: z-index(".search", ".search .search__open-icon");
+		color: var(--color-primary);
+		cursor: pointer;
+	}
+
+	.search__open-icon:hover {
+		color: var(--color-neutral-60);
+	}
+
+	.search__close-icon {
+		color: var(--color-neutral-60);
+		opacity: 0;
+		transition: opacity 0.2s ease-in;
+	}
+
+	&.is-open.has-focus {
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 1px var(--color-primary), 0 0 0 4px var(--color-primary-10);
+		&:hover {
+			box-shadow: 0 0 0 1px var(--color-primary), 0 0 0 4px var(--color-primary-20);
+		}
+	}
+
+	&.is-compact {
+		height: 36px;
+		.search__input {
+			height: 36px;
+			font-size: $font-body-extra-small;
+		}
+
+		.search__open-icon {
+			margin: 0 4px 0 8px;
+			width: 18px;
+		}
+
+		.search__close-icon {
+			width: 18px;
+			margin-right: 8px;
+		}
+	}
+}
+
+// Position collapsed search-button to the right
+// of the container element
+.search.is-expanded-to-container {
+	margin-bottom: 0;
+	position: absolute;
+	display: flex;
+	height: 100%;
+	width: 50px;
+	top: 0;
+	right: 0;
+
+	.search__input-fade {
+		position: relative;
+		flex: 1 1 auto;
+		display: flex;
+	}
+
+	.search__input[type="search"] {
+		flex: 1 1 auto;
+		display: flex;
+	}
+}
+
+.search__input.form-text-input[type="search"] {
+	flex: 1 1 auto;
+	display: none;
+	z-index: z-index(".search", ".search__input");
+	top: 0;
+	border: none;
+	height: 100%;
+	background: var(--color-surface);
+	appearance: none;
+	border-radius: 0;
+	box-sizing: border-box;
+	padding: 0;
+	-webkit-appearance: none;
+
+	&::-webkit-search-cancel-button {
+		-webkit-appearance: none;
+	}
+
+	&:disabled {
+		background: var(--color-surface);
+	}
+
+	&:focus {
+		box-shadow: none;
+		border: none;
+
+		&:hover {
+			border: none;
+			box-shadow: none;
+		}
+	}
+}
+
+// When search input is opened
+.search.is-open {
+	width: 100%;
+
+	.search__open-icon {
+		color: var(--color-neutral-60);
+		opacity: 0.3;
+	}
+
+	.search__close-icon {
+		display: inline-block;
+	}
+
+	.search__input,
+	.search__close-icon {
+		opacity: 1;
+	}
+
+	.search__input {
+		display: block;
+	}
+
+	.search__input-fade {
+		border-radius: 0;
+		flex: 1 1 auto;
+		height: 100%;
+		position: relative;
+		font-size: $font-body;
+		&::before {
+			@include long-content-fade(
+				$size: 32px,
+				$z-index: z-index(".search", ".search__input") + 2
+			);
+			border-radius: inherit;
+		}
+
+		&.ltr {
+			/*!rtl:ignore*/
+			&::before {
+				@include long-content-fade(
+					$direction: right,
+					$size: 32px,
+					$z-index: z-index(".search", ".search__input") + 2
+				);
+				border-radius: inherit;
+			}
+		}
+
+		padding-left: 8px;
+	}
+}
+
+.search.has-open-icon {
+	.search__input-fade {
+		padding-left: 0;
+	}
+}
+
+.search__input-fade .search__text-overlay {
+	color: transparent;
+	position: absolute;
+	pointer-events: none;
+	white-space: nowrap;
+	display: flex;
+	align-items: center;
+	flex: 1 1 auto;
+	overflow: hidden;
+	font-size: inherit;
+	font-family: inherit;
+	width: 100%;
+	height: 100%;
+	top: 1px;
+	left: 0;
+	z-index: z-index(".search", ".search__input") + 1;
+}
+
+.search .spinner {
+	display: none;
+}
+
+.search.is-searching .search__open-icon {
+	display: none;
+}
+
+.search.is-searching .spinner {
+	flex: 0 0 auto;
+	display: flex;
+	width: 50px;
+	height: 100%;
+	background-color: var(--color-surface);
+	z-index: z-index(".search", ".search.is-searching .spinner");
+}
+
+.animating.search-opening .search input {
+	opacity: 1;
+}

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -36,7 +36,7 @@
 				box-shadow: none;
 			}
 
-			.search {
+			.calypso-search-bar {
 				height: 40px;
 				border: 1px;
 			}

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -482,7 +482,7 @@ $z-index: 99999;
 			}
 
 			.search-card {
-				.search {
+				.calypso-search-bar {
 					border: none;
 				}
 			}


### PR DESCRIPTION
Alias the Search card CSS file with another file that is less generic and doesn't break sites when included.

See: p1723148019985739-slack-C02FMH4G8