### PR TITLE
Add: Paid Newsletter Map Stripe Plan to Newsletter tier

### DIFF
--- a/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
+++ b/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
@@ -1,0 +1,73 @@
+import {
+	DefaultError,
+	useMutation,
+	UseMutationOptions,
+	useQueryClient,
+} from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+
+interface MutationVariables {
+	siteId: string;
+	engine: string;
+	currentStep: string;
+	stripePlan: string;
+	productId: number;
+}
+
+export const useMapStripePlanToProductMutation = (
+	options: UseMutationOptions< unknown, DefaultError, MutationVariables > = {}
+) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: async ( {
+			siteId,
+			engine,
+			currentStep,
+			stripePlan,
+			productId,
+		}: MutationVariables ) => {
+			const response = await wp.req.post(
+				{
+					path: `/sites/${ siteId }/site-importer/paid-newsletter/map-stripe-plan-to-product`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					engine: engine,
+					current_step: currentStep,
+					stripe_plan_id: stripePlan,
+					product_id: productId,
+				}
+			);
+
+			if ( ! response.current_step ) {
+				throw new Error( 'unsuccsefully skipped step', response );
+			}
+
+			return response;
+		},
+		...options,
+		onSuccess( ...args ) {
+			const [ , { siteId, engine, currentStep } ] = args;
+			queryClient.invalidateQueries( {
+				queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
+			} );
+			options.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const mapStripePlanToProduct = useCallback(
+		(
+			siteId: string,
+			engine: string,
+			currentStep: string,
+			stripePlan: string,
+			productId: number
+		) => mutate( { siteId, engine, currentStep, stripePlan, productId } ),
+		[ mutate ]
+	);
+
+	return { mapStripePlanToProduct, ...mutation };
+};

--- a/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
+++ b/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
@@ -64,7 +64,7 @@ export const useMapStripePlanToProductMutation = (
 			engine: string,
 			currentStep: string,
 			stripePlan: string,
-			productId: number
+			productId: string
 		) => mutate( { siteId, engine, currentStep, stripePlan, productId } ),
 		[ mutate ]
 	);

