### PR TITLE
Marketplace: fixes before element causing overflow.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -50,7 +50,7 @@
 		padding-top: 0;
 	}
 }
-.plugins-browser__main-container {
+.has-no-sidebar .plugins-browser__main-container {
 	position: relative;
 
 	&::before {
@@ -64,9 +64,10 @@
 		z-index: -1;
 	}
 
-	.plugins-browser-list:last-of-type {
-		padding-bottom: 32px;
-	}
+}
+
+.plugins-browser__main-container .plugins-browser-list:last-of-type {
+	padding-bottom: 32px;
 }
 
 .plugins-browser__upgrade-banner {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Navigating through the tabs in the “Plugin marketplace” breaks the page (tested in Safari and Chrome).

https://github.com/user-attachments/assets/283c18ed-d757-4dd7-8200-87b867727f21


## Proposed Changes

* Applies the before element only for the logged out view where there is no sidebar

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/plugins` while logged in
* Navigate to different categories
* Make sure that the page doesn't break

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
