### PR TITLE
Add newsletter banner component

### DIFF
--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -4,6 +4,7 @@ import { CoreWebVitalsDisplay } from 'calypso/performance-profiler/components/co
 import { Disclaimer } from 'calypso/performance-profiler/components/disclaimer-section';
 import { InsightsSection } from 'calypso/performance-profiler/components/insights-section';
 import { MigrationBanner } from 'calypso/performance-profiler/components/migration-banner';
+import { NewsletterBanner } from 'calypso/performance-profiler/components/newsletter-banner';
 import { PerformanceScore } from 'calypso/performance-profiler/components/performance-score';
 import { ScreenshotThumbnail } from 'calypso/performance-profiler/components/screenshot-thumbnail';
 import { ScreenshotTimeline } from 'calypso/performance-profiler/components/screenshot-timeline';
@@ -39,6 +40,7 @@ export const PerformanceProfilerDashboardContent = ( {
 					ttfb={ ttfb }
 					history={ history }
 				/>
+				<NewsletterBanner />
 				<ScreenshotTimeline screenshots={ screenshots ?? [] } />
 				{ audits && <InsightsSection audits={ audits } /> }
 			</div>

--- a/client/performance-profiler/components/newsletter-banner.tsx
+++ b/client/performance-profiler/components/newsletter-banner.tsx
@@ -23,6 +23,14 @@ const Body = styled.div`
 	color: var( --studio-gray-70 );
 `;
 
+const BlueberryButton = styled( Button )`
+	// && is needed for specificity
+	&& {
+		background: #3858e9;
+		border-color: #3858e9;
+	}
+`;
+
 export const NewsletterBanner = () => {
 	const translate = useTranslate();
 
@@ -37,7 +45,9 @@ export const NewsletterBanner = () => {
 				</Body>
 				<Body>{ translate( 'All you need is a free WordPress.com account to get started.' ) }</Body>
 			</div>
-			<Button variant="primary">{ translate( 'Sign up for email reports' ) }</Button>
+			<BlueberryButton variant="primary">
+				{ translate( 'Sign up for email reports' ) }
+			</BlueberryButton>
 		</Container>
 	);
 };

--- a/client/performance-profiler/components/newsletter-banner.tsx
+++ b/client/performance-profiler/components/newsletter-banner.tsx
@@ -4,13 +4,16 @@ import { useTranslate } from 'i18n-calypso';
 
 const Container = styled.div`
 	background-color: #f7f8fe;
-	padding: 24px;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
 	gap: 24px;
 	justify-content: space-between;
 	width: 100%;
+
+	& > * {
+		margin: 24px;
+	}
 `;
 
 const Heading = styled.div`

--- a/client/performance-profiler/components/newsletter-banner.tsx
+++ b/client/performance-profiler/components/newsletter-banner.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+const Container = styled.div`
+	background-color: #f7f8fe;
+	padding: 24px;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 24px;
+	justify-content: space-between;
+	width: 100%;
+`;
+
+const Heading = styled.div`
+	font-weight: 500;
+	line-height: 24px;
+	text-align: left;
+`;
+
+const Body = styled.div`
+	color: var( --studio-gray-70 );
+`;
+
+export const NewsletterBanner = () => {
+	const translate = useTranslate();
+
+	return (
+		<Container>
+			<div>
+				<Heading>{ translate( 'Sign up for weekly performance reports—it’s free!' ) }</Heading>
+				<Body>
+					{ translate(
+						'Monitor your site’s key performance metrics with a free report delivered to your inbox each week.'
+					) }
+				</Body>
+				<Body>{ translate( 'All you need is a free WordPress.com account to get started.' ) }</Body>
+			</div>
+			<Button variant="primary">{ translate( 'Sign up for email reports' ) }</Button>
+		</Container>
+	);
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8562

## Proposed Changes

* added the newsletter banner component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test-tool?url=example.com`
* Check that the newsletter banner component is rendered

![CleanShot 2024-08-16 at 17 32 34@2x](https://github.com/user-attachments/assets/e5e27490-dc31-4e23-84fe-7389da152c34)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
