### PR TITLE
A4A Dev Sites: Introduce new "Development" sites page / filter

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/hooks/use-managed-sites-map.ts
@@ -23,6 +23,7 @@ export default function useManagedSitesMap( { size = 100 }: Props ) {
 		filter: {
 			issueTypes: [],
 			showOnlyFavorites: false,
+			showOnlyDevelopmentSites: false,
 		},
 	} );
 

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -64,6 +64,7 @@ export default function WPCOMSitesTable( {
 		filter: {
 			issueTypes: [],
 			showOnlyFavorites: false,
+			showOnlyDevelopmentSites: false,
 		},
 	} );
 

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -1,10 +1,11 @@
-import { category, starEmpty, tool, warning } from '@wordpress/icons';
+import { category, code, starEmpty, tool, warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import useNoActiveSite from 'calypso/a8c-for-agencies/hooks/use-no-active-site';
 import {
 	A4A_SITES_LINK,
+	A4A_SITES_LINK_DEVELOPMENT,
 	A4A_SITES_LINK_FAVORITE,
 	A4A_SITES_LINK_NEEDS_ATTENTION,
 	A4A_SITES_LINK_NEEDS_SETUP,
@@ -50,6 +51,15 @@ const useSitesMenuItems = ( path: string ) => {
 				title: translate( 'Needs attention' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Sites / Needs Attention',
+				},
+			},
+			{
+				icon: code,
+				path: A4A_SITES_LINK,
+				link: A4A_SITES_LINK_DEVELOPMENT,
+				title: translate( 'Development' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Sites / Development',
 				},
 			},
 			{

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { category, code, starEmpty, tool, warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -22,6 +23,7 @@ const useSitesMenuItems = ( path: string ) => {
 				features.wpcom_atomic.state === 'pending' && !! features.wpcom_atomic.license_key
 		).length || 0;
 	const shouldAddNeedsSetup = totalAvailableSites > 0;
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	return useMemo( () => {
 		if ( noActiveSite ) {
@@ -51,15 +53,6 @@ const useSitesMenuItems = ( path: string ) => {
 				title: translate( 'Needs attention' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Sites / Needs Attention',
-				},
-			},
-			{
-				icon: code,
-				path: A4A_SITES_LINK,
-				link: A4A_SITES_LINK_DEVELOPMENT,
-				title: translate( 'Development' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Sites / Development',
 				},
 			},
 			{
@@ -97,6 +90,22 @@ const useSitesMenuItems = ( path: string ) => {
 				path
 			);
 			items.splice( 1, 0, needsSetupItem );
+		}
+
+		if ( devSitesEnabled ) {
+			const needsSetupItem = createItem(
+				{
+					icon: code,
+					path: A4A_SITES_LINK,
+					link: A4A_SITES_LINK_DEVELOPMENT,
+					title: translate( 'Development' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Sites / Development',
+					},
+				},
+				path
+			);
+			items.splice( 2, 0, needsSetupItem );
 		}
 
 		return items;

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -4,6 +4,7 @@ export const A4A_SITES_LINK = '/sites';
 export const A4A_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all_issues';
 export const A4A_SITES_LINK_NEEDS_SETUP = '/sites/need-setup';
 export const A4A_SITES_LINK_FAVORITE = '/sites?is_favorite';
+export const A4A_SITES_LINK_DEVELOPMENT = '/sites?is_development';
 export const A4A_SITES_LINK_WALKTHROUGH_TOUR = `${ A4A_SITES_LINK }?tour=sites-walkthrough`;
 export const A4A_SITES_LINK_ADD_NEW_SITE_TOUR = '/sites?tour=add-new-site';
 export const A4A_SITES_CONNECT_URL_LINK = '/sites/connect-url';

--- a/client/a8c-for-agencies/hooks/use-no-active-site.ts
+++ b/client/a8c-for-agencies/hooks/use-no-active-site.ts
@@ -12,6 +12,7 @@ export default function useNoActiveSite() {
 		filter: {
 			issueTypes: [],
 			showOnlyFavorites: false,
+			showOnlyDevelopmentSites: false,
 		},
 		sort: {
 			field: '',

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -84,6 +84,7 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 		filter: {
 			issueTypes: [],
 			showOnlyFavorites: false,
+			showOnlyDevelopmentSites: false,
 			...( filterOutMultisites && { isNotMultisite: true } ),
 		},
 		sort: {

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -27,6 +27,7 @@ function configureSitesContext( context: Context ) {
 		sort_field,
 		sort_direction,
 		is_favorite,
+		is_development,
 	} = context.query;
 
 	const sort: DashboardSortInterface = {
@@ -43,6 +44,9 @@ function configureSitesContext( context: Context ) {
 			hideListingInitialState={ hideListingInitialState }
 			showOnlyFavoritesInitialState={
 				is_favorite === '' || is_favorite === '1' || is_favorite === 'true'
+			}
+			showOnlyDevelopmentInitialState={
+				is_development === '' || is_development === '1' || is_development === 'true'
 			}
 			path={ context.path }
 			searchQuery={ search }
@@ -81,6 +85,7 @@ export const dashboardSitesContext: Callback = ( context: Context, next ) => {
 		sort_direction,
 		issue_types,
 		is_favorite,
+		is_development,
 	} = context.query;
 	const state = context.store.getState();
 	const agency = getActiveAgency( state );
@@ -98,6 +103,7 @@ export const dashboardSitesContext: Callback = ( context: Context, next ) => {
 		filter: {
 			issueTypes: [ issue_types ],
 			showOnlyFavorites: !! is_favorite,
+			showOnlyDevSites: !! is_development,
 		},
 	};
 

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -41,9 +41,16 @@ export const JetpackSitesDataViews = ( {
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
 
-	// TODO: Get showOnlyDevelopmentSites from context and calculate total sites based on that.
-	const { showOnlyFavorites } = useContext( SitesDashboardContext );
-	const totalSites = showOnlyFavorites ? data?.totalFavorites || 0 : data?.total || 0;
+	const { showOnlyFavorites, showOnlyDevelopmentSites } = useContext( SitesDashboardContext );
+	const totalSites = ( () => {
+		if ( showOnlyFavorites ) {
+			return data?.totalFavorites || 0;
+		}
+		if ( showOnlyDevelopmentSites ) {
+			return data?.totalDevelopmentSites || 0;
+		}
+		return data?.total || 0;
+	} )();
 	const sitesPerPage = dataViewsState.perPage > 0 ? dataViewsState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -41,6 +41,7 @@ export const JetpackSitesDataViews = ( {
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
 
+	// TODO: Get showOnlyDevelopmentSites from context and calculate total sites based on that.
 	const { showOnlyFavorites } = useContext( SitesDashboardContext );
 	const totalSites = showOnlyFavorites ? data?.totalFavorites || 0 : data?.total || 0;
 	const sitesPerPage = dataViewsState.perPage > 0 ? dataViewsState.perPage : 20;

--- a/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-set-favorite/index.tsx
@@ -32,10 +32,12 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const agencyId = useSelector( getActiveAgencyId );
-	const { dataViewsState, showOnlyFavorites, currentPage } = useContext( SitesDashboardContext );
+	const { dataViewsState, showOnlyFavorites, showOnlyDevelopmentSites, currentPage } =
+		useContext( SitesDashboardContext );
 	const [ filter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
 		issueTypes: [],
 		showOnlyFavorites: showOnlyFavorites || false,
+		showOnlyDevelopmentSites: showOnlyDevelopmentSites || false,
 	} );
 	useEffect( () => {
 		const selectedFilters = getSelectedFilters( dataViewsState.filters );
@@ -43,8 +45,9 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 		setAgencyDashboardFilter( {
 			issueTypes: selectedFilters,
 			showOnlyFavorites: showOnlyFavorites || false,
+			showOnlyDevelopmentSites: showOnlyDevelopmentSites || false,
 		} );
-	}, [ dataViewsState.filters, showOnlyFavorites ] );
+	}, [ dataViewsState.filters, showOnlyFavorites, showOnlyDevelopmentSites ] );
 	const search = dataViewsState.search;
 
 	const queryKey = [

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-context.ts
@@ -15,6 +15,9 @@ const SitesDashboardContext = createContext< SitesDashboardContextInterface >( {
 	showOnlyFavorites: undefined,
 	setShowOnlyFavorites: () => {},
 
+	showOnlyDevelopmentSites: undefined,
+	setShowOnlyDevelopmentSites: () => {},
+
 	dataViewsState: initialDataViewsState,
 	setDataViewsState: () => {},
 

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard-provider.tsx
@@ -14,6 +14,7 @@ import SitesDashboardContext from './sites-dashboard-context';
 
 interface Props {
 	showOnlyFavoritesInitialState?: boolean;
+	showOnlyDevelopmentInitialState?: boolean;
 	hideListingInitialState?: boolean;
 	categoryInitialState?: string;
 	siteUrlInitialState?: string;
@@ -44,6 +45,7 @@ const buildFilters = ( { issueTypes }: { issueTypes: string } ) => {
 export const SitesDashboardProvider = ( {
 	hideListingInitialState = false,
 	showOnlyFavoritesInitialState = false,
+	showOnlyDevelopmentInitialState = false,
 	categoryInitialState,
 	siteUrlInitialState,
 	siteFeatureInitialState,
@@ -59,6 +61,9 @@ export const SitesDashboardProvider = ( {
 	const [ selectedCategory, setSelectedCategory ] = useState( categoryInitialState );
 	const [ selectedSiteFeature, setSelectedSiteFeature ] = useState( siteFeatureInitialState );
 	const [ showOnlyFavorites, setShowOnlyFavorites ] = useState( showOnlyFavoritesInitialState );
+	const [ showOnlyDevelopmentSites, setShowOnlyDevelopmentSites ] = useState(
+		showOnlyDevelopmentInitialState
+	);
 	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
 	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
 	const [ currentLicenseInfo, setCurrentLicenseInfo ] = useState< string | null >( null );
@@ -98,6 +103,7 @@ export const SitesDashboardProvider = ( {
 		setInitialSelectedSiteUrl( siteUrlInitialState );
 		if ( ! siteUrlInitialState ) {
 			setShowOnlyFavorites( showOnlyFavoritesInitialState );
+			setShowOnlyDevelopmentSites( showOnlyDevelopmentInitialState );
 			setHideListing( false );
 		}
 
@@ -116,6 +122,7 @@ export const SitesDashboardProvider = ( {
 	}, [
 		setDataViewsState,
 		showOnlyFavoritesInitialState,
+		showOnlyDevelopmentInitialState,
 		searchQuery,
 		sort,
 		issueTypes,
@@ -132,6 +139,8 @@ export const SitesDashboardProvider = ( {
 		setHideListing: setHideListing,
 		showOnlyFavorites: showOnlyFavorites,
 		setShowOnlyFavorites: setShowOnlyFavorites,
+		showOnlyDevelopmentSites: showOnlyDevelopmentSites,
+		setShowOnlyDevelopmentSites: setShowOnlyDevelopmentSites,
 		path,
 		currentPage,
 		isBulkManagementActive,

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -64,6 +64,7 @@ export default function SitesDashboard() {
 		selectedCategory: category,
 		setSelectedCategory: setCategory,
 		showOnlyFavorites,
+		showOnlyDevelopmentSites,
 		hideListing,
 		setHideListing,
 		recentlyCreatedSiteId,
@@ -89,6 +90,7 @@ export default function SitesDashboard() {
 	const [ agencyDashboardFilter, setAgencyDashboardFilter ] = useState< AgencyDashboardFilter >( {
 		issueTypes: [],
 		showOnlyFavorites: showOnlyFavorites || false,
+		showOnlyDevelopmentSites: showOnlyDevelopmentSites || false,
 	} );
 
 	useEffect( () => {
@@ -97,8 +99,14 @@ export default function SitesDashboard() {
 		setAgencyDashboardFilter( {
 			issueTypes: selectedFilters,
 			showOnlyFavorites: showOnlyFavorites || false,
+			showOnlyDevelopmentSites: showOnlyDevelopmentSites || false,
 		} );
-	}, [ dataViewsState.filters, setAgencyDashboardFilter, showOnlyFavorites ] );
+	}, [
+		dataViewsState.filters,
+		setAgencyDashboardFilter,
+		showOnlyFavorites,
+		showOnlyDevelopmentSites,
+	] );
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites( {
 		isPartnerOAuthTokenLoaded: false,
@@ -159,6 +167,7 @@ export default function SitesDashboard() {
 			currentPage: dataViewsState.page,
 			sort: dataViewsState.sort,
 			showOnlyFavorites,
+			showOnlyDevelopmentSites,
 		} );
 		if ( page.current !== updatedUrl && updatedUrl !== undefined ) {
 			page.show( updatedUrl );
@@ -173,6 +182,7 @@ export default function SitesDashboard() {
 		dataViewsState.search,
 		dataViewsState.page,
 		showOnlyFavorites,
+		showOnlyDevelopmentSites,
 		dataViewsState.sort,
 		hideListing,
 	] );

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/update-sites-dashboard-url.tsx
@@ -15,12 +15,14 @@ const buildQueryString = ( {
 	currentPage,
 	sort,
 	showOnlyFavorites,
+	showOnlyDevelopmentSites,
 }: {
 	filters: Filter[];
 	search: string;
 	currentPage: number;
 	sort: DashboardSortInterface;
 	showOnlyFavorites?: boolean;
+	showOnlyDevelopmentSites?: boolean;
 } ) => {
 	const urlQuery = new URLSearchParams();
 
@@ -50,7 +52,14 @@ const buildQueryString = ( {
 		urlQuery.set( 'is_favorite', '' );
 	}
 
-	const queryString = urlQuery.toString().replace( 'is_favorite=', 'is_favorite' );
+	if ( showOnlyDevelopmentSites ) {
+		urlQuery.set( 'is_development', '' );
+	}
+
+	const queryString = urlQuery
+		.toString()
+		.replace( 'is_favorite=', 'is_favorite' )
+		.replace( 'is_development=', 'is_development' );
 
 	return queryString ? `?${ queryString }` : '';
 };
@@ -65,6 +74,7 @@ export const updateSitesDashboardUrl = ( {
 	currentPage,
 	sort,
 	showOnlyFavorites,
+	showOnlyDevelopmentSites,
 }: {
 	category?: string;
 	setCategory: ( category: string ) => void;
@@ -75,6 +85,7 @@ export const updateSitesDashboardUrl = ( {
 	currentPage: number;
 	sort: DashboardSortInterface;
 	showOnlyFavorites?: boolean;
+	showOnlyDevelopmentSites?: boolean;
 } ) => {
 	// We need a category in the URL if we have a selected site
 	if ( selectedSite && ! category ) {
@@ -92,6 +103,7 @@ export const updateSitesDashboardUrl = ( {
 		currentPage,
 		sort,
 		showOnlyFavorites,
+		showOnlyDevelopmentSites,
 	} );
 
 	if (

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
@@ -31,9 +31,16 @@ const SitesDataViews = ( {
 	className,
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
-	// TODO: Get showOnlyDevelopmentSites from context and calculate total sites based on that.
-	const { showOnlyFavorites } = useContext( SitesDashboardContext );
-	const totalSites = showOnlyFavorites ? data?.totalFavorites || 0 : data?.total || 0;
+	const { showOnlyFavorites, showOnlyDevelopmentSites } = useContext( SitesDashboardContext );
+	const totalSites = ( () => {
+		if ( showOnlyFavorites ) {
+			return data?.totalFavorites || 0;
+		}
+		if ( showOnlyDevelopmentSites ) {
+			return data?.totalDevelopmentSites || 0;
+		}
+		return data?.total || 0;
+	} )();
 	const sitesPerPage = dataViewsState.perPage > 0 ? dataViewsState.perPage : 20;
 	const totalPages = Math.ceil( totalSites / sitesPerPage );
 	const sites = useFormattedSites( data?.sites ?? [] );

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/index.tsx
@@ -31,6 +31,7 @@ const SitesDataViews = ( {
 	className,
 }: SitesDataViewsProps ) => {
 	const translate = useTranslate();
+	// TODO: Get showOnlyDevelopmentSites from context and calculate total sites based on that.
 	const { showOnlyFavorites } = useContext( SitesDashboardContext );
 	const totalSites = showOnlyFavorites ? data?.totalFavorites || 0 : data?.total || 0;
 	const sitesPerPage = dataViewsState.perPage > 0 ? dataViewsState.perPage : 20;

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/interfaces.ts
@@ -5,6 +5,7 @@ export interface SitesDataResponse {
 	sites: Array< Site >;
 	total: number;
 	perPage: number;
+	totalDevelopmentSites: number;
 	totalFavorites: number;
 }
 

--- a/client/a8c-for-agencies/sections/sites/types.ts
+++ b/client/a8c-for-agencies/sections/sites/types.ts
@@ -20,6 +20,9 @@ export interface SitesDashboardContextInterface {
 	showOnlyFavorites?: boolean;
 	setShowOnlyFavorites: ( showOnlyFavorites: boolean ) => void;
 
+	showOnlyDevelopmentSites?: boolean;
+	setShowOnlyDevelopmentSites: ( showOnlyDevelopmentSites: boolean ) => void;
+
 	initialSelectedSiteUrl?: string;
 	path: string;
 	currentPage: number;

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -20,6 +20,7 @@ const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => 
 		...( filter.showOnlyFavorites && { show_only_favorites: true } ),
 		...( filter.isNotMultisite && { not_multisite: true } ),
 		...( filter?.showOnlyFavorites && { show_only_favorites: true } ),
+		...( filter?.showOnlyDevelopmentSites && { show_only_dev_sites: true } ),
 	};
 };
 
@@ -73,7 +74,6 @@ const useFetchDashboardSites = ( {
 
 	const isAgencyOrPartnerAuthEnabled = isPartnerOAuthTokenLoaded || !! agencyId;
 
-	// TODO: Adjust the query to be able to fetch dev sites based on the related filter
 	return useQuery( {
 		// Disable eslint rule since TS isn't grasping that agencyId is being optionally added to the array
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps
@@ -98,6 +98,7 @@ const useFetchDashboardSites = ( {
 				sites: data.sites,
 				total: data.total,
 				perPage: data.per_page,
+				totalDevelopmentSites: data.total_dev_sites,
 				totalFavorites: data.total_favorites,
 			};
 		},

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -73,6 +73,7 @@ const useFetchDashboardSites = ( {
 
 	const isAgencyOrPartnerAuthEnabled = isPartnerOAuthTokenLoaded || !! agencyId;
 
+	// TODO: Adjust the query to be able to fetch dev sites based on the related filter
 	return useQuery( {
 		// Disable eslint rule since TS isn't grasping that agencyId is being optionally added to the array
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -23,6 +23,7 @@ export const agencyDashboardContext: Callback = ( context, next ) => {
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
 		showOnlyFavorites: context.params.filter === 'favorites',
+		showOnlyDevelopmentSites: context.params.filter === 'development',
 	};
 	const sort = {
 		field: sort_field,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
@@ -5,7 +5,7 @@ const SitesOverviewContext = createContext< SitesOverviewContextInterface >( {
 	currentPage: 1,
 	path: '',
 	search: '',
-	filter: { issueTypes: [], showOnlyFavorites: false },
+	filter: { issueTypes: [], showOnlyFavorites: false, showOnlyDevelopmentSites: false },
 	isBulkManagementActive: false,
 	showSitesDashboardV2: false,
 	setIsBulkManagementActive: () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces.ts
@@ -4,6 +4,7 @@ export interface SitesDataResponse {
 	sites: Array< Site >;
 	total: number;
 	perPage: number;
+	totalDevelopmentSites: number;
 	totalFavorites: number;
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -239,7 +239,11 @@ export interface DashboardOverviewContextInterface {
 	path: string;
 	search: string;
 	currentPage: number;
-	filter: { issueTypes: Array< AgencyDashboardFilterOption >; showOnlyFavorites: boolean };
+	filter: {
+		issueTypes: Array< AgencyDashboardFilterOption >;
+		showOnlyFavorites: boolean;
+		showOnlyDevelopmentSites: boolean;
+	};
 	sort: DashboardSortInterface;
 	showSitesDashboardV2: boolean;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -285,6 +285,7 @@ export interface AgencyDashboardFilterMap {
 export type AgencyDashboardFilter = {
 	issueTypes: Array< AgencyDashboardFilterOption >;
 	showOnlyFavorites: boolean;
+	showOnlyDevelopmentSites: boolean;
 	isNotMultisite?: boolean;
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8666.

## Proposed Changes

* introduce a new "Development" sidebar link and related page that filters out only the development sites; behind the `a4a-dev-sites` feature flag

![Markup on 2024-08-19 at 14:31:07](https://github.com/user-attachments/assets/ea40effa-81ea-4b4d-9ad8-712274379892)

TODOs:
- [x] resolve all the TODOs in the code - mostly the connection to the adjusted endpoint; context: p1723640804885279-slack-C02TCEHP3HA
- [x] add screenshot to the PR description
- [x] review the testing instructions

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR locally and build the app with `yarn start-a8c-for-agencies`.
2. Apply related backend patch (D158729-code) to your sandbox and sandbox `public-api.wordpress.com`.
3. Head over to the Sites section at http://agencies.localhost:3000/sites/?flags=a4a-dev-sites.
4. You should see a new "Development" menu item in the sidebar. Click on it.
5. Review the output of the section - it should list all the development sites only. The list should work correctly as other existing lists.
6. Click through other pages that list sites. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?