### PR TITLE
Fix regression in content frame with reloading themes/domains on desktop

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -73,8 +73,6 @@ $brand-text: "SF Pro Text", $sans;
 		&.focus-content .layout__content {
 			padding-top: calc(var(--masterbar-height) + var(--content-padding-top));
 			padding-bottom: var(--content-padding-bottom);
-			padding-right: 16px;
-			padding-left: 16px;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/93631 

## Proposed Changes

My above PR introduced a regression. Im removing 2 added style rules from it that I thought would be helpful by ensuring a default, but ended up having too much specificity and overriding other necessary styles. I want to revert these 2 left/right padding assignments and let them continue to be supplied elsewhere.

* Domains and Plans paged on desktop load with their content bleeding underneath the sidebar. (only visible if reloading on these pages or visiting these links directly without visiting other calypso)
* This resolves that.

<img width="1093" alt="Screenshot 2024-08-19 at 3 29 32 PM" src="https://github.com/user-attachments/assets/f160a99b-d7b7-429e-85b1-7339f84f6d48">
<img width="1090" alt="Screenshot 2024-08-19 at 3 29 40 PM" src="https://github.com/user-attachments/assets/25f24383-5df0-48a0-bae4-75b20f38f62d">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load global */themes and */domains at desktop viewport. verify the issue is no longer present.
* Test global pages across various viewport widths and verify no regressions are in place.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
