### PR TITLE
Global content areas - fix extra scrollbars on mobile, use css vars for more consistency.

### DIFF
--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -691,19 +691,16 @@
 .wpcom-site div.is-section-plugins.is-global-sidebar-visible {
 	&.focus-content .layout__content,
 	&.focus-sidebar .layout__content {
-		padding-bottom: 16px;
 		min-height: 100vh;
-
-		@include break-small {
-			padding-top: calc(var(--masterbar-height) + 16px);
-		}
+		padding-top: calc(var(--masterbar-height) + var(--content-padding-top));
+		padding-bottom: var(--content-padding-bottom);
 
 		@include break-medium {
 			padding-left: calc(var(--sidebar-width-max));
 			padding-right: 16px;
 
 			.main.a4a-layout.sites-dashboard.sites-dashboard__layout {
-				height: calc(100vh - var(--masterbar-height) - 32px);
+				height: calc(100vh - var(--masterbar-height) - var(--content-padding-bottom) - var(--content-padding-top));
 			}
 		}
 

--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -691,7 +691,7 @@
 .wpcom-site div.is-section-plugins.is-global-sidebar-visible {
 	&.focus-content .layout__content,
 	&.focus-sidebar .layout__content {
-		min-height: 100vh;
+		height: 100vh;
 		padding-top: calc(var(--masterbar-height) + var(--content-padding-top));
 		padding-bottom: var(--content-padding-bottom);
 

--- a/client/hosting/sites/components/dotcom-style.scss
+++ b/client/hosting/sites/components/dotcom-style.scss
@@ -59,11 +59,7 @@
 		}
 	}
 
-	height: calc(100vh - var(--masterbar-height));
-
-	@include break-small {
-		height: calc(100vh - var(--masterbar-height) - 32px);
-	}
+	height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 
 	.sites-site-favicon {
 		margin-right: 0;

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -3,7 +3,7 @@ body.is-section-me {
 	background: var(--studio-gray-0);
 
 	&.rtl .layout__content {
-		padding: calc(var(--masterbar-height) + 12px) calc(var(--sidebar-width-max)) 16px 16px;
+		padding: calc(var(--masterbar-height) + var(--content-padding-top)) calc(var(--sidebar-width-max)) var(--content-padding-bottom) 16px;
 	}
 
 	.layout__content {
@@ -12,7 +12,7 @@ body.is-section-me {
 		min-height: 100vh;
 		padding-bottom: 0;
 		@media only screen and (min-width: 782px) {
-			padding: calc(var(--masterbar-height) + 12px) 16px 16px calc(var(--sidebar-width-max)) !important;
+			padding: calc(var(--masterbar-height) + var(--content-padding-top)) 16px var(--content-padding-bottom) calc(var(--sidebar-width-max)) !important;
 		}
 		@media only screen and (max-width: 600px) {
 			background: var(--studio-white);
@@ -31,20 +31,15 @@ body.is-section-me {
 	}
 
 	div.layout.is-global-sidebar-visible {
-		.main {
-			padding: 24px;
-			border-block-end: 1px solid var(--studio-gray-0);
-		}
 		.layout__primary {
+			.main {
+				padding: 24px;
+				border-block-end: 1px solid var(--studio-gray-0);
+				height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
+			}
 			background: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
 			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
-			@media only screen and (min-width: 601px) {
-				height: calc(100vh - var(--masterbar-height) - 50px);
-			}
-			@media only screen and (min-width: 782px) {
-				height: calc(100vh - var(--masterbar-height) - 28px);
-			}
 			overflow-y: auto;
 			overflow-x: hidden;
 		}

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -179,6 +179,20 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
 			}
 
+			div.layout.is-global-sidebar-visible {
+				.layout__content {
+					padding-top: calc( var( --masterbar-height ) + var( --content-padding-top ) );
+					padding-bottom: var( --content-padding-bottom );
+				}
+				.layout__primary > main {
+					height: calc(
+						100vh - var( --masterbar-height ) - var( --content-padding-top ) - var(
+								--content-padding-bottom
+							)
+					);
+				}
+			}
+
 			@media only screen and ( min-width: 782px ) {
 				.is-global-sidebar-visible {
 					header.navigation-header {
@@ -190,7 +204,6 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						background: var( --color-surface );
 						border-radius: 8px;
 						box-shadow: 0px 0px 17.4px 0px rgba( 0, 0, 0, 0.05 );
-						height: calc( 100vh - var( --masterbar-height ) - 32px );
 						overflow: hidden;
 						max-width: none;
 					}
@@ -246,11 +259,6 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 				.domains-table-toolbar {
 					margin-inline: 0 !important;
 				}
-				div.layout.is-global-sidebar-visible {
-					.layout__primary > main {
-						height: calc( 100vh - var( --masterbar-height ) );
-					}
-				}
 			}
 
 			@media only screen and ( max-width: 781px ) {
@@ -286,11 +294,6 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 						td:first-child {
 							padding: 0 0 0 24px;
 						}
-					}
-				}
-				div.layout.is-global-sidebar-visible {
-					.layout__primary > main {
-						height: calc( 100vh - var( --masterbar-height ) - 48px );
 					}
 				}
 			}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -56,13 +56,9 @@ body.is-section-plugins {
 			background-color: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
 			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
-			height: calc(100vh - var(--masterbar-height));
+			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
 			overflow-y: auto;
-
-			@include break-medium {
-				height: calc(100vh - var(--masterbar-height) - 32px);
-			}
 		}
 
 		.plugins-browser,

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -69,6 +69,13 @@ $brand-text: "SF Pro Text", $sans;
 		--color-global-masterbar-submenu-hover-background: var(--studio-white);
 		--content-padding-top: 16px;
 		--content-padding-bottom: 16px;
+
+		&.focus-content .layout__content {
+			padding-top: calc(var(--masterbar-height) + var(--content-padding-top));
+			padding-bottom: var(--content-padding-bottom);
+			padding-right: 16px;
+			padding-left: 16px;
+		}
 	}
 
 	.is-global-sidebar-collapsed {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -67,6 +67,8 @@ $brand-text: "SF Pro Text", $sans;
 		--color-masterbar-submenu-hover-text: var(--color-accent);
 		--color-global-masterbar-submenu-background: var(--studio-white);
 		--color-global-masterbar-submenu-hover-background: var(--studio-white);
+		--content-padding-top: 16px;
+		--content-padding-bottom: 16px;
 	}
 
 	.is-global-sidebar-collapsed {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -14,7 +14,7 @@
 		.layout__content {
 			min-height: 100vh;
 			@media screen and (min-width: 782px) {
-				padding: calc(var(--masterbar-height) + 16px) 16px 16px var(--sidebar-width-max);
+				padding: calc(var(--masterbar-height) + var(--content-padding-top)) 16px var(--content-padding-bottom) var(--sidebar-width-max);
 			}
 		}
 
@@ -22,13 +22,9 @@
 			background-color: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
 			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
-			height: calc(100vh - var(--masterbar-height));
+			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
 			overflow-y: auto;
-
-			@include break-small {
-				height: calc(100vh - var(--masterbar-height) - 32px);
-			}
 		}
 
 		.navigation-header {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -66,15 +66,17 @@ body.is-section-reader {
 	background: var(--studio-gray-0);
 
 	&.rtl .layout__content {
-		padding: calc(var(--masterbar-height) + 16px) calc(var(--sidebar-width-max)) 16px 16px;
+		padding: calc(var(--masterbar-height) + var(--content-padding-top)) calc(var(--sidebar-width-max)) var(--content-padding-bottom) 16px;
 	}
 
 	.layout__content {
 		// Add border around everything
 		overflow: hidden;
 		min-height: 100vh;
+		padding-top: calc(var(--masterbar-height) + var(--content-padding-top));
+		padding-bottom: var(--content-padding-bottom);
 		@media only screen and (min-width: 782px) {
-			padding: calc(var(--masterbar-height) + 16px) 16px 16px calc(var(--sidebar-width-max)) !important;
+			padding: calc(var(--masterbar-height) + var(--content-padding-top)) 16px var(--content-padding-bottom) calc(var(--sidebar-width-max)) !important;
 		}
 		.layout_primary > div {
 			padding-bottom: 0;
@@ -86,7 +88,7 @@ body.is-section-reader {
 	}
 
 	.has-no-masterbar .layout__content .main {
-		padding-top: 16px;
+		padding-top: var(--content-padding-top);
 	}
 
 	@media only screen and (max-width: 600px) {
@@ -104,7 +106,7 @@ body.is-section-reader {
 			background: var(--color-surface);
 			margin: 0;
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			height: calc(100vh - 46px);
+			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 		}
 	}
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -11,12 +11,7 @@ body.is-section-reader {
 			background: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
 			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
-			@media only screen and (min-width: 600px) {
-				height: calc(100vh - var(--masterbar-height) - 50px);
-			}
-			@media only screen and (min-width: 782px) {
-				height: calc(100vh - var(--masterbar-height) - 32px);
-			}
+			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			overflow: hidden;
 		}
 		.layout__primary > div > div:not(.tags__header) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/93627

## Proposed Changes

Fixes various inconsistencies with `layout__content` and `layout_primary` padding and height settings that were causing extra scrollbars and various viewport widths in various global areas.

* Introduces css variables for `--content-padding-top` and `--content-padding-bottom` in the global areas that can be used for these related styles. That way we can always apply padding with these values, and calculate heights with these values as well (instead of having hard-coded magic numbers all over the place).
* Adapts the global pages to use the variables for determining padding and layout height.


BEFORE / AFTER

SITES
<img width="215" alt="Screenshot 2024-08-16 at 1 27 51 PM" src="https://github.com/user-attachments/assets/ec5f3f1e-aa9c-4e4b-a9c5-01893be1c37b"><img width="215" alt="Screenshot 2024-08-16 at 1 29 05 PM" src="https://github.com/user-attachments/assets/281f70e8-a58d-4e4c-9983-d7eafa77fdf9">

SIDEBAR
<img width="215" alt="Screenshot 2024-08-16 at 1 27 36 PM" src="https://github.com/user-attachments/assets/a8a51636-e123-4e83-8988-eb975ad0db81"><img width="215" alt="Screenshot 2024-08-16 at 1 29 33 PM" src="https://github.com/user-attachments/assets/338775ea-1c96-4be3-8dda-bfcb5fdc1432">

DOMAINS
<img width="215" alt="Screenshot 2024-08-16 at 1 27 29 PM" src="https://github.com/user-attachments/assets/e32aa3cb-c469-4d36-af16-4e6982440a9c"><img width="215" alt="Screenshot 2024-08-16 at 1 37 41 PM" src="https://github.com/user-attachments/assets/2a46a9d7-8d4e-4347-8f0a-6fa1ab12c378">

THEMES
<img width="215" alt="Screenshot 2024-08-16 at 1 28 31 PM" src="https://github.com/user-attachments/assets/c14d48d9-892b-41cf-834d-90e675764f08"><img width="215" alt="Screenshot 2024-08-16 at 1 29 27 PM" src="https://github.com/user-attachments/assets/1b87a4f6-a5da-4b82-814d-143531560989">

PLUGINS
<img width="215" alt="Screenshot 2024-08-16 at 1 28 39 PM" src="https://github.com/user-attachments/assets/ab0ac011-86b9-43e3-adff-4fd23af2b6e8"><img width="215" alt="Screenshot 2024-08-16 at 1 29 41 PM" src="https://github.com/user-attachments/assets/b18f0373-edbc-4ad9-b65e-6bfb8cb762af">

READER
<img width="215" alt="Screenshot 2024-08-16 at 1 28 01 PM" src="https://github.com/user-attachments/assets/20db4d0b-2fd7-4dbf-b739-3b7771de4741"><img width="215" alt="Screenshot 2024-08-16 at 1 29 13 PM" src="https://github.com/user-attachments/assets/fd834329-cfe2-45c9-8b75-d78032c2374c">


PROFILE
<img width="215" alt="Screenshot 2024-08-16 at 1 28 10 PM" src="https://github.com/user-attachments/assets/412e84e4-841d-45b7-b98f-65dc37585c6f"><img width="215" alt="Screenshot 2024-08-16 at 1 37 23 PM" src="https://github.com/user-attachments/assets/23614b3e-d8bf-4c72-8d8c-978d56d00d47">










## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix bug with extra scrollbars
* make development easier and more robust in the future around this. we can adapt padding definitions in one spot, and no longer have to apply changes in a multitude of css files due to padding changes for the global content frame.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test all global pages across various viewport widths.
* Verify the content frame remains as expected and there are no extra scrollbars.
* Test them in the same flow without reloading to verify there is no style bleed messing up any of these pages.
* Test them each with individual reloads to verify they are not dependent on any style bleed.
* Test the global sidebar in these areas and ensure it still scrollable when necessary.
* Smoke test other themes and plugin pages across calypso for regressions (site level and logged out).
* Smoke test other sidebars in calypso for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
