### PR TITLE
Notifications: migrate usages of componentWillMount

### DIFF
--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -48,9 +48,9 @@ export class Notifications extends PureComponent {
 		receiveMessage: noop,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
-		debug( 'component will mount', this.props );
+	constructor( props ) {
+		super( props );
+
 		const { customEnhancer, customMiddleware, isShowing, isVisible, receiveMessage, wpcom } =
 			this.props;
 

--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -70,8 +70,9 @@ class Layout extends Component {
 		selectedNote: null,
 	};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	constructor( props ) {
+		super( props );
+
 		this.filterController = FilterBarController( this.refreshNotesToDisplay );
 		this.props.global.client = this.props.client;
 		this.props.global.toggleNavigation = this.toggleNavigation;
@@ -85,11 +86,10 @@ class Layout extends Component {
 			};
 		}
 		this.props.enableKeyboardShortcuts();
-
-		window.addEventListener( 'keydown', this.handleKeyDown, false );
 	}
 
 	componentDidMount() {
+		window.addEventListener( 'keydown', this.handleKeyDown, false );
 		window.addEventListener( 'resize', this.redraw );
 		if ( this.noteListElement ) {
 			this.height = this.noteListElement.clientHeight;

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -37,8 +37,9 @@ export class NoteList extends Component {
 
 	noteElements = {};
 
-	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
-	UNSAFE_componentWillMount() {
+	constructor( props ) {
+		super( props );
+
 		this.props.global.updateStatusBar = this.updateStatusBar;
 		this.props.global.resetStatusBar = this.resetStatusBar;
 		this.props.global.updateUndoBar = this.updateUndoBar;


### PR DESCRIPTION
Migrates usages of `componentWillMount` to straightforward component constructors.

One exception is adding a `keydown` event listener, which belongs clearly to a didMount method.

I'm not updating #58453 because all modified files still have other `UNSAFE_` usages, mostly `componentWillReceiveProps`. That's harder to migrate.