### PR TITLE
E2E: Fix failing YouTube Block tests

### DIFF
--- a/test/e2e/specs/blocks/blocks__core.ts
+++ b/test/e2e/specs/blocks/blocks__core.ts
@@ -13,7 +13,7 @@ import { createBlockTests } from './shared/block-smoke-testing';
 const blockFlows: BlockFlow[] = [
 	new YouTubeBlockFlow( {
 		embedUrl: 'https://www.youtube.com/watch?v=twGLN4lug-I',
-		expectedVideoTitle: 'Getting Started on @WordPressdotcom',
+		expectedVideoTitle: 'Getting Started on @wordpress-com',
 	} ),
 	new LayoutGridBlockFlow( {
 		leftColumnText: DataHelper.getRandomPhrase(),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Recently, the E2E tests for the YouTube block started failing (the first failure I found is on 17 Aug 04:00). The failures started because apparently the video's title has been updated - or probably the profile's title, which then caused the video's title to be updated as well since it has a handle to the profile. 
This PR fixes it. 

## Proposed Changes
Updates the expected title in the e2e test.

## Testing Instructions
Ensure all Gutenberg tests are passing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
