### PR TITLE
Remove deprecated defaultProps from several components

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -126,15 +126,15 @@ function getEventHandlers( props, dispatch ) {
 	return handlers;
 }
 
-function useDevTool( currentSite, dispatch ) {
+function useDevTool( siteId, dispatch ) {
 	useEffect( () => {
 		// Do not setup the tool in production
-		if ( process.env.NODE_ENV === 'production' || ! currentSite || ! currentSite.ID ) {
+		if ( process.env.NODE_ENV === 'production' || ! siteId ) {
 			return;
 		}
 
-		setupDevTool( currentSite.ID, dispatch );
-	}, [ currentSite, dispatch ] );
+		setupDevTool( siteId, dispatch );
+	}, [ siteId, dispatch ] );
 }
 
 export function JITM( props ) {
@@ -151,7 +151,7 @@ export function JITM( props ) {
 
 	const dispatch = useDispatch();
 
-	useDevTool( currentSite, dispatch );
+	useDevTool( currentSite?.ID, dispatch );
 
 	if ( ! currentSite || ! messagePath ) {
 		return null;

--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -4,12 +4,9 @@ import TranslatableString from 'calypso/components/translatable/proptype';
 import SidebarHeading from 'calypso/layout/sidebar/heading';
 import { decodeEntities } from 'calypso/lib/formatting';
 
-const noop = () => {};
-
 const ExpandableSidebarHeading = ( {
 	title,
 	count,
-	onClick,
 	icon,
 	customIcon,
 	materialIcon,
@@ -24,7 +21,6 @@ const ExpandableSidebarHeading = ( {
 		<SidebarHeading
 			aria-controls={ menuId }
 			aria-expanded={ expanded ? 'true' : 'false' }
-			onClick={ onClick }
 			{ ...props }
 		>
 			{ icon && <Gridicon className="sidebar__menu-icon" icon={ icon } /> }
@@ -57,10 +53,6 @@ ExpandableSidebarHeading.propTypes = {
 	materialIcon: PropTypes.string,
 	materialIconStyle: PropTypes.string,
 	hideExpandableIcon: PropTypes.bool,
-};
-
-ExpandableSidebarHeading.defaultProps = {
-	onClick: noop,
 };
 
 export default ExpandableSidebarHeading;

--- a/packages/components/src/tooltip/index.jsx
+++ b/packages/components/src/tooltip/index.jsx
@@ -5,29 +5,41 @@ import Popover from '../popover';
 
 import './style.scss';
 
-function Tooltip( props ) {
+function Tooltip( {
+	autoPosition,
+	className,
+	id,
+	isVisible,
+	position = 'top',
+	status,
+	showDelay = 100,
+	showOnMobile = false,
+	hideArrow = false,
+	children,
+	context,
+} ) {
 	const isMobile = useMobileBreakpoint();
 
-	if ( ! props.showOnMobile && isMobile ) {
+	if ( ! showOnMobile && isMobile ) {
 		return null;
 	}
 
-	const classes = clsx( [ 'tooltip', props.className ], {
-		[ `is-${ props.status }` ]: props.status,
+	const classes = clsx( [ 'tooltip', className ], {
+		[ `is-${ status }` ]: status,
 	} );
 
 	return (
 		<Popover
-			autoPosition={ props.autoPosition }
+			autoPosition={ autoPosition }
 			className={ classes }
-			context={ props.context }
-			id={ props.id }
-			isVisible={ props.isVisible }
-			position={ props.position }
-			showDelay={ props.showDelay }
-			hideArrow={ props.hideArrow ?? true }
+			context={ context }
+			id={ id }
+			isVisible={ isVisible }
+			position={ position }
+			showDelay={ showDelay }
+			hideArrow={ hideArrow ?? true }
 		>
-			{ props.children }
+			{ children }
 		</Popover>
 	);
 }
@@ -44,13 +56,6 @@ Tooltip.propTypes = {
 	hideArrow: PropTypes.bool,
 	children: PropTypes.node,
 	context: PropTypes.any,
-};
-
-Tooltip.defaultProps = {
-	showDelay: 100,
-	position: 'top',
-	showOnMobile: false,
-	hideArrow: false,
 };
 
 export default Tooltip;

--- a/packages/components/src/tooltip/index.jsx
+++ b/packages/components/src/tooltip/index.jsx
@@ -37,7 +37,7 @@ function Tooltip( {
 			isVisible={ isVisible }
 			position={ position }
 			showDelay={ showDelay }
-			hideArrow={ hideArrow ?? true }
+			hideArrow={ hideArrow }
 		>
 			{ children }
 		</Popover>


### PR DESCRIPTION
This PR removes usage of deprecated `defaultProps` from several components:
- `Tooltip`
- `JITM`
- `ExpandableSidebarHeading`

It removes several console warnings that are currently polluting the Calypso dev mode console.

See the inline comments where I point out some non-obvious details.