### PR TITLE
Re-add background colors - move pseudos to other elements and adjust...

### DIFF
--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -18,10 +18,22 @@ interface SectionHeaderProps {
 	dark?: boolean;
 }
 
-// TODO - re-add background color and usage of dark prop, to something other than a pseudo element.
-// We will need to adjust exterior containers margin etc. to accomodate this.
-// https://github.com/Automattic/wp-calypso/pull/93425
 export const SectionContainer = styled.div< SectionContainerProps >`
+	position: relative;
+	z-index: 1;
+
+	::before {
+		box-sizing: border-box;
+		content: '';
+		background-color: ${ ( props ) =>
+			props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
+		position: absolute;
+		height: 100%;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+		margin-top: -56px;
+	}
 	padding: 56px 0;
 `;
 

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -25,7 +25,21 @@ const ThreeColumnContainer = styled.div`
 `;
 
 const EducationFooterContainer = styled.div`
-	margin-top: 32px;
+	padding-top: 32px;
+	position: relative;
+	z-index: 1;
+
+	::before {
+		box-sizing: border-box;
+		content: '';
+		background-color: var( --studio-white );
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+	}
 
 	> div:first-child {
 		padding: 0;

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -54,6 +54,22 @@
 	display: contents;
 }
 
+.plugins-browser-list,
+.plugins-browser__marketplace-footer {
+	position: relative;
+	&::before {
+		box-sizing: border-box;
+		content: "";
+		background-color: #fff;
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+	}
+ }
+
 .plugins-browser__upgrade-banner {
 	display: table;
 	width: 100%;
@@ -64,7 +80,8 @@
 }
 
 .plugins-browser__marketplace-footer {
-	margin-top: 60px;
+	padding-top: 60px;
+	margin-bottom: -32px;
 }
 
 body.is-section-plugins #primary .main.is-logged-out {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -64,6 +64,11 @@ body.is-section-plugins {
 				height: calc(100vh - var(--masterbar-height) - 32px);
 			}
 		}
+
+		.plugins-browser,
+		.is-plugin-details {
+			overflow-x: hidden;
+		}
 	}
 
 	.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This approach is a lot closer to what we want. There is one thing on my radar that does not yet fit, and it is this blue background for this one cta section on the logged-out page. It seems difficult to get rid of the outer light blue while still keeping the inner dark blue background (with this approach, as the pseudo background seems to override that inner blue background as well).  So maybe need another wrapper element?

<img width="1635" alt="Screenshot 2024-08-13 at 2 04 55 PM" src="https://github.com/user-attachments/assets/f9e4cbb0-31f8-4394-b3dc-1c5d560da7f5">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
