### PR TITLE
Performance Profiler: Add the Insights section

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -128,10 +128,7 @@ export interface UrlSecurityMetricsQueryResponse {
 }
 
 export type PerformanceReport = {
-	audits: {
-		health: PerformanceMetricsDataQueryResponse;
-		performance: PerformanceMetricsDataQueryResponse;
-	};
+	audits: Record< string, PerformanceMetricsItemQueryResponse >;
 	performance: number;
 	overall_score: number;
 	is_wpcom: boolean;

--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -1,7 +1,8 @@
 import { PerformanceReport } from 'calypso/data/site-profiler/types';
+import { CoreWebVitalsDisplay } from 'calypso/performance-profiler/components/core-web-vitals-display';
+import { InsightsSection } from 'calypso/performance-profiler/components/insights-section';
 import { PerformanceScore } from 'calypso/performance-profiler/components/performance-score';
 import './style.scss';
-import { CoreWebVitalsDisplay } from '../core-web-vitals-display';
 
 type PerformanceProfilerDashboardContentProps = {
 	performanceReport: PerformanceReport;
@@ -10,17 +11,14 @@ type PerformanceProfilerDashboardContentProps = {
 export const PerformanceProfilerDashboardContent = ( {
 	performanceReport,
 }: PerformanceProfilerDashboardContentProps ) => {
-	const { overall_score, fcp, lcp, cls, inp, ttfb } = performanceReport;
+	const { overall_score, fcp, lcp, cls, inp, ttfb, audits } = performanceReport;
 
 	return (
 		<div className="performance-profiler-content">
-			<div className="l-block-wrapper">
-				{ overall_score && (
-					<>
-						<PerformanceScore value={ overall_score * 100 } />
-						<CoreWebVitalsDisplay fcp={ fcp } lcp={ lcp } cls={ cls } inp={ inp } ttfb={ ttfb } />
-					</>
-				) }
+			<div className="l-block-wrapper container">
+				<PerformanceScore value={ overall_score * 100 } />
+				<CoreWebVitalsDisplay fcp={ fcp } lcp={ lcp } cls={ cls } inp={ inp } ttfb={ ttfb } />
+				{ audits && <InsightsSection audits={ audits } /> }
 			</div>
 		</div>
 	);

--- a/client/performance-profiler/components/dashboard-content/style.scss
+++ b/client/performance-profiler/components/dashboard-content/style.scss
@@ -1,5 +1,12 @@
 .performance-profiler-content {
 	background: #fff;
-	padding-top: 40px;
 	min-height: 600px;
+
+	.container {
+		display: flex;
+		padding-top: 40px;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 48px;
+	}
 }

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -1,0 +1,34 @@
+import { useTranslate } from 'i18n-calypso';
+import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
+import { MetricsInsight } from 'calypso/performance-profiler/components/metrics-insight';
+import { InsightContent } from 'calypso/performance-profiler/components/metrics-insight/insight-content';
+import { InsightHeader } from 'calypso/performance-profiler/components/metrics-insight/insight-header';
+
+import './style.scss';
+
+type InsightsSectionProps = {
+	audits: Record< string, PerformanceMetricsItemQueryResponse >;
+};
+
+export const InsightsSection = ( props: InsightsSectionProps ) => {
+	const translate = useTranslate();
+	const { audits } = props;
+
+	return (
+		<div className="performance-profiler-insights-section">
+			<h2 className="title">{ translate( "Improve your site's performance" ) }</h2>
+			<p className="subtitle">
+				{ translate( 'We found things you can do to speed up your site.' ) }
+			</p>
+			{ Object.values( audits ).map( ( audit, index ) => (
+				<MetricsInsight
+					key={ `insight-${ audit.id }` }
+					insight={ {
+						header: <InsightHeader data={ audit } index={ index } />,
+						description: <InsightContent data={ audit } />,
+					} }
+				/>
+			) ) }
+		</div>
+	);
+};

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -1,0 +1,198 @@
+$blueberry-color: #3858e9;
+
+.performance-profiler-insights-section {
+	.title {
+		font-size: $font-title-small;
+		font-weight: 500;
+	}
+
+	.subtitle {
+		color: var(--studio-gray-70);
+		font-size: $font-body;
+		margin-bottom: 32px;
+	}
+
+	.metrics-insight-item.foldable-card {
+		box-shadow: none;
+		border-top: 1px solid var(--studio-gray-5);
+
+		&:last-child {
+			border-bottom: 1px solid var(--studio-gray-5);
+		}
+
+		.foldable-card__header {
+			padding: 16px;
+			padding-left: 0;
+
+			.title-description {
+				color: var(--studio-gray-70);
+			}
+		}
+
+		.foldable-card__secondary {
+			display: none;
+		}
+
+		.foldable-card__main {
+			padding-right: 50px;
+
+			a {
+				color: var(--studio-gray-40);
+
+				&:hover {
+					color: #fff;
+				}
+			}
+
+			.value {
+				color: var(--studio-green-40);
+			}
+		}
+
+		&.is-expanded .foldable-card__main {
+			color: #fff;
+
+			a {
+				color: #fff;
+
+				&:hover {
+					color: var(--studio-gray-40);
+				}
+			}
+
+			.value {
+				color: var(--studio-green-50);
+			}
+		}
+
+		&.is-expanded .foldable-card__header {
+			.title-description {
+				color: var(--studio-gray-100);
+			}
+		}
+
+		&.is-expanded .foldable-card__content {
+			border-top: 0;
+			max-height: fit-content;
+		}
+
+		.foldable-card__content {
+			.metrics-insight-detailed-content {
+				margin-top: 24px;
+
+				table {
+					table-layout: fixed;
+					width: 100%;
+					margin-bottom: 0;
+
+					th,
+					td {
+						padding: 8px;
+						word-break: break-word;
+						font-size: $font-body-small;
+						border-bottom: 1px solid var(--studio-gray-5);
+					}
+
+					tr.sub {
+						padding-left: 40px;
+					}
+
+					pre {
+						background: none;
+						padding: 14px 0 0;
+						margin-bottom: 0;
+					}
+
+					code {
+						color: $blueberry-color;
+					}
+
+					.score {
+						font-weight: bold;
+						display: inline-block;
+						width: 40px;
+						height: 25px;
+						line-height: 25px;
+						text-align: center;
+						border-radius: 4px;
+
+						&.dangerous {
+							color: var(--studio-red-60);
+							background: var(--studio-red-10);
+						}
+
+						&.alert {
+							color: var(--studio-yellow-60);
+							background: var(--studio-yellow-10);
+						}
+					}
+				}
+
+				.tree {
+					--spacing: 1.5rem;
+					--radius: 10px; /* stylelint-disable-line scales/radii */
+					margin: 0;
+					padding: 0;
+
+					li {
+						margin: 0;
+						display: block;
+						position: relative;
+						padding-left: calc(2 * var(--spacing) - var(--radius) - 2px);
+						line-height: 30px;
+					}
+
+					ul {
+						margin-left: calc(var(--radius) - var(--spacing));
+						padding-left: 0;
+
+						li {
+							border-left: 2px solid #ddd;
+
+							&:last-child {
+								border-color: transparent;
+							}
+
+							&::before {
+								content: "";
+								display: block;
+								position: absolute;
+								top: calc(var(--spacing) / -2);
+								left: -2px;
+								width: calc(var(--spacing) + 2px);
+								height: calc(var(--spacing) + 1px);
+								border: solid #ddd;
+								border-width: 0 0 2px 2px;
+							}
+						}
+					}
+
+					summary {
+						display: block;
+						cursor: pointer;
+
+						&::marker,
+						&::-webkit-details-marker {
+							display: none;
+						}
+
+						&:focus {
+							outline: none;
+						}
+
+						&:focus-visible {
+							outline: 1px dotted #000;
+						}
+
+						&::before {
+							z-index: 1;
+						}
+					}
+					details[open] > summary::before {
+						background-position: calc(-2 * var(--radius)) 0;
+					}
+				}
+			}
+		}
+	}
+}

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -1,0 +1,124 @@
+import { FoldableCard } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode, useState } from 'react';
+
+interface MetricsInsightProps {
+	insight?: Insight;
+	locked?: boolean;
+	onClick?: () => void;
+}
+
+type Insight = {
+	header?: ReactNode;
+	description?: ReactNode;
+};
+
+const Card = styled( FoldableCard )`
+	font-family: 'SF Pro Text', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto',
+		'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+	font-size: 16px;
+	line-height: normal;
+	letter-spacing: -0.1px;
+`;
+
+type Header = {
+	locked: boolean;
+	children: React.ReactNode;
+};
+
+const Header = styled.div`
+	font-family: 'SF Pro Text', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto',
+		'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+	font-size: 16px;
+	filter: ${ ( props: Header ) => ( props.locked ? 'blur(3px)' : 'none' ) };
+	user-select: ${ ( props: Header ) => ( props.locked ? 'none' : 'auto' ) };
+
+	p {
+		display: inline;
+	}
+
+	span {
+		display: inline-block;
+		color: var( --studio-gray-70 );
+
+		&.is-mobile {
+			display: block;
+		}
+	}
+
+	.counter {
+		color: #3858e9;
+		font-size: 16px;
+		font-weight: 500;
+		margin-right: 8px;
+	}
+`;
+
+const Content = styled.div`
+	padding: 24px;
+`;
+
+export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
+	const translate = useTranslate();
+	const { insight = {}, locked = false, onClick } = props;
+
+	const lockedInsights = useLockedInsights();
+	const [ randomInsight ] = useState( getRandomItem( lockedInsights ) );
+
+	const itemToRender = locked ? randomInsight : insight;
+
+	return (
+		<Card
+			className="metrics-insight-item"
+			header={
+				<Header locked={ locked } onClick={ onClick }>
+					{ itemToRender.header }
+				</Header>
+			}
+			screenReaderText={ translate( 'More' ) }
+			compact
+			clickableHeader
+			smooth
+			disabled={ locked }
+			icon={ locked ? 'lock' : 'chevron-down' }
+			iconSize={ 18 }
+		>
+			<Content>{ itemToRender.description }</Content>
+		</Card>
+	);
+};
+
+function getRandomItem( items: Array< Insight > ): Insight {
+	return items[ Math.floor( Math.random() * items.length ) ];
+}
+
+function useLockedInsights(): Insight[] {
+	const translate = useTranslate();
+
+	return [
+		{
+			header: translate(
+				'The full report will display all the information you need to improve your site.'
+			),
+		},
+		{
+			header: translate(
+				'Click on the "Get full site report - It\'s free" button to unlock all the information you need.'
+			),
+		},
+		{
+			header: translate(
+				"You'll be asked to provide your name and email, and then you will see all of your site stats."
+			),
+		},
+		{
+			header: translate(
+				'The full report will display all the information about how your site is performing currently.'
+			),
+		},
+		{
+			header: translate( "Feel free to use our tool as many times as you want, it's free." ),
+		},
+	];
+}

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -1,0 +1,31 @@
+import Markdown from 'react-markdown';
+import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
+import { InsightDetailedContent } from './insight-detailed-content';
+
+interface InsightContentProps {
+	data: PerformanceMetricsItemQueryResponse;
+}
+
+export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
+	const { data } = props;
+	const { description = '' } = data ?? {};
+
+	return (
+		<div className="metrics-insight-content">
+			<Markdown
+				components={ {
+					a( props ) {
+						return <a target="_blank" { ...props } />;
+					},
+				} }
+			>
+				{ description }
+			</Markdown>
+			{ data.details?.type && (
+				<div className="metrics-insight-detailed-content">
+					<InsightDetailedContent data={ data.details } />
+				</div>
+			) }
+		</div>
+	);
+};

--- a/client/performance-profiler/components/metrics-insight/insight-detailed-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-detailed-content.tsx
@@ -1,0 +1,27 @@
+import { PerformanceMetricsDetailsQueryResponse } from 'calypso/data/site-profiler/types';
+import { InsightTable } from './insight-table';
+import { InsightTree } from './insight-tree';
+
+export interface InsightDetailedContentProps {
+	data: PerformanceMetricsDetailsQueryResponse;
+}
+
+export const InsightDetailedContent: React.FC< InsightDetailedContentProps > = ( props ) => {
+	const { data } = props;
+
+	if ( data.type === 'table' || data.type === 'opportunity' ) {
+		return <InsightTable { ...props } />;
+	}
+
+	if ( data.type === 'list' ) {
+		const tables = data.items ?? [];
+
+		return tables.map( ( item, index ) => <InsightTable key={ index } data={ item as any } /> );
+	}
+
+	if ( data.type === 'criticalrequestchain' ) {
+		return <InsightTree { ...props } />;
+	}
+
+	return null;
+};

--- a/client/performance-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-header.tsx
@@ -1,0 +1,38 @@
+import { isMobile } from '@automattic/viewport';
+import Markdown from 'react-markdown';
+import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
+
+interface InsightHeaderProps {
+	data: PerformanceMetricsItemQueryResponse;
+	index: number;
+}
+
+export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
+	const { data, index } = props;
+	const title = data.title ?? '';
+	const value = data.displayValue ?? '';
+
+	return (
+		<>
+			<span className="counter">{ index + 1 }</span>
+			<Markdown
+				components={ {
+					p( props ) {
+						return <p className="title-description">{ props.children }</p>;
+					},
+					code( props ) {
+						return <span className="value">{ props.children }</span>;
+					},
+				} }
+			>
+				{ title }
+			</Markdown>
+			{ value && isMobile() && <span className="value is-mobile"> { value }</span> }
+			{ value && ! isMobile() && (
+				<span>
+					&nbsp;&minus;&nbsp;<span className="value"> { value }</span>
+				</span>
+			) }
+		</>
+	);
+};

