### PR TITLE
Set max-width for select elements in Reading Settings

### DIFF
--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -66,7 +66,7 @@ export const SiteSettingsSection = ( {
 				disabled={ disabled }
 				isSaving={ isSavingSettings }
 			/>
-			<Card className="site-settings__card">
+			<Card className="site-settings__card site-settings__your-homepage-display-container">
 				<YourHomepageDisplaysSetting
 					value={ { page_for_posts, page_on_front, show_on_front } }
 					onChange={ ( value ) => {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -652,6 +652,14 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 }
 
 .site-settings__reading-settings {
+	.site-settings__your-homepage-display-container fieldset {
+		min-width: 0;
+
+		select {
+			max-width: 100%;
+		}
+	}
+
 	.select-homepage-setting {
 		margin-bottom: 12px;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #88145

## Proposed Changes

This PR adds a max-width to the select elements in the Reading Settings so that they don't overflow if the page title is too long.

| Before | After |
| --- | --- |
| ![Screenshot 2024-08-19 at 2 09 46 PM](https://github.com/user-attachments/assets/6f7c7ebb-186a-491f-9a49-bf60992ec1b7) |  ![Screenshot 2024-08-19 at 2 09 19 PM](https://github.com/user-attachments/assets/730ba584-1d67-4b2a-9f4e-56ec33102329) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a page with a long title.
* Head to /settings/reading/{ SITE_SLUG }.
* Ensure that the select elements don't overflow their container.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
