### PR TITLE
Disable the Business plan upsell

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -11,12 +11,7 @@ import {
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_RESET_PLANS,
 	JETPACK_REDIRECT_URL,
-	PLAN_BUSINESS,
 	redirectCheckoutToWpAdmin,
-	findFirstSimilarPlanKey,
-	getPlan,
-	isPlan,
-	isWpComPremiumPlan,
 	isTitanMail,
 	is100Year,
 	isValidFeatureKey,
@@ -35,17 +30,14 @@ import {
 	getGoogleApps,
 	hasGoogleApps,
 	hasRenewalItem,
-	getAllCartItems,
 	getDomainRegistrations,
 	getRenewalItems,
-	hasJetpackPlan,
 	hasBloggerPlan,
 	hasPersonalPlan,
 	hasPremiumPlan,
 	hasBusinessPlan,
 	hasEcommercePlan,
 	hasTitanMail,
-	hasDIFMProduct,
 	hasProPlan,
 	hasStarterPlan,
 } from 'calypso/lib/cart-values/cart-items';
@@ -619,48 +611,6 @@ function getFallbackDestination( {
 	return `/checkout/thank-you/${ siteSlug }/${ receiptIdOrPlaceholder }`;
 }
 
-/**
- * This function returns the product slug of the next higher plan of the plan item in the cart.
- * Currently, it only supports premium plans.
- * @param {ResponseCart} cart the cart object
- * @returns {string|undefined} the product slug of the next higher plan if it exists, undefined otherwise.
- */
-function getNextHigherPlanSlug( cart: ResponseCart ): string | undefined {
-	const currentPlanSlug = cart && getAllCartItems( cart ).filter( isPlan )[ 0 ]?.product_slug;
-	if ( ! currentPlanSlug ) {
-		return;
-	}
-
-	const currentPlan = getPlan( currentPlanSlug );
-
-	if ( isWpComPremiumPlan( currentPlanSlug ) ) {
-		const planKey = findFirstSimilarPlanKey( PLAN_BUSINESS, { term: currentPlan?.term } );
-		return planKey ? getPlan( planKey )?.getPathSlug?.() : undefined;
-	}
-
-	return;
-}
-
-function getPlanUpgradeUpsellUrl( {
-	receiptId,
-	cart,
-	siteSlug,
-}: {
-	receiptId: ReceiptId | ReceiptIdPlaceholder;
-	cart: ResponseCart | undefined;
-	siteSlug: string | undefined;
-} ): string | undefined {
-	if ( cart && hasPremiumPlan( cart ) ) {
-		const upgradeItem = getNextHigherPlanSlug( cart );
-
-		if ( upgradeItem ) {
-			return `/checkout/${ siteSlug }/offer-plan-upgrade/${ upgradeItem }/${ receiptId }`;
-		}
-	}
-
-	return;
-}
-
 function getRedirectUrlForPostCheckoutUpsell( {
 	receiptId,
 	cart,
@@ -686,28 +636,6 @@ function getRedirectUrlForPostCheckoutUpsell( {
 
 	if ( professionalEmailUpsellUrl ) {
 		return professionalEmailUpsellUrl;
-	}
-
-	if (
-		cart &&
-		! hasJetpackPlan( cart ) &&
-		! hasDIFMProduct( cart ) &&
-		( hasBloggerPlan( cart ) ||
-			hasPersonalPlan( cart ) ||
-			hasPremiumPlan( cart ) ||
-			hasBusinessPlan( cart ) )
-	) {
-		// A user just purchased one of the qualifying plans
-
-		const planUpgradeUpsellUrl = getPlanUpgradeUpsellUrl( {
-			receiptId,
-			cart,
-			siteSlug,
-		} );
-
-		if ( planUpgradeUpsellUrl ) {
-			return planUpgradeUpsellUrl;
-		}
 	}
 }
 

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -10,13 +10,10 @@ import {
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
 	PLAN_PERSONAL,
-	PLAN_PREMIUM,
 	redirectCheckoutToWpAdmin,
 	TITAN_MAIL_MONTHLY_SLUG,
-	WPCOM_DIFM_LITE,
 	PLAN_100_YEARS,
 } from '@automattic/calypso-products';
-import { LINK_IN_BIO_FLOW, NEWSLETTER_FLOW, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import {
 	getEmptyResponseCart,
 	getEmptyResponseCartProduct,
@@ -130,29 +127,6 @@ describe( 'getThankYouPageUrl', () => {
 			cart,
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId' );
-	} );
-
-	// Note: This just verifies the existing behavior; this URL is invalid unless
-	// the `:receiptId` is replaced with a valid receipt ID by the PayPal
-	// transaction flow. When returning from PayPal, the user is redirected
-	// briefly to a backend page that replaces `:receiptId` and 302 redirects to
-	// the updated URL.
-	it( 'redirects to the business plan bump offer page with a placeholder receipt id when a site but no orderId is set and the cart contains the premium plan', () => {
-		const cart = {
-			...getMockCart(),
-			products: [
-				{
-					...getEmptyResponseCartProduct(),
-					product_slug: 'value_bundle',
-				},
-			],
-		};
-		const url = getThankYouPageUrl( {
-			...defaultArgs,
-			siteSlug: 'foo.bar',
-			cart,
-		} );
-		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business/:receiptId' );
 	} );
 
 	it( 'redirects to the thank-you page with a placeholder receiptId with a site when the cart is not empty but there is no receipt id', () => {
@@ -1014,66 +988,6 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
 
-	it( 'redirects to business upgrade nudge if jetpack is not in the cart, and premium is in the cart', () => {
-		const cart = {
-			...getMockCart(),
-			products: [
-				{
-					...getEmptyResponseCartProduct(),
-					product_slug: 'value_bundle',
-					bill_period: '365',
-				},
-			],
-		};
-		const url = getThankYouPageUrl( {
-			...defaultArgs,
-			siteSlug: 'foo.bar',
-			cart,
-			receiptId: samplePurchaseId,
-		} );
-		expect( url ).toBe( `/checkout/foo.bar/offer-plan-upgrade/business/${ samplePurchaseId }` );
-	} );
-
-	it( 'redirects to business monthly upgrade nudge if jetpack is not in the cart, and premium monthly is in the cart', () => {
-		const cart = {
-			...getMockCart(),
-			products: [
-				{
-					...getEmptyResponseCartProduct(),
-					product_slug: 'value_bundle_monthly',
-					bill_period: '31',
-				},
-			],
-		};
-		const url = getThankYouPageUrl( {
-			...defaultArgs,
-			siteSlug: 'foo.bar',
-			cart,
-			receiptId: samplePurchaseId,
-		} );
-		expect( url ).toBe(
-			`/checkout/foo.bar/offer-plan-upgrade/business-monthly/${ samplePurchaseId }`
-		);
-	} );
-
-	it( 'redirects to the business upgrade nudge with a placeholder when jetpack is not in the cart and premium is in the cart but there is no receipt', () => {
-		const cart = {
-			...getMockCart(),
-			products: [
-				{
-					...getEmptyResponseCartProduct(),
-					product_slug: 'value_bundle',
-				},
-			],
-		};
-		const url = getThankYouPageUrl( {
-			...defaultArgs,
-			siteSlug: 'foo.bar',
-			cart,
-		} );
-		expect( url ).toBe( `/checkout/foo.bar/offer-plan-upgrade/business/:receiptId` );
-	} );
-
 	it( 'redirects to the thank you page if jetpack is not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {
 		const cart = {
 			...getMockCart(),
@@ -1392,28 +1306,6 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 
-		it( 'Is not displayed if Premium plan is in the cart; we show the business upgrade instead', () => {
-			const cart = {
-				...getMockCart(),
-				products: [
-					{
-						...getEmptyResponseCartProduct(),
-						product_slug: PLAN_PREMIUM,
-					},
-				],
-			};
-
-			const url = getThankYouPageUrl( {
-				...defaultArgs,
-				cart,
-				domains,
-				receiptId: samplePurchaseId,
-				siteSlug: 'foo.bar',
-			} );
-
-			expect( url ).toBe( `/checkout/foo.bar/offer-plan-upgrade/business/${ samplePurchaseId }` );
-		} );
-
 		it( 'Is not displayed if nudges should be hidden and site has eligible domain and Personal plan is in the cart', () => {
 			const cart = {
 				...getMockCart(),
@@ -1563,126 +1455,6 @@ describe( 'getThankYouPageUrl', () => {
 			sitelessCheckoutType: 'jetpack',
 		} );
 		expect( url ).toBe( '/checkout/jetpack/thank-you/foo.bar/no_product' );
-	} );
-
-	describe( 'Plan Upgrade Upsell Nudge', () => {
-		it( 'offers discounted business plan upgrade when premium plan is purchased.', () => {
-			const cart = {
-				...getMockCart(),
-				products: [
-					{
-						...getEmptyResponseCartProduct(),
-						product_slug: 'value_bundle',
-						bill_period: '365',
-					},
-				],
-			};
-			const url = getThankYouPageUrl( {
-				...defaultArgs,
-				siteSlug: 'foo.bar',
-				receiptId: samplePurchaseId,
-				cart,
-			} );
-			expect( url ).toBe( `/checkout/foo.bar/offer-plan-upgrade/business/${ samplePurchaseId }` );
-		} );
-
-		it( 'offers discounted biennial business plan upgrade when biennial premium plan is purchased.', () => {
-			const cart = {
-				...getMockCart(),
-				products: [
-					{
-						...getEmptyResponseCartProduct(),
-						product_slug: 'value_bundle-2y',
-						bill_period: '730',
-					},
-				],
-			};
-			const url = getThankYouPageUrl( {
-				...defaultArgs,
-				siteSlug: 'foo.bar',
-				receiptId: samplePurchaseId,
-				cart,
-			} );
-			expect( url ).toBe(
-				`/checkout/foo.bar/offer-plan-upgrade/business-2-years/${ samplePurchaseId }`
-			);
-		} );
-
-		it( 'offers discounted monthly business plan upgrade when monthly premium plan is purchased.', () => {
-			const cart = {
-				...getMockCart(),
-				products: [
-					{
-						...getEmptyResponseCartProduct(),
-						product_slug: 'value_bundle_monthly',
-						bill_period: '31',
-					},
-				],
-			};
-			const url = getThankYouPageUrl( {
-				...defaultArgs,
-				siteSlug: 'foo.bar',
-				receiptId: samplePurchaseId,
-				cart,
-			} );
-			expect( url ).toBe(
-				`/checkout/foo.bar/offer-plan-upgrade/business-monthly/${ samplePurchaseId }`
-			);
-		} );
-
-		it( 'Does not offers discounted annual business plan upgrade when annual premium plan and DIFM light is purchased together.', () => {
-			const cart = {
-				...getMockCart(),
-				products: [
-					{
-						...getEmptyResponseCartProduct(),
-						product_slug: 'value_bundle',
-						bill_period: '365',
-					},
-					{
-						...getEmptyResponseCartProduct(),
-						product_slug: WPCOM_DIFM_LITE,
-					},
-				],
-			};
-			const url = getThankYouPageUrl( {
-				...defaultArgs,
-				siteSlug: 'foo.bar',
-				receiptId: samplePurchaseId,
-				cart,
-			} );
-			expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
-		} );
-
-		it( 'Does not offers discounted annual business plan for tailored flows (https://wp.me/p58i-cBr).', () => {
-			[ NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, VIDEOPRESS_FLOW ].forEach( ( flowName ) => {
-				const getUrlFromCookie = jest.fn( () => '/cookie' );
-
-				// set a tailored flow name
-				sessionStorage.setItem( 'wpcom_signup_complete_flow_name', flowName );
-
-				const cart = {
-					...getMockCart(),
-					products: [
-						{
-							...getEmptyResponseCartProduct(),
-							product_slug: 'value_bundle',
-							bill_period: '365',
-						},
-					],
-				};
-				const url = getThankYouPageUrl( {
-					...defaultArgs,
-					getUrlFromCookie,
-					cart,
-				} );
-
-				expect( url ).toBe( `/cookie?notice=purchase-success` );
-
-				// clean up the tailored flow name
-				sessionStorage.removeItem( 'wpcom_signup_complete_flow_name' );
-			} );
-		} );
 	} );
 
 	// Siteless checkout flow


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Disable the Business plan upsell nudge
* Per Slack request p1722215744491869-slack-C02FMH4G8

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Executive request, poor UX that annoys people who just purchased Premium

## Testing Instructions

* Buy Premium of any type
* You should see a thank-you screen rather than the Business plan post-purchase upsell

<img width="810" alt="Screenshot 2024-08-16 at 10 01 43" src="https://github.com/user-attachments/assets/1362c8c1-e990-417e-946d-31439942c1eb">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
