### PR TITLE
Performance Profiler: Add the Tip component on the insights section

### DIFF
--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -17,8 +17,12 @@ export const InsightsSection = ( props: InsightsSectionProps ) => {
 			<p className="subtitle">
 				{ translate( 'We found things you can do to speed up your site.' ) }
 			</p>
-			{ Object.values( audits ).map( ( audit, index ) => (
-				<MetricsInsight key={ `insight-${ index }` } insight={ audit } index={ index } />
+			{ Object.keys( audits ).map( ( key, index ) => (
+				<MetricsInsight
+					key={ `insight-${ index }` }
+					insight={ { ...audits[ key ], id: key } }
+					index={ index }
+				/>
 			) ) }
 		</div>
 	);

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -77,6 +77,13 @@ $blueberry-color: #3858e9;
 		}
 
 		.foldable-card__content {
+			.description-area {
+				display: flex;
+				align-items: flex-start;
+				gap: 32px;
+				align-self: stretch;
+			}
+
 			.metrics-insight-detailed-content {
 				margin-top: 24px;
 

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -4,7 +4,9 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
+import { Tip } from 'calypso/performance-profiler/components/tip';
 import { useSupportChatLLMQuery } from 'calypso/performance-profiler/hooks/use-support-chat-llm-query';
+import { tips } from 'calypso/performance-profiler/utils/tips';
 import { InsightContent } from './insight-content';
 import { InsightHeader } from './insight-header';
 
@@ -67,6 +69,7 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 		insight.description ?? '',
 		isEnabled( 'performance-profiler/llm' ) && retrieveInsight
 	);
+	const tip = tips[ insight.id ];
 
 	return (
 		<Card
@@ -89,6 +92,7 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 						...insight,
 						...( isEnabled( 'performance-profiler/llm' ) ? { description: llmAnswer } : {} ),
 					} }
+					secondaryArea={ tip && <Tip { ...tip } /> }
 					isLoading={ isEnabled( 'performance-profiler/llm' ) && isLoadingLlmAnswer }
 				/>
 			</Content>

--- a/client/performance-profiler/components/metrics-insight/insight-content.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-content.tsx
@@ -5,6 +5,7 @@ import { InsightDetailedContent } from './insight-detailed-content';
 
 interface InsightContentProps {
 	data: PerformanceMetricsItemQueryResponse;
+	secondaryArea?: React.ReactNode;
 	isLoading?: boolean;
 }
 
@@ -19,15 +20,20 @@ export const InsightContent: React.FC< InsightContentProps > = ( props ) => {
 				translate( 'Looking for the best solution…' )
 			) : (
 				<>
-					<Markdown
-						components={ {
-							a( props ) {
-								return <a target="_blank" { ...props } />;
-							},
-						} }
-					>
-						{ description }
-					</Markdown>
+					<div className="description-area">
+						<div className="content">
+							<Markdown
+								components={ {
+									a( props ) {
+										return <a target="_blank" { ...props } />;
+									},
+								} }
+							>
+								{ description }
+							</Markdown>
+						</div>
+						{ props.secondaryArea }
+					</div>
 					{ data.details?.type && (
 						<div className="metrics-insight-detailed-content">
 							<InsightDetailedContent data={ data.details } />

--- a/client/performance-profiler/components/tip/index.tsx
+++ b/client/performance-profiler/components/tip/index.tsx
@@ -1,0 +1,27 @@
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+
+type TipProps = {
+	title: string;
+	content: string;
+	link?: string;
+	linkText?: string;
+};
+
+export const Tip = ( { title, content, link, linkText }: TipProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<div className="performance-profiler-tip">
+			<h4>{ title }</h4>
+			<p>{ content }</p>
+			{ link && (
+				<p className="learn-more-link">
+					<a href={ link } target="_blank" rel="noreferrer">
+						{ linkText ?? translate( 'Learn more ↗' ) }
+					</a>
+				</p>
+			) }
+		</div>
+	);
+};

--- a/client/performance-profiler/components/tip/index.tsx
+++ b/client/performance-profiler/components/tip/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 
-type TipProps = {
+export type TipProps = {
 	title: string;
 	content: string;
 	link?: string;

--- a/client/performance-profiler/components/tip/style.scss
+++ b/client/performance-profiler/components/tip/style.scss
@@ -1,0 +1,22 @@
+.performance-profiler-tip {
+	max-width: 460px;
+	background-color: #e7f0fa;
+	padding: 25px;
+	margin-top: 65px;
+
+	h4 {
+		font-size: $font-body-small;
+		font-weight: 500;
+		line-height: $font-title-small;
+		margin-bottom: 10px;
+	}
+
+	p {
+		font-size: $font-body-small;
+		margin-bottom: 0;
+	}
+
+	.learn-more-link {
+		margin-top: 20px;
+	}
+}

--- a/client/performance-profiler/components/tip/style.scss
+++ b/client/performance-profiler/components/tip/style.scss
@@ -2,7 +2,7 @@
 	max-width: 460px;
 	background-color: #e7f0fa;
 	padding: 25px;
-	margin-top: 65px;
+	min-width: 300px;
 
 	h4 {
 		font-size: $font-body-small;

--- a/client/performance-profiler/pages/dashboard/style.scss
+++ b/client/performance-profiler/pages/dashboard/style.scss
@@ -1,3 +1,5 @@
+$blueberry-color: #3858e9;
+
 .is-group-performance-profiler .layout__content {
 	padding: 0;
 	background: #fff;
@@ -17,6 +19,25 @@
 }
 
 .peformance-profiler-dashboard-container {
+	a {
+		color: $blueberry-color;
+
+		&:hover {
+			color: darken($blueberry-color, 10%);
+			text-decoration: underline;
+		}
+
+		&.is-primary {
+			color: #fff;
+			background-color: $blueberry-color;
+			border-radius: 4px;
+
+			&:hover:not(:disabled) {
+				background-color: darken($blueberry-color, 10%);
+			}
+		}
+	}
+
 	.l-block-wrapper {
 		margin: 0 auto;
 		max-width: 1056px;

--- a/client/performance-profiler/pages/loading-screen/index.tsx
+++ b/client/performance-profiler/pages/loading-screen/index.tsx
@@ -3,6 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import { Tip } from 'calypso/performance-profiler/components/tip';
 import { LayoutBlock } from 'calypso/site-profiler/components/layout';
 
 interface LoadingScreenProps {
@@ -110,29 +111,6 @@ const StyledLoadingScreen = styled.div`
 	}
 `;
 
-const FootNote = styled.div`
-	max-width: 460px;
-	background-color: #e7f0fa;
-	padding: 25px;
-	margin-top: 65px;
-
-	h4 {
-		font-size: 14px;
-		font-weight: 500;
-		line-height: 20px;
-		margin-bottom: 10px;
-	}
-
-	p {
-		font-size: 14px;
-		margin-bottom: 0;
-	}
-
-	.learn-more-link {
-		margin-top: 20px;
-	}
-`;
-
 export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 	const translate = useTranslate();
 	const [ step, setStep ] = useState( 0 );
@@ -229,17 +207,11 @@ export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 					</span>
 				) ) }
 				{ tips[ currentTip ] && (
-					<FootNote>
-						<h4>{ tips[ currentTip ].heading }</h4>
-						<p>{ tips[ currentTip ].description }</p>
-						{ tips[ currentTip ].link && (
-							<p className="learn-more-link">
-								<a href={ tips[ currentTip ].link } target="_blank" rel="noreferrer">
-									{ translate( 'Learn more ↗' ) }
-								</a>
-							</p>
-						) }
-					</FootNote>
+					<Tip
+						title={ tips[ currentTip ].heading }
+						content={ tips[ currentTip ].description }
+						link={ tips[ currentTip ].link }
+					/>
 				) }
 			</StyledLoadingScreen>
 		</LayoutBlock>

--- a/client/performance-profiler/pages/loading-screen/index.tsx
+++ b/client/performance-profiler/pages/loading-screen/index.tsx
@@ -111,6 +111,10 @@ const StyledLoadingScreen = styled.div`
 	}
 `;
 
+const TipContainer = styled.div`
+	margin-top: 65px;
+`;
+
 export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 	const translate = useTranslate();
 	const [ step, setStep ] = useState( 0 );
@@ -207,11 +211,13 @@ export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 					</span>
 				) ) }
 				{ tips[ currentTip ] && (
-					<Tip
-						title={ tips[ currentTip ].heading }
-						content={ tips[ currentTip ].description }
-						link={ tips[ currentTip ].link }
-					/>
+					<TipContainer>
+						<Tip
+							title={ tips[ currentTip ].heading }
+							content={ tips[ currentTip ].description }
+							link={ tips[ currentTip ].link }
+						/>
+					</TipContainer>
 				) }
 			</StyledLoadingScreen>
 		</LayoutBlock>

--- a/client/performance-profiler/utils/tips.ts
+++ b/client/performance-profiler/utils/tips.ts
@@ -1,0 +1,13 @@
+import { translate } from 'i18n-calypso';
+import { TipProps } from '../components/tip';
+
+export const tips: Record< string, TipProps > = {
+	'uses-responsive-images': {
+		title: translate( 'Did you know?' ),
+		content: translate(
+			'WordPress.com automatically optimizes images and delivers them using a Global CDN to ensure they load lightning fast.'
+		),
+		linkText: translate( 'Migrate your site' ),
+		link: 'https://wordpress.com/setup/hosted-site-migration?ref=performance-profiler-dashboard',
+	},
+};


### PR DESCRIPTION

## Proposed Changes

* Create a Tip component
* Use it on the Loading Screen
* Add it to the Insights section

Currently this is only shown on the `Properly size images` recommendation

## Why are these changes being made?

To show tips on predetermined insights.

## Testing Instructions

* Go to `/speed-test-tool?url=https%3A%2F%2Fwordpress.com`
* Go to the Insights section
* Open the `Properly size images` recommendation
* Check if the `Did you know` box is being shown 


![CleanShot 2024-08-16 at 12 18 55@2x](https://github.com/user-attachments/assets/522a4065-9cc7-480d-8f5f-a032286b976c)
