### PR TITLE
Stats: Date Control Update: Add Calendar feature flag

### DIFF
--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { Icon, lock } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -6,6 +7,7 @@ import DateInput from './stats-date-control-date-input';
 import { DateControlPickerDateProps } from './types';
 
 const BASE_CLASS_NAME = 'stats-date-control-picker-date';
+const isCalendarEnabled = config.isEnabled( 'stats/date-picker-calendar' );
 
 const DateControlPickerDate = ( {
 	startDate = '',
@@ -42,6 +44,7 @@ const DateControlPickerDate = ( {
 					<DateInput id="endDate" value={ endDate } onChange={ onEndChange } />
 				</div>
 			</div>
+			{ isCalendarEnabled && <div className={ `${ BASE_CLASS_NAME }s__calendar` }>Calendar</div> }
 			<div className={ `${ BASE_CLASS_NAME }s__buttons` }>
 				<Button onClick={ onCancel }>{ translate( 'Cancel' ) }</Button>
 				<Button variant="primary" onClick={ onApply }>

--- a/config/client.json
+++ b/config/client.json
@@ -25,6 +25,7 @@
 	"stats/empty-module-traffic",
 	"stats/empty-module-v2",
 	"stats/restricted-dashboard",
+	"stats/date-picker-calendar",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -218,6 +218,7 @@
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
+		"stats/date-picker-calendar": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -144,6 +144,7 @@
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
+		"stats/date-picker-calendar": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -189,6 +189,7 @@
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
+		"stats/date-picker-calendar": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -183,6 +183,7 @@
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
+		"stats/date-picker-calendar": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -122,6 +122,7 @@
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
 		"stats/restricted-dashboard": true,
+		"stats/date-picker-calendar": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -181,6 +181,7 @@
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/restricted-dashboard": true,
+		"stats/date-picker-calendar": false,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/119

## Proposed Changes

* Adds a new feature flag `stats/date-picker-calendar` for new datepicker calendar

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Start of new project to add a calendar to the stats datepicker

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch
* verify that the datepicker works as usual
* Apply the `stats/date-picker-calendar` feature flag
* check that this applies the new calendar section 

![image](https://github.com/user-attachments/assets/22f7ca46-b14b-4779-b85a-2918918261e1)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
