### PR TITLE
Plans grid: fix disabled state for button when a selected site exists

### DIFF
--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -129,7 +129,7 @@ const PlanFeatures2023GridActions = ( {
 			planSlug={ planSlug }
 			onClick={ callback }
 			busy={ busy }
-			disabled={ status !== 'enabled' }
+			disabled={ ! callback || 'disabled' === status }
 			classes={ variant === 'secondary' ? 'is-secondary' : '' }
 		>
 			{ text }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1723458571150739-slack-C02FMH4G8

## Proposed Changes

* When there is a "selected site" (returned by this [selector](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/ui/selectors/get-selected-site.ts)), the [`useCheckPlanAvailabilityForPurchase`](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase.ts) hook returns false for plans that are the same as or lower than the current plan. However, this value is ignored when we are in a signup flow context. 
* Due to the way in which the conditions [here](https://github.com/Automattic/wp-calypso/blob/trunk/packages/plans-grid-next/src/components/actions.tsx#L148) are structured, the `<PlanButton />` component used the value passed [here](https://github.com/Automattic/wp-calypso/blob/a5a6b0f04e5565a1fbb0d093e46a1366f3a514c2/packages/plans-grid-next/src/components/actions.tsx#L132) instead of [this one](https://github.com/Automattic/wp-calypso/blob/a5a6b0f04e5565a1fbb0d093e46a1366f3a514c2/packages/plans-grid-next/src/components/actions.tsx#L183), causing the button to be disabled when the `status` value is `undefined`.
* This PR fixes the issue by inverting the condition so that the button will be disabled only when the `status` value is explicitly returned as `disabled` as originally intended.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/home/<site slug>`. (This ensures that the [selector](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/ui/selectors/get-selected-site.ts) returns a value).
* Go to `/setup/newsletter` and proceed to the plans step.
* Confirm that the "Start with Free" button is not disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?