### PR TITLE
Performance Profiler: loading screen.

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -145,6 +145,14 @@ export interface UrlPerformanceMetricsQueryResponse {
 	};
 }
 
+export interface UrlPerformanceInsightsQueryResponse {
+	pagespeed: {
+		status: string;
+		mobile: PerformanceReport;
+		desktop: PerformanceReport;
+	};
+}
+
 export interface PerformanceMetricsDataQueryResponse {
 	diagnostic: Record< string, PerformanceMetricsItemQueryResponse >;
 	pass: Record< string, PerformanceMetricsItemQueryResponse >;

--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -148,8 +148,8 @@ export interface UrlPerformanceMetricsQueryResponse {
 export interface UrlPerformanceInsightsQueryResponse {
 	pagespeed: {
 		status: string;
-		mobile: PerformanceReport;
-		desktop: PerformanceReport;
+		mobile: PerformanceReport | string;
+		desktop: PerformanceReport | string;
 	};
 }
 

--- a/client/data/site-profiler/use-url-performance-insights.ts
+++ b/client/data/site-profiler/use-url-performance-insights.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { UrlPerformanceInsightsQueryResponse } from './types';
+
+function mapResult( response: UrlPerformanceInsightsQueryResponse ) {
+	return response.pagespeed;
+}
+
+export const useUrlPerformanceInsightsQuery = ( url?: string, hash?: string ) => {
+	return useQuery( {
+		queryKey: [ 'url', 'performance', url, hash ],
+		queryFn: () =>
+			wp.req.get(
+				{
+					path: '/site-profiler/metrics/advanced/insights',
+					apiNamespace: 'wpcom/v2',
+				},
+				{ url, hash }
+			),
+		meta: {
+			persist: false,
+		},
+		select: mapResult,
+		enabled: !! url && !! hash,
+		retry: false,
+		refetchOnWindowFocus: false,
+		refetchInterval: ( query ) =>
+			query.state.data?.pagespeed?.status === 'completed' ? false : 5000, // 5 second	;
+	} );
+};

--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -26,6 +26,7 @@ export function PerformanceProfilerDashboardContext( context: Context, next: () 
 							? context.query?.tab
 							: TabType.mobile
 					}
+					hash={ context.query?.hash ?? '' }
 				/>
 			</Main>
 

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -16,12 +16,13 @@ type PerformanceProfilerDashboardProps = {
 
 export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboardProps ) => {
 	const translate = useTranslate();
-	const { url, tab } = props;
+	const { url, tab, hash } = props;
 	const [ activeTab, setActiveTab ] = React.useState< TabType >( tab );
-	const { data: basicMetrics } = useUrlBasicMetricsQuery( url );
+	const { data: basicMetrics } = useUrlBasicMetricsQuery( url, hash, true );
 	const { final_url: finalUrl, token } = basicMetrics || {};
 	const { data: performanceInsights } = useUrlPerformanceInsightsQuery( finalUrl, token );
-	const isLoading = !! performanceInsights;
+	const desktopLoaded = 'completed' === performanceInsights?.status;
+	const mobileLoaded = typeof performanceInsights?.mobile === 'object';
 
 	const getOnTabChange = ( tab: TabType ) => {
 		const queryParams = new URLSearchParams( window.location.search );
@@ -33,14 +34,21 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 	return (
 		<div className="container">
 			<DocumentHead title={ translate( 'Speed Test' ) } />
+
 			<PerformanceProfilerHeader
 				url={ url }
 				activeTab={ activeTab }
 				onTabChange={ getOnTabChange }
 				showNavigationTabs
 			/>
-			{ isLoading && <LoadingScreen isSavedReport={ false } /> }
-			{ ! isLoading && <PerformanceProfilerDashboardContent activeTab={ activeTab } /> }
+			{ 'mobile' === activeTab && ! mobileLoaded && <LoadingScreen isSavedReport={ false } /> }
+			{ 'mobile' === activeTab && mobileLoaded && (
+				<PerformanceProfilerDashboardContent activeTab={ activeTab } />
+			) }
+			{ 'desktop' === activeTab && ! desktopLoaded && <LoadingScreen isSavedReport={ false } /> }
+			{ 'desktop' === activeTab && desktopLoaded && (
+				<PerformanceProfilerDashboardContent activeTab={ activeTab } />
+			) }
 		</div>
 	);
 };

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -2,39 +2,45 @@ import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import './style.scss';
 import DocumentHead from 'calypso/components/data/document-head';
+import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
+import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
 import { PerformanceProfilerDashboardContent } from 'calypso/performance-profiler/components/dashboard-content';
 import { PerformanceProfilerHeader, TabType } from 'calypso/performance-profiler/components/header';
+import { LoadingScreen } from '../loading-screen';
 
 type PerformanceProfilerDashboardProps = {
 	url: string;
 	tab: TabType;
+	hash: string;
 };
 
 export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboardProps ) => {
 	const translate = useTranslate();
 	const { url, tab } = props;
 	const [ activeTab, setActiveTab ] = React.useState< TabType >( tab );
+	const { data: basicMetrics } = useUrlBasicMetricsQuery( url );
+	const { final_url: finalUrl, token } = basicMetrics || {};
+	const { data: performanceInsights } = useUrlPerformanceInsightsQuery( finalUrl, token );
+	const isLoading = !! performanceInsights;
 
 	const getOnTabChange = ( tab: TabType ) => {
 		const queryParams = new URLSearchParams( window.location.search );
 		queryParams.set( 'tab', tab );
 		window.history.pushState( null, '', `?${ queryParams.toString() }` );
-
 		setActiveTab( tab );
 	};
 
 	return (
 		<div className="container">
 			<DocumentHead title={ translate( 'Speed Test' ) } />
-
 			<PerformanceProfilerHeader
 				url={ url }
 				activeTab={ activeTab }
 				onTabChange={ getOnTabChange }
 				showNavigationTabs
 			/>
-
-			<PerformanceProfilerDashboardContent activeTab={ activeTab } />
+			{ isLoading && <LoadingScreen isSavedReport={ false } /> }
+			{ ! isLoading && <PerformanceProfilerDashboardContent activeTab={ activeTab } /> }
 		</div>
 	);
 };

--- a/client/performance-profiler/pages/loading-screen/index.tsx
+++ b/client/performance-profiler/pages/loading-screen/index.tsx
@@ -1,0 +1,58 @@
+import { ProgressBar } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { LayoutBlock } from 'calypso/site-profiler/components/layout';
+
+interface LoadingScreenProps {
+	isSavedReport: boolean;
+}
+
+const Progress = styled( ProgressBar )`
+	div {
+		background: linear-gradient( 90deg, #3858e9 0%, #349f4b 100% );
+	}
+`;
+
+const StyledLoadingScreen = styled.div`
+	padding: 100px 40px;
+
+	h2 {
+		text-align: center;
+	}
+`;
+
+export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
+	const translate = useTranslate();
+
+	const progressHeadings = isSavedReport
+		? [ translate( 'Getting your report…' ) ]
+		: [
+				translate( "Crunching your site's numbers…" ),
+				translate( 'Analyzing speed metrics…' ),
+				translate( 'Comparing with top sites…' ),
+				translate( 'Finalizing your report…' ),
+		  ];
+
+	const [ progress, setProgress ] = useState( 0 );
+	const [ tick, setTick ] = useState( 0 );
+
+	useEffect( () => {
+		const timeoutId = setTimeout( () => {
+			const newProgress = 100 * ( 1 - Math.pow( 1.07, -tick ) );
+			setProgress( newProgress );
+			setTick( tick + 1 );
+		}, 1000 );
+
+		return () => clearTimeout( timeoutId );
+	}, [ progress, tick ] );
+
+	return (
+		<LayoutBlock className="landing-page-header-block" width="medium">
+			<StyledLoadingScreen>
+				<h2>{ progressHeadings[ Math.floor( ( progress / 101 ) * progressHeadings.length ) ] }</h2>
+				<Progress value={ progress } total={ 100 } />
+			</StyledLoadingScreen>
+		</LayoutBlock>
+	);
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes [8558](https://github.com/Automattic/dotcom-forge/issues/8558)

## Proposed Changes

* Adds a component to fetch the basic metrics. This component adds the submission in wpcom and return the CruX data and a token to be used for the performance check.
* Adds a component to fetch the performance data.
* Adds a loading screen, mobile and desktop have their distinct loading screens. Meaning we can show mobile results which are returned first while desktop still runs.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/speed-test-tool?url=https%3A%2F%2Fwww.quintoandar.com.br%2F&tab=mobile`
* Check that loading screen appears
* After 20-30 secs the dashboard content should be revealed
* Check that the same happens for desktop

![CleanShot 2024-08-13 at 18 09 47](https://github.com/user-attachments/assets/96ff3232-0830-4e47-8eab-7900ed056adb)


Items to follow up:
- Update the loading screen to the latest figma designs
- Avoid unmounting and remounting the component cause it causes the loader ( and only the loader ) to restart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
