### PR TITLE
A4A Dev Sites: Add "Prepare for launch" dropdown menu item

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -382,6 +382,8 @@ export const JetpackSitesDataViews = ( {
 						return <div className="sites-dataview__site-error"></div>;
 					}
 
+					const isDevSite = item.isDevSite ?? false;
+
 					return (
 						<>
 							{ item.site.error && <span className="sites-dataview__site-error-span"></span> }
@@ -397,6 +399,7 @@ export const JetpackSitesDataViews = ( {
 										{ ! item.site.error && (
 											<SiteActions
 												isLargeScreen={ isLargeScreen }
+												isDevSite={ isDevSite }
 												site={ item.site }
 												siteError={ item.site.error }
 												onRefetchSite={ onRefetchSite }

--- a/client/a8c-for-agencies/sections/sites/site-actions/get-action-event-name.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/get-action-event-name.ts
@@ -42,6 +42,10 @@ const actionEventNames: ActionEventNames = {
 		large_screen: 'calypso_a4a_sites_dataview_remove_large_screen',
 		small_screen: 'calypso_a4a_sites_dataview_remove_small_screen',
 	},
+	prepare_for_launch: {
+		large_screen: 'calypso_a4a_sites_dataview_prepare_for_launch_large_screen',
+		small_screen: 'calypso_a4a_sites_dataview_prepare_for_launch_small_screen',
+	},
 };
 
 // Returns event name based on the action type

--- a/client/a8c-for-agencies/sections/sites/site-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/index.tsx
@@ -15,6 +15,7 @@ import './style.scss';
 
 interface Props {
 	isLargeScreen?: boolean;
+	isDevSite?: boolean;
 	site: SiteNode;
 	siteError: boolean | undefined;
 	onRefetchSite?: () => Promise< unknown >;
@@ -22,6 +23,7 @@ interface Props {
 
 export default function SiteActions( {
 	isLargeScreen = false,
+	isDevSite,
 	site,
 	siteError,
 	onRefetchSite,
@@ -52,6 +54,7 @@ export default function SiteActions( {
 	const siteActions = useSiteActions( {
 		site,
 		isLargeScreen,
+		isDevSite,
 		siteError,
 		onSelect: onSelectAction,
 	} );

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -18,11 +18,18 @@ import type { SiteNode, AllowedActionTypes } from '../types';
 type Props = {
 	site: SiteNode;
 	isLargeScreen: boolean;
+	isDevSite?: boolean;
 	siteError?: boolean;
 	onSelect?: ( action: AllowedActionTypes ) => void;
 };
 
-export default function useSiteActions( { site, isLargeScreen, siteError, onSelect }: Props ) {
+export default function useSiteActions( {
+	site,
+	isLargeScreen,
+	isDevSite,
+	siteError,
+	onSelect,
+}: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -58,6 +65,13 @@ export default function useSiteActions( { site, isLargeScreen, siteError, onSele
 		const isUrlOnly = site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
 
 		return [
+			{
+				name: translate( 'Prepare for launch' ),
+				href: `https://wordpress.com/settings/general/${ blog_id }?referer=a4a-dashboard`,
+				onClick: () => handleClickMenuItem( 'prepare_for_launch' ),
+				isExternalLink: true,
+				isEnabled: isDevSite,
+			},
 			{
 				name: translate( 'Set up site' ),
 				href: `https://wordpress.com/overview/${ blog_id }`,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/get-action-event-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/get-action-event-name.ts
@@ -42,6 +42,10 @@ const actionEventNames: ActionEventNames = {
 		large_screen: 'calypso_jetpack_agency_dashboard_remove_large_screen',
 		small_screen: 'calypso_jetpack_agency_dashboard_remove_small_screen',
 	},
+	prepare_for_launch: {
+		large_screen: 'calypso_jetpack_agency_dashboard_prepare_for_launch_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_prepare_for_launch_small_screen',
+	},
 };
 
 // Returns event name based on the action type

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -224,7 +224,8 @@ export type AllowedActionTypes =
 	| 'set_up_site'
 	| 'change_domain'
 	| 'hosting_configuration'
-	| 'remove_site';
+	| 'remove_site'
+	| 'prepare_for_launch';
 
 export type ActionEventNames = {
 	[ key in AllowedActionTypes ]: { small_screen: string; large_screen: string };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/8651

## Proposed Changes

* add new "Prepare for launch" menu item (for free development sites only)
  * make the item link lead to the https://wordpress.com/settings/general page with query parameter `referer=a4a-dashboard`

![Markup on 2024-08-13 at 12:12:50](https://github.com/user-attachments/assets/8120567e-575e-4853-9162-d4a1fbb3bc52)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR locally and build the app with `yarn start-a8c-for-agencies`.
2. Head over to the Sites section at http://agencies.localhost:3000/sites/?flags=a4a-dev-sites and click on the kebab menu by any development site.
3. The new "Prepare for launch" menu item should be available.
4. Click the new menu item. You should be redirected to a new tab at `https://wordpress.com/settings/general/{blog-id}?referer=a4a-dashboard`.
5. When you open the kebab menu related to ordinary (non-development) site, there should be no "Prepare for launch" menu item.
6. Similar behavior should be present on other pages as well (i.e. "Needs attention" and "Favorites").

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?