### PR TITLE
A4A: Add a Pressable link in the Hosting details for Pressable sites.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/hosting/overview.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@wordpress/components';
+import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -61,6 +63,24 @@ const HostingOverviewPreview = ( { site }: Props ) => {
 								{ formatHostingProviderName( site.hosting_provider_guess ) }
 							</div>
 						</div>
+						{ site.hosting_provider_guess.toLowerCase() === 'pressable' && (
+							<div className="hosting__content-row">
+								<div className="hosting__content-label"></div>
+
+								<div className="hosting__content-value">
+									<Button
+										target="_blank"
+										rel="norefferer nooppener"
+										href="https://my.pressable.com/agency/auth"
+										variant="link"
+									>
+										{ translate( 'Manage all Pressable sites' ) }
+										<Icon icon={ external } size={ 18 } />
+									</Button>
+								</div>
+							</div>
+						) }
+
 						<div className="hosting__content-row">
 							<div className="hosting__content-label">PHP version</div>
 							<div className="hosting__content-value">


### PR DESCRIPTION
This PR adds a Pressable dashboard link in the Site hosting details for sites hosted on the Pressable.

<img width="454" alt="Screenshot 2024-08-14 at 6 21 28 PM" src="https://github.com/user-attachments/assets/be534ecc-b61d-4223-aed5-570daa4bee41">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/892

## Proposed Changes

* Add a link to the Hosting details component.

## Why are these changes being made?

* This provides a better UI experience for users with a Pressable site.

## Testing Instructions

* Use the A4A live link and go to `/sites/overview/{PRESSABLE_SITE_SLUG}/hosting-overview` page.
* Confirm that the Pressable link is visible and clicking this will open a new tab going to the Pressable dashboard.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
