### PR TITLE
A4A: Normalized Site dashboard Preview panel content styling.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/a4a/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/style.scss
@@ -1,7 +1,3 @@
-.site-details {
-	padding: 1rem 3rem;
-}
-
 .site-details__section-header {
 	margin: 1rem 0;
 }

--- a/client/a8c-for-agencies/sections/sites/features/hosting/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/hosting/style.scss
@@ -1,19 +1,12 @@
 .item-preview__content .hosting__wrapper {
 	.hosting__card {
-		border-radius: 4px;
+		box-shadow: none;
 		padding: 0;
 	}
 
-	.hosting__header {
-		border-bottom: 1px solid var(--color-border-subtle);
-	}
-
 	.hosting__title {
-		padding: 16px 24px;
-		font-size: rem(16px);
-		font-weight: 600;
-		line-height: 24px;
-		text-align: left;
+		@include a4a-font-heading-lg;
+		padding: 0 0 16px;
 	}
 
 	.hosting__content {
@@ -29,7 +22,7 @@
 
 	.hosting__content-value,
 	.hosting__content-label {
-		padding: 12px 24px;
+		padding: 12px 24px 12px 0;
 	}
 
 

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
@@ -1,7 +1,6 @@
 .item-preview__pane {
 
 	.preview-pane__navigation {
-
 		.section-nav-tabs__list {
 			padding: 0 0 0 32px;
 			width: unset;
@@ -20,21 +19,45 @@
 }
 
 .item-preview__content {
+	& > * {
+		width: 100%;
+		max-width: 1400px;
+		box-sizing: border-box;
+
+		.main {
+			max-width: 100%;
+			padding-block-end: 16px;
+		}
+
+		.backup__main-wrap {
+			margin: 0;
+		}
+
+		.backup__header-title,
+		.activity-log-v2__header-title {
+			@include a4a-font-heading-lg;
+		}
+
+		.backup-getting-started {
+			background-image: none;
+		}
+	}
+
 
 	.expanded-card {
 		text-align: left;
 		width: auto;
 		max-width: unset !important;
+		border: none;
+		box-shadow: none;
+		padding: 0 !important;
 
 		.site-expanded-content__card-footer {
 			justify-content: unset !important;
 		}
 
 		.expanded-card__header {
-			font-size: 1.25rem;
-			text-overflow: ellipsis;
-			font-weight: 500;
-			text-align: left;
+			@include a4a-font-heading-lg;
 		}
 
 		.site-expanded-content__card-content-score {
@@ -43,8 +66,7 @@
 	}
 
 	.site-preview-pane__plugins-content {
-		padding: 16px;
-		box-shadow: 0 0 0 1px #dcdcde;
+		padding: 0;
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 0.5rem;
 		text-align: left;
@@ -116,11 +138,6 @@
 }
 
 .site-preview-pane__boost-content {
-
-	.expanded-card {
-		padding: 16px 24px !important;
-	}
-
 	.site-expanded-content__card-content-column {
 		margin-right: 32px;
 	}


### PR DESCRIPTION
This PR addresses styling inconsistency within the Site dashboard preview panel content.

**Before**

https://github.com/user-attachments/assets/b4ff2f5d-403b-4e76-a5a8-c373d4791e6f



**After**


https://github.com/user-attachments/assets/79c43e31-8fd0-47ef-9644-b94ef4f41f98



Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/891

## Proposed Changes

* Remove borders and shadows to the expanded card so all content has more consistent borders.
* Normalized the width of the contents so they span full width.
* Normalized the spacing (padding and margins).
* Normalized header fonts are used to use the official A4A Heading Large font style.

## Why are these changes being made?

* This improves our user interface with more consistent and polished styling in the Site dashboard preview panels.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
