### PR TITLE
Performance Profiler: Add protocol to the URL when its not passed

### DIFF
--- a/client/performance-profiler/controller.tsx
+++ b/client/performance-profiler/controller.tsx
@@ -16,11 +16,15 @@ export function PerformanceProfilerDashboardContext( context: Context, next: () 
 		return;
 	}
 
+	const url = context.query?.url?.startsWith( 'http' )
+		? context.query.url
+		: `https://${ context.query?.url ?? '' }`;
+
 	context.primary = (
 		<>
 			<Main fullWidthLayout>
 				<PerformanceProfilerDashboard
-					url={ context.query?.url ?? '' }
+					url={ url }
 					tab={
 						[ TabType.mobile, TabType.desktop ].indexOf( context.query?.tab ) !== -1
 							? context.query?.tab


### PR DESCRIPTION
## Proposed Changes

Add protocol when the URL passed its doesn't start with http(s).

## Why are these changes being made?

To properly handle the cases where only domains are passed

## Testing Instructions

* Go to `/speed-test-tool?url=wordpress.com`
* The page should load properly
* Go to the same page with the `trunk` version
* You should see an error.

### Missing

We should implement an error page when the URL is not valid (ex: empty).