### PR TITLE
Partner themes: Default plan lengths to a year

### DIFF
--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -1,7 +1,6 @@
 import {
-	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
-	TERM_MONTHLY,
+	TERM_ANNUALLY,
 	findFirstSimilarPlanKey,
 	getPlan,
 	isFreePlan,
@@ -70,12 +69,12 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 		}
 
 		const currentPlanSlug = getSitePlanSlug( state, siteId );
-		let requiredTerm = TERM_MONTHLY;
+		let requiredTerm = TERM_ANNUALLY;
 		if ( currentPlanSlug && ! isFreePlan( currentPlanSlug ) ) {
-			requiredTerm = getPlan( currentPlanSlug )?.term || TERM_MONTHLY;
+			requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
 		}
 		const requiredPlanSlug =
-			findFirstSimilarPlanKey( PLAN_BUSINESS, { term: requiredTerm } ) || PLAN_BUSINESS_MONTHLY;
+			findFirstSimilarPlanKey( PLAN_BUSINESS, { term: requiredTerm } ) || PLAN_BUSINESS;
 
 		const productSlug = getPreferredBillingCycleProductSlug( products, requiredPlanSlug );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/93597

## Proposed Changes

In the theme showcase partner themes were defaulting to having an annual theme subscription and a monthly plan subscription.

This is now changed so that they both default to annually, if you're on the free plan.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Partner themes require a subscription to the theme (can be monthly or yearly) and an atomic capable subscription (monthly, yearly, 2yearly, 3yearly etc).

 * We prefer subscribers to have longer term plans
 * Cancelling the monthly sub would give you an annual theme sub that you couldn't use.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply patch
2. Use calypso live link
3. On a free site navigate to `/themes/partner/:siteSlug`
4. Choose a paid theme
5. Click "Subscribe to activate"
6. Note that you are now in the basket with an annual theme sub and an annual business plan sub
7. Go back, emptying the basket
8. Use the "Subscribe to this theme!" banner, repeat steps 6 & 7.

Try again with a site on a monthly plan, an annual plan, and a bi/tri-annual plan. You should get asked to subscribe to a business plan with the same length.

Note that this code is not used in onboarding, that has it's [own separate implementation](https://github.com/Automattic/wp-calypso//blob/99c63bb1d0f0c31ea26a946efa8595df04e5b46d/client/lib/signup/step-actions/index.js#L608). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
