### PR TITLE
Performance Profiler: Use Math.floor to guarantee a integer is displayed

### DIFF
--- a/client/performance-profiler/components/performance-score/index.tsx
+++ b/client/performance-profiler/components/performance-score/index.tsx
@@ -17,7 +17,7 @@ export const PerformanceScore = ( props: PerformanceScoreProps ) => {
 		<div className="performance-profiler-performance-score">
 			<div className="score-summary">
 				<div className="title">{ translate( 'Performance Score' ) }</div>
-				<div className="score">{ value }</div>
+				<div className="score">{ Math.floor( value ) }</div>
 
 				<div className="score-bar">
 					<div className="full-bar" style={ { width: SCORE_BAR_WIDTH } } />


### PR DESCRIPTION


## Proposed Changes

Use to Math.floor to guarantee a integer is displayed on the Performance Score.

## Testing Instructions

* Go to /speed-test-tool?url=http://wordpress.com and check only integer number is shown

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-08-14 at 10 02 41@2x](https://github.com/user-attachments/assets/96e9f45d-a41f-4e24-9a07-2eecdd3cd093)|![CleanShot 2024-08-14 at 10 06 24@2x](https://github.com/user-attachments/assets/ec597e26-5b14-4036-a53b-df3420e1ec57)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