--- a/client/performance-profiler/components/metrics-insight/insight-table.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-table.tsx
@@ -1,0 +1,130 @@
+import { useTranslate } from 'i18n-calypso';
+import Markdown from 'react-markdown';
+import { PerformanceMetricsDetailsQueryResponse } from 'calypso/data/site-profiler/types';
+import { getFormattedNumber, getFormattedSize } from 'calypso/site-profiler/utils/formatting-data';
+
+export function InsightTable( { data }: { data: PerformanceMetricsDetailsQueryResponse } ) {
+	const { headings = [], items = [] } = data ?? {};
+
+	return (
+		<table>
+			<thead>
+				<tr>
+					{ headings.map( ( heading, index ) => (
+						<th key={ `th-${ index }` }>{ heading.label }</th>
+					) ) }
+				</tr>
+			</thead>
+			<tbody>
+				{ items.map( ( item, index ) => (
+					<>
+						<tr key={ `tr-${ index }` }>
+							{ headings.map( ( heading ) => (
+								<td key={ `td-${ index }-${ heading.key }` }>
+									<Cell data={ item[ heading.key ] } headingValueType={ heading.valueType } />
+								</td>
+							) ) }
+						</tr>
+						{ item.subItems && typeof item.subItems === 'object' && (
+							<SubRows
+								items={ item.subItems?.items }
+								headings={ headings }
+								key={ `subrows-${ index }` }
+							/>
+						) }
+					</>
+				) ) }
+			</tbody>
+		</table>
+	);
+}
+
+function SubRows( { items, headings }: { items: any[]; headings: any[] } ) {
+	return items.map( ( subItem, subIndex ) => (
+		<tr key={ `sub-${ subIndex }` } className="sub">
+			{ headings.map( ( heading, index ) => {
+				const { subItemsHeading } = heading;
+
+				return (
+					<td key={ `subrow-${ index }` }>
+						<Cell
+							data={ subItem[ subItemsHeading?.key ] }
+							headingValueType={ subItemsHeading?.valueType }
+						/>
+					</td>
+				);
+			} ) }
+		</tr>
+	) );
+}
+
+function Cell( {
+	data,
+	headingValueType,
+}: {
+	data: string | number | { [ key: string ]: any };
+	headingValueType: string;
+} ) {
+	const translate = useTranslate();
+
+	if ( typeof data === 'object' ) {
+		switch ( data?.type ) {
+			case 'node':
+				return (
+					<div>
+						<p>{ data?.nodeLabel }</p>
+						<pre>
+							<code>{ data?.snippet }</code>
+						</pre>
+					</div>
+				);
+
+			case 'code':
+				return (
+					<div>
+						<pre>
+							<code>{ data?.value }</code>
+						</pre>
+					</div>
+				);
+			case 'numeric':
+				return getFormattedNumber( data.value );
+			case 'url':
+			case 'source-location':
+				if ( data?.location ) {
+					return `${ data.location.url }:${ data.location.line }:${ data.location.column }`;
+				}
+				return data?.url;
+		}
+
+		return data?.value;
+	}
+
+	if ( typeof data === 'string' || typeof data === 'number' ) {
+		switch ( headingValueType ) {
+			case 'ms':
+			case 'timespanMs':
+				// TODO: Implement a better visualization for ms values. Ex:  '1.2s' instead of '1200ms'
+				return translate( '%(ms)dms', {
+					comment: 'value to be displayed in milliseconds',
+					args: { ms: getFormattedNumber( data ) },
+				} );
+			case 'bytes':
+				return getFormattedSize( Number( data ) || 0 );
+			case 'numeric':
+				return getFormattedNumber( data, 2 );
+			case 'link':
+				return <Markdown>{ data.toString() }</Markdown>;
+			case 'score':
+				return (
+					<span className={ `score ${ Number( data ) > 6 ? 'dangerous' : 'alert' } ` }>
+						{ data }
+					</span>
+				);
+			default:
+				return data;
+		}
+	}
+
+	return data;
+}

