### PR TITLE
Fediverse: private sites UX improvements

### DIFF
--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -225,13 +225,7 @@ export const WpcomFediverseSettingsSection = ( { siteId, needsBorders = true } )
 						}
 					) }
 				</p>
-				<ToggleControl
-					label={ translate( 'Enter the fediverse' ) }
-					disabled={ disabled }
-					checked={ isEnabled }
-					onChange={ ( value ) => setEnabled( value ) }
-				/>
-				{ isPrivate && (
+				{ isPrivate ? (
 					<Notice status="is-warning" translate={ translate } isCompact>
 						{ translate( '{{link}}Launch your site{{/link}} to enter the fediverse!', {
 							components: {
@@ -239,6 +233,13 @@ export const WpcomFediverseSettingsSection = ( { siteId, needsBorders = true } )
 							},
 						} ) }
 					</Notice>
+				) : (
+					<ToggleControl
+						label={ translate( 'Enter the fediverse' ) }
+						disabled={ disabled }
+						checked={ isEnabled }
+						onChange={ ( value ) => setEnabled( value ) }
+					/>
 				) }
 			</Wrapper>
 			{ isEnabled && (

--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -208,6 +208,10 @@ export const WpcomFediverseSettingsSection = ( { siteId, needsBorders = true } )
 		}
 	);
 	const disabled = isLoading || isError || isPrivate;
+	const baseSettingsLink = `/settings/general/${ domain }#site-privacy-settings`;
+	const settingsLink = isJetpackCloud()
+		? `https://wordpress.com${ baseSettingsLink }`
+		: baseSettingsLink;
 	return (
 		<>
 			<Wrapper needsCard={ needsBorders }>
@@ -229,23 +233,11 @@ export const WpcomFediverseSettingsSection = ( { siteId, needsBorders = true } )
 				/>
 				{ isPrivate && (
 					<Notice status="is-warning" translate={ translate } isCompact>
-						{ isJetpackCloud()
-							? translate(
-									'You cannot enter the fediverse until your site is publicly launched. {{link}}Review Privacy settings on WordPress.com{{/link}}.',
-									{
-										components: {
-											link: <a href={ `https://wordpress.com/settings/general/${ domain }` } />,
-										},
-									}
-							  )
-							: translate(
-									'You cannot enter the fediverse until your site is publicly launched. {{link}}Review Privacy settings{{/link}}.',
-									{
-										components: {
-											link: <a href={ `/settings/general/${ domain }` } />,
-										},
-									}
-							  ) }
+						{ translate( '{{link}}Launch your site{{/link}} to enter the fediverse!', {
+							components: {
+								link: <a href={ settingsLink } />,
+							},
+						} ) }
 					</Notice>
 				) }
 			</Wrapper>


### PR DESCRIPTION
Reported by @obenland 

For private sites, the messaging is very "you can't do that" instead of "how to do that."

Also, the link should be directly to the Privacy section, which is possible by URL ID hash.

## Proposed Changes

* Before:

<img width="734" alt="Screenshot 2024-08-12 at 16 01 09" src="https://github.com/user-attachments/assets/ccd11039-3dda-4994-853c-e6dea63df71d">

* After:

<img width="739" alt="Screenshot 2024-08-12 at 16 02 08" src="https://github.com/user-attachments/assets/b8c0cfcc-059d-44a5-9ec2-a31236edb3e2">


## Why are these changes being made?

Help users enter the fediverse with directions towards what they can do, while also linking directly to the Privacy section of Settings -> General.

## Testing Instructions

Vist a site's Discussion or Tools -> Marketing -> Connections section with that site set to private or Coming Soon. In the Fediverse section as pictured above, you should see the improved messaging and the link should be directly to the Privacy section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
