### PR TITLE
Remove all sites hint popover

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -4,7 +4,6 @@ import page from '@automattic/calypso-router';
 import { PromptIcon } from '@automattic/command-palette';
 import { Button, Popover } from '@automattic/components';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
-import { Button as WPButton } from '@wordpress/components';
 import { Icon, category } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -67,7 +66,6 @@ import Notifications from './masterbar-notifications/notifications-button';
 
 const NEW_MASTERBAR_SHIPPING_DATE = new Date( 2022, 3, 14 ).getTime();
 const MENU_POPOVER_PREFERENCE_KEY = 'dismissible-card-masterbar-collapsable-menu-popover';
-const ALL_SITES_POPOVER_PREFERENCE_KEY = 'dismissible-card-masterbar-all-sites-popover';
 
 const MOBILE_BREAKPOINT = '<480px';
 const IS_RESPONSIVE_MENU_BREAKPOINT = '<782px';
@@ -80,7 +78,6 @@ class MasterbarLoggedIn extends Component {
 		isResponsiveMenu: isWithinBreakpoint( IS_RESPONSIVE_MENU_BREAKPOINT ),
 		// making the ref a state triggers a re-render when it changes (needed for popover)
 		menuBtnRef: null,
-		allSitesBtnRef: null,
 	};
 
 	static propTypes = {
@@ -96,7 +93,6 @@ class MasterbarLoggedIn extends Component {
 		isCheckoutFailed: PropTypes.bool,
 		isInEditor: PropTypes.bool,
 		hasDismissedThePopover: PropTypes.bool,
-		hasDismissedAllSitesPopover: PropTypes.bool,
 		isUserNewerThanNewNavigation: PropTypes.bool,
 		loadHelpCenterIcon: PropTypes.bool,
 		isGlobalSidebarVisible: PropTypes.bool,
@@ -288,18 +284,7 @@ class MasterbarLoggedIn extends Component {
 
 	// will render as back button on mobile and in editor
 	renderMySites() {
-		const {
-			domainOnlySite,
-			siteSlug,
-			translate,
-			section,
-			sectionGroup,
-			currentRoute,
-			isFetchingPrefs,
-			hasDismissedAllSitesPopover,
-			isGlobalSidebarVisible,
-		} = this.props;
-		const { allSitesBtnRef } = this.state;
+		const { domainOnlySite, siteSlug, translate, section, currentRoute } = this.props;
 
 		const mySitesUrl = domainOnlySite
 			? domainManagementList( siteSlug, currentRoute, true )
@@ -312,51 +297,17 @@ class MasterbarLoggedIn extends Component {
 		}
 
 		return (
-			<>
-				<Item
-					className="masterbar__item-my-sites"
-					url={ mySitesUrl }
-					tipTarget="my-sites"
-					icon={ icon }
-					onClick={ this.clickMySites }
-					isActive={ this.isMySitesActive() }
-					tooltip={ translate( 'Manage your sites' ) }
-					preloadSection={ this.preloadMySites }
-					ref={ ( ref ) => ref !== allSitesBtnRef && this.setState( { allSitesBtnRef: ref } ) }
-					hasGlobalBorderStyle
-				/>
-				{ allSitesBtnRef && (
-					<Popover
-						className="masterbar__all-sites-popover"
-						isVisible={
-							sectionGroup === 'sites' &&
-							! isGlobalSidebarVisible &&
-							! isFetchingPrefs &&
-							! hasDismissedAllSitesPopover
-						}
-						context={ allSitesBtnRef }
-						position="bottom left"
-						showDelay={ 500 }
-						ignoreViewportSize
-					>
-						<h1 className="masterbar__all-sites-popover-heading">
-							{ translate( 'All your sites', {
-								comment: 'This is a popover title under the masterbar',
-							} ) }
-						</h1>
-						<p className="masterbar__all-sites-popover-description">
-							{ translate(
-								'Click on the WordPress.com logo to access your sites, domains, account settings, and more.'
-							) }
-						</p>
-						<div className="masterbar__all-sites-popover-actions">
-							<WPButton isPrimary onClick={ this.dismissLogoPopover }>
-								{ translate( 'Got it', { comment: 'Got it, as in OK' } ) }
-							</WPButton>
-						</div>
-					</Popover>
-				) }
-			</>
+			<Item
+				className="masterbar__item-my-sites"
+				url={ mySitesUrl }
+				tipTarget="my-sites"
+				icon={ icon }
+				onClick={ this.clickMySites }
+				isActive={ this.isMySitesActive() }
+				tooltip={ translate( 'Manage your sites' ) }
+				preloadSection={ this.preloadMySites }
+				hasGlobalBorderStyle
+			/>
 		);
 	}
 
@@ -366,10 +317,6 @@ class MasterbarLoggedIn extends Component {
 
 	dismissPopover = () => {
 		this.props.savePreference( MENU_POPOVER_PREFERENCE_KEY, true );
-	};
-
-	dismissLogoPopover = () => {
-		this.props.savePreference( ALL_SITES_POPOVER_PREFERENCE_KEY, true );
 	};
 
 	renderCheckout() {
@@ -946,7 +893,6 @@ export default connect(
 			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			hasDismissedThePopover: getPreference( state, MENU_POPOVER_PREFERENCE_KEY ),
-			hasDismissedAllSitesPopover: getPreference( state, ALL_SITES_POPOVER_PREFERENCE_KEY ),
 			isFetchingPrefs: isFetchingPreferences( state ),
 			// If the user is newer than new navigation shipping date, don't tell them this nav is new. Everything is new to them.
 			isUserNewerThanNewNavigation:

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -216,56 +216,6 @@ body.is-mobile-app-view {
 	right: 16px;
 }
 
-.masterbar__all-sites-popover {
-	.popover__arrow::before {
-		--color-border-inverted: var(--color-neutral-100);
-	}
-
-	.popover__arrow {
-		border: 10px dashed var(--color-neutral-70) !important;
-		border-bottom-style: solid !important;
-		border-top: none !important;
-		border-left-color: transparent !important;
-		border-right-color: transparent !important;
-	}
-	.popover__inner {
-		display: flex;
-		gap: 16px;
-		padding: 16px;
-		flex-direction: column;
-		align-items: flex-start;
-		border-radius: 4px !important;
-		background-color: var(--color-neutral-100) !important;
-		border: 1px solid var(--color-neutral-70) !important;
-		left: 0 !important;
-	}
-
-	.masterbar__all-sites-popover-heading {
-		font-size: rem(16px);
-		color: var(--color-text-inverted);
-		font-weight: 500;
-	}
-
-	.masterbar__all-sites-popover-description {
-		max-width: 325px;
-		margin-top: -8px;
-		font-size: rem(13px);
-		color: var(--color-neutral-0);
-		text-align: left;
-	}
-
-	.masterbar__all-sites-popover-actions {
-		display: flex;
-		align-items: center;
-		justify-content: flex-end;
-		width: 100%;
-		button {
-			padding: 4px 8px;
-			font-size: rem(13px);
-		}
-	}
-}
-
 .masterbar__section {
 	display: flex;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8620

## Proposed Changes
Remove the all sites hint popover applied [here](https://github.com/Automattic/wp-calypso/pull/92915)

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/dfde80cf-42a6-4d17-9b97-ce6ba81e17d7) | ![image](https://github.com/user-attachments/assets/bbd1ed6d-5ec8-471a-a693-eb2d40cd5723) |

## Testing Instructions
- Remove the `dismissible-card-masterbar-all-sites-popover` preference from the user
- Visit any site `/home` in Calypso and you should not see the popover
