### PR TITLE
Added Manage plugins button at the Global view

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -40,7 +40,7 @@ function renderSinglePlugin( context, siteUrl ) {
 			path: context.path,
 			pluginSlug,
 			siteUrl,
-			isJetpackCloud: true, // TODO: this should only be true when inside the "Manage plugins" section
+			isJetpackCloud: context.path?.includes( 'manage=true' ),
 		} );
 	}
 }

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -40,6 +40,7 @@ function renderSinglePlugin( context, siteUrl ) {
 			path: context.path,
 			pluginSlug,
 			siteUrl,
+			isJetpackCloud: true, // TODO: this should only be true when inside the "Manage plugins" section
 		} );
 	}
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -57,7 +57,9 @@ export default function PluginRowFormatter( {
 			<Button
 				borderless
 				compact
-				href={ `/plugins/${ item.slug }${ selectedSite ? `/${ selectedSite.domain }` : '' }` }
+				href={ `/plugins/${ item.slug }${
+					selectedSite ? `/${ selectedSite.domain }` : ''
+				}?manage=true` }
 				{ ...props }
 			/>
 		);

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -36,7 +36,8 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					selected={
 						path.startsWith( '/plugins' ) &&
 						! path.startsWith( '/plugins/scheduled-updates' ) &&
-						! path.startsWith( '/plugins/manage' )
+						! path.startsWith( '/plugins/manage' ) &&
+						! path.includes( 'manage=true' )
 					}
 					customIcon={ <SidebarIconPlugins /> }
 				/>
@@ -53,7 +54,7 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					link="/plugins/manage"
 					label={ translate( 'Manage plugins' ) }
 					tooltip={ isCollapsed && translate( 'Manage plugins' ) }
-					selected={ path.startsWith( '/plugins/manage' ) }
+					selected={ path.startsWith( '/plugins/manage' ) || path.includes( 'manage=true' ) }
 					customIcon={ <SidebarIconPlugins /> }
 				/>
 			</SidebarMenu>

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -34,7 +34,9 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					label={ translate( 'Marketplace' ) }
 					tooltip={ isCollapsed && translate( 'Marketplace' ) }
 					selected={
-						path.startsWith( '/plugins' ) && ! path.startsWith( '/plugins/scheduled-updates' )
+						path.startsWith( '/plugins' ) &&
+						! path.startsWith( '/plugins/scheduled-updates' ) &&
+						! path.startsWith( '/plugins/manage' )
 					}
 					customIcon={ <SidebarIconPlugins /> }
 				/>
@@ -45,6 +47,14 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 					tooltip={ isCollapsed && translate( 'Scheduled Updates' ) }
 					selected={ path.startsWith( '/plugins/scheduled-updates' ) }
 					customIcon={ <SidebarIconCalendar /> }
+				/>
+				<SidebarItem
+					className="sidebar__menu-item--plugins"
+					link="/plugins/manage"
+					label={ translate( 'Manage plugins' ) }
+					tooltip={ isCollapsed && translate( 'Manage plugins' ) }
+					selected={ path.startsWith( '/plugins/manage' ) }
+					customIcon={ <SidebarIconPlugins /> }
 				/>
 			</SidebarMenu>
 		</GlobalSidebar>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8603

## Proposed Changes

* We'll allow users to manage their plugins in a global view, reusing Jetpack Manage features


<img width="1733" alt="image" src="https://github.com/user-attachments/assets/2547e2d0-e965-483a-abc6-958db849a1f0">

TODO:
- ~~Make all plugin management navigation inside the `/plugins/manage` path, so we can know for sure when we're managing multiple plugins in the `isJetpackCloud` mode.~~
- Ensure the `Manage plugins` menu will always be enabled using a new base route

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
