### PR TITLE
Notifications: fix i18n for filter bar

### DIFF
--- a/apps/notifications/src/panel/templates/filter-bar-controller.js
+++ b/apps/notifications/src/panel/templates/filter-bar-controller.js
@@ -37,7 +37,7 @@ FilterBarController.prototype.getFilteredNotes = function ( notes ) {
 
 	const filterFunction = ( note ) =>
 		( 'unread' === filterName && noteHasFilteredRead( state, note.id ) ) ||
-		activeTab().filter( note );
+		activeTab.filter( note );
 
 	return notes.filter( filterFunction );
 };

--- a/apps/notifications/src/panel/templates/filter-bar.jsx
+++ b/apps/notifications/src/panel/templates/filter-bar.jsx
@@ -34,9 +34,7 @@ export class FilterBar extends Component {
 	}
 
 	setFilterItems = () => {
-		this.filterItems = Object.keys( Filters )
-			.map( ( name ) => Filters[ name ]() )
-			.sort( ( a, b ) => a.index - b.index );
+		this.filterItems = Object.values( Filters ).sort( ( a, b ) => a.index - b.index );
 	};
 
 	getFilterItems = () => {
@@ -122,7 +120,7 @@ export class FilterBar extends Component {
 								aria-controls="wpnc__note-list"
 								tabIndex={ isSelected ? 0 : -1 }
 							>
-								{ label }
+								{ label( translate ) }
 							</li>
 						);
 					} ) }

--- a/apps/notifications/src/panel/templates/filters.js
+++ b/apps/notifications/src/panel/templates/filters.js
@@ -1,100 +1,96 @@
-import i18n from 'i18n-calypso';
 import { store } from '../state';
 import getNoteIsRead from '../state/selectors/get-is-note-read';
 
