### PR TITLE
Add the "for" property to the Radio component

### DIFF
--- a/client/components/forms/form-radio/index.tsx
+++ b/client/components/forms/form-radio/index.tsx
@@ -6,15 +6,18 @@ import './style.scss';
 const FormRadio = ( {
 	className,
 	label,
+	htmlFor,
 	...otherProps
 }: {
 	className?: string;
 	label?: ReactNode;
+	htmlFor?: string;
 } & Omit< HTMLProps< HTMLInputElement >, 'label' > ) => (
 	<>
 		<input { ...otherProps } type="radio" className={ clsx( className, 'form-radio' ) } />
-		{ label && (
-			<label className="form-radio__label" htmlFor={ otherProps?.id }>
+		{ label && ! htmlFor && <span className="form-radio__label">{ label }</span> }
+		{ label && htmlFor && (
+			<label className="form-radio__label" htmlFor={ htmlFor }>
 				{ label }
 			</label>
 		) }

--- a/client/components/forms/form-radio/index.tsx
+++ b/client/components/forms/form-radio/index.tsx
@@ -13,7 +13,11 @@ const FormRadio = ( {
 } & Omit< HTMLProps< HTMLInputElement >, 'label' > ) => (
 	<>
 		<input { ...otherProps } type="radio" className={ clsx( className, 'form-radio' ) } />
-		{ label && <span className="form-radio__label">{ label }</span> }
+		{ label && (
+			<label className="form-radio__label" htmlFor={ otherProps?.id }>
+				{ label }
+			</label>
+		) }
 	</>
 );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -78,6 +78,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 					<FormLabel>{ translate( 'How can we access your site?' ) }</FormLabel>
 					<div className="site-migration-credentials__radio">
 						<FormRadio
+							id="site-migration-credentials__radio-credentials"
 							label={ translate( 'WordPress credentials' ) }
 							value="credentials"
 							name="how-to-access-site"
@@ -88,6 +89,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 					</div>
 					<div className="site-migration-credentials__radio">
 						<FormRadio
+							id="site-migration-credentials__radio-backup"
 							label={ translate( 'Backup file' ) }
 							value="backup"
 							name="how-to-access-site"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -79,6 +79,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 					<div className="site-migration-credentials__radio">
 						<FormRadio
 							id="site-migration-credentials__radio-credentials"
+							htmlFor="site-migration-credentials__radio-credentials"
 							label={ translate( 'WordPress credentials' ) }
 							value="credentials"
 							name="how-to-access-site"
@@ -90,6 +91,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 					<div className="site-migration-credentials__radio">
 						<FormRadio
 							id="site-migration-credentials__radio-backup"
+							htmlFor="site-migration-credentials__radio-backup"
 							label={ translate( 'Backup file' ) }
 							value="backup"
 							name="how-to-access-site"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -76,29 +76,31 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 			<Card>
 				<div>
 					<FormLabel>{ translate( 'How can we access your site?' ) }</FormLabel>
-					<div className="site-migration-credentials__radio">
-						<FormRadio
-							id="site-migration-credentials__radio-credentials"
-							htmlFor="site-migration-credentials__radio-credentials"
-							label={ translate( 'WordPress credentials' ) }
-							value="credentials"
-							name="how-to-access-site"
-							checked={ accessMethod === 'credentials' }
-							onChange={ handleAccessMethodChange }
-							disabled={ false }
-						/>
-					</div>
-					<div className="site-migration-credentials__radio">
-						<FormRadio
-							id="site-migration-credentials__radio-backup"
-							htmlFor="site-migration-credentials__radio-backup"
-							label={ translate( 'Backup file' ) }
-							value="backup"
-							name="how-to-access-site"
-							checked={ accessMethod === 'backup' }
-							onChange={ handleAccessMethodChange }
-							disabled={ false }
-						/>
+					<div className="site-migration-credentials__radio-group">
+						<div className="site-migration-credentials__radio">
+							<FormRadio
+								id="site-migration-credentials__radio-credentials"
+								htmlFor="site-migration-credentials__radio-credentials"
+								label={ translate( 'WordPress credentials' ) }
+								value="credentials"
+								name="how-to-access-site"
+								checked={ accessMethod === 'credentials' }
+								onChange={ handleAccessMethodChange }
+								disabled={ false }
+							/>
+						</div>
+						<div className="site-migration-credentials__radio">
+							<FormRadio
+								id="site-migration-credentials__radio-backup"
+								htmlFor="site-migration-credentials__radio-backup"
+								label={ translate( 'Backup file' ) }
+								value="backup"
+								name="how-to-access-site"
+								checked={ accessMethod === 'backup' }
+								onChange={ handleAccessMethodChange }
+								disabled={ false }
+							/>
+						</div>
 					</div>
 				</div>
 				<hr />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -10,6 +10,10 @@
 	.card {
 		max-width: 500px;
 		padding: 2em;
+
+		@media (max-width: $break-mobile) {
+			padding: 1.25em;
+		}
 		hr {
 			margin-top: 1em;
 			background: var(--color-border-subtle);
@@ -29,6 +33,17 @@
 		}
 		.site-migration-credentials__form-field {
 			margin-top: 1em;
+		}
+		.site-migration-credentials__radio-group {
+			display: flex;
+			flex-direction: column;
+			gap: 4px;
+
+			@media (max-width: $break-mobile) {
+				flex-direction: row;
+				gap: 8px;
+				flex-wrap: wrap;
+			}
 		}
 		.site-migration-credentials__radio {
 			display: flex;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -26,7 +26,7 @@
 			display: flex;
 			flex-direction: row;
 			gap: 1em;
-			@media (max-width: $break-mobile) {
+			@media (max-width: 510px) {
 				flex-direction: column;
 				gap: 0;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -50,6 +50,10 @@
 			align-items: center;
 			.form-radio__label {
 				margin-left: 0.5em;
+
+				&:hover {
+					cursor: pointer;
+				}
 			}
 			.form-radio {
 				margin: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Changes the Radio label from a `span` element to `label`.
* Make it possible to have the "for" property on the Radio label.
* I decided to keep the previous behavior to avoid problems if other parts of the code use the span element for something.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* While we worked on #93509, @fditrapani noticed that clicking on the radio option label did not select the option. I noticed that we were using a span element to be the label of the radio, which doesn't support the "for/htmlFor" property. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch to your local environment or add use the Calypso Live link below.
* Open the dev console and activate the feature flag by running the following command:
```
window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')
```
* Now go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Now click on the Radio labels and verify that it selects the option
 
<img width="535" alt="Captura de Tela 2024-08-15 às 09 45 56" src="https://github.com/user-attachments/assets/651ca0a4-315b-462e-a3d8-fbe67ff244d1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
