### PR TITLE
Add migration flow revamp feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
@@ -1,9 +1,13 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { type Flow } from './internals/types';
+import migration from './migration';
 import siteMigration from './site-migration-flow';
 
+const baseFlow = isEnabled( 'migration-flow/revamp' ) ? migration : siteMigration;
+
 const hostedSiteMigrationFlow: Flow = {
-	...siteMigration,
+	...baseFlow,
 	variantSlug: HOSTED_SITE_MIGRATION_FLOW,
 	isSignupFlow: true,
 };

--- a/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosted-site-migration-flow.ts
@@ -1,13 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { type Flow } from './internals/types';
-import migration from './migration';
 import siteMigration from './site-migration-flow';
 
-const baseFlow = isEnabled( 'migration-flow/revamp' ) ? migration : siteMigration;
-
 const hostedSiteMigrationFlow: Flow = {
-	...baseFlow,
+	...siteMigration,
 	variantSlug: HOSTED_SITE_MIGRATION_FLOW,
 	isSignupFlow: true,
 };

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -246,7 +246,7 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 
 export default {
 	name: MIGRATION_FLOW,
-	isSignupFlow: false,
+	isSignupFlow: true,
 	useSteps() {
 		return stepsWithRequiredLogin( [
 			PLATFORM_IDENTIFICATION,

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -5,6 +5,7 @@ import { isHostedSiteMigrationFlow } from '@automattic/onboarding';
 import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -25,6 +26,26 @@ import { AssertConditionState } from './internals/types';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
 
 const FLOW_NAME = 'site-migration';
+
+/**
+ * Redirects users coming from 'move-lp' and 'hosting-lp' to the new migration flow.
+ */
+const useMigrationFlowRevampRedirect = () => {
+	const [ query ] = useSearchParams();
+	const fullQueryString = query.toString();
+	const ref = query.get( 'ref' ) ?? '';
+
+	// Redirect user to the new flow.
+	useEffect( () => {
+		if ( ! config.isEnabled( 'migration-flow/revamp' ) ) {
+			return;
+		}
+
+		if ( [ 'move-lp', 'hosting-lp' ].includes( ref ) ) {
+			window.location.assign( '/setup/migration?' + fullQueryString );
+		}
+	}, [ fullQueryString, ref ] );
+};
 
 const siteMigration: Flow = {
 	name: FLOW_NAME,
@@ -60,6 +81,7 @@ const siteMigration: Flow = {
 	},
 
 	useAssertConditions(): AssertConditionResult {
+		useMigrationFlowRevampRedirect();
 		const { siteSlug, siteId } = useSiteData();
 		const { isAdmin } = useIsSiteAdmin();
 		const userIsLoggedIn = useSelect(

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -48,12 +48,12 @@ const useMigrationFlowRevampRedirect = () => {
 		// If user is coming from 'move-lp' and has a source site, we assume it's a WordPress site because it's already validated there.
 		if ( 'move-lp' === ref && '' !== from ) {
 			window.location.replace(
-				'/setup/migration/' + STEPS.SITE_CREATION_STEP.slug + '?' + fullQueryString
+				`/setup/migration/${ STEPS.SITE_CREATION_STEP.slug }?${ fullQueryString }`
 			);
 			return;
 		}
 
-		window.location.replace( '/setup/migration?' + fullQueryString );
+		window.location.replace( `/setup/migration?${ fullQueryString }` );
 	}, [ fullQueryString, ref, from ] );
 };
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -38,10 +38,7 @@ const useMigrationFlowRevampRedirect = () => {
 
 	// Redirect user to the new migration flow.
 	useEffect( () => {
-		if (
-			! config.isEnabled( 'migration-flow/revamp' ) &&
-			! window.localStorage.getItem( 'migration-flow/revamp' )
-		) {
+		if ( ! config.isEnabled( 'migration-flow/revamp' ) ) {
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -34,6 +34,7 @@ const useMigrationFlowRevampRedirect = () => {
 	const [ query ] = useSearchParams();
 	const fullQueryString = query.toString();
 	const ref = query.get( 'ref' ) ?? '';
+	const from = query.get( 'from' ) ?? '';
 
 	// Redirect user to the new flow.
 	useEffect( () => {
@@ -41,10 +42,18 @@ const useMigrationFlowRevampRedirect = () => {
 			return;
 		}
 
-		if ( [ 'move-lp', 'hosting-lp' ].includes( ref ) ) {
-			window.location.assign( '/setup/migration?' + fullQueryString );
+		// If user is coming from 'move-lp' and has a source site, we assume it's a WordPress site because it's already validated there.
+		if ( 'move-lp' === ref && '' !== from ) {
+			window.location.replace(
+				'/setup/migration/' + STEPS.SITE_CREATION_STEP.slug + '?' + fullQueryString
+			);
+			return;
 		}
-	}, [ fullQueryString, ref ] );
+
+		if ( [ 'move-lp', 'hosting-lp' ].includes( ref ) ) {
+			window.location.replace( '/setup/migration?' + fullQueryString );
+		}
+	}, [ fullQueryString, ref, from ] );
 };
 
 const siteMigration: Flow = {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -30,11 +30,11 @@ const FLOW_NAME = 'site-migration';
 /**
  * Redirects users coming from landing pages and "/sites" to the new migration flow.
  */
-const useMigrationFlowRevampRedirect = () => {
+const useMigrationFlowRevampRedirect = ( flowPath: string ) => {
 	const [ query ] = useSearchParams();
 	const fullQueryString = query.toString();
 	const ref = query.get( 'ref' );
-	const from = query.get( 'from' ) ?? '';
+	const from = query.get( 'from' );
 
 	// Redirect user to the new migration flow.
 	useEffect( () => {
@@ -43,7 +43,8 @@ const useMigrationFlowRevampRedirect = () => {
 		}
 
 		// If user is coming from 'move-lp' and has a source site, we assume it's a WordPress site because it's already validated there.
-		const shouldSkipPlatformSelection = ref && from && isHostedSiteMigrationFlow( flow );
+		const shouldSkipPlatformSelection =
+			'move-lp' === ref && from && isHostedSiteMigrationFlow( flowPath );
 		if ( shouldSkipPlatformSelection ) {
 			return window.location.replace(
 				`/setup/migration/${ STEPS.SITE_CREATION_STEP.slug }?${ fullQueryString }&signup=1`
@@ -51,7 +52,7 @@ const useMigrationFlowRevampRedirect = () => {
 		}
 
 		window.location.replace( `/setup/migration?${ fullQueryString }&signup=1` );
-	}, [ fullQueryString, ref, from ] );
+	}, [ fullQueryString, ref, from, flowPath ] );
 };
 
 const siteMigration: Flow = {
@@ -88,14 +89,16 @@ const siteMigration: Flow = {
 	},
 
 	useAssertConditions(): AssertConditionResult {
-		useMigrationFlowRevampRedirect();
+		const flowPath = this.variantSlug ?? FLOW_NAME;
+
+		useMigrationFlowRevampRedirect( flowPath );
+
 		const { siteSlug, siteId } = useSiteData();
 		const { isAdmin } = useIsSiteAdmin();
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const flowPath = this.variantSlug ?? FLOW_NAME;
 
 		useEffect( () => {
 			if ( isAdmin === false ) {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -45,12 +45,12 @@ const useMigrationFlowRevampRedirect = () => {
 		// If user is coming from 'move-lp' and has a source site, we assume it's a WordPress site because it's already validated there.
 		if ( 'move-lp' === ref && '' !== from ) {
 			window.location.replace(
-				`/setup/migration/${ STEPS.SITE_CREATION_STEP.slug }?${ fullQueryString }`
+				`/setup/migration/${ STEPS.SITE_CREATION_STEP.slug }?${ fullQueryString }&signup=1`
 			);
 			return;
 		}
 
-		window.location.replace( `/setup/migration?${ fullQueryString }` );
+		window.location.replace( `/setup/migration?${ fullQueryString }&signup=1` );
 	}, [ fullQueryString, ref, from ] );
 };
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -33,7 +33,7 @@ const FLOW_NAME = 'site-migration';
 const useMigrationFlowRevampRedirect = () => {
 	const [ query ] = useSearchParams();
 	const fullQueryString = query.toString();
-	const ref = query.get( 'ref' ) ?? '';
+	const ref = query.get( 'ref' );
 	const from = query.get( 'from' ) ?? '';
 
 	// Redirect user to the new migration flow.
@@ -43,7 +43,8 @@ const useMigrationFlowRevampRedirect = () => {
 		}
 
 		// If user is coming from 'move-lp' and has a source site, we assume it's a WordPress site because it's already validated there.
-		if ( 'move-lp' === ref && '' !== from ) {
+		const shouldSkipPlatformSelection = ref && from && isHostedSiteMigrationFlow( flow );
+		if ( shouldSkipPlatformSelection ) {
 			window.location.replace(
 				`/setup/migration/${ STEPS.SITE_CREATION_STEP.slug }?${ fullQueryString }&signup=1`
 			);

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -38,7 +38,10 @@ const useMigrationFlowRevampRedirect = () => {
 
 	// Redirect user to the new migration flow.
 	useEffect( () => {
-		if ( ! config.isEnabled( 'migration-flow/revamp' ) ) {
+		if (
+			! config.isEnabled( 'migration-flow/revamp' ) &&
+			! window.localStorage.getItem( 'migration-flow/revamp' )
+		) {
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -34,7 +34,6 @@ const useMigrationFlowRevampRedirect = () => {
 	const [ query ] = useSearchParams();
 	const fullQueryString = query.toString();
 	const ref = query.get( 'ref' ) ?? '';
-	const source = query.get( 'source' ) ?? '';
 	const from = query.get( 'from' ) ?? '';
 
 	// Redirect user to the new migration flow.
@@ -51,15 +50,8 @@ const useMigrationFlowRevampRedirect = () => {
 			return;
 		}
 
-		if (
-			// Landing pages.
-			[ 'move-lp', 'hosting-lp' ].includes( ref ) ||
-			// "Add new site" dropdown in /sites
-			( 'sites-dashboard' === source && 'topbar' === ref )
-		) {
-			window.location.replace( '/setup/migration?' + fullQueryString );
-		}
-	}, [ fullQueryString, ref, source, from ] );
+		window.location.replace( '/setup/migration?' + fullQueryString );
+	}, [ fullQueryString, ref, from ] );
 };
 
 const siteMigration: Flow = {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -28,15 +28,16 @@ import type { AssertConditionResult, Flow, ProvidedDependencies } from './intern
 const FLOW_NAME = 'site-migration';
 
 /**
- * Redirects users coming from 'move-lp' and 'hosting-lp' to the new migration flow.
+ * Redirects users coming from landing pages and "/sites" to the new migration flow.
  */
 const useMigrationFlowRevampRedirect = () => {
 	const [ query ] = useSearchParams();
 	const fullQueryString = query.toString();
 	const ref = query.get( 'ref' ) ?? '';
+	const source = query.get( 'source' ) ?? '';
 	const from = query.get( 'from' ) ?? '';
 
-	// Redirect user to the new flow.
+	// Redirect user to the new migration flow.
 	useEffect( () => {
 		if ( ! config.isEnabled( 'migration-flow/revamp' ) ) {
 			return;
@@ -50,10 +51,15 @@ const useMigrationFlowRevampRedirect = () => {
 			return;
 		}
 
-		if ( [ 'move-lp', 'hosting-lp' ].includes( ref ) ) {
+		if (
+			// Landing pages.
+			[ 'move-lp', 'hosting-lp' ].includes( ref ) ||
+			// "Add new site" dropdown in /sites
+			( 'sites-dashboard' === source && 'topbar' === ref )
+		) {
 			window.location.replace( '/setup/migration?' + fullQueryString );
 		}
-	}, [ fullQueryString, ref, from ] );
+	}, [ fullQueryString, ref, source, from ] );
 };
 
 const siteMigration: Flow = {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -45,10 +45,9 @@ const useMigrationFlowRevampRedirect = () => {
 		// If user is coming from 'move-lp' and has a source site, we assume it's a WordPress site because it's already validated there.
 		const shouldSkipPlatformSelection = ref && from && isHostedSiteMigrationFlow( flow );
 		if ( shouldSkipPlatformSelection ) {
-			window.location.replace(
+			return window.location.replace(
 				`/setup/migration/${ STEPS.SITE_CREATION_STEP.slug }?${ fullQueryString }&signup=1`
 			);
-			return;
 		}
 
 		window.location.replace( `/setup/migration?${ fullQueryString }&signup=1` );

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -18,6 +18,19 @@ const originalLocation = window.location;
 jest.mock( '../../utils/checkout' );
 jest.mock( '@automattic/data-stores/src/user/selectors' );
 jest.mock( 'calypso/landing/stepper/hooks/use-is-site-owner' );
+jest.mock( '@automattic/calypso-config', () => {
+	const actual = jest.requireActual( '@automattic/calypso-config' );
+	const actualIsEnabled = actual.isEnabled;
+
+	actual.isEnabled = jest.fn().mockImplementation( ( feature ) => {
+		if ( 'migration-flow/revamp' === feature ) {
+			return false;
+		}
+		return actualIsEnabled( feature );
+	} );
+
+	return actual;
+} );
 
 describe( 'Hosted site Migration Flow', () => {
 	beforeAll( () => {

--- a/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/hosted-site-migration-flow.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import config from '@automattic/calypso-config';
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
 import { waitFor } from '@testing-library/react';
@@ -18,19 +19,6 @@ const originalLocation = window.location;
 jest.mock( '../../utils/checkout' );
 jest.mock( '@automattic/data-stores/src/user/selectors' );
 jest.mock( 'calypso/landing/stepper/hooks/use-is-site-owner' );
-jest.mock( '@automattic/calypso-config', () => {
-	const actual = jest.requireActual( '@automattic/calypso-config' );
-	const actualIsEnabled = actual.isEnabled;
-
-	actual.isEnabled = jest.fn().mockImplementation( ( feature ) => {
-		if ( 'migration-flow/revamp' === feature ) {
-			return false;
-		}
-		return actualIsEnabled( feature );
-	} );
-
-	return actual;
-} );
 
 describe( 'Hosted site Migration Flow', () => {
 	beforeAll( () => {
@@ -55,9 +43,13 @@ describe( 'Hosted site Migration Flow', () => {
 		nock( apiBaseUrl ).get( testSettingsEndpoint ).reply( 200, {} );
 		nock( apiBaseUrl ).post( testSettingsEndpoint ).reply( 200, {} );
 		nock( apiBaseUrl ).post( '/wpcom/v2/guides/trigger' ).reply( 200, {} );
+
+		config.disable( 'migration-flow/revamp' );
 	} );
 
 	afterEach( () => {
+		config.enable( 'migration-flow/revamp' );
+
 		// Restore the original implementation after each test
 		jest.restoreAllMocks();
 	} );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -24,6 +24,19 @@ jest.mock( 'calypso/landing/stepper/hooks/use-is-site-admin' );
 jest.mock( 'calypso/lib/guides/trigger-guides-for-step', () => ( {
 	triggerGuidesForStep: jest.fn(),
 } ) );
+jest.mock( '@automattic/calypso-config', () => {
+	const actual = jest.requireActual( '@automattic/calypso-config' );
+	const actualIsEnabled = actual.isEnabled;
+
+	actual.isEnabled = jest.fn().mockImplementation( ( feature ) => {
+		if ( 'migration-flow/revamp' === feature ) {
+			return false;
+		}
+		return actualIsEnabled( feature );
+	} );
+
+	return actual;
+} );
 
 describe( 'Site Migration Flow', () => {
 	beforeAll( () => {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -75,7 +75,7 @@ describe( 'Site Migration Flow', () => {
 				} );
 
 				expect( window.location.replace ).toHaveBeenCalledWith(
-					'/setup/migration?param1=1&param2=2'
+					'/setup/migration?param1=1&param2=2&signup=1'
 				);
 			} );
 
@@ -88,7 +88,7 @@ describe( 'Site Migration Flow', () => {
 				} );
 
 				expect( window.location.replace ).toHaveBeenCalledWith(
-					`/setup/migration/${ STEPS.SITE_CREATION_STEP.slug }?ref=move-lp&from=example.com`
+					`/setup/migration/${ STEPS.SITE_CREATION_STEP.slug }?ref=move-lp&from=example.com&signup=1`
 				);
 			} );
 		} );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -28,7 +28,7 @@ jest.mock( 'calypso/lib/guides/trigger-guides-for-step', () => ( {
 describe( 'Site Migration Flow', () => {
 	beforeAll( () => {
 		Object.defineProperty( window, 'location', {
-			value: { ...originalLocation, assign: jest.fn(), replace: jest.fn() },
+			value: { ...originalLocation, assign: jest.fn() },
 		} );
 	} );
 
@@ -38,7 +38,6 @@ describe( 'Site Migration Flow', () => {
 
 	beforeEach( () => {
 		( window.location.assign as jest.Mock ).mockClear();
-		( window.location.replace as jest.Mock ).mockClear();
 		( isCurrentUserLoggedIn as jest.Mock ).mockReturnValue( true );
 		( useIsSiteAdmin as jest.Mock ).mockReturnValue( {
 			isAdmin: true,
@@ -61,38 +60,6 @@ describe( 'Site Migration Flow', () => {
 	} );
 
 	describe( 'useAssertConditions', () => {
-		describe( 'Redirect to the new migration flow', () => {
-			beforeEach( () => {
-				config.enable( 'migration-flow/revamp' );
-			} );
-
-			it( 'redirects the user to the new flow with the existing query string', () => {
-				const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );
-
-				runUseAssertionCondition( {
-					currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
-					currentURL: `/setup/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }?param1=1&param2=2`,
-				} );
-
-				expect( window.location.replace ).toHaveBeenCalledWith(
-					'/setup/migration?param1=1&param2=2&signup=1'
-				);
-			} );
-
-			it( 'redirects the user to the site creation when it comes from the /move page with a "from"', () => {
-				const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );
-
-				runUseAssertionCondition( {
-					currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
-					currentURL: `/setup/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }?ref=move-lp&from=example.com`,
-				} );
-
-				expect( window.location.replace ).toHaveBeenCalledWith(
-					`/setup/migration/${ STEPS.SITE_CREATION_STEP.slug }?ref=move-lp&from=example.com&signup=1`
-				);
-			} );
-		} );
-
 		it( 'redirects the user to the start page when there is not siteSlug and SiteID', () => {
 			const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );
 

--- a/config/development.json
+++ b/config/development.json
@@ -147,6 +147,7 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/revamp": false,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"oauth": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -94,6 +94,7 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/revamp": false,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -121,6 +121,7 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/revamp": false,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -117,6 +117,7 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/revamp": false,
 		"my-sites/add-ons": true,
 		"onboarding/design-choices": true,
 		"onboarding/import": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,7 +87,7 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
-		"migration-flow/revamp": false,
+		"migration-flow/revamp": true,
 		"my-sites/add-ons": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,6 +87,7 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/revamp": false,
 		"my-sites/add-ons": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -114,6 +114,7 @@
 		"me/vat-details": true,
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/revamp": false,
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/design-choices": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93345

## Proposed Changes

* Create a feature flag.
* Redirect from `hosted-site-migration` flow to the new flow if the feature flag is enabled.
* It also includes a feature flag similar to the feature flag, so it can be activated in the CfT without needing to activate the whole feature in staging.

### Not covered in this PR

* https://github.com/Automattic/wp-calypso/issues/93800
* https://github.com/Automattic/wp-calypso/issues/93802

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The initial phase of this will replace the `hosted-site-migration`, so we are initially preparing it with a feature flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Activate the feature flag by adding the content `ACTIVE_FEATURE_FLAGS="migration-flow/revamp"` to your `.env` file.
* In `https://wordpress.com/move`, copy the migration link from the section "Meet unmatched WordPress hosting", apply the same link in your dev environment, and make sure you are redirected to the new migration flow with the whole query string.
* In `https://wordpress.com/move`, submit the form to migrate a site, copy the URL, apply in your dev env, and make sure it's redirected to the new migration flow with the whole query string, directly to the site creation.
* In `https://wordpress.com/hosting`, copy a migration link, apply the same link in your dev environment, and make sure you are redirected to the new migration flow with the whole query string.

Local Storage test:

* Disable the feature flag.
* Repeat one of the tests, and make sure the redirect doesn't happen.
* Run in your console: `window.localStorage.setItem('migration-flow/revamp', '1');`.
* Repeat one of the tests, and make sure the redirect works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
