### PR TITLE
Plugins marketplace - bring back background elements in a stable way.

### DIFF
--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -23,6 +23,21 @@ interface SectionHeaderProps {
 // https://github.com/Automattic/wp-calypso/pull/93425
 export const SectionContainer = styled.div< SectionContainerProps >`
 	padding: 56px 0;
+	position: relative;
+	z-index: 1;
+
+	::before {
+		box-sizing: border-box;
+		content: '';
+		background-color: ${ ( props ) =>
+			props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
+		position: absolute;
+		height: 100%;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+		margin-top: -56px;
+	}
 `;
 
 export const SectionHeader = styled.div< SectionHeaderProps >`

--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -32,7 +32,8 @@ export const SectionContainer = styled.div< SectionContainerProps >`
 		background-color: ${ ( props ) =>
 			props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
 		position: absolute;
-		height: 100%;
+		top: 0;
+		bottom: 0;
 		width: 200vw;
 		left: -100vw;
 		z-index: -1;

--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -32,8 +32,7 @@ export const SectionContainer = styled.div< SectionContainerProps >`
 		background-color: ${ ( props ) =>
 			props.dark ? 'var( --studio-gray-100 )' : 'var( --studio-white )' };
 		position: absolute;
-		top: 0;
-		bottom: 0;
+		height: 100%;
 		width: 200vw;
 		left: -100vw;
 		z-index: -1;

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -68,7 +68,7 @@ const MarketplaceContainer = styled.div< { isloggedIn: boolean } >`
 	${ ( { isloggedIn } ) =>
 		! isloggedIn &&
 		`${ SectionContainer } {
-		padding-bottom: 0;
+		padding-bottom: 32px;
 	}` }
 
 	${ SectionContainer }::before {

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -54,6 +54,7 @@ const EducationFooterContainer = styled.div`
 const MarketplaceContainer = styled.div< { isloggedIn: boolean } >`
 	--color-accent: #117ac9;
 	--color-accent-60: #0e64a5;
+	margin-bottom: -32px;
 
 	.marketplace-cta {
 		min-width: 122px;

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -530,11 +530,7 @@ function PluginDetails( props ) {
 					/>
 				</div>
 			) }
-			{ isMarketplaceProduct && ! showPlaceholder && (
-				<div className="plugins-details__marketplace-footer">
-					<MarketplaceFooter />
-				</div>
-			) }
+			{ isMarketplaceProduct && ! showPlaceholder && <MarketplaceFooter /> }
 		</MainComponent>
 	);
 }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -530,7 +530,11 @@ function PluginDetails( props ) {
 					/>
 				</div>
 			) }
-			{ isMarketplaceProduct && ! showPlaceholder && <MarketplaceFooter /> }
+			{ isMarketplaceProduct && ! showPlaceholder && (
+				<div className="plugins-details__marketplace-footer">
+					<MarketplaceFooter />
+				</div>
+			) }
 		</MainComponent>
 	);
 }

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -77,7 +77,7 @@
 
 .plugins-browser__marketplace-footer {
 	position: relative;
-	margin-top: 60px;
+	padding-top: 60px;
 	margin-bottom: -32px;
 
 	&::before {

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -51,7 +51,19 @@
 	}
 }
 .plugins-browser__main-container {
-	display: contents;
+	position: relative;
+
+	&::before {
+		box-sizing: border-box;
+		content: "";
+		background-color: #fff;
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+	}
 }
 
 .plugins-browser__upgrade-banner {
@@ -64,7 +76,21 @@
 }
 
 .plugins-browser__marketplace-footer {
+	position: relative;
 	margin-top: 60px;
+	margin-bottom: -32px;
+
+	&::before {
+		box-sizing: border-box;
+		content: "";
+		background-color: #fff;
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+	}
 }
 
 body.is-section-plugins #primary .main.is-logged-out {

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -79,7 +79,6 @@
 }
 
 .plugins-browser__marketplace-footer {
-	position: relative;
 	margin-bottom: -32px;
 }
 

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -58,11 +58,14 @@
 		content: "";
 		background-color: #fff;
 		position: absolute;
-		top: 0;
-		bottom: 0;
+		height: 100%;
 		width: 200vw;
 		left: -100vw;
 		z-index: -1;
+	}
+
+	.plugins-browser-list:last-of-type {
+		padding-bottom: 32px;
 	}
 }
 
@@ -77,20 +80,7 @@
 
 .plugins-browser__marketplace-footer {
 	position: relative;
-	padding-top: 60px;
 	margin-bottom: -32px;
-
-	&::before {
-		box-sizing: border-box;
-		content: "";
-		background-color: #fff;
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		width: 200vw;
-		left: -100vw;
-		z-index: -1;
-	}
 }
 
 body.is-section-plugins #primary .main.is-logged-out {

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -78,10 +78,6 @@
 	}
 }
 
