### PR TITLE
Subscriptions: Reset paid newsletter importer on first step

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -1,11 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
+interface PaidNewsletterStep {
+	status: string;
+	content?: any;
+}
+
+interface PaidNewsletterData {
+	current_step: string;
+	steps: Record< string, PaidNewsletterStep >;
+}
+
 export const usePaidNewsletterQuery = ( engine: string, currentStep: string, siteId?: number ) => {
 	return useQuery( {
 		enabled: !! siteId,
 		queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
-		queryFn: () => {
+		queryFn: (): Promise< PaidNewsletterData > => {
 			return wp.req.get(
 				{
 					path: `/sites/${ siteId }/site-importer/paid-newsletter`,

--- a/client/data/paid-newsletter/use-reset-mutation.ts
+++ b/client/data/paid-newsletter/use-reset-mutation.ts
@@ -8,12 +8,12 @@ import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
 interface MutationVariables {
-	siteId: string;
+	siteId: number;
 	engine: string;
 	currentStep: string;
 }
 
-export const useSkipNextStepMutation = (
+export const useResetMutation = (
 	options: UseMutationOptions< unknown, DefaultError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
@@ -49,7 +49,7 @@ export const useSkipNextStepMutation = (
 	const { mutate } = mutation;
 
 	const resetPaidNewsletter = useCallback(
-		( siteId: string, engine: string, currentStep: string ) =>
+		( siteId: number, engine: string, currentStep: string ) =>
 			mutate( { siteId, engine, currentStep } ),
 		[ mutate ]
 	);

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -51,40 +51,6 @@
 	}
 }
 
-.logo-chain {
-	display: flex;
-	justify-content: center;
-	margin-bottom: 20px;
-}
-
-.logo-chain__logo {
-	width: 48px;
-	height: 48px;
-	margin: 0 -16px 0 0;
-	border-radius: 50%;
-	overflow: hidden;
-	position: relative;
-}
-
-.logo-chain__logo .importer__service-icon.wordpress {
-	background-color: #3858e9;
-	width: 46px;
-	height: 46px;
-	min-width: 46px;
-	position: absolute;
-	left: 1px;
-	top: 1px;
-}
-
-.logo-chain__logo .importer__service-icon.substack-logo {
-	width: 46px;
-	min-width: 46px;
-	height: 46px;
-	position: absolute;
-	left: 1px;
-	top: 1px;
-}
-
 .select-newsletter-form__help {
 	margin-top: 8px;
 	font-size: 0.75rem;

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -102,12 +102,13 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 
 	useEffect( () => {
 		if ( urlData?.platform === engine ) {
-			setValidFromSite( true );
-			selectedSite &&
-				step === stepSlugs[ 0 ] &&
+			if ( selectedSite && step === stepSlugs[ 0 ] && validFromSite === false ) {
 				resetPaidNewsletter( selectedSite.ID, engine, stepSlugs[ 0 ] );
+			}
+
+			setValidFromSite( true );
 		}
-	}, [ urlData, fromSite, engine, selectedSite, resetPaidNewsletter ] );
+	}, [ urlData, fromSite, engine, selectedSite, resetPaidNewsletter, step, validFromSite ] );
 
 	const stepUrl = `/import/newsletter/${ engine }/${ siteSlug }/${ stepSlugs[ stepIndex ] }`;
 	const nextStepUrl = addQueryArgs( `/import/newsletter/${ engine }/${ siteSlug }/${ nextStep }`, {

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -9,8 +9,8 @@ import { useSkipNextStepMutation } from 'calypso/data/paid-newsletter/use-skip-n
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import ImporterLogo from '../importer-logo';
 import Content from './content';
+import { LogoChain } from './logo-chain';
 import PaidSubscribers from './paid-subscribers';
 import SelectNewsletterForm from './select-newsletter-form';
 import Subscribers from './subscribers';
@@ -18,28 +18,14 @@ import Summary from './summary';
 
 import './importer.scss';
 
-type Logo = {
-	name: string;
-	color: string;
-};
-type LogoChainProps = {
-	logos: Logo[];
-};
-function LogoChain( { logos }: LogoChainProps ) {
-	return (
-		<div className="logo-chain">
-			{ logos.map( ( logo ) => (
-				<div key={ logo.name } className="logo-chain__logo" style={ { background: logo.color } }>
-					<ImporterLogo key={ logo.name } icon={ logo.name } />
-				</div>
-			) ) }
-		</div>
-	);
-}
-
 const steps = [ Content, Subscribers, PaidSubscribers, Summary ];
 
 const stepSlugs = [ 'content', 'subscribers', 'paid-subscribers', 'summary' ];
+
+const logoChainLogos = [
+	{ name: 'substack', color: 'var(--color-substack)' },
+	{ name: 'wordpress', color: '#3858E9' },
+];
 
 type NewsletterImporterProps = {
 	siteSlug: string;
@@ -119,12 +105,8 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 
 	return (
 		<div className="newsletter-importer">
-			<LogoChain
-				logos={ [
-					{ name: 'substack', color: 'var(--color-substack)' },
-					{ name: 'wordpress', color: '#3858E9' },
-				] }
-			/>
+			<LogoChain logos={ logoChainLogos } />
+
 			<FormattedHeader headerText={ getTitle( urlData ) } />
 			{ ( ! validFromSite || isResetPaidNewsletterPending ) && (
 				<SelectNewsletterForm
@@ -134,9 +116,11 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 					validFromSite={ validFromSite }
 				/>
 			) }
+
 			{ validFromSite && ! isResetPaidNewsletterPending && (
 				<StepProgress steps={ stepsProgress } currentStep={ stepIndex } />
 			) }
+
 			{ selectedSite && validFromSite && ! isResetPaidNewsletterPending && (
 				<Step
 					siteSlug={ siteSlug }

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -91,7 +91,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 	} );
 
 	const { skipNextStep } = useSkipNextStepMutation();
-	const { resetPaidNewsletter, isPending: isResettingPaidNewsletterPending } = useResetMutation();
+	const { resetPaidNewsletter, isPending: isResetPaidNewsletterPending } = useResetMutation();
 
 	const { data: urlData, isFetching } = useAnalyzeUrlQuery( fromSite );
 
@@ -126,18 +126,18 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 				] }
 			/>
 			<FormattedHeader headerText={ getTitle( urlData ) } />
-			{ ( ! validFromSite || isResettingPaidNewsletterPending ) && (
+			{ ( ! validFromSite || isResetPaidNewsletterPending ) && (
 				<SelectNewsletterForm
 					stepUrl={ stepUrl }
 					urlData={ urlData }
-					isLoading={ isFetching || isResettingPaidNewsletterPending }
+					isLoading={ isFetching || isResetPaidNewsletterPending }
 					validFromSite={ validFromSite }
 				/>
 			) }
-			{ validFromSite && ! isResettingPaidNewsletterPending && (
+			{ validFromSite && ! isResetPaidNewsletterPending && (
 				<StepProgress steps={ stepsProgress } currentStep={ stepIndex } />
 			) }
-			{ selectedSite && validFromSite && ! isResettingPaidNewsletterPending && (
+			{ selectedSite && validFromSite && ! isResetPaidNewsletterPending && (
 				<Step
 					siteSlug={ siteSlug }
 					nextStepUrl={ nextStepUrl }

--- a/client/my-sites/importer/newsletter/logo-chain.scss
+++ b/client/my-sites/importer/newsletter/logo-chain.scss
@@ -1,0 +1,33 @@
+.logo-chain {
+	display: flex;
+	justify-content: center;
+	margin-bottom: 20px;
+}
+
+.logo-chain__logo {
+	width: 48px;
+	height: 48px;
+	margin: 0 -16px 0 0;
+	border-radius: 50%;
+	overflow: hidden;
+	position: relative;
+}
+
+.logo-chain__logo .importer__service-icon.wordpress {
+	background-color: #3858e9;
+	width: 46px;
+	height: 46px;
+	min-width: 46px;
+	position: absolute;
+	left: 1px;
+	top: 1px;
+}
+
+.logo-chain__logo .importer__service-icon.substack-logo {
+	width: 46px;
+	min-width: 46px;
+	height: 46px;
+	position: absolute;
+	left: 1px;
+	top: 1px;
+}

--- a/client/my-sites/importer/newsletter/logo-chain.tsx
+++ b/client/my-sites/importer/newsletter/logo-chain.tsx
@@ -1,0 +1,24 @@
+import ImporterLogo from '../importer-logo';
+
+import './logo-chain.scss';
+
+type Logo = {
+	name: string;
+	color: string;
+};
+
+type LogoChainProps = {
+	logos: Logo[];
+};
+
+export function LogoChain( { logos }: LogoChainProps ) {
+	return (
+		<div className="logo-chain">
+			{ logos.map( ( logo ) => (
+				<div key={ logo.name } className="logo-chain__logo" style={ { background: logo.color } }>
+					<ImporterLogo key={ logo.name } icon={ logo.name } />
+				</div>
+			) ) }
+		</div>
+	);
+}

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -12,6 +12,7 @@ type Props = {
 	isLoading: boolean;
 	validFromSite: boolean;
 };
+
 export default function SelectNewsletterForm( {
 	stepUrl,
 	urlData,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93150

## Proposed Changes

It:
- resets the paid newsletter importer after the original site is defined
- moves the `LogoChain` component to separate file
- adds some types

## Why are these changes being made?

To fix the paid subscriber flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
