### PR TITLE
Automated Migration: Add the mutation to request the automated migration

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-request-automated-migration.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-request-automated-migration.ts
@@ -21,6 +21,15 @@ interface AutomatedMigrationRequest {
 	howToAccessSite: 'credentials' | 'backup';
 }
 
+interface AutomatedMigrationBody {
+	migration_type: 'credentials' | 'backup';
+	from_url?: string;
+	username?: string;
+	password?: string;
+	backup_file_location?: string;
+	notes?: string;
+}
+
 export const useRequestAutomatedMigration = <
 	TData = AutomatedMigrationAPIResponse | APIError,
 	TError = APIError,
@@ -36,21 +45,35 @@ export const useRequestAutomatedMigration = <
 			backupFileLocation,
 			notes,
 			howToAccessSite,
-		} ) =>
-			wpcomRequest( {
+		} ) => {
+			let body: AutomatedMigrationBody = {
+				migration_type: howToAccessSite,
+				notes,
+			};
+
+			if ( howToAccessSite === 'credentials' ) {
+				body = {
+					...body,
+					from_url: siteAddress,
+					username,
+					password,
+				};
+			} else {
+				// In case of backup, we need to send the backup file location
+				body = {
+					...body,
+					from_url: backupFileLocation,
+				};
+			}
+
+			return wpcomRequest( {
 				path: 'help/automated-migration',
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
 				method: 'POST',
-				body: {
-					migration_type: howToAccessSite,
-					from_url: siteAddress,
-					username,
-					password,
-					backup_file_location: backupFileLocation,
-					notes,
-				},
-			} ),
+				body,
+			} );
+		},
 		...options,
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-request-automated-migration.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-request-automated-migration.ts
@@ -1,0 +1,61 @@
+import { useMutation } from '@tanstack/react-query';
+import { UseMutationOptions } from '@tanstack/react-query/build/modern';
+import wpcomRequest from 'wpcom-proxy-request';
+
+interface AutomatedMigrationAPIResponse {
+	success: boolean;
+}
+
+interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+}
+
+interface AutomatedMigrationRequest {
+	siteAddress: string;
+	username: string;
+	password: string;
+	backupFileLocation: string;
+	notes: string;
+	howToAccessSite: 'credentials' | 'backup';
+}
+
+export const useRequestAutomatedMigration = <
+	TData = AutomatedMigrationAPIResponse | APIError,
+	TError = APIError,
+	TContext = unknown,
+>(
+	options: UseMutationOptions< TData, TError, AutomatedMigrationRequest, TContext > = {}
+) => {
+	const { mutate, ...rest } = useMutation( {
+		mutationFn: ( {
+			siteAddress,
+			username,
+			password,
+			backupFileLocation,
+			notes,
+			howToAccessSite,
+		} ) =>
+			wpcomRequest( {
+				path: 'help/automated-migration',
+				apiNamespace: 'wpcom/v2/',
+				apiVersion: '2',
+				method: 'POST',
+				body: {
+					migration_type: howToAccessSite,
+					from_url: siteAddress,
+					username,
+					password,
+					backup_file_location: backupFileLocation,
+					notes,
+				},
+			} ),
+		...options,
+	} );
+
+	return {
+		requestAutomatedMigration: mutate,
+		...rest,
+	};
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -2,7 +2,6 @@ import { FormLabel } from '@automattic/components';
 import Card from '@automattic/components/src/card';
 import { NextButton, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { type FC } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import getValidationMessage from 'calypso/blocks/import/capture/url-validation-message-helper';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
@@ -13,12 +12,13 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isValidUrl } from 'calypso/lib/importer/url-validation';
+import { useRequestAutomatedMigration } from './hooks/use-request-automated-migration';
 import type { Step } from '../../types';
 
 import './style.scss';
 
 interface CredentialsFormProps {
-	onSubmit: ( data: CredentialsFormData ) => void;
+	onSubmit: () => void;
 }
 
 interface CredentialsFormData {
@@ -32,18 +32,6 @@ interface CredentialsFormData {
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 	const translate = useTranslate();
-
-	const validateSiteAddress = ( siteAddress: string ) => {
-		const isSiteAddressValid = CAPTURE_URL_RGX.test( siteAddress );
-
-		if ( ! isSiteAddressValid ) {
-			return getValidationMessage( siteAddress, translate );
-		}
-	};
-
-	const isBackupFileLocationValid = ( fileLocation: string ) => {
-		return ! isValidUrl( fileLocation ) ? translate( 'Please enter a valid URL.' ) : undefined;
-	};
 
 	const {
 		formState: { errors },
@@ -63,11 +51,33 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 		},
 	} );
 
+	const { isPending, requestAutomatedMigration } = useRequestAutomatedMigration( {
+		onSuccess: () => {
+			recordTracksEvent( 'calypso_site_migration_automated_request_success' );
+			onSubmit();
+		},
+		onError: () => {
+			recordTracksEvent( 'calypso_site_migration_automated_request_error' );
+		},
+	} );
+
+	const validateSiteAddress = ( siteAddress: string ) => {
+		const isSiteAddressValid = CAPTURE_URL_RGX.test( siteAddress );
+
+		if ( ! isSiteAddressValid ) {
+			return getValidationMessage( siteAddress, translate );
+		}
+	};
+
+	const isBackupFileLocationValid = ( fileLocation: string ) => {
+		return ! isValidUrl( fileLocation ) ? translate( 'Please enter a valid URL.' ) : undefined;
+	};
+
 	// Subscribe only this field to the access method value
 	const accessMethod = watch( 'howToAccessSite' );
 
 	const submitHandler = ( data: CredentialsFormData ) => {
-		onSubmit( data );
+		requestAutomatedMigration( data );
 	};
 
 	return (
@@ -248,7 +258,10 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 				</div>
 			</Card>
 			<div className="site-migration-credentials__skip">
-				<button className="button navigation-link step-container__navigation-link has-underline is-borderless">
+				<button
+					className="button navigation-link step-container__navigation-link has-underline is-borderless"
+					disabled={ isPending }
+				>
 					{ translate( 'Skip, I need help providing access' ) }
 				</button>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93252

## Proposed Changes

* Adds the mutation to request the automated migration on the credentials step. The back-end changes are being worked on here: D158344-code.
* While it's loading, we will block the UI.
* Note that we had to add a condition while creating the body to adapt to the discussion we had here(p1723842281887209-slack-C07G7FG6J8Y). I thought about using the spread operator conditionally but adding the if/else block is more readable.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to start the jobs when we get the credentials and the site address, or the back file URL. This PR will make the request to the back-end to start the jobs necessary for the Automated Migration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Apply this branch to your local environment or add the Calypso Live link below.
* Open the dev console and activate the feature flag by running the following command:
```
window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')
```
* Now go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Fill in the form and click on continue
  * Make sure the request is complete and that you go to the instruction step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?