### PR TITLE
Plans: Extract the default WPCOM plans-intent into a hook

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-default-wpcom-plans-intent.ts
+++ b/client/my-sites/plans-features-main/hooks/use-default-wpcom-plans-intent.ts
@@ -1,0 +1,18 @@
+import type { PlansIntent } from '@automattic/plans-grid-next';
+
+/**
+ * Used for defining the default plans intent for general WordPress.com plans UI.
+ *
+ * The default intent is used in various scenarios, such as:
+ * - signup flows / plans page that do not require a tailored plans mix
+ * - switching to the default plans through an escape hatch (button) when a tailored mix is rendered
+ * - showing the default plans in the comparison grid when a tailored mix is rendered otherwise
+ *
+ * When experimenting with different default plans, this hook can be used to define the intent.
+ * We will need an exclusion mechanism in that case (to not mix with other intents).
+ */
+const useDefaultWpcomPlansIntent = (): PlansIntent | undefined => {
+	return 'plans-default-wpcom';
+};
+
+export default useDefaultWpcomPlansIntent;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -68,6 +68,7 @@ import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
 import PlansPageSubheader from './components/plans-page-subheader';
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
+import useDefaultWpcomPlansIntentSlug from './hooks/use-default-wpcom-plans-intent-slug';
 import useFilteredDisplayedIntervals from './hooks/use-filtered-displayed-intervals';
 import useGenerateActionHook from './hooks/use-generate-action-hook';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
@@ -238,6 +239,7 @@ const PlansFeaturesMain = ( {
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const getPlanTypeDestination = usePlanTypeDestinationCallback();
+	const defaultWpcomPlansIntentSlug = useDefaultWpcomPlansIntentSlug();
 
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
@@ -299,13 +301,13 @@ const PlansFeaturesMain = ( {
 		// TODO: plans from upsell takes precedence for setting intent right now
 		// - this is currently set to the default wpcom set until we have updated tailored features for all plans
 		// - at which point, we'll inject the upsell plan to the tailored plans mix instead
-		if ( 'plans-default-wpcom' !== intent && forceDefaultPlans ) {
-			setIntent( 'plans-default-wpcom' );
+		if ( defaultWpcomPlansIntentSlug !== intent && forceDefaultPlans ) {
+			setIntent( defaultWpcomPlansIntentSlug );
 		} else if ( ! intent ) {
 			setIntent(
 				planFromUpsells
-					? 'plans-default-wpcom'
-					: intentFromProps || intentFromSiteMeta.intent || 'plans-default-wpcom'
+					? defaultWpcomPlansIntentSlug
+					: intentFromProps || intentFromSiteMeta.intent || defaultWpcomPlansIntentSlug
 			);
 		}
 	}, [
@@ -315,10 +317,11 @@ const PlansFeaturesMain = ( {
 		planFromUpsells,
 		forceDefaultPlans,
 		intentFromSiteMeta.processing,
+		defaultWpcomPlansIntentSlug,
 	] );
 
 	const showEscapeHatch =
-		intentFromSiteMeta.intent && ! isInSignup && 'plans-default-wpcom' !== intent;
+		intentFromSiteMeta.intent && ! isInSignup && defaultWpcomPlansIntentSlug !== intent;
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 
@@ -372,7 +375,7 @@ const PlansFeaturesMain = ( {
 		eligibleForFreeHostingTrial,
 		hasRedeemedDomainCredit: currentPlan?.hasRedeemedDomainCredit,
 		hiddenPlans,
-		intent,
+		intent: shouldForceDefaultPlansBasedOnIntent( intent ) ? defaultWpcomPlansIntentSlug : intent,
 		isDisplayingPlansNeededForFeature,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
 		selectedFeature,
@@ -383,7 +386,6 @@ const PlansFeaturesMain = ( {
 		term,
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
-		forceDefaultIntent: shouldForceDefaultPlansBasedOnIntent( intent ),
 	} );
 
 	// we need only the visible ones for features grid (these should extend into plans-ui data store selectors)

--- a/packages/plans-grid-next/src/hooks/data-store/types.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/types.ts
@@ -17,7 +17,6 @@ export interface UseGridPlansParams {
 	selectedFeature?: string | null;
 	selectedPlan?: PlanSlug;
 	showLegacyStorageFeature?: boolean;
-	forceDefaultIntent?: boolean;
 	siteId?: number | null;
 	storageAddOns: ( AddOnMeta | null )[];
 	term?: ( typeof TERMS_LIST )[ number ]; // defaults to monthly

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-comparison-grid.ts
@@ -27,7 +27,6 @@ const useGridPlansForComparisonGrid = ( {
 	term,
 	useCheckPlanAvailabilityForPurchase,
 	useFreeTrialPlanSlugs,
-	forceDefaultIntent,
 }: UseGridPlansParams ): GridPlan[] | null => {
 	const gridPlans = useGridPlans( {
 		allFeaturesList,
@@ -45,7 +44,6 @@ const useGridPlansForComparisonGrid = ( {
 		term,
 		useCheckPlanAvailabilityForPurchase,
 		useFreeTrialPlanSlugs,
-		forceDefaultIntent,
 	} );
 
 	const planFeaturesForComparisonGrid = useRestructuredPlanFeaturesForComparisonGrid( {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -228,7 +228,6 @@ const useGridPlans: UseGridPlansType = ( {
 	coupon,
 	siteId,
 	isDisplayingPlansNeededForFeature,
-	forceDefaultIntent,
 	highlightLabelOverrides,
 } ) => {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs?.( {
@@ -248,7 +247,7 @@ const useGridPlans: UseGridPlansType = ( {
 	} );
 	const planSlugsForIntent = usePlansFromTypes( {
 		planTypes: usePlanTypesWithIntent( {
-			intent: forceDefaultIntent ? 'plans-default-wpcom' : intent,
+			intent,
 			selectedPlan,
 			siteId,
 			hiddenPlans,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3303

## Proposed Changes

- Moves the hardcoded mention of the default plans intent (`plans-default-wpcom`) behind a hook to allow tailoring it to experiments and other conditions.
- Updates the guided flows to use same mechanism. These previously hardcoded the default intent behind a condition in the `useGridPlans*` hooks. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The default plans intent was primarily intended to serve general WPCOM plans UI where a tailored plans mix isn't needed. It evolved to apply in other scenarios, such as:
- switching to the default plans through an escape hatch (button) when a tailored mix is rendered (such as when viewed on a site created through Newsletter flow)
- showing the default plans in the comparison grid when a tailored mix is rendered otherwise (so not introducing a separate intent, but parsing the data through the default - this is still questionable whether it's the right approach, but so be it)

In upcoming work, we will be experimenting with a different set of base/default plans, while maintaining the previous ones (to serve previous plan mentions). This hook will serve as the inclusion/exclusion mechanism for the new plans set.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure `/start/plans` renders the default/correct plans
* Go to `/plans/[ Newsletter site ]` and ensure a tailored plans mix is rendered. 
  * Click on the escape hatch ("show all plans" button). Ensure the grid switches to showing the full default plans set
* Go through the guided onboarding flow (`/start/guided`), pick through the various segmentations, and proceed to plans step. 
  * Ensure the comparison grid renders the full/default plans mix and the Features grid a tailored variation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
