### PR TITLE
A4A: Update revoke license endpoint path

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/hooks/use-revoke-license-mutation.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/hooks/use-revoke-license-mutation.ts
@@ -1,36 +1,27 @@
 import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { useSelector } from 'calypso/state';
-import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import type { APILicense } from 'calypso/state/partner-portal/types';
 
 interface MutationRevokeLicenseVariables {
 	licenseKey: string;
-	agencyId?: number;
 }
 
 function mutationRevokeLicense( {
 	licenseKey,
-	agencyId,
 }: MutationRevokeLicenseVariables ): Promise< APILicense > {
-	if ( ! agencyId ) {
-		throw new Error( 'Agency ID is required to assign a license' );
-	}
 	return wpcom.req.post( {
 		method: 'DELETE',
 		apiNamespace: 'wpcom/v2',
-		path: '/jetpack-licensing/license',
-		body: { license_key: licenseKey, agency_id: agencyId },
+		path: '/agency/license',
+		body: { license_key: licenseKey },
 	} );
 }
 
 export default function useRevokeLicenseMutation< TContext = unknown >(
 	options?: UseMutationOptions< APILicense, Error, MutationRevokeLicenseVariables, TContext >
 ): UseMutationResult< APILicense, Error, MutationRevokeLicenseVariables, TContext > {
-	const agencyId = useSelector( getActiveAgencyId );
-
 	return useMutation< APILicense, Error, MutationRevokeLicenseVariables, TContext >( {
 		...options,
-		mutationFn: ( args ) => mutationRevokeLicense( { ...args, agencyId } ),
+		mutationFn: ( args ) => mutationRevokeLicense( { ...args } ),
 	} );
 }


### PR DESCRIPTION
Updates the delete license path to the new endpoint added in D158657-code. Also cleans up the mutation by removing the unused `agency_id`.

Do not merge before D158657-code is deployed.

## Testing Instructions

* Sandbox `public-api.wordpress.com`
* Apply this patch
* Apply D158657-code
* In the dashboard, try to cancel a license
* Confirm in your network tab that the request was done via `wpcom/v2/agency/license`
* Confirm that the license was canceled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?