### PR TITLE
A4A Dev Sites: Add "Refer to client" button and copy related to free dev sites to the Launch panel

### DIFF
--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -33,11 +33,6 @@ const LaunchSite = () => {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 	const isPaidPlan = useSelector( ( state ) => isCurrentPlanPaid( state, siteId ) );
 	const isComingSoon = useSelector( ( state ) => isSiteComingSoon( state, siteId ) );
-	// TODO: replace with actual value whether the site is a development site
-	const urlParams = new URLSearchParams( window.location.search );
-	const isDevelomentSite = urlParams.get( 'referer' ) === 'a4a-dashboard';
-	// TODO: retrieve the actual agency name
-	const agencyName = 'MyCoolAgency';
 	const hasSitePreviewLink = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS )
 	);
@@ -88,6 +83,13 @@ const LaunchSite = () => {
 	const showPreviewLink = isComingSoon && hasSitePreviewLink;
 
 	const LaunchCard = showPreviewLink ? CompactCard : Card;
+
+	// TODO: replace with actual value whether the site is a development site
+	const urlParams = new URLSearchParams( window.location.search );
+	const isDevelomentSite = urlParams.get( 'referer' ) === 'a4a-dashboard';
+
+	// TODO: retrieve the actual agency name
+	const agencyName = 'MyCoolAgency';
 
 	return (
 		<>

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -104,26 +104,22 @@ const LaunchSite = () => {
 										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
 								  ) }
 						</p>
-						{
-							// TODO: add feature flag check
-							isDevelomentSite && (
-								<p>
-									{ translate(
-										'Once the site is launched, %(agencyName)s will be billed for this site in the next billing cycle.',
-										{
-											args: {
-												agencyName: agencyName,
-											},
-											comment: 'name of the agency that will be billed for the site',
-										}
-									) }
-								</p>
-							)
-						}
+						{ isDevelomentSite && (
+							<p>
+								{ translate(
+									'Once the site is launched, %(agencyName)s will be billed for this site in the next billing cycle.',
+									{
+										args: {
+											agencyName: agencyName,
+										},
+										comment: 'name of the agency that will be billed for the site',
+									}
+								) }
+							</p>
+						) }
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
 					{
-						// TODO: add feature flag check
 						// TODO: add onClick handler
 						isDevelomentSite && (
 							<div className={ launchSiteClasses }>

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -23,7 +23,6 @@ import {
 } from 'calypso/state/ui/selectors';
 import SettingsSectionHeader from '../settings-section-header';
 import { LaunchSiteTrialUpsellNotice } from './launch-site-trial-notice';
-
 import './styles.scss';
 
 const LaunchSite = () => {
@@ -34,6 +33,8 @@ const LaunchSite = () => {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 	const isPaidPlan = useSelector( ( state ) => isCurrentPlanPaid( state, siteId ) );
 	const isComingSoon = useSelector( ( state ) => isSiteComingSoon( state, siteId ) );
+	// TODO: replace with actual value whether the site is a development site
+	const isDevelomentSite = true;
 	const hasSitePreviewLink = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS )
 	);
@@ -101,8 +102,30 @@ const LaunchSite = () => {
 										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
 								  ) }
 						</p>
+						{
+							// TODO: add feature flag check
+							// TODO: replace agency name with actual agency name
+							isDevelomentSite && (
+								<p>
+									{ translate(
+										'Once the site is launched, MyCoolAgency will be billed for this site in the next billing cycle.'
+									) }
+								</p>
+							)
+						}
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
+					{
+						// TODO: add feature flag check
+						// TODO: add onClick handler
+						isDevelomentSite && (
+							<div className={ launchSiteClasses }>
+								<Button onClick={ null } disabled={ false }>
+									{ translate( 'Refer to client' ) }
+								</Button>
+							</div>
+						)
+					}
 				</div>
 			</LaunchCard>
 			{ showPreviewLink && (

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -35,6 +35,8 @@ const LaunchSite = () => {
 	const isComingSoon = useSelector( ( state ) => isSiteComingSoon( state, siteId ) );
 	// TODO: replace with actual value whether the site is a development site
 	const isDevelomentSite = true;
+	// TODO: retrieve the actual agency name
+	const agencyName = 'MyCoolAgency';
 	const hasSitePreviewLink = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS )
 	);
@@ -104,11 +106,16 @@ const LaunchSite = () => {
 						</p>
 						{
 							// TODO: add feature flag check
-							// TODO: replace agency name with actual agency name
 							isDevelomentSite && (
 								<p>
 									{ translate(
-										'Once the site is launched, MyCoolAgency will be billed for this site in the next billing cycle.'
+										'Once the site is launched, %(agencyName)s will be billed for this site in the next billing cycle.',
+										{
+											args: {
+												agencyName: agencyName,
+											},
+											comment: 'name of the agency that will be billed for the site',
+										}
 									) }
 								</p>
 							)

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -34,7 +34,8 @@ const LaunchSite = () => {
 	const isPaidPlan = useSelector( ( state ) => isCurrentPlanPaid( state, siteId ) );
 	const isComingSoon = useSelector( ( state ) => isSiteComingSoon( state, siteId ) );
 	// TODO: replace with actual value whether the site is a development site
-	const isDevelomentSite = true;
+	const urlParams = new URLSearchParams( window.location.search );
+	const isDevelomentSite = urlParams.get( 'referer' ) === 'a4a-dashboard';
 	// TODO: retrieve the actual agency name
 	const agencyName = 'MyCoolAgency';
 	const hasSitePreviewLink = useSelector( ( state ) =>

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -86,7 +86,7 @@ const LaunchSite = () => {
 
 	// TODO: replace with actual value whether the site is a development site
 	const urlParams = new URLSearchParams( window.location.search );
-	const isDevelomentSite = urlParams.get( 'referer' ) === 'a4a-dashboard';
+	const isDevelopmentSite = urlParams.get( 'referer' ) === 'a4a-dashboard';
 
 	// TODO: retrieve the actual agency name
 	const agencyName = 'MyCoolAgency';
@@ -107,7 +107,7 @@ const LaunchSite = () => {
 										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
 								  ) }
 						</p>
-						{ isDevelomentSite && (
+						{ isDevelopmentSite && (
 							<p>
 								{ translate(
 									'Once the site is launched, %(agencyName)s will be billed for this site in the next billing cycle.',
@@ -124,7 +124,7 @@ const LaunchSite = () => {
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
 					{
 						// TODO: add onClick handler
-						isDevelomentSite && (
+						isDevelopmentSite && (
 							<div className={ launchSiteClasses }>
 								<Button onClick={ null } disabled={ false }>
 									{ translate( 'Refer to client' ) }

--- a/client/my-sites/site-settings/site-visibility/styles.scss
+++ b/client/my-sites/site-settings/site-visibility/styles.scss
@@ -8,6 +8,8 @@
 }
 
 .site-settings__general-settings-launch-site-button {
+	margin-top: auto;
+	margin-bottom: auto;
 	margin-left: 20px;
 	white-space: nowrap;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8667.

## Proposed Changes

* add "Refer to client" button and copy related to free dev sites to the Launch panel if the `referer` URL parameter is set to `a4a-dashboard` (this is a temporary solution until we have related endpoint ready)

![Markup on 2024-08-20 at 11:54:01](https://github.com/user-attachments/assets/e2db31e3-d9cf-4601-b7d5-d12fc4793757)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out and build this PR with `yarn start`.
2. Navigate to http://calypso.localhost:3000/settings/general/{blog-id}?referer=a4a-dashboard (`blog-id` needs to be replaced with one of your blogs ID).
3. A new copy and a "Refer to client" button should be rendered (as can be seen in the screenshot).
4. Remove the `?referer=a4a-dashboard` parameter from the URL.
5. The new copy and the "Refer to client" button should be gone.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?