### PR TITLE
Use correct capitalization for German taxonomy

### DIFF
--- a/client/my-sites/site-settings/taxonomies/index.jsx
+++ b/client/my-sites/site-settings/taxonomies/index.jsx
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -13,6 +14,7 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 const Taxonomies = ( { translate, labels, postType, taxonomy } ) => {
+	const locale = useLocale();
 	const taxonomyName = labels.name?.toLowerCase();
 
 	return (
@@ -27,7 +29,7 @@ const Taxonomies = ( { translate, labels, postType, taxonomy } ) => {
 				subtitle={ translate(
 					'Create, edit, and manage the %(taxonomy)s on your site. {{learnMoreLink/}}',
 					{
-						args: { taxonomy: taxonomyName },
+						args: { taxonomy: locale === 'de' ? labels.name : taxonomyName },
 						components: {
 							learnMoreLink: (
 								<InlineSupportLink


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#863

## Proposed Changes

* Use the original capitalization of the taxonomy if the locale is German.

## Why are these changes being made?

In the WordPress dashboard > Posts > Categories, the word "Kategorien" is a noun and needs to start with a capital K in German.

## Testing Instruction


* Set your WordPress.com account to a non-German locale, e.g. English
* Visit `WordPress dashboard > Posts > Categories` and verify that the word for `Categories` in the sentence `Create, edit, and manage the categories on your site.` is in lowercase
* Switch your locale to German
* Visit `WordPress dashboard > Posts > Categories` and verify that the word for `Kategorien` in the sentence `Erstelle, bearbeite und verwalte die kategorien auf deiner Website.` begins with an uppercase `K`.

**Before**
![CleanShot 2024-08-18 at 11 52 31@2x](https://github.com/user-attachments/assets/00a508af-432f-4c67-b022-55e7d9359cbd)

**After**

![CleanShot 2024-08-18 at 11 56 14@2x](https://github.com/user-attachments/assets/d308d05e-6696-4882-b86d-fe01e7577991)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
