### PR TITLE
Update: Add incompatible plugins to match wpcomsh

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -21,6 +21,7 @@ const incompatiblePlugins = new Set( [
 	'extended-wp-reset',
 	'file-manager-advanced',
 	'file-manager',
+	'hide-my-wp',
 	'plugins-garbage-collector',
 	'post-type-switcher',
 	'reset-wp',
@@ -51,9 +52,12 @@ const incompatiblePlugins = new Set( [
 	'backup-wd',
 	'backupwordpress',
 	'backwpup',
+	'backwpup-pro',
+	'jetpack-backup',
 	'wp-db-backup',
 
 	// caching
+	'breeze',
 	'cache-enabler',
 	'comet-cache',
 	'hyper-cache',
@@ -101,6 +105,7 @@ const incompatiblePlugins = new Set( [
 	'disable-xml-rpc-fully',
 	'disable-xml-rpc-unset-x-pingback',
 	'disable-xml-rpc',
+	'ithemes-security-pro',
 	'manage-xml-rpc',
 	'sg-security',
 	'simple-xml-rpc-disabler',
@@ -118,6 +123,7 @@ const incompatiblePlugins = new Set( [
 
 	// cloning/staging
 	'flo-launch',
+	'wp-staging',
 
 	// misc
 	'adult-mass-photos-downloader',
@@ -135,12 +141,14 @@ const incompatiblePlugins = new Set( [
 	'facetwp-manipulator',
 	'fast-velocity-minify',
 	'nginx-helper',
+	'one-click-ssl',
 	'p3',
 	'pexlechris-adminer',
 	'plugin-detective',
 	'porn-embed',
 	'propellerads-official',
 	'really-simple-ssl',
+	'really-simple-ssl-pro',
 	'speed-contact-bar',
 	'trafficzion',
 	'tubeace',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR adds some of the incompatible plugins found in[ wpcomsh](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php) that are missing in Calypso.

The following plugins have been added: 

- backwpup-pro
- breeze
- hide-my-wp
- jetpack-backup
- really-simple-ssl-pro
- wp-staging
- one-click-ssl
- ithemes-security-pro

Note, some of the Pro plugins aren't currently found on the marketplace, but I think it would still be a good idea to mirror what is on wpcomsh.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* While wpcomsh disables plugins that are already installed, this array in Calypso is used to prevent the installation of incompatible plugins on the marketplace. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Try installing one of the added plugins above, i..e, https://wordpress.com/plugins/breeze

Before: 
<img width="1213" alt="image" src="https://github.com/user-attachments/assets/7578e38f-274c-401e-b4a6-90f9e12cc571">

After: 
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/c50762f3-ef21-4085-9464-feab9331523a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
