### PR TITLE
Fix Redux error when calypso_preferences are empty

### DIFF
--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -50,7 +50,7 @@ export const localValues = ( state = {}, action ) => {
 export const remoteValues = withSchemaValidation( remoteValuesSchema, ( state = null, action ) => {
 	switch ( action.type ) {
 		case PREFERENCES_RECEIVE: {
-			const { values } = action;
+			const { values = {} } = action;
 			return values;
 		}
 	}

--- a/client/state/preferences/test/reducer.js
+++ b/client/state/preferences/test/reducer.js
@@ -121,6 +121,15 @@ describe( 'reducer', () => {
 				baz: 'qux',
 			} );
 		} );
+
+		test( 'should default undefined value to an empty object', () => {
+			const state = remoteValues( null, {
+				type: PREFERENCES_RECEIVE,
+				values: undefined,
+			} );
+
+			expect( state ).toEqual( {} );
+		} );
 	} );
 
 	describe( 'fetching()', () => {


### PR DESCRIPTION
This fixes an error reported in Sentry where the `preferences` reducer is called with a `PREFERENCES_RECEIVE` action that has `values: undefined` field. That can happen when the `/me/preferences` REST responses has no `calypso_preferences` field. Then the return value from the `remoteValues` reducer is `undefined`, which is prohibited by Redux and leads to [error number 14](https://redux.js.org/errors).

I'm fixing this by defaulting the `undefined` value to `{}`.

Something similar was also reported by @ellatrix when going through a signup flow. I suspect that when a user is brand new, just created a moment ago, she doesn't have the `calypso_preferences` yet.
