### PR TITLE
Updates to global top bar - small refinements

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -667,7 +667,7 @@ body.is-mobile-app-view {
 
 	&.masterbar__item-my-sites,
 	&.masterbar__item-no-sites {
-		padding: 0 7px 0 5px; // trying to match core's 35px width
+		padding: 0 10px;
 
 		@media only screen and (max-width: 781px) {
 			padding: 0;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -43,7 +43,7 @@ body.is-mobile-app-view {
 	justify-content: space-between;
 	opacity: 1;
 	transition: all 0.3s ease-in-out;
-	--masterbar-item-active-border-radius: 4px; /* stylelint-disable-line scales/radii */
+	--masterbar-item-active-border-radius: 4px;
 
 	.is-support-session & {
 		// Use generic colors so that they override whatever theme colors the user has picked.

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -43,7 +43,7 @@ body.is-mobile-app-view {
 	justify-content: space-between;
 	opacity: 1;
 	transition: all 0.3s ease-in-out;
-	--masterbar-item-active-border-radius: 6px; /* stylelint-disable-line scales/radii */
+	--masterbar-item-active-border-radius: 4px; /* stylelint-disable-line scales/radii */
 
 	.is-support-session & {
 		// Use generic colors so that they override whatever theme colors the user has picked.
@@ -288,10 +288,10 @@ body.is-mobile-app-view {
 	justify-content: center;
 
 	&.masterbar__reader {
-		padding: 0 10px 0 6px;
+		padding: 0 8px;
 
 		.masterbar_svg-reader {
-			padding: 0 0 0 4px;
+			padding: 0 8px 0 0;
 		}
 	}
 
@@ -667,7 +667,7 @@ body.is-mobile-app-view {
 
 	&.masterbar__item-my-sites,
 	&.masterbar__item-no-sites {
-		padding: 0 10px;
+		padding: 0 8px;
 
 		@media only screen and (max-width: 781px) {
 			padding: 0;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -734,6 +734,7 @@ body.is-mobile-app-view {
 
 			&.masterbar__item-howdy {
 				border-top-right-radius: 0;
+				padding: 0 10px;
 			}
 
 			&::before,

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -289,10 +289,6 @@ body.is-mobile-app-view {
 
 	&.masterbar__reader {
 		padding: 0 8px;
-
-		.masterbar_svg-reader {
-			padding: 0 8px 0 0;
-		}
 	}
 
 	&.masterbar__item-my-site,

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -734,7 +734,6 @@ body.is-mobile-app-view {
 
 			&.masterbar__item-howdy {
 				border-top-right-radius: 0;
-				padding: 0 10px;
 			}
 
 			&::before,


### PR DESCRIPTION
## Description

I notices some small inconsistencies between the figma file and what was in production for the recently updated global top bar treatment:

![image](https://github.com/user-attachments/assets/95bfa7a1-b75a-4589-bbde-6d8774755692)

1) Width seemed off (especially for the WP logo)
2 & 3) border radius seemed off

## Comparison

Here's what I've got so far in this PR:

![CleanShot 2024-08-19 at 15 06 56@2x](https://github.com/user-attachments/assets/3a78f34f-af24-494c-b6a3-497b566eda52)

A couple notes:

- I reduced the rounded corner from 6px to 4px like you had it in Figma
- I kept the reader icon at 24px width instead of 20px. I tried 20px, but the icon started to get too rasterized and tiny looking.
- I also kept 8px to the right of the reader icon, to match all of the other links in the top nav (where you had much less of a gap in Figma)
