### PR TITLE
Server: Use the default locale explicitly for redirects to /plans with no locale param

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -707,7 +707,7 @@ function wpcomPages( app ) {
 	} );
 
 	app.get( `/:locale([a-z]{2,3}|[a-z]{2}-[a-z]{2})?/plans`, function ( req, res, next ) {
-		const locale = req.params?.locale;
+		const locale = req.params?.locale ?? config( 'i18n_default_locale_slug' );
 
 		if ( ! req.context.isLoggedIn ) {
 			const queryFor = req.query?.for;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1723840860317639-slack-C029GN3KD

## Proposed Changes

* Use the `i18n_default_locale_slug` as a fallback when the `locale` parameter is not present.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When the `locale` parameter is not present, the `localizeUrl` function is called with `undefined`, which results in [reading the locale from the i18n-calypso data](https://github.com/Automattic/wp-calypso/blob/trunk/packages/i18n-utils/src/localize-url.tsx#L203). In the server context, the state is shared across different users, which may result in having locale data from another session still being loaded and `localizeUrl` defaulting to that locale, when it's expected to default to English.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot Calypso locally on `trunk`.
* Visit `/es/themes`, then visit `/plans` logged-out.
* Confirm you get redirected to `/es/pricing`.
* Repeat for other Mag-16 locales.
* Checkout this branch locally and repeat the same steps.
* Visiting `/plans` should now redirect to `/pricing`.
* Visit `/{locale}/plans` logged-out to confirm you still get redirected to `/{locale}/pricing` as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