--- a/client/performance-profiler/components/metrics-insight/insight-tree.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-tree.tsx
@@ -1,0 +1,58 @@
+import { useTranslate } from 'i18n-calypso';
+import { PerformanceMetricsDetailsQueryResponse } from 'calypso/data/site-profiler/types';
+import { getFormattedNumber, getFormattedSize } from 'calypso/site-profiler/utils/formatting-data';
+
+interface InsightTreeProps {
+	data: PerformanceMetricsDetailsQueryResponse;
+}
+
+export const InsightTree: React.FC< InsightTreeProps > = ( { data } ) => {
+	const translate = useTranslate();
+	const chains: { [ key: string ]: any } = data?.chains ?? {};
+
+	return Object.keys( chains ).map( ( item: string, index ) => {
+		const request = chains[ item ];
+		const children = chains[ item ][ 'children' ];
+
+		return (
+			<ul className="tree" key={ index }>
+				{ translate( 'Initial Request' ) }
+				<li>
+					<details open>
+						<summary>
+							<Request request={ request } />
+						</summary>
+						<ul>
+							{ Object.keys( children ).map( ( item, index ) => {
+								const childRequest = children[ item ];
+								return (
+									<li key={ index }>
+										<Request request={ childRequest } />
+									</li>
+								);
+							} ) }
+						</ul>
+					</details>
+				</li>
+			</ul>
+		);
+	} );
+};
+
+function Request( { request }: { request: any } ) {
+	const translate = useTranslate();
+	const { url, responseReceivedTime, transferSize } = request.request;
+
+	return (
+		<span>
+			{ translate( '%(url)s - {{b}}%(ms)sms{{/b}}, %(size)s', {
+				args: {
+					url,
+					ms: getFormattedNumber( responseReceivedTime ),
+					size: getFormattedSize( transferSize ),
+				},
+				components: { b: <b /> },
+			} ) }
+		</span>
+	);
+}

