### PR TITLE
Fix max-width of qr code on smaller screens

### DIFF
--- a/client/blocks/qr-code-login/style.scss
+++ b/client/blocks/qr-code-login/style.scss
@@ -72,6 +72,11 @@
 		max-width: 100%;
 		max-height: calc(100vw - 48px);
 
+		svg {
+			max-width: 100%;
+			max-height: calc(100vw - 48px);
+		}
+
 		canvas {
 			max-width: 100%;
 			max-height: calc(100vw - 48px);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/93482

## Proposed Changes

* Replicates bounding applied to canvas, to svg as well, suspect maybe the underlying modified what they use: https://www.npmjs.com/package/qrcode.react

## Testing

View, logged out, with screen width < 375px: http://calypso.localhost:3000/log-in/qr

Before / After

![Screenshot_2024-08-15_17-01-34](https://github.com/user-attachments/assets/36102afe-4165-45b3-a527-5d5b73d47aab)
![Screenshot_2024-08-15_17-01-14](https://github.com/user-attachments/assets/dc2b1516-468a-4e7c-92c6-389878650b1a)

