### PR TITLE
Fediverse: update explanation wording

### DIFF
--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -166,7 +166,7 @@ const EnabledSettingsSection = ( { data, siteId, needsCard } ) => {
 			<Wrapper needsCard={ needsCard }>
 				<p>
 					{ translate(
-						'Anyone in the fediverse (eg Mastodon) can follow your site with this identifier:'
+						'People on the Fediverse (such as on Mastodon) can follow your site using this identifier:'
 					) }
 				</p>
 				{ isDomainPending && <DomainPendingWarning siteId={ siteId } domains={ domains } /> }


### PR DESCRIPTION
Fixes #93656

## Proposed Changes

Instead of just fixing the typo, I tried to make the whole sentence clearer, with no shorthand.

## Testing Instructions

* Check for more typos.

## Pre-merge Checklist


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
