### PR TITLE
Add Stripe card networks object to redux store

### DIFF
--- a/client/my-sites/checkout/src/components/payment-logos.js
+++ b/client/my-sites/checkout/src/components/payment-logos.js
@@ -28,6 +28,54 @@ VisaLogo.propTypes = {
 	className: PropTypes.string,
 };
 
+export function CBLogo( { className } ) {
+	return (
+		<svg
+			className={ className }
+			width="41"
+			height="17"
+			viewBox="0 0 26 17"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<radialGradient
+				id="b"
+				cx="1.47"
+				cy="18.27"
+				gradientTransform="matrix(1 0 0 .94 0 .5)"
+				gradientUnits="userSpaceOnUse"
+				r="26.83"
+			>
+				<stop offset=".09" stopColor="#009245" />
+				<stop offset=".23" stopColor="#049552" stopOpacity=".89" />
+				<stop offset=".52" stopColor="#0d9e74" stopOpacity=".59" />
+				<stop offset=".91" stopColor="#1bacab" stopOpacity=".12" />
+				<stop offset="1" stopColor="#1fb0b8" stopOpacity="0" />
+			</radialGradient>
+			<radialGradient id="c" cx="5.89" cy="19.23" gradientUnits="userSpaceOnUse" r="34.42">
+				<stop offset=".15" stopColor="#1fb0b8" stopOpacity="0" />
+				<stop offset=".35" stopColor="#1c7491" stopOpacity=".4" />
+				<stop offset=".56" stopColor="#1a4471" stopOpacity=".73" />
+				<stop offset=".74" stopColor="#18265e" stopOpacity=".93" />
+				<stop offset=".87" stopColor="#181b57" />
+			</radialGradient>
+			<g>
+				<path d="M0 0h26.47v18.16H0z" fill="#29abe2" />
+				<path d="M0 0h26.47v18.16H0z" fill="url(#b)" />
+				<path d="M0 0h26.47v18.16H0z" fill="url(#c)" />
+			</g>
+			<g fill="#fff">
+				<path d="M14.39 3.86h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V3.86zM14.39 9.36h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V9.36zM8.23 9.36V8.8h5.69a5.51 5.51 0 0 0-5.69-4.94 5.47 5.47 0 0 0-5.69 5.22 5.47 5.47 0 0 0 5.69 5.22 5.51 5.51 0 0 0 5.69-4.94z" />
+			</g>
+		</svg>
+	);
+}
+CBLogo.propTypes = {
+	className: PropTypes.string,
+};
+
 export function MastercardLogo( { className } ) {
 	return (
 		<svg

--- a/client/my-sites/checkout/src/components/payment-logos.js
+++ b/client/my-sites/checkout/src/components/payment-logos.js
@@ -28,54 +28,6 @@ VisaLogo.propTypes = {
 	className: PropTypes.string,
 };
 
-export function CBLogo( { className } ) {
-	return (
-		<svg
-			className={ className }
-			width="41"
-			height="17"
-			viewBox="0 0 26 17"
-			fill="none"
-			xmlns="http://www.w3.org/2000/svg"
-			aria-hidden="true"
-			focusable="false"
-		>
-			<radialGradient
-				id="b"
-				cx="1.47"
-				cy="18.27"
-				gradientTransform="matrix(1 0 0 .94 0 .5)"
-				gradientUnits="userSpaceOnUse"
-				r="26.83"
-			>
-				<stop offset=".09" stopColor="#009245" />
-				<stop offset=".23" stopColor="#049552" stopOpacity=".89" />
-				<stop offset=".52" stopColor="#0d9e74" stopOpacity=".59" />
-				<stop offset=".91" stopColor="#1bacab" stopOpacity=".12" />
-				<stop offset="1" stopColor="#1fb0b8" stopOpacity="0" />
-			</radialGradient>
-			<radialGradient id="c" cx="5.89" cy="19.23" gradientUnits="userSpaceOnUse" r="34.42">
-				<stop offset=".15" stopColor="#1fb0b8" stopOpacity="0" />
-				<stop offset=".35" stopColor="#1c7491" stopOpacity=".4" />
-				<stop offset=".56" stopColor="#1a4471" stopOpacity=".73" />
-				<stop offset=".74" stopColor="#18265e" stopOpacity=".93" />
-				<stop offset=".87" stopColor="#181b57" />
-			</radialGradient>
-			<g>
-				<path d="M0 0h26.47v18.16H0z" fill="#29abe2" />
-				<path d="M0 0h26.47v18.16H0z" fill="url(#b)" />
-				<path d="M0 0h26.47v18.16H0z" fill="url(#c)" />
-			</g>
-			<g fill="#fff">
-				<path d="M14.39 3.86h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V3.86zM14.39 9.36h7.07a2.47 2.47 0 0 1 2.47 2.47 2.47 2.47 0 0 1-2.47 2.47h-7.07V9.36zM8.23 9.36V8.8h5.69a5.51 5.51 0 0 0-5.69-4.94 5.47 5.47 0 0 0-5.69 5.22 5.47 5.47 0 0 0 5.69 5.22 5.51 5.51 0 0 0 5.69-4.94z" />
-			</g>
-		</svg>
-	);
-}
-CBLogo.propTypes = {
-	className: PropTypes.string,
-};
-
 export function MastercardLogo( { className } ) {
 	return (
 		<svg

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
@@ -45,6 +45,7 @@ export default function CreditCardFields( {
 	const { __ } = useI18n();
 	const theme = useTheme();
 	const [ isStripeFullyLoaded, setIsStripeFullyLoaded ] = useState( false );
+
 	const fields: CardFieldState = useSelect(
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getFields(),
 		[]
@@ -63,6 +64,7 @@ export default function CreditCardFields( {
 	const {
 		setFieldValue,
 		changeBrand,
+		changeCardNetworks,
 		setCardDataError,
 		setCardDataComplete,
 		setUseForAllSubscriptions,
@@ -148,6 +150,7 @@ export default function CreditCardFields( {
 
 					<FieldRow>
 						<CreditCardNumberField
+							changeCardNetworks={ changeCardNetworks }
 							setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
 							handleStripeFieldChange={ handleStripeFieldChange }
 							stripeElementStyle={ stripeElementStyle }

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
@@ -150,9 +150,9 @@ export default function CreditCardFields( {
 
 					<FieldRow>
 						<CreditCardNumberField
-							changeCardNetworks={ changeCardNetworks }
 							setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
 							handleStripeFieldChange={ handleStripeFieldChange }
+							changeCardNetworks={ changeCardNetworks }
 							stripeElementStyle={ stripeElementStyle }
 							shouldUseEbanx={ shouldUseEbanx }
 							getErrorMessagesForField={ getErrorMessagesForField }

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -78,8 +78,19 @@ export default function CreditCardNumberField( {
 					onChange={ ( input ) => {
 						handleStripeFieldChange( input );
 					} }
+					onNetworksChange={ ( event ) => {
+						switch ( event.networks ) {
+							case null:
+							case undefined:
+								break;
+							default: {
+								setShowNetworkSelector( true );
+								break;
+							}
+						}
+					} }
 				/>
-				<PaymentLogo brand={ brand } />
+				{ showNetworkSelector ? <PaymentLogo brand="cb" /> : <PaymentLogo brand={ brand } /> }
 
 				{ cardNumberError && <StripeErrorMessage>{ cardNumberError }</StripeErrorMessage> }
 			</StripeFieldWrapper>

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -21,7 +21,7 @@ export default function CreditCardNumberField( {
 }: {
 	setIsStripeFullyLoaded: ( isLoaded: boolean ) => void;
 	handleStripeFieldChange: ( input: StripeFieldChangeInput ) => void;
-	changeCardNetworks: ( networks: string[] ) => void;
+	changeCardNetworks: ( networks: [] ) => void;
 	stripeElementStyle: StripeElementStyle;
 	shouldUseEbanx?: boolean;
 	getErrorMessagesForField: ( key: string ) => string[];

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -12,6 +12,7 @@ import type { StripeElementStyle } from '@stripe/stripe-js';
 export default function CreditCardNumberField( {
 	setIsStripeFullyLoaded,
 	handleStripeFieldChange,
+	changeCardNetworks,
 	stripeElementStyle,
 	shouldUseEbanx = false,
 	getErrorMessagesForField,
@@ -20,6 +21,7 @@ export default function CreditCardNumberField( {
 }: {
 	setIsStripeFullyLoaded: ( isLoaded: boolean ) => void;
 	handleStripeFieldChange: ( input: StripeFieldChangeInput ) => void;
+	changeCardNetworks: ( networks: string[] ) => void;
 	stripeElementStyle: StripeElementStyle;
 	shouldUseEbanx?: boolean;
 	getErrorMessagesForField: ( key: string ) => string[];
@@ -85,6 +87,7 @@ export default function CreditCardNumberField( {
 								break;
 							default: {
 								setShowNetworkSelector( true );
+								changeCardNetworks( event.networks );
 								break;
 							}
 						}

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -92,14 +92,13 @@ export default function CreditCardNumberField( {
 							case undefined:
 								break;
 							default: {
-								setShowNetworkSelector( true );
 								changeCardNetworks( event.networks );
 								break;
 							}
 						}
 					} }
 				/>
-				{ showNetworkSelector ? <PaymentLogo brand="cb" /> : <PaymentLogo brand={ brand } /> }
+				<PaymentLogo brand={ brand } />
 
 				{ cardNumberError && <StripeErrorMessage>{ cardNumberError }</StripeErrorMessage> }
 			</StripeFieldWrapper>

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -36,11 +36,6 @@ export default function CreditCardNumberField( {
 		[]
 	);
 
-	const cardNetworks: { brand: string }[] = useSelect(
-		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getCardNetworks(),
-		[]
-	);
-
 	const { cardNumber: cardNumberError } = useSelect(
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getCardDataErrors(),
 		[]

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -35,6 +35,12 @@ export default function CreditCardNumberField( {
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getBrand(),
 		[]
 	);
+
+	const cardNetworks: { brand: string }[] = useSelect(
+		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getCardNetworks(),
+		[]
+	);
+
 	const { cardNumber: cardNumberError } = useSelect(
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getCardDataErrors(),
 		[]

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -81,7 +81,7 @@ export default function CreditCardNumberField( {
 					onChange={ ( input ) => {
 						handleStripeFieldChange( input );
 					} }
-					onNetworksChange={ ( event ) => {
+					onNetworksChange={ ( event: { elementType: 'cardNumber'; networks: [] } ) => {
 						switch ( event.networks ) {
 							case null:
 							case undefined:

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -81,12 +81,17 @@ export default function CreditCardNumberField( {
 					onChange={ ( input ) => {
 						handleStripeFieldChange( input );
 					} }
-					onNetworksChange={ ( event: { elementType: 'cardNumber'; networks: [] } ) => {
+					/* Note, the onNetworksChange event is deprecated and will be removed at some point
+					 * This will need to be updated before we upgrade Stripe beyond v3
+					 */
+					onNetworksChange={ ( event ) => {
+						// @ts-expect-error: The onNetworksChange method is deprecated, but is necessary for cobrand compliance
 						switch ( event.networks ) {
 							case null:
 							case undefined:
 								break;
 							default: {
+								// @ts-expect-error: The onNetworksChange method is deprecated, but is necessary for cobrand compliance
 								changeCardNetworks( event.networks );
 								break;
 							}

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -3,7 +3,6 @@ import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { Fragment } from 'react';
 import {
-	CBLogo,
 	VisaLogo,
 	MastercardLogo,
 	AmexLogo,
@@ -62,7 +61,6 @@ const CreditCardLabel: React.FC< {
 function CreditCardLogos() {
 	return (
 		<PaymentMethodLogos className="credit-card__logo payment-logos">
-			<CBLogo />
 			<VisaLogo />
 			<MastercardLogo />
 			<AmexLogo />

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -3,6 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { Fragment } from 'react';
 import {
+	CBLogo,
 	VisaLogo,
 	MastercardLogo,
 	AmexLogo,
@@ -42,9 +43,9 @@ function CreditCardSummary() {
 	);
 }
 
-const CreditCardLabel: React.FC< { hasExistingCardMethods: boolean | undefined } > = ( {
-	hasExistingCardMethods,
-} ) => {
+const CreditCardLabel: React.FC< {
+	hasExistingCardMethods: boolean | undefined;
+} > = ( { hasExistingCardMethods } ) => {
 	const { __ } = useI18n();
 	return (
 		<Fragment>
@@ -61,6 +62,7 @@ const CreditCardLabel: React.FC< { hasExistingCardMethods: boolean | undefined }
 function CreditCardLogos() {
 	return (
 		<PaymentMethodLogos className="credit-card__logo payment-logos">
+			<CBLogo />
 			<VisaLogo />
 			<MastercardLogo />
 			<AmexLogo />

--- a/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
@@ -18,7 +18,7 @@ export const actions = {
 	changeBrand( payload: string ): CardStoreAction {
 		return { type: 'BRAND_SET', payload };
 	},
-	changeCardNetworks( payload: string[] ): CardStoreAction {
+	changeCardNetworks( payload: { brand: string }[] ): CardStoreAction {
 		return { type: 'CARD_NETWORKS_SET', payload };
 	},
 	setCardDataError( type: CardElementType, message: string | null ): CardStoreAction {
@@ -159,7 +159,7 @@ export function createCreditCardPaymentMethodStore( {
 	}
 
 	function cardNetworksReducer(
-		state: string[] | null | undefined = null,
+		state: { brand: string }[] | null | undefined = null,
 		action?: CardStoreAction
 	) {
 		switch ( action?.type ) {

--- a/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
@@ -48,7 +48,7 @@ export const selectors = {
 	getBrand( state: CardStoreState ): string {
 		return state.brand || '';
 	},
-	getCardNetworks( state: CardStoreState ): string[] {
+	getCardNetworks( state: CardStoreState ): { brand: string }[] {
 		return state.cardNetworks || [];
 	},
 	getCardDataErrors( state: CardStoreState ) {

--- a/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/store.ts
@@ -18,6 +18,9 @@ export const actions = {
 	changeBrand( payload: string ): CardStoreAction {
 		return { type: 'BRAND_SET', payload };
 	},
+	changeCardNetworks( payload: string[] ): CardStoreAction {
+		return { type: 'CARD_NETWORKS_SET', payload };
+	},
 	setCardDataError( type: CardElementType, message: string | null ): CardStoreAction {
 		return { type: 'CARD_DATA_ERROR_SET', payload: { type, message } };
 	},
@@ -44,6 +47,9 @@ export const actions = {
 export const selectors = {
 	getBrand( state: CardStoreState ): string {
 		return state.brand || '';
+	},
+	getCardNetworks( state: CardStoreState ): string[] {
+		return state.cardNetworks || [];
 	},
 	getCardDataErrors( state: CardStoreState ) {
 		return state.cardDataErrors;
@@ -152,6 +158,18 @@ export function createCreditCardPaymentMethodStore( {
 		}
 	}
 
+	function cardNetworksReducer(
+		state: string[] | null | undefined = null,
+		action?: CardStoreAction
+	) {
+		switch ( action?.type ) {
+			case 'CARD_NETWORKS_SET':
+				return action.payload;
+			default:
+				return state;
+		}
+	}
+
 	function allSubscriptionsReducer( state: boolean, action?: CardStoreAction ) {
 		switch ( action?.type ) {
 			case 'USE_FOR_ALL_SUBSCRIPTIONS_SET':
@@ -179,6 +197,7 @@ export function createCreditCardPaymentMethodStore( {
 					cardDataErrors: cardDataErrorsReducer(),
 					cardDataComplete: cardDataCompleteReducer(),
 					brand: brandReducer(),
+					cardNetworks: cardNetworksReducer(),
 					useForAllSubscriptions: getInitialUseForAllSubscriptionsValue(),
 				},
 				action: AnyAction
@@ -188,6 +207,7 @@ export function createCreditCardPaymentMethodStore( {
 					cardDataErrors: cardDataErrorsReducer( state.cardDataErrors, action ),
 					cardDataComplete: cardDataCompleteReducer( state.cardDataComplete, action ),
 					brand: brandReducer( state.brand, action ),
+					cardNetworks: cardNetworksReducer( state.cardNetworks, action ),
 					useForAllSubscriptions: allowUseForAllSubscriptions
 						? allSubscriptionsReducer( state.useForAllSubscriptions, action )
 						: false,

--- a/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
@@ -19,7 +19,7 @@ export type CardDataCompleteState = Record< CardElementType, boolean >;
 
 export interface CardStoreState {
 	brand: string | null | undefined;
-	cardNetworks: string[];
+	cardNetworks: { brand: string }[];
 	fields: CardFieldState;
 	cardDataErrors: Record< string, string | null >;
 	cardDataComplete: CardDataCompleteState;

--- a/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
@@ -35,7 +35,7 @@ export type CardElementType = CardNumberElementType | CardExpiryElementType | Ca
 
 export type CardStoreAction =
 	| { type: 'BRAND_SET'; payload: string }
-	| { type: 'CARD_NETWORKS_SET'; payload: string[] }
+	| { type: 'CARD_NETWORKS_SET'; payload: { brand: string }[] }
 	| { type: 'CARD_DATA_ERROR_SET'; payload: { type: CardElementType; message: string | null } }
 	| { type: 'CARD_DATA_COMPLETE_SET'; payload: { type: CardElementType; complete: boolean } }
 	| { type: 'FIELD_VALUE_SET'; payload: { key: string; value: string } }

--- a/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/types.ts
@@ -19,6 +19,7 @@ export type CardDataCompleteState = Record< CardElementType, boolean >;
 
 export interface CardStoreState {
 	brand: string | null | undefined;
+	cardNetworks: string[];
 	fields: CardFieldState;
 	cardDataErrors: Record< string, string | null >;
 	cardDataComplete: CardDataCompleteState;
@@ -34,6 +35,7 @@ export type CardElementType = CardNumberElementType | CardExpiryElementType | Ca
 
 export type CardStoreAction =
 	| { type: 'BRAND_SET'; payload: string }
+	| { type: 'CARD_NETWORKS_SET'; payload: string[] }
 	| { type: 'CARD_DATA_ERROR_SET'; payload: { type: CardElementType; message: string | null } }
 	| { type: 'CARD_DATA_COMPLETE_SET'; payload: { type: CardElementType; complete: boolean } }
 	| { type: 'FIELD_VALUE_SET'; payload: { key: string; value: string } }


### PR DESCRIPTION
Part 2 of 3 for enabling the new card network selector component outlined in https://github.com/Automattic/payments-shilling/issues/3045


## Proposed Changes
This PR adds a `cardNetworks` array of strings to the `wpcom-credit-card` store to help query available networks when the CreditCardNumberField is updated. This allows us to then trigger the new card network selector components found in part 3/3 https://github.com/Automattic/wp-calypso/pull/93648

## Testing Instructions
- Go to `/checkout` for one of your sites
- Scroll to 'Pick a payment method' and click on 'New credit or debit card'
- Open Redux Devtools or any other redux tool you may have https://github.com/reduxjs/redux-devtools
- Observe that the state for `cardNetworks` is `null`
- Add the following Cartes Bancaires test number into the credit card field `4000002500001001`
- Observe that the state for `cardNetworks` is now `cardNetworks: ['cartes_bancaires', 'visa']`

**Before entering the test card number**

![image](https://github.com/user-attachments/assets/dbcba8e2-3dd8-44b7-b707-eeff013a9394)

**After**

![image](https://github.com/user-attachments/assets/c7fe4c5f-c6b0-41a4-8f9f-41c60e1b5df2)
