### PR TITLE
Launchpad: Add an `a` link hover to pending tasks and completed enabled styles

### DIFF
--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -203,6 +203,8 @@
 // pending tasks and completed enabled
 .checklist-item__task.completed.enabled > button:hover,
 .checklist-item__task.pending > button:hover,
+.checklist-item__task.completed.enabled > a:hover,
+.checklist-item__task.pending > a:hover,
 .checklist-item__task.completed.enabled > a:focus,
 .checklist-item__task.pending > a:focus {
 	.checklist-item__text {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8742

## Proposed Changes

* This PR adds an `a` link hover state to pending and completed enabled tasks on the Launchpad.
* Note that disabled tasks do not receive this hover state.

Before | After
--|--
<video src="https://github.com/user-attachments/assets/549c52d8-c97e-4f4b-af58-628afe7fb12d" > | <video src="https://github.com/user-attachments/assets/681858b4-a9f9-4c71-b5ff-7bd1b7bfac64" >





## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency in design and UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start and create a new site with a free domain and free plan.
* Select "Choose a theme" and select "Twenty Twenty Four". Be sure to pick a "Style variation" and in the popup select "Decide later".
* On the "Let's get ready to launch!" screen you should see the style change when you hover over "Select a design" and "Choose a plan".
* You can confirm that "disabled" tasks do not change on hover by starting a Newsletter with your main WordPress account here: https://wordpress.com/setup/newsletter/?ref=newsletter-lp
* Select all the free options.
* When you get to the Launchpad "Verify email address" should be disabled (because you've already done this before) and when you hover over it, nothing about the style should change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
