### PR TITLE
Fix the top value of Help Center on mobile

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -150,6 +150,7 @@ $z-index: 99999;
 			bottom: 0;
 			left: 0;
 			right: 0;
+			top: 0;
 			max-height: calc(100% - 45px);
 			height: 100%;
 

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -34,7 +34,7 @@ $z-index: 99999;
 			height: $head-foot-height;
 			padding: 16px 8px 16px 16px;
 
-			> div {
+			>div {
 				display: flex;
 				align-items: center;
 				justify-content: start;
@@ -150,9 +150,10 @@ $z-index: 99999;
 			bottom: 0;
 			left: 0;
 			right: 0;
-			top: 0;
+			// If the masterbar is there, don't cover it, if not, go to the top.
+			top: var(--masterbar-height, 0);
 			max-height: calc(100% - 45px);
-			height: 100%;
+			height: calc(100% - var(--masterbar-height, 0));
 
 			.help-center__container-content {
 				flex: auto;
@@ -314,7 +315,7 @@ $z-index: 99999;
 	.help-center__container-content {
 		padding: 0 !important;
 
-		>div > *:not(iframe):not(.help-center__container-content-odie) {
+		> div > *:not(iframe):not(.help-center__container-content-odie) {
 			padding: 16px;
 			box-sizing: border-box;
 		}


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/pull/93446#pullrequestreview-2232563773

### Testing steps

1. Open the Help Center in My Home mobile, it should sit right under the masterbar.
2. Make sure the the bottom of the Help Center sites at the bottom of the screen.
3. Open it in the Thank you screen /marketplace/thank-you/YOUR_SITE?themes=cottage, it should sit right under the masterbar.
4. Make sure the the bottom of the Help Center sites at the bottom of the screen.