### PR TITLE
Performance Profiler: Update the Did you know link to contain the passed URL

### DIFF
--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -42,7 +42,7 @@ export const PerformanceProfilerDashboardContent = ( {
 				/>
 				<NewsletterBanner />
 				<ScreenshotTimeline screenshots={ screenshots ?? [] } />
-				{ audits && <InsightsSection audits={ audits } /> }
+				{ audits && <InsightsSection audits={ audits } url={ url } /> }
 			</div>
 
 			<Disclaimer />

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -5,6 +5,7 @@ import './style.scss';
 
 type InsightsSectionProps = {
 	audits: Record< string, PerformanceMetricsItemQueryResponse >;
+	url: string;
 };
 
 export const InsightsSection = ( props: InsightsSectionProps ) => {
@@ -22,6 +23,7 @@ export const InsightsSection = ( props: InsightsSectionProps ) => {
 					key={ `insight-${ index }` }
 					insight={ { ...audits[ key ], id: key } }
 					index={ index }
+					url={ props.url }
 				/>
 			) ) }
 		</div>

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -14,6 +14,7 @@ interface MetricsInsightProps {
 	insight: PerformanceMetricsItemQueryResponse;
 	onClick?: () => void;
 	index: number;
+	url?: string;
 }
 
 const Card = styled( FoldableCard )`
@@ -70,6 +71,10 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 		isEnabled( 'performance-profiler/llm' ) && retrieveInsight
 	);
 	const tip = tips[ insight.id ];
+
+	if ( props.url && tip ) {
+		tip.link = `https://wordpress.com/setup/hosted-site-migration?from=${ props.url }&ref=performance-profiler-dashboard`;
+	}
 
 	return (
 		<Card


### PR DESCRIPTION
Fixes [Performance Profiler: Autofill did you know migration CTA](https://github.com/Automattic/dotcom-forge/issues/8833)

## Proposed Changes

Autofill the submitted URL on the Migration Link

![CleanShot 2024-08-20 at 12 18 01@2x](https://github.com/user-attachments/assets/dfbe9085-0780-4c6f-98b2-aff5c1e76855)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix the issue on [Performance Profiler: Autofill did you know migration CTA](https://github.com/Automattic/dotcom-forge/issues/8833)



## Testing Instructions

 * Go to `/speed-test-tool?url=wordpress.com`
 * On the recommendations go to the `Properly size images` option
 * Check if the `Did you know?` box is displayed
 * Click on the `Migrate your site` link 
 * Check if you are redirected to a migration page with your link autofilled
