### PR TITLE
Reader: Fix the comment button in the Reader full post page

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -96,6 +96,7 @@ export class FullPostView extends Component {
 	};
 
 	hasScrolledToCommentAnchor = false;
+	readerMainWrapper = createRef();
 	commentsWrapper = createRef();
 	postContentWrapper = createRef();
 
@@ -301,6 +302,7 @@ export class FullPostView extends Component {
 			if ( commentsNode && commentsNode.offsetTop ) {
 				scrollTo( {
 					x: 0,
+					container: this.readerMainWrapper.current,
 					y: commentsNode.offsetTop - 48,
 					duration: 300,
 					onComplete: () => {
@@ -495,7 +497,7 @@ export class FullPostView extends Component {
 		return (
 			// add extra div wrapper for consistent content frame layout/styling for reader.
 			<div>
-				<ReaderMain className={ clsx( classes ) }>
+				<ReaderMain className={ clsx( classes ) } forwardRef={ this.readerMainWrapper }>
 					{ site && <QueryPostLikes siteId={ post.site_ID } postId={ post.ID } /> }
 					{ ! post || post._state === 'pending' ? (
 						<DocumentHead title={ translate( 'Loading' ) } />

--- a/client/reader/components/reader-main/index.jsx
+++ b/client/reader/components/reader-main/index.jsx
@@ -42,9 +42,9 @@ export default class ReaderMain extends Component {
 	}
 
 	render() {
-		const { children, ...props } = this.props;
+		const { children, forwardRef, ...props } = this.props;
 		return (
-			<div>
+			<div ref={ forwardRef }>
 				<Main { ...props }>
 					<SyncReaderFollows key="syncReaderFollows" />
 					{ children }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93415

## Proposed Changes

* Fix the comment button scrolling in the Reader full post page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug Fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link and go to `/discover`
* Click on a random post
* Click on the comment icon
* The window should scroll to the comment section
![Screenshot 2024-08-12 at 16 00 10](https://github.com/user-attachments/assets/bd978a47-19b0-4da1-8568-5e86864ee87c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
