### PR TITLE
Masterbar Item: fix thank you page header in mobile

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
@@ -3,48 +3,50 @@
 	--color-masterbar-text: var(--studio-gray-60);
 	padding-right: 24px;
 	border-bottom: 0;
-}
 
-.checkout-thank-you__logo {
-	fill: rgb(54, 54, 54);
-	margin: 24px 12px 24px 24px;
-	@media (min-width: 480px) {
-		margin: 24px;
-	}
-}
-
-.checkout-thank-you__item-wrapper {
-	flex: 1;
-}
-
-.checkout-thank-you__item {
-	cursor: pointer;
-	font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
-	font-weight: 500;
-
-	&:hover {
-		background: var(--studio-white);
-
-		.masterbar__item-content {
-			color: var(--color-masterbar-text);
-			text-decoration: underline;
-		}
-
-		.gridicon {
-			fill: var(--studio-black);
+	.checkout-thank-you__logo {
+		fill: rgb(54, 54, 54);
+		margin: 24px 12px 24px 24px;
+		@media (min-width: 480px) {
+			margin: 24px;
 		}
 	}
-	.gridicon {
-		height: 17px;
-		fill: var(--studio-black);
-		@media (max-width: 480px) {
-			margin: 0;
-		}
-	}
-	@media (max-width: 480px) {
-		.gridicon + .masterbar__item-content {
-			display: block;
-			padding: 0 0 0 2px;
+
+	.checkout-thank-you__item-wrapper {
+		flex: 1;
+
+		.checkout-thank-you__item {
+			width: 100%;
+			justify-content: start;
+			cursor: pointer;
+			font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
+			font-weight: 500;
+
+			&:hover {
+				background: var(--studio-white);
+
+				.masterbar__item-content {
+					color: var(--color-masterbar-text);
+					text-decoration: underline;
+				}
+
+				.gridicon {
+					fill: var(--studio-black);
+				}
+			}
+			.gridicon {
+				height: 17px;
+				fill: var(--studio-black);
+				@media (max-width: 480px) {
+					margin: 0;
+				}
+			}
+			@media (max-width: 480px) {
+				.gridicon + .masterbar__item-content {
+					display: block;
+					padding: 0 0 0 2px;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #93028

## Proposed Changes

1. Adjust the order in the SCSS file to give higher priority
2. Add width and justification to the masterbar item.

## Why are these changes being made?

In mobile the `Back to dashboard` button was not aligned properly. This can be seen in many places. After purchasing something, after activating a theme, after activating a plugin, etc.

| Before | After |
| - | - |
| <img width="400" alt="Screen Shot 2024-08-12 at 10 20 56" src="https://github.com/user-attachments/assets/91d4ab84-083c-4ab9-a928-daa8e725ebc5"> | <img width="400" alt="Screen Shot 2024-08-12 at 10 20 36" src="https://github.com/user-attachments/assets/c2f2dac8-a675-4d69-9336-3d95531ca6f1"> |
| <img width="400" alt="Screen Shot 2024-08-12 at 10 21 55" src="https://github.com/user-attachments/assets/5add6542-13b5-49c4-9b13-de3e37725472"> | <img width="400" alt="Screen Shot 2024-08-12 at 10 21 43" src="https://github.com/user-attachments/assets/4aea3cc4-2619-4b67-a501-1bf358b63924"> |
| <img width="423" alt="Screen Shot 2024-08-12 at 10 39 25" src="https://github.com/user-attachments/assets/39ba9031-65c9-4757-b414-7b84b9a00349"> | <img width="420" alt="Screen Shot 2024-08-12 at 10 39 40" src="https://github.com/user-attachments/assets/e46a9a35-bd13-4450-8c31-49fb3b6dcaff"> |

## Testing Instructions

1. Using live link go to any site and activate a theme, activate a plugin, or make a purchase.
2. When you see the "thank you" page switch back and forth between mobile and desktop to make sure it looks correct.
3. Check against the current styling in production.