### PR TITLE
Modify Applied Coupon Code Copy and Hide Coupon Box

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -23,10 +23,11 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useExperiment } from 'calypso/lib/explat';
 import { useSelector } from 'calypso/state';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import useCartKey from '../../use-cart-key';
-import { getAffiliateCouponLabel } from '../../utils';
+import { getAffiliateCouponLabel, getCouponLabel } from '../../utils';
 import type { Theme } from '@automattic/composite-checkout';
 import type { LineItemCostOverrideForDisplay } from '@automattic/wpcom-checkout';
 
@@ -323,17 +324,20 @@ export function CouponCostOverride( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
+	const [ , experimentAssignment ] = useExperiment( 'calypso_hide_coupon_box' );
 
 	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
 		return null;
 	}
 
-	// translators: The label of the coupon line item in checkout, including the coupon code
+	// translators: The label of the coupon line item in checkout, including the coupon coden
+	const couponLabel = translate( 'Coupon: %(couponCode)s', {
+		args: { couponCode: responseCart.coupon },
+	} );
+
 	const label = isOnboardingAffiliateFlow
 		? getAffiliateCouponLabel()
-		: translate( 'Coupon: %(couponCode)s', {
-				args: { couponCode: responseCart.coupon },
-		  } );
+		: getCouponLabel( couponLabel as string, experimentAssignment?.variationName || null );
 	return (
 		<CostOverridesListStyle>
 			<div className="cost-overrides-list-item cost-overrides-list-item--coupon">

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -333,7 +333,7 @@ export function CouponCostOverride( {
 		return null;
 	}
 
-	// translators: The label of the coupon line item in checkout, including the coupon coden
+	// translators: The label of the coupon line item in checkout, including the coupon code
 	const couponLabel = translate( 'Coupon: %(couponCode)s', {
 		args: { couponCode: responseCart.coupon },
 	} );

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -324,7 +324,7 @@ export function CouponCostOverride( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
-	const [ , experimentAssignment ] = useExperiment( 'calypso_hide_coupon_box' );
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box' );
 
 	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
 		return null;

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -340,7 +340,7 @@ export function CouponCostOverride( {
 
 	const label = isOnboardingAffiliateFlow
 		? getAffiliateCouponLabel()
-		: getCouponLabel( couponLabel as string, experimentAssignment?.variationName || null );
+		: getCouponLabel( couponLabel as string, experimentAssignment?.variationName );
 	return (
 		<CostOverridesListStyle>
 			<div className="cost-overrides-list-item cost-overrides-list-item--coupon">

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -324,7 +324,10 @@ export function CouponCostOverride( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box' );
+	const productSlugs = responseCart.products?.map( ( product ) => product.product_slug );
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box', {
+		isEligible: ! productSlugs.some( ( slug ) => 'wp_difm_lite' === slug ),
+	} );
 
 	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
 		return null;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -9,6 +9,7 @@ import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
+import { useExperiment } from 'calypso/lib/explat';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -16,6 +17,7 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/co
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import { getIsCouponBoxHidden } from '../../utils';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -204,7 +206,14 @@ export function CouponFieldArea( {
 		}
 	}, [ couponStatus, setCouponFieldValue ] );
 
-	if ( isPurchaseFree || couponStatus === 'applied' || isOnboardingAffiliateFlow ) {
+	const [ , experimentAssignment ] = useExperiment( 'calypso_hide_coupon_box' );
+
+	if (
+		isPurchaseFree ||
+		couponStatus === 'applied' ||
+		isOnboardingAffiliateFlow ||
+		getIsCouponBoxHidden( experimentAssignment?.variationName || null )
+	) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -17,7 +17,7 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/co
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
-import { getIsCouponBoxHidden } from '../../utils';
+import { isCouponBoxHidden } from '../../utils';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -198,6 +198,9 @@ export function CouponFieldArea( {
 	const translate = useTranslate();
 	const { setCouponFieldValue } = couponFieldStateProps;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+	const productSlugs = responseCart.products?.map( ( product ) => product.product_slug );
 
 	useEffect( () => {
 		if ( couponStatus === 'applied' ) {
@@ -212,7 +215,7 @@ export function CouponFieldArea( {
 		isPurchaseFree ||
 		couponStatus === 'applied' ||
 		isOnboardingAffiliateFlow ||
-		getIsCouponBoxHidden( experimentAssignment?.variationName || null )
+		isCouponBoxHidden( productSlugs, experimentAssignment?.variationName || null )
 	) {
 		return null;
 	}

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -209,7 +209,7 @@ export function CouponFieldArea( {
 		}
 	}, [ couponStatus, setCouponFieldValue ] );
 
-	const [ , experimentAssignment ] = useExperiment( 'calypso_hide_coupon_box' );
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box' );
 
 	if (
 		isPurchaseFree ||

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -217,7 +217,7 @@ export function CouponFieldArea( {
 		isPurchaseFree ||
 		couponStatus === 'applied' ||
 		isOnboardingAffiliateFlow ||
-		isCouponBoxHidden( productSlugs, experimentAssignment?.variationName || null )
+		isCouponBoxHidden( productSlugs, experimentAssignment?.variationName )
 	) {
 		return null;
 	}

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -209,7 +209,9 @@ export function CouponFieldArea( {
 		}
 	}, [ couponStatus, setCouponFieldValue ] );
 
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box' );
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box', {
+		isEligible: ! productSlugs.some( ( slug ) => 'wp_difm_lite' === slug ),
+	} );
 
 	if (
 		isPurchaseFree ||

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -20,13 +20,14 @@ import {
 import styled from '@emotion/styled';
 import { useState, useCallback, useMemo } from 'react';
 import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
+import { useExperiment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
-import { getAffiliateCouponLabel } from '../../utils';
+import { getAffiliateCouponLabel, getCouponLabel } from '../../utils';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeAkProQuantity } from './akismet-pro-quantity-dropdown';
@@ -93,8 +94,12 @@ export function WPOrderReviewLineItems( {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
-	if ( isOnboardingAffiliateFlow && couponLineItem ) {
-		couponLineItem.label = getAffiliateCouponLabel();
+	const [ , experimentAssignment ] = useExperiment( 'calypso_hide_coupon_box' );
+
+	if ( couponLineItem ) {
+		couponLineItem.label = isOnboardingAffiliateFlow
+			? getAffiliateCouponLabel()
+			: getCouponLabel( couponLineItem.label, experimentAssignment?.variationName || null );
 	}
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -94,7 +94,7 @@ export function WPOrderReviewLineItems( {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
-	const [ , experimentAssignment ] = useExperiment( 'calypso_hide_coupon_box' );
+	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_hide_coupon_box' );
 
 	if ( couponLineItem ) {
 		couponLineItem.label = isOnboardingAffiliateFlow

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -102,8 +102,8 @@ export function WPOrderReviewLineItems( {
 	if ( couponLineItem ) {
 		couponLineItem.label = isOnboardingAffiliateFlow
 			? getAffiliateCouponLabel()
-			: getCouponLabel( couponLineItem.label, experimentAssignment?.variationName || null );
-		if ( isCouponBoxHidden( productSlugs, experimentAssignment?.variationName || null ) ) {
+			: getCouponLabel( couponLineItem.label, experimentAssignment?.variationName );
+		if ( isCouponBoxHidden( productSlugs, experimentAssignment?.variationName ) ) {
 			couponLineItem.hasDeleteButton = false;
 		}
 	}

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -100,6 +100,9 @@ export function WPOrderReviewLineItems( {
 		couponLineItem.label = isOnboardingAffiliateFlow
 			? getAffiliateCouponLabel()
 			: getCouponLabel( couponLineItem.label, experimentAssignment?.variationName || null );
+		if ( experimentAssignment?.variationName === 'treatment' ) {
+			couponLineItem.hasDeleteButton = false;
+		}
 	}
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -143,6 +143,16 @@ export function getCouponLabel(
 	return experimentVariationName === 'treatment' ? translate( 'Offer Applied' ) : originalLabel;
 }
 
-export function getIsCouponBoxHidden( experimentVariationName: string | null ): boolean {
+export function isCouponBoxHidden(
+	productSlugs: string[],
+	experimentVariationName: string | null
+): boolean {
+	const ignoredProductSlugs = [ 'wp_difm_lite', 'wp_difm_premium', 'wp_difm_extra_page' ];
+	const containsIgnoredProduct = productSlugs.some( ( slug ) =>
+		ignoredProductSlugs.includes( slug )
+	);
+	if ( containsIgnoredProduct ) {
+		return false;
+	}
 	return experimentVariationName === 'treatment' ? true : false;
 }

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -135,3 +135,14 @@ export function getAffiliateCouponLabel(): string {
 	// translators: The label of the coupon line item in checkout
 	return translate( 'Exclusive Offer Applied' );
 }
+
+export function getCouponLabel(
+	originalLabel: string,
+	experimentVariationName: string | null
+): string {
+	return experimentVariationName === 'treatment' ? translate( 'Offer Applied' ) : originalLabel;
+}
+
+export function getIsCouponBoxHidden( experimentVariationName: string | null ): boolean {
+	return experimentVariationName === 'treatment' ? true : false;
+}

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -147,7 +147,7 @@ export function isCouponBoxHidden(
 	productSlugs: string[],
 	experimentVariationName: string | null
 ): boolean {
-	const ignoredProductSlugs = [ 'wp_difm_lite', 'wp_difm_premium', 'wp_difm_extra_page' ];
+	const ignoredProductSlugs = [ 'wp_difm_lite' ];
 	const containsIgnoredProduct = productSlugs.some( ( slug ) =>
 		ignoredProductSlugs.includes( slug )
 	);

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -138,14 +138,14 @@ export function getAffiliateCouponLabel(): string {
 
 export function getCouponLabel(
 	originalLabel: string,
-	experimentVariationName: string | null
+	experimentVariationName: string | null | undefined
 ): string {
 	return experimentVariationName === 'treatment' ? translate( 'Offer Applied' ) : originalLabel;
 }
 
 export function isCouponBoxHidden(
 	productSlugs: string[],
-	experimentVariationName: string | null
+	experimentVariationName: string | null | undefined
 ): boolean {
 	const ignoredProductSlugs = [ 'wp_difm_lite' ];
 	const containsIgnoredProduct = productSlugs.some( ( slug ) =>


### PR DESCRIPTION
PR Will require String Freeze 

Related to #
Project Thread pau2Xa-6fe-p2

## Proposed Changes

Changes are related to project pau2Xa-6fe-p2.
We will be running an AB Test to verify the impact of removing the coupon box area.

Summary of changes: 
1. Modify applied Coupon Code copy from mentioning Coupon code to "Offer Applied"
2. Remove coupon box for users assigned to AB Test Treatment


## Testing Instructions

**How to assign self to treatment bucket** 
To manually assign a variant to yourself or a test user, head over to your experiment’s overview page in ExPlat:

- Go to details for experiment `calypso_checkout_hide_coupon_box`  in ExPlat and click on the Overview tab.
- Navigate to the Audience section and hover over the assignment group to be assigned.
- Upon mouse hover, click on the link to be assigned that assignment group.

1. Apply patch 
2. Navigate to checkout
3. If you are assigned to the treatment you should not see the "Have a coupon?" link 

<img width="228" alt="image" src="https://github.com/user-attachments/assets/b7d815e8-6b2b-4442-a453-4fd998a3c0a5">

4. Embedded a coupon to the checkout URL ?coupon= and refresh. 
5. You should see "Offer Applied" listed where the Coupon code would have been
<img width="228" alt="image" src="https://github.com/user-attachments/assets/c1e2d2b7-8806-48d0-9609-ad2f6aa1ea63">
<img width="326" alt="image" src="https://github.com/user-attachments/assets/548eb791-1ef0-40cc-ad0a-8cf5a4be82f1">
