### PR TITLE
Performance Profiler: Use LLM to clarify the performance insights

### DIFF
--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -1,9 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
 import { MetricsInsight } from 'calypso/performance-profiler/components/metrics-insight';
-import { InsightContent } from 'calypso/performance-profiler/components/metrics-insight/insight-content';
-import { InsightHeader } from 'calypso/performance-profiler/components/metrics-insight/insight-header';
-
 import './style.scss';
 
 type InsightsSectionProps = {
@@ -21,13 +18,7 @@ export const InsightsSection = ( props: InsightsSectionProps ) => {
 				{ translate( 'We found things you can do to speed up your site.' ) }
 			</p>
 			{ Object.values( audits ).map( ( audit, index ) => (
-				<MetricsInsight
-					key={ `insight-${ audit.id }` }
-					insight={ {
-						header: <InsightHeader data={ audit } index={ index } />,
-						description: <InsightContent data={ audit } />,
-					} }
-				/>
+				<MetricsInsight key={ `insight-${ index }` } insight={ audit } index={ index } />
 			) ) }
 		</div>
 	);

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -1,30 +1,39 @@
+import { useTranslate } from 'i18n-calypso';
 import Markdown from 'react-markdown';
 import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
 import { InsightDetailedContent } from './insight-detailed-content';
 
 interface InsightContentProps {
 	data: PerformanceMetricsItemQueryResponse;
+	isLoading?: boolean;
 }
 
 export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
-	const { data } = props;
+	const translate = useTranslate();
+	const { data, isLoading } = props;
 	const { description = '' } = data ?? {};
 
 	return (
 		<div className="metrics-insight-content">
-			<Markdown
-				components={ {
-					a( props ) {
-						return <a target="_blank" { ...props } />;
-					},
-				} }
-			>
-				{ description }
-			</Markdown>
-			{ data.details?.type && (
-				<div className="metrics-insight-detailed-content">
-					<InsightDetailedContent data={ data.details } />
-				</div>
+			{ isLoading ? (
+				translate( 'Looking for the best solution…' )
+			) : (
+				<>
+					<Markdown
+						components={ {
+							a( props ) {
+								return <a target="_blank" { ...props } />;
+							},
+						} }
+					>
+						{ description }
+					</Markdown>
+					{ data.details?.type && (
+						<div className="metrics-insight-detailed-content">
+							<InsightDetailedContent data={ data.details } />
+						</div>
+					) }
+				</>
 			) }
 		</div>
 	);

--- a/client/performance-profiler/hooks/use-support-chat-llm-query.ts
+++ b/client/performance-profiler/hooks/use-support-chat-llm-query.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+
+function mapResult( response: WPComSupportQueryResponse ) {
+	return response.messages?.[ 0 ]?.content ?? '';
+}
+
+export const useSupportChatLLMQuery = ( description: string, enable: boolean ) => {
+	const question = `I need to fix the following issue to improve the performance of site: ${ description }.`;
+	const howToAnswer =
+		'Answer me in two topics in bold: "Why is this important?" and "How to fix this?"';
+	const message = `${ question } ${ howToAnswer }`;
+
+	return useQuery( {
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
+		queryKey: [ 'support', 'chat', description ],
+		queryFn: () =>
+			wp.req.post(
+				{
+					path: '/odie/chat/wpcom-support-chat/',
+					apiNamespace: 'wpcom/v2',
+				},
+				{ message }
+			),
+		meta: {
+			persist: false,
+		},
+		select: mapResult,
+		enabled: !! description && enable,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};
+
+type WPComSupportQueryResponse = {
+	messages: Array< WPComSupportMessageQueryResponse >;
+};
+
+type WPComSupportMessageQueryResponse = {
+	content: string;
+};

--- a/config/development.json
+++ b/config/development.json
@@ -169,6 +169,7 @@
 		"page/export": true,
 		"pattern-assembler/v2": true,
 		"performance-profiler": true,
+		"performance-profiler/llm": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
Fixes [Performance Profiler: Create recommendation section for the results page](https://github.com/Automattic/dotcom-forge/issues/8563)

## Proposed Changes

* Add a feature flag for the LLM experiment: `"performance-profiler/llm"`
* Do a request to Odie when the user clicks on each insight
* The request should be cached so if the user closes and reopen they should see the result instantly

## Why are these changes being made?

To have more rich answers with the LLM than we had with the pagespeed requests.

## Testing Instructions

* Go to `/speed-test-tool?url=https://wordpress.com`
* Click on an item on the insights list and they should behave the same way as in trunk
* Enable the flag by appending the following piece to the URL: `&flags=performance-profiler%2Fllm`
* Click on an item on the insights list
* You should see the message we are retrieving the information 
* And then you should see a message structure similar as the image below

![CleanShot 2024-08-15 at 19 57 00@2x](https://github.com/user-attachments/assets/ca5009c9-84e2-4794-90c7-bc584282b970)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
