### PR TITLE
Fix the default migration support form message

### DIFF
--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import MigrationContactSupportForm from '../a4a-migration-offer-v2/migration-contact-support-form';
 import UserContactSupportModalForm from '../user-contact-support-modal-form';
@@ -7,6 +8,8 @@ export const CONTACT_URL_HASH_FRAGMENT = '#contact-support';
 export const CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT = '#contact-support-migration-offer';
 
 export default function A4AContactSupportWidget() {
+	const translate = useTranslate();
+
 	const hashSupportFormHash =
 		window.location.hash === CONTACT_URL_HASH_FRAGMENT ||
 		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT;
@@ -26,10 +29,24 @@ export default function A4AContactSupportWidget() {
 		setShowUserSupportForm( true );
 	}
 
+	// TODO: remove this when we remove the feature flag for the new hosting page.
+	const migrationOfferDefaultMessage =
+		translate( "I'd like to chat more about the migration offer." ) +
+		'\n\n' +
+		translate( '[your message here]' );
+
 	return isNewHostingPage &&
 		window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT ? (
 		<MigrationContactSupportForm show={ showUserSupportForm } onClose={ onCloseUserSupportForm } />
 	) : (
-		<UserContactSupportModalForm show={ showUserSupportForm } onClose={ onCloseUserSupportForm } />
+		<UserContactSupportModalForm
+			show={ showUserSupportForm }
+			onClose={ onCloseUserSupportForm }
+			defaultMessage={
+				window.location.hash === CONTACT_URL_FOR_MIGRATION_OFFER_HASH_FRAGMENT
+					? migrationOfferDefaultMessage
+					: undefined
+			}
+		/>
 	);
 }

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/index.tsx
@@ -18,7 +18,6 @@ import './style.scss';
 type Props = {
 	show: boolean;
 	onClose?: () => void;
-	defaultMessage?: string;
 };
 
 const DEFAULT_PRODUCT_VALUE = 'wpcom';


### PR DESCRIPTION
## Proposed Changes

* This PR fixes the default message for the migration support form that was removed in a previous PR.

## Why are these changes being made?

* To add back the default message.

## Testing Instructions

* Open the A4A live link
* Go Marketplace - Hosting > Append the URL with ?flags=-a4a-hosting-page-redesign
* Click the `Contact us` CTA on the migration banner.
* Verify the default message is shown below:

<img width="925" alt="Screenshot 2024-08-09 at 1 35 29 PM" src="https://github.com/user-attachments/assets/77349b2a-810e-417d-a827-4c4579d23a93">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
