### PR TITLE
Increase resources for desktop Linux CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ jobs:
     # version to keep this one working for now.
       - image: cimg/node:20.8.1-browsers
     <<: *desktop_defaults
+    resource_class: medium+
     shell: /bin/bash --login
     environment:
       CONFIG_ENV: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
     <<: *desktop_defaults
     environment:
       VERSION: << pipeline.git.tag >>
-      PLAYWRIGHT_SKIP_DOWNLOAD: true
+      PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
     working_directory: ~/wp-calypso
     steps:
       - checkout
@@ -173,7 +173,7 @@ jobs:
     working_directory: /Users/distiller/wp-calypso
     environment:
       CONFIG_ENV: release
-      PLAYWRIGHT_SKIP_DOWNLOAD: true
+      PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
     steps:
       - checkout
       - attach_workspace:
@@ -252,7 +252,7 @@ jobs:
     shell: /bin/bash --login
     environment:
       CONFIG_ENV: release
-      PLAYWRIGHT_SKIP_DOWNLOAD: true
+      PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
     steps:
       - checkout
       - attach_workspace:
@@ -321,7 +321,7 @@ jobs:
     working_directory: C:\Users\circleci\wp-calypso
     environment:
       CONFIG_ENV: release
-      PLAYWRIGHT_SKIP_DOWNLOAD: true
+      PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Increases the [resource class](https://circleci.com/docs/configuration-reference/#docker-execution-environment) for the Docker container that runs the builds for desktop Linux in CircleCI.

ref: pdnsEh-1OD-p2

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Builds were failing most of the time (but not all the time), and `exit code 129` was being thrown from the build process abruptly.
* The Resources graph in CircleCI showed 100% RAM usage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that `wp-desktop-linux` ran successfully in CI.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

N/A - this is an update to CI only.

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?