### PR TITLE
Redirect to wp-admin instead of My Home for Classic Sites after log-in

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -65,7 +65,6 @@ import ThemesSelection from './themes-selection';
 import ThemesToolbarGroup from './themes-toolbar-group';
 import './theme-showcase.scss';
 
-
 const optionShape = PropTypes.shape( {
 	label: PropTypes.string,
 	header: PropTypes.string,

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -65,6 +65,7 @@ import ThemesSelection from './themes-selection';
 import ThemesToolbarGroup from './themes-toolbar-group';
 import './theme-showcase.scss';
 
+
 const optionShape = PropTypes.shape( {
 	label: PropTypes.string,
 	header: PropTypes.string,

--- a/client/root.js
+++ b/client/root.js
@@ -10,8 +10,8 @@ import {
 	canCurrentUserUseCustomerHome,
 	getSite,
 	getSiteSlug,
-	getSiteOption,
-	getSiteUrl,
+	getSiteAdminUrl,
+	isAdminInterfaceWPAdmin,
 } from 'calypso/state/sites/selectors';
 import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 
@@ -97,9 +97,6 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 	const primarySiteId = getPrimarySiteId( getState() );
 	await dispatch( waitForSite( primarySiteId ) );
 	const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
-	const primarySiteURL = getSiteUrl( getState(), primarySiteId );
-	const adminInterface = getSiteOption( getState(), primarySiteId, 'wpcom_admin_interface' );
-	const isClassicAdmin = adminInterface === 'wp-admin';
 
 	if ( ! primarySiteSlug ) {
 		if ( getIsSubscriptionOnly( getState() ) ) {
@@ -112,9 +109,9 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( getState(), primarySiteId );
 
 	if ( isCustomerHomeEnabled ) {
-		if ( isClassicAdmin ) {
+		if ( isAdminInterfaceWPAdmin( getState(), primarySiteId ) ) {
 			// This URL starts with 'https://' because it's the access to wp-admin.
-			return `${ primarySiteURL }/wp-admin/`;
+			return getSiteAdminUrl( getState(), primarySiteId );
 		}
 		return `/home/${ primarySiteSlug }`;
 	}

--- a/client/root.js
+++ b/client/root.js
@@ -6,7 +6,13 @@ import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selector
 import getIsSubscriptionOnly from 'calypso/state/selectors/get-is-subscription-only';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { requestSite } from 'calypso/state/sites/actions';
-import { canCurrentUserUseCustomerHome, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import {
+	canCurrentUserUseCustomerHome,
+	getSite,
+	getSiteSlug,
+	getSiteOption,
+	getSiteUrl,
+} from 'calypso/state/sites/selectors';
 import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 
 /**
@@ -41,7 +47,12 @@ async function handleLoggedIn( page, context ) {
 		redirectPath += `?${ context.querystring }`;
 	}
 
-	page.redirect( redirectPath );
+	if ( redirectPath.startsWith( '/' ) ) {
+		page.redirect( redirectPath );
+	} else {
+		// Case for wp-admin redirection when primary site has classic admin interface.
+		window.location.assign( redirectPath );
+	}
 }
 
 // Helper thunk that ensures that the requested site info is fetched into Redux state before we
@@ -85,8 +96,10 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 	// ensure that the primary site info is loaded into Redux before proceeding.
 	const primarySiteId = getPrimarySiteId( getState() );
 	await dispatch( waitForSite( primarySiteId ) );
-
 	const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
+	const primarySiteURL = getSiteUrl( getState(), primarySiteId );
+	const adminInterface = getSiteOption( getState(), primarySiteId, 'wpcom_admin_interface' );
+	const isClassicAdmin = adminInterface === 'wp-admin';
 
 	if ( ! primarySiteSlug ) {
 		if ( getIsSubscriptionOnly( getState() ) ) {
@@ -99,6 +112,10 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( getState(), primarySiteId );
 
 	if ( isCustomerHomeEnabled ) {
+		if ( isClassicAdmin ) {
+			// This URL starts with 'https://' because it's the access to wp-admin.
+			return `${ primarySiteURL }/wp-admin/`;
+		}
 		return `/home/${ primarySiteSlug }`;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8795

## Proposed Changes

* When a user has as primary site a site with classic admin interface, redirect to wp-admin instead of My Home after login.>

>[!IMPORTANT]
>This PR adds a case respecting the current redirection logic. 
> For example, the setting "Admin home" that forces the redirection to `/sites` [here](https://github.com/Automattic/wp-calypso/blob/149a00fb8d1fd4385bd826f526f40e759a784792/client/root.js#L81) still works.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When a user's primary site is set to a Classic site, the expected behavior is redirect to the wp-admin dashboard instead of the My Home page because `https://wordpress.com/home/{ SITE }` is only used for sites with Default admin interface. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/me/account 
  * Set a site with Classic admin interface as your primary site
  * Make sure the setting "Admin home" is disabled
* Visit http://calypso.localhost:3000 or the root of Calypso live
  * Verify you are redirected to `{ SITE }/wp-admin`
* Go back to `/me/account` and enable "Admin home"
  * Visit http://calypso.localhost:3000 or the root of Calypso live
  * Verify you are redirected to `/sites`  
* Go back to `/me/account` and select a site with Default admin as your primary site
  * Visit http://calypso.localhost:3000 or the root of Calypso live
  * Verify it goes to `/home/{ SITE }`


https://github.com/user-attachments/assets/73cfc84d-78d9-46f3-9ef6-0dc48bf352c6




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
