### PR TITLE
Mailpoet / logged out links and sizing on mobile

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -203,7 +203,7 @@ class MasterbarLoggedOut extends Component {
 	}
 
 	render() {
-		const { title, isCheckout, isCheckoutPending, isCheckoutFailed } = this.props;
+		const { title, isCheckout, isCheckoutPending, isCheckoutFailed, sectionName } = this.props;
 
 		if ( isCheckout || isCheckoutPending || isCheckoutFailed ) {
 			return (
@@ -221,13 +221,21 @@ class MasterbarLoggedOut extends Component {
 			<Masterbar className="masterbar__loggedout">
 				{ this.renderWordPressItem() }
 				{ title && <Item className="masterbar__item-title">{ title }</Item> }
-				<div className="masterbar__login-links">
-					{ this.renderDiscoverItem() }
-					{ this.renderTagsItem() }
-					{ this.renderSearchItem() }
-					{ this.renderLoginItem() }
-					{ this.renderSignupItem() }
-				</div>
+				{ sectionName === 'reader' && (
+					<div className="masterbar__login-links">
+						{ this.renderDiscoverItem() }
+						{ this.renderTagsItem() }
+						{ this.renderSearchItem() }
+						{ this.renderLoginItem() }
+						{ this.renderSignupItem() }
+					</div>
+				) }
+				{ sectionName !== 'reader' && (
+					<div className="masterbar__login-links">
+						{ this.renderLoginItem() }
+						{ this.renderSignupItem() }
+					</div>
+				) }
 			</Masterbar>
 		);
 	}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -83,10 +83,15 @@ body.is-mobile-app-view {
 			color: var(--color-sidebar-text);
 		}
 		@media only screen and (max-width: 781px) {
+			padding-top: 0;
+
 			.masterbar__login-links {
 				.masterbar__item {
+					height: 30px;
+					line-height: 30px;
 					width: unset !important;
 					padding: 0 8px;
+					margin: 8px 8px 0 0;
 
 					.masterbar__item-content {
 						display: block !important;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/85089

## Proposed Changes

Logged out masterbar changes:
* Hides reader icons on non reader sections
* Shrinks item button sizes on mobile breakpoints

## Testing Instructions

Test any logged out page e.g.:
* http://calypso.localhost:3000/devdocs/start
* http://calypso.localhost:3000/discover
* http://calypso.localhost:3000/log-in?client_id=79002&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26redirect_uri%3Dhttps%253A%252F%252Faccount.mailpoet.com%252Flogin%252Fwpcom%252Fcallback%26scope%3Dauth%26client_id%3D79002

Compare with production:
* https://wordpress.com/discover
* https://wordpress.com/log-in?client_id=79002&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26redirect_uri%3Dhttps%253A%252F%252Faccount.mailpoet.com%252Flogin%252Fwpcom%252Fcallback%26scope%3Dauth%26client_id%3D79002

- [ ] Confirm mobile headers look ok at different screen sizes
- [ ] Confirm reader nav links are only shown in the reader pages

Before / Afters

https://github.com/user-attachments/assets/14241eea-c542-4d04-843b-5b8ff6f04718


https://github.com/user-attachments/assets/3402ca16-0412-4193-8b6a-7f17fa6e1028


https://github.com/user-attachments/assets/02449d31-9e18-42f7-a362-5b6d23571b41


https://github.com/user-attachments/assets/14c29207-7eb6-417a-9df1-ddb6521a40fa