-.plugins-browser__marketplace-footer {
-	margin-bottom: -32px;
-}
-
 body.is-section-plugins #primary .main.is-logged-out {
 	padding-top: 0;
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -64,6 +64,11 @@ body.is-section-plugins {
 				height: calc(100vh - var(--masterbar-height) - 32px);
 			}
 		}
+
+		.plugins-browser,
+		.is-plugin-details {
+			overflow-x: hidden;
+		}
 	}
 
 	.is-logged-in main:not(.a4a-layout):not(.a4a-layout-column) {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -45,21 +45,7 @@
 }
 
 .plugins-details__marketplace-footer {
-	position: relative;
-	padding-top: 60px;
 	margin-bottom: -32px;
-
-	&::before {
-		box-sizing: border-box;
-		content: "";
-		background-color: #fff;
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		width: 200vw;
-		left: -100vw;
-		z-index: -1;
-	}
 }
 
 body.is-section-plugins {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -44,6 +44,24 @@
 	}
 }
 
+.plugins-details__marketplace-footer {
+	position: relative;
+	padding-top: 60px;
+	margin-bottom: -32px;
+
+	&::before {
+		box-sizing: border-box;
+		content: "";
+		background-color: #fff;
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 200vw;
+		left: -100vw;
+		z-index: -1;
+	}
+}
+
 body.is-section-plugins {
 	.is-section-plugins.is-global-sidebar-visible {
 		background: var(--studio-gray-0);

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -44,10 +44,6 @@
 	}
 }
 
-.plugins-details__marketplace-footer {
-	margin-bottom: -32px;
-}
-
 body.is-section-plugins {
 	.is-section-plugins.is-global-sidebar-visible {
 		background: var(--studio-gray-0);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/93460 

Prior art https://github.com/Automattic/wp-calypso/pull/93425 and https://github.com/Automattic/wp-calypso/pull/93381

## Proposed Changes

Re-adds the background elements that were previously removed due to causing a layout bug. This adds them back with some subtle differences to ensure they do not break the layout again. The main differences in this approach from the previous (prior to removing):
*  Ensure `relative` position is set on the parents of background elements. This ensures the absolutely positioned elements are positioned with respect to their parents and not something higher in the DOM. The lack of this was causing layouts to break in various areas.
* Removes `display: contents` from the plugin browser container. This allows the positioning for these background elements to work consistently where expected. Using this display property breaks the layout on global pages (possibly other areas as well, seems inconsistent there), and doesn't seem to provide any benefit elsewhere.
* Also adds some minor style tweaks to align the footers in logged out view and prevent horizontal scrollbar in global view.

BEFORE (site level)
<img width="700" alt="Screenshot 2024-08-13 at 3 22 11 PM" src="https://github.com/user-attachments/assets/fd4717fc-9206-47ad-a23a-69e89d420c25">

BEFORE (logged out)
<img width="700" alt="Screenshot 2024-08-13 at 3 22 57 PM" src="https://github.com/user-attachments/assets/8d3028e0-6520-41a3-b463-454be709a60a">
<img width="700" alt="Screenshot 2024-08-13 at 3 23 07 PM" src="https://github.com/user-attachments/assets/aca7790a-86fe-4989-9cec-b4b5b2694cb0">


AFTER (Site level)

<img width="700" alt="Screenshot 2024-08-13 at 3 21 48 PM" src="https://github.com/user-attachments/assets/b906b46d-a862-48d8-b23a-5eefeada706d">

AFTER (logged out)

<img width="700" alt="Screenshot 2024-08-13 at 3 22 29 PM" src="https://github.com/user-attachments/assets/56f02651-1e81-4edb-acb4-251c622e3e06">
<img width="700" alt="Screenshot 2024-08-13 at 3 22 42 PM" src="https://github.com/user-attachments/assets/f272a2a4-b99f-4dad-8d74-da48840b9e25">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to maintain good looking styles. this is the appearance we previously had, but regressed when we had to remove these elements due to an experience breaking bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Verify the background colors are back in place and look good in the site level and logged-out plugins showcases.
* Confirm the previous layout breaking bug no longer happens:
    * Go to the plugins marketplace at the global level (starting at */sites -> click plugins in sidebar).
    * Click into and back from individual plugins that previously showcased this issue (like yoast SEO premium), verify the content frame layout does not change.
    * Go to the plugins marketplace at the site level (my home -> plugins in sidebar).
    * Click into individual plugins that previously showcased this issue (like yoast SEO premium), verify the full plugin page is visible and the top is no longer cut off.
    * Go to the logged out plugins page */plugins.
    * Click into and back out of plugins that show this issue, verify the full page is always visible and the layout is not adjusting to cut off the top section of the screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
