### PR TITLE
Restore the Wix importer to the Stepper import lists

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -49,11 +49,8 @@ export default function ListStep( props: Props ) {
 	const title = props.title || __( 'Import content from another platform' );
 	const subTitle = props.subTitle || __( 'Select the platform where your content lives' );
 	const skipTracking = props.skipTracking;
+	const primaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'primary' );
 
-	// We need to remove the wix importer from the primary importers list.
-	const primaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'primary' ).filter(
-		( option ) => option.value !== 'wix'
-	);
 	// We need to remove the icon property for secondary importers to avoid display issues.
 	const secondaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'secondary' ).map(
 		( { icon, ...rest } ) => rest


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #93208

## Proposed Changes

This restores Wix to the list of primary importers.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Wix was mistakenly removed from the importer list in #91609.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are tests for the two new functions for retrieving importer details:

```
yarn test-client client/lib/importer/test/importer-config.tsx
```

To test the actual UI, you can use either calypso.live or check out this branch and run it locally.

Then there are two ways to get to the importer list.

1. Visit `/sites`, click the `^` next to "Add new site" and click "Import an existing site".
2. Or you can go through `/start` and select the "Import existing content or website" Goal.

You'll eventually arrive at the "Let's find your site" step
![image](https://github.com/Automattic/wp-calypso/assets/917632/ab615c2f-27c5-46fd-851f-04b14e715f5b)

Click "pick your current platform from a list". You should be taken to "Import content from another platform".
![CleanShot 2024-08-14 at 14 02 34](https://github.com/user-attachments/assets/e19acbc1-c2e3-4ec6-912f-e5237004d12f)

From here, verify that the options are displaying correctly.

3. Go to `/import/siteSlug` and verify the Wix option is available.

![CleanShot 2024-08-14 at 14 03 42](https://github.com/user-attachments/assets/87de40c5-f11f-4eac-8398-937f5bd3fdfa)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
