### PR TITLE
A4A Dev Sites: Update the "Created site" banners / notifications logic to work with free dev sites

### DIFF
--- a/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
+++ b/client/a8c-for-agencies/data/sites/use-is-site-ready.ts
@@ -15,6 +15,7 @@ type Site = {
 		};
 	};
 };
+
 export default function useIsSiteReady( { siteId }: Props ) {
 	const [ site, setSite ] = useState< Site | null >( null );
 	const { data } = useFetchActiveSites( { autoRefresh: ! site } );
@@ -26,6 +27,8 @@ export default function useIsSiteReady( { siteId }: Props ) {
 
 		if ( match ) {
 			setSite( match );
+		} else {
+			setSite( null );
 		}
 	}, [ data, site, siteId ] );
 

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -4,7 +4,7 @@ import page from '@automattic/calypso-router';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useContext, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
@@ -18,7 +18,6 @@ import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-co
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
-import SitesDashboardContext from '../sites-dashboard-context';
 import SitesHeaderActions from '../sites-header-actions';
 import ClientSite from './client-site';
 import { AvailablePlans } from './plan-field';
@@ -136,15 +135,12 @@ export default function NeedSetup( { licenseKey }: Props ) {
 				features.wpcom_atomic.state === 'provisioning' && !! features.wpcom_atomic.license_key
 		);
 