-export const Filters = {
-	all: function () {
-		return {
-			name: 'all',
-			index: 0,
-			label: i18n.translate( 'All', {
+const Filters = {
+	all: {
+		name: 'all',
+		index: 0,
+		label: ( translate ) =>
+			translate( 'All', {
 				comment: "Notifications filter: all of a users' notifications",
 			} ),
-			emptyMessage: i18n.translate( 'No notifications yet.', {
+		emptyMessage: ( translate ) =>
+			translate( 'No notifications yet.', {
 				comment: 'Notifications all filter: no notifications',
 			} ),
-			emptyLinkMessage: i18n.translate( 'Get active! Comment on posts from blogs you follow.', {
+		emptyLinkMessage: ( translate ) =>
+			translate( 'Get active! Comment on posts from blogs you follow.', {
 				comment: 'Notifications all filter: no notifications',
 			} ),
-			emptyLink: 'https://wordpress.com/read/',
-
-			filter: () => true,
-		};
+		emptyLink: 'https://wordpress.com/read/',
+		filter: () => true,
 	},
-	unread: function () {
-		return {
-			name: 'unread',
-			index: 1,
-			label: i18n.translate( 'Unread', {
+	unread: {
+		name: 'unread',
+		index: 1,
+		label: ( translate ) =>
+			translate( 'Unread', {
 				comment: 'Notifications filter: unread notifications',
 			} ),
-			emptyMessage: i18n.translate( "You're all caught up!", {
+		emptyMessage: ( translate ) =>
+			translate( "You're all caught up!", {
 				comment: 'Notifications unread filter: no notifications',
 			} ),
-			emptyLinkMessage: i18n.translate( 'Reignite the conversation: write a new post.', {
+		emptyLinkMessage: ( translate ) =>
+			translate( 'Reignite the conversation: write a new post.', {
 				comment: 'Notifications unread filter: no notifications',
 			} ),
-			emptyLink: 'https://wordpress.com/post/',
-
-			filter: ( note ) => ! getNoteIsRead( store.getState(), note ),
-		};
+		emptyLink: 'https://wordpress.com/post/',
+		filter: ( note ) => ! getNoteIsRead( store.getState(), note ),
 	},
-	comments: function () {
-		return {
-			name: 'comments',
-			index: 2,
-			label: i18n.translate( 'Comments', {
+	comments: {
+		name: 'comments',
+		index: 2,
+		label: ( translate ) =>
+			translate( 'Comments', {
 				comment: 'Notifications filter: comment notifications',
 			} ),
-			emptyMessage: i18n.translate( 'No new comments yet!', {
+		emptyMessage: ( translate ) =>
+			translate( 'No new comments yet!', {
 				comment: 'Notifications comments filter: no notifications',
 			} ),
-			emptyLinkMessage: i18n.translate(
-				'Join a conversation: search for blogs that share your interests in the Reader.',
-				{
-					comment: 'Notifications comments filter: no notifications',
-				}
-			),
-			emptyLink: 'https://wordpress.com/read/search/',
-
-			filter: ( { type } ) => 'comment' === type,
-		};
+		emptyLinkMessage: ( translate ) =>
+			translate( 'Join a conversation: search for blogs that share your interests in the Reader.', {
+				comment: 'Notifications comments filter: no notifications',
+			} ),
+		emptyLink: 'https://wordpress.com/read/search/',
+		filter: ( { type } ) => 'comment' === type,
 	},
-	follows: function () {
-		return {
-			name: 'follows',
-			index: 3,
-			label: i18n.translate( 'Subscribers', {
+	follows: {
+		name: 'follows',
+		index: 3,
+		label: ( translate ) =>
+			translate( 'Subscribers', {
 				comment: 'Notifications filter: notifications about users subscribing to your blogs',
 			} ),
-			emptyMessage: i18n.translate( 'No new subscribers to report yet.', {
+		emptyMessage: ( translate ) =>
+			translate( 'No new subscribers to report yet.', {
 				comment: 'Notifications subscribers filter: no notifications',
 			} ),
-			emptyLinkMessage: i18n.translate( "Get noticed: comment on posts you've read.", {
+		emptyLinkMessage: ( translate ) =>
+			translate( "Get noticed: comment on posts you've read.", {
 				comment: 'Notifications subscribers filter: no notifications',
 			} ),
-			emptyLink: 'https://wordpress.com/activities/likes/',
-
-			filter: ( { type } ) => 'follow' === type,
-		};
+		emptyLink: 'https://wordpress.com/activities/likes/',
+		filter: ( { type } ) => 'follow' === type,
 	},
-	likes: function () {
-		return {
-			name: 'likes',
-			index: 4,
-			label: i18n.translate( 'Likes', {
+	likes: {
+		name: 'likes',
+		index: 4,
+		label: ( translate ) =>
+			translate( 'Likes', {
 				comment: 'Notifications filter: notifications about users liking your posts or comments',
 			} ),
-			emptyMessage: i18n.translate( 'No new likes to show yet.', {
+		emptyMessage: ( translate ) =>
+			translate( 'No new likes to show yet.', {
 				comment: 'Notifications likes filter: no Notifications',
 			} ),
-			emptyLinkMessage: i18n.translate( "Get noticed: comment on posts you've read.", {
+		emptyLinkMessage: ( translate ) =>
+			translate( "Get noticed: comment on posts you've read.", {
 				comment: 'Notifications likes filter: no Notifications',
 			} ),
-			emptyLink: 'https://wordpress.com/activities/likes/',
-
-			filter: ( { type } ) => 'comment_like' === type || 'like' === type,
-		};
+		emptyLink: 'https://wordpress.com/activities/likes/',
+		filter: ( { type } ) => 'comment_like' === type || 'like' === type,
 	},
 };
 

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -203,20 +203,22 @@ export class NoteList extends Component {
 	};
 
 	render() {
+		const { translate } = this.props;
+
 		const groupTitles = [
-			this.props.translate( 'Today', {
+			translate( 'Today', {
 				comment: 'heading for a list of notifications from today',
 			} ),
-			this.props.translate( 'Yesterday', {
+			translate( 'Yesterday', {
 				comment: 'heading for a list of notifications from yesterday',
 			} ),
-			this.props.translate( 'Older than 2 days', {
+			translate( 'Older than 2 days', {
 				comment: 'heading for a list of notifications that are more than 2 days old',
 			} ),
-			this.props.translate( 'Older than a week', {
+			translate( 'Older than a week', {
 				comment: 'heading for a list of notifications that are more than a week old',
 			} ),
-			this.props.translate( 'Older than a month', {
+			translate( 'Older than a month', {
 				comment: 'heading for a list of notifications that are more than a month old',
 			} ),
 		];
@@ -296,7 +298,7 @@ export class NoteList extends Component {
 
 		const emptyNoteList = 0 === notes.length;
 
-		const filter = Filters[ this.props.filterName ]();
+		const filter = Filters[ this.props.filterName ];
 		const loadingIndicatorVisibility = { opacity: 0 };
 		if ( this.props.isLoading ) {
 			loadingIndicatorVisibility.opacity = 1;
@@ -306,9 +308,9 @@ export class NoteList extends Component {
 		} else if ( ! this.props.initialLoad && emptyNoteList && filter.emptyMessage ) {
 			notes = (
 				<EmptyMessage
-					emptyMessage={ filter.emptyMessage }
+					emptyMessage={ filter.emptyMessage( translate ) }
 					height={ this.props.height }
-					linkMessage={ filter.emptyLinkMessage }
+					linkMessage={ filter.emptyLinkMessage( translate ) }
 					link={ filter.emptyLink }
 					name={ filter.name }
 					showing={ this.props.isPanelOpen }


### PR DESCRIPTION
Fixes a bug where the Notifications filter bar, when loaded as a standalone widget, is never localized. Look at this screenshot and notice how the filter bar labels (All, Unread) are not in German, but in English:

<img width="406" alt="Screenshot 2024-08-19 at 10 57 05" src="https://github.com/user-attachments/assets/f108bc19-4c2f-4f10-8d54-8e3c3870ee5f">

You can see for yourself by loading the `https://wordpress.com/widgets/notifications/?locale=de` URL.

The cause is that the filters translations are done statically, on initial render, and are not reactively updated when the `i18n-calypso` translations are updated.

I'm fixing this by:
- converting the `label`, `emptyMessage` and `emptyLinkMessage` into functions that take a `translate` argument.
- calling these functions during render, passing a `translate` argument from `localize`.
- the `Filters` items no longer need to be functions, they can be static objects.
- I need to carefully remove all places where these functions were called

The result is that the filter bar is now properly localized:

<img width="368" alt="Screenshot 2024-08-19 at 10 44 06" src="https://github.com/user-attachments/assets/d2901c23-0e51-4c85-8c88-8af00c49d5bc">

This is a follow-up to #93390.

**How to test:**
1. Apply this patch and build notifications and sync them to your sandbox:
   ```
   cd apps/notifications
   NODE_ENV=production yarn dev --sync
   ```
2. Sandbox `wordpress.com` and `widgets.wp.com` and open the `https://wordpress.com/widgets/notifications/?locale=de` URL again.
3. Verify that the widget's filter bar is localized.

During review, verify that all usages of `label`, `emptyMessage` and `emptyLinkMessage` are converted to function calls, and that all `Filters[ name ]()` function calls are converted to `Filters[ name ]`.
