### PR TITLE
Plugins: Widen search field

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -43,6 +43,7 @@ const SEARCH_CATEGORIES_HEIGHT = 36;
 const LAYOUT_PADDING = 16;
 const MASTERBAR_HEIGHT = 32;
 
+// If adding new, longer search terms, ensure that the search input field is wide enough to accommodate it.
 const searchTerms = [ 'woocommerce', 'seo', 'file manager', 'jetpack', 'ecommerce', 'form' ];
 
 const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews, isLoggedIn } ) => {

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -14,7 +14,7 @@ $search-categories-padding-top: 40px;
 	}
 
 	.search-categories__searchbox {
-		max-width: 245px;
+		max-width: 265px;
 		width: 100%;
 		height: 36px;
 		z-index: 0;


### PR DESCRIPTION
Widening the search field so that it is wide enough to show all of the placeholders completely (in English at least).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93586

## Proposed Changes

 1. Widen the search field on /plugins so that it is wide enough to fit the longest suggested placeholder

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Open calypso live link
 2. Go to /plugins
 3. Watch the search field, as the placeholders are being rotated through, ensure that they all fit inside the box.

Note that the fade effect is intentional and consistent with other search boxes using the same component. If a searchbox not being big enough for a placeholder is a bug, perhaps this fade effect can be removed everywhere.

Before
<img width="1459" alt="Screenshot 2024-08-19 at 11 06 31" src="https://github.com/user-attachments/assets/b9e67926-e2c1-4df6-8886-2406ace4f96f"> 
After
<img width="1459" alt="Screenshot 2024-08-19 at 11 07 27" src="https://github.com/user-attachments/assets/34793ac8-7b95-48b5-bbee-bac5bb9803a9">

> [!NOTE]
> These search terms are not translatable. The change made here wouldn't work if the placeholders were translated and the translations were longer

> [!WARNING]
> The trade-off here is that the last category name "Events Calendar" is now truncated. (See screenshots)

If this isn't ok then design input is required.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
