### PR TITLE
A4A: Fixes a typo in the Marketplace Hosting page's included features.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/premier-agency-hosting/index.tsx
@@ -55,7 +55,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 					translate( 'Plugin update manager' ),
 					translate( '24/7 expert support' ),
 					translate( 'Free staging sites with sync tools' ),
-					translate( 'SFTP/SHH, WP-CLI, Git tools' ),
+					translate( 'SFTP/SSH, WP-CLI, Git tools' ),
 					translate( 'Resource isolation across every site' ),
 				] }
 			/>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-v2/standard-agency-hosting/index.tsx
@@ -61,7 +61,7 @@ export default function StandardAgencyHosting( { onAddToCart }: Props ) {
 					translate( 'Plugin update manager' ),
 					translate( '24/7 expert support' ),
 					translate( 'Free staging sites with sync tools' ),
-					translate( 'SFTP/SHH, WP-CLI, Git tools' ),
+					translate( 'SFTP/SSH, WP-CLI, Git tools' ),
 					translate( 'Resource isolation across every site' ),
 				] }
 			/>


### PR DESCRIPTION
Fixes a typo in the Marketplace Hosting page's included features.

<img width="1267" alt="Screenshot 2024-08-13 at 9 23 12 PM" src="https://github.com/user-attachments/assets/068e9782-fd92-4f3f-9eb3-9366feb47dc5">


## Proposed Changes

* Fix the wrong translation string.

## Why are these changes being made?

*

## Testing Instructions

* Use the A4A live link and go to the `/marketplace/hosting` page.
* Scroll down to the included features section.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