-	const { setRecentlyCreatedSiteId } = useContext( SitesDashboardContext );
-
 	const onCreateSiteSuccess = useCallback(
 		( id: number ) => {
 			refetchPendingSites();
-			//page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
-			setRecentlyCreatedSiteId( id );
+			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
 		},
-		[ refetchPendingSites, setRecentlyCreatedSiteId ]
+		[ refetchPendingSites ]
 	);
 
 	const onCreateSiteWithConfig = useCallback(

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -4,7 +4,7 @@ import page from '@automattic/calypso-router';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useContext, useCallback, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutColumn from 'calypso/a8c-for-agencies/components/layout/column';
 import LayoutHeader, {
@@ -18,6 +18,7 @@ import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-co
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useCreateWPCOMSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-create-wpcom-site';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
+import SitesDashboardContext from '../sites-dashboard-context';
 import SitesHeaderActions from '../sites-header-actions';
 import ClientSite from './client-site';
 import { AvailablePlans } from './plan-field';
@@ -135,12 +136,15 @@ export default function NeedSetup( { licenseKey }: Props ) {
 				features.wpcom_atomic.state === 'provisioning' && !! features.wpcom_atomic.license_key
 		);
 
+	const { setRecentlyCreatedSiteId } = useContext( SitesDashboardContext );
+
 	const onCreateSiteSuccess = useCallback(
 		( id: number ) => {
 			refetchPendingSites();
-			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
+			//page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
+			setRecentlyCreatedSiteId( id );
 		},
-		[ refetchPendingSites ]
+		[ refetchPendingSites, setRecentlyCreatedSiteId ]
 	);
 
 	const onCreateSiteWithConfig = useCallback(

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -38,6 +38,9 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 
 	isPopoverOpen: false,
 	setIsPopoverOpen: () => {},
+
+	recentlyCreatedSiteId: null,
+	setRecentlyCreatedSiteId: () => {},
 } );
 
 export default SitesDashboardContext;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -65,6 +65,7 @@ export const SitesDashboardProvider = ( {
 	const [ mostRecentConnectedSite, setMostRecentConnectedSite ] = useState< string | null >( null );
 	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
 	const [ initialSelectedSiteUrl, setInitialSelectedSiteUrl ] = useState( siteUrlInitialState );
+	const [ recentlyCreatedSiteId, setRecentlyCreatedSiteId ] = useState< number | null >( null );
 
 	const handleSetBulkManagementActive = ( isActive: boolean ) => {
 		setIsBulkManagementActive( isActive );
@@ -148,6 +149,8 @@ export const SitesDashboardProvider = ( {
 		dataViewsState,
 		setDataViewsState,
 		featurePreview,
+		recentlyCreatedSiteId,
+		setRecentlyCreatedSiteId,
 	};
 	return (
 		<SitesDashboardContext.Provider value={ sitesDashboardContextValue }>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -53,7 +53,6 @@ export default function SitesDashboard() {
 
 	const agencyId = useSelector( getActiveAgencyId );
 
-	const recentlyCreatedSite = getQueryArg( window.location.href, 'created_site' ) ?? null;
 	const migrationIntent = getQueryArg( window.location.href, 'migration' ) ?? null;
 
 	const {
@@ -66,6 +65,7 @@ export default function SitesDashboard() {
 		showOnlyFavorites,
 		hideListing,
 		setHideListing,
+		recentlyCreatedSiteId,
 	} = useContext( SitesDashboardContext );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
@@ -223,9 +223,9 @@ export default function SitesDashboard() {
 			{ ! hideListing && (
 				<LayoutColumn className="sites-overview" wide>
 					<LayoutTop withNavigation={ navItems.length > 1 }>
-						{ recentlyCreatedSite && (
+						{ recentlyCreatedSiteId && (
 							<ProvisioningSiteNotification
-								siteId={ Number( recentlyCreatedSite ) }
+								siteId={ Number( recentlyCreatedSiteId ) }
 								migrationIntent={ !! migrationIntent }
 							/>
 						) }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -53,6 +53,7 @@ export default function SitesDashboard() {
 
 	const agencyId = useSelector( getActiveAgencyId );
 
+	const recentlyCreatedSite = getQueryArg( window.location.href, 'created_site' ) ?? null;
 	const migrationIntent = getQueryArg( window.location.href, 'migration' ) ?? null;
 
 	const {
@@ -66,7 +67,14 @@ export default function SitesDashboard() {
 		hideListing,
 		setHideListing,
 		recentlyCreatedSiteId,
+		setRecentlyCreatedSiteId,
 	} = useContext( SitesDashboardContext );
+
+	useEffect( () => {
+		if ( recentlyCreatedSite ) {
+			setRecentlyCreatedSiteId( Number( recentlyCreatedSite ) );
+		}
+	}, [ recentlyCreatedSite, setRecentlyCreatedSiteId ] );
 
 	const isLargeScreen = isWithinBreakpoint( '>960px' );
 	// FIXME: We should switch to a new A4A-specific endpoint when it becomes available, instead of using the public-facing endpoint for A4A

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import useIsSiteReady from 'calypso/a8c-for-agencies/data/sites/use-is-site-ready';
 import { addQueryArgs } from 'calypso/lib/url';
 
@@ -13,6 +13,12 @@ type Props = {
 export default function ProvisioningSiteNotification( { siteId, migrationIntent }: Props ) {
 	const { isReady, site } = useIsSiteReady( { siteId } );
 	const [ showBanner, setShowBanner ] = useState( true );
+
+	useEffect( () => {
+		if ( siteId ) {
+			setShowBanner( true );
+		}
+	}, [ siteId ] );
 
 	const translate = useTranslate();
 

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -8,7 +8,10 @@ import { useCallback, useContext, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
-import { A4A_MARKETPLACE_PRODUCTS_LINK, A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_MARKETPLACE_PRODUCTS_LINK,
+	A4A_SITES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -4,18 +4,16 @@ import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import AddNewSiteButton from 'calypso/a8c-for-agencies/components/add-new-site-button';
 import { GuidedTourStep } from 'calypso/a8c-for-agencies/components/guided-tour-step';
-import {
-	A4A_MARKETPLACE_PRODUCTS_LINK,
-	A4A_SITES_LINK,
-} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { A4A_MARKETPLACE_PRODUCTS_LINK, A4A_SITES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import SiteConfigurationsModal from 'calypso/a8c-for-agencies/components/site-configurations-modal';
 import { useRandomSiteName } from 'calypso/a8c-for-agencies/components/site-configurations-modal/use-random-site-name';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import SitesDashboardContext from '../sites-dashboard-context';
 
 import './style.scss';
 
@@ -37,9 +35,12 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 		setShowConfigurationModal( ! showConfigurationModal );
 	}, [ showConfigurationModal ] );
 
+	const { setRecentlyCreatedSiteId } = useContext( SitesDashboardContext );
+
 	const onCreateSiteSuccess = useCallback(
 		( id: number ) => {
 			refetchPendingSites();
+			setRecentlyCreatedSiteId( id );
 			page( addQueryArgs( A4A_SITES_LINK, { created_site: id } ) );
 		},
 		[ refetchPendingSites ]

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -41,4 +41,7 @@ export interface SitesDashboardContextInterface {
 	setIsPopoverOpen: Dispatch< SetStateAction< boolean > >;
 
 	featurePreview: ReactNode | null;
+
+	recentlyCreatedSiteId: number | null;
+	setRecentlyCreatedSiteId: ( value: number ) => void;
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/8352.

## Proposed Changes

* introduce new context state `recentlyCreatedSiteId`
  * when the site is created from the `/sites` page, utilize the new `recentlyCreatedSiteId` context state to store `created_site` ID value  
  * on the other hand, when the site is created from the `sites/need-setup` page, then rely on the `created_site` URL parameter (current `trunk` behaviour)
  * `useEffect` prioritizes the use of `created_site` from the URL parameter if it is available
* adjust the logic of `ProvisioningSiteNotification` component and related `useIsSiteReady` hook with the aim to allow the banner to be displayed multiple times (e.g. when user creates multiple sites in the row)

![Markup on 2024-08-09 at 17:57:47](https://github.com/user-attachments/assets/0e2804ff-f636-4cf6-a918-bc248bd94061)

Related discussion: p1722964042140779-slack-C02TCEHP3HA.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR locally and build the app with `yarn start-a8c-for-agencies`.
2. Head over to the Sites section at http://agencies.localhost:3000/sites/need-setup?flags=a4a-dev-sites and click on the "Start developing for free" CTA button.
3. As the site is being created, you should see an orange and then green banner on top.
4. Close the banner.
5. Head over to the "Needs setup" page and use one of your purchased licenses to create a new "normal" site.
6. You should be redirected to the Sites page and the correct banners should load.
7. Go back to the "Needs setup" page and try to create a new free dev site again. As before, you should be redirected to the Sites page and the correct banners should load.
8. Feel free to experiment with creating multiple "normal" and free dev sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?