### PR TITLE
[Wapuu] Make error system more robust

### DIFF
--- a/packages/odie-client/src/components/message/sources.tsx
+++ b/packages/odie-client/src/components/message/sources.tsx
@@ -29,7 +29,7 @@ export const Sources = ( { message }: { message: Message } ) => {
 			];
 		}
 		return [];
-	}, [ message.context?.sources, trackEvent ] );
+	}, [ message?.context?.sources, trackEvent ] );
 
 	const hasSources = message?.context?.sources && message.context?.sources.length > 0;
 	if ( ! hasSources ) {

--- a/packages/odie-client/src/components/message/sources.tsx
+++ b/packages/odie-client/src/components/message/sources.tsx
@@ -29,7 +29,7 @@ export const Sources = ( { message }: { message: Message } ) => {
 			];
 		}
 		return [];
-	}, [ message?.context?.sources ] );
+	}, [ message.context?.sources, trackEvent ] );
 
 	const hasSources = message?.context?.sources && message.context?.sources.length > 0;
 	if ( ! hasSources ) {

--- a/packages/odie-client/src/query/index.ts
+++ b/packages/odie-client/src/query/index.ts
@@ -105,7 +105,7 @@ export const useOdieSendMessage = (): UseMutationResult<
 
 	return useMutation<
 		{ chat_id: string; messages: Message[] },
-		unknown,
+		{ data: { status: number; messages: Message[] } },
 		{ message: Message },
 		{ internal_message_id: string }
 	>( {
@@ -211,8 +211,8 @@ export const useOdieSendMessage = (): UseMutationResult<
 				throw new Error( 'Context is undefined' );
 			}
 
-			const { data } = response as { data: { status: number } };
-			const isRateLimitError = data.status === 429;
+			const isRateLimitError =
+				response && response.data && response.data.status === 429 ? true : false;
 
 			const { internal_message_id } = context;
 			const message = {


### PR DESCRIPTION
## Proposed Changes

If somehow we end up having errors from server without no body, client is unable to recover from the error state. This address it

## Why are these changes being made?
In the rare case where we receive 500 error from the server without body response, we couldn't recover the Wapuu client from the error state. This patch addresses it.

## Testing Instructions
Have a quick chat with Wapuu and ask to contact with happiness engineers. It should work as expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
