### PR TITLE
A4A: Make the entire row in the site dashboard clickable.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { Button, Gridicon } from '@automattic/components';
 import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useContext, useMemo, useState, ReactNode } from 'react';
@@ -123,7 +122,7 @@ export const JetpackSitesDataViews = ( {
 	const [ monitorRef, setMonitorRef ] = useState< HTMLElement | null >();
 	const [ scanRef, setScanRef ] = useState< HTMLElement | null >();
 	const [ pluginsRef, setPluginsRef ] = useState< HTMLElement | null >();
-	const [ actionsRef, setActionsRef ] = useState< HTMLElement | null >();
+	const [ actionsRef ] = useState< HTMLElement | null >();
 
 	const fields = useMemo< DataViewsColumn[] >(
 		() => [
@@ -405,14 +404,6 @@ export const JetpackSitesDataViews = ( {
 												onRefetchSite={ onRefetchSite }
 											/>
 										) }
-										<Button
-											onClick={ () => openSitePreviewPane( item.site.value ) }
-											className="site-preview__open"
-											borderless
-											ref={ ( ref ) => setActionsRef( ( current ) => current || ref ) }
-										>
-											<Gridicon icon="chevron-right" />
-										</Button>
 									</>
 								) }
 							</div>
@@ -468,6 +459,51 @@ export const JetpackSitesDataViews = ( {
 		dataViewsState: dataViewsState,
 		onSelectionChange: ( [ item ]: SiteData[] ) => openSitePreviewPane( item.site.value ),
 	} );
+
+	useEffect( () => {
+		// If the user clicks on a row, open the preview pane by triggering the View details button click.
+		const handleRowClick = ( event: Event ) => {
+			const target = event.target as HTMLElement;
+			const row = target.closest(
+				'.dataviews-view-table__row, li:has(.dataviews-view-list__item)'
+			);
+
+			if ( row ) {
+				const isButtonOrLink = target.closest( 'button, a' );
+				if ( ! isButtonOrLink ) {
+					const button = row.querySelector( '.sites-dataviews__site' ) as HTMLButtonElement;
+					if ( button ) {
+						button.click();
+					}
+				}
+			}
+		};
+
+		const rowsContainer = document.querySelector( '.dataviews-view-table, .dataviews-view-list' );
+
+		if ( rowsContainer ) {
+			rowsContainer.addEventListener( 'click', handleRowClick as EventListener );
+		}
+
+		// We need to trigger the click event on the View details button when the selected item changes to ensure highlighted row is correct.
+		if (
+			rowsContainer?.classList.contains( 'dataviews-view-list' ) &&
+			dataViewsState?.selectedItem?.client_id
+		) {
+			const trigger: HTMLButtonElement | null = rowsContainer.querySelector(
+				`li:not(.is-selected) .sites-dataviews__site`
+			);
+			if ( trigger ) {
+				trigger.click();
+			}
+		}
+
+		return () => {
+			if ( rowsContainer ) {
+				rowsContainer.removeEventListener( 'click', handleRowClick as EventListener );
+			}
+		};
+	}, [ dataViewsState ] );
 
 	// Actions: Pause Monitor, Resume Monitor, Custom Notification, Reset Notification
 	// todo: Currently not in use until bulk selections are properly implemented.

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
@@ -8,4 +8,7 @@
 		background: initial;
 	}
 
+	.dataviews-view-table__row {
+		cursor: pointer;
+	}
 }

--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
@@ -163,7 +163,8 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 
 	const { isPending, mutate } = useToggleFavoriteSiteMutation( handleMutation() );
 
-	const handleFavoriteChange = ( e: never ) => {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const handleFavoriteChange = ( e: any ) => {
 		mutate( {
 			siteId,
 			isFavorite,

--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
@@ -163,7 +163,7 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 
 	const { isPending, mutate } = useToggleFavoriteSiteMutation( handleMutation() );
 
-	const handleFavoriteChange = () => {
+	const handleFavoriteChange = ( e: never ) => {
 		mutate( {
 			siteId,
 			isFavorite,
@@ -176,6 +176,7 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 					: 'calypso_jetpack_agency_dashboard_set_favorite_site'
 			)
 		);
+		e.stopPropagation();
 	};
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -67,7 +67,7 @@ export default function ToggleActivateMonitoring( {
 		setShowNotificationSettings( ( isOpen ) => ! isOpen );
 	}
 
-	const statusContentRef = useRef< HTMLSpanElement | null >( null );
+	const statusContentRef = useRef< HTMLButtonElement | null >( null );
 
 	const isChecked = status !== 'disabled';
 	const isLoading = statuses?.[ site.blog_id ] === 'loading';
@@ -195,7 +195,7 @@ export default function ToggleActivateMonitoring( {
 
 	return (
 		<>
-			<span
+			<button
 				className="toggle-activate-monitoring__toggle-button"
 				// We don't want to hide the tooltip when the user clicks on the
 				// upgrade popover since it has buttons that user can interact with.
@@ -203,13 +203,11 @@ export default function ToggleActivateMonitoring( {
 				onMouseEnter={ handleShowTooltip }
 				onMouseLeave={ handleHideTooltip }
 				ref={ statusContentRef }
-				role="button"
-				tabIndex={ 0 }
 			>
 				{ toggleContent }
 
 				{ onHoverContent() }
-			</span>
+			</button>
 
 			{ showNotificationSettings && (
 				<NotificationSettings


### PR DESCRIPTION
This PR removes the chevron icon that indicates the site row collapsing to reduce the UX disparity on the fly-out panel to the WPCOM's Site dashboard.

<img width="1071" alt="Screenshot 2024-08-09 at 7 55 37 PM" src="https://github.com/user-attachments/assets/2f2ac40e-0bbf-4c18-a197-e57cb6b371b9">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/503

## Proposed Changes

* Updates the A4A site dashboard to make the entire area of a site row clickable and trigger a preview panel. 
* "Remove the chevron icon from the site row to reduce visual clutter."
## Why are these changes being made?

* It is important that the A4A and Dotcom experiences are as 1:1 as possible. This PR reduces the disparity between A4A and Dotcom.


## Testing Instructions

* Make sure you have added sites to your A4A account before testing.
* Use the A4A live link and go to the `/sites` page.
* In the Sites dashboard, click any area on any site row.
  * Confirm that the preview panel is displayed.
  * Confirm that clicking any interactive button in the row still working as expected.
  * Confirm that the chevron icon is no longer rendered.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
