### PR TITLE
Automated Migrations: Adapt the Instructions step for the Automated Migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -44,13 +44,15 @@ const ImporterMigrateMessage: Step = () => {
 		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
 			path: window.location.pathname,
 		} );
-		sendTicket( {
-			locale,
-			from_url: fromUrl,
-			blog_url: siteSlug,
-		} );
+		if ( ! config.isEnabled( 'automated-migration/collect-credentials' ) || isCredentialsSkipped ) {
+			sendTicket( {
+				locale,
+				from_url: fromUrl,
+				blog_url: siteSlug,
+			} );
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ isCredentialsSkipped, config, fromUrl, siteSlug ] );
 	let whatToExpect: WhatToExpectProps[] = [];
 	let actions: ActionsProps[] = [];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';
@@ -17,6 +18,17 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import FlowCard from '../components/flow-card';
 import { redirect } from '../import/util';
 import { useSubmitMigrationTicket } from './hooks/use-submit-migration-ticket';
+
+interface ActionsProps {
+	title: string;
+	text: string;
+	onClick: () => void;
+}
+
+interface WhatToExpectProps {
+	icon: JSX.Element;
+	text: string;
+}
 
 const ImporterMigrateMessage: Step = () => {
 	const locale = useLocale();
@@ -38,6 +50,71 @@ const ImporterMigrateMessage: Step = () => {
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
+	let whatToExpect: WhatToExpectProps[] = [];
+	let actions: ActionsProps[] = [];
+
+	if ( config.isEnabled( 'automated-migration/collect-credentials' ) ) {
+		whatToExpect = [
+			{
+				icon: group,
+				text: __(
+					`We'll bring over a copy of your site, without affecting the current live version.`
+				),
+			},
+			{
+				icon: backup,
+				text: __(
+					`You'll get an update on the progress of your migration within 2-3 business days.`
+				),
+			},
+		];
+		actions = [
+			{
+				title: __( 'Explore features' ),
+				text: __( 'Discover the features available on WordPress.com' ),
+				onClick: () => redirect( `/home/${ siteSlug }` ),
+			},
+			{
+				title: __( 'Learn about WordPress.com' ),
+				text: __( 'Access guides and tutorials to better understand how to use WordPress.com.' ),
+				onClick: () => redirect( '/support' ),
+			},
+		];
+	} else {
+		whatToExpect = [
+			{
+				icon: shield,
+				text: __( `We'll explain how to securely share your site credentials with us.` ),
+			},
+			{
+				icon: backup,
+				text: __(
+					`We'll update you on the progress of the migration, which usually takes 2-3 business days.`
+				),
+			},
+			{
+				icon: group,
+				text: __( `We'll create a copy of your live site, allowing you to compare the two.` ),
+			},
+		];
+		actions = [
+			{
+				title: __( 'Let me explore' ),
+				text: __( 'Discover more features and options available on WordPress.com on your own.' ),
+				onClick: () => redirect( `/home/${ siteSlug }` ),
+			},
+			{
+				title: __( 'Help me learn' ),
+				text: __( 'Access guides and tutorials to better understand how to use WordPress.com.' ),
+				onClick: () => redirect( '/support' ),
+			},
+		];
+	}
+
+	whatToExpect.push( {
+		icon: globe,
+		text: __( `We'll help you switch your domain over after the migration is complete.` ),
+	} );
 
 	const title = hasEnTranslation( "We'll take it from here!" )
 		? __( "We'll take it from here!" )
@@ -72,47 +149,18 @@ const ImporterMigrateMessage: Step = () => {
 						</div>
 					) }
 					<h3>{ __( 'What to expect' ) }</h3>
-					<div className="feature">
-						<span className="icon">
-							<Icon icon={ shield } />
-						</span>
-						{ __( `We'll explain how to securely share your site credentials with us.` ) }
-					</div>
-					<div className="feature">
-						<span className="icon">
-							<Icon icon={ backup } />
-						</span>
-						{ __(
-							`We'll update you on the progress of the migration, which usually takes 2-3 business days.`
-						) }
-					</div>
-					<div className="feature">
-						<span className="icon">
-							<Icon icon={ group } />
-						</span>
-						{ __( `We’ll create a copy of your live site, allowing you to compare the two.` ) }
-					</div>
-					<div className="feature">
-						<span className="icon">
-							<Icon icon={ globe } />
-						</span>
-						{ __( `We'll help you with the domain changes after the migration is completed.` ) }
-					</div>
+					{ whatToExpect.map( ( { icon, text }, index ) => (
+						<div key={ index } className="feature">
+							<span className="icon">
+								<Icon icon={ icon } />
+							</span>
+							{ text }
+						</div>
+					) ) }
 					<div className="migration-message__actions">
-						<FlowCard
-							title={ __( 'Let me explore' ) }
-							text={ __(
-								'Discover more features and options available on WordPress.com on your own.'
-							) }
-							onClick={ () => redirect( `/home/${ siteSlug }` ) }
-						/>
-						<FlowCard
-							title={ __( 'Help me learn' ) }
-							text={ __(
-								'Access guides and tutorials to better understand how to use WordPress.com.'
-							) }
-							onClick={ () => redirect( '/support' ) }
-						/>
+						{ actions.map( ( { title, text, onClick }, index ) => (
+							<FlowCard key={ index } title={ title } text={ text } onClick={ onClick } />
+						) ) }
 					</div>
 				</>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -37,6 +37,7 @@ const ImporterMigrateMessage: Step = () => {
 	const siteSlugParam = useSiteSlugParam();
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const siteSlug = siteSlugParam ?? '';
+	const isCredentialsSkipped = useQuery().get( 'credentials' ) === 'skipped';
 	const { isPending, sendTicket } = useSubmitMigrationTicket();
 
 	useEffect( () => {
@@ -53,7 +54,7 @@ const ImporterMigrateMessage: Step = () => {
 	let whatToExpect: WhatToExpectProps[] = [];
 	let actions: ActionsProps[] = [];
 
-	if ( config.isEnabled( 'automated-migration/collect-credentials' ) ) {
+	if ( ! isCredentialsSkipped && config.isEnabled( 'automated-migration/collect-credentials' ) ) {
 		whatToExpect = [
 			{
 				icon: group,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -3,7 +3,7 @@ import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
-import { Icon, globe, group, shield, backup } from '@wordpress/icons';
+import { Icon, globe, group, shield, backup, scheduled } from '@wordpress/icons';
 import { createElement, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -63,7 +63,7 @@ const ImporterMigrateMessage: Step = () => {
 				),
 			},
 			{
-				icon: backup,
+				icon: scheduled,
 				text: __(
 					`You'll get an update on the progress of your migration within 2-3 business days.`
 				),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/index.tsx
@@ -43,6 +43,8 @@ const ImporterMigrateMessage: Step = () => {
 	useEffect( () => {
 		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
 			path: window.location.pathname,
+			automated_migration: config.isEnabled( 'automated-migration/collect-credentials' ),
+			skipped_credentials: isCredentialsSkipped,
 		} );
 		if ( ! config.isEnabled( 'automated-migration/collect-credentials' ) || isCredentialsSkipped ) {
 			sendTicket( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
@@ -69,6 +69,9 @@
 
 		@include break-small {
 			flex-direction: row;
+			.flow-question {
+				width: 50%;
+			}
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -19,6 +19,7 @@ import './style.scss';
 
 interface CredentialsFormProps {
 	onSubmit: ( data: CredentialsFormData ) => void;
+	onSkip: () => void;
 }
 
 interface CredentialsFormData {
@@ -30,7 +31,7 @@ interface CredentialsFormData {
 	howToAccessSite: 'credentials' | 'backup';
 }
 
-export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
+export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
 	const translate = useTranslate();
 
 	const validateSiteAddress = ( siteAddress: string ) => {
@@ -252,7 +253,10 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 				</div>
 			</Card>
 			<div className="site-migration-credentials__skip">
-				<button className="button navigation-link step-container__navigation-link has-underline is-borderless">
+				<button
+					className="button navigation-link step-container__navigation-link has-underline is-borderless"
+					onClick={ onSkip }
+				>
 					{ translate( 'Skip, I need help providing access' ) }
 				</button>
 			</div>
@@ -265,6 +269,12 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 
 	const handleSubmit = () => {
 		return navigation.submit?.();
+	};
+
+	const handleSkip = () => {
+		return navigation.submit?.( {
+			action: 'skip',
+		} );
 	};
 
 	return (
@@ -287,7 +297,7 @@ const SiteMigrationCredentials: Step = function ( { navigation } ) {
 						align="center"
 					/>
 				}
-				stepContent={ <CredentialsForm onSubmit={ handleSubmit } /> }
+				stepContent={ <CredentialsForm onSubmit={ handleSubmit } onSkip={ handleSkip } /> }
 				recordTracksEvent={ recordTracksEvent }
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -408,6 +408,19 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_MIGRATION_CREDENTIALS.slug: {
+					const { action } = providedDependencies as {
+						action: 'skip' | 'submit';
+					};
+
+					if ( action === 'skip' ) {
+						return navigate(
+							addQueryArgs(
+								{ siteId, from: fromQueryParam, siteSlug, credentials: 'skipped' },
+								STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
+							)
+						);
+					}
+
 					return navigate( STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug, {
 						siteId,
 						siteSlug,

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -310,6 +310,22 @@ describe( 'Site Migration Flow', () => {
 			config.disable( 'automated-migration/collect-credentials' );
 		} );
 
+		it( 'Skipping the credentials step redirects the user to the instructions page', () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_CREDENTIALS.slug,
+				dependencies: {
+					action: 'skip',
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: `/${ STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug }?siteSlug=example.wordpress.com&credentials=skipped`,
+				state: null,
+			} );
+		} );
+
 		it( 'redirects the user to the instructions page when the user submits the credentials step', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #93638

## Proposed Changes

* Add the new copies to the Instructions step to reflect the changes in phase one.
* I also fixed a few issues:
  * The sizes of the action items could cause a visual bug.
  * There was a ` char when it should '.
* When the user skips the credentials step, we should show the current design of the Instruction step.
* This PR also prevents the request to create the ticket when we already created it on the credentials step.

![Captura de Tela 2024-08-20 às 06 50 49](https://github.com/user-attachments/assets/6c12ae95-4a63-49d2-b6c0-2b111429fb74)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the Automated Migration, we are already collecting the credentials, and the instructions step should not say that we'd give instructions on how to share the credentials.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch to your local environment or add the Calypso Live link below.
* Open the dev console and activate the feature flag by running the following command:
```
window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')
```
* Now go through the migration flow by navigating to `/start`:
  * Go through the domain selection step
  * Select the free plan on the `Plans` page
  * On the `Goals` step, select the "Import existing content or website" option and click continue
  * Input the source site URL in the Identify step
  * Next, select the "Migrate Site" option on the `Import or Migrate` step
  * Select "Do it for me" on the `How to migrate` step
  * Go through the checkout
  * Once you complete the checkout, you should land on the new `Credentials` step
  * Fill in the form and click on continue
  * Now, on the Instructions step, make sure the copy matches the Figma design: F8foKv974Gc5dTHSh0i0Wo-fi-257_2924

Note: you should also test skipping the Credentials step. The instructions step should not have change in this case.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?