### PR TITLE
fix(hosting-overview-refinements): a few fixes of hosting overview UI

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -34,8 +34,9 @@ $blueberry-color: #3858e9;
 					font-size: inherit;
 					padding: 0;
 					height: auto;
-					.item-preview__header-env-data-item-link-capitalize {
+					.item-preview__header-env-data-item-link-description {
 						text-transform: capitalize;
+						padding-left: 2px;
 					}
 				}
 			}


### PR DESCRIPTION
Related tohttps://github.com/Automattic/dotcom-forge/issues/8652
Discussion: p1723170990128299-slack-C06ELHR6L9J

## Proposed Changes
With this PR we are fixing a few UI bugs of Hosting Overview page

## Why are these changes being made?
1. Add click tracking for clicks to the WP / PHP versions.
2. Add 2px padding between the WP version number and version label. Right now they are too close together.
3. Append version label ONLY for staging sites, since users can’t change WP version for production sites.
4. Render only 6.6.1 for all production sites, instead of 6.6.1-alpha-...


## Testing Instructions
1. Open /sites
2. Select Atomic site
3. Assert that clicks on PHP/WP triggers `calypso_hosting_configuration_php_version_update` and `calypso_hosting_configuration_wp_version_update` appropriately.
4. Assert that you don't see `Latest` WP label <br /><img width="214" alt="Screenshot 2024-08-09 at 16 08 48" src="https://github.com/user-attachments/assets/e072a3a2-93a7-48dc-a05a-a7416d7a9ff5">
5. Select Staging site
6. Assert that you  see `Latest/Beta` WP label <br /><img width="237" alt="Screenshot 2024-08-09 at 16 09 29" src="https://github.com/user-attachments/assets/64b6571c-0f1f-4ec2-9aa3-e67c3c4aea60">
7. And assert that there is small gap between WP version an `(Latest|Beta)`
8. Open Simple site (and Atomic/Staging), and assert that you always see only WP version number, w/o `alfa` etc.