### PR TITLE
Wapuu: Adding TrainTracks to sources

### DIFF
--- a/packages/odie-client/src/components/message/sources.tsx
+++ b/packages/odie-client/src/components/message/sources.tsx
@@ -16,7 +16,7 @@ export const Sources = ( { message }: { message: Message } ) => {
 			message.context?.sources?.forEach( ( source: Source, index: number ) => {
 				trackEvent( 'sources_traintracks_render', {
 					fetch_algo: source?.railcar?.fetch_algo,
-					ui_algo: source?.railcar?.ui_algo,
+					ui_algo: 'default',
 					railcar: source?.railcar?.railcar,
 					fetch_position: source?.railcar?.fetch_position,
 					ui_position: index,

--- a/packages/odie-client/src/components/message/sources.tsx
+++ b/packages/odie-client/src/components/message/sources.tsx
@@ -12,6 +12,18 @@ export const Sources = ( { message }: { message: Message } ) => {
 	const sources = useMemo( () => {
 		const messageLength = message?.context?.sources?.length ?? 0;
 		if ( messageLength > 0 ) {
+			// Record TrainTracks render events
+			let uiPosition = 0;
+			message.context?.sources?.forEach( ( source: Source ) => {
+				trackEvent( 'sources_traintracks_render', {
+					fetch_algo: source?.railcar?.fetch_algo,
+					ui_algo: source?.railcar?.ui_algo,
+					railcar: source?.railcar?.railcar,
+					fetch_position: source?.railcar?.fetch_position,
+					ui_position: uiPosition,
+				} );
+				uiPosition++;
+			} );
 			return [
 				...new Map(
 					message.context?.sources?.map( ( source: Source ) => [ source.url, source ] )
@@ -60,6 +72,11 @@ export const Sources = ( { message }: { message: Message } ) => {
 									trackEvent( 'chat_message_action_click', {
 										action: 'link',
 										in_chat_view: true,
+										href: source.url,
+									} );
+									trackEvent( 'sources_traintracks_interact', {
+										railcar: source?.railcar?.railcar,
+										action: 'click',
 										href: source.url,
 									} );
 									navigateToSupportDocs(

--- a/packages/odie-client/src/components/message/sources.tsx
+++ b/packages/odie-client/src/components/message/sources.tsx
@@ -13,16 +13,14 @@ export const Sources = ( { message }: { message: Message } ) => {
 		const messageLength = message?.context?.sources?.length ?? 0;
 		if ( messageLength > 0 ) {
 			// Record TrainTracks render events
-			let uiPosition = 0;
-			message.context?.sources?.forEach( ( source: Source ) => {
+			message.context?.sources?.forEach( ( source: Source, index: number ) => {
 				trackEvent( 'sources_traintracks_render', {
 					fetch_algo: source?.railcar?.fetch_algo,
 					ui_algo: source?.railcar?.ui_algo,
 					railcar: source?.railcar?.railcar,
 					fetch_position: source?.railcar?.fetch_position,
-					ui_position: uiPosition,
+					ui_position: index,
 				} );
-				uiPosition++;
 			} );
 			return [
 				...new Map(

--- a/packages/odie-client/src/types/index.ts
+++ b/packages/odie-client/src/types/index.ts
@@ -7,6 +7,13 @@ export type Source = {
 	blog_id: number;
 	post_id: number;
 	content: string;
+	railcar?: {
+		ui_position: number;
+		ui_algo: string;
+		fetch_algo: string;
+		fetch_position: number;
+		railcar: string;
+	};
 };
 
 export type CurrentUser = {


### PR DESCRIPTION
In order to be able to improve the relevancy of search results, we need to be able to track them. This adds TrainTracks to Wapuu, which allow us to calculate click-through rate of the sources found by Wapuu. If Wapuu finds relevant sources, they will be clicked on. Irrelevant looking sources will not be clicked on usually. 

## Proposed Changes
Add TrainTracks render and interact events.

## Testing Instructions

Open up the Help Center and click on the chat icon to start up Wapuu. Ask Wapuu a question, e.g. 
"how do I create a domain".
In the Network pane, filter for `t.gif`
You should see events being fired with `_en=calypso_odie_sources_traintracks_render`, one for every source found.

If you click on one of the links, you should then see another `t.gif` request with `_en=calypso_odie_sources_traintracks_interact`. Make sure that the `railcar` ID is the same for the two events.
![traintracks-interact](https://github.com/user-attachments/assets/577c4bb6-bd17-4b9f-bfd8-7e32ce839035)
![traintracks-render](https://github.com/user-attachments/assets/1b653336-f02a-4c2f-97c8-86275f74aa4e)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
