### PR TITLE
Fix e2e: Remove business plan upsell skip option

### DIFF
--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -124,14 +124,6 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 			await cartCheckoutPage.purchase( { timeout: 90 * 1000 } );
 		} );
 
-		it( 'Skip business plan upsell', async function () {
-			const selector = 'button[data-e2e-button="decline"]';
-
-			const locator = page.locator( selector );
-
-			await locator.click( { timeout: 30 * 1000 } );
-		} );
-
 		it( 'Checks the active theme', async function () {
 			const restAPIClient = new RestAPIClient(
 				{

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -110,14 +110,6 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 			await cartCheckoutPage.purchase( { timeout: 90 * 1000 } );
 		} );
 
-		it( 'Skip business plan upsell', async function () {
-			const selector = 'button[data-e2e-button="decline"]';
-
-			const locator = page.locator( selector );
-
-			await locator.click( { timeout: 30 * 1000 } );
-		} );
-
 		it( 'Installs theme in Marketplace thank you page', async () => {
 			await page.getByText( 'Customize this design' ).waitFor();
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* This is a follow-up to https://github.com/Automattic/wp-calypso/pull/93600. The pre-release E2E tests failed for https://github.com/Automattic/wp-calypso/pull/93600, so this PR fixes the E2E test.
* We will remove the skipping of the business plan upsell since the upsell is now disabled. This should allow the pre-release e2e tests to pass.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass
