### PR TITLE
Remove translation fallback for video stats module

### DIFF
--- a/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-upsell-wpcom.tsx
@@ -1,5 +1,4 @@
-import { hasTranslation } from '@wordpress/i18n';
-import { translate, getLocaleSlug } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { preventWidows } from 'calypso/lib/formatting';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
@@ -17,8 +16,6 @@ import { Props } from '.';
 import './style.scss';
 
 const getUpsellCopy = ( statType: string ) => {
-	const defaultCopy = translate( 'Upgrade your plan to unlock Jetpack Stats.' );
-
 	switch ( statType ) {
 		case STAT_TYPE_REFERRERS:
 			return translate(
@@ -35,12 +32,9 @@ const getUpsellCopy = ( statType: string ) => {
 		case STATS_FEATURE_DATE_CONTROL:
 			return translate( 'Compare different time periods to analyze your site’s growth.' );
 		case STAT_TYPE_VIDEO_PLAYS:
-			return getLocaleSlug()?.startsWith( 'en' ) ||
-				hasTranslation( 'Discover your most popular videos and find out how they performed.' )
-				? translate( 'Discover your most popular videos and find out how they performed.' )
-				: defaultCopy;
+			return translate( 'Discover your most popular videos and find out how they performed.' );
 		default:
-			return defaultCopy;
+			return translate( 'Upgrade your plan to unlock Jetpack Stats.' );
 	}
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #92887

## Proposed Changes

Followup to https://github.com/Automattic/wp-calypso/pull/93237 to remove the translation fallback string.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The fallback string is no longer needed as the translations are now [complete](https://translate.wordpress.com/deliverables/overview/16460727).

## Testing Instructions

1. Visit `/me/account` and change the 'Interface Language' to something other than English
2. Visit `/stats/day/:site` and confirm that the translated text is displayed

Eg. after changing the locale to ES, the [translated text](https://translate.wordpress.com/deliverables/es/16460727/) should appear as:

<img width=400 src="https://github.com/user-attachments/assets/d0b915b9-41d2-486a-a3ed-0186de011d21" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
