### PR TITLE
Frictionless Email Subscriptions: Match continue as user page styling with existing styles

### DIFF
--- a/client/signup/steps/subscribe-email/style.scss
+++ b/client/signup/steps/subscribe-email/style.scss
@@ -14,8 +14,22 @@
 		margin: 0 auto;
 		width: 100%;
 
+		.continue-as-user__user-info {
+			a {
+				margin: 13px auto;
+				min-width: 100%;
+			}
+		}
+
 		@include break-small {
 			width: 400px;
+
+			.continue-as-user__user-info {
+				a {
+					margin: 13px auto;
+					min-width: 170px;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Matches frictionless email continue as user page styling with log-in continue as user page styling

### Frictionless Email Subscriptions Continue as user page

#### Before
<img width="558" alt="Screenshot 2024-08-15 at 3 41 06 PM" src="https://github.com/user-attachments/assets/3688a767-7fb6-42f9-90c1-9a74192b90c3">

#### After
<img width="547" alt="Screenshot 2024-08-15 at 3 36 08 PM" src="https://github.com/user-attachments/assets/9a490bc1-1c46-453e-843f-8302cafa005a">

### Log-in Continue as user page
<img width="625" alt="Screenshot 2024-08-15 at 3 36 01 PM" src="https://github.com/user-attachments/assets/d1b1a5c7-48b6-487c-9a3f-0e4964dd1c3c">

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to maintain design consistency across our different pages, especially when the function of the pages is similar

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in as a WordPress.com user
* Check out this branch
* Navigate to calypso.localhost:3000/start/email-subscription/subscribe?user_email=test412412%40gmail.com&first_name=edna&last_name=mode&mailing_list=learn&redirect_to=%2Flearn&from=%2F
* The continue as user page should appear
* Verify that the general layout and styling of the previous page matches the layout and styling of https://wordpress.com/log-in

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
