### PR TITLE
Onboarding: Prioritize build over write intent

### DIFF
--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -24,6 +24,11 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 		return SiteIntent.Sell;
 	}
 
+	// Prioritize Build over Write
+	if ( goals.includes( SiteGoal.Promote ) ) {
+		return SiteIntent.Build;
+	}
+
 	const intentDecidingGoal = ( goals as IntentDecidingGoal[] ).find( ( goal ) =>
 		INTENT_DECIDING_GOALS.includes( goal )
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-feedback/issues/281

## Proposed Changes

* Prioritizes build over write intent

## Why are these changes being made?
* See https://github.com/Automattic/dotcom-feedback/issues/281

## Testing Instructions

* Start a new site
* On the goal selection step, choose both writing and promote myself options
* The next step should be pick a design, not set a site title


https://github.com/user-attachments/assets/a31e7826-c81e-4ab7-9112-dd95f001665f

