### PR TITLE
Stepper: Add a flag to trigger calypso_signup_start on any stepper step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -1,6 +1,6 @@
 import { SENSEI_FLOW } from '@automattic/onboarding';
-import { useEffect, useMemo } from 'react';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { recordSignupStart } from 'calypso/lib/analytics/signup';
 import { type Flow } from '../../types';
 
@@ -14,11 +14,11 @@ interface Props {
 
 export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 	const steps = flow.useSteps();
-	const queryParams = useQuery();
+	const [ queryParams, setQuery ] = useSearchParams();
 	const ref = queryParams.get( 'ref' ) || '';
 	const isSignupStep = queryParams.has( 'signup' );
 
-	// TODO: Check if we can remove the sensei flow reference from here.
+	// TODO: Using the new signup flag we can remove reference to SENSEI_FLOW
 	const firstStepSlug = ( flow.name === SENSEI_FLOW ? steps[ 1 ] : steps[ 0 ] ).slug;
 	const isFirstStep = firstStepSlug === currentStepRoute;
 	const flowVariant = flow.variantSlug;
@@ -33,12 +33,16 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 	);
 	const flowName = flow.name;
 	const shouldTrack = flow.isSignupFlow && ( isFirstStep || isSignupStep );
+	const removeSignupParam = useCallback( () => {
+		queryParams.delete( 'signup' );
+		setQuery( queryParams );
+	}, [ queryParams, setQuery ] );
 
 	useEffect( () => {
 		if ( ! shouldTrack ) {
 			return;
 		}
-
 		recordSignupStart( flowName, ref, extraProps || {} );
-	}, [ extraProps, flowName, ref, shouldTrack ] );
+		removeSignupParam();
+	}, [ extraProps, flowName, ref, removeSignupParam, shouldTrack ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -34,8 +34,10 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 	const flowName = flow.name;
 	const shouldTrack = flow.isSignupFlow && ( isFirstStep || isSignupStep );
 	const removeSignupParam = useCallback( () => {
-		queryParams.delete( 'signup' );
-		setQuery( queryParams );
+		if ( queryParams.has( 'signup' ) ) {
+			queryParams.delete( 'signup' );
+			setQuery( queryParams );
+		}
 	}, [ queryParams, setQuery ] );
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx
@@ -16,7 +16,7 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 	const steps = flow.useSteps();
 	const queryParams = useQuery();
 	const ref = queryParams.get( 'ref' ) || '';
-	const signedUp = queryParams.has( 'signed_up' );
+	const isSignupStep = queryParams.has( 'signup' );
 
 	// TODO: Check if we can remove the sensei flow reference from here.
 	const firstStepSlug = ( flow.name === SENSEI_FLOW ? steps[ 1 ] : steps[ 0 ] ).slug;
@@ -32,7 +32,7 @@ export const useSignUpStartTracking = ( { flow, currentStepRoute }: Props ) => {
 		[ signupStartEventProps, flowVariant ]
 	);
 	const flowName = flow.name;
-	const shouldTrack = flow.isSignupFlow && isFirstStep && ! signedUp;
+	const shouldTrack = flow.isSignupFlow && ( isFirstStep || isSignupStep );
 
 	useEffect( () => {
 		if ( ! shouldTrack ) {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/test/index.tsx
@@ -65,6 +65,12 @@ describe( 'useSignUpTracking', () => {
 		expect( recordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
+	it( 'does not track event when the flow is not a isSignupFlow and the signup flag is set', () => {
+		render( { flow: regularFlow, currentStepRoute: 'step-1', queryParams: { signup: 1 } } );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
 	describe( 'sign-up-flow', () => {
 		it( 'tracks the event current step is first step', () => {
 			render( {
@@ -79,14 +85,17 @@ describe( 'useSignUpTracking', () => {
 			} );
 		} );
 
-		it( 'skips the tracking when the signed up flag is set', () => {
+		it( 'tracks the event when the step is not the first but the signup flag is set', () => {
 			render( {
 				flow: signUpFlow,
-				currentStepRoute: 'step-1',
-				queryParams: { signed_up: 1 },
+				currentStepRoute: 'step-2',
+				queryParams: { signup: 1 },
 			} );
 
-			expect( recordTracksEvent ).not.toHaveBeenCalled();
+			expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_signup_start', {
+				flow: 'sign-up-flow',
+				ref: '',
+			} );
 		} );
 
 		it( 'tracks the event with extra props from useSighupStartEventProps', () => {
@@ -124,12 +133,6 @@ describe( 'useSignUpTracking', () => {
 
 		it( 'does not track events current step is NOT the first step', () => {
 			render( { flow: signUpFlow, currentStepRoute: 'step-2' } );
-
-			expect( recordTracksEvent ).not.toHaveBeenCalled();
-		} );
-
-		it( 'does not track events current step is the first step AND the user is returning from the sign in flow', () => {
-			render( { flow: signUpFlow, currentStepRoute: 'step-1', queryParams: { signed_up: true } } );
 
 			expect( recordTracksEvent ).not.toHaveBeenCalled();
 		} );


### PR DESCRIPTION
Closes #[93484](https://github.com/Automattic/wp-calypso/issues/93484)

## Proposed Changes

* Add the global `signup` query param to trigger the calypso_signup_start on any step.

## Why are these changes being made?
Currently, we trigger the `calypso_signup_start` event only when the user reaches the first step in a signup flow. However, we have encountered situations where our call-to-action (CTA) leads the user to different initial steps.

Example of cases
1. paYKcK-59M-p2
2. https://github.com/Automattic/wp-calypso/blob/28d9dba91aee52a22e5b0e048f1751e1a0d3b807/client/landing/stepper/declarative-flow/internals/hooks/use-sign-up-start-tracking/index.tsx#L22-L23
3. We are going to have more cases incoming from the new site migration project.


## Testing Instructions
* Access the second step of any signup flow  [E.g., `/setup/newsletter/newsletterSetup`]
* Check no calypso_signup_start event is triggered
* Access again using the flag `signup`  [E.g `/setup/newsletter/newsletterSetup?signup=true`]


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?