### PR TITLE
Re-add backgrounds to plugins marketplace sections - wrapper approach

### DIFF
--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -8,6 +8,14 @@ interface SectionProps {
 	subheader?: string | ReactElement;
 	children: ReactNode;
 	dark?: boolean;
+	isLoggedIn?: boolean;
+	marginBottom?: string;
+}
+
+interface SectionWrapperProps {
+	dark?: boolean;
+	isLoggedIn?: boolean;
+	marginBottom?: string;
 }
 
 interface SectionContainerProps {
@@ -18,31 +26,27 @@ interface SectionHeaderProps {
 	dark?: boolean;
 }
 
-export const SectionContainer = styled.div< SectionContainerProps >`
-	padding: 56px 0;
+export const SectionWrapper = styled.div< SectionWrapperProps >`
+	--content-width: ${ ( props ) =>
+		props.isLoggedIn
+			? `calc( 100vw - var( --sidebar-width-max, 0px ) - ( var( --content-frame-right-padding, 0px ))  )`
+			: '100vw' };
+	width: var( --content-width );
+	position: relative;
+	left: 50%;
+	right: 50%;
+	margin-left: calc( -1 * var( --content-width ) / 2 );
+	margin-right: calc( -1 * var( --content-width ) / 2 );
 	background-color: ${ ( props ) =>
 		props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
-	position: relative;
+	${ ( props ) => props.marginBottom && `margin-bottom: ${ props.marginBottom };` }
+`;
 
-	::before,
-	::after {
-		content: '';
-		position: absolute;
-		box-sizing: border-box;
-		background-color: ${ ( props ) =>
-			props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
-		top: 0;
-		bottom: 0;
-		width: var( --content-margin );
-	}
-
-	::before {
-		left: calc( -1 * var( --content-margin ) );
-	}
-
-	::after {
-		right: calc( -1 * var( --content-margin ) );
-	}
+export const SectionContainer = styled.div< SectionContainerProps >`
+	padding: 56px var( --content-margin, 0 );
+	max-width: 1040px;
+	margin: 0 auto;
+	box-sizing: border-box;
 `;
 
 export const SectionHeader = styled.div< SectionHeaderProps >`
@@ -82,18 +86,20 @@ export const SectionHeaderContainer = styled.div< SectionHeaderProps >`
 const SectionContent = styled.div``;
 
 const Section = ( props: SectionProps ) => {
-	const { children, header, subheader, dark } = props;
+	const { children, header, subheader, dark, isLoggedIn, marginBottom } = props;
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<SectionContainer dark={ dark }>
-			<SectionHeaderContainer>
-				<SectionHeader dark={ dark } className="wp-brand-font">
-					{ header }
-				</SectionHeader>
-				{ subheader && <SectionSubHeader>{ subheader }</SectionSubHeader> }
-			</SectionHeaderContainer>
-			<SectionContent>{ children }</SectionContent>
-		</SectionContainer>
+		<SectionWrapper dark={ dark } isLoggedIn={ isLoggedIn } marginBottom={ marginBottom }>
+			<SectionContainer dark={ dark }>
+				<SectionHeaderContainer>
+					<SectionHeader dark={ dark } className="wp-brand-font">
+						{ header }
+					</SectionHeader>
+					{ subheader && <SectionSubHeader>{ subheader }</SectionSubHeader> }
+				</SectionHeaderContainer>
+				<SectionContent>{ children }</SectionContent>
+			</SectionContainer>
+		</SectionWrapper>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };

--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -18,11 +18,31 @@ interface SectionHeaderProps {
 	dark?: boolean;
 }
 
-// TODO - re-add background color and usage of dark prop, to something other than a pseudo element.
-// We will need to adjust exterior containers margin etc. to accomodate this.
-// https://github.com/Automattic/wp-calypso/pull/93425
 export const SectionContainer = styled.div< SectionContainerProps >`
 	padding: 56px 0;
+	background-color: ${ ( props ) =>
+		props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
+	position: relative;
+
+	::before,
+	::after {
+		content: '';
+		position: absolute;
+		box-sizing: border-box;
+		background-color: ${ ( props ) =>
+			props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
+		top: 0;
+		bottom: 0;
+		width: var( --content-margin );
+	}
+
+	::before {
+		left: calc( -1 * var( --content-margin ) );
+	}
+
+	::after {
+		right: calc( -1 * var( --content-margin ) );
+	}
 `;
 
 export const SectionHeader = styled.div< SectionHeaderProps >`

--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -695,16 +695,18 @@
 .wpcom-site div.is-section-plugins.is-global-sidebar-visible {
 	&.focus-content .layout__content,
 	&.focus-sidebar .layout__content {
-		padding-bottom: 16px;
+		--content-frame-padding: 16px;
+		padding-bottom: var(--content-frame-padding);
 		min-height: 100vh;
 
 		@include break-small {
-			padding-top: calc(var(--masterbar-height) + 16px);
+			padding-top: calc(var(--masterbar-height) + var(--content-frame-padding));
 		}
 
 		@include break-medium {
+			--content-frame-right-padding: var(--content-frame-padding);
 			padding-left: calc(var(--sidebar-width-max));
-			padding-right: 16px;
+			padding-right: var(--content-frame-right-padding);
 
 			.main.a4a-layout.sites-dashboard.sites-dashboard__layout {
 				height: calc(100vh - var(--masterbar-height) - 32px);

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
 import FeatureItem from 'calypso/components/feature-item';
 import LinkCard from 'calypso/components/link-card';
-import Section, { SectionContainer } from 'calypso/components/section';
+import Section, { SectionContainer, SectionWrapper } from 'calypso/components/section';
 import { preventWidows } from 'calypso/lib/formatting';
 import { addQueryArgs } from 'calypso/lib/route';
 import PluginsResultsHeader from 'calypso/my-sites/plugins/plugins-results-header';
@@ -71,12 +71,8 @@ const MarketplaceContainer = styled.div< { isloggedIn: boolean } >`
 		padding-bottom: 0;
 	}` }
 
-	${ SectionContainer } {
+	${ SectionWrapper } {
 		background-color: #f6f7f7;
-		::before,
-		::after {
-			background-color: #f6f7f7;
-		}
 	}
 `;
 
@@ -106,6 +102,8 @@ export const MarketplaceFooter = () => {
 		<MarketplaceContainer isloggedIn={ isLoggedIn }>
 			<Section
 				header={ preventWidows( __( 'You pick the plugin. We’ll take care of the rest.' ) ) }
+				isLoggedIn={ isLoggedIn }
+				marginBottom="-32px"
 			>
 				{ ( ! isLoggedIn || currentUserSiteCount === 0 ) && (
 					<Button className="is-primary marketplace-cta" href={ startUrl }>

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -71,8 +71,12 @@ const MarketplaceContainer = styled.div< { isloggedIn: boolean } >`
 		padding-bottom: 0;
 	}` }
 
-	${ SectionContainer }::before {
+	${ SectionContainer } {
 		background-color: #f6f7f7;
+		::before,
+		::after {
+			background-color: #f6f7f7;
+		}
 	}
 `;
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -64,6 +64,10 @@ body.is-section-plugins {
 				height: calc(100vh - var(--masterbar-height) - 32px);
 			}
 		}
+
+		.plugins-browser__content-wrapper {
+			overflow: hidden;
+		}
 	}
 
 	.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column) {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -70,8 +70,9 @@ body.is-section-plugins {
 		&:not(.plugins-browser),
 		&.plugins-browser .plugins-browser__content-wrapper {
 			@include break-small {
-				padding-left: 2rem;
-				padding-right: 2rem;
+				--content-margin: 2rem;
+				padding-left: var(--content-margin);
+				padding-right: var(--content-margin);
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
 This seems unfruitful, whack a mole approach. This method seems like it will require too much complexity to cover all cases.
*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
