### PR TITLE
Add Smooch to Zendesk client package

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { domainProductSlugs } from 'calypso/lib/domains/constants';
 import { isRefactoredForThankYouV2 } from '../utils';
 

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -67,7 +67,7 @@ const HelpCenter: React.FC< Container > = ( {
 			initSmooch( ref.current );
 		}
 		return destroy;
-	}, [ isMessagingScriptLoaded, ref?.current ] );
+	}, [ destroy, initSmooch, isMessagingScriptLoaded ] );
 
 	const openingCoordinates = useOpeningCoordinates( isHelpCenterShown, isMinimized );
 

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -63,12 +63,10 @@ const HelpCenter: React.FC< Container > = ( {
 	const ref = useRef( null );
 
 	useEffect( () => {
-		if ( isMessagingScriptLoaded && ref?.current ) {
+		if ( isMessagingScriptLoaded && ref.current ) {
 			initSmooch( ref.current );
 		}
-		return () => {
-			destroy();
-		};
+		return destroy;
 	}, [ isMessagingScriptLoaded, ref?.current ] );
 
 	const openingCoordinates = useOpeningCoordinates( isHelpCenterShown, isMinimized );
@@ -96,7 +94,7 @@ const HelpCenter: React.FC< Container > = ( {
 				currentRoute={ currentRoute }
 				openingCoordinates={ openingCoordinates }
 			/>
-			<div ref={ ref } style={ { display: 'none' } }></div>
+			<div className="help-center__smooch-container" ref={ ref } style={ { display: 'none' } } />
 		</>,
 		portalParent
 	);

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -22,6 +22,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/calypso-analytics": "workspace:^",
 		"@tanstack/react-query": "^5.15.5",
 		"@types/smooch": "^5.3.7",
 		"@wordpress/api-fetch": "^7.2.0",

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -23,9 +23,11 @@
 	},
 	"dependencies": {
 		"@tanstack/react-query": "^5.15.5",
+		"@types/smooch": "^5.3.7",
 		"@wordpress/api-fetch": "^7.2.0",
 		"@wordpress/element": "^6.2.0",
 		"@wordpress/url": "^4.2.0",
+		"smooch": "5.6.0",
 		"wpcom-proxy-request": "workspace:^"
 	},
 	"devDependencies": {

--- a/packages/zendesk-client/src/constants.ts
+++ b/packages/zendesk-client/src/constants.ts
@@ -1,2 +1,3 @@
+export const SMOOCH_INTEGRATION_ID = '6453b7fc45cea5c267e60fed';
 export const ZENDESK_SOURCE_URL_TICKET_FIELD_ID = 23752099174548;
 export const ZENDESK_SCRIPT_ID = 'ze-snippet';

--- a/packages/zendesk-client/src/index.ts
+++ b/packages/zendesk-client/src/index.ts
@@ -1,6 +1,7 @@
 export { useZendeskMessagingBindings } from './use-zendesk-messaging-bindings';
 export { useLoadZendeskMessaging } from './use-load-zendesk-messaging';
 export { useCanConnectToZendeskMessaging } from './use-can-connect-to-zendesk-messaging';
+export { useSmooch } from './use-smooch';
 export { useOpenZendeskMessaging } from './use-open-zendesk-messaging';
 export { useZendeskMessagingAvailability } from './use-zendesk-messaging-availability';
 export { ZENDESK_SOURCE_URL_TICKET_FIELD_ID } from './constants';

--- a/packages/zendesk-client/src/types.ts
+++ b/packages/zendesk-client/src/types.ts
@@ -24,6 +24,7 @@ export type UserFields = {
 
 export type MessagingAuth = {
 	user: {
+		external_id?: string;
 		jwt: string;
 	};
 };
@@ -42,3 +43,5 @@ export type MessagingMetadata = {
 	onError?: () => void;
 	onSuccess?: () => void;
 };
+
+export type ZendeskAuthType = 'zendesk' | 'messenger';

--- a/packages/zendesk-client/src/use-smooch.ts
+++ b/packages/zendesk-client/src/use-smooch.ts
@@ -1,10 +1,54 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import Smooch from 'smooch';
 import { SMOOCH_INTEGRATION_ID } from './constants';
 import { UserFields } from './types';
 import { useAuthenticateZendeskMessaging } from './use-authenticate-zendesk-messaging';
 import { useUpdateZendeskUserFields } from './use-update-zendesk-user-fields';
+
+const destroy = () => {
+	Smooch.destroy();
+};
+
+const getConversation = async ( chatId?: number ): Promise< Conversation | undefined > => {
+	if ( chatId ) {
+		const existingConversation = Smooch.getConversations?.().find( ( conversation ) => {
+			return conversation.metadata[ 'odieChatId' ] === chatId;
+		} );
+		if ( ! existingConversation ) {
+			return;
+		}
+		const result = await Smooch.getConversationById( existingConversation.id );
+		if ( result ) {
+			Smooch.markAllAsRead( result.id );
+			return result;
+		}
+	}
+	return;
+};
+
+const sendMessage = ( message: string, chatId?: number | null ) => {
+	if ( chatId ) {
+		const conversation = Smooch.getConversations().find( ( conversation ) => {
+			return conversation.metadata[ 'odieChatId' ] === chatId;
+		} );
+		if ( ! conversation ) {
+			return;
+		}
+		Smooch.sendMessage( { type: 'text', text: message }, conversation.id );
+	}
+};
+
+const addMessengerListener = ( callback: ( message: Message ) => void ) => {
+	Smooch.on( 'message:received', ( message, data ) => {
+		callback( message );
+		Smooch.markAllAsRead( data.conversation.id );
+	} );
+};
+
+const addUnreadCountListener = ( callback: ( unreadCount: number ) => void ) => {
+	Smooch.on( 'unreadCount', callback );
+};
 
 export const useSmooch = () => {
 	const [ init, setInit ] = useState( typeof Smooch.getConversations === 'function' );
@@ -12,35 +56,47 @@ export const useSmooch = () => {
 	const { isPending: isSubmittingZendeskUserFields, mutateAsync: submitUserFields } =
 		useUpdateZendeskUserFields();
 
-	const initSmooch = ( ref: HTMLDivElement ) => {
-		if ( authData?.jwt && authData?.externalId && ! Smooch.getConversations ) {
-			Smooch.init( {
-				integrationId: SMOOCH_INTEGRATION_ID,
-				embedded: true,
-				externalId: authData?.externalId,
-				jwt: authData?.jwt,
-			} )
-				.then( () => {
-					recordTracksEvent( 'calypso_smooch_messenger_init', {
-						success: true,
-						error: '',
-					} );
-					setInit( true );
+	const initSmooch = useCallback(
+		( ref: HTMLDivElement ) => {
+			if ( authData?.jwt && authData?.externalId && ! init ) {
+				Smooch.init( {
+					integrationId: SMOOCH_INTEGRATION_ID,
+					embedded: true,
+					externalId: authData?.externalId,
+					jwt: authData?.jwt,
 				} )
-				.catch( ( error ) => {
-					recordTracksEvent( 'calypso_smooch_messenger_init', {
-						success: false,
-						error: error.message,
+					.then( () => {
+						recordTracksEvent( 'calypso_smooch_messenger_init', {
+							success: true,
+							error: '',
+						} );
+						setInit( true );
+					} )
+					.catch( ( error ) => {
+						recordTracksEvent( 'calypso_smooch_messenger_init', {
+							success: false,
+							error: error.message,
+						} );
+						setInit( false );
 					} );
-					setInit( false );
-				} );
-			Smooch.render( ref );
-		}
-	};
+				Smooch.render( ref );
+			}
+		},
+		[ init, authData ]
+	);
 
-	const destroy = () => {
-		Smooch.destroy();
-	};
+	const createConversation = useCallback(
+		async ( userfields: UserFields, metadata: Conversation[ 'metadata' ] ) => {
+			if ( isSubmittingZendeskUserFields ) {
+				return;
+			}
+			if ( metadata.odieChatId ) {
+				await submitUserFields( userfields );
+				await Smooch.createConversation( { metadata } );
+			}
+		},
+		[ isSubmittingZendeskUserFields, submitUserFields ]
+	);
 
 	if ( ! init ) {
 		return {
@@ -54,59 +110,6 @@ export const useSmooch = () => {
 			sendMessage: () => undefined,
 		};
 	}
-
-	const getConversation = async ( chatId?: number ): Promise< Conversation | undefined > => {
-		if ( chatId ) {
-			const existingConversation = Smooch.getConversations?.().find( ( conversation ) => {
-				return conversation.metadata[ 'odieChatId' ] === chatId;
-			} );
-			if ( ! existingConversation ) {
-				return;
-			}
-			const result = await Smooch.getConversationById( existingConversation.id );
-			if ( result ) {
-				Smooch.markAllAsRead( result.id );
-				return result;
-			}
-		}
-		return;
-	};
-
-	const createConversation = async (
-		userfields: UserFields,
-		metadata: Conversation[ 'metadata' ]
-	) => {
-		if ( isSubmittingZendeskUserFields ) {
-			return;
-		}
-		if ( metadata.odieChatId ) {
-			await submitUserFields( userfields );
-			await Smooch.createConversation( { metadata } );
-		}
-	};
-
-	const sendMessage = ( message: string, chatId?: number | null ) => {
-		if ( chatId ) {
-			const conversation = Smooch.getConversations().find( ( conversation ) => {
-				return conversation.metadata[ 'odieChatId' ] === chatId;
-			} );
-			if ( ! conversation ) {
-				return;
-			}
-			Smooch.sendMessage( { type: 'text', text: message }, conversation.id );
-		}
-	};
-
-	const addMessengerListener = ( callback: ( message: Message ) => void ) => {
-		Smooch.on( 'message:received', ( message, data ) => {
-			callback( message );
-			Smooch.markAllAsRead( data.conversation.id );
-		} );
-	};
-
-	const addUnreadCountListener = ( callback: ( unreadCount: number ) => void ) => {
-		Smooch.on( 'unreadCount', callback );
-	};
 
 	return {
 		init,

--- a/packages/zendesk-client/src/use-smooch.ts
+++ b/packages/zendesk-client/src/use-smooch.ts
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useState } from 'react';
 import Smooch from 'smooch';
 import { SMOOCH_INTEGRATION_ID } from './constants';
@@ -18,9 +19,21 @@ export const useSmooch = () => {
 				embedded: true,
 				externalId: authData?.externalId,
 				jwt: authData?.jwt,
-			} ).then( () => {
-				setInit( true );
-			} );
+			} )
+				.then( () => {
+					recordTracksEvent( 'calypso_smooch_messenger_init', {
+						success: true,
+						error: '',
+					} );
+					setInit( true );
+				} )
+				.catch( ( error ) => {
+					recordTracksEvent( 'calypso_smooch_messenger_init', {
+						success: false,
+						error: error.message,
+					} );
+					setInit( false );
+				} );
 			Smooch.render( ref );
 		}
 	};

--- a/packages/zendesk-client/src/use-smooch.ts
+++ b/packages/zendesk-client/src/use-smooch.ts
@@ -103,11 +103,6 @@ export const useSmooch = () => {
 			init,
 			destroy,
 			initSmooch,
-			getConversation: async () => undefined,
-			createConversation: async () => undefined,
-			addMessengerListener: () => undefined,
-			addUnreadCountListener: () => undefined,
-			sendMessage: () => undefined,
 		};
 	}
 

--- a/packages/zendesk-client/src/use-smooch.ts
+++ b/packages/zendesk-client/src/use-smooch.ts
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import Smooch from 'smooch';
+import { SMOOCH_INTEGRATION_ID } from './constants';
+import { UserFields } from './types';
+import { useAuthenticateZendeskMessaging } from './use-authenticate-zendesk-messaging';
+import { useUpdateZendeskUserFields } from './use-update-zendesk-user-fields';
+
+export const useSmooch = () => {
+	const [ init, setInit ] = useState( typeof Smooch.getConversations === 'function' );
+	const { data: authData } = useAuthenticateZendeskMessaging( true, 'messenger' );
+	const { isPending: isSubmittingZendeskUserFields, mutateAsync: submitUserFields } =
+		useUpdateZendeskUserFields();
+
+	const initSmooch = ( ref: HTMLDivElement ) => {
+		if ( authData?.jwt && authData?.externalId && ! Smooch.getConversations ) {
+			Smooch.init( {
+				integrationId: SMOOCH_INTEGRATION_ID,
+				embedded: true,
+				externalId: authData?.externalId,
+				jwt: authData?.jwt,
+			} ).then( () => {
+				setInit( true );
+			} );
+			Smooch.render( ref );
+		}
+	};
+
+	const destroy = () => {
+		Smooch.destroy();
+	};
+
+	if ( ! init ) {
+		return {
+			init,
+			destroy,
+			initSmooch,
+			getConversation: async () => undefined,
+			createConversation: async () => undefined,
+			addMessengerListener: () => undefined,
+			addUnreadCountListener: () => undefined,
+			sendMessage: () => undefined,
+		};
+	}
+
+	const getConversation = async ( chatId?: number ): Promise< Conversation | undefined > => {
+		if ( chatId ) {
+			const existingConversation = Smooch.getConversations?.().find( ( conversation ) => {
+				return conversation.metadata[ 'odieChatId' ] === chatId;
+			} );
+			if ( ! existingConversation ) {
+				return;
+			}
+			const result = await Smooch.getConversationById( existingConversation.id );
+			if ( result ) {
+				Smooch.markAllAsRead( result.id );
+				return result;
+			}
+		}
+		return;
+	};
+
+	const createConversation = async (
+		userfields: UserFields,
+		metadata: Conversation[ 'metadata' ]
+	) => {
+		if ( isSubmittingZendeskUserFields ) {
+			return;
+		}
+		if ( metadata.odieChatId ) {
+			await submitUserFields( userfields );
+			await Smooch.createConversation( { metadata } );
+		}
+	};
+
+	const sendMessage = ( message: string, chatId?: number | null ) => {
+		if ( chatId ) {
+			const conversation = Smooch.getConversations().find( ( conversation ) => {
+				return conversation.metadata[ 'odieChatId' ] === chatId;
+			} );
+			if ( ! conversation ) {
+				return;
+			}
+			Smooch.sendMessage( { type: 'text', text: message }, conversation.id );
+		}
+	};
+
+	const addMessengerListener = ( callback: ( message: Message ) => void ) => {
+		Smooch.on( 'message:received', ( message, data ) => {
+			callback( message );
+			Smooch.markAllAsRead( data.conversation.id );
+		} );
+	};
+
+	const addUnreadCountListener = ( callback: ( unreadCount: number ) => void ) => {
+		Smooch.on( 'unreadCount', callback );
+	};
+
+	return {
+		init,
+		initSmooch,
+		destroy,
+		getConversation,
+		createConversation,
+		addMessengerListener,
+		addUnreadCountListener,
+		sendMessage,
+	};
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,6 +2329,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/zendesk-client@workspace:packages/zendesk-client"
   dependencies:
+    "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@tanstack/react-query": "npm:^5.15.5"
     "@types/smooch": "npm:^5.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,9 +2331,11 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@tanstack/react-query": "npm:^5.15.5"
+    "@types/smooch": "npm:^5.3.7"
     "@wordpress/api-fetch": "npm:^7.2.0"
     "@wordpress/element": "npm:^6.2.0"
     "@wordpress/url": "npm:^4.2.0"
+    smooch: "npm:5.6.0"
     typescript: "npm:^5.3.3"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -8420,6 +8422,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: ef55b05fb2d12ed790d8e3b46d96bb84224c67bbcdfb6a867d14129ffc77f7b3edbf66b1eb5e737953d1f1b2ce9928f3505fe29061bfb048016616beaf866ef8
+  languageName: node
+  linkType: hard
+
+"@types/smooch@npm:^5.3.7":
+  version: 5.3.7
+  resolution: "@types/smooch@npm:5.3.7"
+  checksum: b37b0a50037933e4b2313b0e1f0a31df1c9d8a033ff994eb7342720596a9941745a9b6fd1012ab58f828397a5e76d493d818eeb1bfb6576453021afbfc0bf115
   languageName: node
   linkType: hard
 
@@ -29723,6 +29732,13 @@ __metadata:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
+  languageName: node
+  linkType: hard
+
+"smooch@npm:5.6.0":
+  version: 5.6.0
+  resolution: "smooch@npm:5.6.0"
+  checksum: 3a1c4cd17a136903443372a92e197752a80423fe8d8f299d96853dba4af6f51f43a6b573b23fbc04fc558b0b707a679361edce17e3e9f8ae9809a03cfccc0978
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* Adds Smooch Web Messaging hook
* Loads Smooch on Help Center

## Why are these changes being made?

* Context: p58i-hTi-p2
* With the goal to keep PRs small and easy to review, I've added the code to load the Smooch Web Messenger on Help Center. 
* By using tracks events, we can start collecting data on the widget load, and identify any potential issues we might face before releasing the new chat feature.

## Testing Instructions

* Load Calypso
* Check if the smooch init tracks events are being triggered
* I've tested the init fail by doing something like: `Smooch.init = () => Promise.reject(new Error('Simulated error'));`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?