### PR TITLE
A4A Dev Sites: Get the `isDevSite` value from the `site` object

### DIFF
--- a/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
+++ b/client/a8c-for-agencies/sections/sites/hooks/use-formatted-sites.ts
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import {
 	StatsNode,
 	BoostNode,
@@ -26,19 +25,6 @@ const formatBoostData = ( site: Site ): BoostNode => ( {
 	type: 'boost',
 	value: site.jetpack_boost_scores,
 } );
-
-const useFormatDevSite = () => {
-	const { data: { licenses = [] } = {} } = useFetchDevLicenses();
-
-	return useCallback(
-		( site: Site ) =>
-			!! licenses.find(
-				( license: { managed_site_id: number | undefined } ) =>
-					license.managed_site_id === site.a4a_site_id
-			),
-		[ licenses ]
-	);
-};
 
 const useFormatBackupData = () => {
 	const translate = useTranslate();
@@ -203,7 +189,6 @@ const useFormatSite = () => {
 	const formatMonitorData = useFormatMonitorData();
 	const formatPluginData = useFormatPluginData();
 	const formatScanData = useFormatScanData();
-	const formatDevSite = useFormatDevSite();
 
 	return useCallback(
 		( site: Site, isConnected: boolean ): SiteData => {
@@ -221,13 +206,13 @@ const useFormatSite = () => {
 				monitor: formatMonitorData( site ),
 				plugin: formatPluginData( site ),
 				error: formatErrorData( isConnected ),
-				isDevSite: formatDevSite( site ),
+				isDevSite: site.a4a_is_dev_site,
 				isFavorite: site.is_favorite,
 				isSelected: site.isSelected,
 				onSelect: site.onSelect,
 			};
 		},
-		[ formatBackupData, formatMonitorData, formatPluginData, formatScanData, formatDevSite ]
+		[ formatBackupData, formatMonitorData, formatPluginData, formatScanData ]
 	);
 };
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -118,6 +118,7 @@ export interface Site {
 	site_color?: string;
 	enabled_plugin_slugs?: Array< string >;
 	a4a_site_id?: number;
+	a4a_is_dev_site: boolean;
 }
 export interface SiteNode {
 	value: Site;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -118,7 +118,7 @@ export interface Site {
 	site_color?: string;
 	enabled_plugin_slugs?: Array< string >;
 	a4a_site_id?: number;
-	a4a_is_dev_site: boolean;
+	a4a_is_dev_site?: boolean;
 }
 export interface SiteNode {
 	value: Site;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/8830.

## Proposed Changes

* since `a4a_is_dev_site` is now available as a part of the `site` object, let's use it instead of relying on the `useFormatDevSite` callback. This will simplify the code and we won't need to fetch dev licenses.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR locally and build the app with `yarn start-a8c-for-agencies`.
2. Head over to the Sites section at http://agencies.localhost:3000/sites/?flags=a4a-dev-sites.
3. The `Development` label should be rendered at each development site as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?