### PR TITLE
A4A: show 0 prices as 'Free'

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/item.tsx
@@ -30,6 +30,7 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 					args: { productName: productDisplayName, quantity: item.quantity },
 			  } )
 			: productDisplayName;
+	const isFree = actualCost === 0;
 
 	return (
 		<li className="shopping-cart__menu-list-item">
@@ -37,19 +38,25 @@ export default function ShoppingCartMenuItem( { item, onRemoveItem }: ItemProps 
 			<div className="shopping-cart__menu-list-item-details">
 				<div className="shopping-cart__menu-list-item-title">{ itemDisplayName }</div>
 				<div className="shopping-cart__menu-list-item-price">
-					<span className="shopping-cart__menu-list-item-price-discounted">
-						{ formatCurrency( discountedCost, item.currency ) }
-					</span>
-					{ actualCost > discountedCost && (
-						<span className="shopping-cart__menu-list-item-price-actual">
-							{ formatCurrency( actualCost, item.currency ) }
-						</span>
+					{ isFree ? (
+						translate( 'Free' )
+					) : (
+						<>
+							<span className="shopping-cart__menu-list-item-price-discounted">
+								{ formatCurrency( discountedCost, item.currency ) }
+							</span>
+							{ actualCost > discountedCost && (
+								<span className="shopping-cart__menu-list-item-price-actual">
+									{ formatCurrency( actualCost, item.currency ) }
+								</span>
+							) }
+							<span>
+								{ translate( '/mo', {
+									comment: 'Abbreviation for per month',
+								} ) }
+							</span>
+						</>
 					) }
-					<span>
-						{ translate( '/mo', {
-							comment: 'Abbreviation for per month',
-						} ) }
-					</span>
 				</div>
 			</div>
 			{ onRemoveItem && (

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
@@ -72,6 +72,7 @@
 
 .components-button.is-link.shopping-cart__menu-item-remove-button {
 	color: var(--color-neutral-50);
+	background-color: inherit;
 }
 
 .shopping-cart__menu-footer {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/914

## Proposed Changes

- As a follow-up for https://github.com/Automattic/wp-calypso/pull/93221 we are now showing 'Free' word instead of $0.00 prices in Cart and Checkout:

<img width="499" alt="Screenshot 2024-08-15 at 8 19 14 AM" src="https://github.com/user-attachments/assets/394f6293-5a78-4537-90d5-e710fad3ed8f">

<img width="453" alt="Screenshot 2024-08-15 at 8 20 49 AM" src="https://github.com/user-attachments/assets/df2a15a0-fa27-4c4b-b2ff-92f6212890f2">

It also fixes a small issue with 'Remove' button background in checkout:
<img width="91" alt="Screenshot 2024-08-15 at 8 20 23 AM" src="https://github.com/user-attachments/assets/93a3efdd-8900-4412-bebd-c860056297b4">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/marketplace/checkout` and check the prices.
- Add some 'Free' items to the cart and check the cart.
- Navigate to 'Checkout' and confirm that prices represented correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
