### PR TITLE
Performance Profiler: Append hash in the URL as test is queued in backend

### DIFF
--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -1,5 +1,6 @@
+import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import React, { useEffect } from 'react';
 import './style.scss';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
@@ -20,14 +21,35 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 	const [ activeTab, setActiveTab ] = React.useState< TabType >( tab );
 	const { data: basicMetrics } = useUrlBasicMetricsQuery( url, hash, true );
 	const { final_url: finalUrl, token } = basicMetrics || {};
-	const { data: performanceInsights } = useUrlPerformanceInsightsQuery( finalUrl, token );
+	const { data: performanceInsights } = useUrlPerformanceInsightsQuery( url, hash );
 	const desktopLoaded = 'completed' === performanceInsights?.status;
 	const mobileLoaded = typeof performanceInsights?.mobile === 'object';
 
-	const getOnTabChange = ( tab: TabType ) => {
+	const updateQueryParams = ( params: Record< string, string >, forceReload = false ) => {
 		const queryParams = new URLSearchParams( window.location.search );
-		queryParams.set( 'tab', tab );
-		window.history.pushState( null, '', `?${ queryParams.toString() }` );
+		Object.keys( params ).forEach( ( key ) => {
+			if ( params[ key ] ) {
+				queryParams.set( key, params[ key ] );
+			}
+		} );
+
+		// If forceReload is true, we want to reload the page with the new query params instead of just updating the URL
+		if ( forceReload ) {
+			page( `/speed-test-tool?${ queryParams.toString() }` );
+		} else {
+			window.history.replaceState( {}, '', `?${ queryParams.toString() }` );
+		}
+	};
+
+	// Append hash to the URL if it's not there to avoid losing it on page reload
+	useEffect( () => {
+		if ( ! hash && token ) {
+			updateQueryParams( { hash: token, url: finalUrl ?? url }, true );
+		}
+	}, [ hash, token, finalUrl, url ] );
+
+	const getOnTabChange = ( tab: TabType ) => {
+		updateQueryParams( { tab: tab } );
 		setActiveTab( tab );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8699

## Proposed Changes

* Adds logic to redirect users to the URL with a hash
* Adds logic to start pooling for the data as soon as hash is available
* Reloading the page prevents new profiler tests from being queued. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/speed-test-tool?url=https://www.quintoandar.com.br/
* Make sure the URL is updated with HASH and the final URL
* Open the network tab and make sure pooling has started for the data
* Reload the page and make sure the profiler doesn't queue requests by looking at the requests. It should not send requests to the basic metrics endpoint. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
