### PR TITLE
Upgrade Electron Notarize to 2.4.0 to use new Apple notarization tool

### DIFF
--- a/desktop/bin/after_sign_hook.js
+++ b/desktop/bin/after_sign_hook.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const path = require( 'path' );
-const { notarize } = require( 'electron-notarize' );
+const { notarize } = require( '@electron/notarize' );
 
 const APP_ID = 'com.automattic.wordpress';
 const NOTARIZATION_ID = process.env.WPDESKTOP_NOTARIZATION_ID;

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -39,7 +39,7 @@
 		"copy-webpack-plugin": "^10.2.4",
 		"electron": "26.2.4",
 		"electron-builder": "23.0.3",
-		"electron-notarize": "^0.1.1",
+		"electron-notarize": "^2.4.0",
 		"electron-rebuild": "^2.3.5",
 		"jest": "^29.7.0",
 		"lodash": "^4.17.21",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -36,10 +36,10 @@
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
+		"@electron/notarize": "^2.4.0",
 		"copy-webpack-plugin": "^10.2.4",
 		"electron": "26.2.4",
 		"electron-builder": "23.0.3",
-		"electron-notarize": "^2.4.0",
 		"electron-rebuild": "^2.3.5",
 		"jest": "^29.7.0",
 		"lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,6 +3957,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron/notarize@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "@electron/notarize@npm:2.4.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    fs-extra: "npm:^9.0.1"
+    promise-retry: "npm:^2.0.1"
+  checksum: 87703b8abe27f07622f18d056eb2999ac403c6e34140445d6475eebfaa86f0c348269c7411a5b2e1acf6ac16e872917f7ec2a5fde6d1386c2f017fc2b57e3343
+  languageName: node
+  linkType: hard
+
 "@electron/universal@npm:1.2.0":
   version: 1.2.0
   resolution: "@electron/universal@npm:1.2.0"
@@ -10214,13 +10225,13 @@ __metadata:
   dependencies:
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-eslint-overrides": "workspace:^"
+    "@electron/notarize": "npm:^2.4.0"
     archiver: "npm:^3.1.1"
     copy-webpack-plugin: "npm:^10.2.4"
     cross-env: "npm:^7.0.3"
     electron: "npm:26.2.4"
     electron-builder: "npm:23.0.3"
     electron-fetch: "npm:^1.7.4"
-    electron-notarize: "npm:^0.1.1"
     electron-rebuild: "npm:^2.3.5"
     electron-store: "npm:^8.1.0"
     electron-updater: "npm:^4.2.5"
@@ -15365,16 +15376,6 @@ __metadata:
   dependencies:
     encoding: "npm:^0.1.13"
   checksum: 67b4497d6b02449f24f2e776c367944696ad83fe5c6827c43bf96a92453d71dccef6ca0cfe9607d202f5fdf49c0fdf90533d4188fbbce72c823b90df12ba4d54
-  languageName: node
-  linkType: hard
-
-"electron-notarize@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "electron-notarize@npm:0.1.1"
-  dependencies:
-    debug: "npm:^4.1.1"
-    fs-extra: "npm:^8.0.1"
-  checksum: 9e5fb5bf7925408cb009e8c70d55745127937b17837bb3f42c5facd753e25bd8799dd087229514ac6ff80810f8fda1579ba1772a9b76a482eba7614f9d808ccb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p8Qyks-9cp-p2

## Proposed Changes

I propose to upgrade the Electron Notarie package to fix the notarization step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Apple [changed the notarization tool](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool), Electron updated [notarize](https://github.com/electron/notarize/) package to use the tool, but WP Desktop still uses the older version.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?