### PR TITLE
Fediverse: don't hide the toggle for private sites

### DIFF
--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -225,7 +225,7 @@ export const WpcomFediverseSettingsSection = ( { siteId, needsBorders = true } )
 						}
 					) }
 				</p>
-				{ isPrivate ? (
+				{ isPrivate && (
 					<Notice status="is-warning" translate={ translate } isCompact>
 						{ translate( '{{link}}Launch your site{{/link}} to enter the fediverse!', {
 							components: {
@@ -233,14 +233,13 @@ export const WpcomFediverseSettingsSection = ( { siteId, needsBorders = true } )
 							},
 						} ) }
 					</Notice>
-				) : (
-					<ToggleControl
-						label={ translate( 'Enter the fediverse' ) }
-						disabled={ disabled }
-						checked={ isEnabled }
-						onChange={ ( value ) => setEnabled( value ) }
-					/>
 				) }
+				<ToggleControl
+					label={ translate( 'Enter the fediverse' ) }
+					disabled={ disabled }
+					checked={ isEnabled }
+					onChange={ ( value ) => setEnabled( value ) }
+				/>
 			</Wrapper>
 			{ isEnabled && (
 				<EnabledSettingsSection data={ data } siteId={ siteId } needsCard={ needsBorders } />

--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -225,6 +225,12 @@ export const WpcomFediverseSettingsSection = ( { siteId, needsBorders = true } )
 						}
 					) }
 				</p>
+				<ToggleControl
+					label={ translate( 'Enter the fediverse' ) }
+					disabled={ disabled }
+					checked={ isEnabled }
+					onChange={ ( value ) => setEnabled( value ) }
+				/>
 				{ isPrivate && (
 					<Notice status="is-warning" translate={ translate } isCompact>
 						{ translate( '{{link}}Launch your site{{/link}} to enter the fediverse!', {
@@ -234,12 +240,6 @@ export const WpcomFediverseSettingsSection = ( { siteId, needsBorders = true } )
 						} ) }
 					</Notice>
 				) }
-				<ToggleControl
-					label={ translate( 'Enter the fediverse' ) }
-					disabled={ disabled }
-					checked={ isEnabled }
-					onChange={ ( value ) => setEnabled( value ) }
-				/>
 			</Wrapper>
 			{ isEnabled && (
 				<EnabledSettingsSection data={ data } siteId={ siteId } needsCard={ needsBorders } />


### PR DESCRIPTION
Following on from #93469 it became clear that no, the user would not know that a toggle control will magically appear when you return to this page. We regret the breakdown in projecting "developer brain"

## Proposed Changes

Before 
<img width="739" alt="Screenshot 2024-08-12 at 16 02 08" src="https://github.com/user-attachments/assets/b8c0cfcc-059d-44a5-9ec2-a31236edb3e2">

After
<img width="737" alt="Screenshot 2024-08-12 at 15 52 29" src="https://github.com/user-attachments/assets/0e4776b2-7886-44a3-9668-55f852988e69">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Less magical thinking expected

## Testing Instructions

Vist a site's Discussion or Tools -> Marketing -> Connections section with that site set to private or Coming Soon. In the Fediverse section as pictured above, you should see the disabled toggle still shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
