### PR TITLE
Installing Jetpack optionally while provisioning site at A4A flow

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -42,9 +42,12 @@ export default function SiteConfigurationsModal( {
 	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading );
 	const { mutate: createWPCOMSite } = useCreateWPCOMSiteMutation();
 	const { mutate: createWPCOMDevSite } = useCreateWPCOMDevSiteMutation();
+	const [ useJetpack, setUseJetpack ] = useState( false );
 
 	const toggleAllowClientsToUseSiteHelpCenter = () =>
 		setAllowClientsToUseSiteHelpCenter( ! allowClientsToUseSiteHelpCenter );
+
+	const toggleUseJetpack = () => setUseJetpack( ! useJetpack );
 
 	const phpVersionsElements = phpVersions.map( ( version ) => {
 		if ( version.disabled ) {
@@ -88,6 +91,7 @@ export default function SiteConfigurationsModal( {
 			...trackingParams,
 			id: siteId,
 			site_name: siteName.siteName,
+			plugins_for_site_provisioning: [ useJetpack ? 'jetpack' : undefined ],
 		};
 
 		recordTracksEvent( 'calypso_a4a_create_site_config_submit', trackingParams );
@@ -222,6 +226,33 @@ export default function SiteConfigurationsModal( {
 						{ dataCenterOptionsElements }
 					</FormSelect>
 				</FormField>
+
+				<FormField label={ translate( 'Plugins to activate' ) }>
+					<CheckboxControl
+						id="configure-your-site-modal-form__jetpack-plugin-checkbox"
+						onChange={ toggleUseJetpack }
+						checked={ useJetpack }
+						name="plugins_to_activate_jetpack"
+						disabled={ isSubmitting }
+					/>
+					<label
+						className={ isDevSite ? 'disabled-label' : '' }
+						htmlFor="configure-your-site-modal-form__allow-clients-to-use-help-center-checkbox"
+					>
+						{ translate( 'Activate {{JetpackLink}}Jetpack{{/JetpackLink}} plugin on this site.', {
+							components: {
+								JetpackLink: (
+									<a
+										target="_blank"
+										href={ localizeUrl( 'https://jetpack.com/' ) }
+										rel="noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</label>
+				</FormField>
+
 				<FormField label="">
 					<div className="configure-your-site-modal-form__allow-clients-to-use-help-center">
 						<CheckboxControl


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8695

## Proposed Changes

* Installing Jetpack optionally while provisioning site at A4A flow



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
