### PR TITLE
Sensei: Redirect to WP Admin after the onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -63,7 +63,7 @@ const sensei: Flow = {
 					return navigate( 'senseiLaunch' );
 				case 'senseiLaunch':
 				default:
-					return window.location.assign( `/home/${ siteSlug }` );
+					return window.location.assign( `https://${ siteSlug }/wp-admin/admin.php?page=sensei` );
 			}
 		};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/86546

## Proposed Changes

* Redirect to the homepage of sensei flow on WP Admin after the onboarding. The downside is the user will see the login screen first because we cannot help the user to auth the atomic site automatically (the `loginme=direct` feature is only on wpcom) 🤔

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, the user is taken to the My Home page in Calypso after completing the flow, where they are presented with a Site setup onboarding checklist, not the Sensei-specific one. Calypso is also difficult to navigate, and it's easy to get lost when you're constantly switching in and out of Calypso vs. WP admin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/sensei/senseiSetup`
* Finish the onboarding flow
* Make sure the final destination is `/wp-admin/admin.php?page=sensei`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
