### PR TITLE
DO NOT MERGE: POC for conditionally load ad-trackers depending on Explat

### DIFF
--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -87,6 +87,18 @@ const checkGtmInit = (): boolean => {
 	return 'dataLayer' in window && 'google_tag_manager' in window;
 };
 
+/**
+ * Assign a user via Explat, or get the user's assignment. If a user is assigned to the treatment
+ * group, we do not load trackers or fire tracking events. Note, this does not involve Tracks, only
+ * third-party trackers.
+ */
+const mayWeTrackUserExplat = (): boolean => {
+	// Replace this with an explat assignment and return a boolean for whether we should load
+	// trackers and fire off tracking events in the signup.
+	// Check if we're in Stepper or Signup.
+	return false;
+};
+
 export const AdTrackersInitGuards: Partial< { [ key in AdTracker ]: () => boolean } > = {
 	ga: checkGtagInit,
 	gaEnhancedEcommerce: checkGtagInit,
@@ -113,7 +125,11 @@ const isTrackerIntialized = ( tracker: AdTracker ): boolean => {
 };
 
 export const mayWeTrackGeneral = () =>
-	! isE2ETest() && ! getDoNotTrack() && ! isPiiUrl() && config.isEnabled( 'ad-tracking' );
+	! isE2ETest() &&
+	! getDoNotTrack() &&
+	! isPiiUrl() &&
+	config.isEnabled( 'ad-tracking' ) &&
+	mayWeTrackUserExplat();
 
 export const mayWeTrackByBucket = ( bucket: Bucket ) => {
 	if ( ! mayWeTrackGeneral() ) {


### PR DESCRIPTION
Context: p55Cj4-3jZ-p2

This is just a proof of concept for how we could allow/disallow ad-tracking in signup for users based on Explat assignment. This would be done to see whether async tracking code (for third-party trackers) impacts signup completes on slower devices/connections.

This does not impact Tracks.

This is not production code. It's just for showing how it could be done. We'd need to assign a user via an experiment, and also check that we're in  the Signup/Stepper.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Implement an additional check for whether we should fire third-party trackers for a user.

## Why are these changes being made?
See the linked discussion above.

## Testing Instructions
* Allow ad-tracking and cookie-banner (see below)
* Start Calypso locally, observe that no third-party trackers are firing (no gtag, fbevents.js, etc. are loaded). Check signup, and random pages in Calypso. Try to go through the cart.
* Toggle the boolean return value in `mayWeTrackUserExplat.` It will now work as it does in production.

Enabling ad-tracking:
- Copy-pasta the below, and `pbpaste | git apply` 
```diff
diff --git a/config/development.json b/config/development.json
index f4a652209c..d752542167 100644
--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,7 @@
        "zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
        "zendesk_support_chat_key": "715f17a8-4a28-4a7f-8447-0ef8f06c70d7",
        "features": {
-               "ad-tracking": false,
+               "ad-tracking": true,
                "akismet/checkout-quantity-dropdown": true,
                "automated-migration/collect-credentials": false,
                "calypso/ai-blogging-prompts": true,
@@ -70,7 +70,7 @@
                "external-media/free-photo-library": true,
                "external-media/google-photos": true,
                "external-media/openverse": true,
-               "cookie-banner": false,
+               "cookie-banner": true,
                "google-drive": true,
                "google-my-business": true,
                "help": true,

```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
