### PR TITLE
A4A: Add 'Referral order' expiration notice.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -97,6 +97,12 @@ export default function NoticeSummary( { type }: Props ) {
 						"Your client will be sent an invoice where they will be asked to create a WordPress.com account to pay for these products. Once paid, you'll be able to manage these products on behalf of the client."
 					),
 					translate( 'The client can cancel their products at any time.' ),
+
+					<b key="referral-expiration-notice">
+						{ translate(
+							'Important: Your referral order link is only valid for 12 hours. Please notify your client to complete the payment within this timeframe to avoid expiration.'
+						) }
+					</b>,
 				];
 
 			case 'request-payment-method':

--- a/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/notice-summary.tsx
@@ -97,12 +97,6 @@ export default function NoticeSummary( { type }: Props ) {
 						"Your client will be sent an invoice where they will be asked to create a WordPress.com account to pay for these products. Once paid, you'll be able to manage these products on behalf of the client."
 					),
 					translate( 'The client can cancel their products at any time.' ),
-
-					<b key="referral-expiration-notice">
-						{ translate(
-							'Important: Your referral order link is only valid for 12 hours. Please notify your client to complete the payment within this timeframe to avoid expiration.'
-						) }
-					</b>,
 				];
 
 			case 'request-payment-method':

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -132,6 +132,18 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 					{ translate( 'Request payment from client' ) }
 				</Button>
 			</div>
+
+			<div className="checkout__summary-notice-item">
+				{ translate(
+					'{{b}}Important:{{/b}} Your referral order link is only valid for {{u}}12 hours{{/u}}. Please notify your client to complete the payment within this timeframe to avoid expiration.',
+					{
+						components: {
+							b: <b />,
+							u: <u />,
+						},
+					}
+				) }
+			</div>
 		</>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -168,12 +168,12 @@
 		font-size: 1rem;
 		color: var(--color-neutral-70);
 	}
+}
 
-	.checkout__summary-notice-item {
-		font-size: 0.75rem;
-		color: var(--color-neutral-50);
-		margin-block-end: 0.5rem;
-	}
+.checkout__summary-notice-item {
+	font-size: 0.75rem;
+	color: var(--color-neutral-50);
+	margin-block-end: 0.5rem;
 }
 
 .checkout__aside-actions {
@@ -182,6 +182,7 @@
 	align-items: stretch;
 	gap: 16px;
 	text-align: center;
+	margin-block-end: 8px;
 
 	> .button {
 		display: flex;


### PR DESCRIPTION
This pull request adds an expiration notice that highlights the duration of a referral order.

<img width="573" alt="Screenshot 2024-08-16 at 5 22 29 PM" src="https://github.com/user-attachments/assets/f5abe750-3928-4b45-b12f-aeb95818e637">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/935

## Proposed Changes

* Update the summary component to include the expiration notice.

## Why are these changes being made?

* The objective is to highlight via copy that links are valid for 12 hours. This will make agencies aware of this and send links to their clients when they know the client will be available to use them.

## Testing Instructions

* Use the A4A live link below and go to `/marketplace/products` page.
* Toggle the 'Refer products' and proceed to add and checkout items.
* Confirm that on the checkout page, the new expiration notice is displayed.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
