### PR TITLE
Hosting Overview: replace spacing css vars with sass vars

### DIFF
--- a/client/hosting/overview/components/style.scss
+++ b/client/hosting/overview/components/style.scss
@@ -1,5 +1,6 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/variables";
 
 $card-padding: 24px;
 $blueberry-color: #3858e9;
@@ -215,7 +216,7 @@ $blueberry-color: #3858e9;
 .hosting-overview__site-metrics-footer {
 	display: flex;
 	justify-content: space-between;
-	gap: var(--grid-unit-10, 8px);
+	gap: $grid-unit-10;
 	margin-top: 8px;
 }
 
@@ -233,17 +234,17 @@ $blueberry-color: #3858e9;
 	border-radius: 4px;
 	border: 1px solid var(--studio-gray-0);
 	background: var(--studio-gray-0);
-	padding: var(--grid-unit-20, 16px);
+	padding: $grid-unit-20;
 }
 
 .hosting-overview__plan-storage {
-	gap: var(--grid-unit-15, 12px);
+	gap: $grid-unit-15;
 }
 
 .hosting-overview__plan-bandwidth,
 .hosting-overview__plan-site-visits {
 	flex: 1;
-	gap: var(--grid-unit-10, 8px);
+	gap: $grid-unit-10;
 }
 
 .hosting-overview__plan-storage-title-wrapper,
@@ -251,7 +252,7 @@ $blueberry-color: #3858e9;
 .hosting-overview__plan-site-visits-title-wrapper {
 	display: flex;
 	justify-content: space-between;
-	gap: var(--grid-unit-10, 8px);
+	gap: $grid-unit-10;
 }
 
 .hosting-overview__plan-storage-title,
@@ -277,7 +278,7 @@ $blueberry-color: #3858e9;
 .hosting-overview__plan-bandwidth-placeholder,
 .hosting-overview__plan-site-visits-placeholder {
 	height: 1em;
-	max-width: calc(100% - var(--grid-unit-30, 24px));
+	max-width: calc(100% - $grid-unit-30);
 }
 
 @media (max-width: $break-xlarge) {
@@ -339,7 +340,7 @@ button.hosting-overview__action-button {
 
 .hosting-overview__action {
 	border-bottom: 1px solid var(--gutenberg-gray-100, #f0f0f0);
-	padding: var(--grid-unit-15, 12px) 0;
+	padding: $grid-unit-15 0;
 
 	svg {
 		color: var(--studio-gray-30);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/93032#discussion_r1709565371

## Proposed Changes

The `@wordpress/base-styles` package provides [a grid based spacing system](https://github.com/WordPress/gutenberg/blob/e0b54b3596b35e7df15bd674f7c9ead918f05b07/packages/base-styles/_variables.scss#L25-L40) that's used somewhat sporadically in Calypso. In the case of the Hosting Overview styles, there are a few instances of this system in the form of CSS vars with `px` fallbacks (eg: `var(--grid-unit-20, 16px)`. This PR imports the variables from `@wordpress/base-styles` and accesses them via sass variables instead.

## Why are these changes being made?

While I haven't found evidence (I'm still looking/asking around) of an organized effort to bring the core grid system to Calypso, it does appear to be gradually creeping in, and over time it would be nice to have standardized spacing in place. Most implementations (about a dozen different files spread across different areas of the codebase) of the system in Calypso are sass variables, which work great. The css vars in this file are an exception, as they variable itself doesn't actually work, and the fallback takes over. It's a good idea, because it puts the var in place in the event that we do take on a wider adoption of these variables in the future.

Another plus: actually importing the variables this way makes them easier to grok and track down. Previously we didn't even have an import statement to point in to more info on the variables appearing in the file.

Switching to sass vars brings this file more in line with other areas of Calypso, ensures the variable values are actually being respected, and cuts down on potential confusion. Currently whenever a change is made, the grid value (which isn't immediately intuitive unless you look into it a bit) and the `px` fallback  need to be kept in sync, which increases the risk of errors/regressions.

## Testing Instructions

- Visit the Calypso Live link for this branch
- Open /`overview` for any of your sites by clicking on the Hosting Overview button
- Append `?flags=hosting-overview-refinements` to the end of the url
- Confirm the layout and spacing of the site metrics (storage, bandwidth, site visits) matches trunk (don't forget your feature flag when checking trunk)