### PR TITLE
Login: Preserve redirect_to param if it already exists

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -3,6 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
+import { getQueryArgs } from '@wordpress/url';
 import { isGravatarOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -147,6 +148,10 @@ const SignupFormSocialFirst = ( {
 				  }
 				: {};
 
+			const redirectToParam =
+				( getQueryArgs( window.location.href )?.redirect_to as string ) ??
+				window.location.origin + `/setup/${ flowName }`;
+
 			return (
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
@@ -166,7 +171,7 @@ const SignupFormSocialFirst = ( {
 										{
 											email_address: email,
 											is_signup_existing_account: true,
-											redirect_to: window.location.origin + `/setup/${ flowName }`,
+											redirect_to: redirectToParam,
 										},
 										logInUrl
 									)

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -3,7 +3,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
-import { getQueryArgs } from '@wordpress/url';
 import { isGravatarOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -13,6 +12,10 @@ import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerc
 import PasswordlessSignupForm from './passwordless';
 import SocialSignupForm from './social';
 import './style.scss';
+
+interface QueryArgs {
+	redirect_to?: string;
+}
 
 interface SignupFormSocialFirst {
 	goToNextStep: () => void;
@@ -33,7 +36,7 @@ interface SignupFormSocialFirst {
 		} | null
 	) => void;
 	isReskinned: boolean;
-	queryArgs: object;
+	queryArgs: QueryArgs;
 	userEmail: string;
 	notice: JSX.Element | false;
 	isSocialFirst: boolean;
@@ -149,8 +152,7 @@ const SignupFormSocialFirst = ( {
 				: {};
 
 			const redirectToParam =
-				( getQueryArgs( window.location.href )?.redirect_to as string ) ??
-				window.location.origin + `/setup/${ flowName }`;
+				queryArgs?.redirect_to ?? window.location.origin + `/setup/${ flowName }`;
 
 			return (
 				<div className="signup-form-social-first-email">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93522
Fixes https://github.com/Automattic/wp-calypso/issues/93522

## Proposed Changes

* Update social first signup form to preserve `redirect_to` param if it already exists

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When going through a flow such as the newsletter flow as a logged out, youre prompted to signup or login before you can begin the flow. A `redirect_to` param is set to return the user back to the newsletter flow after they login/signup, but that param is overridden. Due to this `redirect_to` param change, the user is not returned to the correct location after logging in.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use the live link.
* Log out of WordPress.com.
* Go to `wordpress.com/newsletter` and click the `Start my newsletter` button. 
* Click `Continue with email`, enter an existing email, and complete the login flow. 
* Verify you are redirected to the newsletter flow (`setup/newsletter/newsletterSetup`).
* Test the other login methods. Repeat the steps until you reach the login screen (`Continue with email`) and test the other login methods ( `Login via app`, `Continue with Github`, etc.).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
