### PR TITLE
Performance Profiler: Update tab SVG

### DIFF
--- a/client/assets/images/performance-profiler/left-outer-border.svg
+++ b/client/assets/images/performance-profiler/left-outer-border.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="6" viewBox="0 0 6 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Subtract" fill-rule="evenodd" clip-rule="evenodd" d="M0.000976562 6H6.00098V0C6.00098 3.31371 3.31468 6 0.000976562 6Z" fill="white"/>
+</svg>

--- a/client/assets/images/performance-profiler/right-outer-border.svg
+++ b/client/assets/images/performance-profiler/right-outer-border.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="6" viewBox="0 0 6 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Subtract" fill-rule="evenodd" clip-rule="evenodd" d="M6.00098 6H0.000976562V0C0.000976562 3.31371 2.68727 6 6.00098 6Z" fill="white"/>
+</svg>

--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -37,7 +37,7 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 					</div>
 
 					<div className="profiler-header__action">
-						<Button href="/speed-test">Test another site</Button>
+						<Button href="/speed-test">{ translate( 'Test another site' ) }</Button>
 					</div>
 				</div>
 				{ showNavigationTabs && (

--- a/client/performance-profiler/components/header/style.scss
+++ b/client/performance-profiler/components/header/style.scss
@@ -104,17 +104,21 @@
 				&::before,
 				&::after {
 					position: absolute;
-					bottom: -7px;
+					width: 6px;
+					height: 6px;
+					bottom: 0;
 				}
 
 				&::before {
 					left: -6px;
-					content: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2IiBoZWlnaHQ9IjciIHZpZXdCb3g9IjAgMCA2IDciIGZpbGw9Im5vbmUiPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTAgNi4xMzc3SDZWMC4xMzc2OTVDNiAzLjQ1MTQgMy4zMTM3MSA2LjEzNzcgMCA2LjEzNzdaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4=);
+					background-image: url(calypso/assets/images/performance-profiler/left-outer-border.svg);
+					content: "";
 				}
 
 				&::after {
 					right: -6px;
-					content: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2IiBoZWlnaHQ9IjciIHZpZXdCb3g9IjAgMCA2IDciIGZpbGw9Im5vbmUiPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTYgNi4xMzc3SDBWMC4xMzc2OTVDMCAzLjQ1MTQgMi42ODYyOSA2LjEzNzcgNiA2LjEzNzdaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4=);
+					background-image: url(calypso/assets/images/performance-profiler/right-outer-border.svg);
+					content: "";
 				}
 
 				.section-nav-tab__link {


### PR DESCRIPTION


## Proposed Changes

Add the right and left outer tabs svgs to the project and use background-image to render it, instead of content.

## Why are these changes being made?

To fix issues on some browsers


## Testing Instructions

* Go to `/speed-test-tool?url=http://wordpress.com`
* Check the tabs (and mainly the outer border) works well zooming in and out.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
