### PR TITLE
A4A: Fix the issue with 'Need setup' not appearing when there are no active sites. 

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -23,10 +23,42 @@ const useSitesMenuItems = ( path: string ) => {
 	const shouldAddNeedsSetup = totalAvailableSites > 0;
 
 	return useMemo( () => {
-		if ( noActiveSite ) {
-			// We hide the rest of the options when we do not have sites yet.
-			return [
-				createItem(
+		const items = noActiveSite
+			? [
+					// We hide the rest of the options when we do not have sites yet.
+					createItem(
+						{
+							id: 'sites-all-menu-item',
+							icon: category,
+							path: A4A_SITES_LINK,
+							link: A4A_SITES_LINK,
+							title: translate( 'All' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Sites / All',
+							},
+						},
+						path
+					),
+			  ]
+			: [
+					{
+						icon: warning,
+						path: A4A_SITES_LINK,
+						link: A4A_SITES_LINK_NEEDS_ATTENTION,
+						title: translate( 'Needs attention' ),
+						trackEventProps: {
+							menu_item: 'Automattic for Agencies / Sites / Needs Attention',
+						},
+					},
+					{
+						icon: starEmpty,
+						path: A4A_SITES_LINK,
+						link: A4A_SITES_LINK_FAVORITE,
+						title: translate( 'Favorites' ),
+						trackEventProps: {
+							menu_item: 'Automattic for Agencies / Sites / Favorites',
+						},
+					},
 					{
 						id: 'sites-all-menu-item',
 						icon: category,
@@ -37,41 +69,7 @@ const useSitesMenuItems = ( path: string ) => {
 							menu_item: 'Automattic for Agencies / Sites / All',
 						},
 					},
-					path
-				),
-			];
-		}
-
-		const items = [
-			{
-				icon: warning,
-				path: A4A_SITES_LINK,
-				link: A4A_SITES_LINK_NEEDS_ATTENTION,
-				title: translate( 'Needs attention' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Sites / Needs Attention',
-				},
-			},
-			{
-				icon: starEmpty,
-				path: A4A_SITES_LINK,
-				link: A4A_SITES_LINK_FAVORITE,
-				title: translate( 'Favorites' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Sites / Favorites',
-				},
-			},
-			{
-				id: 'sites-all-menu-item',
-				icon: category,
-				path: A4A_SITES_LINK,
-				link: A4A_SITES_LINK,
-				title: translate( 'All' ),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Sites / All',
-				},
-			},
-		].map( ( item ) => createItem( item, path ) );
+			  ].map( ( item ) => createItem( item, path ) );
 
 		if ( shouldAddNeedsSetup ) {
 			const needsSetupItem = createItem(
@@ -86,7 +84,7 @@ const useSitesMenuItems = ( path: string ) => {
 				},
 				path
 			);
-			items.splice( 1, 0, needsSetupItem );
+			items.splice( noActiveSite ? 0 : 1, 0, needsSetupItem );
 		}
 
 		return items;


### PR DESCRIPTION
When we have a pending WordPress.com plan and no active sites in our dashboard, the 'Need setup' does not appear. This PR fixes this bug.

<img width="266" alt="Screenshot 2024-08-16 at 5 05 29 PM" src="https://github.com/user-attachments/assets/4be6bb71-7d16-4509-9191-ca25e4faacc9">


Closes  https://github.com/Automattic/automattic-for-agencies-dev/issues/933


## Proposed Changes

* Fix the broken Sidebar conditional flow that causes the 'Need setup' menu not appearing when there is no active site.

## Why are these changes being made?

* For new agencies without active sites, the bug prevents users from creating a WordPress.com site, even if they have a pending site.

## Testing Instructions

* Purchase some WPCOM sites and make sure you do not activate them so the 'Need setup' menu appears.
* Remove all your sites from your dashboard.
* Confirm that the 'Need setup' menu still appears.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
