### PR TITLE
Site Assembler: Introduce the Experiment

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { connect, useSelector } from 'react-redux';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import Theme from 'calypso/components/theme';
+import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { getWooMyCustomThemeOptions } from 'calypso/my-sites/themes/theme-options';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -80,6 +81,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 	} = props;
 	const themesListRef = useRef( null );
 	const [ showSecondUpsellNudge, setShowSecondUpsellNudge ] = useState( false );
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'theme-showcase' );
 	const updateShowSecondUpsellNudge = useCallback( () => {
 		const minColumnWidth = 320; // $theme-item-min-width: 320px;
 		const margin = 32; // $theme-item-horizontal-margin: 32px;
@@ -228,7 +230,8 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 			{ ! props.isWooCYSEligibleSite &&
 				! ( props.isSiteWooExpressOrEcomFreeTrial && props.tier === 'free' ) &&
 				tabFilter !== 'my-themes' &&
-				_themes.length > 0 && <PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } /> }
+				_themes.length > 0 &&
+				isSiteAssemblerEnabled && <PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } /> }
 			{ /* The Woo Design with AI banner will be displayed on the 2nd or last row.The behavior is controlled by CSS */ }
 			{ props.isWooCYSEligibleSite && _themes.length > 0 && (
 				<WooDesignWithAIBanner

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -187,6 +187,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 				searchTerm={ props.searchTerm }
 				translate={ props.translate }
 				upsellCardDisplayed={ props.upsellCardDisplayed }
+				isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 			/>
 		);
 	}
@@ -346,7 +347,14 @@ export function ThemeBlock( props ) {
 	);
 }
 
-function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsellCardDisplayed } ) {
+function Options( {
+	isFSEActive,
+	recordTracksEvent,
+	searchTerm,
+	translate,
+	upsellCardDisplayed,
+	isSiteAssemblerEnabled,
+} ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const selectedSite = useSelector( getSelectedSite );
 	const canInstallTheme = useSelector( ( state ) =>
@@ -374,7 +382,7 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 	}, [ upsellCardDisplayed ] );
 
 	// Design your own theme / homepage.
-	if ( isFSEActive || assemblerCtaData.shouldGoToAssemblerStep ) {
+	if ( ( isFSEActive || assemblerCtaData.shouldGoToAssemblerStep ) && isSiteAssemblerEnabled ) {
 		options.push( {
 			title: assemblerCtaData.title,
 			icon: addTemplate,
@@ -516,6 +524,7 @@ function Empty( props ) {
 				searchTerm={ props.searchTerm }
 				translate={ props.translate }
 				upsellCardDisplayed={ props.upsellCardDisplayed }
+				isSiteAssemblerEnabled={ props.isSiteAssemblerEnabled }
 			/>
 		</>
 	);

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -14,6 +14,10 @@ jest.mock( 'calypso/components/theme', () => ( { theme } ) => (
 	<div data-testid={ `theme-${ theme.id }` } />
 ) );
 
+jest.mock( 'calypso/data/site-assembler', () => ( {
+	useIsSiteAssemblerEnabledExp: () => true,
+} ) );
+
 jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useSelector: () => false,

--- a/client/data/site-assembler/index.ts
+++ b/client/data/site-assembler/index.ts
@@ -32,5 +32,5 @@ export const useIsSiteAssemblerEnabledExp = (
 		return false;
 	}
 
-	return true;
+	return isLoggedIn;
 };

--- a/client/data/site-assembler/index.ts
+++ b/client/data/site-assembler/index.ts
@@ -4,16 +4,21 @@ export const useIsSiteAssemblerEnabledExp = (
 	source: 'design-choices' | 'design-picker' | 'theme-showcase'
 ) => {
 	const [ isLoading, assignment ] = useExperiment( 'calypso_disable_site_assembler' );
+	const variationName =
+		assignment?.variationName ||
+		// TODO: Remove the following one after testing.
+		window.sessionStorage.getItem( 'calypso_disable_site_assembler' ) ||
+		'control';
 
 	if ( isLoading ) {
 		return false;
 	}
 
-	if ( assignment?.variationName === 'control' ) {
+	if ( variationName === 'control' ) {
 		return true;
 	}
 
-	if ( assignment?.variationName === 'treatment_disable_all' ) {
+	if ( variationName === 'treatment_disable_all' ) {
 		return false;
 	}
 

--- a/client/data/site-assembler/index.ts
+++ b/client/data/site-assembler/index.ts
@@ -7,27 +7,26 @@ export const useIsSiteAssemblerEnabledExp = (
 	const variationName =
 		assignment?.variationName ||
 		// TODO: Remove the following one after testing.
-		window.sessionStorage.getItem( 'calypso_disable_site_assembler' ) ||
-		'control';
+		window.sessionStorage.getItem( 'calypso_disable_site_assembler' );
 
 	if ( isLoading ) {
 		return false;
 	}
 
-	if ( variationName === 'control' ) {
-		return true;
+	if ( variationName === 'treatment_disable_onboarding' ) {
+		switch ( source ) {
+			case 'theme-showcase':
+				return true;
+			case 'design-choices':
+			case 'design-picker':
+			default:
+				return false;
+		}
 	}
 
 	if ( variationName === 'treatment_disable_all' ) {
 		return false;
 	}
 
-	switch ( source ) {
-		case 'theme-showcase':
-			return true;
-		case 'design-choices':
-		case 'design-picker':
-		default:
-			return false;
-	}
+	return true;
 };

--- a/client/data/site-assembler/index.ts
+++ b/client/data/site-assembler/index.ts
@@ -1,8 +1,11 @@
 import { useExperiment } from 'calypso/lib/explat';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export const useIsSiteAssemblerEnabledExp = (
 	source: 'design-choices' | 'design-picker' | 'theme-showcase'
 ) => {
+	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
 	const [ isLoading, assignment ] = useExperiment( 'calypso_disable_site_assembler' );
 	const variationName =
 		assignment?.variationName ||
@@ -16,7 +19,7 @@ export const useIsSiteAssemblerEnabledExp = (
 	if ( variationName === 'treatment_disable_onboarding' ) {
 		switch ( source ) {
 			case 'theme-showcase':
-				return true;
+				return isLoggedIn;
 			case 'design-choices':
 			case 'design-picker':
 			default:

--- a/client/data/site-assembler/index.ts
+++ b/client/data/site-assembler/index.ts
@@ -1,0 +1,28 @@
+import { useExperiment } from 'calypso/lib/explat';
+
+export const useIsSiteAssemblerEnabledExp = (
+	source: 'design-choices' | 'design-picker' | 'theme-showcase'
+) => {
+	const [ isLoading, assignment ] = useExperiment( 'calypso_disable_site_assembler' );
+
+	if ( isLoading ) {
+		return false;
+	}
+
+	if ( assignment?.variationName === 'control' ) {
+		return true;
+	}
+
+	if ( assignment?.variationName === 'treatment_disable_all' ) {
+		return false;
+	}
+
+	switch ( source ) {
+		case 'theme-showcase':
+			return true;
+		case 'design-choices':
+		case 'design-picker':
+		default:
+			return false;
+	}
+};

--- a/client/data/site-assembler/index.ts
+++ b/client/data/site-assembler/index.ts
@@ -10,7 +10,8 @@ export const useIsSiteAssemblerEnabledExp = (
 	const variationName =
 		assignment?.variationName ||
 		// TODO: Remove the following one after testing.
-		window.sessionStorage.getItem( 'calypso_disable_site_assembler' );
+		( typeof window !== 'undefined' &&
+			window.sessionStorage.getItem( 'calypso_disable_site_assembler' ) );
 
 	if ( isLoading ) {
 		return false;

--- a/client/data/site-assembler/index.ts
+++ b/client/data/site-assembler/index.ts
@@ -7,11 +7,7 @@ export const useIsSiteAssemblerEnabledExp = (
 ) => {
 	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
 	const [ isLoading, assignment ] = useExperiment( 'calypso_disable_site_assembler' );
-	const variationName =
-		assignment?.variationName ||
-		// TODO: Remove the following one after testing.
-		( typeof window !== 'undefined' &&
-			window.sessionStorage.getItem( 'calypso_disable_site_assembler' ) );
+	const variationName = assignment?.variationName;
 
 	if ( isLoading ) {
 		return false;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useIsBigSkyEligible } from '../../../../hooks/use-is-site-big-sky-eligible';
 import { ONBOARD_STORE } from '../../../../stores';
@@ -33,6 +34,9 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 	);
 
 	const { isEligible, isLoading } = useIsBigSkyEligible();
+
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'design-choices' );
+
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 
 	useEffect( () => {
@@ -81,14 +85,16 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 								destination="designSetup"
 								onSelect={ handleSubmit }
 							/>
-							<DesignChoice
-								className="design-choices__design-your-own"
-								title={ translate( 'Design your own' ) }
-								description={ translate( 'Design your site with patterns, pages, styles.' ) }
-								imageSrc={ assemblerIllustrationImage }
-								destination="pattern-assembler"
-								onSelect={ handleSubmit }
-							/>
+							{ isSiteAssemblerEnabled && (
+								<DesignChoice
+									className="design-choices__design-your-own"
+									title={ translate( 'Design your own' ) }
+									description={ translate( 'Design your site with patterns, pages, styles.' ) }
+									imageSrc={ assemblerIllustrationImage }
+									destination="pattern-assembler"
+									onSelect={ handleSubmit }
+								/>
+							) }
 							{ ! isLoading && isEligible && (
 								<BigSkyDisclaimerModal flow={ flow } stepName={ stepName }>
 									<DesignChoice

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -44,6 +44,7 @@ import {
 } from 'calypso/components/theme-tier/constants';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
+import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
 import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
@@ -127,6 +128,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const siteTitle = site?.name;
 	const siteDescription = site?.description;
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
+
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'design-picker' );
+
 	const isDesignFirstFlow =
 		flow === DESIGN_FIRST_FLOW || queryParams.get( 'flowToReturnTo' ) === DESIGN_FIRST_FLOW;
 
@@ -922,6 +926,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 			getBadge={ getBadge }
 			oldHighResImageLoading={ oldHighResImageLoading }
+			isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
 import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
+import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -150,6 +151,12 @@ const siteSetupFlow: Flow = {
 		);
 
 		const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'design-choices' );
+
+		const { isEligible: isBigSkyEligible } = useIsBigSkyEligible();
+
+		const isDesignChoicesStepEnabled =
+			isEnabled( 'onboarding/design-choices' ) &&
+			( ( isAssemblerSupported() && isSiteAssemblerEnabled ) || isBigSkyEligible );
 
 		const { setPendingAction, resetOnboardStoreWithSkipFlags, setIntent } =
 			useDispatch( ONBOARD_STORE );
@@ -354,11 +361,7 @@ const siteSetupFlow: Flow = {
 						case SiteIntent.Sell:
 							return navigate( 'options' );
 						default: {
-							if (
-								isEnabled( 'onboarding/design-choices' ) &&
-								isAssemblerSupported() &&
-								isSiteAssemblerEnabled
-							) {
+							if ( isDesignChoicesStepEnabled ) {
 								return navigate( 'design-choices' );
 							}
 							return navigate( 'designSetup' );
@@ -506,11 +509,7 @@ const siteSetupFlow: Flow = {
 						case SiteIntent.Write:
 							return navigate( 'bloggerStartingPoint' );
 						default: {
-							if (
-								isEnabled( 'onboarding/design-choices' ) &&
-								isAssemblerSupported() &&
-								isSiteAssemblerEnabled
-							) {
+							if ( isDesignChoicesStepEnabled ) {
 								return navigate( 'design-choices' );
 							}
 							return navigate( 'goals' );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { MIGRATION_FLOW } from '@automattic/onboarding';
@@ -155,8 +154,7 @@ const siteSetupFlow: Flow = {
 		const { isEligible: isBigSkyEligible } = useIsBigSkyEligible();
 
 		const isDesignChoicesStepEnabled =
-			isEnabled( 'onboarding/design-choices' ) &&
-			( ( isAssemblerSupported() && isSiteAssemblerEnabled ) || isBigSkyEligible );
+			( isAssemblerSupported() && isSiteAssemblerEnabled ) || isBigSkyEligible;
 
 		const { setPendingAction, resetOnboardStoreWithSkipFlags, setIntent } =
 			useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -6,6 +6,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { isTargetSitePlanCompatible } from 'calypso/blocks/importer/util';
+import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -147,6 +148,9 @@ const siteSetupFlow: Flow = {
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStoreType(),
 			[]
 		);
+
+		const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'design-choices' );
+
 		const { setPendingAction, resetOnboardStoreWithSkipFlags, setIntent } =
 			useDispatch( ONBOARD_STORE );
 		const { setDesignOnSite } = useDispatch( SITE_STORE );
@@ -350,7 +354,11 @@ const siteSetupFlow: Flow = {
 						case SiteIntent.Sell:
 							return navigate( 'options' );
 						default: {
-							if ( isEnabled( 'onboarding/design-choices' ) && isAssemblerSupported() ) {
+							if (
+								isEnabled( 'onboarding/design-choices' ) &&
+								isAssemblerSupported() &&
+								isSiteAssemblerEnabled
+							) {
 								return navigate( 'design-choices' );
 							}
 							return navigate( 'designSetup' );
@@ -498,7 +506,11 @@ const siteSetupFlow: Flow = {
 						case SiteIntent.Write:
 							return navigate( 'bloggerStartingPoint' );
 						default: {
-							if ( isEnabled( 'onboarding/design-choices' ) && isAssemblerSupported() ) {
+							if (
+								isEnabled( 'onboarding/design-choices' ) &&
+								isAssemblerSupported() &&
+								isSiteAssemblerEnabled
+							) {
 								return navigate( 'design-choices' );
 							}
 							return navigate( 'goals' );

--- a/client/my-sites/themes/pattern-assembler-button/index.tsx
+++ b/client/my-sites/themes/pattern-assembler-button/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useIsSiteAssemblerEnabledExp } from 'calypso/data/site-assembler';
 import './style.scss';
 
 type Props = {
@@ -9,6 +10,11 @@ type Props = {
 
 export default function PatternAssemblerButton( { isPrimary, onClick }: Props ) {
 	const translate = useTranslate();
+	const isSiteAssemblerEnabled = useIsSiteAssemblerEnabledExp( 'theme-showcase' );
+
+	if ( ! isSiteAssemblerEnabled ) {
+		return null;
+	}
 
 	return (
 		<Button className="themes__pattern-assembler-button" primary={ isPrimary } onClick={ onClick }>

--- a/config/development.json
+++ b/config/development.json
@@ -150,7 +150,6 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"oauth": false,
-		"onboarding/design-choices": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,7 +96,6 @@
 		"migration-flow/introductory-offer": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"onboarding/design-choices": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"pattern-assembler/v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -122,7 +122,6 @@
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
 		"my-sites/add-ons": true,
-		"onboarding/design-choices": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,7 +118,6 @@
 		"migration-flow/enable-migration-assistant": true,
 		"migration-flow/introductory-offer": true,
 		"my-sites/add-ons": true,
-		"onboarding/design-choices": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -116,7 +116,6 @@
 		"migration-flow/introductory-offer": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"onboarding/design-choices": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -243,6 +243,7 @@ interface DesignPickerProps {
 	shouldLimitGlobalStyles?: boolean;
 	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
+	isSiteAssemblerEnabled?: boolean; // Temporary for A/B test
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -257,6 +258,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	shouldLimitGlobalStyles,
 	getBadge,
 	oldHighResImageLoading,
+	isSiteAssemblerEnabled,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredDesigns = useMemo( () => {
@@ -280,7 +282,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						selectedSlug={ categorization.selection }
 					/>
 				) }
-				{ assemblerCtaData.shouldGoToAssemblerStep && (
+				{ assemblerCtaData.shouldGoToAssemblerStep && isSiteAssemblerEnabled && (
 					<Button
 						className={ clsx( 'design-picker__design-your-own-button', {
 							'design-picker__design-your-own-button-without-categories': ! hasCategories,
@@ -313,7 +315,9 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						/>
 					);
 				} ) }
-				<PatternAssemblerCta onButtonClick={ () => onDesignYourOwn( getAssemblerDesign() ) } />
+				{ isSiteAssemblerEnabled && (
+					<PatternAssemblerCta onButtonClick={ () => onDesignYourOwn( getAssemblerDesign() ) } />
+				) }
 			</div>
 		</div>
 	);
@@ -333,6 +337,7 @@ export interface UnifiedDesignPickerProps {
 	shouldLimitGlobalStyles?: boolean;
 	getBadge: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
+	isSiteAssemblerEnabled?: boolean; // Temporary for A/B test
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -349,6 +354,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	shouldLimitGlobalStyles,
 	getBadge,
 	oldHighResImageLoading,
+	isSiteAssemblerEnabled,
 } ) => {
 	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 
@@ -382,6 +388,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 					getBadge={ getBadge }
 					oldHighResImageLoading={ oldHighResImageLoading }
+					isSiteAssemblerEnabled={ isSiteAssemblerEnabled }
 				/>
 				{ bottomAnchorContent }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-68Y-p2

## Proposed Changes

* Introduce the experiment, `calypso_disable_site_assembler`, to determine whether to display the entry point of the Assembler

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A/B testing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the sessionStorage to control the variation of experiment for testing
  * `window.sessionStorage.setItem( 'calypso_disable_site_assembler', 'control' );` - The default behavior
  * `window.sessionStorage.setItem( 'calypso_disable_site_assembler', 'treatment_disable_all' );` - To disable all the entry point of the Assembler
  * `window.sessionStorage.setItem( 'calypso_disable_site_assembler', 'treatment_disable_onboarding' );` - To disable the entry point of the Assembler on the onboarding flow
* Go to /setup?siteSlug=<your_site>
* Continue directly
* Make sure the Design Choices screen is visible only when the variation is `control`
* On the Design Picker screen
  * Make sure the “Design your own” button is visible only when the variation is `control`
  * Make sure the banner of the Assembler at the bottom is visible only when the variation is `control`
* Go to /themes?siteSlug=<your_site>
* Scroll down to make sure the banner of the Assembler is invisible only when the variation is `treatment_disable_all`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?