### PR TITLE
fix(hosting-overview-refinements): tracking names for WP and PHP versions

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -65,11 +65,11 @@ export default function ItemPreviewPaneHeader( {
 		config.isEnabled( 'hosting-overview-refinements' ) && isAtomic && ( wpVersion || phpVersion );
 
 	const handlePhpVersionClick = () => {
-		dispatch( recordTracksEvent( 'calypso_hosting_configuration_php_version_update' ) );
+		dispatch( recordTracksEvent( 'calypso_hosting_php_version_click' ) );
 	};
 
 	const handleWpVersionClick = () => {
-		dispatch( recordTracksEvent( 'calypso_hosting_configuration_wp_version_update' ) );
+		dispatch( recordTracksEvent( 'calypso_hosting_wp_version_click' ) );
 	};
 
 	return (


### PR DESCRIPTION
Related to p1724080429781159-slack-C06ELHR6L9J

## Why are these changes being made?
I remember when I was reading this (pcYYuD-1Pw-p2) the first time - I knew what was necessary to do, but later I didn't read it again and just copy-pasted existing names which are used in another place. My bad. With this PR we are adding the new appropriate tracking names.

## Testing Instructions
Visual review should suffice