### PR TITLE
Content Importer: Allow to upload only supported file types

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -25,6 +25,7 @@ export interface ImporterConfig {
 	weight: number;
 	overrideDestination?: string;
 	optionalUrl?: ImporterOptionalURL;
+	acceptedFileTypes?: string[];
 }
 
 interface ImporterConfigMap {
@@ -130,6 +131,7 @@ function getConfig( {
 				},
 			}
 		),
+		acceptedFileTypes: [ '.xml' ],
 		weight: 0,
 	};
 
@@ -171,6 +173,7 @@ function getConfig( {
 				},
 			}
 		),
+		acceptedFileTypes: [ '.zip' ],
 		weight: 0,
 	};
 
@@ -231,6 +234,7 @@ function getConfig( {
 				args: { exampleUrl: 'https://example-newsletter.substack.com/' },
 			} ),
 		},
+		acceptedFileTypes: [ '.zip' ],
 		weight: 0,
 	};
 
@@ -274,6 +278,7 @@ function getConfig( {
 				},
 			}
 		),
+		acceptedFileTypes: [ '.xml' ],
 		weight: 0,
 	};
 

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -39,6 +39,7 @@ class FileImporter extends PureComponent {
 			icon: PropTypes.string.isRequired,
 			description: PropTypes.node.isRequired,
 			uploadDescription: PropTypes.node,
+			acceptedFileTypes: PropTypes.array,
 		} ).isRequired,
 		importerStatus: PropTypes.shape( {
 			errorData: PropTypes.shape( {
@@ -73,8 +74,15 @@ class FileImporter extends PureComponent {
 	};
 
 	render() {
-		const { title, icon, description, overrideDestination, uploadDescription, optionalUrl } =
-			this.props.importerData;
+		const {
+			title,
+			icon,
+			description,
+			overrideDestination,
+			uploadDescription,
+			optionalUrl,
+			acceptedFileTypes,
+		} = this.props.importerData;
 		const { importerStatus, site, fromSite, hideActionButtons } = this.props;
 		const { errorData, importerState } = importerStatus;
 		const isEnabled = appStates.DISABLED !== importerState;
@@ -131,6 +139,7 @@ class FileImporter extends PureComponent {
 						site={ site }
 						optionalUrl={ optionalUrl }
 						fromSite={ fromSite }
+						acceptedFileTypes={ acceptedFileTypes }
 						hideActionButtons={ hideActionButtons }
 					/>
 				) }

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -49,6 +49,7 @@ export class UploadingPane extends PureComponent {
 			validate: PropTypes.func,
 		} ),
 		fromSite: PropTypes.string,
+		acceptedFileTypes: PropTypes.array,
 		hideActionButtons: PropTypes.bool,
 	};
 
@@ -242,7 +243,8 @@ export class UploadingPane extends PureComponent {
 	};
 
 	render() {
-		const { importerStatus, site, isEnabled, fromSite, hideActionButtons } = this.props;
+		const { importerStatus, site, isEnabled, fromSite, acceptedFileTypes, hideActionButtons } =
+			this.props;
 		const isReadyForImport = this.isReadyForImport();
 		const importerStatusClasses = clsx(
 			'importer__upload-content',
@@ -288,6 +290,7 @@ export class UploadingPane extends PureComponent {
 							type="file"
 							name="exportFile"
 							onChange={ this.initiateFromForm }
+							accept={ acceptedFileTypes ? acceptedFileTypes.join( ',' ) : undefined }
 						/>
 					) }
 					<DropZone onFilesDrop={ isReadyForImport ? this.initiateFromDrop : noop } />


### PR DESCRIPTION
## Proposed Changes

It allows to select only supported file types when uploading content.

### Before (all files enabled to upload)

<img width="813" alt="Screenshot 2024-08-20 at 14 59 42" src="https://github.com/user-attachments/assets/15483a32-bd7e-4443-b4b1-af44d50145e5">

### After (only supported ones)

<img width="813" alt="Screenshot 2024-08-20 at 14 59 24" src="https://github.com/user-attachments/assets/02565cc0-500d-45ea-8065-c12ff25130a4">

## Why are these changes being made?

To limit failures when importing content.

## Testing Instructions

1. Have file with Substack content exported
2. Go to Tools -> Import -> Substack
3. Click uploading section
4. Make sure you can upload only `.zip` files

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
