### PR TITLE
Performance Profiler: Fix chart designs issues

### DIFF
--- a/client/performance-profiler/components/charts/history-chart.jsx
+++ b/client/performance-profiler/components/charts/history-chart.jsx
@@ -91,7 +91,7 @@ const drawLine = ( svg, data, xScale, yScale ) => {
 		.datum( data )
 		.attr( 'd', lineGenerator )
 		.attr( 'stroke', 'url(#line-gradient)' )
-		.attr( 'stroke-width', 4 )
+		.attr( 'stroke-width', 2 )
 		.attr( 'fill', 'none' );
 };
 
@@ -105,7 +105,7 @@ const drawAxes = ( svg, xScale, yScale, data, margin, width, height ) => {
 		.call(
 			d3AxisBottom( xScale )
 				.tickValues( dates )
-				.tickFormat( d3TimeFormat( '%m/%d' ) )
+				.tickFormat( d3TimeFormat( '%-m/%d' ) )
 				.tickPadding( 10 )
 		)
 		.call( ( g ) => g.select( '.domain' ).remove() );
@@ -193,7 +193,7 @@ const HistoryChart = ( { data, range, height, width } ) => {
 		// Clear previous chart
 		d3Select( svgRef.current ).selectAll( '*' ).remove();
 
-		const margin = { top: 20, right: 30, bottom: 40, left: 40 };
+		const margin = { top: 20, right: 0, bottom: 40, left: 40 };
 
 		const { xScale, yScale, colorScale } = createScales( data, range, margin, width, height );
 

--- a/client/performance-profiler/components/charts/style.scss
+++ b/client/performance-profiler/components/charts/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/components/src/styles/typography";
+
 .chart-container {
 	cursor: pointer;
 	display: inline-block;
@@ -8,7 +10,7 @@
 		}
 
 		text {
-			font-size: 1rem;
+			font-size: $font-body-small;
 			fill: var(--studio-gray-70);
 		}
 	}
@@ -21,7 +23,7 @@
 		color: #fff;
 		padding: 7px 10px;
 		border-radius: 3px;
-		font-size: 1rem;
+		font-size: $font-body-small;
 	}
 
 	.chart {

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -19,7 +19,7 @@ type CoreWebVitalsDisplayProps = Record< Metrics, number > & {
 
 export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 	const translate = useTranslate();
-	const [ activeTab, setActiveTab ] = useState< Metrics >( 'lcp' );
+	const [ activeTab, setActiveTab ] = useState< Metrics >( 'fcp' );
 
 	const { displayName } = metricsNames[ activeTab as keyof typeof metricsNames ];
 	const value = props[ activeTab ];
@@ -144,7 +144,7 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 								formatUnit( metricsTresholds[ activeTab ].good ),
 								formatUnit( metricsTresholds[ activeTab ].needsImprovement ),
 							] }
-							width={ 600 }
+							width={ 550 }
 							height={ 300 }
 						/>
 					</span>

--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -74,6 +74,10 @@ $blueberry-color: #3858e9;
 	color: var(--studio-gray-70);
 }
 
+.core-web-vitals-display__description p {
+	margin-top: 15px;
+}
+
 .core-web-vitals-display__description a {
 	color: $blueberry-color;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8568

## Proposed Changes

* Remove the right margin from the chart to free up space
* Remove leading 0 from x-axis when to free up up clutter from the chart
* Reduce the font size to 14 px to match with rest of the components.
* Reduce the stroke to 2 from 4 for the lines on chart
* Reduce the width of the chart to 550 from 600. 
* Open fcp tab by default when loading the report for the first time. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/speed-test-tool?url=https%3A%2F%2Fwww.atliq.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NjkzNH0.uoPBbETEfzOEqTdJ_kro-zUpmvSF6vQz7JabJYumwME&tab=mobile`
- Look at rendered graph and compare

#### Designs
![CleanShot 2024-08-16 at 14 51 07@2x](https://github.com/user-attachments/assets/9d064aa1-2fc6-47c1-86cf-d276f31292d8)

#### Trunk
![CleanShot 2024-08-16 at 14 51 19@2x](https://github.com/user-attachments/assets/68956f6b-df5d-4cdb-8a83-b9ee87de9338)

#### This branch

![CleanShot 2024-08-16 at 14 51 14@2x](https://github.com/user-attachments/assets/2e67496e-ba96-4fa7-ab71-7170c934e114)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
