### PR TITLE
Stats: Updating calendar to change input value

### DIFF
--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -20,6 +20,14 @@ const DateControlPickerDate = ( {
 }: DateControlPickerDateProps ) => {
 	const translate = useTranslate();
 
+	const handleStartSeletion = ( date: string ) => {
+		onStartChange( date.split( 'T' )?.[ 0 ] );
+	};
+
+	const handleEndSeletion = ( date: string ) => {
+		onEndChange( date.split( 'T' )?.[ 0 ] );
+	};
+
 	return (
 		<div
 			className={ clsx( BASE_CLASS_NAME, {
@@ -46,8 +54,8 @@ const DateControlPickerDate = ( {
 			</div>
 			{ isCalendarEnabled && (
 				<div className={ `${ BASE_CLASS_NAME }s__calendar` }>
-					<DatePicker currentDate={ startDate } />
-					<DatePicker currentDate={ endDate } />
+					<DatePicker currentDate={ startDate } onChange={ handleStartSeletion } />
+					<DatePicker currentDate={ endDate } onChange={ handleEndSeletion } />
 				</div>
 			) }
 			<div className={ `${ BASE_CLASS_NAME }s__buttons` }>

--- a/client/components/stats-date-control/stats-date-control-picker.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker.tsx
@@ -34,12 +34,10 @@ const DateControlPicker = ( {
 	const [ popoverOpened, togglePopoverOpened ] = useState( false );
 
 	const changeStartDate = ( value: string ) => {
-		// do more here
 		setInputStartDate( value );
 	};
 
 	const changeEndDate = ( value: string ) => {
-		// do more here
 		setInputEndDate( value );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/120

## Proposed Changes

* implement onChange event handlers for the new calendar

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* it's part of the project improving UI for the users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply `stats/date-picker-calendar` to the live branch
* verify that clicking on the calendar updates the proper input above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
