### PR TITLE
Update title in the confirmation step of the assisted migration

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -1,4 +1,4 @@
-import { useLocale } from '@automattic/i18n-utils';
+import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
@@ -20,6 +20,7 @@ import { useSubmitMigrationTicket } from './hooks/use-submit-migration-ticket';
 
 const ImporterMigrateMessage: Step = () => {
 	const locale = useLocale();
+	const hasEnTranslation = useHasEnTranslation();
 	const user = useSelector( getCurrentUser ) as UserData;
 	const siteSlugParam = useSiteSlugParam();
 	const fromUrl = useQuery().get( 'from' ) || '';
@@ -38,11 +39,15 @@ const ImporterMigrateMessage: Step = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
+	const title = hasEnTranslation( "We'll take it from here!" )
+		? __( "We'll take it from here!" )
+		: __( 'Let us take it from here!' );
+
 	return (
 		<StepContainer
 			stepName="migration-message"
 			hideBack
-			formattedHeader={ <FormattedHeader headerText={ __( 'Let us take it from here!' ) } /> }
+			formattedHeader={ <FormattedHeader headerText={ title } /> }
 			isHorizontalLayout={ false }
 			stepContent={
 				<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93307

## Proposed Changes

* Update title in the confirmation step of the assisted migration.
  * The main approach we were using in other steps were to create a wrapper component and change only the title. In this case, I just updated the original step instead since it would make sense in this case. p1723833680495009-slack-C07FPA0R0KB

<img width="1231" alt="Screenshot 2024-08-16 at 15 58 46" src="https://github.com/user-attachments/assets/9d12215c-864c-455c-b87e-c39500a45407">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/setup/migration
* Choose a WordPress migration.
* Use the option "Do it for me".
* And navigate until the confirmation step.
* Make sure the title was changed to "We'll take it from here!".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?