### PR TITLE
fix(hosting-overview-refinements): checking status of transition from Simple to Atomic

### DIFF
--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -61,7 +61,8 @@ const HostingFeatures = () => {
 	const { data: siteTransferData, refetch: refetchSiteTransferData } = useSiteTransferStatusQuery(
 		siteId || undefined
 	);
-	// We have some bug at the backend, when the transfer is complited, but isSiteAtomic is still false, so we need such extra condition
+	// `siteTransferData?.isTransferring` is not a fully reliable indicator by itself, which is why
+	// we also look at `siteTransferData.status`
 	const isTransferInProgress =
 		siteTransferData?.isTransferring || siteTransferData?.status === transferStates.COMPLETED;
 

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -64,7 +64,6 @@ const HostingFeatures = () => {
 	useEffect( () => {
 		if ( isSiteAtomic && ! isPlanExpired ) {
 			page.replace( redirectUrl.current );
-			//window.location.href = redirectUrl.current;
 		}
 	}, [ isSiteAtomic, isPlanExpired ] );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8654

## Proposed Changes
We can two options when a website becomes atomic: activating hosting features (http://calypso.localhost:3000/hosting-features/<WEBSITE_DOMAIN>) and creating A4A website (https://agencies.automattic.com). In both cases there is some delay during provisioning, so there is case when a user opens "Hosting Feature" and we need to show spinner and appropriate copy and the main point - as soon as a website is ready - we need reload the page to render all hosting features on the page, and it's exactly the point of this PR - watch the status and reload the page.
ATM it works but there is a bug - sometimes, randomly, reloading the page doesn't make any effect, actually the property `is_wpcom_atomic` appears as false, however it should be `true`. So as a first step we are fixing some bugs and make a bit refactoing with this PR. And as a follow up PR - we will fix that random bug about `is_wpcom_atomic`.

## Testing Instructions
### A4A tests
1. Open `https://agencies.automattic.com/`
2. Purchase licences, if you don't have (Left sidebar "Purchase" -> "Issue New License")
3. Click on `Sites` in left sidebar
4. Click on "Needs setup"
5. Click on "Create new site" and proceed
6. Wait till you see the next notification<br /> <img width="531" alt="Screenshot 2024-08-13 at 12 58 24" src="https://github.com/user-attachments/assets/98ea9aab-f607-4998-815a-1c403b9f1020">
7. Copy selected domain on the screenshot above
8. And open new tab with the next URL `http://calypso.localhost:3000/hosting-features/<COPYED_DOMAIN_IN_7TH_STEP>`
9. Assert that you see spinner and copy about "things in progress" <br /><img width="636" alt="Screenshot 2024-08-13 at 13 00 43" src="https://github.com/user-attachments/assets/ae8817f1-da5d-4d06-9c57-3437ea7f5c1b">
10. Wait till it's finished
11. Assert that you are redirected to "Overview" tab
12. Assert that tabs are changed from: <br /><img width="332" alt="Screenshot 2024-08-13 at 13 01 17" src="https://github.com/user-attachments/assets/10cf6714-f889-460e-b79a-145646063c1c"> <br />To: <br /><img width="654" alt="Screenshot 2024-08-13 at 13 01 53" src="https://github.com/user-attachments/assets/4924ece6-81d7-41e0-a7a3-f6d685962df7">

### Manually turning on Hosting Features
1. Purchase domain with `Starter` plan
2. Open "Hosting features" tab on "Sites" page (Let's call this tab as `A` during testing)
3. Copy the URL and open a separate tab (Let's call this tab as `B` during testing, we will use it in the end for testing)
4. In tab A, click `Upgrade now` and proceed with upgrading
5. Now let's repeat the 3-rd step to open one more separate tab (Let's call this tab as `C` during testing, we will use it in the end for testing), so that you will have the next tabs `B` and `C`:<br /><img width="2296" alt="Screenshot 2024-07-29 at 16 12 45" src="https://github.com/user-attachments/assets/7ee4bc76-a06c-43dd-b64f-1b8c9c295a7c">
6. Now, in tab `A` click `Activate now` and proceed
7. During activating process, the copy on tabs B and C should be changed to the next (with CTA buttons hidden)<br /><img width="2293" alt="Screenshot 2024-07-29 at 16 15 28" src="https://github.com/user-attachments/assets/00b3e02f-cf04-482e-8ad8-eebbee3d8528">


