### PR TITLE
`ReaderFeaturedImage`: Remove `width: '100%'` on portrait images

### DIFF
--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -152,6 +152,8 @@ const ReaderFeaturedImage = ( {
 		height: containerHeight,
 	};
 
+	const isPortrait = imageHeight > imageWidth;
+
 	if ( children ) {
 		// If there are children, then we are rendering an image tag inside the anchor tag
 		// In this case we will need to anchor tag will need specific styling to show the image(s)
@@ -164,9 +166,17 @@ const ReaderFeaturedImage = ( {
 			backgroundRepeat: 'no-repeat',
 		};
 	} else {
+		if ( isPortrait ) {
+			featuredImageStyle.background = 'var(--studio-gray-0)';
+		}
+
 		// Since there is no children in props, we need to create a new image tag to ensure the correct size is rendered
 		children = (
-			<img src={ safeCssUrl } alt="Featured" style={ { height: containerHeight, width: '100%' } } />
+			<img
+				src={ safeCssUrl }
+				alt="Featured"
+				style={ { height: containerHeight, ...( ! isPortrait && { width: '100%' } ) } }
+			/>
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93672

## Proposed Changes

* When the image featured on the reader is a portrait picture, prevent it from getting cropped by not forcing its `width` to `100%`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/read/feeds/154166941`
* Check that portrait images aren't cropped:

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/d38f4101-0750-4b4d-9a80-b1951fe035bf)|![image](https://github.com/user-attachments/assets/9c2c75f6-c687-4af8-a5a6-f19932fadf70)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
