### PR TITLE
Add track page view to the calypso importer page

### DIFF
--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -3,6 +3,7 @@ import { get } from 'lodash';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'calypso/my-sites/controller';
 import { importSite, importerList, importSubstackSite } from 'calypso/my-sites/importer/controller';
+import addTracker from './tracker';
 
 export default function () {
 	page( '/import', siteSelection, navigation, sites, makeLayout, clientRender );
@@ -13,6 +14,7 @@ export default function () {
 		navigation,
 		redirectWithoutSite( '/import' ),
 		importSite,
+		addTracker,
 		makeLayout,
 		clientRender
 	);
@@ -33,6 +35,7 @@ export default function () {
 		navigation,
 		redirectWithoutSite( '/import' ),
 		importerList,
+		addTracker,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/importer/tracker.tsx
+++ b/client/my-sites/importer/tracker.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from 'react';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+interface Context {
+	siteSlug: string;
+	query: {
+		engine: string;
+	};
+	primary: ReactNode;
+}
+
+type NextFunction = () => void;
+
+/**
+ * Middleware to add a page view tracker to the site importer page.
+ * @param {Context} context Context object.
+ */
+const addTracker = ( context: Context, next: NextFunction ) => {
+	const title = [ 'Site Importer', context.siteSlug, context.query.engine ?? null ]
+		.filter( Boolean )
+		.join( ' > ' );
+
+	context.primary = (
+		<>
+			<PageViewTracker
+				path="/import/:siteSlug"
+				title={ title }
+				properties={ { engine: context.query.engine } }
+			/>
+			{ context.primary }
+		</>
+	);
+
+	next();
+};
+
+export default addTracker;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #93225

## Proposed Changes
* Add middleware to track the importer page viewer
* Track engine

## Why are these changes being made?
Nowadays, we track [multiple events](https://github.com/Automattic/wp-calypso/blob/9fec6bccfe92f7fe5123fdb4268dbf9de66dba3b/client/my-sites/importer/section-import.jsx#L144-L153) from this page, but the page_view event was not tracked. It is a standard event if we are using it to build our funnels.


> [!NOTE]  
> There is no `calypso_page_view` when the UI changes from the import list to the import file view. There are specialized events covering it.

## Testing Instructions
* Create a simple site 
* Go to  /import/[YOUR_SITE_SLUG]
* Check if a calypso_page_view was triggered without the `engine` attribute
* Go to  /import/[YOUR_SITE_SLUG]/?engine=blogger (You need to type directly in your browser navigation bar).
* Check if the same event was triggered and attribute `engine: blogger` is available.

<img width="511" alt="image" src="https://github.com/user-attachments/assets/bd476ddc-c49a-4200-8037-7ccfdabd2cfe">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
