### PR TITLE
Newsletter: start using new paid newsletter state endpoint

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+
+export const usePaidNewsletterQuery = ( engine: string, currentStep: string, siteId?: number ) => {
+	return useQuery( {
+		enabled: !! siteId,
+		queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
+		queryFn: () => {
+			return wp.req.get(
+				{
+					path: `/sites/${ siteId }/site-importer/paid-newsletter`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					engine: engine,
+					current_step: currentStep,
+				}
+			);
+		},
+		staleTime: 3600000, // 1 hour
+	} );
+};

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -4,7 +4,7 @@ import wp from 'calypso/lib/wp';
 export const usePaidNewsletterQuery = ( engine: string, currentStep: string, siteId?: number ) => {
 	return useQuery( {
 		enabled: !! siteId,
-		queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
+		queryKey: [ 'paid-newsletter-importer', siteId, engine ],
 		queryFn: () => {
 			return wp.req.get(
 				{

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -17,6 +17,7 @@ export const usePaidNewsletterQuery = ( engine: string, currentStep: string, sit
 				}
 			);
 		},
-		staleTime: 3600000, // 1 hour
+		refetchOnWindowFocus: true,
+		staleTime: 6000, // 1 hour
 	} );
 };

--- a/client/data/paid-newsletter/use-reset-mutation.ts
+++ b/client/data/paid-newsletter/use-reset-mutation.ts
@@ -1,11 +1,24 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+	DefaultError,
+	useMutation,
+	UseMutationOptions,
+	useQueryClient,
+} from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
-export const useSkipNextStepMutation = ( options = {} ) => {
+interface MutationVariables {
+	siteId: string;
+	engine: string;
+	currentStep: string;
+}
+
+export const useSkipNextStepMutation = (
+	options: UseMutationOptions< unknown, DefaultError, MutationVariables > = {}
+) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
-		mutationFn: async ( { siteId, engine, currentStep } ) => {
+		mutationFn: async ( { siteId, engine, currentStep }: MutationVariables ) => {
 			const response = await wp.req.post(
 				{
 					path: `/sites/${ siteId }/site-importer/paid-newsletter/reset`,
@@ -36,7 +49,8 @@ export const useSkipNextStepMutation = ( options = {} ) => {
 	const { mutate } = mutation;
 
 	const resetPaidNewsletter = useCallback(
-		( siteId, engine, currentStep ) => mutate( { siteId, engine, currentStep } ),
+		( siteId: string, engine: string, currentStep: string ) =>
+			mutate( { siteId, engine, currentStep } ),
 		[ mutate ]
 	);
 

--- a/client/data/paid-newsletter/use-reset-mutation.ts
+++ b/client/data/paid-newsletter/use-reset-mutation.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+
+export const useSkipNextStepMutation = ( options = {} ) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: async ( { siteId, engine, currentStep } ) => {
+			const response = await wp.req.post(
+				{
+					path: `/sites/${ siteId }/site-importer/paid-newsletter/reset`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					engine: engine,
+					current_step: currentStep,
+				}
+			);
+
+			if ( ! response.current_step ) {
+				throw new Error( 'unsuccsefully skipped step', response );
+			}
+
+			return response;
+		},
+		...options,
+		onSuccess( ...args ) {
+			const [ , { siteId, engine } ] = args;
+			queryClient.invalidateQueries( {
+				queryKey: [ 'paid-newsletter-importer', siteId, engine ],
+			} );
+			options.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const resetPaidNewsletter = useCallback(
+		( siteId, engine, currentStep ) => mutate( { siteId, engine, currentStep } ),
+		[ mutate ]
+	);
+
+	return { resetPaidNewsletter, ...mutation };
+};

--- a/client/data/paid-newsletter/use-skip-next-step-mutation.ts
+++ b/client/data/paid-newsletter/use-skip-next-step-mutation.ts
@@ -1,11 +1,25 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+	DefaultError,
+	useMutation,
+	UseMutationOptions,
+	useQueryClient,
+} from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
-export const useSkipNextStepMutation = ( options = {} ) => {
+interface MutationVariables {
+	siteId: number;
+	engine: string;
+	currentStep: string;
+	skipStep: string;
+}
+
+export const useSkipNextStepMutation = (
+	options: UseMutationOptions< unknown, DefaultError, MutationVariables > = {}
+) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
-		mutationFn: async ( { siteId, engine, currentStep, skipStep } ) => {
+		mutationFn: async ( { siteId, engine, currentStep, skipStep }: MutationVariables ) => {
 			const response = await wp.req.post(
 				{
 					path: `/sites/${ siteId }/site-importer/paid-newsletter`,
@@ -37,7 +51,7 @@ export const useSkipNextStepMutation = ( options = {} ) => {
 	const { mutate } = mutation;
 
 	const skipNextStep = useCallback(
-		( siteId, engine, currentStep, skipStep ) =>
+		( siteId: number, engine: string, currentStep: string, skipStep: string ) =>
 			mutate( { siteId, engine, currentStep, skipStep } ),
 		[ mutate ]
 	);

--- a/client/data/paid-newsletter/use-skip-next-step-mutation.ts
+++ b/client/data/paid-newsletter/use-skip-next-step-mutation.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+
+export const useSkipNextStepMutation = ( options = {} ) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: async ( { siteId, engine, currentStep, skipStep } ) => {
+			const response = await wp.req.post(
+				{
+					path: `/sites/${ siteId }/site-importer/paid-newsletter`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					engine: engine,
+					current_step: currentStep,
+					skip: skipStep,
+				}
+			);
+
+			if ( ! response.current_step ) {
+				throw new Error( 'unsuccsefully skipped step', response );
+			}
+
+			return response;
+		},
+		...options,
+		onSuccess( ...args ) {
+			const [ , { siteId, engine } ] = args;
+			queryClient.invalidateQueries( {
+				queryKey: [ 'paid-newsletter-importer', siteId, engine ],
+			} );
+			options.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const skipNextStep = useCallback(
+		( siteId, engine, currentStep, skipStep ) =>
+			mutate( { siteId, engine, currentStep, skipStep } ),
+		[ mutate ]
+	);
+
+	return { skipNextStep, ...mutation };
+};

--- a/client/my-sites/importer/newsletter/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/connect-stripe.tsx
@@ -1,10 +1,7 @@
 import { Card } from '@automattic/components';
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import StripeLogo from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
-import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getConnectUrlForSiteId } from 'calypso/state/memberships/settings/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ImporterActionButton from '../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../importer-action-buttons/container';
 
@@ -14,13 +11,13 @@ import ImporterActionButtonContainer from '../importer-action-buttons/container'
  * @param fromSite
  * @returns string
  */
-function updateConnectUrl( connectUrl: string, fromSite: string ): string {
+function updateConnectUrl( connectUrl: string, fromSite: string, engine: string ): string {
 	let stateQueryString = getQueryArg( connectUrl, 'state' ) as string | string[];
 	stateQueryString = Array.isArray( stateQueryString ) ? stateQueryString[ 0 ] : stateQueryString;
 
 	const decodedState = JSON.parse( atob( stateQueryString ) );
 	decodedState.from_site = fromSite;
-	decodedState.engine = 'substack'; // Currently we only support substack but in the future we want to pass this parameter down.
+	decodedState.engine = engine;
 
 	return addQueryArgs( connectUrl, { state: btoa( JSON.stringify( decodedState ) ) } );
 }
@@ -28,18 +25,19 @@ function updateConnectUrl( connectUrl: string, fromSite: string ): string {
 type Props = {
 	nextStepUrl: string;
 	skipNextStep: () => void;
+	cardData: any;
 	fromSite: string;
+	engine: string;
 };
 
-export default function ConnectStripe( { nextStepUrl, fromSite, skipNextStep }: Props ) {
-	const site = useSelector( getSelectedSite );
-	let connectUrl: string = useSelector( ( state ) => getConnectUrlForSiteId( state, site?.ID ) );
-
-	try {
-		connectUrl = updateConnectUrl( connectUrl, fromSite );
-	} catch ( error ) {
-		// Do nothing
-	}
+export default function ConnectStripe( {
+	nextStepUrl,
+	skipNextStep,
+	cardData,
+	fromSite,
+	engine,
+}: Props ) {
+	const connectUrl = updateConnectUrl( cardData.connect_url, fromSite, engine );
 
 	return (
 		<Card>

--- a/client/my-sites/importer/newsletter/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/connect-stripe.tsx
@@ -27,10 +27,11 @@ function updateConnectUrl( connectUrl: string, fromSite: string ): string {
 
 type Props = {
 	nextStepUrl: string;
+	skipNextStep: () => void;
 	fromSite: string;
 };
 
-export default function ConnectStripe( { nextStepUrl, fromSite }: Props ) {
+export default function ConnectStripe( { nextStepUrl, fromSite, skipNextStep }: Props ) {
 	const site = useSelector( getSelectedSite );
 	let connectUrl: string = useSelector( ( state ) => getConnectUrlForSiteId( state, site?.ID ) );
 
@@ -61,6 +62,7 @@ export default function ConnectStripe( { nextStepUrl, fromSite }: Props ) {
 					href={ nextStepUrl }
 					onClick={ () => {
 						recordTracksEvent( 'calypso_paid_importer_connect_stripe_skipped' );
+						skipNextStep();
 					} }
 				>
 					Skip for now

--- a/client/my-sites/importer/newsletter/content-upload/file-importer.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/file-importer.jsx
@@ -53,6 +53,7 @@ class FileImporter extends PureComponent {
 		} ),
 		fromSite: PropTypes.string,
 		nextStepUrl: PropTypes.string,
+		skipNextStep: PropTypes.func,
 	};
 
 	handleClick = ( shouldStartImport ) => {
@@ -73,7 +74,7 @@ class FileImporter extends PureComponent {
 
 	render() {
 		const { title, overrideDestination, uploadDescription, optionalUrl } = this.props.importerData;
-		const { importerStatus, site, fromSite, nextStepUrl } = this.props;
+		const { importerStatus, site, fromSite, nextStepUrl, skipNextStep } = this.props;
 		const { errorData, importerState } = importerStatus;
 		const isEnabled = appStates.DISABLED !== importerState;
 		const showStart = includes( compactStates, importerState );
@@ -129,6 +130,7 @@ class FileImporter extends PureComponent {
 						optionalUrl={ optionalUrl }
 						fromSite={ fromSite }
 						nextStepUrl={ nextStepUrl }
+						skipNextStep={ skipNextStep }
 					/>
 				) }
 			</Card>

--- a/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/uploading-pane.jsx
@@ -49,6 +49,7 @@ export class UploadingPane extends PureComponent {
 		} ),
 		fromSite: PropTypes.string,
 		nextStepUrl: PropTypes.string,
+		skipNextStep: PropTypes.func,
 	};
 
 	static defaultProps = { description: null, optionalUrl: null };
@@ -236,7 +237,7 @@ export class UploadingPane extends PureComponent {
 	};
 
 	render() {
-		const { fromSite, nextStepUrl } = this.props;
+		const { fromSite, nextStepUrl, skipNextStep } = this.props;
 		const isReadyForImport = this.isReadyForImport();
 		const importerStatusClasses = clsx(
 			'importer__upload-content',
@@ -296,7 +297,9 @@ export class UploadingPane extends PureComponent {
 					</div>
 				) }
 				<ImporterActionButtonContainer noSpacing>
-					<ImporterActionButton href={ nextStepUrl }>Skip for now</ImporterActionButton>
+					<ImporterActionButton href={ nextStepUrl } onClick={ skipNextStep }>
+						Skip for now
+					</ImporterActionButton>
 				</ImporterActionButtonContainer>
 			</div>
 		);

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -14,9 +14,17 @@ type ContentProps = {
 	selectedSite?: SiteDetails;
 	siteSlug: string;
 	fromSite: QueryArgParsed;
+	content: any;
+	skipNextStep: () => void;
 };
 
-export default function Content( { nextStepUrl, selectedSite, siteSlug, fromSite }: ContentProps ) {
+export default function Content( {
+	nextStepUrl,
+	selectedSite,
+	siteSlug,
+	fromSite,
+	skipNextStep,
+}: ContentProps ) {
 	const siteTitle = selectedSite?.title;
 	const siteId = selectedSite?.ID;
 

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -77,6 +77,7 @@ export default function Content( {
 					importerData={ importerData }
 					fromSite={ fromSite as string }
 					nextStepUrl={ nextStepUrl }
+					skipNextStep={ skipNextStep }
 				/>
 			) }
 		</Card>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -70,16 +70,18 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 	let stepIndex = 0;
 	let nextStep = stepSlugs[ 0 ];
 
-	const { data: paidNewsletterQuery } = usePaidNewsletterQuery( engine, step, selectedSite?.ID );
+	const { data: paidNewsletterQuery, isFetching: isFetchingPaidNewsletter } =
+		usePaidNewsletterQuery( engine, step, selectedSite?.ID );
 
 	stepSlugs.forEach( ( stepName, index ) => {
 		if ( stepName === step ) {
 			stepIndex = index;
 			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
 		}
-
-		const status = paidNewsletterQuery?.steps[ stepName ]?.status ?? '';
-		stepsProgress[ index ] = stepsProgress[ index ] + ' (' + status + ')';
+		if ( ! isFetchingPaidNewsletter ) {
+			const status = paidNewsletterQuery?.steps[ stepName ]?.status ?? '';
+			stepsProgress[ index ] = stepsProgress[ index ] + ' (' + status + ')';
+		}
 	} );
 
 	const { skipNextStep } = useSkipNextStepMutation();
@@ -98,6 +100,11 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 	} );
 
 	const Step = steps[ stepIndex ] || steps[ 0 ];
+
+	let stepContent = {};
+	if ( ! isFetchingPaidNewsletter ) {
+		stepContent = paidNewsletterQuery?.steps[ step ]?.content ?? {};
+	}
 
 	return (
 		<div className="newsletter-importer">
@@ -126,6 +133,8 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					skipNextStep={ () => {
 						skipNextStep( selectedSite?.ID, engine, nextStep, step );
 					} }
+					cardData={ stepContent }
+					engine={ engine }
 				/>
 			) }
 		</div>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -2,6 +2,8 @@ import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useState, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import StepProgress from 'calypso/components/step-progress';
+import { usePaidNewsletterQuery } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import { useSkipNextStepMutation } from 'calypso/data/paid-newsletter/use-skip-next-step-mutation';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -43,6 +45,13 @@ type NewsletterImporterProps = {
 	step: string;
 };
 
+function getTitle( urlData: any ) {
+	if ( urlData?.meta?.title ) {
+		return `Import ${ urlData?.meta?.title }`;
+	}
+	return 'Import your newsletter';
+}
+
 export default function NewsletterImporter( { siteSlug, engine, step }: NewsletterImporterProps ) {
 	const selectedSite = useSelector( getSelectedSite ) ?? undefined;
 
@@ -51,7 +60,29 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 	const stepsProgress = [ 'Content', 'Subscribers', 'Paid Subscribers', 'Summary' ];
 
 	let fromSite = getQueryArg( window.location.href, 'from' ) as string | string[];
+
+	// Steps
 	fromSite = Array.isArray( fromSite ) ? fromSite[ 0 ] : fromSite;
+	if ( fromSite && ! step ) {
+		step = stepSlugs[ 0 ];
+	}
+
+	let stepIndex = 0;
+	let nextStep = stepSlugs[ 0 ];
+
+	const { data: paidNewsletterQuery } = usePaidNewsletterQuery( engine, step, selectedSite?.ID );
+
+	stepSlugs.forEach( ( stepName, index ) => {
+		if ( stepName === step ) {
+			stepIndex = index;
+			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
+		}
+
+		const status = paidNewsletterQuery?.steps[ stepName ].status ?? 'nope';
+		stepsProgress[ index ] = stepsProgress[ index ] + ' (' + status + ')';
+	} );
+
+	const { skipNextStep } = useSkipNextStepMutation();
 
 	const { data: urlData, isFetching } = useAnalyzeUrlQuery( fromSite );
 
@@ -61,30 +92,12 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 		}
 	}, [ urlData, fromSite, engine ] );
 
-	if ( fromSite && ! step ) {
-		step = stepSlugs[ 0 ];
-	}
-
-	let stepIndex = 0;
-	let nextStep = stepSlugs[ 0 ];
-
-	stepSlugs.forEach( ( stepName, index ) => {
-		if ( stepName === step ) {
-			stepIndex = index;
-			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
-		}
-	} );
-
 	const stepUrl = `/import/newsletter/${ engine }/${ siteSlug }/${ stepSlugs[ stepIndex ] }`;
 	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {
 		from: fromSite,
 	} );
-	const Step = steps[ stepIndex ] || steps[ 0 ];
 
-	let title = 'Import your newsletter';
-	if ( urlData?.meta?.title ) {
-		title = `Import ${ urlData?.meta?.title }`;
-	}
+	const Step = steps[ stepIndex ] || steps[ 0 ];
 
 	return (
 		<div className="newsletter-importer">
@@ -94,7 +107,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					{ name: 'wordpress', color: '#3858E9' },
 				] }
 			/>
-			<FormattedHeader headerText={ title } />
+			<FormattedHeader headerText={ getTitle( urlData ) } />
 			{ ! validFromSite && (
 				<SelectNewsletterForm
 					stepUrl={ stepUrl }
@@ -110,6 +123,9 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					nextStepUrl={ nextStepUrl }
 					selectedSite={ selectedSite }
 					fromSite={ fromSite }
+					skipNextStep={ () => {
+						skipNextStep( selectedSite?.ID, engine, nextStep, step );
+					} }
 				/>
 			) }
 		</div>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -78,7 +78,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 			nextStep = stepSlugs[ index + 1 ] ? stepSlugs[ index + 1 ] : stepSlugs[ index ];
 		}
 
-		const status = paidNewsletterQuery?.steps[ stepName ].status ?? 'nope';
+		const status = paidNewsletterQuery?.steps[ stepName ]?.status ?? '';
 		stepsProgress[ index ] = stepsProgress[ index ] + ' (' + status + ')';
 	} );
 

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -124,17 +124,18 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 				/>
 			) }
 			{ validFromSite && <StepProgress steps={ stepsProgress } currentStep={ stepIndex } /> }
-			{ validFromSite && (
+			{ selectedSite && validFromSite && (
 				<Step
 					siteSlug={ siteSlug }
 					nextStepUrl={ nextStepUrl }
 					selectedSite={ selectedSite }
 					fromSite={ fromSite }
 					skipNextStep={ () => {
-						skipNextStep( selectedSite?.ID, engine, nextStep, step );
+						skipNextStep( selectedSite.ID, engine, nextStep, step );
 					} }
 					cardData={ stepContent }
 					engine={ engine }
+					content={ stepContent }
 				/>
 			) }
 		</div>

--- a/client/my-sites/importer/newsletter/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/map-plans.tsx
@@ -6,6 +6,7 @@ import ImporterActionButtonContainer from '../importer-action-buttons/container'
 type Props = {
 	nextStepUrl: string;
 	skipNextStep: () => void;
+	cardData: any;
 };
 
 export default function MapPlans( { nextStepUrl, skipNextStep }: Props ) {

--- a/client/my-sites/importer/newsletter/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/map-plans.tsx
@@ -1,11 +1,14 @@
 import { Card } from '@automattic/components';
-import { Button } from '@wordpress/components';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import ImporterActionButton from '../importer-action-buttons/action-button';
+import ImporterActionButtonContainer from '../importer-action-buttons/container';
 
 type Props = {
 	nextStepUrl: string;
+	skipNextStep: () => void;
 };
 
-export default function MapPlans( { nextStepUrl }: Props ) {
+export default function MapPlans( { nextStepUrl, skipNextStep }: Props ) {
 	return (
 		<Card>
 			<h2>Paid newsletter offering</h2>
@@ -15,10 +18,26 @@ export default function MapPlans( { nextStepUrl }: Props ) {
 				</strong>{ ' ' }
 				to prevent disruption to your current paid subscribers.
 			</p>
-			<Button variant="primary">Continue</Button>{ ' ' }
-			<Button variant="secondary" href={ nextStepUrl }>
-				Skip for now
-			</Button>
+			<ImporterActionButtonContainer noSpacing>
+				<ImporterActionButton
+					primary
+					href={ nextStepUrl }
+					onClick={ () => {
+						recordTracksEvent( 'calypso_paid_importer_map_plans' );
+					} }
+				>
+					Continue
+				</ImporterActionButton>
+				<ImporterActionButton
+					href={ nextStepUrl }
+					onClick={ () => {
+						recordTracksEvent( 'calypso_paid_importer_map_plans_skipped' );
+						skipNextStep();
+					} }
+				>
+					Skip for now
+				</ImporterActionButton>
+			</ImporterActionButtonContainer>
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers.tsx
@@ -1,28 +1,29 @@
 import { hasQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
-import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
-import { useSelector, useDispatch } from 'calypso/state';
-import { getIsConnectedForSiteId } from 'calypso/state/memberships/settings/selectors';
+import { useDispatch } from 'calypso/state';
 import { infoNotice, successNotice } from 'calypso/state/notices/actions';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectStripe from './connect-stripe';
 import MapPlans from './map-plans';
 type Props = {
 	nextStepUrl: string;
 	skipNextStep: () => void;
 	fromSite: string;
+	engine: string;
+	cardData: any;
 };
 
-export default function PaidSubscribers( { nextStepUrl, fromSite, skipNextStep }: Props ) {
-	const site = useSelector( getSelectedSite );
+export default function PaidSubscribers( {
+	nextStepUrl,
+	fromSite,
+	engine,
+	skipNextStep,
+	cardData,
+}: Props ) {
 	const dispatch = useDispatch();
-
-	const hasConnectedAccount = useSelector( ( state ) =>
-		getIsConnectedForSiteId( state, site?.ID )
-	);
-
 	const isCancelled = hasQueryArg( window.location.href, 'stripe_connect_cancelled' );
 	const isSuccess = hasQueryArg( window.location.href, 'stripe_connect_success' );
+
+	const hasConnectedAccount = cardData.is_connected_stripe;
 
 	useEffect( () => {
 		if ( isSuccess ) {
@@ -34,18 +35,18 @@ export default function PaidSubscribers( { nextStepUrl, fromSite, skipNextStep }
 
 	return (
 		<>
-			{ site?.ID && (
-				<QueryMembershipsSettings siteId={ site.ID } source="import-paid-subscribers" />
-			) }
-
 			{ ! hasConnectedAccount && (
 				<ConnectStripe
 					nextStepUrl={ nextStepUrl }
-					fromSite={ fromSite }
 					skipNextStep={ skipNextStep }
+					cardData={ cardData }
+					fromSite={ fromSite }
+					engine={ engine }
 				/>
 			) }
-			{ hasConnectedAccount && <MapPlans nextStepUrl={ nextStepUrl } /> }
+			{ hasConnectedAccount && (
+				<MapPlans nextStepUrl={ nextStepUrl } cardData={ cardData } skipNextStep={ skipNextStep } />
+			) }
 		</>
 	);
 }

--- a/client/my-sites/importer/newsletter/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers.tsx
@@ -9,10 +9,11 @@ import ConnectStripe from './connect-stripe';
 import MapPlans from './map-plans';
 type Props = {
 	nextStepUrl: string;
+	skipNextStep: () => void;
 	fromSite: string;
 };
 
-export default function PaidSubscribers( { nextStepUrl, fromSite }: Props ) {
+export default function PaidSubscribers( { nextStepUrl, fromSite, skipNextStep }: Props ) {
 	const site = useSelector( getSelectedSite );
 	const dispatch = useDispatch();
 
@@ -38,7 +39,11 @@ export default function PaidSubscribers( { nextStepUrl, fromSite }: Props ) {
 			) }
 
 			{ ! hasConnectedAccount && (
-				<ConnectStripe nextStepUrl={ nextStepUrl } fromSite={ fromSite } />
+				<ConnectStripe
+					nextStepUrl={ nextStepUrl }
+					fromSite={ fromSite }
+					skipNextStep={ skipNextStep }
+				/>
 			) }
 			{ hasConnectedAccount && <MapPlans nextStepUrl={ nextStepUrl } /> }
 		</>

--- a/client/my-sites/importer/newsletter/subscriber-upload-form.tsx
+++ b/client/my-sites/importer/newsletter/subscriber-upload-form.tsx
@@ -15,9 +15,10 @@ import ImporterActionButtonContainer from '../importer-action-buttons/container'
 type Props = {
 	nextStepUrl: string;
 	siteId: number;
+	skipNextStep: () => void;
 };
 
-export default function SubscriberUploadForm( { nextStepUrl, siteId }: Props ) {
+export default function SubscriberUploadForm( { nextStepUrl, siteId, skipNextStep }: Props ) {
 	const [ selectedFile, setSelectedFile ] = useState< File >();
 	const [ isOpen, setIsOpen ] = useState( false );
 
@@ -155,6 +156,7 @@ export default function SubscriberUploadForm( { nextStepUrl, siteId }: Props ) {
 				<ImporterActionButton
 					href={ nextStepUrl }
 					onClick={ () => {
+						skipNextStep();
 						recordTracksEvent( 'calypso_paid_importer_connect_stripe_skipped' );
 					} }
 				>

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -7,9 +7,15 @@ type Props = {
 	nextStepUrl: string;
 	selectedSite?: SiteDetails;
 	fromSite: QueryArgParsed;
+	skipNextStep: () => void;
 };
 
-export default function Subscribers( { nextStepUrl, selectedSite, fromSite }: Props ) {
+export default function Subscribers( {
+	nextStepUrl,
+	selectedSite,
+	fromSite,
+	skipNextStep,
+}: Props ) {
 	if ( ! selectedSite ) {
 		return null;
 	}
@@ -26,7 +32,11 @@ export default function Subscribers( { nextStepUrl, selectedSite, fromSite }: Pr
 			<hr />
 			<h2>Step 2: Import your subscribers to WordPress.com</h2>
 			{ selectedSite.ID && (
-				<SubscriberUploadForm siteId={ selectedSite.ID } nextStepUrl={ nextStepUrl } />
+				<SubscriberUploadForm
+					siteId={ selectedSite.ID }
+					nextStepUrl={ nextStepUrl }
+					skipNextStep={ skipNextStep }
+				/>
 			) }
 		</Card>
 	);


### PR DESCRIPTION
This PR is a adds the new paid newsletter state endpoint. That helps us keep track of the state of the state importer. 

See D158054-code

## Proposed Changes

* Add a new state endpoint that lets you know in what state the import process is in. So we can display it to the user. 

## Why are these changes being made?
* The idea is that we will start using the new endpoint to show the state of the importer. 

## Testing Instructions
* Sandbox public-api.wordpress.com
* Apply D158054-code

Notice that now when you skip the step (name tell you that it was skipped)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
