### PR TITLE
A4A: Update Pressable purchase flow success message.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/hooks/use-issue-and-assign-licenses.tsx
@@ -37,6 +37,21 @@ const useGetLicenseIssuedMessage = () => {
 			if ( licenses.length === 1 ) {
 				const productName =
 					products?.data?.find?.( ( p ) => p.slug === licenses[ 0 ].slug )?.name ?? '';
+
+				if ( licenses[ 0 ].slug.startsWith( 'pressable-wp' ) ) {
+					return translate(
+						'Thanks for your purchase! Below you can view and manage your new {{strong}}%(productName)s{{/strong}}',
+						{
+							args: {
+								productName,
+							},
+							components: {
+								strong: <strong />,
+							},
+						}
+					);
+				}
+
 				return translate(
 					'Thanks for your purchase! Below you can view and assign your new {{strong}}%(productName)s{{/strong}} license to a website.',
 					'Thanks for your purchase! Below you can view and assign your new {{strong}}%(productName)s{{/strong}} licenses to a website.',

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useEffect } from 'react';
 import { isPressableHostingProduct } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
@@ -102,7 +103,7 @@ export default function LicenseDetailsActions( {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					{ translate( 'Manage in Pressable' ) }
+					{ translate( 'Manage in Pressable' ) } <Icon icon={ external } size={ 18 } />
 				</Button>
 			) }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Badge, Button, Gridicon } from '@automattic/components';
+import { Icon, external } from '@wordpress/icons';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -199,6 +200,7 @@ export default function LicensePreview( {
 									href={ pressableManageUrl }
 								>
 									{ translate( 'Manage in Pressable' ) }
+									<Icon className="gridicon" icon={ external } size={ 18 } />
 								</a>
 							) }
 							{ ! domain && licenseState === LicenseState.Detached && (

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -38,7 +38,22 @@
 }
 
 .license-preview__product-pressable-link {
-	text-decoration: underline;
+
+	&,
+	&:visited {
+		@include a4a-font-body-md($font-weight: 500);
+		display: flex;
+		flex-direction: row;
+		gap: 4px;
+		align-items: center;
+		text-decoration: underline;
+		color: var(--color-text);
+	}
+
+	.gridicon {
+		fill: var(--color-text);
+
+	}
 }
 
 .license-preview__domain {


### PR DESCRIPTION
This PR corrects the wording of the Pressable purchase flow success message for better accuracy.

| Before | After |
|--------|--------|
| <img width="820" alt="Screenshot 2024-08-12 at 9 13 05 PM" src="https://github.com/user-attachments/assets/553836ab-f600-4263-b595-ffbb4c649691"> | <img width="711" alt="Screenshot 2024-08-12 at 8 54 11 PM" src="https://github.com/user-attachments/assets/f554cf1f-60c3-4d36-9477-28a2ba81a406"> | 

Additionally, this PR fixes the 'Manage in Pressable' CTA button to match the standard styling for external links in Licenses table.

| Before | After |
|--------|--------|
| <img width="166" alt="Screenshot 2024-08-12 at 9 13 26 PM" src="https://github.com/user-attachments/assets/77bdce22-d1ea-4880-9f13-1af566ac6b0e"> | <img width="195" alt="Screenshot 2024-08-12 at 9 14 40 PM" src="https://github.com/user-attachments/assets/d559057b-6be6-4a90-a94d-d0d413a146b9"> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/886

## Proposed Changes

* Add special condition for the Pressable plan purchase message.
* Update 'Managed in Pressable' CTA button styling to match the standard external link design.

## Why are these changes being made?

*

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting/pressable` page.
* Purchase a Pressable plan.
* Confirm that you can see the correct success message.
* Please also test other Purchase flows and confirm there is no regression with the success messages.
* Additionally, confirm that the external links for 'Manage in Pressable' CTA button matches the standard design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
