### PR TITLE
Fixes spacing for hundred year plans

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-setup/styles.scss
@@ -3,9 +3,7 @@
 @import "../hundred-year-plan-step-wrapper/mixins";
 
 .hundred-year-plan.step-route {
-	@media (max-width: 600px) {
-		margin-top: -60px;
-	}
+	margin-top: -60px;
 }
 
 .hundred-year-plan-setup {


### PR DESCRIPTION
## Proposed Changes

Earlier I fixed [an issue](https://github.com/Automattic/wp-calypso/pull/93621) that effected the hundred year domains flow on mobile. It introduced a bug further in the flow. This PR fixes it across the entire flow.  


**Before**
<img width="1783" alt="image" src="https://github.com/user-attachments/assets/3c495f6f-6713-486c-943e-f35371cc726f">

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/5967efa5-8a41-4a4c-84ed-0a39398dee0f">

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/7796a5c8-b47e-4300-bddf-a970f068108b">

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/a6f55906-fabe-486e-b422-66b22b59d80a">



**After**

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/f96fb0c5-8aab-4121-8642-01cf132a78ce">

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/115c7fb2-a8e0-4d2c-a05c-5c243bf3948e">

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/921940e4-49a1-4869-9406-ae28da50dee3">

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/ef8a7691-cc3e-45eb-b07a-77145fe82807">


## Testing Instructions

Visit /setup/hundred-year-plan/new-or-existing-site and test it at different breakpoints.