### PR TITLE
Themes: Include Broken Themes and Errors

### DIFF
--- a/client/my-sites/themes/theme-errors.jsx
+++ b/client/my-sites/themes/theme-errors.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'calypso/components/notice';
+import wpcom from 'calypso/lib/wp';
+
+/**
+ * We make a separate request rather than using getSite here to
+ * avoid querying the WP.com cache of a site, which returns theme
+ * errors for the multisite (caused by its 'force=wpcom' param).
+ */
+async function querySiteDataWithoutForceWpcom( siteId ) {
+	return await wpcom.req.get( {
+		path: '/sites/' + encodeURIComponent( siteId ),
+		apiVersion: '1.1',
+	} );
+}
+
+const ThemeErrors = ( { siteId } ) => {
+	const translate = useTranslate();
+	const [ themeErrors, setThemeErrors ] = useState( [] );
+
+	useEffect( () => {
+		const fetchData = async () => {
+			const siteData = await querySiteDataWithoutForceWpcom( siteId );
+			const errors = siteData?.options?.theme_errors;
+			setThemeErrors( errors || [] );
+		};
+
+		fetchData();
+	}, [ siteId ] );
+
+	const dismissNotice = ( themeName, errorIndex ) => {
+		setThemeErrors( ( prevErrors ) =>
+			prevErrors
+				.map( ( theme ) =>
+					theme.name === themeName
+						? {
+								...theme,
+								errors: theme.errors.filter( ( _, index ) => index !== errorIndex ),
+						  }
+						: theme
+				)
+				.filter( ( theme ) => theme.errors.length > 0 )
+		);
+	};
+
+	if ( themeErrors.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ themeErrors.map( ( theme ) =>
+				theme.errors.map( ( error, index ) => (
+					<Notice
+						status="is-error"
+						key={ index }
+						onDismissClick={ () => dismissNotice( theme.name, index ) }
+					>
+						{ translate( 'Error with theme {{strong}}%(themeName)s{{/strong}}: %(themeError)s', {
+							args: {
+								themeName: theme.name,
+								themeError: error,
+							},
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+					</Notice>
+				) )
+			) }
+		</>
+	);
+};
+
+export default ThemeErrors;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -64,6 +64,7 @@ import ThemesSelection from './themes-selection';
 import ThemesToolbarGroup from './themes-toolbar-group';
 import './theme-showcase.scss';
 
+
 const optionShape = PropTypes.shape( {
 	label: PropTypes.string,
 	header: PropTypes.string,

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -58,12 +58,12 @@ import {
 	shouldSelectSite,
 } from './helpers';
 import PatternAssemblerButton from './pattern-assembler-button';
+import ThemeErrors from './theme-errors';
 import ThemePreview from './theme-preview';
 import ThemeShowcaseHeader from './theme-showcase-header';
 import ThemesSelection from './themes-selection';
 import ThemesToolbarGroup from './themes-toolbar-group';
 import './theme-showcase.scss';
-
 
 const optionShape = PropTypes.shape( {
 	label: PropTypes.string,
@@ -603,6 +603,7 @@ class ThemeShowcase extends Component {
 			pathName,
 			featureStringFilter,
 			filterString,
+			isJetpackSite,
 			isMultisite,
 			premiumThemesEnabled,
 			isSiteECommerceFreeTrial,
@@ -648,6 +649,9 @@ class ThemeShowcase extends Component {
 		const classnames = clsx( 'theme-showcase', {
 			'is-collection-view': isCollectionView,
 		} );
+
+		const showThemeErrors =
+			siteId && this.props.category === staticFilters.MYTHEMES.key && isJetpackSite;
 
 		return (
 			<div className={ classnames }>
@@ -744,6 +748,7 @@ class ThemeShowcase extends Component {
 						/>
 					) }
 					<div className="themes__showcase">
+						{ showThemeErrors && <ThemeErrors siteId={ siteId } /> }
 						{ ! isSiteWooExpressOrEcomFreeTrial && this.renderBanner() }
 						{ this.renderThemes( themeProps ) }
 					</div>


### PR DESCRIPTION
Fixes #93132

## Proposed Changes

Displays the broken themes for a site and the errors associated with them.

## Why are these changes being made?

At present, if a user uploads a theme and it doesn't work, it's a little unclear why it won't show in the "My Themes" section. This exists on WP-Admin, but that section was retired on WordPress.com and these errors were never ported over.

## Testing Instructions

You first need to break a theme - the easiest way is probably to remove the stylesheet. Alternatively, you could install a Varia-based theme like this one, and then remove the Varia child theme: https://wordpress.com/theme/maywood

I thought it made sense to show them only under the "My Themes" section because these errors only exist for themes which the user has uploaded. I also think they deserve a prominent location as a user might be pretty confused about why a theme they've installed isn't displaying, and the notice is dismissable. I'd be happy to implement any feedback on this or the design though! 

<img width="1188" alt="Screenshot 2024-08-15 at 12 30 47" src="https://github.com/user-attachments/assets/83508668-6dea-4801-ad50-1d164e8676d9">

cc @lsl, @dsas