### PR TITLE
Add migrate entire site button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -15,7 +15,8 @@ export function getFinalImporterUrl(
 	targetSlug: string,
 	fromSite: string,
 	platform: ImporterPlatform,
-	backToFlow?: string
+	backToFlow?: string,
+	migrateEntireSiteFlow?: string
 ) {
 	let importerUrl;
 	const encodedFromSite = encodeURIComponent( fromSite );
@@ -42,6 +43,12 @@ export function getFinalImporterUrl(
 	if ( backToFlow ) {
 		importerUrl = addQueryArgs( importerUrl, {
 			backToFlow,
+		} );
+	}
+
+	if ( migrateEntireSiteFlow ) {
+		importerUrl = addQueryArgs( importerUrl, {
+			migrateEntireSiteFlow,
 		} );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
@@ -1,3 +1,6 @@
+import { StepNavigationLink } from '@automattic/onboarding';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import WordpressImporter from 'calypso/blocks/importer/wordpress';
 import { WPImportOption } from 'calypso/blocks/importer/wordpress/types';
 import { MigrationAssistanceModal } from 'calypso/landing/stepper/declarative-flow/internals/components/migration-assistance-modal';
@@ -16,6 +19,7 @@ interface Props extends StepProps {
 }
 
 const ImporterWordpress: FC< Props > = function ( props ) {
+	const translate = useTranslate();
 	const queryParams = useQuery();
 	const site = useSite();
 	const migrateFrom = queryParams.get( 'from' );
@@ -28,6 +32,23 @@ const ImporterWordpress: FC< Props > = function ( props ) {
 		siteSlug,
 		migrateFrom
 	);
+
+	const customizedActionLabel = queryParams.get( 'customizedActionLabel' );
+	let customizedActionButtons;
+
+	if ( customizedActionLabel ) {
+		customizedActionButtons = (
+			<StepNavigationLink
+				direction="forward"
+				handleClick={ () => {
+					props.navigation.submit?.( { action: 'customized-action-flow' } );
+				} }
+				label={ translate( 'I want to migrate my entire site' ) }
+				cssClass={ clsx( 'step-container__navigation-link', 'forward', 'has-underline' ) }
+				borderless
+			/>
+		);
+	}
 
 	return (
 		<>
@@ -46,7 +67,11 @@ const ImporterWordpress: FC< Props > = function ( props ) {
 					navigateBack={ props.navigation.goBack }
 				/>
 			) }
-			<Importer importer="wordpress" { ...props } />
+			<Importer
+				importer="wordpress"
+				{ ...props }
+				customizedActionButtons={ customizedActionButtons }
+			/>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
@@ -2,15 +2,20 @@ import WordpressImporter from 'calypso/blocks/importer/wordpress';
 import { WPImportOption } from 'calypso/blocks/importer/wordpress/types';
 import { MigrationAssistanceModal } from 'calypso/landing/stepper/declarative-flow/internals/components/migration-assistance-modal';
 import { useStepNavigator } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator';
-import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { withImporterWrapper } from '../importer';
+import type { StepProps } from '../../types';
+import type { FC, ReactElement } from 'react';
 import './style.scss';
 
 const Importer = withImporterWrapper( WordpressImporter );
 
-const ImporterWordpress: Step = function ( props ) {
+interface Props extends StepProps {
+	customizedActionButtons?: ReactElement;
+}
+
+const ImporterWordpress: FC< Props > = function ( props ) {
 	const queryParams = useQuery();
 	const site = useSite();
 	const migrateFrom = queryParams.get( 'from' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
@@ -1,4 +1,4 @@
-import { StepNavigationLink } from '@automattic/onboarding';
+import { StepNavigationLink, MIGRATION_FLOW } from '@automattic/onboarding';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import WordpressImporter from 'calypso/blocks/importer/wordpress';
@@ -33,10 +33,8 @@ const ImporterWordpress: FC< Props > = function ( props ) {
 		migrateFrom
 	);
 
-	const customizedActionLabel = queryParams.get( 'customizedActionLabel' );
 	let customizedActionButtons;
-
-	if ( customizedActionLabel ) {
+	if ( queryParams.get( 'ref' ) === MIGRATION_FLOW ) {
 		customizedActionButtons = (
 			<StepNavigationLink
 				direction="forward"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -44,15 +44,18 @@ import type { ImporterCompType } from './types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { Importer, ImportJob } from 'calypso/blocks/importer/types';
 
+type StepContainerProps = React.ComponentProps< typeof StepContainer >;
+
 interface Props {
 	importer: Importer;
+	customizedActionButtons?: StepContainerProps[ 'customizedActionButtons' ];
 }
 
 export function withImporterWrapper( Importer: ImporterCompType ) {
 	const ImporterWrapper = ( props: Props & StepProps ) => {
 		const { __ } = useI18n();
 		const dispatch = useDispatch();
-		const { importer, navigation, flow } = props;
+		const { importer, customizedActionButtons, navigation, flow } = props;
 		const currentSearchParams = useQuery();
 		/**
 	 	↓ Fields
@@ -213,6 +216,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 						}
 					) }
 					stepName="importer-step"
+					customizedActionButtons={ customizedActionButtons }
 					hideSkip
 					hideBack={ isMigrationInProgress }
 					hideFormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-upgrade-plan/index.tsx
@@ -1,44 +1,30 @@
 import { StepNavigationLink } from '@automattic/onboarding';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
 import { Step } from '../../types';
 import SiteMigrationUpgradePlan from '../site-migration-upgrade-plan';
 import { MigrationUpgradePlanActions as Actions } from './actions';
 
-interface Props {
-	onClick: () => void;
-	label: string;
-}
-const ImportButton: FC< Props > = ( { onClick, label } ) => {
-	return (
-		<div className="step-container__skip-wrapper">
-			<StepNavigationLink
-				direction="forward"
-				handleClick={ onClick }
-				label={ label }
-				cssClass={ clsx( 'step-container__navigation-link', 'has-underline' ) }
-				borderless
-			/>
-		</div>
-	);
-};
-
 const MigrationUpgradePlan: Step = ( props ) => {
 	const translate = useTranslate();
 	const { navigation } = props;
+
+	const handleClick = () =>
+		navigation?.submit?.( {
+			action: Actions.IMPORT_CONTENT_ONLY,
+		} );
+
 	return (
 		<SiteMigrationUpgradePlan
 			{ ...props }
 			headerText={ translate( 'Here’s the plan you need' ) }
 			customizedActionButtons={
-				<ImportButton
+				<StepNavigationLink
+					direction="forward"
+					handleClick={ handleClick }
 					label={ translate( 'I want to import my content only' ) }
-					onClick={ () =>
-						navigation?.submit?.( {
-							action: Actions.IMPORT_CONTENT_ONLY,
-						} )
-					}
+					cssClass={ clsx( 'step-container__navigation-link', 'forward', 'has-underline' ) }
+					borderless
 				/>
 			}
 		/>

--- a/client/landing/stepper/declarative-flow/migration/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/migration/helpers/index.ts
@@ -1,6 +1,6 @@
 import { MIGRATION_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
-import { addQueryArgs } from '@wordpress/url';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
+import { addQueryArgs } from 'calypso/lib/url';
 import { getFinalImporterUrl } from '../../internals/steps-repository/import/helper';
 import { StepperStep } from '../../internals/types';
 
@@ -43,12 +43,15 @@ export const goToImporter = ( {
 		return goTo( path, replaceHistory );
 	}
 
-	const stepURL = addQueryArgs( `/setup/${ SITE_SETUP_FLOW }/${ path }`, {
-		siteId,
-		siteSlug,
-		ref: MIGRATION_FLOW,
-		...( platform === 'wordpress' ? { option: 'content' } : {} ),
-	} );
+	const stepURL = addQueryArgs(
+		{
+			siteId,
+			siteSlug,
+			ref: MIGRATION_FLOW,
+			...( platform === 'wordpress' ? { option: 'content' } : {} ),
+		},
+		`/setup/${ SITE_SETUP_FLOW }/${ path }`
+	);
 
 	return goTo( stepURL, replaceHistory );
 };

--- a/client/landing/stepper/declarative-flow/migration/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/migration/helpers/index.ts
@@ -12,15 +12,11 @@ interface GoToImporterParams {
 	siteId: string;
 	siteSlug: string;
 	backToStep?: StepperStep;
+	migrateEntireSiteStep?: StepperStep;
 	replaceHistory?: boolean;
-	customizedActionButton?: {
-		step: string;
-		flow: string;
-		label: string;
-	};
 }
 
-const getBackToFlowParam = ( step: string ) => `/${ MIGRATION_FLOW }/${ step }`;
+const getFlowPath = ( step: string ) => `/${ MIGRATION_FLOW }/${ step }`;
 const goTo = ( path: string, replaceHistory: boolean ) => {
 	if ( replaceHistory ) {
 		return window.location.replace( path );
@@ -34,11 +30,14 @@ export const goToImporter = ( {
 	siteId,
 	siteSlug,
 	backToStep,
+	migrateEntireSiteStep,
 	replaceHistory = false,
-	customizedActionButton,
 }: GoToImporterParams ) => {
-	const backToFlow = backToStep ? getBackToFlowParam( backToStep?.slug ) : undefined;
-	const path = getFinalImporterUrl( siteSlug, '', platform, backToFlow );
+	const backToFlow = backToStep ? getFlowPath( backToStep?.slug ) : undefined;
+	const migrateEntireSiteFlow = migrateEntireSiteStep
+		? getFlowPath( migrateEntireSiteStep?.slug )
+		: undefined;
+	const path = getFinalImporterUrl( siteSlug, '', platform, backToFlow, migrateEntireSiteFlow );
 
 	if ( isWpAdminImporter( path ) ) {
 		return goTo( path, replaceHistory );
@@ -49,12 +48,6 @@ export const goToImporter = ( {
 		siteSlug,
 		ref: MIGRATION_FLOW,
 		...( platform === 'wordpress' ? { option: 'content' } : {} ),
-		...( customizedActionButton
-			? {
-					customizedActionFlow: `${ customizedActionButton.flow }/${ customizedActionButton.step }`,
-					customizedActionLabel: customizedActionButton.label,
-			  }
-			: {} ),
 	} );
 
 	return goTo( stepURL, replaceHistory );

--- a/client/landing/stepper/declarative-flow/migration/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/migration/helpers/index.ts
@@ -1,6 +1,6 @@
 import { MIGRATION_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
-import { addQueryArgs } from 'calypso/lib/url';
 import { getFinalImporterUrl } from '../../internals/steps-repository/import/helper';
 import { StepperStep } from '../../internals/types';
 
@@ -13,6 +13,11 @@ interface GoToImporterParams {
 	siteSlug: string;
 	backToStep?: StepperStep;
 	replaceHistory?: boolean;
+	customizedActionButton?: {
+		step: string;
+		flow: string;
+		label: string;
+	};
 }
 
 const getBackToFlowParam = ( step: string ) => `/${ MIGRATION_FLOW }/${ step }`;
@@ -30,6 +35,7 @@ export const goToImporter = ( {
 	siteSlug,
 	backToStep,
 	replaceHistory = false,
+	customizedActionButton,
 }: GoToImporterParams ) => {
 	const backToFlow = backToStep ? getBackToFlowParam( backToStep?.slug ) : undefined;
 	const path = getFinalImporterUrl( siteSlug, '', platform, backToFlow );
@@ -38,15 +44,18 @@ export const goToImporter = ( {
 		return goTo( path, replaceHistory );
 	}
 
-	const stepURL = addQueryArgs(
-		{
-			siteId,
-			siteSlug,
-			ref: MIGRATION_FLOW,
-			...( platform === 'wordpress' ? { option: 'content' } : {} ),
-		},
-		`/setup/${ SITE_SETUP_FLOW }/${ path }`
-	);
+	const stepURL = addQueryArgs( `/setup/${ SITE_SETUP_FLOW }/${ path }`, {
+		siteId,
+		siteSlug,
+		ref: MIGRATION_FLOW,
+		...( platform === 'wordpress' ? { option: 'content' } : {} ),
+		...( customizedActionButton
+			? {
+					customizedActionFlow: `${ customizedActionButton.flow }/${ customizedActionButton.step }`,
+					customizedActionLabel: customizedActionButton.label,
+			  }
+			: {} ),
+	} );
 
 	return goTo( stepURL, replaceHistory );
 };

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -5,7 +5,6 @@ import {
 	PLAN_BUSINESS_3_YEARS,
 } from '@automattic/calypso-products';
 import { MIGRATION_FLOW } from '@automattic/onboarding';
-import { translate } from 'i18n-calypso';
 import { useSearchParams } from 'react-router-dom';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
@@ -178,19 +177,13 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 				const plan = props?.plan as string;
 
 				if ( props?.action === MigrationUpgradePlanActions.IMPORT_CONTENT_ONLY ) {
-					const customizedActionButton = {
-						step: MIGRATION_UPGRADE_PLAN.slug,
-						flow: flowPath,
-						label: translate( 'I want to migrate my entire site' ),
-					};
-
 					return goToImporter( {
 						platform: 'wordpress',
 						siteId,
 						siteSlug,
 						backToStep: PLATFORM_IDENTIFICATION,
+						migrateEntireSiteStep: MIGRATION_UPGRADE_PLAN,
 						replaceHistory: true,
-						customizedActionButton,
 					} );
 				}
 

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -188,7 +188,7 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 						platform: 'wordpress',
 						siteId,
 						siteSlug,
-						backToStep: MIGRATION_UPGRADE_PLAN,
+						backToStep: PLATFORM_IDENTIFICATION,
 						replaceHistory: true,
 						customizedActionButton,
 					} );

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -5,6 +5,7 @@ import {
 	PLAN_BUSINESS_3_YEARS,
 } from '@automattic/calypso-products';
 import { MIGRATION_FLOW } from '@automattic/onboarding';
+import { translate } from 'i18n-calypso';
 import { useSearchParams } from 'react-router-dom';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
@@ -177,11 +178,19 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 				const plan = props?.plan as string;
 
 				if ( props?.action === MigrationUpgradePlanActions.IMPORT_CONTENT_ONLY ) {
+					const customizedActionButton = {
+						step: MIGRATION_UPGRADE_PLAN.slug,
+						flow: flowPath,
+						label: translate( 'I want to migrate my entire site' ),
+					};
+
 					return goToImporter( {
 						platform: 'wordpress',
 						siteId,
 						siteSlug,
 						backToStep: MIGRATION_UPGRADE_PLAN,
+						replaceHistory: true,
+						customizedActionButton,
 					} );
 				}
 

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -296,10 +296,9 @@ describe( `${ flow.name }`, () => {
 						from: '',
 						option: 'content',
 						backToFlow: '/migration/platform-identification',
+						migrateEntireSiteFlow: '/migration/migration-upgrade-plan',
 						siteId: 123,
 						ref: 'migration',
-						customizedActionFlow: 'migration/migration-upgrade-plan',
-						customizedActionLabel: 'I want to migrate my entire site',
 					} )
 				);
 			} );

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -295,7 +295,7 @@ describe( `${ flow.name }`, () => {
 						siteSlug: 'example.wordpress.com',
 						from: '',
 						option: 'content',
-						backToFlow: '/migration/migration-upgrade-plan',
+						backToFlow: '/migration/platform-identification',
 						siteId: 123,
 						ref: 'migration',
 						customizedActionFlow: 'migration/migration-upgrade-plan',

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -290,7 +290,7 @@ describe( `${ flow.name }`, () => {
 					},
 				} );
 
-				expect( window.location.assign ).toHaveBeenCalledWith(
+				expect( window.location.replace ).toHaveBeenCalledWith(
 					addQueryArgs( '/setup/site-setup/importerWordpress', {
 						siteSlug: 'example.wordpress.com',
 						from: '',
@@ -298,6 +298,8 @@ describe( `${ flow.name }`, () => {
 						backToFlow: '/migration/migration-upgrade-plan',
 						siteId: 123,
 						ref: 'migration',
+						customizedActionFlow: 'migration/migration-upgrade-plan',
+						customizedActionLabel: 'I want to migrate my entire site',
 					} )
 				);
 			} );

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -3,9 +3,9 @@
  */
 import { URLSearchParams } from 'url';
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
-import { addQueryArgs } from '@wordpress/url';
 import { useIsSiteOwner } from 'calypso/landing/stepper/hooks/use-is-site-owner';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
+import { addQueryArgs } from 'calypso/lib/url';
 import flow from '../';
 import { HOW_TO_MIGRATE_OPTIONS } from '../../../constants';
 import { STEPS } from '../../internals/steps';
@@ -46,7 +46,7 @@ describe( `${ flow.name }`, () => {
 		runUseStepNavigationSubmit( {
 			currentStep: from.slug,
 			dependencies: dependencies,
-			currentURL: addQueryArgs( `/${ flow.name }/${ from.slug }`, query ),
+			currentURL: addQueryArgs( query, `/${ flow.name }/${ from.slug }` ),
 		} );
 
 		const destination = getFlowLocation();
@@ -64,7 +64,7 @@ describe( `${ flow.name }`, () => {
 		runUseStepNavigationGoBack( {
 			currentStep: from.slug,
 			dependencies: dependencies,
-			currentURL: addQueryArgs( `/setup/${ from.slug }`, query ),
+			currentURL: addQueryArgs( query, `/setup/${ from.slug }` ),
 		} );
 
 		const destination = getFlowLocation();
@@ -127,13 +127,16 @@ describe( `${ flow.name }`, () => {
 				} );
 
 				expect( window.location.assign ).toHaveBeenCalledWith(
-					addQueryArgs( '/setup/site-setup/importerBlogger', {
-						siteSlug: 'example.wordpress.com',
-						from: '',
-						backToFlow: '/migration/platform-identification',
-						siteId: 123,
-						ref: 'migration',
-					} )
+					addQueryArgs(
+						{
+							siteSlug: 'example.wordpress.com',
+							from: '',
+							backToFlow: '/migration/platform-identification',
+							siteId: 123,
+							ref: 'migration',
+						},
+						'/setup/site-setup/importerBlogger'
+					)
 				);
 			} );
 		} );
@@ -180,13 +183,16 @@ describe( `${ flow.name }`, () => {
 				} );
 
 				expect( window.location.replace ).toHaveBeenCalledWith(
-					addQueryArgs( '/setup/site-setup/importerBlogger', {
-						siteSlug: 'example.wordpress.com',
-						from: '',
-						backToFlow: '/migration/platform-identification',
-						siteId: 123,
-						ref: 'migration',
-					} )
+					addQueryArgs(
+						{
+							siteSlug: 'example.wordpress.com',
+							from: '',
+							backToFlow: '/migration/platform-identification',
+							siteId: 123,
+							ref: 'migration',
+						},
+						'/setup/site-setup/importerBlogger'
+					)
 				);
 			} );
 
@@ -201,11 +207,14 @@ describe( `${ flow.name }`, () => {
 				} );
 
 				expect( window.location.replace ).toHaveBeenCalledWith(
-					addQueryArgs( '/import/example.wordpress.com', {
-						engine: 'substack',
-						'from-site': '',
-						backToFlow: '/migration/platform-identification',
-					} )
+					addQueryArgs(
+						{
+							engine: 'substack',
+							'from-site': '',
+							backToFlow: '/migration/platform-identification',
+						},
+						'/import/example.wordpress.com'
+					)
 				);
 			} );
 
@@ -291,15 +300,18 @@ describe( `${ flow.name }`, () => {
 				} );
 
 				expect( window.location.replace ).toHaveBeenCalledWith(
-					addQueryArgs( '/setup/site-setup/importerWordpress', {
-						siteSlug: 'example.wordpress.com',
-						from: '',
-						option: 'content',
-						backToFlow: '/migration/platform-identification',
-						migrateEntireSiteFlow: '/migration/migration-upgrade-plan',
-						siteId: 123,
-						ref: 'migration',
-					} )
+					addQueryArgs(
+						{
+							siteSlug: 'example.wordpress.com',
+							from: '',
+							option: 'content',
+							backToFlow: '/migration/platform-identification',
+							migrateEntireSiteFlow: '/migration/migration-upgrade-plan',
+							siteId: 123,
+							ref: 'migration',
+						},
+						'/setup/site-setup/importerWordpress'
+					)
 				);
 			} );
 		} );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -447,13 +447,12 @@ const siteSetupFlow: Flow = {
 					if ( providedDependencies?.type === 'redirect' ) {
 						return exitFlow( providedDependencies?.url as string );
 					}
-
 					switch ( providedDependencies?.action ) {
 						case 'verify-email':
 							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
 						case 'checkout':
 							return exitFlow( providedDependencies?.checkoutUrl as string );
-						case 'migrate-entire-site': {
+						case 'customized-action-flow': {
 							const migrateEntireSiteFlow = urlQueryParams.get( 'migrateEntireSiteFlow' );
 							if ( migrateEntireSiteFlow ) {
 								return goToFlow( migrateEntireSiteFlow );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -448,17 +448,17 @@ const siteSetupFlow: Flow = {
 						return exitFlow( providedDependencies?.url as string );
 					}
 
-					const customizedActionFlow = urlQueryParams.get( 'customizedActionFlow' );
-
 					switch ( providedDependencies?.action ) {
 						case 'verify-email':
 							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
 						case 'checkout':
 							return exitFlow( providedDependencies?.checkoutUrl as string );
-						case 'customized-action-flow':
-							if ( customizedActionFlow ) {
-								return goToFlow( customizedActionFlow );
+						case 'migrate-entire-site': {
+							const migrateEntireSiteFlow = urlQueryParams.get( 'migrateEntireSiteFlow' );
+							if ( migrateEntireSiteFlow ) {
+								return goToFlow( migrateEntireSiteFlow );
 							}
+						}
 						default:
 							return navigate( providedDependencies?.url as string );
 					}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -448,11 +448,17 @@ const siteSetupFlow: Flow = {
 						return exitFlow( providedDependencies?.url as string );
 					}
 
+					const customizedActionFlow = urlQueryParams.get( 'customizedActionFlow' );
+
 					switch ( providedDependencies?.action ) {
 						case 'verify-email':
 							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
 						case 'checkout':
 							return exitFlow( providedDependencies?.checkoutUrl as string );
+						case 'customized-action-flow':
+							if ( customizedActionFlow ) {
+								return goToFlow( customizedActionFlow );
+							}
 						default:
 							return navigate( providedDependencies?.url as string );
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93463
Related to #93308

## Proposed Changes

* Add migrate entire site button to the "Import content from WordPress" step, so the user can switch back to the migrate option.

<img width="1263" alt="Screenshot 2024-08-21 at 13 04 15" src="https://github.com/user-attachments/assets/79e90be8-1ee6-485f-885d-eb829ff4c300">

### Alternative

I think the current approach is a little ugly, sending the label and the flow through URL, but it's similar to the `backToFlow` approach, with the difference that we also send a label. A concern with the label could be security, since someone could send a link customizing the text and a link to a different flow. But since it's a navigation restricted to a flow, I think it's fine.

The other alternative I considered was to add the `importerWordpress` step to the migration flow, similar to the other steps of the `/setup/migration` flow. But if my understand is correct, the steps from `site-setup` flow were more designed to live exclusively there and we just redirect instead of re-using that steps.

See the commit I started for this, in case we decide to go with this approach: https://github.com/Automattic/wp-calypso/commit/93296c878409f0144f5a3f4cec4bfe9e59399ca3. It's not ready yet, but it's almost ready. We would need to copy some parts of the client/landing/stepper/declarative-flow/site-setup-flow.ts, write tests, and make some small style tweaks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/setup/migration`.
2. Choose the "WordPress" option.
3. Click on "I want to import my content only".
4. Click on "I want to migrate my entire site", and make sure you navigate back to the migration option.
5. Also make sure the same step in other flows continue working properly without any customized action.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
