### PR TITLE
Add/step progress indicator

### DIFF
--- a/client/components/step-progress/README.md
+++ b/client/components/step-progress/README.md
@@ -6,7 +6,7 @@ This component is distinguished from `Wizard` and `WizardProgressBar` in that in
 
 ## Properties
 
-### `steps { string | { message: string, onClick: () => void}[] }`
+### `steps { string | { message: string, onClick: () => void, indicator: <Icon icon={check} />, show: 'always' }[] }`
 
 A list of the display name of the steps to progress through. Optionally an object with a click handler
 

--- a/client/components/step-progress/docs/example.tsx
+++ b/client/components/step-progress/docs/example.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { Spinner } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import { FunctionComponent, useState } from 'react';
 import StepProgress from 'calypso/components/step-progress';
@@ -14,8 +15,14 @@ const StepProgressExample: FunctionComponent = () => {
 			indicator: <Icon icon={ check } />,
 		},
 		{
-			message: 'Host locator ( clickable once complete )',
+			message: 'In Progress',
 			onClick: () => setCurrentStep( 1 ),
+			indicator: <Spinner style={ { color: 'red' } } />,
+			show: 'onComplete',
+		},
+		{
+			message: 'Host locator ( clickable once complete )',
+			onClick: () => setCurrentStep( 2 ),
 			show: 'onComplete',
 		},
 		'Credentials ( no click handler )',

--- a/client/components/step-progress/docs/example.tsx
+++ b/client/components/step-progress/docs/example.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { Icon, check } from '@wordpress/icons';
 import { FunctionComponent, useState } from 'react';
 import StepProgress from 'calypso/components/step-progress';
 import type { ClickHandler } from '../index';
@@ -10,6 +11,7 @@ const StepProgressExample: FunctionComponent = () => {
 		{
 			message: 'You got this!',
 			onClick: () => setCurrentStep( 0 ),
+			indicator: <Icon icon={ check } />,
 		},
 		{
 			message: 'Host locator ( clickable once complete )',

--- a/client/components/step-progress/index.tsx
+++ b/client/components/step-progress/index.tsx
@@ -1,12 +1,12 @@
 import { TranslateResult } from 'i18n-calypso';
-import React, { FunctionComponent } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 
 import './style.scss';
 
 export interface ClickHandler {
 	onClick: () => void;
 	message: TranslateResult;
-	indicator?: React.ReactNode;
+	indicator?: ReactNode;
 	show?: 'always' | 'onComplete' | 'beforeComplete';
 }
 

--- a/client/components/step-progress/index.tsx
+++ b/client/components/step-progress/index.tsx
@@ -54,8 +54,11 @@ const StepProgress: FunctionComponent< Props > = ( { currentStep, steps } ) => {
 							disabled={ undefined === clickHandler }
 							onClick={ clickHandler }
 						>
-							{ step.indicator }
-							{ ! step.indicator && <span>{ index + 1 }</span> }
+							{ isClickHandler( step ) && !! step.indicator ? (
+								step.indicator
+							) : (
+								<span>{ index + 1 }</span>
+							) }
 						</button>
 						<span className="step-progress__element-step-name">
 							{ isClickHandler( step ) ? step.message : step }

--- a/client/components/step-progress/index.tsx
+++ b/client/components/step-progress/index.tsx
@@ -1,11 +1,12 @@
 import { TranslateResult } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 
 import './style.scss';
 
 export interface ClickHandler {
 	onClick: () => void;
 	message: TranslateResult;
+	indicator?: React.ReactNode;
 	show?: 'always' | 'onComplete' | 'beforeComplete';
 }
 
@@ -53,7 +54,8 @@ const StepProgress: FunctionComponent< Props > = ( { currentStep, steps } ) => {
 							disabled={ undefined === clickHandler }
 							onClick={ clickHandler }
 						>
-							<span>{ index + 1 }</span>
+							{ step.indicator }
+							{ ! step.indicator && <span>{ index + 1 }</span> }
 						</button>
 						<span className="step-progress__element-step-name">
 							{ isClickHandler( step ) ? step.message : step }

--- a/client/components/step-progress/style.scss
+++ b/client/components/step-progress/style.scss
@@ -67,6 +67,7 @@
 		justify-content: center;
 		margin-top: -2px;
 		margin-left: -2px;
+		fill: currentColor;
 	}
 
 }

--- a/client/components/step-progress/style.scss
+++ b/client/components/step-progress/style.scss
@@ -55,6 +55,20 @@
 	&:not(:disabled) {
 		cursor: pointer;
 	}
+
+	.components-spinner {
+		display: flex;
+		justify-content: center;
+		margin-top: 0;
+		margin-left: 2px;
+	}
+	svg {
+		display: flex;
+		justify-content: center;
+		margin-top: -2px;
+		margin-left: -2px;
+	}
+
 }
 
 .step-progress__element-complete {

--- a/client/components/step-progress/style.scss
+++ b/client/components/step-progress/style.scss
@@ -62,6 +62,7 @@
 		margin-top: 0;
 		margin-left: 2px;
 	}
+
 	svg {
 		display: flex;
 		justify-content: center;
@@ -69,7 +70,6 @@
 		margin-left: -2px;
 		fill: currentColor;
 	}
-
 }
 
 .step-progress__element-complete {


### PR DESCRIPTION
We are implementing this new properly so that we can implement the step indicator as designed. 

## Proposed Changes

* Add a new indicator step prop so that we can pass different types of indicators such as icons and spinners. 


## Why are these changes being made?

* Add support for spinner and icons in the step indicator. 

## Testing Instructions
Visit http://calypso.localhost:3000/devdocs/design/step-progress to notice the new icon and indicator

See 

<img width="1260" alt="Screenshot 2024-08-12 at 4 11 13 PM" src="https://github.com/user-attachments/assets/96b0420f-c601-4a25-a17b-b61f5b3af960">

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
