### PR TITLE
Fix/jetpack post connect redirection

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1000,7 +1000,7 @@ export class JetpackAuthorize extends Component {
 		}
 
 		const jpcTarget = addQueryArgs(
-			{ redirect: redirectAfterAuth },
+			{ redirectTo: redirectAfterAuth },
 			`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
 		);
 		debug( 'authorization-form: getRedirectionTarget -> Redirection target is: %s', jpcTarget );

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1000,7 +1000,7 @@ export class JetpackAuthorize extends Component {
 		}
 
 		const jpcTarget = addQueryArgs(
-			{ redirectTo: redirectAfterAuth },
+			{ redirect_to: redirectAfterAuth },
 			`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
 		);
 		debug( 'authorization-form: getRedirectionTarget -> Redirection target is: %s', jpcTarget );

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -464,7 +464,7 @@ describe( 'JetpackAuthorize', () => {
 			await userEvent.click( screen.getByText( 'Return to your site' ) );
 
 			expect( windowOpenSpy ).toHaveBeenCalledWith(
-				`${ JPC_PATH_PLANS }/${ SITE_SLUG }?redirect=${ encodeURIComponent(
+				`${ JPC_PATH_PLANS }/${ SITE_SLUG }?redirect_to=${ encodeURIComponent(
 					DEFAULT_PROPS.authQuery.redirectAfterAuth
 				) }`,
 				expect.any( String )
@@ -487,7 +487,7 @@ describe( 'JetpackAuthorize', () => {
 			await userEvent.click( screen.getByText( 'Return to your site' ) );
 
 			expect( windowOpenSpy ).toHaveBeenCalledWith(
-				`${ JPC_PATH_PLANS }/${ SITE_SLUG }?redirect=${ encodeURIComponent(
+				`${ JPC_PATH_PLANS }/${ SITE_SLUG }?redirect_to=${ encodeURIComponent(
 					DEFAULT_PROPS.authQuery.redirectAfterAuth
 				) }`,
 				expect.any( String )
@@ -514,7 +514,7 @@ describe( 'JetpackAuthorize', () => {
 			await userEvent.click( screen.getByText( 'Return to your site' ) );
 
 			expect( windowOpenSpy ).toHaveBeenCalledWith(
-				`${ JPC_PATH_PLANS }/${ SITE_SLUG }?redirect=${ encodeURIComponent(
+				`${ JPC_PATH_PLANS }/${ SITE_SLUG }?redirect_to=${ encodeURIComponent(
 					DEFAULT_PROPS.authQuery.redirectAfterAuth
 				) }`,
 				expect.any( String )

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -73,8 +73,8 @@ export default function useJetpackFreeButtonProps(
 
 	if (
 		! siteWpAdminUrl &&
-		urlQueryArgs?.redirect &&
-		urlQueryArgs.redirect.toLowerCase().includes( 'wp-admin/admin.php?page=my-jetpack' )
+		urlQueryArgs?.redirectTo &&
+		urlQueryArgs.redirectTo.toLowerCase().includes( 'wp-admin/admin.php?page=my-jetpack' )
 	) {
 		if ( site?.options?.admin_url ) {
 			siteWpAdminUrl = getUrlFromParts( {

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/use-jetpack-free-button-props.ts
@@ -73,8 +73,8 @@ export default function useJetpackFreeButtonProps(
 
 	if (
 		! siteWpAdminUrl &&
-		urlQueryArgs?.redirectTo &&
-		urlQueryArgs.redirectTo.toLowerCase().includes( 'wp-admin/admin.php?page=my-jetpack' )
+		urlQueryArgs?.redirect_to &&
+		urlQueryArgs.redirect_to.toLowerCase().includes( 'wp-admin/admin.php?page=my-jetpack' )
 	) {
 		if ( site?.options?.admin_url ) {
 			siteWpAdminUrl = getUrlFromParts( {


### PR DESCRIPTION
## Proposed Changes

* Updates the redirect parameter used in the Jetpack connect redirect to the pricing page from `redirect` to `redirect_to`, which allows for proper handling of the redirect after the checkout.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This change is being made so that a passed redirect to the connection flow is respected if a purchase is made

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start on a new test site with VideoPress installed but not the main Jetpack plugin
* From My Jetpack, click on the "connect user account" CTA on the banner that shows at the top of the page
![Screenshot 2024-08-15 at 5 13 27 PM](https://github.com/user-attachments/assets/e88584a3-6875-49c4-839e-5424c02749ee)
* This should take you to into the connection flow
* Once you get to the authorization step for Jetpack (shows your user photo with a green "Authorize" button) - stop
* In a separate tab, run this branch on Calypso local or on Calypso cloud
* Copy and paste the URL from the authorization screen in the first tab to the Calypso environment (keeping the local calypso host in place of wordpress.com)
* Now, authorize the connection
* You should be redirected to the Jetpack pricing page
* Select and purchase a VideoPress plan
* After the purchase, you should be redirected back to My Jetpack on your test site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