--- a/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
+++ b/client/data/paid-newsletter/use-map-stripe-plan-to-product-mutation.ts
@@ -12,7 +12,7 @@ interface MutationVariables {
 	engine: string;
 	currentStep: string;
 	stripePlan: string;
-	productId: number;
+	productId: string;
 }
 
 export const useMapStripePlanToProductMutation = (

--- a/client/my-sites/importer/newsletter/paid-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers.tsx
@@ -2,14 +2,15 @@ import { hasQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
 import { useDispatch } from 'calypso/state';
 import { infoNotice, successNotice } from 'calypso/state/notices/actions';
-import ConnectStripe from './connect-stripe';
-import MapPlans from './map-plans';
+import ConnectStripe from './paid-subscribers/connect-stripe';
+import MapPlans from './paid-subscribers/map-plans';
 type Props = {
 	nextStepUrl: string;
 	skipNextStep: () => void;
 	fromSite: string;
 	engine: string;
 	cardData: any;
+	selectedSite: any;
 	isFetchingContent: boolean;
 };
 
@@ -17,6 +18,7 @@ export default function PaidSubscribers( {
 	nextStepUrl,
 	fromSite,
 	engine,
+	selectedSite,
 	skipNextStep,
 	cardData,
 	isFetchingContent,
@@ -24,7 +26,6 @@ export default function PaidSubscribers( {
 	const dispatch = useDispatch();
 	const isCancelled = hasQueryArg( window.location.href, 'stripe_connect_cancelled' );
 	const isSuccess = hasQueryArg( window.location.href, 'stripe_connect_success' );
-
 	const hasConnectedAccount = cardData.is_connected_stripe;
 
 	useEffect( () => {
@@ -48,7 +49,14 @@ export default function PaidSubscribers( {
 				/>
 			) }
 			{ hasConnectedAccount && (
-				<MapPlans nextStepUrl={ nextStepUrl } cardData={ cardData } skipNextStep={ skipNextStep } />
+				<MapPlans
+					nextStepUrl={ nextStepUrl }
+					cardData={ cardData }
+					skipNextStep={ skipNextStep }
+					engine={ engine }
+					siteId={ selectedSite?.ID }
+					currentStep="paid-subscribers"
+				/>
 			) }
 		</>
 	);

--- a/client/my-sites/importer/newsletter/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/connect-stripe.tsx
@@ -2,8 +2,8 @@ import { Card } from '@automattic/components';
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import StripeLogo from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import ImporterActionButton from '../importer-action-buttons/action-button';
-import ImporterActionButtonContainer from '../importer-action-buttons/container';
+import ImporterActionButton from '../../importer-action-buttons/action-button';
+import ImporterActionButtonContainer from '../../importer-action-buttons/container';
 
 /**
  * Update the connect URL with the from_site and engine parameters.

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.scss
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.scss
@@ -1,0 +1,49 @@
+.map-plan {
+	display: flex;
+	margin-bottom: 20px;
+	align-items: center;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 16px;
+	justify-content: space-between;
+	flex-wrap: wrap;
+}
+.map-plan__select-product,
+.map-plan__info {
+	min-height: 80px;
+	display: flex;
+	align-items: center;
+	min-width: 230px;
+}
+.map-plan__info {
+	flex-direction: column;
+	justify-content: center;
+	p {
+		margin: 0;
+	}
+}
+.map-plan__select-product {
+	display: flex;
+	justify-content: flex-end;
+}
+
+.map-plan__select-product .map-plan__selected {
+	display: flex;
+	height: auto;
+
+	p {
+		margin: 0;
+	}
+}
+
+.map-plan__select-product-select {
+	min-width: 200px;
+
+	.components-dropdown-menu {
+		width: 100%;
+	}
+}
+
+.map-plan__arrow {
+	padding: 0 24px;
+}

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -1,0 +1,159 @@
+import { formatCurrency } from '@automattic/format-currency';
+import { DropdownMenu, MenuGroup, MenuItem, MenuItemsChoice, Button } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+import { chevronDown, Icon, arrowRight } from '@wordpress/icons';
+import { useState } from 'react';
+import { useMapStripePlanToProductMutation } from 'calypso/data/paid-newsletter/use-map-stripe-plan-to-product-mutation';
+
+import './map-plan.scss';
+
+type Plan = {
+	plan_id: string;
+	name: string;
+	plan_interval: string;
+	active_subscriptions: number;
+	is_active: boolean;
+	plan_currency: string;
+	plan_amount_decimal: number;
+	product_id: string;
+};
+
+type Product = {
+	id: number;
+	price: string;
+	currency: string;
+	title: string;
+	interval: string;
+};
+
+type MapPlanProps = {
+	plan: Plan;
+	products: Array< Product >;
+	map_plans: any;
+	siteId: string;
+	engine: string;
+	currentStep: string;
+};
+
+function displayProduct( productId: string, products: Array< Product > ) {
+	if ( ! productId ) {
+		return 'Select a Newsletter Tier';
+	}
+
+	const product = products.find( ( product: Product ) => product.id.toString() === productId );
+	if ( ! product ) {
+		return '';
+	}
+	return (
+		<div>
+			<strong>{ product.title || '' }</strong>
+			<p>
+				{ formatCurrency( parseFloat( product.price ), product.currency ) }/{ product.interval }
+			</p>
+		</div>
+	);
+}
+
+function getProductChoices( products: Array< Product > ) {
+	return products.map( ( product ) => ( {
+		info: `${ formatCurrency( parseFloat( product.price ), product.currency ) } / ${
+			product.interval
+		}`,
+		label: product.title,
+		value: product.id.toString(),
+	} ) );
+}
+
+export default function MapPlan( {
+	plan,
+	products,
+	map_plans,
+	siteId,
+	engine,
+	currentStep,
+}: MapPlanProps ) {
+	const { mapStripePlanToProduct } = useMapStripePlanToProductMutation();
+	let active_subscriptions = '';
+	if ( plan.active_subscriptions ) {
+		active_subscriptions = ` • ${ plan.active_subscriptions } active subscribers`;
+	}
+
+	const mappedProduct =
+		( map_plans.hasOwnProperty( plan.product_id ) && map_plans[ plan.product_id ] ) ?? '';
+
+	const [ selectedProduct, setSelectedProduct ] = useState( mappedProduct );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const handleProductChange = ( productId: string, onClose ) => {
+		setSelectedProduct( productId );
+		mapStripePlanToProduct( siteId, engine, currentStep, plan.product_id, productId );
+		onClose();
+	};
+
+	const specificProducts = products.filter( ( product ) => {
+		return product.interval === plan.plan_interval;
+	} );
+
+	return (
+		<div className="map-plan">
+			<div className="map-plan__info">
+				<strong>{ plan.name }</strong>
+				<p>
+					{ formatCurrency( plan.plan_amount_decimal, plan.plan_currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ) }
+					/{ plan.plan_interval } { active_subscriptions }
+				</p>
+			</div>
+			<div className="map-plan__arrow">
+				<Icon icon={ arrowRight } />
+			</div>
+			<div className="map-plan__select-product">
+				<Button
+					aria-haspopup="true"
+					tabIndex={ 0 }
+					className="map-plan__selected"
+					onClick={ () => {
+						setIsOpen( ! isOpen );
+					} }
+					onKeyDown={ ( event ) => {
+						if ( event.key === 'Enter' || event.key === ' ' ) {
+							setIsOpen( ! isOpen );
+						}
+					} }
+				>
+					{ displayProduct( selectedProduct, products ) }
+				</Button>
+				<DropdownMenu
+					onToggle={ ( openState: boolean ) => {
+						setIsOpen( openState );
+					} }
+					icon={ chevronDown }
+					label="Choose a Newsletter Tier"
+					open={ isOpen }
+				>
+					{ ( { onClose } ) => (
+						<Fragment>
+							<MenuGroup label="Newsletter Tiers">
+								<MenuItemsChoice
+									choices={ getProductChoices( specificProducts ) }
+									onSelect={ ( productId ) => {
+										handleProductChange( productId, onClose );
+									} }
+									onHover={ () => {} }
+									value={ selectedProduct.toString() }
+								/>
+							</MenuGroup>
+							<MenuGroup label="OR">
+								<MenuItem key="add-new" onClick={ onClose }>
+									Add Newsletter Tier
+								</MenuItem>
+							</MenuGroup>
+						</Fragment>
+					) }
+				</DropdownMenu>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -35,7 +35,7 @@ type MapPlanProps = {
 	currentStep: string;
 };
 
-function displayProduct( product ) {
+function displayProduct( product: Product | undefined ) {
 	if ( ! product ) {
 		return 'Select a Newsletter Tier';
 	}

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
@@ -41,7 +41,7 @@ export default function MapPlans( {
 						engine={ engine }
 						currentStep={ currentStep }
 						plan={ plan }
-						products={ cardData.availabible_tiers }
+						products={ cardData.available_tiers }
 						map_plans={ cardData.map_plans }
 					/>
 				) ) }

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
@@ -1,15 +1,26 @@
 import { Card } from '@automattic/components';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import ImporterActionButton from '../importer-action-buttons/action-button';
-import ImporterActionButtonContainer from '../importer-action-buttons/container';
+import ImporterActionButton from '../../importer-action-buttons/action-button';
+import ImporterActionButtonContainer from '../../importer-action-buttons/container';
+import MapPlan from './map-plan';
 
 type Props = {
 	nextStepUrl: string;
 	skipNextStep: () => void;
 	cardData: any;
+	siteId: string;
+	engine: string;
+	currentStep: string;
 };
 
-export default function MapPlans( { nextStepUrl, skipNextStep }: Props ) {
+export default function MapPlans( {
+	nextStepUrl,
+	skipNextStep,
+	cardData,
+	siteId,
+	engine,
+	currentStep,
+}: Props ) {
 	return (
 		<Card>
 			<h2>Paid newsletter offering</h2>
@@ -19,6 +30,22 @@ export default function MapPlans( { nextStepUrl, skipNextStep }: Props ) {
 				</strong>{ ' ' }
 				to prevent disruption to your current paid subscribers.
 			</p>
+			<div className="map-plans__mapping">
+				<p>
+					<strong>Existing Stripe plans</strong>
+				</p>
+				{ cardData.plans.map( ( plan: any ) => (
+					<MapPlan
+						key={ plan.plan_id }
+						siteId={ siteId }
+						engine={ engine }
+						currentStep={ currentStep }
+						plan={ plan }
+						products={ cardData.availabible_tiers }
+						map_plans={ cardData.map_plans }
+					/>
+				) ) }
+			</div>
 			<ImporterActionButtonContainer noSpacing>
 				<ImporterActionButton
 					primary


### PR DESCRIPTION
## Proposed Changes

* Implements the Mapping step from Stripe Plan to Newsletter tier. 
Requires to have D158467-code in place. 

If it hasn't been merged yet. 
Sandbox public-api.wordpress.com and then 




## Why are these changes being made?
See video
*

https://github.com/user-attachments/assets/8b3256e2-0b39-40b8-be77-82a0465ab42e

## Testing Instructions

* Connect Your Stripe account to Substack, 
* Connect Your Stripe account to your test site. 
* Create a newsletter tier.
* Visit /import/newsletter/substack/example.com/paid-subscribers?from=example.substack.com

Notice that you are asked to map Stripe accounts plans to Newsletter tiers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?