### PR TITLE
Fix `manage paid memberships` page not found redirection

### DIFF
--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -29,7 +30,10 @@ const useUnsubscribeModal = (
 	const onConfirmModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
 		if ( action === UnsubscribeActionType.Manage ) {
 			recordRemoveModal( true, 'manage_button_clicked' );
-			navigate( `/earn/supporters/${ selectedSiteSlug ?? '' }` );
+			const link = isJetpackCloud()
+				? `/monetize/supporters/${ selectedSiteSlug }`
+				: `/earn/supporters/${ selectedSiteSlug }`;
+			navigate( link ?? '' );
 		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
 			mutate( subscriber, {
 				onSuccess: () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/93694

## Proposed Changes

* When in Jetpack Cloud context the button should redirect to `monetize/supporters` instead of `/earn/supporters`
![image](https://github.com/user-attachments/assets/78e6fb2c-c225-49a7-8695-af2eee262152)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users trying to manage paid subscribers in Jetpack Cloud context encounters `page not found` error

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to https://cloud.jetpack.com/subscribers/{BLOG_ID}
2. Add a subscriber (make it paid sub see p1724185875473279/1724104349.995299-slack-C07GZ2UA3T)N 
3. Click to remove
4. In modal, click “Manage paid subscribers”
5. Verify it redirects to `/monetize/supporters/siteSlug`

**Regression**
Perform the same tests on wordpress.com 
- Go to https://wordpress.com/subscribers/{BLOG_ID}
- Verify `Manage paid subscribers` redirects to `/earn/supporters/siteSlug`
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?