### PR TITLE
Fix/paid newsletter fix export content link

### DIFF
--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -65,7 +65,11 @@ export default function Content( {
 				To generate a ZIP file of all your Substack posts, go to Settings { '>' } Exports and click
 				'Create a new export.' Once the ZIP file is downloaded, upload it in the next step.
 			</p>
-			<Button href={ `https://${ fromSite }/publish/settings#exports` }>
+			<Button
+				href={ `https://${ fromSite }/publish/settings#import-export-settings` }
+				target="_blank"
+				rel="noreferrer noopener"
+			>
 				Export content <Gridicon icon="external" />
 			</Button>
 			<hr />

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -66,7 +66,7 @@ export default function Content( {
 				'Create a new export.' Once the ZIP file is downloaded, upload it in the next step.
 			</p>
 			<Button
-				href={ `https://${ fromSite }/publish/settings#import-export-settings` }
+				href={ `https://${ fromSite }/publish/settings?search=export` }
 				target="_blank"
 				rel="noreferrer noopener"
 			>

--- a/client/my-sites/importer/newsletter/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers.tsx
@@ -26,7 +26,11 @@ export default function Subscribers( {
 				To generate a CSV file of all your Substack subscribers, go to the Subscribers tab and click
 				'Export.' Once the CSV file is downloaded, upload it in the next step.
 			</p>
-			<Button href={ `https://${ fromSite }/publish/subscribers` }>
+			<Button
+				href={ `https://${ fromSite }/publish/subscribers` }
+				target="_blank"
+				rel="noreferrer noopener"
+			>
 				Export subscribers <Gridicon icon="external" />
 			</Button>
 			<hr />


### PR DESCRIPTION
This PR fixes 2 links that help the use export content.

## Proposed Changes

* Make the links open in new tabs. 
* Fix the URL for the export content so that it works more like expected.

## Why are these changes being made?
* Make it easier to find the content that you would expect.

## Testing Instructions
* visit /import/newsletter/substack/yoursite.com/content?from=enej0077.substack.com
* visit /import/newsletter/substack/yoursite.com/subscribers?from=enej0077.substack.com
* Click on the export content and subscriber links in the flow. 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
