### PR TITLE
Migration: Enable back from`SOURCE_URL` step to `HOW TO MIGRATE`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-source-url/index.tsx
@@ -13,6 +13,7 @@ const MigrationSourceUrl: Step = ( props ) => {
 			subHeaderText={ translate(
 				"Just drop your site's URL below and our team will review and start your migration."
 			) }
+			showBack
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
@@ -105,8 +105,9 @@ const SiteMigrationSourceUrl: FC< SourceURLProps > = function ( {
 				stepName={ stepName }
 				flowName={ flow }
 				className="import__onboarding-page"
-				hideBack
+				hideBack={ navigation?.goBack === undefined }
 				hideSkip
+				goBack={ navigation?.goBack }
 				hideFormattedHeader
 				goNext={ navigation?.submit }
 				isFullLayout

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
@@ -74,6 +74,7 @@ const saveSiteSettings = async ( siteSlug: string, settings: Record< string, unk
 interface SourceURLProps extends StepProps {
 	headerText?: string;
 	subHeaderText?: string;
+	showBack?: boolean;
 }
 
 const SiteMigrationSourceUrl: FC< SourceURLProps > = function ( {
@@ -82,6 +83,7 @@ const SiteMigrationSourceUrl: FC< SourceURLProps > = function ( {
 	subHeaderText,
 	stepName,
 	flow,
+	showBack = true,
 } ) {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
@@ -105,7 +107,7 @@ const SiteMigrationSourceUrl: FC< SourceURLProps > = function ( {
 				stepName={ stepName }
 				flowName={ flow }
 				className="import__onboarding-page"
-				hideBack={ navigation?.goBack === undefined }
+				hideBack={ ! showBack }
 				hideSkip
 				goBack={ navigation?.goBack }
 				hideFormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-url/index.tsx
@@ -83,7 +83,7 @@ const SiteMigrationSourceUrl: FC< SourceURLProps > = function ( {
 	subHeaderText,
 	stepName,
 	flow,
-	showBack = true,
+	showBack = false,
 } ) {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -150,7 +150,11 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 				const siteId = getFromPropsOrUrl( 'siteId', props );
 				const siteSlug = getFromPropsOrUrl( 'siteSlug', props );
 
-				return navigate( addQueryArgs( { siteId, siteSlug }, MIGRATION_HOW_TO_MIGRATE.slug ) );
+				return navigate(
+					addQueryArgs( { siteId, siteSlug }, MIGRATION_HOW_TO_MIGRATE.slug ),
+					{},
+					true
+				);
 			},
 		},
 	};

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -146,6 +146,12 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 					addQueryArgs( { siteId, siteSlug, from }, SITE_MIGRATION_ASSISTED_MIGRATION.slug )
 				);
 			},
+			goBack: ( props?: ProvidedDependencies ) => {
+				const siteId = getFromPropsOrUrl( 'siteId', props );
+				const siteSlug = getFromPropsOrUrl( 'siteSlug', props );
+
+				return navigate( addQueryArgs( { siteId, siteSlug }, MIGRATION_HOW_TO_MIGRATE.slug ) );
+			},
 		},
 	};
 };

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -58,6 +58,24 @@ describe( `${ flow.name }`, () => {
 		};
 	};
 
+	const runNavigationBack = ( { from, dependencies = {}, query = {} } ) => {
+		const { runUseStepNavigationGoBack } = renderFlow( flow );
+
+		runUseStepNavigationGoBack( {
+			currentStep: from.slug,
+			dependencies: dependencies,
+			currentURL: addQueryArgs( `/setup/${ from.slug }`, query ),
+		} );
+
+		const destination = getFlowLocation();
+		const [ pathname, searchParams ] = destination?.path?.split( '?' ) ?? [ '', '' ];
+
+		return {
+			step: pathname.replace( /^\/+/, '' ),
+			query: new URLSearchParams( searchParams ),
+		};
+	};
+
 	describe( 'useStepNavigation', () => {
 		it( 'redirects the user from platform identification to create site step', () => {
 			const destination = runNavigation( {
@@ -214,6 +232,20 @@ describe( `${ flow.name }`, () => {
 					siteSlug: 'example.wordpress.com',
 					from: 'http://oldsite.example.com',
 				},
+			} );
+		} );
+	} );
+
+	describe( 'useStepNavigation > goBack', () => {
+		it( 'redirect back user from SOURCE URL TO HOW TO MIGRATE', () => {
+			const destination = runNavigationBack( {
+				from: STEPS.MIGRATION_SOURCE_URL,
+				query: { siteId: 123, siteSlug: 'example.wordpress.com' },
+			} );
+
+			expect( destination ).toMatchDestination( {
+				step: STEPS.MIGRATION_HOW_TO_MIGRATE,
+				query: { siteId: 123, siteSlug: 'example.wordpress.com' },
 			} );
 		} );
 	} );


### PR DESCRIPTION
Part of #93308 

## Proposed Changes

* Enable  back from`Let’s migrate your site` to `How to migrate`

## Testing Instructions
* Access `/setup/migration`
* Select `WordPress` and follow all steps until you arrive on the `Let’s migrate your site` step
* Click on the back button and check if the siteId and the slug Slug are there
* Select the manual migration option and check if it works properly



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
