### PR TITLE
Revisions: Add support for revision fields

### DIFF
--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -174,15 +174,14 @@ class EditorDiffViewer extends PureComponent {
 
 		const fields = [];
 
-		for ( const field in diff ) {
-			// Skip post_title field.
-			if ( 'post_title' === field ) {
-				continue;
-			}
+		const { post_title, totals, ...fieldsWithoutTitle } = diff;
 
+		for ( const field in fieldsWithoutTitle ) {
 			fields.push(
 				<div key={ field }>
-					<h2 className="editor-diff-viewer__fieldname">{ revisionFields[ field ] }</h2>
+					{ Object.keys( fieldsWithoutTitle ).length > 1 && (
+						<h2 className="editor-diff-viewer__fieldname">{ revisionFields[ field ] }</h2>
+					) }
 					<pre className="editor-diff-viewer__content">
 						<TextDiff operations={ diff[ field ] } splitLines />
 					</pre>

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -14,6 +14,11 @@
 		-webkit-overflow-scrolling: touch;
 	}
 
+	.editor-diff-viewer__fieldname {
+		font-size: $font-title-small;
+		font-weight: 600;
+	}
+
 	.editor-diff-viewer__title {
 		font-family: $serif;
 		font-size: $font-title-large;

--- a/client/state/posts/revisions/actions.js
+++ b/client/state/posts/revisions/actions.js
@@ -36,11 +36,12 @@ export const requestPostRevisions = ( siteId, postId, postType = 'posts', compar
 /**
  * Action creator function: POST_REVISIONS_RECEIVE
  */
-export const receivePostRevisions = ( { diffs, postId, revisions, siteId } ) => ( {
+export const receivePostRevisions = ( { diffs, postId, revisions, revision_fields, siteId } ) => ( {
 	type: POST_REVISIONS_RECEIVE,
 	diffs,
 	postId,
 	revisions,
+	revision_fields,
 	siteId,
 } );
 

--- a/client/state/posts/revisions/reducer.js
+++ b/client/state/posts/revisions/reducer.js
@@ -12,7 +12,10 @@ import {
 import { combineReducers } from 'calypso/state/utils';
 import authors from './authors/reducer';
 
-export function diffs( state = {}, { diffs: diffsFromServer, postId, revisions, siteId, type } ) {
+export function diffs(
+	state = {},
+	{ diffs: diffsFromServer, postId, revisions, revision_fields, siteId, type }
+) {
 	if ( type !== POST_REVISIONS_RECEIVE ) {
 		return state;
 	}
@@ -62,6 +65,7 @@ export function diffs( state = {}, { diffs: diffsFromServer, postId, revisions, 
 					...keyBy( filteredDiffs, ( d ) => `${ d.from }:${ d.to }` ),
 				},
 				revisions: mergedRevisions,
+				revisionFields: revision_fields,
 			},
 		},
 	};

--- a/client/state/posts/selectors/get-post-revision-fields.js
+++ b/client/state/posts/selectors/get-post-revision-fields.js
@@ -1,0 +1,9 @@
+import { createSelector } from '@automattic/state-utils';
+import { get } from 'lodash';
+
+export const getPostRevisionFields = createSelector(
+	( state, siteId, postId ) => {
+		return get( state.posts.revisions.diffs, [ siteId, postId, 'revisionFields' ] );
+	},
+	( state ) => [ state.posts.revisions.diffs ]
+);

--- a/client/state/posts/selectors/get-post-revision-fields.js
+++ b/client/state/posts/selectors/get-post-revision-fields.js
@@ -1,9 +1,8 @@
 import { createSelector } from '@automattic/state-utils';
-import { get } from 'lodash';
 
 export const getPostRevisionFields = createSelector(
 	( state, siteId, postId ) => {
-		return get( state.posts.revisions.diffs, [ siteId, postId, 'revisionFields' ] );
+		return state.posts.revisions.diffs?.[ siteId ]?.[ postId ]?.revisionFields;
 	},
 	( state ) => [ state.posts.revisions.diffs ]
 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/80933

## Proposed Changes

* Add support for revision fields (e.g. footnotes)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Adds support for footnotes revisions and other revision fields.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D158755-code on your sandbox
* Use the live link
* Create a new post in /posts/your-site (Calypso iframe)
* Add some revisions that contain footnotes
* Click on the revisions UI
* Compare the results with it's Core equivalent
* The core equivalent is located in wp-admin/revision.php (that can be accessible from WP-Admin Gutenberg - classic view).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
