### PR TITLE
A4A: fix user referral purchases

### DIFF
--- a/client/a8c-for-agencies/sections/client/client-landing.tsx
+++ b/client/a8c-for-agencies/sections/client/client-landing.tsx
@@ -10,13 +10,10 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import {
 	A4A_CLIENT_SUBSCRIPTIONS_LINK,
-	A4A_LANDING_LINK,
+	A4A_OVERVIEW_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useSelector } from 'calypso/state';
-import {
-	hasFetchedAgency,
-	isAgencyClientUser,
-} from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { hasAgency, hasFetchedAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 /**
  * Redirect with Current Query
@@ -32,24 +29,24 @@ export default function ClientLanding() {
 	const title = translate( 'Automattic for Agencies' );
 
 	const hasFetchedAgencies = useSelector( hasFetchedAgency );
-	const isClientUser = useSelector( isAgencyClientUser );
+	const isAgency = useSelector( hasAgency );
 
 	useEffect( () => {
 		if ( ! hasFetchedAgencies ) {
 			return;
 		}
 
-		if ( isClientUser ) {
-			const returnQuery = getQueryArg( window.location.href, 'return' ) as string;
-			if ( returnQuery ) {
-				page.redirect( returnQuery );
-				return;
-			}
-			return redirectWithCurrentQuery( A4A_CLIENT_SUBSCRIPTIONS_LINK );
+		if ( isAgency ) {
+			page.redirect( A4A_OVERVIEW_LINK );
+			return;
 		}
-
-		return page.redirect( A4A_LANDING_LINK );
-	}, [ hasFetchedAgencies, isClientUser ] );
+		const returnQuery = getQueryArg( window.location.href, 'return' ) as string;
+		if ( returnQuery ) {
+			page.redirect( returnQuery );
+			return;
+		}
+		return redirectWithCurrentQuery( A4A_CLIENT_SUBSCRIPTIONS_LINK );
+	}, [ hasFetchedAgencies, isAgency ] );
 
 	return (
 		<Layout className="a4a-landing" title={ title } wide>


### PR DESCRIPTION
Partially revert https://github.com/Automattic/wp-calypso/pull/93276 to allow user referral purchases

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1723236678080639-slack-C06JY8QL0TU

## Proposed Changes

I'm reverting partially commit, that affects client login. The problem is that we use `has_referrals` here D157644-code, but we can't find it, as the user at the moment of Referral is not created yet.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?