### PR TITLE
Performance Profiler: Show the dashboard with real data

### DIFF
--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -1,21 +1,22 @@
-import { TabType } from 'calypso/performance-profiler/components/header';
+import { PerformanceReport } from 'calypso/data/site-profiler/types';
 import { PerformanceScore } from 'calypso/performance-profiler/components/performance-score';
 import './style.scss';
 
 type PerformanceProfilerDashboardContentProps = {
-	activeTab: TabType;
+	performanceReport?: PerformanceReport;
 };
 
 export const PerformanceProfilerDashboardContent = (
 	props: PerformanceProfilerDashboardContentProps
 ) => {
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const { activeTab } = props;
+	const { performanceReport } = props;
 
 	return (
 		<div className="performance-profiler-content">
 			<div className="l-block-wrapper">
-				<PerformanceScore value={ 70 } />
+				{ performanceReport?.overall_score && (
+					<PerformanceScore value={ performanceReport.overall_score * 100 } />
+				) }
 			</div>
 		</div>
 	);

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -31,6 +31,12 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 		setActiveTab( tab );
 	};
 
+	const mobileReport =
+		typeof performanceInsights?.mobile === 'string' ? undefined : performanceInsights?.mobile;
+	const desktopReport =
+		typeof performanceInsights?.desktop === 'string' ? undefined : performanceInsights?.desktop;
+	const performanceReport = activeTab === TabType.mobile ? mobileReport : desktopReport;
+
 	return (
 		<div className="container">
 			<DocumentHead title={ translate( 'Speed Test' ) } />
@@ -43,11 +49,11 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 			/>
 			{ 'mobile' === activeTab && ! mobileLoaded && <LoadingScreen isSavedReport={ false } /> }
 			{ 'mobile' === activeTab && mobileLoaded && (
-				<PerformanceProfilerDashboardContent activeTab={ activeTab } />
+				<PerformanceProfilerDashboardContent performanceReport={ performanceReport } />
 			) }
 			{ 'desktop' === activeTab && ! desktopLoaded && <LoadingScreen isSavedReport={ false } /> }
 			{ 'desktop' === activeTab && desktopLoaded && (
-				<PerformanceProfilerDashboardContent activeTab={ activeTab } />
+				<PerformanceProfilerDashboardContent performanceReport={ performanceReport } />
 			) }
 		</div>
 	);


### PR DESCRIPTION


## Proposed Changes

* Pass the proper data to the DashboardContent component 
  * Based on the active tab (mobile or desktop)
* Render the PerformanceScore component with real data 

## Why are these changes being made?

To allow other components to be used with real data

## Testing Instructions

* Go to `/speed-test-tool/url=:url`. Ex: `/speed-test-tool?url=https://wordpress.com`
* Reload the page and verify the data changes, this is expected

![CleanShot 2024-08-13 at 13 13 56@2x](https://github.com/user-attachments/assets/6ebb70d6-a684-4d88-9f1c-a3eb8e923aa2)
