### PR TITLE
Plugins browser - fix scroll position on return.

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -112,10 +112,10 @@ const PluginsBrowserListElement = ( props ) => {
 	}, [ site, plugin, selectedSite, props.listName ] );
 
 	const onClickItem = useCallback( () => {
-		dispatch( setLastVisitedPlugin( plugin.slug ) );
+		dispatch( setLastVisitedPlugin( plugin.slug, props.listName ) );
 
 		trackPluginLinkClick();
-	}, [ trackPluginLinkClick, dispatch, plugin.slug ] );
+	}, [ trackPluginLinkClick, dispatch, plugin.slug, props.listName ] );
 
 	const isWpcomPreinstalled = useMemo( () => {
 		if ( plugin.isPreinstalled ) {
@@ -163,7 +163,7 @@ const PluginsBrowserListElement = ( props ) => {
 	}, [ selectedSite, plugin ] );
 
 	const isLastVisitedPlugin = useSelector( ( state ) =>
-		getIsLastVisitedPlugin( state, plugin.slug )
+		getIsLastVisitedPlugin( state, plugin.slug, props.listName )
 	);
 
 	useEffect( () => {

--- a/client/state/plugins/last-visited/actions.js
+++ b/client/state/plugins/last-visited/actions.js
@@ -1,9 +1,9 @@
 import { PLUGINS_SET_LAST_VISITED } from 'calypso/state/action-types';
 import 'calypso/state/plugins/init';
 
-export function setLastVisitedPlugin( state ) {
+export function setLastVisitedPlugin( pluginSlug, pluginListName ) {
 	return {
 		type: PLUGINS_SET_LAST_VISITED,
-		payload: state,
+		payload: { slug: pluginSlug, listName: pluginListName },
 	};
 }

--- a/client/state/plugins/last-visited/reducer.js
+++ b/client/state/plugins/last-visited/reducer.js
@@ -1,6 +1,6 @@
 import { PLUGINS_SET_LAST_VISITED } from 'calypso/state/action-types';
 
-export function lastVisited( state = '', action ) {
+export function lastVisited( state = { slug: '', listName: '' }, action ) {
 	if ( action.type === PLUGINS_SET_LAST_VISITED ) {
 		return action.payload;
 	}

--- a/client/state/plugins/last-visited/selectors.js
+++ b/client/state/plugins/last-visited/selectors.js
@@ -4,6 +4,8 @@ export const getLastVisitedPlugin = function ( state ) {
 	return state.plugins.lastVisited;
 };
 
-export const isLastVisitedPlugin = function ( state, pluginSlug ) {
-	return getLastVisitedPlugin( state ) === pluginSlug;
+export const isLastVisitedPlugin = function ( state, pluginSlug, pluginListName ) {
+	const lastVisitedPlugin = getLastVisitedPlugin( state );
+	const { slug, listName } = lastVisitedPlugin || {};
+	return slug === pluginSlug && listName === pluginListName;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/93420

## Proposed Changes

Fixes the return position for plugins browser when navigating back from an individual plugin page.

* adds `listName` to the state (action, reducer, selector, and their usages) for tracking the last plugin item visited. 
    *  We often show the same plugin multiple times on the plugins browser in different lists. But the selector and state for determining the last plugin visited only accounted for the plugin's `slug`. This means multiple individual plugin item components would read `true` for being the last plugin visited, triggering a scroll to each instance of that plugin and ending the scroll position at the last one rendered. Now that we track which list the plugin was selected from, there should no longer be ambiguity and false positives for which plugin item was the last one to be clicked and thus scrolled to.

BEFORE
![plugins-bad-scroll](https://github.com/user-attachments/assets/cf921da6-c361-42f4-b918-9d842cd0e0e4)

AFTER
![plugins-good-scroll](https://github.com/user-attachments/assets/f5e637d0-d7c1-4e3a-8301-f696ce0c7890)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because return scroll position is bad and jarring. You rarely end up when you had clicked or been previously.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the plugins browser (test at global, site, and logged out instances of this).
* Click into a plugin.
* Click "back" or "plugins" in the top left to go back (the copy/button changes depending on screen size).
* Verify when you return to the plugin browser that your scroll position shows the plugin item and corresponding list that you had clicked from, and is not showing a different area of the plugins browser.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
