### PR TITLE
Help Center: add prefix to .card selector

### DIFF
--- a/apps/help-center/postcss.config.js
+++ b/apps/help-center/postcss.config.js
@@ -7,6 +7,12 @@ module.exports = {
 				if ( path.includes( 'search/style.scss' ) ) {
 					return selector === '.search' ? prefixedSelector : selector;
 				}
+
+				// The search component has very generic class that causes many bugs.
+				if ( path.includes( 'card/style.scss' ) ) {
+					return selector === '.card' ? prefixedSelector : selector;
+				}
+
 				return selector;
 			},
 		} ),


### PR DESCRIPTION
## Proposed Changes

This adds another prefix case to cover the very generic `.card` selector.

## Why are these changes being made?

More context: p1723211943612859-slack-C029S5LLB7D

The calypso `Card` component comes with a very generic style selector. This causes style collisions. 

| Before | After |
| - | - |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/eb1756ef-9079-4f54-b86f-21e5173cbede"> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/90fef21d-4223-42a0-9826-8779115595d9"> |



## Testing Instructions

1. `yarn dev --sync` from apps/help-center
2. Sandbox widgets.wp.com and make sure Help Center style is no longer bleeding. You can check [this site](https://myrealdata.in) to see the problem is resolved.
3. Use the live link and check to make sure there is no regressions