### PR TITLE
Paid Importer: Improve the fetching of the paid newsletter state

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -4,7 +4,7 @@ import wp from 'calypso/lib/wp';
 export const usePaidNewsletterQuery = ( engine: string, currentStep: string, siteId?: number ) => {
 	return useQuery( {
 		enabled: !! siteId,
-		queryKey: [ 'paid-newsletter-importer', siteId, engine ],
+		queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
 		queryFn: () => {
 			return wp.req.get(
 				{

--- a/client/data/paid-newsletter/use-reset-mutation.ts
+++ b/client/data/paid-newsletter/use-reset-mutation.ts
@@ -38,9 +38,9 @@ export const useSkipNextStepMutation = (
 		},
 		...options,
 		onSuccess( ...args ) {
-			const [ , { siteId, engine } ] = args;
+			const [ , { siteId, engine, currentStep } ] = args;
 			queryClient.invalidateQueries( {
-				queryKey: [ 'paid-newsletter-importer', siteId, engine ],
+				queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
 			} );
 			options.onSuccess?.( ...args );
 		},

--- a/client/data/paid-newsletter/use-skip-next-step-mutation.ts
+++ b/client/data/paid-newsletter/use-skip-next-step-mutation.ts
@@ -40,9 +40,9 @@ export const useSkipNextStepMutation = (
 		},
 		...options,
 		onSuccess( ...args ) {
-			const [ , { siteId, engine } ] = args;
+			const [ , { siteId, engine, currentStep } ] = args;
 			queryClient.invalidateQueries( {
-				queryKey: [ 'paid-newsletter-importer', siteId, engine ],
+				queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
 			} );
 			options.onSuccess?.( ...args );
 		},

--- a/client/my-sites/importer/newsletter/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/connect-stripe.tsx
@@ -28,6 +28,7 @@ type Props = {
 	cardData: any;
 	fromSite: string;
 	engine: string;
+	isFetchingContent: boolean;
 };
 
 export default function ConnectStripe( {
@@ -36,8 +37,13 @@ export default function ConnectStripe( {
 	cardData,
 	fromSite,
 	engine,
+	isFetchingContent,
 }: Props ) {
-	const connectUrl = updateConnectUrl( cardData.connect_url, fromSite, engine );
+	if ( isFetchingContent || cardData?.connect_url === undefined ) {
+		return null;
+	}
+
+	const connectUrl = updateConnectUrl( cardData?.connect_url ?? '', fromSite, engine );
 
 	return (
 		<Card>

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -135,6 +135,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					} }
 					cardData={ stepContent }
 					engine={ engine }
+					isFetchingContent={ isFetchingPaidNewsletter }
 					content={ stepContent }
 				/>
 			) }

--- a/client/my-sites/importer/newsletter/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers.tsx
@@ -10,6 +10,7 @@ type Props = {
 	fromSite: string;
 	engine: string;
 	cardData: any;
+	isFetchingContent: boolean;
 };
 
 export default function PaidSubscribers( {
@@ -18,6 +19,7 @@ export default function PaidSubscribers( {
 	engine,
 	skipNextStep,
 	cardData,
+	isFetchingContent,
 }: Props ) {
 	const dispatch = useDispatch();
 	const isCancelled = hasQueryArg( window.location.href, 'stripe_connect_cancelled' );
@@ -42,6 +44,7 @@ export default function PaidSubscribers( {
 					cardData={ cardData }
 					fromSite={ fromSite }
 					engine={ engine }
+					isFetchingContent={ isFetchingContent }
 				/>
 			) }
 			{ hasConnectedAccount && (


### PR DESCRIPTION
This is a small PR that fixes some bugs that currently exist when you are navigating the UI and skipping steps. 

Related to #

## Proposed Changes

* Use the currentStep in the query key so that as the step changes we refetch the state. 

## Why are these changes being made?
It fixes a bug where the content wasn't update when we moved to the paid-subscriber step since only that step fetches the plan. Since that part can be slow and it is not needed for every step. 

## Testing Instructions

* Load this PR. 
* Naviaget to the paid impoeter 
* /import/newsletter/substack/example.com 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
