### PR TITLE
fix(hosting-overview-refinements): add tracking events on clicks on meters links

### DIFF
--- a/client/hosting/overview/components/plan-bandwidth.tsx
+++ b/client/hosting/overview/components/plan-bandwidth.tsx
@@ -3,7 +3,8 @@ import { LoadingPlaceholder } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { convertBytes } from 'calypso/my-sites/backup/backup-contents-page/file-browser/util';
 import { useSiteMetricsQuery } from 'calypso/my-sites/site-monitoring/use-metrics-query';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -32,6 +33,8 @@ const getCurrentMonthRangeTimestamps = () => {
 };
 
 export function PlanBandwidth( { siteId }: PlanBandwidthProps ) {
+	const dispatch = useDispatch();
+
 	const selectedSiteData = useSelector( getSelectedSite );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
@@ -86,7 +89,14 @@ export function PlanBandwidth( { siteId }: PlanBandwidthProps ) {
 	const getBandwidthFooterLink = () => {
 		if ( isAtomic ) {
 			return (
-				<a href={ `/site-monitoring/${ siteSlug }` }>
+				<a
+					href={ `/site-monitoring/${ siteSlug }` }
+					onClick={ () => {
+						dispatch(
+							recordTracksEvent( 'calypso_hosting_overview_monitor_site_performance_click' )
+						);
+					} }
+				>
 					{ translate( 'Monitor site performance', {
 						comment: 'A link to the "Monitoring" tab of the Hosting Overview',
 					} ) }
@@ -96,7 +106,14 @@ export function PlanBandwidth( { siteId }: PlanBandwidthProps ) {
 
 		if ( isEligibleForAtomic ) {
 			return (
-				<a href={ `/hosting-features/${ siteSlug }` }>
+				<a
+					href={ `/hosting-features/${ siteSlug }` }
+					onClick={ () => {
+						dispatch(
+							recordTracksEvent( 'calypso_hosting_overview_activate_hosting_features_click' )
+						);
+					} }
+				>
 					{ translate( 'Activate hosting features', {
 						comment: 'A link to the Hosting Features page to click an activation button',
 					} ) }
@@ -105,7 +122,12 @@ export function PlanBandwidth( { siteId }: PlanBandwidthProps ) {
 		}
 
 		return (
-			<a href={ `/hosting-features/${ siteSlug }` }>
+			<a
+				href={ `/hosting-features/${ siteSlug }` }
+				onClick={ () => {
+					dispatch( recordTracksEvent( 'calypso_hosting_overview_hosting_features_click' ) );
+				} }
+			>
 				{ translate( 'Upgrade to monitor site', {
 					comment: 'A link to the Hosting Features page to click an upgrade button',
 				} ) }

--- a/client/hosting/overview/components/plan-card.tsx
+++ b/client/hosting/overview/components/plan-card.tsx
@@ -161,6 +161,7 @@ const PricingSection: FC = () => {
 };
 
 const PlanCard: FC = () => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const site = useSelector( getSelectedSite );
 	const planDetails = site?.plan;
@@ -264,6 +265,11 @@ const PlanCard: FC = () => {
 												className="hosting-overview__link-button"
 												plain
 												href={ `/add-ons/${ site?.slug }` }
+												onClick={ () => {
+													dispatch(
+														recordTracksEvent( 'calypso_hosting_overview_need_more_storage_click' )
+													);
+												} }
 											>
 												{ translate( 'Need more storage?' ) }
 											</Button>

--- a/client/hosting/overview/components/plan-site-visits.tsx
+++ b/client/hosting/overview/components/plan-site-visits.tsx
@@ -4,7 +4,8 @@ import moment from 'moment';
 import { useEffect, useState } from 'react'; // eslint-disable-line no-unused-vars -- used in the jsdoc types
 import wpcom from 'calypso/lib/wp';
 import './style.scss';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 
@@ -17,6 +18,7 @@ interface VisitResponse {
 }
 
 export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
+	const dispatch = useDispatch();
 	const [ visitsNumber, setVisitsNumber ] = useState< number | null >( null );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const canViewStat = useSelector( ( state ) => canCurrentUser( state, siteId, 'publish_posts' ) );
@@ -86,7 +88,12 @@ export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 				</div>
 			</div>
 			<div className="hosting-overview__plan-site-visits-content">{ getSiteVisitsContent() }</div>
-			<a href={ `/stats/month/${ siteSlug }` }>
+			<a
+				href={ `/stats/month/${ siteSlug }` }
+				onClick={ () => {
+					dispatch( recordTracksEvent( 'calypso_hosting_overview_visit_stats_click' ) );
+				} }
+			>
 				{ translate( 'Visit stats', {
 					comment: 'A link taking the user to more detailed site statistics',
 				} ) }


### PR DESCRIPTION
Related to p1724118840154049/1724080429.781159-slack-C06ELHR6L9J

## Proposed Changes
With this PR we are adding tracking events on meters links here:<br />
<img width="420" alt="Screenshot 2024-08-20 at 10 35 11" src="https://github.com/user-attachments/assets/ef0a5de0-6be4-441c-aea9-b89c30cda93c">

## Testing Instructions
1) Create Atomic website
2) Asert that clicks work correctly with appropriate tracking events
Need more storage -> `calypso_hosting_overview_need_more_storage_click`
Monitor site performance -> `calypso_hosting_overview_monitor_site_performance_click`
Visit Stats -> `calypso_hosting_overview_visit_stats_click`
3) Create Simple website with basic plan
4) Asert that clicks work correctly with appropriate tracking events
Upgrade to monitor site -> `calypso_hosting_overview_hosting_features_click`
5) Upgrade Simpel website to Business plan
6) Asert that clicks work correctly with appropriate tracking events
Activate hosting features -> `calypso_hosting_overview_activate_hosting_features_click`