### PR TITLE
Migration: Enable user back from `UPGRADE_PLAN` to `PLATFORM_IDENTIFICATION` 

### DIFF
--- a/client/landing/stepper/declarative-flow/migration/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/migration/helpers/index.ts
@@ -12,27 +12,41 @@ interface GoToImporterParams {
 	siteId: string;
 	siteSlug: string;
 	backToStep?: StepperStep;
+	replaceHistory?: boolean;
 }
 
 const getBackToFlowParam = ( step: string ) => `/${ MIGRATION_FLOW }/${ step }`;
+const goTo = ( path: string, replaceHistory: boolean ) => {
+	if ( replaceHistory ) {
+		return window.location.replace( path );
+	}
 
-export const goToImporter = ( { platform, siteId, siteSlug, backToStep }: GoToImporterParams ) => {
+	return window.location.assign( path );
+};
+
+export const goToImporter = ( {
+	platform,
+	siteId,
+	siteSlug,
+	backToStep,
+	replaceHistory = false,
+}: GoToImporterParams ) => {
 	const backToFlow = backToStep ? getBackToFlowParam( backToStep?.slug ) : undefined;
 	const path = getFinalImporterUrl( siteSlug, '', platform, backToFlow );
 
 	if ( isWpAdminImporter( path ) ) {
-		return window.location.replace( path );
+		return goTo( path, replaceHistory );
 	}
 
-	return window.location.replace(
-		addQueryArgs(
-			{
-				siteId,
-				siteSlug,
-				ref: MIGRATION_FLOW,
-				...( platform === 'wordpress' ? { option: 'content' } : {} ),
-			},
-			`/setup/${ SITE_SETUP_FLOW }/${ path }`
-		)
+	const stepURL = addQueryArgs(
+		{
+			siteId,
+			siteSlug,
+			ref: MIGRATION_FLOW,
+			...( platform === 'wordpress' ? { option: 'content' } : {} ),
+		},
+		`/setup/${ SITE_SETUP_FLOW }/${ path }`
 	);
+
+	return goTo( stepURL, replaceHistory );
 };

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -146,6 +146,7 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 						siteId,
 						siteSlug,
 						backToStep: PLATFORM_IDENTIFICATION,
+						replaceHistory: true,
 					} );
 				}
 

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -122,7 +122,7 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 					} );
 				}
 
-				return navigate( addQueryArgs( { platform }, SITE_CREATION_STEP.slug ), {}, true );
+				return navigate( addQueryArgs( { platform }, SITE_CREATION_STEP.slug ), {} );
 			},
 		},
 		[ SITE_CREATION_STEP.slug ]: {

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -189,6 +189,13 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 					return navigateToCheckout( { siteId, siteSlug, plan, props } );
 				}
 			},
+			goBack: ( props?: ProvidedDependencies ) => {
+				const siteId = getFromPropsOrUrl( 'siteId', props ) as string;
+				const siteSlug = getFromPropsOrUrl( 'siteSlug', props ) as string;
+				const plan = getFromPropsOrUrl( 'plan', props ) as string;
+
+				return navigate( addQueryArgs( { siteId, siteSlug, plan }, PLATFORM_IDENTIFICATION.slug ) );
+			},
 		},
 		[ MIGRATION_HOW_TO_MIGRATE.slug ]: {
 			submit: ( props?: ProvidedDependencies ) => {

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -378,4 +378,16 @@ describe( `${ flow.name }`, () => {
 			} );
 		} );
 	} );
+
+	it( 'redirect back user from MIGRATION_UPGRADE_PLAN > PLATFORM_IDENTIFICATION', () => {
+		const destination = runNavigationBack( {
+			from: STEPS.MIGRATION_UPGRADE_PLAN,
+			query: { siteId: 123, siteSlug: 'example.wordpress.com', plan: 'business' },
+		} );
+
+		expect( destination ).toMatchDestination( {
+			step: STEPS.PLATFORM_IDENTIFICATION,
+			query: { siteId: 123, siteSlug: 'example.wordpress.com', plan: 'business' },
+		} );
+	} );
 } );

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -126,7 +126,7 @@ describe( `${ flow.name }`, () => {
 					},
 				} );
 
-				expect( window.location.replace ).toHaveBeenCalledWith(
+				expect( window.location.assign ).toHaveBeenCalledWith(
 					addQueryArgs( '/setup/site-setup/importerBlogger', {
 						siteSlug: 'example.wordpress.com',
 						from: '',
@@ -290,7 +290,7 @@ describe( `${ flow.name }`, () => {
 					},
 				} );
 
-				expect( window.location.replace ).toHaveBeenCalledWith(
+				expect( window.location.assign ).toHaveBeenCalledWith(
 					addQueryArgs( '/setup/site-setup/importerWordpress', {
 						siteSlug: 'example.wordpress.com',
 						from: '',


### PR DESCRIPTION
Related to #93308 

## Proposed Changes

* Improve `history`  replace  scenarios 04ed37e6f452ab4d19f8b4216b4083d9e9cfdcde based on the [comment](https://github.com/Automattic/wp-calypso/pull/93700#discussion_r1723476741)
* Enable the back button on the `UPGRADE_PLAN` screen.


## Testing Instructions

Scenario: Back button
* Go to `/setup/migration`
* Select `WordPress` 
* When you arrive on the page `Here’s the plan you need` 
* Click the back button to check if you have been redirected to the platform identification. 
* Select WordPress again and check we are NOT creating  a new site

Scenario: History improvements
* Go to `/setup/migration`
* Select `substack` 
* Wait until you are redirected to the `/import/[YOUR_SITE]` 
* Click on the browser back button.
* Check if you were redirected to the platform identification.

> [!IMPORTANT]  
>  About the history improvement. The browser history will not retain the created site/siteSlug, so a new one will be created when the flow creates a site before redirecting to the importer page. 
It will only happens if you access the `platform-identification` step with an already-existent site (E.g /setup/migration?siteId=...&siteSlug=


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
