### PR TITLE
A4A: Add the Team section and initial structure of the pages.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -8,6 +8,7 @@ import {
 	tag,
 	cog,
 	commentAuthorAvatar,
+	people,
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -24,6 +25,7 @@ import {
 	A4A_SETTINGS_LINK,
 	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_REFERRALS_DASHBOARD,
+	A4A_TEAM_LINK,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -150,6 +152,19 @@ const useMainMenuItems = ( path: string ) => {
 							title: translate( 'Settings' ),
 							trackEventProps: {
 								menu_item: 'Automattic for Agencies / Settings',
+							},
+						},
+				  ]
+				: [] ),
+			...( isSectionNameEnabled( 'a8c-for-agencies-team' )
+				? [
+						{
+							icon: people,
+							path: '/',
+							link: A4A_TEAM_LINK,
+							title: translate( 'Team' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Team',
 							},
 						},
 				  ]

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -36,6 +36,8 @@ export const A4A_MIGRATIONS_LINK = '/migrations';
 export const A4A_SETTINGS_LINK = '/settings';
 export const A4A_PARTNER_DIRECTORY_LINK = '/partner-directory';
 export const A4A_PARTNER_DIRECTORY_DASHBOARD_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/dashboard`;
+export const A4A_TEAM_LINK = '/team';
+export const A4A_TEAM_INVITE_LINK = 'team/invite';
 export const EXTERNAL_A4A_KNOWLEDGE_BASE = 'http://automattic.com/for-agencies/help';
 
 // Client

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -37,7 +37,7 @@ export const A4A_SETTINGS_LINK = '/settings';
 export const A4A_PARTNER_DIRECTORY_LINK = '/partner-directory';
 export const A4A_PARTNER_DIRECTORY_DASHBOARD_LINK = `${ A4A_PARTNER_DIRECTORY_LINK }/dashboard`;
 export const A4A_TEAM_LINK = '/team';
-export const A4A_TEAM_INVITE_LINK = 'team/invite';
+export const A4A_TEAM_INVITE_LINK = '/team/invite';
 export const EXTERNAL_A4A_KNOWLEDGE_BASE = 'http://automattic.com/for-agencies/help';
 
 // Client

--- a/client/a8c-for-agencies/sections/team/controller.tsx
+++ b/client/a8c-for-agencies/sections/team/controller.tsx
@@ -1,0 +1,29 @@
+import { type Callback } from '@automattic/calypso-router';
+import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
+import MainSidebar from '../../components/sidebar-menu/main';
+import TeamInvite from './primary/team-invite';
+import TeamList from './primary/team-list';
+
+export const teamContext: Callback = ( context, next ) => {
+	context.secondary = <MainSidebar path={ context.path } />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Manage team" path={ context.path } />
+			<TeamList />
+		</>
+	);
+
+	next();
+};
+
+export const teamInviteContext: Callback = ( context, next ) => {
+	context.secondary = <MainSidebar path={ context.path } />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Manage team > Invite a team member" path={ context.path } />
+			<TeamInvite />
+		</>
+	);
+
+	next();
+};

--- a/client/a8c-for-agencies/sections/team/index.tsx
+++ b/client/a8c-for-agencies/sections/team/index.tsx
@@ -1,0 +1,14 @@
+import page from '@automattic/calypso-router';
+import {
+	A4A_TEAM_INVITE_LINK,
+	A4A_TEAM_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { teamContext, teamInviteContext } from './controller';
+
+export default function () {
+	page( A4A_TEAM_INVITE_LINK, requireAccessContext, teamContext, makeLayout, clientRender );
+
+	page( A4A_TEAM_LINK, requireAccessContext, teamInviteContext, makeLayout, clientRender );
+}

--- a/client/a8c-for-agencies/sections/team/index.tsx
+++ b/client/a8c-for-agencies/sections/team/index.tsx
@@ -8,7 +8,7 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import { teamContext, teamInviteContext } from './controller';
 
 export default function () {
-	page( A4A_TEAM_INVITE_LINK, requireAccessContext, teamContext, makeLayout, clientRender );
+	page( A4A_TEAM_LINK, requireAccessContext, teamContext, makeLayout, clientRender );
 
-	page( A4A_TEAM_LINK, requireAccessContext, teamInviteContext, makeLayout, clientRender );
+	page( A4A_TEAM_INVITE_LINK, requireAccessContext, teamInviteContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/team/primary/team-invite.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite.tsx
@@ -1,0 +1,3 @@
+export default function TeamInvite() {
+	return <>Team member invite</>;
+}

--- a/client/a8c-for-agencies/sections/team/primary/team-invite.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite.tsx
@@ -1,3 +1,29 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderBreadcrumb as Breadcrumb,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import { A4A_TEAM_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+
 export default function TeamInvite() {
-	return <>Team member invite</>;
+	const translate = useTranslate();
+	const title = translate( 'Invite a team member' );
+
+	return (
+		<Layout className="a4a-team-list" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Breadcrumb
+						items={ [
+							{ label: translate( 'Manage team members' ), href: A4A_TEAM_LINK },
+							{ label: title },
+						] }
+					/>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>Team invite</LayoutBody>
+		</Layout>
+	);
 }

--- a/client/a8c-for-agencies/sections/team/primary/team-list.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list.tsx
@@ -1,0 +1,3 @@
+export default function TeamList() {
+	return <>Team member list</>;
+}

--- a/client/a8c-for-agencies/sections/team/primary/team-list.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list.tsx
@@ -1,3 +1,40 @@
-export default function TeamList() {
-	return <>Team member list</>;
+import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import { A4A_TEAM_INVITE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function Overview() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const title = translate( 'Manage team members' );
+
+	const onInviteClick = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_team_invite_team_member_click' ) );
+		page( A4A_TEAM_INVITE_LINK );
+	};
+
+	return (
+		<Layout className="a4a-team-list" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+					<Actions>
+						<Button variant="primary" onClick={ onInviteClick }>
+							{ translate( 'Invite a team member' ) }
+						</Button>
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>Team list</LayoutBody>
+		</Layout>
+	);
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -852,7 +852,7 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-team',
-		paths: [ '/team' ],
+		paths: [ '/team', '/team/invite' ],
 		module: 'calypso/a8c-for-agencies/sections/team',
 		group: 'a8c-for-agencies',
 	},

--- a/client/sections.js
+++ b/client/sections.js
@@ -851,6 +851,12 @@ const sections = [
 		group: 'a8c-for-agencies',
 	},
 	{
+		name: 'a8c-for-agencies-team',
+		paths: [ '/team' ],
+		module: 'calypso/a8c-for-agencies/sections/team',
+		group: 'a8c-for-agencies',
+	},
+	{
 		name: 'a8c-for-agencies-signup',
 		paths: [ '/signup', '/signup/finish', '/signup/oauth/token' ],
 		module: 'calypso/a8c-for-agencies/sections/signup',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -173,6 +173,7 @@
 		"a8c-for-agencies-settings": false,
 		"a8c-for-agencies-partner-directory": false,
 		"a8c-for-agencies-client": false,
+		"a8c-for-agencies-team": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -59,7 +59,8 @@
 		"a8c-for-agencies-settings": true,
 		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true,
-		"a8c-for-agencies-client": true
+		"a8c-for-agencies-client": true,
+		"a8c-for-agencies-team": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -52,7 +52,8 @@
 		"a8c-for-agencies-settings": true,
 		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true,
-		"a8c-for-agencies-client": true
+		"a8c-for-agencies-client": true,
+		"a8c-for-agencies-team": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -52,7 +52,8 @@
 		"a8c-for-agencies-settings": false,
 		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true,
-		"a8c-for-agencies-client": true
+		"a8c-for-agencies-client": true,
+		"a8c-for-agencies-team": false
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -55,7 +55,8 @@
 		"a8c-for-agencies-settings": false,
 		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true,
-		"a8c-for-agencies-client": true
+		"a8c-for-agencies-client": true,
+		"a8c-for-agencies-team": false
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
This pull request introduces the 'Team' section to the A4A and related routings, controllers, and initial page.

<img width="1727" alt="Screenshot 2024-08-19 at 12 56 06 PM" src="https://github.com/user-attachments/assets/e8357916-58fd-47de-915e-6c435c7b1791">
<img width="1727" alt="Screenshot 2024-08-19 at 12 56 13 PM" src="https://github.com/user-attachments/assets/83338d31-529d-4e50-991a-e3b05c02adf6">

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/940
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/941

## Proposed Changes

* Add the 'Team' section with its related routings, controllers, and pages.
* Add the 'Team' menu item in the sidebar.
* Implement initial page with bare structure.

## Testing Instructions

* Use the A4A live link and go to `/team` page.
* Confirm the page is visible.
* Confirm that clicking the 'Invite a team member' button will redirect you to the Invite form page.
* Confirm the 'Team' menu item is visible in the sidebar.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
