### PR TITLE
A4A: Show secondary confirmation dialog when revoking a Pressable plan.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { noop } from 'calypso/jetpack-cloud/sections/partner-portal/lib/constants';
 import { LicenseRole } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { useDispatch } from 'calypso/state';
@@ -9,6 +9,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import useRefetchLicenses from '../hooks/use-refetch-licenses';
 import LicensesOverviewContext from '../licenses-overview/context';
 import useRevokeLicenseMutation from './hooks/use-revoke-license-mutation';
+import { SecondaryConfirmationDialog } from './secondary-confirmation-dialog';
 
 import './style.scss';
 
@@ -38,6 +39,8 @@ export default function RevokeLicenseDialog( {
 
 	const { mutate, isPending, status, error } = useRevokeLicenseMutation();
 
+	const [ showPressableConfirmationDialog, setShowPressableConfirmationDialog ] = useState( false );
+
 	useEffect( () => {
 		if ( status === 'success' ) {
 			close();
@@ -54,24 +57,32 @@ export default function RevokeLicenseDialog( {
 		}
 	}, [ onClose, isPending ] );
 
-	const revoke = useCallback( () => {
-		dispatch(
-			recordTracksEvent( 'calypso_a4a_license_list_revoke_dialog_revoke', {
-				license_role: licenseRole,
-			} )
-		);
-		mutate( { licenseKey } );
-	}, [ dispatch, licenseKey, licenseRole, mutate ] );
+	const revoke = useCallback(
+		( force?: boolean ) => {
+			if ( ! force && licenseKey.startsWith( 'pressable-wp' ) ) {
+				setShowPressableConfirmationDialog( true );
+				return;
+			}
+
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_license_list_revoke_dialog_revoke', {
+					license_role: licenseRole,
+				} )
+			);
+			mutate( { licenseKey } );
+		},
+		[ dispatch, licenseKey, licenseRole, mutate ]
+	);
 
 	const isParentLicense = licenseRole === LicenseRole.Parent;
 	const isAssignedChildLicense = licenseRole === LicenseRole.Child && siteUrl;
 
 	const buttons = [
-		<Button disabled={ false } onClick={ close }>
+		<Button disabled={ false } onClick={ close } key="cancel-button">
 			{ translate( 'Go back' ) }
 		</Button>,
 
-		<Button primary scary busy={ isPending } onClick={ revoke }>
+		<Button primary scary busy={ isPending } onClick={ () => revoke() } key="revoke-button">
 			{ isParentLicense ? translate( 'Revoke bundle' ) : translate( 'Revoke License' ) }
 		</Button>,
 	];
@@ -183,6 +194,20 @@ export default function RevokeLicenseDialog( {
 			</>
 		);
 	};
+
+	if ( showPressableConfirmationDialog ) {
+		return (
+			<SecondaryConfirmationDialog
+				title={ translate( 'Are you sure you want to revoke your Pressable plan?' ) }
+				description={ translate(
+					'If you continue revoking, you will lose access to all of your Pressable sites. Are you sure you want to proceed?'
+				) }
+				onConfirm={ () => revoke( true ) }
+				onCancel={ () => setShowPressableConfirmationDialog( false ) }
+				isPending={ isPending }
+			/>
+		);
+	}
 
 	return (
 		<Dialog

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
@@ -200,7 +200,7 @@ export default function RevokeLicenseDialog( {
 			<SecondaryConfirmationDialog
 				title={ translate( 'Are you sure you want to revoke your Pressable plan?' ) }
 				description={ translate(
-					'If you continue revoking, you will lose access to all of your Pressable sites. Are you sure you want to proceed?'
+					'If you continue to revoke, you will lose access to all of your Pressable sites. Are you sure you want to proceed?'
 				) }
 				onConfirm={ () => revoke( true ) }
 				onCancel={ () => setShowPressableConfirmationDialog( false ) }

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/secondary-confirmation-dialog.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/secondary-confirmation-dialog.tsx
@@ -1,0 +1,47 @@
+import { Button, Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+type Props = {
+	title: string;
+	description: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+	isPending?: boolean;
+};
+
+export function SecondaryConfirmationDialog( {
+	title,
+	description,
+	onConfirm,
+	onCancel,
+	isPending,
+}: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<Dialog
+			isVisible
+			additionalClassNames="revoke-license-dialog"
+			onClose={ close }
+			buttons={ [
+				<Button disabled={ false } onClick={ onCancel } key="cancel-secondary-confirmation">
+					{ translate( 'Cancel' ) }
+				</Button>,
+
+				<Button
+					primary
+					scary
+					busy={ isPending }
+					onClick={ onConfirm }
+					key="confirm-secondary-confirmation"
+				>
+					{ translate( 'Continue revoke' ) }
+				</Button>,
+			] }
+		>
+			<h2 className="revoke-license-dialog__heading">{ title }</h2>
+
+			{ description }
+		</Dialog>
+	);
+}


### PR DESCRIPTION
Revoking a Pressable plan is very destructive, and we want to ensure that agency users do not accidentally revoke it. This PR addresses this by adding a secondary confirmation dialog for revoking a Pressable plan.

<img width="706" alt="Screenshot 2024-08-13 at 10 49 06 PM" src="https://github.com/user-attachments/assets/2a3c1a70-e923-4cd6-a025-d81410e071f0">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/894

## Proposed Changes

* Show secondary dialog

## Why are these changes being made?


* Helps avoid accidentally triggering a destructive revoke operation.

## Testing Instructions

* Purchase a Pressable plan if you haven't.
* Use the A4A live link and go to the `/purchases/licenses` page.
* Revoke a Pressable plan.
* Confirm that you can see a secondary confirmation dialog when revoking one.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
