### PR TITLE
Avoid line breaks in the plan interval/discount in the dropdown

### DIFF
--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -101,6 +101,7 @@
 			display: flex;
 			padding: 13px 13px 13px 16px;
 			font-size: 0.875rem;
+			text-wrap: nowrap;
 
 			.discount {
 				display: flex;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 735-gh-Automattic/i18n-issues

## Proposed Changes

* Fix the wrapping of plan intervals (yearly, 2-year, 3-years, monthly) in the dropdown, which currently wraps for some languages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The wrapping doesn't look pleasing and fixing it should improve the user experience in affected locales.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the calypso.live instance or local install, change your locale to Spanish, Brazilian Portuguese, Indonesian or German.
* Go to the /plans page for one of your sites and check the dropdown.
* Start creating a new site from /start and check the dropdown values on the plans step.

Before:
<img width="939" alt="Screenshot 2024-08-15 at 17 40 18" src="https://github.com/user-attachments/assets/de9a8b38-6d9d-4278-894c-cbf9568b186c">
<img width="1243" alt="Screenshot 2024-08-15 at 17 46 54" src="https://github.com/user-attachments/assets/eb4181fe-ea3b-423d-bd03-4e86e994f361">

After:
<img width="939" alt="Screenshot 2024-08-15 at 17 46 30" src="https://github.com/user-attachments/assets/603f2c64-5153-47b9-be6c-e764c582e991">
<img width="1243" alt="Screenshot 2024-08-15 at 17 47 15" src="https://github.com/user-attachments/assets/9e11b1c9-6a4a-4415-baa3-f8a675aad746">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
