### PR TITLE
Pricing: Use useTranslate hook for translatable enterprise feature list

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/enterprise-features.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/enterprise-features.tsx
@@ -1,7 +1,8 @@
 import { getPlanClass, isWpcomEnterpriseGridPlan } from '@automattic/calypso-products';
 import { ClientLogoList, FoldableCard } from '@automattic/components';
 import clsx from 'clsx';
-import i18n from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import { usePlansGridContext } from '../../grid-context';
 import { GridPlan } from '../../types';
 import { PlanFeaturesItem } from '../item';
@@ -14,41 +15,40 @@ type PreviousFeaturesIncludedTitleProps = {
 	};
 };
 
-const PLAN_ENTERPRISE_FEATURE_LIST_TITLE: string = i18n.translate(
-	'High performance platform, with:'
-);
-
-const PLAN_ENTERPRISE_FEATURE_LIST: string[] = [
-	i18n.translate( 'Multifaceted security' ),
-	i18n.translate( 'Generative AI' ),
-	i18n.translate( 'Integrated content analytics' ),
-	i18n.translate( '24/7 support' ),
-	i18n.translate( 'Professional services' ),
-	i18n.translate( 'API mesh and node hosting' ),
-	i18n.translate( 'Containerized environment' ),
-	i18n.translate( 'Global infrastructure' ),
-	i18n.translate( 'Dynamic autoscaling' ),
-	i18n.translate( 'Integrated CDN' ),
-	i18n.translate( 'Integrated code repository' ),
-	i18n.translate( 'Staging environments' ),
-	i18n.translate( 'Management dashboard' ),
-	i18n.translate( 'Command line interface (CLI)' ),
-	i18n.translate( 'Efficient multi-site management' ),
-	i18n.translate( 'Advanced access controls' ),
-	i18n.translate( 'Single sign-on (SSO)' ),
-	i18n.translate( 'DDoS protection and mitigation' ),
-	i18n.translate( 'Plugin and theme vulnerability scanning' ),
-	i18n.translate( 'Automated plugin upgrade' ),
-	i18n.translate( 'Integrated enterprise search' ),
-	i18n.translate( 'Integrated APM' ),
-];
-
 const EnterpriseFeatures = ( {
 	renderedGridPlans,
 	options,
 }: PreviousFeaturesIncludedTitleProps ) => {
 	const { featureGroupMap, enableCategorisedFeatures } = usePlansGridContext();
+	const translate = useTranslate();
 	const isTableCell = options?.isTableCell;
+	const enterpriseFeaturesList = useMemo(
+		() => [
+			translate( 'Multifaceted security' ),
+			translate( 'Generative AI' ),
+			translate( 'Integrated content analytics' ),
+			translate( '24/7 support' ),
+			translate( 'Professional services' ),
+			translate( 'API mesh and node hosting' ),
+			translate( 'Containerized environment' ),
+			translate( 'Global infrastructure' ),
+			translate( 'Dynamic autoscaling' ),
+			translate( 'Integrated CDN' ),
+			translate( 'Integrated code repository' ),
+			translate( 'Staging environments' ),
+			translate( 'Management dashboard' ),
+			translate( 'Command line interface (CLI)' ),
+			translate( 'Efficient multi-site management' ),
+			translate( 'Advanced access controls' ),
+			translate( 'Single sign-on (SSO)' ),
+			translate( 'DDoS protection and mitigation' ),
+			translate( 'Plugin and theme vulnerability scanning' ),
+			translate( 'Automated plugin upgrade' ),
+			translate( 'Integrated enterprise search' ),
+			translate( 'Integrated APM' ),
+		],
+		[ translate ]
+	);
 
 	const CardContainer = ( props: React.ComponentProps< typeof FoldableCard > ) => {
 		const { children, className, ...otherProps } = props;
@@ -63,7 +63,7 @@ const EnterpriseFeatures = ( {
 					'plans-grid-next-features-grid__mobile-plan-card-foldable-container',
 					className
 				) }
-				header={ i18n.translate( 'Show all features' ) }
+				header={ translate( 'Show all features' ) }
 				{ ...otherProps }
 				compact
 				clickableHeader
@@ -107,9 +107,9 @@ const EnterpriseFeatures = ( {
 
 						<CardContainer>
 							<div className={ clsx( 'plan-features-2023-grid__common-title', planClassName ) }>
-								{ PLAN_ENTERPRISE_FEATURE_LIST_TITLE }
+								{ translate( 'High performance platform, with:' ) }
 							</div>
-							{ PLAN_ENTERPRISE_FEATURE_LIST.map( ( title, index ) => (
+							{ enterpriseFeaturesList.map( ( title, index ) => (
 								<PlanFeaturesItem key={ index }>
 									<span className="plan-features-2023-grid__item-info is-available">
 										<span className="plan-features-2023-grid__item-title">{ title }</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 862-gh-Automattic/i18n-issues

## Proposed Changes

* Use `useTranslate` hook for the translatable strings in the Enterprise Feature list on the Pricing Grid.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4d1ce35a-4003-43e1-892d-bdd4c358c312) | ![pjWNBDzOwOfPlZxi](https://github.com/user-attachments/assets/9ca0c709-43a1-4104-920f-9b94935b050d) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The feature list translatable strings were defined as a constant at the top level of the module using static `i18n.translate()`, which is likely to result in executing the translate calls before the translation data is loaded.
* Using the `useTranslate` hook ensures that the component is being re-rendered when i18n data changes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Change UI to a Mag-16 language.
* Navigate to `/start/plans` and confirm the features list in the Enterprise column is fully translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
