### PR TITLE
A4A Dev Sites: Add "Prepare for launch" menu item on WordPress.com Global Sites View.

### DIFF
--- a/client/hosting/sites/components/sites-dashboard.tsx
+++ b/client/hosting/sites/components/sites-dashboard.tsx
@@ -126,7 +126,7 @@ const SitesDashboard = ( {
 		[],
 		sitesFilterCallback,
 		'all',
-		[],
+		[ 'is_a4a_dev_site' ],
 		[ 'theme_slug' ]
 	);
 

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -87,6 +87,21 @@ const LaunchItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	);
 };
 
+const PrepareForLaunchItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+
+	return (
+		<MenuItem
+			onClick={ () => {
+				window.location.href = `https://wordpress.com/settings/general/${ site.ID }?referer=a4a-dashboard`;
+				recordTracks( 'calypso_sites_dashboard_site_action_prepare_for_launch_click' );
+			} }
+		>
+			{ __( 'Prepare for launch' ) }
+		</MenuItem>
+	);
+};
+
 const SettingsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
 
@@ -505,6 +520,7 @@ export const SitesEllipsisMenu = ( {
 	const { shouldShowSiteCopyItem, startSiteCopy } = useSiteCopy( site );
 	const hasCustomDomain = isCustomDomain( site.slug );
 	const isLaunched = site.launch_status !== 'unlaunched';
+	const isA4ADevSite = site.is_a4a_dev_site;
 	const isClassicSimple = isWpAdminInterface && isSimpleSite( site );
 	const isWpcomStagingSite = useSelector( ( state: AppState ) =>
 		isSiteWpcomStaging( state, site.ID )
@@ -521,7 +537,10 @@ export const SitesEllipsisMenu = ( {
 
 		return (
 			<SiteMenuGroup>
-				{ ! isWpcomStagingSite && ! isLaunched && <LaunchItem { ...props } /> }
+				{ ! isWpcomStagingSite && ! isLaunched && ! isA4ADevSite && <LaunchItem { ...props } /> }
+				{ ! isWpcomStagingSite && ! isLaunched && isA4ADevSite && (
+					<PrepareForLaunchItem { ...props } />
+				) }
 				<SettingsItem { ...props } />
 				{ hasHostingFeatures && <HostingConfigurationSubmenu { ...props } /> }
 				{ site.is_wpcom_atomic && <SiteMonitoringItem { ...props } /> }

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -30,6 +30,7 @@ export const SITE_REQUEST_FIELDS = [
 	'user_interactions',
 	'is_deleted',
 	'is_a4a_client',
+	'is_a4a_dev_site',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -132,6 +132,7 @@ export interface SiteDetails {
 	is_wpcom_atomic?: boolean;
 	is_wpcom_staging_site?: boolean;
 	is_a4a_client?: boolean;
+	is_a4a_dev_site?: boolean;
 	jetpack: boolean;
 	lang?: string;
 	launch_status: string;

--- a/packages/sites/src/site-excerpt-types.ts
+++ b/packages/sites/src/site-excerpt-types.ts
@@ -19,5 +19,6 @@ export type SiteExcerptData = Pick<
 > & {
 	title: string;
 	is_deleted?: boolean;
+	is_a4a_dev_site?: boolean;
 	options?: Pick< SiteDetailsOptions, ( typeof SITE_EXCERPT_REQUEST_OPTIONS )[ number ] >;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8668

## Proposed Changes

* Add "Prepare for launch" menu item for A4A dev sites on WordPress.com Global Sites View.
* Ensure the relevant sites endpoint also queries for `is-a4a-dev-site` attribute.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of this project. pdDOJh-3Cl-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you have A4A dev sites provisioned on or after 17 Jul (as those will have the relevant blog stickers, see D158724-code).
* Go to http://calypso.localhost:3000/sites.
* Look for your A4A dev site.
* You should see the "Prepare for launch" menu item.
* Clicking on the menu item should go to the hosting settings page.


<img width="1249" alt="image" src="https://github.com/user-attachments/assets/72e36792-e362-415c-9b70-12abae9ed8dd">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?