### PR TITLE
Launchpad: Adds the completion logic for the 'Install the mobile app' task

### DIFF
--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -15,6 +15,7 @@ const TASKS_TO_COMPLETE_ON_CLICK = [
 	'site_monitoring_page',
 	'front_page_updated',
 	'post_sharing_enabled',
+	'mobile_app_installed',
 ];
 
 export const setUpActionsForTasks = ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1723090894572069-slack-C029GN3KD

## Proposed Changes

* Mark the "Install the mobile app" task complete when clicking on the task instead of actually requiring the users to complete it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As explained here p1723090894572069-slack-C029GN3KD, @niranjan-uma-shankar believes that making it easy to complete and dismiss the Launchpad on the Customer Home might drive upsells, as the users will see the banner more frequently. For the data about the task, please check the link.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local environment or use the Calypso Live link below.
* Make sure you are sandboxed.
* Edit this file fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Subzr%2Sivrjf.cuc%3Se%3Q9nrp8684%23211-og to always return:
```
return inject_launchpad_view( $views, LAUNCHPAD_LEGACY_SITE_SETUP );
```
* Select an existing site in which a Launchpad is displayed on the Customer Home page or create a new one and go through the flow until you see the post-launch Launchpad.
* On wpsh, run the following command to:
  * Remove the attribute that currently makes the task complete
  * Switch to the blog
  * Mark the task as incomplete
    ```
    return delete_user_attribute(<YOUR USER ID>, 'jp_mobile_app_last_seen');
    return switch_to_blog(<YOUR TESTING BLOG ID>);
    return wpcom_mark_launchpad_task_incomplete('mobile_app_installed');
    ```
* On the Customer Home, you should now see the "Install the mobile app" task as incomplete.
* Click on it and return to the Customer Home page. The task should be complete.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?