### PR TITLE
Jetpack: Link to Jetpack/Akismet instructions on how to activate a license key

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -350,7 +350,7 @@ function PurchaseJetpackUserLicense( { purchaseId }: { purchaseId: number } ) {
 			size={ licenseKeyInputSize }
 			value={ licenseKey }
 			loading={ isLoading || isInitialLoading }
-			activationURL="https://jetpack.com/support/activate-a-jetpack-product-via-license-key/"
+			activationUrl="https://jetpack.com/support/activate-a-jetpack-product-via-license-key/"
 		/>
 	);
 }
@@ -373,7 +373,7 @@ function PurchaseAkismetApiKey() {
 				size={ keyInputSize }
 				value={ akismetApiKey }
 				loading={ isLoading }
-				activationURL="https://akismet.com/support/getting-started/api-key/"
+				activationUrl="https://akismet.com/support/getting-started/api-key/"
 			/>
 		</>
 	);
@@ -384,13 +384,13 @@ function PurchaseClipboardCard( {
 	value,
 	size,
 	loading = false,
-	activationURL,
+	activationUrl,
 }: {
 	label: string;
 	value: string;
 	size: number;
 	loading?: boolean;
-	activationURL: string;
+	activationUrl: string;
 } ) {
 	const translate = useTranslate();
 	const [ isCopied, setCopied ] = useState( false );
@@ -424,7 +424,7 @@ function PurchaseClipboardCard( {
 					</>
 				) }
 			</div>
-			<ExternalLink className="manage-purchase__license-clipboard-link" href={ activationURL }>
+			<ExternalLink className="manage-purchase__license-clipboard-link" href={ activationUrl }>
 				{ translate( 'How to activate' ) }
 			</ExternalLink>
 		</Card>

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -350,6 +350,7 @@ function PurchaseJetpackUserLicense( { purchaseId }: { purchaseId: number } ) {
 			size={ licenseKeyInputSize }
 			value={ licenseKey }
 			loading={ isLoading || isInitialLoading }
+			activationURL="https://jetpack.com/support/activate-a-jetpack-product-via-license-key/"
 		/>
 	);
 }
@@ -372,6 +373,7 @@ function PurchaseAkismetApiKey() {
 				size={ keyInputSize }
 				value={ akismetApiKey }
 				loading={ isLoading }
+				activationURL="https://akismet.com/support/getting-started/api-key/"
 			/>
 		</>
 	);
@@ -382,11 +384,13 @@ function PurchaseClipboardCard( {
 	value,
 	size,
 	loading = false,
+	activationURL,
 }: {
 	label: string;
 	value: string;
 	size: number;
 	loading?: boolean;
+	activationURL: string;
 } ) {
 	const translate = useTranslate();
 	const [ isCopied, setCopied ] = useState( false );
@@ -420,10 +424,7 @@ function PurchaseClipboardCard( {
 					</>
 				) }
 			</div>
-			<ExternalLink
-				className="manage-purchase__license-clipboard-link"
-				href="https://jetpack.com/support/activate-a-jetpack-product-via-license-key/"
-			>
+			<ExternalLink className="manage-purchase__license-clipboard-link" href={ activationURL }>
 				{ translate( 'How to activate' ) }
 			</ExternalLink>
 		</Card>


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/93367

## Proposed Changes

Links to instructions on the Jetpack.com or Akismet.com site on how to activate an unassigned Jetpack/Akismet license key:

* For Jetpack licenses, sends users to https://jetpack.com/support/activate-a-jetpack-product-via-license-key/
* For Akismet licenses, sends users to https://akismet.com/support/getting-started/api-key/

Reported in p1722601810633389-slack-C06PK2W8F42

## Why are these changes being made?

* On the purchases section of [WordPress.com](http://wordpress.com/) for a siteless purchase, we don’t link to any instructions about how to activate a Jetpack/Akismet license key.

## Testing Instructions

* Fire up this PR.
* Go to `/me/purchases` while having an unassigned Jetpack license.
* Click on the unassigned license to jump into the page.
* Ensure you see the new “How to activate” link and sends you to:
  * https://jetpack.com/support/activate-a-jetpack-product-via-license-key/ for Jetpack licenses
  * https://akismet.com/support/getting-started/api-key/ for Akismet licenses

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?