### PR TITLE
Hosting Overview Refinements: Display WP and PHP version numbers only for Simple sites

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -125,31 +125,27 @@ export default function ItemPreviewPaneHeader( {
 									{ wpVersion && (
 										<div className="item-preview__header-env-data-item">
 											WordPress{ ' ' }
-											<Button
+											<a
 												className="item-preview__header-env-data-item-link"
 												href={ `/hosting-config/${ selectedSite?.domain }#wp` }
 												onClick={ handleWpVersionClick }
 											>
 												{ wpVersion }
-												{ wpVersionName && isStagingSite && (
-													<span className="item-preview__header-env-data-item-description">
-														({ wpVersionName })
-													</span>
-												) }
-											</Button>
+												{ wpVersionName && isStagingSite && <span> ({ wpVersionName })</span> }
+											</a>
 										</div>
 									) }
 
 									{ phpVersion && (
 										<div className="item-preview__header-env-data-item">
 											PHP{ ' ' }
-											<Button
+											<a
 												className="item-preview__header-env-data-item-link"
 												onClick={ handlePhpVersionClick }
 												href={ `/hosting-config/${ selectedSite?.domain }#php` }
 											>
 												{ phpVersion }
-											</Button>
+											</a>
 										</div>
 									) }
 								</div>

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -61,6 +61,9 @@ export default function ItemPreviewPaneHeader( {
 	const siteIconFallback =
 		extraProps?.siteIconFallback ?? ( itemData.isDotcomSite ? 'wordpress-logo' : 'color' );
 
+	const shouldDisplayVersionNumbers =
+		config.isEnabled( 'hosting-overview-refinements' ) && isAtomic && ( wpVersion || phpVersion );
+
 	const handlePhpVersionClick = () => {
 		dispatch( recordTracksEvent( 'calypso_hosting_configuration_php_version_update' ) );
 	};
@@ -116,45 +119,43 @@ export default function ItemPreviewPaneHeader( {
 									''
 								) }
 							</div>
-							{ config.isEnabled( 'hosting-overview-refinements' ) &&
-								( wpVersion || phpVersion ) && (
-									<div className="item-preview__header-env-data">
-										{ wpVersion && (
-											<div className="item-preview__header-env-data-item">
-												WordPress{ ' ' }
-												{ isAtomic ? (
-													<Button
-														className="item-preview__header-env-data-item-link"
-														href={ `/hosting-config/${ selectedSite?.domain }#wp` }
-														onClick={ handleWpVersionClick }
-													>
-														{ wpVersion }
-														{ wpVersionName && isStagingSite && (
-															<span className="item-preview__header-env-data-item-link-description">
-																({ wpVersionName })
-															</span>
-														) }
-													</Button>
-												) : (
-													wpVersion
+
+							{ shouldDisplayVersionNumbers && (
+								<div className="item-preview__header-env-data">
+									{ wpVersion && (
+										<div className="item-preview__header-env-data-item">
+											WordPress{ ' ' }
+											<Button
+												className="item-preview__header-env-data-item-link"
+												href={ `/hosting-config/${ selectedSite?.domain }#wp` }
+												onClick={ handleWpVersionClick }
+											>
+												{ wpVersion }
+												{ wpVersionName && isStagingSite && (
+													<span className="item-preview__header-env-data-item-description">
+														({ wpVersionName })
+													</span>
 												) }
-											</div>
-										) }
-										{ phpVersion && (
-											<div className="item-preview__header-env-data-item">
-												PHP{ ' ' }
-												<Button
-													className="item-preview__header-env-data-item-link"
-													onClick={ handlePhpVersionClick }
-													href={ `/hosting-config/${ selectedSite?.domain }#php` }
-												>
-													{ phpVersion }
-												</Button>
-											</div>
-										) }
-									</div>
-								) }
+											</Button>
+										</div>
+									) }
+
+									{ phpVersion && (
+										<div className="item-preview__header-env-data-item">
+											PHP{ ' ' }
+											<Button
+												className="item-preview__header-env-data-item-link"
+												onClick={ handlePhpVersionClick }
+												href={ `/hosting-config/${ selectedSite?.domain }#php` }
+											>
+												{ phpVersion }
+											</Button>
+										</div>
+									) }
+								</div>
+							) }
 						</div>
+
 						{ isPreviewLoaded && (
 							<div className="item-preview__header-actions">
 								{ extraProps?.headerButtons ? (

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -34,10 +34,7 @@ $blueberry-color: #3858e9;
 					font-size: inherit;
 					padding: 0;
 					height: auto;
-					.item-preview__header-env-data-item-description {
-						text-transform: capitalize;
-						padding-left: 2px;
-					}
+					text-transform: capitalize;
 				}
 			}
 		}

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/style.scss
@@ -34,7 +34,7 @@ $blueberry-color: #3858e9;
 					font-size: inherit;
 					padding: 0;
 					height: auto;
-					.item-preview__header-env-data-item-link-description {
+					.item-preview__header-env-data-item-description {
 						text-transform: capitalize;
 						padding-left: 2px;
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Follow-up to #93223 and #93419.

This PR makes it so that the WP and PHP version numbers on the Hosting Overview page display only for Atomic sites. Since users can't install plugins or themes on Simple sites, the WP version should be less of a concern – especially in the hosting dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/sites?flags=hosting-overview-refinements`
2. Click on an Atomic site
3. Ensure that the WP and PHP version numbers display in the header
4. Click on a staging site
5. Ensure that the WP and PHP version numbers display in the header
6. Click on a simple site
7. Ensure that the WP and PHP version numbers **do not** display in the header