### PR TITLE
Stepper: enable React concurrent mode

### DIFF
--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -24,6 +24,21 @@ import {
 } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
 
+const CONNECT_DOMAIN_STEPS = [
+	{
+		slug: 'plans',
+		asyncComponent: () => import( './internals/steps-repository/plans' ),
+	},
+	{
+		slug: 'createSite',
+		asyncComponent: () => import( './internals/steps-repository/create-site' ),
+	},
+	{
+		slug: 'processing',
+		asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+	},
+];
+
 const connectDomain: Flow = {
 	name: CONNECT_DOMAIN_FLOW,
 	get title() {
@@ -89,17 +104,7 @@ const connectDomain: Flow = {
 		}, [] );
 	},
 	useSteps() {
-		return [
-			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
-			{
-				slug: 'createSite',
-				asyncComponent: () => import( './internals/steps-repository/create-site' ),
-			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
-		];
+		return CONNECT_DOMAIN_STEPS;
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -22,6 +22,7 @@ import {
 	AssertConditionState,
 	Flow,
 	ProvidedDependencies,
+	StepProps,
 } from './internals/types';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -69,6 +70,27 @@ function useIsValidSite() {
 	};
 }
 
+function ProcessingCopy( props: StepProps ) {
+	return (
+		<ProcessingStep
+			{ ...props }
+			title={ translate( 'We’re copying your site' ) }
+			subtitle={ translate(
+				'Feel free to close this window. We’ll email you when your new site is ready.'
+			) }
+		/>
+	);
+}
+
+const COPY_SITE_STEPS = [
+	{ slug: 'domains', component: DomainsStep },
+	{ slug: 'create-site', component: CreateSite },
+	{ slug: 'processing', component: ProcessingStep },
+	{ slug: 'automated-copy', component: AutomatedCopySite },
+	{ slug: 'processing-copy', component: ProcessingCopy },
+	{ slug: 'resuming', component: ProcessingStep }, // Needs siteSlug param
+];
+
 const copySite: Flow = {
 	name: COPY_SITE_FLOW,
 
@@ -78,25 +100,7 @@ const copySite: Flow = {
 	isSignupFlow: false,
 
 	useSteps() {
-		return [
-			{ slug: 'domains', component: DomainsStep },
-			{ slug: 'create-site', component: CreateSite },
-			{ slug: 'processing', component: ProcessingStep },
-			{ slug: 'automated-copy', component: AutomatedCopySite },
-			{
-				slug: 'processing-copy',
-				component: ( props ) => (
-					<ProcessingStep
-						{ ...props }
-						title={ translate( 'We’re copying your site' ) }
-						subtitle={ translate(
-							'Feel free to close this window. We’ll email you when your new site is ready.'
-						) }
-					/>
-				),
-			},
-			{ slug: 'resuming', component: ProcessingStep }, // Needs siteSlug param
-		];
+		return COPY_SITE_STEPS;
 	},
 
 	useStepNavigation( _currentStepSlug, navigate ) {

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -5,7 +5,7 @@ import {
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useEffect, useMemo, lazy } from 'react';
+import React, { useEffect, lazy } from 'react';
 import Modal from 'react-modal';
 import { Route, Routes } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -28,6 +28,28 @@ import { AssertConditionState, type Flow, type StepperStep, type StepProps } fro
 import type { StepperInternalSelect } from '@automattic/data-stores';
 import './global.scss';
 
+const lazyCache = new WeakMap<
+	() => Promise< { default: React.ComponentType< StepProps > } >,
+	React.ComponentType< StepProps >
+>();
+
+function flowStepComponent( flowStep: StepperStep | undefined ) {
+	if ( ! flowStep ) {
+		return null;
+	}
+
+	if ( 'asyncComponent' in flowStep ) {
+		let lazyComponent = lazyCache.get( flowStep.asyncComponent );
+		if ( ! lazyComponent ) {
+			lazyComponent = lazy( flowStep.asyncComponent );
+			lazyCache.set( flowStep.asyncComponent, lazyComponent );
+		}
+		return lazyComponent;
+	}
+
+	return flowStep.component;
+}
+
 /**
  * This component accepts a single flow property. It does the following:
  *
@@ -49,19 +71,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	// Start tracking performance for this step.
 	useStartStepperPerformanceTracking( params.flow || '', currentStepRoute );
 	useFlowAnalytics( { flow: params.flow, step: currentStepRoute, variant: flow.variantSlug } );
-
-	const stepComponents: Record< string, React.FC< StepProps > > = useMemo(
-		() =>
-			flowSteps.reduce(
-				( acc, flowStep ) => ( {
-					...acc,
-					[ flowStep.slug ]:
-						'asyncComponent' in flowStep ? lazy( flowStep.asyncComponent ) : flowStep.component,
-				} ),
-				{}
-			),
-		[ flowSteps ]
-	);
 
 	const { __ } = useI18n();
 	useSaveQueryParams();
@@ -126,7 +135,10 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				return null;
 		}
 
-		const StepComponent = stepComponents[ step.slug ];
+		const StepComponent = flowStepComponent( flowSteps.find( ( { slug } ) => slug === step.slug ) );
+		if ( ! StepComponent ) {
+			return null;
+		}
 
 		return (
 			<StepComponent

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -8,7 +8,7 @@ import { IMPORT_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
-import ReactDom from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { BrowserRouter, matchPath } from 'react-router-dom';
 import { requestAllBlogsAccess } from 'wpcom-proxy-request';
@@ -122,7 +122,8 @@ window.AppBoot = async () => {
 	const flowLoader = determineFlow();
 	const { default: flow } = await flowLoader();
 
-	ReactDom.render(
+	const root = createRoot( document.getElementById( 'wpcom' ) as HTMLElement );
+	root.render(
 		<CalypsoI18nProvider i18n={ defaultCalypsoI18n }>
 			<Provider store={ reduxStore }>
 				<QueryClientProvider client={ queryClient }>
@@ -144,7 +145,6 @@ window.AppBoot = async () => {
 					) }
 				</QueryClientProvider>
 			</Provider>
-		</CalypsoI18nProvider>,
-		document.getElementById( 'wpcom' )
+		</CalypsoI18nProvider>
 	);
 };


### PR DESCRIPTION
This PR enables React concurrent mode for Stepper and shows how to fix bugs that need to be fixed in order to make it work.

If you just enable concurrent mode and do nothing else, a search field in site picker in a migration flow will lose focus when typing. Go to `http://calypso.localhost:300/setup/hosted-site-migration/sitePicker`, start typing and see for yourself:

https://d.pr/v/9Vd3vp

This is caused by Suspense and importing lazy step components:
1. `flow.useSteps` usually returns a new array on each call. Often even the array members are created anew on every call, and the returned `asyncComponent: () => import( '...' )` functions have a different identity on every render.
2. There is a memoized call that converts the `() => import` callback to a component with `React.lazy`. But because the inputs to this `useMemo` are not memoized, the memoization doesn't work and new component is returned on every render.
3. React is forced to always do the lazy `import` "from scratch". Usually, when mounted, `React.lazy` remembers the resolved value, and needs to call the function and wait for the promise only once. But here the component is different on each render, so React always suspends and always shows the `fallback` placeholder for a moment.
4. This suspension is what takes focus away from the search field. There is some subtle behavior difference between Suspense in concurrent mode and non-concurrent mode.

I'm fixing this by memoizing the `React.lazy` results in a weakmap.

But to truly finish this fix, all inputs to `React.lazy` must also be "stable", i.e., not created anew on each render. In this PR I'm doing the necessary changes for two randomly chosen steps, "connect domain" and "copy site". But there are still more than 50 remaining `useSteps()` hooks that need to be reviewed and modified.