### PR TITLE
Include the Updated Fiverr Cards Under Marketing Tools

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -87,10 +87,11 @@ export const MarketingTools: FunctionComponent = () => {
 						{ translate( 'Get started' ) }
 					</Button>
 				</MarketingToolsFeature>
+
 				<MarketingToolsFeature
-					title={ translate( 'Want to build a great brand? Start with a great logo' ) }
+					title={ translate( 'Fiverr logo maker' ) }
 					description={ translate(
-						'A custom logo helps your brand pop and makes your site memorable. Make a professional logo in a few clicks with our partner today.'
+						'Create a standout brand with a custom logo. Our partner makes it easy and quick to design a professional logo that leaves a lasting impression.'
 					) }
 					imagePath={ fiverrLogo }
 					imageAlt={ translate( 'Fiverr logo' ) }
@@ -100,7 +101,7 @@ export const MarketingTools: FunctionComponent = () => {
 						href="https://wp.me/logo-maker/?utm_campaign=marketing_tab"
 						target="_blank"
 					>
-						{ translate( 'Create a logo' ) }
+						{ translate( 'Make your brand' ) }
 					</Button>
 				</MarketingToolsFeature>
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -93,6 +93,17 @@ export const MarketingTools: FunctionComponent = () => {
 				</MarketingToolsFeature>
 
 				<MarketingToolsFeature
+					title={ translate( 'Monetize your site' ) }
+					description={ translate(
+						'Accept payments or donations with our native payment blocks, limit content to paid subscribers only, opt into our ad network to earn revenue, and refer friends to WordPress.com for credits.'
+					) }
+					imagePath={ earnIllustration }
+					imageAlt={ translate( 'A stack of coins' ) }
+				>
+					<Button onClick={ handleEarnClick }>{ translate( 'Start earning' ) }</Button>
+				</MarketingToolsFeature>
+
+				<MarketingToolsFeature
 					title={ translate( 'Fiverr logo maker' ) }
 					description={ translate(
 						'Create a standout brand with a custom logo. Our partner makes it easy and quick to design a professional logo that leaves a lasting impression.'
@@ -124,17 +135,6 @@ export const MarketingTools: FunctionComponent = () => {
 					>
 						{ translate( 'Talk to an SEO expert today' ) }
 					</Button>
-				</MarketingToolsFeature>
-
-				<MarketingToolsFeature
-					title={ translate( 'Monetize your site' ) }
-					description={ translate(
-						'Accept payments or donations with our native payment blocks, limit content to paid subscribers only, opt into our ad network to earn revenue, and refer friends to WordPress.com for credits.'
-					) }
-					imagePath={ earnIllustration }
-					imageAlt={ translate( 'A stack of coins' ) }
-				>
-					<Button onClick={ handleEarnClick }>{ translate( 'Start earning' ) }</Button>
 				</MarketingToolsFeature>
 
 				<MarketingToolsFeature

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -48,6 +48,10 @@ export const MarketingTools: FunctionComponent = () => {
 		recordTracksEvent( 'calypso_marketing_tools_create_a_logo_button_click' );
 	};
 
+	const handleHireAnSEOExpertClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_hire_an_seo_expert_button_click' );
+	};
+
 	const handleSimpleTextingClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_simpletexting_button_click' );
 	};
@@ -102,6 +106,23 @@ export const MarketingTools: FunctionComponent = () => {
 						target="_blank"
 					>
 						{ translate( 'Make your brand' ) }
+					</Button>
+				</MarketingToolsFeature>
+
+				<MarketingToolsFeature
+					title={ translate( 'Hire an SEO expert' ) }
+					description={ translate(
+						'In today’s digital age, visibility is key. Hire an SEO expert to boost your online presence and capture valuable opportunities.'
+					) }
+					imagePath={ fiverrLogo }
+					imageAlt={ translate( 'Fiverr logo' ) }
+				>
+					<Button
+						onClick={ handleHireAnSEOExpertClick }
+						href="https://wp.me/logo-maker/?utm_campaign=marketing_tab"
+						target="_blank"
+					>
+						{ translate( 'Talk to an SEO expert today' ) }
 					</Button>
 				</MarketingToolsFeature>
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -130,7 +130,7 @@ export const MarketingTools: FunctionComponent = () => {
 				>
 					<Button
 						onClick={ handleHireAnSEOExpertClick }
-						href="https://wp.me/logo-maker/?utm_campaign=marketing_tab"
+						href="https://wp.me/hire-seo-expert/?utm_source=marketing_tab"
 						target="_blank"
 					>
 						{ translate( 'Talk to an SEO expert today' ) }


### PR DESCRIPTION
![Screenshot](https://github.com/user-attachments/assets/490d80fc-b3e0-4bd9-a751-cbb16eb7d6e7)

## Why are these changes being made?

pfuQfP-pr-p2#comment-985

## Testing Instructions

* Visit `/marketing/tools/:site`
* Ensure the page matches the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?