### PR TITLE
A4A: Implement Team member list getting started view.

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/step-section-item/style.scss
@@ -139,7 +139,7 @@
 	font-size: rem(12px);
 	font-weight: 600;
 	text-align: center;
-	width: 20px;
+	min-width: 20px;
 	height: 20px;
 	border-radius: 50%;
 	border: 2px solid var(--color-accent);

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -1,0 +1,96 @@
+import { Button } from '@wordpress/components';
+import { Icon, external } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import { A4A_TEAM_INVITE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import StepSection from '../../../referrals/common/step-section';
+import StepSectionItem from '../../../referrals/common/step-section-item';
+
+import './style.scss';
+
+export default function GetStarted() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const title = translate( 'Manage team members' );
+
+	const onInviteClick = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_team_invite_team_member_click' ) );
+	};
+
+	return (
+		<Layout className="team-list-get-started" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+					<Actions>
+						<Button variant="primary" onClick={ onInviteClick }>
+							{ translate( 'Invite a team member' ) }
+						</Button>
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<div className="team-list-get-started__heading">
+					{ translate( `Invite team members to help manage your clients' sites.` ) }
+				</div>
+
+				<div className="team-list-get-started__subtitle">
+					{ translate(
+						'You can invite team members to manage sites and referrals for your clients.'
+					) }
+				</div>
+
+				<StepSection heading={ translate( 'How do I start?' ) }>
+					<StepSectionItem
+						isNewLayout
+						stepNumber={ 1 }
+						heading={ translate( 'Invite a team member' ) }
+						description={
+							<>
+								{ translate(
+									`Team members get almost the same permissions as admins, but they can't do things like:`
+								) }
+
+								<ul className="team-list-get-started__excluded-operation-list">
+									<li>{ translate( 'Delete sites from the dashboard.' ) }</li>
+									<li>{ translate( 'Remove payment methods.' ) }</li>
+									<li>{ translate( 'Cancel or revoke licenses and plans.' ) }</li>
+									<li>{ translate( 'Remove other users.' ) }</li>
+								</ul>
+							</>
+						}
+						buttonProps={ {
+							children: translate( 'Invite a team member' ),
+							href: A4A_TEAM_INVITE_LINK,
+							onClick: onInviteClick,
+							primary: true,
+							compact: true,
+						} }
+					/>
+				</StepSection>
+
+				<StepSection heading={ translate( 'Learn more about team members' ) }>
+					<Button
+						className="team-list-get-started__learn-more-button"
+						variant="link"
+						target="_blank"
+						href="#" // FIXME: Add link to the KB article
+					>
+						{ translate( 'Team members Knowledge Base article?' ) }
+						<Icon icon={ external } size={ 18 } />
+					</Button>
+					<br />
+				</StepSection>
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/team/primary/get-started/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/style.scss
@@ -1,0 +1,19 @@
+.team-list-get-started .a4a-layout__body-wrapper {
+	max-width: 700px;
+}
+
+.team-list-get-started__heading {
+	@include a4a-font-heading-xl;
+
+	margin-block-start: 48px;
+	margin-block-end: 8px;
+}
+
+.team-list-get-started__subtitle {
+	@include a4a-font-body-lg;
+	margin-block-end: 32px;
+}
+
+a.team-list-get-started__learn-more-button.is-link {
+	color: var(--color-primary-50);
+}

--- a/client/a8c-for-agencies/sections/team/primary/team-list.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list.tsx
@@ -11,8 +11,9 @@ import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import { A4A_TEAM_INVITE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import GetStarted from './get-started';
 
-export default function Overview() {
+export default function TeamList() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const title = translate( 'Manage team members' );
@@ -21,6 +22,12 @@ export default function Overview() {
 		dispatch( recordTracksEvent( 'calypso_a4a_team_invite_team_member_click' ) );
 		page( A4A_TEAM_INVITE_LINK );
 	};
+
+	const isEmpty = true; // FIXME: Fetch team members and check if empty
+
+	if ( isEmpty ) {
+		return <GetStarted />;
+	}
 
 	return (
 		<Layout className="a4a-team-list" title={ title } wide>


### PR DESCRIPTION
This pull request adds the "Get started" view to the Team Member List page.

<img width="1478" alt="Screenshot 2024-08-19 at 7 30 23 PM" src="https://github.com/user-attachments/assets/14744ae8-5138-409d-a726-4e150474f297">


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/942

## Proposed Changes

* Implement the 'Get started' page in the Team member list page.


## Testing Instructions

* Use the A4A live link and go to `/team` page
* Confirm the 'Get started' view is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
