### PR TITLE
i18n: only load translation chunk when still in the same locale request

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -295,8 +295,10 @@ function addRequireChunkTranslationsHandler( localeSlug = i18n.getLocaleSlug(), 
 
 		const translationChunkPromise = getTranslationChunkFile( chunkId, localeSlug )
 			.then( ( translations ) => {
-				addTranslations( translations, userTranslations );
-				loadedTranslationChunks[ chunkId ] = true;
+				if ( localeSlug === i18n.getLocaleSlug() ) {
+					addTranslations( translations, userTranslations );
+					loadedTranslationChunks[ chunkId ] = true;
+				}
 			} )
 			.catch( ( cause ) => {
 				const error = new Error(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/7754

## Proposed Changes

In:

- https://github.com/Automattic/wp-calypso/pull/93369 (note that this is the base branch of this PR)

, we add ability to use site-level user language (can be set on `wp-admin/profile.php`). When switching between global or site-specific pages, Calypso needs to listen to the locale changes, so I added the following logic in that PR: 

https://github.com/Automattic/wp-calypso/pull/93369/files#diff-7d1eb73ef67c978553b9d47cf17a8f4b9d93bd396ee6cb5ce89e75aedb8b0f19R276-R278

However, I found that during the locale switch, somehow the old translations are "bleeding" to the new one. This happens in this case:

- Our wpcom user language is set to default (English US) in /me/account
- We're visiting a site that has a different language set in wp-admin/profile.php
- Then, we click on Reader icon in the masterbar.

See the following:

### Before
|||
|-|-|
|<img width="742" alt="image" src="https://github.com/user-attachments/assets/cb688258-64d3-47ad-8a30-fc646321aca0">|<img width="743" alt="image" src="https://github.com/user-attachments/assets/40f7b583-3a55-429b-b7b6-3df801f2634a">|

I fixed this by preventing the newly fetched translations to be merged to the existing one if the locale already changed. See the changes in this PR.


### After
|||
|-|-|
|<img width="742" alt="image" src="https://github.com/user-attachments/assets/cb688258-64d3-47ad-8a30-fc646321aca0">|<img width="787" alt="image" src="https://github.com/user-attachments/assets/5681759a-a34a-4b90-882f-f806712977f0">|

However, this still does not fix the case when the wpcom user language is not the default English US. For instance, when I set my wpcom user language (in /me/account) to Indonesian, some old Japanese translations are still bleeding:

|||
|-|-|
|<img width="742" alt="image" src="https://github.com/user-attachments/assets/cb688258-64d3-47ad-8a30-fc646321aca0">|<img width="803" alt="image" src="https://github.com/user-attachments/assets/765452da-a97d-4715-9899-43d8c5ebfa09">|

## My Ask

@Automattic/i18n, am I doing the right thing here? And do you have any idea how to solve the particular case above?


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes a bug when locale is changed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Prepare a Simple Classic site.
2. Follow the steps in this PR description.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