--- a/client/site-profiler/components/health-section/index.tsx
+++ b/client/site-profiler/components/health-section/index.tsx
@@ -22,7 +22,7 @@ const OVERALL_SCORE_THRESHOLD = 0.8;
 export const HealthSection: React.FC< HealthSectionProps > = ( props ) => {
 	const translate = useTranslate();
 	const { url, hash, hostingProvider, healthMetricsRef, setIsGetReportFormOpen } = props;
-	const { data } = useUrlPerformanceMetricsQuery( url, hash );
+	const { data }: { data: any } = useUrlPerformanceMetricsQuery( url, hash );
 	const { truncated, diagnostic: healthData = {} } = data?.audits.health ?? {};
 
 	const isWPcom = hostingProvider?.slug?.toLowerCase() === 'automattic';
@@ -68,7 +68,7 @@ export const HealthSection: React.FC< HealthSectionProps > = ( props ) => {
 			}
 			ref={ healthMetricsRef }
 		>
-			{ Object.values( healthData ).map( ( metric ) => (
+			{ Object.values( healthData ).map( ( metric: any ) => (
 				<MetricsInsight
 					key={ `insight-${ metric.id }` }
 					insight={ {

--- a/client/site-profiler/components/performance-section/index.tsx
+++ b/client/site-profiler/components/performance-section/index.tsx
@@ -22,7 +22,7 @@ const PERFORMANCE_THRESHOLD = 0.9;
 export const PerformanceSection: React.FC< PerformanceSectionProps > = ( props ) => {
 	const translate = useTranslate();
 	const { url, hash, hostingProvider, performanceMetricsRef, setIsGetReportFormOpen } = props;
-	const { data } = useUrlPerformanceMetricsQuery( url, hash );
+	const { data }: { data: any } = useUrlPerformanceMetricsQuery( url, hash );
 	const { truncated, diagnostic: performanceData = {} } = data?.audits.performance ?? {};
 
 	const isWPcom = hostingProvider?.slug?.toLowerCase() === 'automattic';
@@ -68,7 +68,7 @@ export const PerformanceSection: React.FC< PerformanceSectionProps > = ( props )
 			}
 			ref={ performanceMetricsRef }
 		>
-			{ Object.values( performanceData ).map( ( metric ) => (
+			{ Object.values( performanceData ).map( ( metric: any ) => (
 				<MetricsInsight
 					key={ `insight-${ metric.id }` }
 					insight={ {

--- a/client/site-profiler/components/security-section/index.tsx
+++ b/client/site-profiler/components/security-section/index.tsx
@@ -20,7 +20,7 @@ interface SecuritySectionProps {
 export const SecuritySection: React.FC< SecuritySectionProps > = ( props ) => {
 	const translate = useTranslate();
 	const { url, hash, hostingProvider, securityMetricsRef, setIsGetReportFormOpen } = props;
-	const { data } = useUrlSecurityMetricsQuery( url, hash );
+	const { data }: { data: any } = useUrlSecurityMetricsQuery( url, hash );
 	const { truncated, fail: securityData = {} } = data?.report?.audits ?? {};
 	const overallVulnerabilities = data?.report?.ovc ?? 0;
 
@@ -73,7 +73,7 @@ export const SecuritySection: React.FC< SecuritySectionProps > = ( props ) => {
 			}
 			ref={ securityMetricsRef }
 		>
-			{ Object.values( securityData ).map( ( metric ) => (
+			{ Object.values( securityData ).map( ( metric: any ) => (
 				<MetricsInsight
 					key={ `insight-${ metric.id }` }
 					insight={ {


### PR DESCRIPTION
Related [Performance Profiler: Create recommendation section for the results page](https://github.com/Automattic/dotcom-forge/issues/8563)

## Proposed Changes

Display the list of insights for the sites.
Properly render the title and content (including its tables)

## Why are these changes being made?


To match the proposed design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Go to `http://calypso.localhost:3000/speed-test-tool?url=wordpress.com`
* Check if the list of recommendations are shown at the bottom of the content area
* Check if different results are shown for mobile and desktop

| List of items  | Expanded item |
| ------------- | ------------- |
|![CleanShot 2024-08-14 at 16 39 22@2x](https://github.com/user-attachments/assets/e8caff2f-978a-43eb-a8f5-52f2d6be2f79)|![CleanShot 2024-08-14 at 16 39 31@2x](https://github.com/user-attachments/assets/3c580522-7ada-4e1a-a471-ff2dec1d5b69)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
