### PR TITLE
Performace Profiler: speed-test route is only available in wordpress.com.

### DIFF
--- a/client/performance-profiler/components/header/index.tsx
+++ b/client/performance-profiler/components/header/index.tsx
@@ -39,7 +39,9 @@ export const PerformanceProfilerHeader = ( props: HeaderProps ) => {
 					</div>
 
 					<div className="profiler-header__action">
-						<Button href="/speed-test">{ translate( 'Test another site' ) }</Button>
+						<Button href="https://wordpress.com/speed-test">
+							{ translate( 'Test another site' ) }
+						</Button>
 					</div>
 				</div>
 				{ showNavigationTabs && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1724070620077129-slack-C02JPCHEKDY