### PR TITLE
Stats: Date control - Adding a calendar

### DIFF
--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Button } from '@wordpress/components';
+import { Button, DatePicker } from '@wordpress/components';
 import { Icon, lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -44,7 +44,12 @@ const DateControlPickerDate = ( {
 					<DateInput id="endDate" value={ endDate } onChange={ onEndChange } />
 				</div>
 			</div>
-			{ isCalendarEnabled && <div className={ `${ BASE_CLASS_NAME }s__calendar` }>Calendar</div> }
+			{ isCalendarEnabled && (
+				<div className={ `${ BASE_CLASS_NAME }s__calendar` }>
+					<DatePicker currentDate={ startDate } />
+					<DatePicker currentDate={ endDate } />
+				</div>
+			) }
 			<div className={ `${ BASE_CLASS_NAME }s__buttons` }>
 				<Button onClick={ onCancel }>{ translate( 'Cancel' ) }</Button>
 				<Button variant="primary" onClick={ onApply }>

--- a/client/components/stats-date-control/style.scss
+++ b/client/components/stats-date-control/style.scss
@@ -134,6 +134,12 @@ $date-control-mobile-layout-switch: $break-small;
 	}
 }
 
+.stats-date-control-picker-dates__calendar {
+	display: flex;
+	gap: 18px;
+	padding-bottom: 18px;
+}
+
 .stats-date-control-picker__popover-content {
 	display: flex;
 	min-width: 320px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/118

## Proposed Changes

* add Gutenberg calendar to the date control in order to replace the native calendar popup

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* it's part of a project to improve user experience for date selection 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply `stats/date-picker-calendar` to the live branch
* verify that the date control has a calendar

![SCR-20240813-jpet](https://github.com/user-attachments/assets/e59b4e75-b1ab-4581-add3-a8c5e729b286)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
