### PR TITLE
A4A Dev Sites: Add isDevSite to formatted sites object and show Development label.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -186,7 +186,7 @@ export const JetpackSitesDataViews = ( {
 						);
 					}
 
-					const isDevSite = item.isDevSite;
+					const isDevSite = item.isDevSite ?? false;
 
 					return (
 						<>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -186,12 +186,15 @@ export const JetpackSitesDataViews = ( {
 						);
 					}
 
+					const isDevSite = item.isDevSite;
+
 					return (
 						<>
 							{ item.site.error && <span className="sites-dataview__site-error-span"></span> }
 							<SiteDataField
 								site={ site }
 								isLoading={ isLoading }
+								isDevSite={ isDevSite }
 								onSiteTitleClick={ openSitePreviewPane }
 							/>
 						</>

--- a/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
+++ b/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
+import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import {
 	StatsNode,
 	BoostNode,
@@ -25,6 +26,19 @@ const formatBoostData = ( site: Site ): BoostNode => ( {
 	type: 'boost',
 	value: site.jetpack_boost_scores,
 } );
+
+const useFormatDevSite = () => {
+	const { data: { licenses = [] } = {} } = useFetchDevLicenses();
+
+	return useCallback(
+		( site: Site ) =>
+			!! licenses.find(
+				( license: { managed_site_id: number | undefined } ) =>
+					license.managed_site_id === site.a4a_site_id
+			),
+		[ licenses ]
+	);
+};
 
 const useFormatBackupData = () => {
 	const translate = useTranslate();
@@ -189,6 +203,7 @@ const useFormatSite = () => {
 	const formatMonitorData = useFormatMonitorData();
 	const formatPluginData = useFormatPluginData();
 	const formatScanData = useFormatScanData();
+	const formatDevSite = useFormatDevSite();
 
 	return useCallback(
 		( site: Site, isConnected: boolean ): SiteData => {
@@ -206,12 +221,13 @@ const useFormatSite = () => {
 				monitor: formatMonitorData( site ),
 				plugin: formatPluginData( site ),
 				error: formatErrorData( isConnected ),
+				isDevSite: formatDevSite( site ),
 				isFavorite: site.is_favorite,
 				isSelected: site.isSelected,
 				onSelect: site.onSelect,
 			};
 		},
-		[ formatBackupData, formatMonitorData, formatPluginData, formatScanData ]
+		[ formatBackupData, formatMonitorData, formatPluginData, formatScanData, formatDevSite ]
 	);
 };
 

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -7,17 +7,16 @@ import { Site } from '../types';
 interface SiteDataFieldProps {
 	isLoading: boolean;
 	site: Site;
+	isDevSite: boolean;
 	onSiteTitleClick: ( site: Site ) => void;
 }
 
-const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProps ) => {
+const SiteDataField = ( { isLoading, site, isDevSite, onSiteTitleClick }: SiteDataFieldProps ) => {
 	if ( isLoading ) {
 		return <TextPlaceholder />;
 	}
 
 	const migrationInProgress = site.sticker?.includes( 'migration-in-progress' );
-	// TODO: Replace with actual dev site check
-	const isDevSite = false;
 
 	return (
 		<Button

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -7,7 +7,7 @@ import { Site } from '../types';
 interface SiteDataFieldProps {
 	isLoading: boolean;
 	site: Site;
-	isDevSite: boolean;
+	isDevSite?: boolean;
 	onSiteTitleClick: ( site: Site ) => void;
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -177,6 +177,7 @@ export interface SiteData {
 	plugin: PluginNode;
 	monitor: MonitorNode;
 	error: ErrorNode;
+	isDevSite?: boolean;
 	isFavorite?: boolean;
 	isSelected?: boolean;
 	onSelect?: () => void;


### PR DESCRIPTION
Related to #https://github.com/Automattic/dotcom-forge/issues/8527

## Proposed Changes

* Add `isDevSite` property to formatted sites object.
* Show `Development` label on the sites list.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pdDOJh-3Cl-p2 project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D158017-code and sandbox `public-api.wordpress.com`.
* Run `yarn start-a8c-for-agencies`.
* Go to http://agencies.localhost:3000/sites.
* You should see `Development` label on development sites.

<img width="1423" alt="image" src="https://github.com/user-attachments/assets/35efe2b7-84b4-4358-8426-3ce3529a815a">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?