### PR TITLE
wpcom-block-editor: Replace automattic/nux store with automattic/wpcom-welcome-guide

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js
@@ -19,7 +19,7 @@ const ClassicGuide = () => {
 	};
 
 	// Make sure we don't end up with the standard wpcom nux showing as well.
-	const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
+	const { setWpcomNuxStatus } = useDispatch( 'automattic/wpcom-welcome-guide' );
 
 	// Check that wpcom nux store is available.
 	// See p9F6qB-5Ja-p2 for more information.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83654, p9F6qB-fSH-p2, p1723186454644719-slack-C02FMH4G8

## Proposed Changes

* Replace automattic/nux store with automattic/wpcom-welcome-guide

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The store has been renamed by https://github.com/Automattic/wp-calypso/pull/51055 for a long time so we were getting `null` when calling `useDispatch( 'automattic/nux' );`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create/Edit a page
* Append `&in-editor-deprecation-group` to your URL
* Make sure you can see the following error
  ```
  The "wpcom-classic-block-editor-nux" plugin has encountered an error and cannot be rendered.
  ```
* Apply changes to your sandbox and sandbox `widgets.wp.com`
* Refresh the page
* Make sure the error is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?