### PR TITLE
Stats: Combine navigation to update both calendars

### DIFF
--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -3,6 +3,7 @@ import { Button, DatePicker } from '@wordpress/components';
 import { Icon, lock } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import DateInput from './stats-date-control-date-input';
 import { DateControlPickerDateProps } from './types';
 
@@ -20,12 +21,25 @@ const DateControlPickerDate = ( {
 }: DateControlPickerDateProps ) => {
 	const translate = useTranslate();
 
+	const [ previewDateStart, setPreviewDateStart ] = useState( startDate );
+	const [ previewDateEnd, setPreviewDateEnd ] = useState( endDate );
+
 	const handleStartSeletion = ( date: string ) => {
 		onStartChange( date.split( 'T' )?.[ 0 ] );
 	};
 
 	const handleEndSeletion = ( date: string ) => {
 		onEndChange( date.split( 'T' )?.[ 0 ] );
+	};
+
+	const handleStartMonthTogglePrevious = ( date: string ) => {
+		setPreviewDateEnd( previewDateStart );
+		setPreviewDateStart( date );
+	};
+
+	const handleEndMonthToggleNext = ( date: string ) => {
+		setPreviewDateStart( previewDateEnd );
+		setPreviewDateEnd( date );
 	};
 
 	return (
@@ -54,8 +68,20 @@ const DateControlPickerDate = ( {
 			</div>
 			{ isCalendarEnabled && (
 				<div className={ `${ BASE_CLASS_NAME }s__calendar` }>
-					<DatePicker currentDate={ startDate } onChange={ handleStartSeletion } />
-					<DatePicker currentDate={ endDate } onChange={ handleEndSeletion } />
+					<div className={ `${ BASE_CLASS_NAME }s__calendar--from` }>
+						<DatePicker
+							currentDate={ previewDateStart || startDate }
+							onChange={ handleStartSeletion }
+							onMonthPreviewed={ handleStartMonthTogglePrevious }
+						/>
+					</div>
+					<div className={ `${ BASE_CLASS_NAME }s__calendar--to` }>
+						<DatePicker
+							currentDate={ previewDateEnd || endDate }
+							onChange={ handleEndSeletion }
+							onMonthPreviewed={ handleEndMonthToggleNext }
+						/>
+					</div>
 				</div>
 			) }
 			<div className={ `${ BASE_CLASS_NAME }s__buttons` }>

--- a/client/components/stats-date-control/style.scss
+++ b/client/components/stats-date-control/style.scss
@@ -138,6 +138,48 @@ $date-control-mobile-layout-switch: $break-small;
 	display: flex;
 	gap: 18px;
 	padding-bottom: 18px;
+
+	.stats-date-control-picker-dates__calendar--from {
+		.components-datetime__date {
+			h3 + button {
+				display: none;
+			}
+
+			[data-wp-component="HStack"] {
+				button {
+					position: absolute;
+					left: 0;
+				}
+			}
+		}
+	}
+
+	.stats-date-control-picker-dates__calendar--to {
+		.components-datetime__date {
+			button:first-of-type {
+				display: none;
+			}
+
+			[data-wp-component="HStack"] {
+				button {
+					position: absolute;
+					right: 0;
+				}
+			}
+		}
+	}
+
+	[data-wp-component="HStack"] {
+		position: relative;
+	}
+
+	h3 {
+		margin: 0 auto;
+		height: 36px;
+		display: flex;
+		gap: 4px;
+		align-items: center;
+	}
 }
 
 .stats-date-control-picker__popover-content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/146

## Proposed Changes

* use a calendar month preview event to toggle both calendars at the same time

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* it's part of the project improving UI for the users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply `stats/date-picker-calendar` to the live branch
* verify that navigating one calendar updates both

![SCR-20240816-ogaw](https://github.com/user-attachments/assets/423c7b7e-fdd7-4597-8503-e98c013c6a87)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
