### PR TITLE
A4A > Marketplace: Hide WPCOM slider if there are >=10 owned plans

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -1,5 +1,6 @@
 import formatCurrency from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useMemo, useState } from 'react';
 import A4ANumberInput from 'calypso/a8c-for-agencies/components/a4a-number-input';
@@ -24,6 +25,8 @@ type PlanDetailsProps = {
 	quantity: number;
 	setQuantity: ( quantity: number ) => void;
 };
+
+const MAX_SLIDER_POINTS = 10;
 
 function PlanDetails( {
 	plan,
@@ -173,10 +176,17 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 		return;
 	}
 
+	// Show the WPCOM slider if the user has less than 10 plans and is not in referral mode.
+	const showWPCOMSlider = ! referralMode && ownedPlans < MAX_SLIDER_POINTS;
+
 	return (
-		<div className="wpcom-plan-selector">
+		<div
+			className={ clsx( 'wpcom-plan-selector', {
+				'is-slider-hidden': ! showWPCOMSlider,
+			} ) }
+		>
 			<div className="wpcom-plan-selector__slider-container">
-				{ ! referralMode && (
+				{ showWPCOMSlider && (
 					<WPCOMPlanSlider
 						quantity={ quantity }
 						onChange={ setQuantity }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/index.tsx
@@ -26,7 +26,7 @@ type PlanDetailsProps = {
 	setQuantity: ( quantity: number ) => void;
 };
 
-const MAX_SLIDER_POINTS = 10;
+const MAX_PLANS_FOR_SLIDER = 10;
 
 function PlanDetails( {
 	plan,
@@ -177,7 +177,7 @@ export default function WPCOMPlanSelector( { onSelect }: WPCOMPlanSelectorProps 
 	}
 
 	// Show the WPCOM slider if the user has less than 10 plans and is not in referral mode.
-	const showWPCOMSlider = ! referralMode && ownedPlans < MAX_SLIDER_POINTS;
+	const showWPCOMSlider = ! referralMode && ownedPlans < MAX_PLANS_FOR_SLIDER;
 
 	return (
 		<div

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/wpcom-plan-selector/style.scss
@@ -5,6 +5,10 @@
 	display: flex;
 	flex-direction: column;
 	gap: 32px;
+
+	&.is-slider-hidden {
+		gap: 24px;
+	}
 }
 
 .wpcom-plan-selector__slider-container {


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/472

## Proposed Changes

* This PR hides the WPCOM slider if there are >=10 owned plans

## Why are these changes being made?

* This change is done to avoid the confusion. The slider becomes useless when there are 10 sites. So, we hide it if a user has 10 or more sites.

## Testing Instructions

* Open the A4A live link
* Go to Marketplace - Hosting - Standard agency hosting 
* Verify that the slider is shown only when there are less than 10 sites.

**When there are 9 sites**

<img width="1434" alt="Screenshot 2024-08-09 at 8 54 23 AM" src="https://github.com/user-attachments/assets/945d95f9-d3c2-4487-adcf-fd53dd8c0aa3">

**When there are 10 sites**

<img width="1434" alt="Screenshot 2024-08-09 at 8 53 44 AM" src="https://github.com/user-attachments/assets/b25021ea-c0bb-46a9-91cd-49a2a2a1a868">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
