### PR TITLE
Sites: Fix new URL console error when scrolling sites dashboard

### DIFF
--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -26,7 +26,9 @@ export const getSite: ( state: State, siteId: number | string ) => SiteDetails |
 		// Try matching numeric site ID
 		state.sites[ siteId ] ||
 		// Then try matching primary domain
-		Object.values( state.sites ).find( ( site ) => site?.URL && new URL( site.URL ).host === siteId ) ||
+		Object.values( state.sites ).find(
+			( site ) => site?.URL && new URL( site.URL ).host === siteId
+		) ||
 		// Then try matching second domain
 		Object.values( state.sites ).find(
 			( site ) =>

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -26,7 +26,13 @@ export const getSite: ( state: State, siteId: number | string ) => SiteDetails |
 		// Try matching numeric site ID
 		state.sites[ siteId ] ||
 		// Then try matching primary domain
-		Object.values( state.sites ).find( ( site ) => site && new URL( site.URL ).host === siteId ) ||
+		Object.values( state.sites ).find( ( site ) => {
+			try {
+				site && new URL( site.URL ).host === siteId;
+			} catch ( error ) {
+				return false;
+			}
+		} ) ||
 		// Then try matching second domain
 		Object.values( state.sites ).find(
 			( site ) =>

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -26,13 +26,7 @@ export const getSite: ( state: State, siteId: number | string ) => SiteDetails |
 		// Try matching numeric site ID
 		state.sites[ siteId ] ||
 		// Then try matching primary domain
-		Object.values( state.sites ).find( ( site ) => {
-			try {
-				site && new URL( site.URL ).host === siteId;
-			} catch ( error ) {
-				return false;
-			}
-		} ) ||
+		Object.values( state.sites ).find( ( site ) => site?.URL && new URL( site.URL ).host === siteId ) ||
 		// Then try matching second domain
 		Object.values( state.sites ).find(
 			( site ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1721916065615249/1721849099.444909-slack-C06ELHR6L9J

## Proposed Changes

* Fix console error when scrolling sites dashboard (`/sites`)

<img width="470" alt="CleanShot 2024-08-12 at 14 20 13@2x" src="https://github.com/user-attachments/assets/83dcb2cf-d0f8-4627-85b0-a2b21f0c7a7d">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Sites that don't have a `URL` (deleted sites) will throw an exception when using the `URL` constructor, which then leads to a blank page 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Delete a site on your account
* Navigate to `/sites` and scroll until you see your deleted site (will have a blank state, no title, icon, etc)
* Verify the page doesn't throw an exception and show a blank screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?