### PR TITLE
Automated Migration: Fix the error state on the credentials step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -128,6 +128,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									render={ ( { field } ) => (
 										<FormTextInput
 											id="site-address"
+											isError={ !! errors.siteAddress }
 											placeholder={ translate( 'Enter your WordPress site address.' ) }
 											type="text"
 											{ ...field }
@@ -157,6 +158,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 											<FormTextInput
 												id="username"
 												type="text"
+												isError={ !! errors.username }
 												placeholder={ translate( 'Username' ) }
 												{ ...field }
 											/>
@@ -175,6 +177,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 											<FormTextInput
 												id="password"
 												type="password"
+												isError={ !! errors.password }
 												placeholder={ translate( 'Password' ) }
 												{ ...field }
 											/>
@@ -206,6 +209,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 									render={ ( { field } ) => (
 										<FormTextInput
 											type="text"
+											isError={ !! errors.backupFileLocation }
 											placeholder={ translate( 'Enter your backup file location' ) }
 											{ ...field }
 										/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #93535

## Proposed Changes

* Changes the input's border color to red when there's an error.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I missed adding the `isError` property back with the updates on the Credentials step. This way, we lost a key design change, which updated the border color of the inputs to red on having an error related to it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch to your local environment or add use the Calypso Live link below.
* Open the dev console and activate the feature flag by running the following command:
```
window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')
```
* Now go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Now input some invalid URL value on the source address input and leave the username or the password empty
  * Click on submit, the validation errors should be shown, and the input should be red
  * Now, click on the "Backup file" radio under `How can we access your site?`
  * Add an invalid URL to the backup file input and press `Continue`
  * You should see the validation error for that input, and it should be red

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
