### PR TITLE
Fix mobile issues for hundred year plans

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/styles.scss
@@ -3,7 +3,7 @@
 @import "../hundred-year-plan-step-wrapper/mixins";
 
 .hundred-year-plan.step-route {
-	@include break-small {
+	@media (max-width: 600px) {
 		margin-top: -60px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -31,10 +31,7 @@
 		}
 
 		.button.select-items__item-button {
-			width: 279px;
-			@include break-small {
-				width: 140px;
-			}
+			width: 140px;
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

This PR fixes two mobile issues for the hundred year plans onboarding screens. Here's how it currently looks at some different breakpoints:

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/a2ca2fe0-bd68-49d5-b355-494f0fa3512a">

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/c4fdedbf-2912-444e-a720-210e4c0e7f41">

Here's how the updates look:

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/b9edd211-9851-4387-a308-a9237e5ee7cf">


<img width="1064" alt="image" src="https://github.com/user-attachments/assets/e7139b2f-7f6c-4bfb-8a1d-95d65dc6f017">

@aneeshd16 @escapemanuele I requested your review on this because it's what github suggested. If you know someone more appropriate to review this, please let me know.

## Testing Instructions
* Visit `/setup/hundred-year-plan/new-or-existing-site` and test it at different breakpoints.

