### PR TITLE
Use react hook form on the automated migration credential form

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -27,13 +27,13 @@ interface CredentialsFormData {
 	password: string;
 	backupFileLocation: string;
 	notes: string;
-	howToAccessSite: string;
+	howToAccessSite: 'credentials' | 'backup';
 }
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 	const translate = useTranslate();
 
-	const validateCredentials = ( siteAddress: string ) => {
+	const validateSiteAddress = ( siteAddress: string ) => {
 		const isSiteAddressValid = CAPTURE_URL_RGX.test( siteAddress );
 
 		if ( ! isSiteAddressValid ) {
@@ -51,7 +51,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 		handleSubmit,
 		watch,
 	} = useForm< CredentialsFormData >( {
-		mode: 'onBlur',
+		mode: 'onSubmit',
 		defaultValues: {
 			siteAddress: '',
 			username: '',
@@ -62,13 +62,15 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 		},
 	} );
 
+	console.log( errors );
+
 	// Subscribe only this field to the access method value
 	const accessMethod = watch( 'howToAccessSite' );
 
 	const submitHandler = ( data: CredentialsFormData ) => {
 		// eslint-disable-next-line no-console
 		console.log( { data } );
-		onSubmit();
+		// onSubmit();
 	};
 
 	return (
@@ -122,7 +124,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 								<Controller
 									control={ control }
 									name="siteAddress"
-									rules={ { required: true, validate: validateCredentials } }
+									rules={ { required: true, validate: validateSiteAddress } }
 									render={ ( { field } ) => (
 										<FormTextInput
 											id="site-address"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -18,7 +18,7 @@ import type { Step } from '../../types';
 import './style.scss';
 
 interface CredentialsFormProps {
-	onSubmit: () => void;
+	onSubmit: ( data: CredentialsFormData ) => void;
 }
 
 interface CredentialsFormData {
@@ -41,8 +41,8 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 		}
 	};
 
-	const isValidFile = ( fileLocation: string ) => {
-		return ! isValidUrl( fileLocation ) ? translate( 'Please enter a valid URL' ) : undefined;
+	const isBackupFileLocationValid = ( fileLocation: string ) => {
+		return ! isValidUrl( fileLocation ) ? translate( 'Please enter a valid URL.' ) : undefined;
 	};
 
 	const {
@@ -52,6 +52,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 		watch,
 	} = useForm< CredentialsFormData >( {
 		mode: 'onSubmit',
+		reValidateMode: 'onSubmit',
 		defaultValues: {
 			siteAddress: '',
 			username: '',
@@ -62,15 +63,11 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 		},
 	} );
 
-	console.log( errors );
-
 	// Subscribe only this field to the access method value
 	const accessMethod = watch( 'howToAccessSite' );
 
 	const submitHandler = ( data: CredentialsFormData ) => {
-		// eslint-disable-next-line no-console
-		console.log( { data } );
-		// onSubmit();
+		onSubmit( data );
 	};
 
 	return (
@@ -124,7 +121,10 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 								<Controller
 									control={ control }
 									name="siteAddress"
-									rules={ { required: true, validate: validateSiteAddress } }
+									rules={ {
+										required: translate( 'Please enter your WordPress site address.' ),
+										validate: validateSiteAddress,
+									} }
 									render={ ( { field } ) => (
 										<FormTextInput
 											id="site-address"
@@ -150,7 +150,9 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									<Controller
 										control={ control }
 										name="username"
-										rules={ { required: true } }
+										rules={ {
+											required: translate( 'Please enter your WordPress admin username.' ),
+										} }
 										render={ ( { field } ) => (
 											<FormTextInput
 												id="username"
@@ -166,7 +168,9 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									<Controller
 										control={ control }
 										name="password"
-										rules={ { required: true } }
+										rules={ {
+											required: translate( 'Please enter your WordPress admin password.' ),
+										} }
 										render={ ( { field } ) => (
 											<FormTextInput
 												id="password"
@@ -195,7 +199,10 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 								<Controller
 									control={ control }
 									name="backupFileLocation"
-									rules={ { required: true, validate: isValidFile } }
+									rules={ {
+										required: translate( 'Please enter a valid URL.' ),
+										validate: isBackupFileLocationValid,
+									} }
 									render={ ( { field } ) => (
 										<FormTextInput
 											type="text"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -2,7 +2,8 @@ import { FormLabel } from '@automattic/components';
 import Card from '@automattic/components/src/card';
 import { NextButton, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, FormEvent, useState, type FC } from 'react';
+import { type FC } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import getValidationMessage from 'calypso/blocks/import/capture/url-validation-message-helper';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -20,87 +21,96 @@ interface CredentialsFormProps {
 	onSubmit: () => void;
 }
 
+interface CredentialsFormData {
+	siteAddress: string;
+	username: string;
+	password: string;
+	backupFileLocation: string;
+	notes: string;
+	howToAccessSite: string;
+}
+
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 	const translate = useTranslate();
 
-	const [ accessMethod, setAccessMethod ] = useState< string >( 'credentials' );
-	const [ siteAddress, setSiteAddress ] = useState< string >( '' );
-	const [ username, setUsername ] = useState< string >( '' );
-	const [ password, setPassword ] = useState< string >( '' );
-	const [ backupFileLocation, setBackupFileLocation ] = useState< string >( '' );
-	const [ notes, setNotes ] = useState< string >( '' );
-	const [ errors, setError ] = useState< Record< string, string > >();
-
-	const handleAccessMethodChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
-		setAccessMethod( event.target.value );
-	};
-
-	const validateCredentials = () => {
-		const credentialsErrors: Record< string, string > = {};
+	const validateCredentials = ( siteAddress: string ) => {
 		const isSiteAddressValid = CAPTURE_URL_RGX.test( siteAddress );
 
 		if ( ! isSiteAddressValid ) {
-			const siteAddressError = getValidationMessage( siteAddress, translate );
-			credentialsErrors.siteAddress = siteAddressError;
+			return getValidationMessage( siteAddress, translate );
 		}
-
-		if ( ! username || ! password ) {
-			credentialsErrors.credentials = translate(
-				'Enter your WordPress admin username and password.'
-			);
-		}
-
-		return credentialsErrors;
 	};
 
-	const handleSubmit = ( e: FormEvent ) => {
-		e.preventDefault();
-		setError( {} );
-		if ( accessMethod === 'credentials' ) {
-			const credentialsErrors = validateCredentials();
-			if ( Object.keys( credentialsErrors ).length ) {
-				setError( credentialsErrors );
-				return;
-			}
-		} else if ( accessMethod === 'backup' ) {
-			if ( ! isValidUrl( backupFileLocation ) ) {
-				setError( { backupFileLocation: translate( 'Please enter a valid URL' ) } );
-				return;
-			}
-		}
+	const isValidFile = ( fileLocation: string ) => {
+		return ! isValidUrl( fileLocation ) ? translate( 'Please enter a valid URL' ) : undefined;
+	};
+
+	const {
+		formState: { errors },
+		control,
+		handleSubmit,
+		watch,
+	} = useForm< CredentialsFormData >( {
+		mode: 'onBlur',
+		defaultValues: {
+			siteAddress: '',
+			username: '',
+			password: '',
+			backupFileLocation: '',
+			notes: '',
+			howToAccessSite: 'credentials',
+		},
+	} );
+
+	// Subscribe only this field to the access method value
+	const accessMethod = watch( 'howToAccessSite' );
+
+	const submitHandler = ( data: CredentialsFormData ) => {
+		// eslint-disable-next-line no-console
+		console.log( { data } );
 		onSubmit();
 	};
 
 	return (
-		<form onSubmit={ handleSubmit }>
+		<form onSubmit={ handleSubmit( submitHandler ) }>
 			<Card>
 				<div>
 					<FormLabel>{ translate( 'How can we access your site?' ) }</FormLabel>
-					<div className="site-migration-credentials__radio-group">
-						<div className="site-migration-credentials__radio">
-							<FormRadio
-								id="site-migration-credentials__radio-credentials"
-								htmlFor="site-migration-credentials__radio-credentials"
-								label={ translate( 'WordPress credentials' ) }
-								value="credentials"
-								name="how-to-access-site"
-								checked={ accessMethod === 'credentials' }
-								onChange={ handleAccessMethodChange }
-								disabled={ false }
-							/>
-						</div>
-						<div className="site-migration-credentials__radio">
-							<FormRadio
-								id="site-migration-credentials__radio-backup"
-								htmlFor="site-migration-credentials__radio-backup"
-								label={ translate( 'Backup file' ) }
-								value="backup"
-								name="how-to-access-site"
-								checked={ accessMethod === 'backup' }
-								onChange={ handleAccessMethodChange }
-								disabled={ false }
-							/>
-						</div>
+					<div className="site-migration-credentials__radio">
+						<Controller
+							control={ control }
+							name="howToAccessSite"
+							defaultValue="credentials"
+							render={ ( { field: { value, ...props } } ) => (
+								<FormRadio
+									id="site-migration-credentials__radio-credentials"
+									htmlFor="site-migration-credentials__radio-credentials"
+									label={ translate( 'WordPress credentials' ) }
+									checked={ value === 'credentials' }
+									{ ...props }
+									value="credentials"
+									ref={ null }
+								/>
+							) }
+						/>
+					</div>
+					<div className="site-migration-credentials__radio">
+						<Controller
+							control={ control }
+							name="howToAccessSite"
+							defaultValue="backup"
+							render={ ( { field: { value, onBlur, ...props } } ) => (
+								<FormRadio
+									id="site-migration-credentials__radio-backup"
+									htmlFor="site-migration-credentials__radio-backup"
+									{ ...props }
+									checked={ value === 'backup' }
+									value="backup"
+									label={ translate( 'Backup file' ) }
+									ref={ null }
+								/>
+							) }
+						/>
 					</div>
 				</div>
 				<hr />
@@ -109,19 +119,23 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 						<div className="site-migration-credentials__form">
 							<div className="site-migration-credentials__form-field">
 								<FormLabel htmlFor="site-address">{ translate( 'Site address' ) }</FormLabel>
-								<FormTextInput
-									type="text"
-									id="site-address"
-									value={ siteAddress }
-									placeholder={ translate( 'Enter your WordPress site address.' ) }
-									isError={ errors?.siteAddress }
-									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
-										setSiteAddress( e.target.value )
-									}
+								<Controller
+									control={ control }
+									name="siteAddress"
+									rules={ { required: true, validate: validateCredentials } }
+									render={ ( { field } ) => (
+										<FormTextInput
+											id="site-address"
+											placeholder={ translate( 'Enter your WordPress site address.' ) }
+											type="text"
+											{ ...field }
+										/>
+									) }
 								/>
+
 								{ errors?.siteAddress && (
 									<div className="site-migration-credentials__form-error">
-										{ errors.siteAddress }
+										{ errors.siteAddress.message }
 									</div>
 								) }
 							</div>
@@ -131,34 +145,42 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									<FormLabel htmlFor="username">
 										{ translate( 'WordPress admin username' ) }
 									</FormLabel>
-									<FormTextInput
-										type="text"
-										id="username"
-										value={ username }
-										placeholder={ translate( 'Username' ) }
-										isError={ errors?.credentials && ! username }
-										onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
-											setUsername( e.target.value )
-										}
+									<Controller
+										control={ control }
+										name="username"
+										rules={ { required: true } }
+										render={ ( { field } ) => (
+											<FormTextInput
+												id="username"
+												type="text"
+												placeholder={ translate( 'Username' ) }
+												{ ...field }
+											/>
+										) }
 									/>
 								</div>
 								<div className="site-migration-credentials__form-field">
 									<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
-									<FormTextInput
-										type="password"
-										id="password"
-										value={ password }
-										placeholder={ translate( 'Password' ) }
-										isError={ errors?.credentials && ! password }
-										onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
-											setPassword( e.target.value )
-										}
+									<Controller
+										control={ control }
+										name="password"
+										rules={ { required: true } }
+										render={ ( { field } ) => (
+											<FormTextInput
+												id="password"
+												type="password"
+												placeholder={ translate( 'Password' ) }
+												{ ...field }
+											/>
+										) }
 									/>
 								</div>
 							</div>
 
-							{ errors?.credentials && (
-								<div className="site-migration-credentials__form-error">{ errors.credentials }</div>
+							{ ( errors.username || errors.password ) && (
+								<div className="site-migration-credentials__form-error">
+									{ errors.username?.message || errors.password?.message }
+								</div>
 							) }
 						</div>
 					</div>
@@ -168,20 +190,22 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 						<div className="site-migration-credentials__form">
 							<div className="site-migration-credentials__form-field">
 								<FormLabel htmlFor="backup-file">{ translate( 'Backup file location' ) }</FormLabel>
-								<FormTextInput
-									type="text"
-									id="backup-file"
-									value={ backupFileLocation }
-									isError={ errors?.backupFileLocation }
-									onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
-										setBackupFileLocation( e.target.value )
-									}
-									placeholder={ translate( 'Enter your backup file location' ) }
+								<Controller
+									control={ control }
+									name="backupFileLocation"
+									rules={ { required: true, validate: isValidFile } }
+									render={ ( { field } ) => (
+										<FormTextInput
+											type="text"
+											placeholder={ translate( 'Enter your backup file location' ) }
+											{ ...field }
+										/>
+									) }
 								/>
 							</div>
 							{ errors?.backupFileLocation && (
 								<div className="site-migration-credentials__form-error">
-									{ errors.backupFileLocation }
+									{ errors.backupFileLocation?.message }
 								</div>
 							) }
 							<div className="site-migration-credentials__form-note">
@@ -195,14 +219,19 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 
 				<div className="site-migration-credentials__form-field">
 					<FormLabel htmlFor="site-address">{ translate( 'Notes (optional)' ) }</FormLabel>
-					<FormTextArea
-						type="text"
-						id="site-address"
-						placeholder={ translate(
-							'Share any other details that will help us access your site for the migration.'
+					<Controller
+						control={ control }
+						name="notes"
+						render={ ( { field } ) => (
+							<FormTextArea
+								type="text"
+								placeholder={ translate(
+									'Share any other details that will help us access your site for the migration.'
+								) }
+								{ ...field }
+								ref={ null }
+							/>
 						) }
-						value={ notes }
-						onChange={ ( e: ChangeEvent< HTMLInputElement > ) => setNotes( e.target.value ) }
 					/>
 				</div>
 				<div>

--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
 		"photon": "workspace:^",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
+		"react-hook-form": "^7.52.2",
 		"react-intersection-observer": "^9.4.3",
 		"react-modal": "^3.16.1",
 		"redux": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26593,6 +26593,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-hook-form@npm:^7.52.2":
+  version: 7.52.2
+  resolution: "react-hook-form@npm:7.52.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18 || ^19
+  checksum: 2b8d37239d40f4326a24609c1bf5b4ba2cf66bc4a988213ccd7eb92a254dd5bf9c4b94caa353bce4b1d6d8a9ecd2ea3103e25c6d2d72d53f7be26f09053a8b2f
+  languageName: node
+  linkType: hard
+
 "react-intersection-observer@npm:^9.4.3":
   version: 9.4.3
   resolution: "react-intersection-observer@npm:9.4.3"
@@ -32891,6 +32900,7 @@ __metadata:
     prettier: "npm:wp-prettier@3.0.3"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
+    react-hook-form: "npm:^7.52.2"
     react-intersection-observer: "npm:^9.4.3"
     react-modal: "npm:^3.16.1"
     react-refresh: "npm:^0.14.0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  p1723651841864779/1723578338.511629-slack-C07G7FG6J8Y

## Proposed Changes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Handles the form data and validation through the new [react-hook-form](https://react-hook-form.com/docs) package we added.
* We intend to simplify the data and validation handling in forms using this new package.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch to your local environment or use the Calypso Live link below.
  * In case you test it locally, make sure you run `yarn` to install the new package
* Open the dev console and activate the feature flag by running the following command:
```
window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')
```
* Now go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Play around with invalid data on the inputs and verify that validation still works correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?