### PR TITLE
Make Poema the default theme for the write flow & write intent

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -1,10 +1,10 @@
 import type { Design } from '@automattic/design-picker';
 
 export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
-	slug: 'hey',
-	title: 'Hey',
+	slug: 'hola',
+	title: 'Hola',
 	categories: [],
-	theme: 'hey',
+	theme: 'hola',
 	design_tier: null,
 };
 

--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -1,10 +1,10 @@
 import type { Design } from '@automattic/design-picker';
 
 export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
-	slug: 'hola',
-	title: 'Hola',
+	slug: 'poema',
+	title: 'Poema',
 	categories: [],
-	theme: 'hola',
+	theme: 'poema',
 	design_tier: null,
 };
 

--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -1,5 +1,6 @@
 import type { Design } from '@automattic/design-picker';
 
+// Changing this? Consider also updating DEFAULT_START_WRITING_THEME so the write *flow* matches the write intent.
 export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
 	slug: 'poema',
 	title: 'Poema',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -56,7 +56,8 @@ const DEFAULT_LINK_IN_BIO_THEME = 'pub/lynx';
 const DEFAULT_WOOEXPRESS_FLOW = 'pub/twentytwentytwo';
 const DEFAULT_ENTREPRENEUR_FLOW = 'pub/twentytwentytwo';
 const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
-const DEFAULT_START_WRITING_THEME = 'pub/hey';
+// Changing this? Consider also updating WRITE_INTENT_DEFAULT_DESIGN so the write *intent* matches the write flow
+const DEFAULT_START_WRITING_THEME = 'pub/poema';
 
 function hasSourceSlug( data: unknown ): data is { sourceSlug: string } {
 	if ( data && ( data as { sourceSlug: string } ).sourceSlug ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8774

## Proposed Changes

Make Poema the default theme for the write flow and the write intent.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Poema includes the site title so that the data that people enter during onboarding shows up in their site. Additionally it doesn't require any template editing to get started, users can just get writing with it and launch.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Intent
1. Use calypso live link
2. Go to /start
3. After the domains and plan steps choose the "Write & Publish" goal
4. Enter a site name and tagline
5. Press "Skip to dashboard"
6. Confirm by going to /themes/:siteSlug that Poema is the active theme
7. Visit your website, you should be able to see the site title and tagline and you should see that Poema is the active theme.

### Flow
 1. Use Calypso live link
 2. Go to /setup/blog/blogger-intent?ref=create-blog-lp (linked to via https://wordpress.com/create-blog/)
 3. Press Start Writing
 4. Choose Start a New Site
 5. Write and publish a post
 6. Look at the preview, it should look like Poema
 7. Confirm by going to /themes/:siteSlug that Poema is the active theme
 8. 

Before | After
-------|------
![image](https://github.com/user-attachments/assets/ae0a0b3c-5fe2-4d98-9ee1-3dc02d9f196f) | ![image](https://github.com/user-attachments/assets/6bb31a20-242b-43bc-9db3-372f6b40928b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
