### PR TITLE
Theme details: Remove the Next theme button

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -44,7 +44,6 @@ import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
-import SectionHeader from 'calypso/components/section-header';
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
@@ -459,10 +458,6 @@ class ThemeSheet extends Component {
 		this.trackButtonClick( 'css_forum' );
 	};
 
-	trackNextThemeClick = () => {
-		this.trackButtonClick( 'next_theme' );
-	};
-
 	renderBar = () => {
 		const { author, name, translate, softLaunched } = this.props;
 
@@ -705,7 +700,7 @@ class ThemeSheet extends Component {
 	};
 
 	renderSectionContent = () => {
-		const { isPremium, isWpcomTheme, supportDocumentation } = this.props;
+		const { isPremium, supportDocumentation } = this.props;
 
 		return (
 			<div className="theme__sheet-content">
@@ -721,7 +716,6 @@ class ThemeSheet extends Component {
 						{ this.renderOverviewTab() }
 						{ ! isPremium && supportDocumentation && this.renderSetupTab() }
 						{ this.renderSupportTab() }
-						{ isWpcomTheme && this.renderNextTheme() }
 					</>
 				) }
 			</div>
@@ -896,23 +890,6 @@ class ThemeSheet extends Component {
 				title={ translate( 'Partner themes cannot be purchased on staging sites' ) }
 				description={ translate( 'Subscribe to this theme on your production site.' ) }
 			/>
-		);
-	};
-
-	renderNextTheme = () => {
-		const { next, siteSlug, translate, locale, isLoggedIn } = this.props;
-		const sitePart = siteSlug ? `/${ siteSlug }` : '';
-
-		const nextThemeHref = localizeThemesPath(
-			`/theme/${ next }${ sitePart }`,
-			locale,
-			! isLoggedIn
-		);
-
-		return (
-			<div onClick={ this.trackNextThemeClick } role="presentation">
-				<SectionHeader href={ nextThemeHref } label={ translate( 'Next theme' ) } />
-			</div>
 		);
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93464

## Proposed Changes

* Remove the Next button from the Theme details

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Implementing a proper solution for the next button would take a considerable amount of effort
* There's low usage for the button and it doesn't bring any added value
* The SEO benefits are no longer needed since the themes are included in the sitemap.xml file on WordPress.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Go to /themes and click on a theme
* Notice that we no longer display the Next theme button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
