### PR TITLE
Performance Profiler: Create header area for loading screen & result page

### DIFF
--- a/client/performance-profiler/components/header.scss
+++ b/client/performance-profiler/components/header.scss
@@ -1,0 +1,105 @@
+.profiler-header {
+	.profiler-header__heading {
+		width: fit-content;
+		display: flex;
+		padding: 6px 14px;
+		align-items: flex-start;
+		gap: 16px;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 28px;
+		border: 2px solid transparent;
+		background: linear-gradient(#101517, #000) padding-box, linear-gradient(to right, #4458e4, #069e08) border-box;
+	}
+
+	.profiler-header__site-url {
+		display: flex;
+		flex-direction: row;
+		align-content: flex-end;
+
+		h2 {
+			font-size: 2.25rem;
+			font-weight: 500;
+		}
+
+		p {
+			color: #ddd;
+			align-self: flex-end;
+			margin-bottom: 7px;
+			margin-left: 7px;
+		}
+	}
+
+	.profiler-header__action {
+		a {
+			color: #fff;
+			font-size: 1rem;
+			padding: 0;
+			border-bottom: 1px solid #fff;
+			border-radius: 0;
+		}
+
+		a:hover {
+			color: #ddd;
+			border-color: #ddd;
+		}
+	}
+
+	.section-nav {
+		background: none;
+		box-shadow: none;
+		margin: 20px 0 0 0;
+
+		.section-nav-tab {
+			border: 0;
+			margin-right: 10px;
+			position: relative;
+
+			.section-nav-tab__link {
+				color: #fff;
+				font-size: 1rem;
+				padding: 15px 25px 12px;
+				border-radius: 4px 4px 0 0;
+
+				svg {
+					fill: #fff;
+					margin-right: 5px;
+				}
+
+				&:hover {
+					color: #000;
+					background: #fff;
+
+					svg {
+						fill: #000;
+					}
+				}
+
+				.section-nav-tab__text {
+					display: flex;
+					align-items: center;
+				}
+			}
+
+			&.is-selected .section-nav-tab__link {
+				color: #000;
+				background: #fff;
+
+				svg {
+					fill: #000;
+				}
+
+				&:hover {
+					color: #000;
+					fill: #000;
+				}
+			}
+		}
+
+		.profiler-header__navbar-right {
+			p {
+				margin-bottom: 0;
+				font-size: 1rem;
+			}
+		}
+	}
+}

--- a/client/performance-profiler/components/header.tsx
+++ b/client/performance-profiler/components/header.tsx
@@ -1,0 +1,59 @@
+import { Button } from '@wordpress/components';
+import { Icon, mobile, desktop } from '@wordpress/icons';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+
+import './header.scss';
+
+type HeaderProps = {
+	url: string;
+	active: string;
+	onTabChange: ( tab: string ) => void;
+};
+
+const PerformanceProfilerHeader = ( props: HeaderProps ) => {
+	const { url, active, onTabChange } = props;
+	const parts = new URL( url );
+	const displayPath = ( pathname: string ) => {
+		if ( pathname && pathname !== '/' && ! pathname.endsWith( '/' ) ) {
+			return <p>{ pathname }</p>;
+		}
+	};
+
+	return (
+		<div className="profiler-header l-block-wrapper">
+			<div className="profiler-header__heading">
+				<h1>WordPress Speed Test</h1>
+			</div>
+
+			<div className="profiler-header__site-url">
+				<h2>{ parts.hostname ?? '' }</h2>
+				{ displayPath( parts.pathname ) }
+			</div>
+
+			<div className="profiler-header__action">
+				<Button href="/speed-test">Test another site</Button>
+			</div>
+
+			<SectionNav>
+				<NavTabs>
+					<NavItem onClick={ () => onTabChange( 'mobile' ) } selected={ active === 'mobile' }>
+						<Icon icon={ mobile } />
+						Mobile
+					</NavItem>
+					<NavItem onClick={ () => onTabChange( 'desktop' ) } selected={ active === 'desktop' }>
+						<Icon icon={ desktop } />
+						Desktop
+					</NavItem>
+				</NavTabs>
+
+				<div className="profiler-header__navbar-right">
+					<p>Tested on July 16th, 2024 at 12:03:23 AM</p>
+				</div>
+			</SectionNav>
+		</div>
+	);
+};
+
+export default PerformanceProfilerHeader;

--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -18,7 +18,10 @@ export function PerformanceProfilerDashboardContext( context: Context, next: () 
 	context.primary = (
 		<>
 			<Main fullWidthLayout>
-				<PerformanceProfilerDashboard url={ context.query?.url ?? '' } />
+				<PerformanceProfilerDashboard
+					url={ context.query?.url ?? '' }
+					tab={ context.query?.tab ?? '' }
+				/>
 			</Main>
 
 			<UniversalNavbarFooter isLoggedIn={ isLoggedIn } />

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -2,21 +2,37 @@ import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import './style.scss';
 import DocumentHead from 'calypso/components/data/document-head';
+import PerformanceProfilerHeader from 'calypso/performance-profiler/components/header';
 
 type PerformanceProfilerDashboardProps = {
 	url: string;
+	tab: string;
 };
 
 export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboardProps ) => {
 	const translate = useTranslate();
-	const { url } = props;
+	const { url, tab } = props;
+	const [ activeTab, setActiveTab ] = React.useState( tab );
+
+	const getOnTabChange = ( tab: string ) => {
+		window.history.pushState( {}, '', `?url=${ url }&tab=${ tab }` );
+		setActiveTab( tab );
+	};
 
 	return (
 		<div className="container">
 			<DocumentHead title={ translate( 'Speed Test' ) } />
 
-			<div className="top-section"> Top section - { url } </div>
-			<div className="dahsboard-content">Dashboard content</div>
+			<div className="top-section">
+				<PerformanceProfilerHeader
+					url={ url }
+					active={ activeTab }
+					onTabChange={ getOnTabChange }
+				/>
+			</div>
+			<div className="dashboard-content">
+				<div className="l-block-wrapper">Dashboard content { activeTab }</div>
+			</div>
 		</div>
 	);
 };

--- a/client/performance-profiler/pages/dashboard/style.scss
+++ b/client/performance-profiler/pages/dashboard/style.scss
@@ -4,11 +4,15 @@
 
 .top-section {
 	color: #fff;
-	min-height: 200px;
 	padding-top: 40px;
 	background: linear-gradient(180deg, var(--studio-gray-100) 25.44%, rgba(16, 21, 23, 0) 100%), url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iOCIgY3k9IjgiIHI9IjEiIGZpbGw9IndoaXRlIiBmaWxsLW9wYWNpdHk9IjAuMjUiLz4KPC9zdmc+Cg==) repeat, var(--studio-gray-100);
 }
 
-.dahsboard-content {
+.l-block-wrapper {
+	margin: 0 auto;
+	max-width: 1056px;
+}
+
+.dashboard-content {
 	min-height: 600px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8660

## Proposed Changes

* Adds header section template for performance profiler
* Handled active tab event and saved the state into the URL

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/speed-test-tool?url=http://mattwest.design/&tab=mobile` and ensure the header renders as per designs (p9Jlb4-dpx-p2).

![CleanShot 2024-08-12 at 17 09 45@2x](https://github.com/user-attachments/assets/a0136e8d-3124-45f4-a82d-721bf5990bd4)
- And Visit `/speed-test-tool?url=http://mattwest.design/example/directory/about&&tab=mobile` to check long URL. 

![CleanShot 2024-08-12 at 17 14 09@2x](https://github.com/user-attachments/assets/71c7a99c-a032-4861-93ac-d15fb9f1de14)

- Navigate to the mobile and desktop tab and ensure that the URL is updated with the respective tab. 
- The tabs should stay open even if you reload /refresh the page. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?