### PR TITLE
Automated Migrations: Add the credentials validation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -2,7 +2,7 @@ import { FormLabel } from '@automattic/components';
 import Card from '@automattic/components/src/card';
 import { NextButton, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useState, type FC } from 'react';
+import { ChangeEvent, FormEvent, useState, type FC } from 'react';
 import getValidationMessage from 'calypso/blocks/import/capture/url-validation-message-helper';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -53,7 +53,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 		return credentialsErrors;
 	};
 
-	const handleSubmit = ( e: any ) => {
+	const handleSubmit = ( e: FormEvent ) => {
 		e.preventDefault();
 		setError( {} );
 		if ( accessMethod === 'credentials' ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -3,12 +3,15 @@ import Card from '@automattic/components/src/card';
 import { NextButton, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useState, type FC } from 'react';
+import getValidationMessage from 'calypso/blocks/import/capture/url-validation-message-helper';
+import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { isValidUrl } from 'calypso/lib/importer/url-validation';
 import type { Step } from '../../types';
 
 import './style.scss';
@@ -25,13 +28,46 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 	const [ username, setUsername ] = useState< string >( '' );
 	const [ password, setPassword ] = useState< string >( '' );
 	const [ backupFileLocation, setBackupFileLocation ] = useState< string >( '' );
+	const [ notes, setNotes ] = useState< string >( '' );
+	const [ errors, setError ] = useState< Record< string, string > >();
 
 	const handleAccessMethodChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setAccessMethod( event.target.value );
 	};
 
-	const handleSubmit = () => {
-		// Handle form submission logic here
+	const validateCredentials = () => {
+		const credentialsErrors: Record< string, string > = {};
+		const isSiteAddressValid = CAPTURE_URL_RGX.test( siteAddress );
+
+		if ( ! isSiteAddressValid ) {
+			const siteAddressError = getValidationMessage( siteAddress, translate );
+			credentialsErrors.siteAddress = siteAddressError;
+		}
+
+		if ( ! username || ! password ) {
+			credentialsErrors.credentials = translate(
+				'Enter your WordPress admin username and password.'
+			);
+		}
+
+		return credentialsErrors;
+	};
+
+	const handleSubmit = ( e: any ) => {
+		e.preventDefault();
+		setError( {} );
+		if ( accessMethod === 'credentials' ) {
+			const credentialsErrors = validateCredentials();
+			if ( Object.keys( credentialsErrors ).length ) {
+				setError( credentialsErrors );
+				return;
+			}
+		} else if ( accessMethod === 'backup' ) {
+			if ( ! isValidUrl( backupFileLocation ) ) {
+				setError( { backupFileLocation: translate( 'Please enter a valid URL' ) } );
+				return;
+			}
+		}
 		onSubmit();
 	};
 
@@ -76,9 +112,11 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 										setSiteAddress( e.target.value )
 									}
 								/>
-								<div className="site-migration-credentials__form-error">
-									{ translate( 'Enter the URL of your source site.' ) }
-								</div>
+								{ errors?.siteAddress && (
+									<div className="site-migration-credentials__form-error">
+										{ errors.siteAddress }
+									</div>
+								) }
 							</div>
 
 							<div className="site-migration-credentials__form-fields-row">
@@ -109,9 +147,10 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									/>
 								</div>
 							</div>
-							<div className="site-migration-credentials__form-error">
-								{ translate( 'Enter your WordPress admin username and password.' ) }
-							</div>
+
+							{ errors?.credentials && (
+								<div className="site-migration-credentials__form-error">{ errors.credentials }</div>
+							) }
 						</div>
 					</div>
 				) }
@@ -130,6 +169,11 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									placeholder={ translate( 'Enter your backup file location' ) }
 								/>
 							</div>
+							{ errors?.backupFileLocation && (
+								<div className="site-migration-credentials__form-error">
+									{ errors.backupFileLocation }
+								</div>
+							) }
 							<div className="site-migration-credentials__form-note">
 								{ translate(
 									"Upload your file to a service like Dropbox or Google Drive to get a link. Don't forget to make sure that anyone with the link can access it."
@@ -147,8 +191,8 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 						placeholder={ translate(
 							'Share any other details that will help us access your site for the migration.'
 						) }
-						value={ siteAddress }
-						onChange={ ( e: ChangeEvent< HTMLInputElement > ) => setSiteAddress( e.target.value ) }
+						value={ notes }
+						onChange={ ( e: ChangeEvent< HTMLInputElement > ) => setNotes( e.target.value ) }
 					/>
 				</div>
 				<div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -108,6 +108,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									id="site-address"
 									value={ siteAddress }
 									placeholder={ translate( 'Enter your WordPress site address.' ) }
+									isError={ errors?.siteAddress }
 									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
 										setSiteAddress( e.target.value )
 									}
@@ -129,6 +130,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 										id="username"
 										value={ username }
 										placeholder={ translate( 'Username' ) }
+										isError={ errors?.credentials && ! username }
 										onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
 											setUsername( e.target.value )
 										}
@@ -141,6 +143,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 										id="password"
 										value={ password }
 										placeholder={ translate( 'Password' ) }
+										isError={ errors?.credentials && ! password }
 										onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
 											setPassword( e.target.value )
 										}
@@ -163,6 +166,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									type="text"
 									id="backup-file"
 									value={ backupFileLocation }
+									isError={ errors?.backupFileLocation }
 									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
 										setBackupFileLocation( e.target.value )
 									}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .site-migration-credentials {
 	#site-migration-credentials-header {
 		.formatted-header__subtitle {
@@ -20,6 +22,10 @@
 			display: flex;
 			flex-direction: row;
 			gap: 1em;
+			@media (max-width: $break-mobile) {
+				flex-direction: column;
+				gap: 0;
+			}
 		}
 		.site-migration-credentials__form-field {
 			margin-top: 1em;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -41,6 +41,7 @@
 		.site-migration-credentials__form-error {
 			color: var(--color-error);
 			font-size: 0.875rem;
+			margin-top: 0.25rem;
 		}
 	}
 	.site-migration-credentials__skip {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93252

## Proposed Changes

* Adds a simple front-end validation for the new Credentials steps and removes the fixed validation messages.

<img width="616" alt="Captura de Tela 2024-08-13 às 17 44 19" src="https://github.com/user-attachments/assets/89fc3d0d-16dc-4bc6-9659-b99078d5fa70">

<img width="653" alt="Captura de Tela 2024-08-13 às 17 43 59" src="https://github.com/user-attachments/assets/72add66d-c5b9-4136-a3af-ca8a880e9064">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the UI changes for the Credentials collection step, which is part of the Automated Migrations(paYKcK-5a3-p2) project, we want some basic validation on the UI before making the request to the backend.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch to your local environment or add use the Calypso Live link below.
* Open the dev console and activate the feature flag by running the following command:
```
window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')
```
* Now go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Now input some invalid URL value on the source address input and leave the username or the password empty
  * Click on submit, the validation errors should be shown
  * Now, click on the "Backup file" radio under `How can we access your site?`
  * Add an invalid URL to the backup file input and press `Continue`
  * You should see the validation error for that input

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?