### PR TITLE
Performance Profiler: Add DashboardContent skeleton

### DIFF
--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -1,0 +1,18 @@
+import { TabType } from 'calypso/performance-profiler/components/header';
+import './style.scss';
+
+type PerformanceProfilerDashboardContentProps = {
+	activeTab: TabType;
+};
+
+export const PerformanceProfilerDashboardContent = (
+	props: PerformanceProfilerDashboardContentProps
+) => {
+	const { activeTab } = props;
+
+	return (
+		<div className="performance-profiler-content">
+			<div className="l-block-wrapper">Dashboard content { activeTab }</div>
+		</div>
+	);
+};

--- a/client/performance-profiler/components/dashboard-content/style.scss
+++ b/client/performance-profiler/components/dashboard-content/style.scss
@@ -1,0 +1,5 @@
+.performance-profiler-content {
+	background: #fff;
+	padding-top: 100px;
+	min-height: 600px;
+}

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -2,17 +2,18 @@ import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import './style.scss';
 import DocumentHead from 'calypso/components/data/document-head';
+import { PerformanceProfilerDashboardContent } from 'calypso/performance-profiler/components/dashboard-content';
 import { PerformanceProfilerHeader, TabType } from 'calypso/performance-profiler/components/header';
 
 type PerformanceProfilerDashboardProps = {
 	url: string;
-	tab: string;
+	tab: TabType;
 };
 
 export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboardProps ) => {
 	const translate = useTranslate();
 	const { url, tab } = props;
-	const [ activeTab, setActiveTab ] = React.useState( tab );
+	const [ activeTab, setActiveTab ] = React.useState< TabType >( tab );
 
 	const getOnTabChange = ( tab: TabType ) => {
 		const queryParams = new URLSearchParams( window.location.search );
@@ -33,9 +34,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 				showNavigationTabs
 			/>
 
-			<div className="dashboard-content">
-				<div className="l-block-wrapper">Dashboard content { activeTab }</div>
-			</div>
+			<PerformanceProfilerDashboardContent activeTab={ activeTab } />
 		</div>
 	);
 };

--- a/client/performance-profiler/pages/dashboard/style.scss
+++ b/client/performance-profiler/pages/dashboard/style.scss
@@ -6,9 +6,3 @@
 	margin: 0 auto;
 	max-width: 1056px;
 }
-
-.dashboard-content {
-	background: #fff;
-	padding-top: 100px;
-	min-height: 600px;
-}


### PR DESCRIPTION
Based on https://github.com/Automattic/wp-calypso/pull/93468

## Proposed Changes

Create the skeleton for the DashboardContent component. 

## Why are these changes being made?
This component will be used to handle the data while the main Dashboard page will be used to handle URL params and put the pieces together (header, content, footer).


## Testing Instructions

Everything should be working exactly as in https://github.com/Automattic/wp-calypso/pull/93468


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
