### PR TITLE
remove pseudo elements from plugins marketplace and section component

### DIFF
--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -8,33 +8,19 @@ interface SectionProps {
 	subheader?: string | ReactElement;
 	children: ReactNode;
 	dark?: boolean;
-	hideBackgroundElement?: boolean;
 }
 
 interface SectionContainerProps {
 	dark?: boolean;
-	hideBackgroundElement?: boolean;
 }
 
 interface SectionHeaderProps {
 	dark?: boolean;
 }
 
+// TODO - re-add background color and usage of dark prop, to something other than a pseudo element.
+// We will need to adjust exterior containers margin etc. to accomodate this.
 export const SectionContainer = styled.div< SectionContainerProps >`
-	${ ( props ) =>
-		! props.hideBackgroundElement &&
-		`::before {
-		box-sizing: border-box;
-		content: '';
-		background-color: ${ props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
-		position: absolute;
-		height: 100%;
-		width: 200vw;
-		left: -100vw;
-		z-index: -1;
-		margin-top: -56px;
-	}` }
-
 	padding: 56px 0;
 `;
 
@@ -75,10 +61,10 @@ export const SectionHeaderContainer = styled.div< SectionHeaderProps >`
 const SectionContent = styled.div``;
 
 const Section = ( props: SectionProps ) => {
-	const { children, header, subheader, dark, hideBackgroundElement } = props;
+	const { children, header, subheader, dark } = props;
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<SectionContainer dark={ dark } hideBackgroundElement={ hideBackgroundElement }>
+		<SectionContainer dark={ dark }>
 			<SectionHeaderContainer>
 				<SectionHeader dark={ dark } className="wp-brand-font">
 					{ header }

--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -20,6 +20,7 @@ interface SectionHeaderProps {
 
 // TODO - re-add background color and usage of dark prop, to something other than a pseudo element.
 // We will need to adjust exterior containers margin etc. to accomodate this.
+// https://github.com/Automattic/wp-calypso/pull/93425
 export const SectionContainer = styled.div< SectionContainerProps >`
 	padding: 56px 0;
 `;

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -12,8 +12,7 @@ import PluginsResultsHeader from 'calypso/my-sites/plugins/plugins-results-heade
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { isUserLoggedIn, getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
-import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
-import { getSectionGroup, getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSectionName } from 'calypso/state/ui/selectors';
 
 const ThreeColumnContainer = styled.div`
 	@media ( max-width: 660px ) {
@@ -90,12 +89,7 @@ export const MarketplaceFooter = () => {
 	const { __ } = useI18n();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
-	const sectionName = useSelector( getSectionName ) || '';
-	const sectionGroup = useSelector( getSectionGroup ) || '';
-	const siteId = useSelector( getSelectedSiteId );
-	const isGlobalSidebarVisible = useSelector( ( state ) =>
-		getShouldShowGlobalSidebar( state, siteId, sectionGroup, sectionName )
-	);
+	const sectionName = useSelector( getSectionName );
 
 	const startUrl = addQueryArgs(
 		{
@@ -108,7 +102,6 @@ export const MarketplaceFooter = () => {
 		<MarketplaceContainer isloggedIn={ isLoggedIn }>
 			<Section
 				header={ preventWidows( __( 'You pick the plugin. We’ll take care of the rest.' ) ) }
-				hideBackgroundElement={ isLoggedIn && isGlobalSidebarVisible }
 			>
 				{ ( ! isLoggedIn || currentUserSiteCount === 0 ) && (
 					<Button className="is-primary marketplace-cta" href={ startUrl }>

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -52,17 +52,6 @@
 }
 .plugins-browser__main-container {
 	display: contents;
-
-	.theme-default:not(.is-global) &::before {
-		box-sizing: border-box;
-		content: "";
-		background-color: #fff;
-		position: absolute;
-		height: 100%;
-		width: 200vw;
-		left: -100vw;
-		z-index: -1;
-	}
 }
 
 .plugins-browser__upgrade-banner {

--- a/client/signup/accordion-form/accordion-form-section.tsx
+++ b/client/signup/accordion-form/accordion-form-section.tsx
@@ -106,48 +106,51 @@ export default function AccordionFormSection< T >( props: AccordionFormSectionPr
 	const isRTL = useRtl();
 
 	return (
-		<Section>
-			<SectionHeader
-				isExpanded={ props.isExpanded }
-				isTouched={ props.isTouched }
-				onClick={ () => ( props.blockNavigation ? null : props.onOpen() ) }
-				disabled={ props.blockNavigation }
-			>
-				<span>{ props.title }</span>
-				{ props.isExpanded && ! props.showSkip && (
-					<RequiredLabel>{ translate( 'Required' ) }</RequiredLabel>
-				) }
-				{ ! props.isExpanded && props.summary && <SummaryLabel>{ props.summary }</SummaryLabel> }
-			</SectionHeader>
-			{ props.isExpanded && (
-				<SectionContent>
-					{ props.component ? props.component : props.children }
-					<ButtonsContainer>
-						<ActionButton
-							onClick={ props.onSave }
-							disabled={ props.blockNavigation || props.isSaving || ! props.hasUnsavedChanges }
-						>
-							{ props.isSaving ? translate( 'Saving' ) : translate( 'Save Changes' ) }
-						</ActionButton>
-						<ActionButton
-							primary={ props.showSubmit }
-							onClick={ props.onNext }
-							disabled={ props.blockNavigation || props.isSaving }
-						>
-							{ props.showSubmit ? translate( 'Submit' ) : translate( 'Next' ) }
-							{ ! props.showSubmit && <Gridicon icon={ isRTL ? 'arrow-left' : 'arrow-right' } /> }
-						</ActionButton>
-						{ props.showSkip && ! props.showSubmit && (
-							<SkipLink
-								disabled={ props.blockNavigation }
-								onClick={ () => ( props.blockNavigation ? null : props.onNext() ) }
+		<>
+			<h1>I AM THE ACCORDION FORM SECTION</h1>
+			<Section>
+				<SectionHeader
+					isExpanded={ props.isExpanded }
+					isTouched={ props.isTouched }
+					onClick={ () => ( props.blockNavigation ? null : props.onOpen() ) }
+					disabled={ props.blockNavigation }
+				>
+					<span>{ props.title }</span>
+					{ props.isExpanded && ! props.showSkip && (
+						<RequiredLabel>{ translate( 'Required' ) }</RequiredLabel>
+					) }
+					{ ! props.isExpanded && props.summary && <SummaryLabel>{ props.summary }</SummaryLabel> }
+				</SectionHeader>
+				{ props.isExpanded && (
+					<SectionContent>
+						{ props.component ? props.component : props.children }
+						<ButtonsContainer>
+							<ActionButton
+								onClick={ props.onSave }
+								disabled={ props.blockNavigation || props.isSaving || ! props.hasUnsavedChanges }
 							>
-								{ translate( 'Skip' ) }
-							</SkipLink>
-						) }
-					</ButtonsContainer>
-				</SectionContent>
-			) }
-		</Section>
+								{ props.isSaving ? translate( 'Saving' ) : translate( 'Save Changes' ) }
+							</ActionButton>
+							<ActionButton
+								primary={ props.showSubmit }
+								onClick={ props.onNext }
+								disabled={ props.blockNavigation || props.isSaving }
+							>
+								{ props.showSubmit ? translate( 'Submit' ) : translate( 'Next' ) }
+								{ ! props.showSubmit && <Gridicon icon={ isRTL ? 'arrow-left' : 'arrow-right' } /> }
+							</ActionButton>
+							{ props.showSkip && ! props.showSubmit && (
+								<SkipLink
+									disabled={ props.blockNavigation }
+									onClick={ () => ( props.blockNavigation ? null : props.onNext() ) }
+								>
+									{ translate( 'Skip' ) }
+								</SkipLink>
+							) }
+						</ButtonsContainer>
+					</SectionContent>
+				) }
+			</Section>
+		</>
 	);
 }

--- a/client/signup/accordion-form/accordion-form-section.tsx
+++ b/client/signup/accordion-form/accordion-form-section.tsx
@@ -106,51 +106,48 @@ export default function AccordionFormSection< T >( props: AccordionFormSectionPr
 	const isRTL = useRtl();
 
 	return (
-		<>
-			<h1>I AM THE ACCORDION FORM SECTION</h1>
-			<Section>
-				<SectionHeader
-					isExpanded={ props.isExpanded }
-					isTouched={ props.isTouched }
-					onClick={ () => ( props.blockNavigation ? null : props.onOpen() ) }
-					disabled={ props.blockNavigation }
-				>
-					<span>{ props.title }</span>
-					{ props.isExpanded && ! props.showSkip && (
-						<RequiredLabel>{ translate( 'Required' ) }</RequiredLabel>
-					) }
-					{ ! props.isExpanded && props.summary && <SummaryLabel>{ props.summary }</SummaryLabel> }
-				</SectionHeader>
-				{ props.isExpanded && (
-					<SectionContent>
-						{ props.component ? props.component : props.children }
-						<ButtonsContainer>
-							<ActionButton
-								onClick={ props.onSave }
-								disabled={ props.blockNavigation || props.isSaving || ! props.hasUnsavedChanges }
-							>
-								{ props.isSaving ? translate( 'Saving' ) : translate( 'Save Changes' ) }
-							</ActionButton>
-							<ActionButton
-								primary={ props.showSubmit }
-								onClick={ props.onNext }
-								disabled={ props.blockNavigation || props.isSaving }
-							>
-								{ props.showSubmit ? translate( 'Submit' ) : translate( 'Next' ) }
-								{ ! props.showSubmit && <Gridicon icon={ isRTL ? 'arrow-left' : 'arrow-right' } /> }
-							</ActionButton>
-							{ props.showSkip && ! props.showSubmit && (
-								<SkipLink
-									disabled={ props.blockNavigation }
-									onClick={ () => ( props.blockNavigation ? null : props.onNext() ) }
-								>
-									{ translate( 'Skip' ) }
-								</SkipLink>
-							) }
-						</ButtonsContainer>
-					</SectionContent>
+		<Section>
+			<SectionHeader
+				isExpanded={ props.isExpanded }
+				isTouched={ props.isTouched }
+				onClick={ () => ( props.blockNavigation ? null : props.onOpen() ) }
+				disabled={ props.blockNavigation }
+			>
+				<span>{ props.title }</span>
+				{ props.isExpanded && ! props.showSkip && (
+					<RequiredLabel>{ translate( 'Required' ) }</RequiredLabel>
 				) }
-			</Section>
-		</>
+				{ ! props.isExpanded && props.summary && <SummaryLabel>{ props.summary }</SummaryLabel> }
+			</SectionHeader>
+			{ props.isExpanded && (
+				<SectionContent>
+					{ props.component ? props.component : props.children }
+					<ButtonsContainer>
+						<ActionButton
+							onClick={ props.onSave }
+							disabled={ props.blockNavigation || props.isSaving || ! props.hasUnsavedChanges }
+						>
+							{ props.isSaving ? translate( 'Saving' ) : translate( 'Save Changes' ) }
+						</ActionButton>
+						<ActionButton
+							primary={ props.showSubmit }
+							onClick={ props.onNext }
+							disabled={ props.blockNavigation || props.isSaving }
+						>
+							{ props.showSubmit ? translate( 'Submit' ) : translate( 'Next' ) }
+							{ ! props.showSubmit && <Gridicon icon={ isRTL ? 'arrow-left' : 'arrow-right' } /> }
+						</ActionButton>
+						{ props.showSkip && ! props.showSubmit && (
+							<SkipLink
+								disabled={ props.blockNavigation }
+								onClick={ () => ( props.blockNavigation ? null : props.onNext() ) }
+							>
+								{ translate( 'Skip' ) }
+							</SkipLink>
+						) }
+					</ButtonsContainer>
+				</SectionContent>
+			) }
+		</Section>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/93421 and https://github.com/Automattic/wp-calypso/issues/93423 

## Proposed Changes

* Removes problematic background pseudo elements from the plugins marketplace and section component entirely. These are causing the layout breakage noted in the issue above.
    * The section component seems to be primarily used by the plugins marketplace.
* Undoes some changes from https://github.com/Automattic/wp-calypso/pull/93381 that recently removed these from global areas only. We thought the problem was limited to global areas, but these also seem to mess up site level and logged out plugins sections.
* CURRENTLY this means we have no backgrounds on our sections. This seems better than having broken layouts. Applying the background another way may take a little more consideration and refactoring, so it may be good to handle this in a follow up so we can get the more pressing experience fix out asap.

BEFORE
![logged-out-cutoff](https://github.com/user-attachments/assets/8b3d8307-c3f9-4635-b8f3-423ba93ddb1d)
![image](https://github.com/user-attachments/assets/b9118cdb-6fda-4c8a-80a4-4192fcd962ce)



AFTER
![plugins-global-better](https://github.com/user-attachments/assets/166e6cd1-5223-4def-960f-8de7f60bb1f6)

<img width="1338" alt="Screenshot 2024-08-09 at 12 51 23 PM" src="https://github.com/user-attachments/assets/a1c85539-729d-435b-bfd9-9139274ac61a">


NOTE the styles on the logged out plugin page feel quite a bit different without the backgrounds currently. I think they still look great, and are greatly preferable over a broken experience. We will need to follow up with design and evaluate the priority of changing these back (another way, without the pseudo elements).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These pseudo elements for background are breaking the layout everywhere the plugins marketplace is used.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the plugins marketplace at  the global level (starting at */sites -> click plugins in sidebar).
* Click into and back from individual plugins that have this issue (like yoast), verify the content frame layout does not change.
* Go to the plugins marketplace at the site level (my home -> plugins in sidebar).
* Click into individual plugins that have this issue, verify the full plugin page is visible and the top is no longer cut off.
* Go to the logged out plugins page `*/plugins`.
* Click into and back out of plugins that show this issue, verify the full page is always visible and the layout is not adjusting to cut off the top section of the screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
