### PR TITLE
RT: Generate content based on locale and only for the main content

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/api/generate-content/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/api/generate-content/index.ts
@@ -3,36 +3,28 @@ import { ReadymadeTemplate } from 'calypso/my-sites/patterns/types';
 
 const generateAIContentForTemplate = async (
 	readymadeTemplate: ReadymadeTemplate,
-	context: string
+	context: string,
+	locale: string = 'en'
 ): Promise< ReadymadeTemplate > => {
-	const paths = [
-		{ content: readymadeTemplate.home.header, sectionName: 'Header' },
-		{ content: readymadeTemplate.home.content, sectionName: 'Front Page Content' },
-		{ content: readymadeTemplate.home.footer, sectionName: 'Footer' },
-	];
-
-	const requests = paths.map( ( { content, sectionName } ) =>
-		wpcom.req.post( {
+	try {
+		const response = await wpcom.req.post( {
 			path: '/ai-content/html',
 			apiNamespace: 'wpcom/v2',
 			method: 'POST',
 			body: {
-				html: content,
+				html: readymadeTemplate.home.content,
 				context: context,
-				section_name: sectionName,
-				section_description: `This is the ${ sectionName.toLowerCase() } of the site's frontpage`,
+				section_name: 'Website Frontpage',
+				locale: locale,
+				section_description: 'This is the front page of the site',
 			},
-		} )
-	);
+		} );
 
-	try {
-		const responses = await Promise.all( requests );
 		return {
 			...readymadeTemplate,
 			home: {
-				header: responses[ 0 ],
-				content: responses[ 1 ],
-				footer: responses[ 2 ],
+				...readymadeTemplate.home,
+				content: response,
 			},
 		};
 	} catch ( error ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/readymade-template-generate-content/index.tsx
@@ -1,5 +1,6 @@
 import { FormLabel } from '@automattic/components';
 import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -40,6 +41,7 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 	const [ aiGeneratedRT, setAiGeneratedRT ] = useState( selectedReadymadeTemplate );
 	const { assembleSite } = useDispatch( SITE_STORE );
 	const { setSelectedReadymadeTemplate } = useDispatch( ONBOARD_STORE );
+	const locale = useLocale();
 
 	const markContentGenerationTaskComplete = () =>
 		updateLaunchpadSettings( siteSlug, {
@@ -73,7 +75,7 @@ const ReadymadeTemplateGenerateContent: React.FC< ReadymadeTemplateGenerateConte
 
 	const generateContent = () => {
 		setIsGeneratingContent( true );
-		generateAIContentForTemplate( selectedReadymadeTemplate, aiContext )
+		generateAIContentForTemplate( selectedReadymadeTemplate, aiContext, locale )
 			.then( ( aiGeneratedRt: ReadymadeTemplate ) => {
 				setAiGeneratedRT( aiGeneratedRt );
 				return updateSiteContents( aiGeneratedRt );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* We added the locale to the gen AI API call.
* We removed gen AI from the header and footer.

The header and footer removal are because the header never got updated since the texts are too short. And on the footer we were getting subpar results because the AI tries to generate text instead of specific site information like the open times, address and such, which the AI can't make up anyways and will require the user to manually change that information.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support multilingual content generation.
* Improve the quality of the footer by not generating long text paragraphs for the footer.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link.
* Go to the Generate content with AI step.
* The generated content should be in your locale when the prompt is also in your locale (normal use)
* The footer should not be overridden with paragraphs of text that break the look and feel.

#### Video of locale working

https://github.com/user-attachments/assets/a97de8db-74e0-490e-9a80-6f5ee67b5012




#### Footer content remains the same after generating content:
![Screenshot 2024-08-14 at 13 27 44](https://github.com/user-attachments/assets/a32af8d8-cb33-488b-9e4a-84aedaedaa10)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
