### PR TITLE
Fix performance profiler visual issues

### DIFF
--- a/client/performance-profiler/components/charts/history-chart.jsx
+++ b/client/performance-profiler/components/charts/history-chart.jsx
@@ -183,7 +183,7 @@ const generateSampleData = ( range ) => {
 const HistoryChart = ( { data, range, height, width } ) => {
 	const svgRef = createRef();
 	const tooltipRef = createRef();
-	const dataAvailable = data && data.length;
+	const dataAvailable = data && data.some( ( e ) => e.value !== null );
 
 	if ( ! dataAvailable ) {
 		data = generateSampleData( range );

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -36,12 +36,12 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 
 	const displayUnit = () => {
 		if ( [ 'lcp', 'fcp', 'ttfb' ].includes( activeTab ) ) {
-			return translate( 'seconds', { comment: 'Used for displaying a range, eg. 1-2 seconds' } );
+			return translate( 's', { comment: 'Used for displaying a time range in seconds, eg. 1-2s' } );
 		}
 
 		if ( [ 'inp' ].includes( activeTab ) ) {
-			return translate( 'milliseconds', {
-				comment: 'Used for displaying a range, eg. 100-200 millisenconds',
+			return translate( 'ms', {
+				comment: 'Used for displaying a range in milliseconds, eg. 100-200ms',
 			} );
 		}
 
@@ -81,8 +81,9 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 							<div className="range-description">
 								<div className="range-heading">{ translate( 'Fast' ) }</div>
 								<div className="range-subheading">
-									{ translate( '0–%(to)s %(unit)s', {
+									{ translate( '0–%(to)s%(unit)s', {
 										args: { to: formatUnit( good ), unit: displayUnit() },
+										comment: 'Displaying a time range, eg. 0-1s',
 									} ) }
 								</div>
 							</div>
@@ -92,12 +93,13 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 							<div className="range-description">
 								<div className="range-heading">{ translate( 'Moderate' ) }</div>
 								<div className="range-subheading">
-									{ translate( '%(from)s–%(to)s %(unit)s', {
+									{ translate( '%(from)s–%(to)s%(unit)s', {
 										args: {
 											from: formatUnit( good ),
 											to: formatUnit( needsImprovement ),
 											unit: displayUnit(),
 										},
+										comment: 'Displaying a time range, eg. 2-3s',
 									} ) }
 								</div>
 							</div>
@@ -107,11 +109,12 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 							<div className="range-description">
 								<div className="range-heading">{ translate( 'Slow' ) }</div>
 								<div className="range-subheading">
-									{ translate( '%(from)s+ %(unit)s', {
+									{ translate( '>%(from)s%(unit)s', {
 										args: {
 											from: formatUnit( needsImprovement ),
 											unit: displayUnit(),
 										},
+										comment: 'Displaying a time range, eg. >2s',
 									} ) }
 								</div>
 							</div>

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -59,6 +59,7 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 	// the comparison is inverse here because the last value is the most recent
 	const positiveTendency = metrics[ metrics.length - 1 ] < metrics[ 0 ];
 
+	const dataAvailable = metrics.length > 0 && metrics.some( ( item ) => item !== null );
 	const historicalData = metrics.map( ( item, index ) => {
 		return {
 			date: dates[ index ],
@@ -135,22 +136,26 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 					</p>
 				</div>
 				<div className="core-web-vitals-display__history-graph">
-					<span className="core-web-vitals-display__description-subheading">
-						{ positiveTendency
-							? translate( '%s has improved over the past eight weeks', { args: [ displayName ] } )
-							: translate( '%s has declined over the past eight weeks', {
-									args: [ displayName ],
-							  } ) }
-						<HistoryChart
-							data={ historicalData }
-							range={ [
-								formatUnit( metricsTresholds[ activeTab ].good ),
-								formatUnit( metricsTresholds[ activeTab ].needsImprovement ),
-							] }
-							width={ 550 }
-							height={ 300 }
-						/>
-					</span>
+					{ dataAvailable && (
+						<span className="core-web-vitals-display__description-subheading">
+							{ positiveTendency
+								? translate( '%s has improved over the past eight weeks', {
+										args: [ displayName ],
+								  } )
+								: translate( '%s has declined over the past eight weeks', {
+										args: [ displayName ],
+								  } ) }
+						</span>
+					) }
+					<HistoryChart
+						data={ dataAvailable && historicalData }
+						range={ [
+							formatUnit( metricsTresholds[ activeTab ].good ),
+							formatUnit( metricsTresholds[ activeTab ].needsImprovement ),
+						] }
+						width={ 550 }
+						height={ 300 }
+					/>
 				</div>
 			</div>
 		</div>

--- a/client/performance-profiler/components/metric-scale/index.tsx
+++ b/client/performance-profiler/components/metric-scale/index.tsx
@@ -37,7 +37,7 @@ export const MetricScale = ( { metricName, value, valuation }: Props ) => {
 					className={ clsx( 'bar-section bad', { active: valuation === 'bad' } ) }
 					style={ { width: `${ ( ( bad - needsImprovement ) / bad ) * 100 }%` } }
 				></div>
-				<div className="dot" style={ { left: `${ ( value / bad ) * 100 }%` } }>
+				<div className="dot" style={ { left: `${ value > bad ? 100 : ( value / bad ) * 100 }%` } }>
 					<div className="label">{ formatValue( value ) }</div>
 				</div>
 			</div>

--- a/client/performance-profiler/components/metric-scale/index.tsx
+++ b/client/performance-profiler/components/metric-scale/index.tsx
@@ -1,7 +1,7 @@
 import './style.scss';
 import clsx from 'clsx';
 import { Valuation } from 'calypso/performance-profiler/types/performance-metrics';
-import { metricsTresholds } from 'calypso/performance-profiler/utils/metrics';
+import { metricsTresholds, max2Decimals } from 'calypso/performance-profiler/utils/metrics';
 
 type Props = {
 	metricName: string;
@@ -14,10 +14,14 @@ export const MetricScale = ( { metricName, value, valuation }: Props ) => {
 		metricsTresholds[ metricName as keyof typeof metricsTresholds ];
 
 	const formatValue = ( value: number ): string => {
-		if ( [ 'lcp', 'fcp', 'ttfb' ].includes( metricName ) ) {
-			return `${ +( value / 1000 ).toFixed( 2 ) }`;
+		if ( value === null || value === undefined ) {
+			return '';
 		}
-		return `${ value }`;
+
+		if ( [ 'lcp', 'fcp', 'ttfb' ].includes( metricName ) ) {
+			return `${ max2Decimals( value / 1000 ) }`;
+		}
+		return `${ max2Decimals( value ) }`;
 	};
 
 	return (

--- a/client/performance-profiler/components/metric-tab-bar/index.tsx
+++ b/client/performance-profiler/components/metric-tab-bar/index.tsx
@@ -18,25 +18,30 @@ export const MetricTabBar = ( props: Props ) => {
 
 	return (
 		<div className="metric-tab-bar">
-			{ Object.entries( metricsNames ).map( ( [ key, { displayName } ] ) => (
-				<button
-					key={ key }
-					className={ clsx( 'metric-tab-bar__tab', { active: key === activeTab } ) }
-					onClick={ () => setActiveTab( key as Metrics ) }
-				>
-					<div className="metric-tab-bar__tab-status">
-						<StatusIndicator
-							speed={ mapThresholdsToStatus( key as Metrics, props[ key as Metrics ] ) }
-						/>
-					</div>
-					<div className="metric-tab-bar__tab-text">
-						<div className="metric-tab-bar__tab-header">{ displayName }</div>
-						<div className="metric-tab-bar__tab-metric">
-							{ displayValue( key as Metrics, props[ key as Metrics ] ) }
+			{ Object.entries( metricsNames ).map( ( [ key, { displayName } ] ) => {
+				if ( props[ key as Metrics ] === undefined || props[ key as Metrics ] === null ) {
+					return null;
+				}
+				return (
+					<button
+						key={ key }
+						className={ clsx( 'metric-tab-bar__tab', { active: key === activeTab } ) }
+						onClick={ () => setActiveTab( key as Metrics ) }
+					>
+						<div className="metric-tab-bar__tab-status">
+							<StatusIndicator
+								speed={ mapThresholdsToStatus( key as Metrics, props[ key as Metrics ] ) }
+							/>
 						</div>
-					</div>
-				</button>
-			) ) }
+						<div className="metric-tab-bar__tab-text">
+							<div className="metric-tab-bar__tab-header">{ displayName }</div>
+							<div className="metric-tab-bar__tab-metric">
+								{ displayValue( key as Metrics, props[ key as Metrics ] ) }
+							</div>
+						</div>
+					</button>
+				);
+			} ) }
 		</div>
 	);
 };

--- a/client/performance-profiler/pages/dashboard/style.scss
+++ b/client/performance-profiler/pages/dashboard/style.scss
@@ -5,6 +5,11 @@
 	.main {
 		padding: 0;
 	}
+
+	.lpc-footer-nav-container a,
+	.lpc-footer-automattic-nav a {
+		text-decoration: none;
+	}
 }
 
 .performance-profiler-content {

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -118,7 +118,7 @@ export const mapThresholdsToStatus = ( metric: Metrics, value: number ): Valuati
 	return 'bad';
 };
 
-export const max2Decimals = ( val: number ) => +val.toFixed( 2 );
+export const max2Decimals = ( val: number ) => +Number( val ).toFixed( 2 );
 
 export const displayValue = ( metric: Metrics, value: number ): string => {
 	if ( value === null || value === undefined ) {

--- a/client/performance-profiler/utils/metrics.ts
+++ b/client/performance-profiler/utils/metrics.ts
@@ -118,14 +118,20 @@ export const mapThresholdsToStatus = ( metric: Metrics, value: number ): Valuati
 	return 'bad';
 };
 
+export const max2Decimals = ( val: number ) => +val.toFixed( 2 );
+
 export const displayValue = ( metric: Metrics, value: number ): string => {
+	if ( value === null || value === undefined ) {
+		return '';
+	}
+
 	if ( [ 'lcp', 'fcp', 'ttfb' ].includes( metric ) ) {
-		return `${ ( value / 1000 ).toFixed( 2 ) }s`;
+		return `${ max2Decimals( value / 1000 ) }s`;
 	}
 
 	if ( [ 'inp', 'fid' ].includes( metric ) ) {
-		return `${ value }ms`;
+		return `${ max2Decimals( value ) }ms`;
 	}
 
-	return `${ value }`;
+	return `${ max2Decimals( value ) }`;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8760

## Proposed Changes

* Put the dot at the end of the metric scale if the value is too high
* Remove link text decorations in the footer
* Change metric scale explanations to shorhands (seconds -> s, milliseconds -> ms)
* Limit tab metric displays to 2 decimal places
* Handle no historical data being available correctly
* Hide tab id there's no data available

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a URL for which there's no available data for some metrics. I used vilagoklangja.hu, eg `/speed-test-tool?url=https%3A%2F%2Fvilagoklangja.hu%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6Njk0Mn0.mTAXRxC_AKF3TPnxDZfW9rvrIHKy04T4BIl-CM2KBHI&tab=desktop`
* Check that the Interactivity tab is not rendered
* Check that the tabs render with 2 decimal places max
* Check that the history graph shows the default state where there's no data available
* Check the updated metric scale explanations
* Go to `/speed-test-tool?url=example.com`
* Check for regressions

| Area | Before | After |
|--------|--------|--------|
| Metric tab without data | ![CleanShot 2024-08-16 at 16 13 34@2x1](https://github.com/user-attachments/assets/fd55e4e3-9577-4928-9b43-f2cf2b7ead28) | ![CleanShot 2024-08-16 at 16 16 05@2x1](https://github.com/user-attachments/assets/31a56dd2-793f-4085-a7af-56ebc43641e2) |
| Metric tab decimal places | ![CleanShot 2024-08-16 at 16 13 34@2x2](https://github.com/user-attachments/assets/b1014e15-9a13-477a-aa79-6a5c90fe5f58) | ![CleanShot 2024-08-16 at 16 16 05@2x2](https://github.com/user-attachments/assets/c697a552-8254-4559-99c6-8dab61d66302) |
| History graph default state | ![CleanShot 2024-08-16 at 16 13 34@2x3](https://github.com/user-attachments/assets/265f246d-d3ef-4ff6-8258-4be56645daba) | ![CleanShot 2024-08-16 at 16 16 05@2x3](https://github.com/user-attachments/assets/931abc6c-5703-4f92-95fc-da63c715d5ec) |
| Metric scale explanations | ![CleanShot 2024-08-16 at 16 21 01@2x](https://github.com/user-attachments/assets/fe8dc73a-df2e-4945-9913-dd32a68315c7) | ![CleanShot 2024-08-16 at 16 21 01@2x](https://github.com/user-attachments/assets/e668ff1d-5a70-414c-a491-ec4ba7977abe) |
| Footer links | <img width="999" alt="image" src="https://github.com/user-attachments/assets/74b2c1f4-a753-4879-b840-bc7b76f2e99f"> | ![CleanShot 2024-08-16 at 16 23 23@2x](https://github.com/user-attachments/assets/856ae94e-f53c-46ce-9e81-3c61b6813123) |
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
