### PR TITLE
A4A Dev Sites: Add dev license to cart on Checkout using `referral_blog_id` param

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-dev-license.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-dev-license.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export default function useFetchDevLicense( blogId?: number ) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: [ 'a4a-dev-license', agencyId, blogId ],
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: '/agency/license/dev-site',
+				},
+				{
+					...( agencyId && { agency_id: agencyId } ),
+					...( blogId && { blog_id: blogId } ),
+				}
+			),
+		select: ( data ) => ( {
+			a4aSiteId: data?.a4a_site_id,
+			licenseId: data?.license_id,
+			productId: data?.product_id,
+			siteUrl: data?.site_url,
+		} ),
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -23,8 +23,8 @@ import { MarketplaceTypeContext } from '../context';
 import withMarketplaceType, { MARKETPLACE_TYPE_REFERRAL } from '../hoc/with-marketplace-type';
 import useProductsById from '../hooks/use-products-by-id';
 import useProductsBySlug from '../hooks/use-products-by-slug';
+import useReferralDevSite from '../hooks/use-referral-dev-site';
 import useShoppingCart from '../hooks/use-shopping-cart';
-import useReferralDevSite from '../hosting-overview/hooks/use-referral-dev-site';
 import { getClientReferralQueryArgs } from '../lib/get-client-referral-query-args';
 import useSubmitForm from '../products-overview/product-listing/hooks/use-submit-form';
 import NoticeSummary from './notice-summary';
@@ -127,6 +127,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 	}, [ dispatch ] );
 
 	const { addReferralPlanToCart, isLoading: isLoadingReferralDevSite } = useReferralDevSite(
+		selectedCartItems,
 		setSelectedCartItems,
 		referralBlogId
 	);
@@ -137,7 +138,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 			addReferralPlanToCart();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ referralBlogId && isLoadingReferralDevSite ] );
+	}, [ isLoadingReferralDevSite ] );
 
 	const title = isAutomatedReferrals ? translate( 'Referral checkout' ) : translate( 'Checkout' );
 

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -88,11 +88,14 @@ export const marketplaceWpcomContext: Callback = ( context, next ) => {
 };
 
 export const checkoutContext: Callback = ( context, next ) => {
+	const { referral_blog_id } = context.query;
+	const referralBlogId = referral_blog_id ? parseInt( referral_blog_id ) : undefined;
+
 	context.secondary = <MarketplaceSidebar path={ context.path } />;
 	context.primary = (
 		<>
 			<PageViewTracker title="Marketplace > Checkout" path={ context.path } />
-			<Checkout />
+			<Checkout referralBlogId={ referralBlogId } />
 		</>
 	);
 	next();

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-referral-dev-site.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-referral-dev-site.ts
@@ -1,22 +1,27 @@
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import useFetchDevLicense from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-license';
 import { MarketplaceTypeContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
 import { MARKETPLACE_TYPE_REFERRAL } from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type';
-import { ShoppingCartItem } from '../../types';
+import { ShoppingCartItem } from '../types';
 
 export default function useReferralDevSite(
+	selectedCartItems: ShoppingCartItem[],
 	setSelectedCartItems: ( items: ShoppingCartItem[] ) => void,
 	referralBlogId?: number
 ) {
 	const { data: allProducts, isLoading: isLoadingProducts } = useProductsQuery();
 	const { data: license, isLoading: isLoadingLicense } = useFetchDevLicense( referralBlogId );
 	const { setMarketplaceType } = useContext( MarketplaceTypeContext );
-	const [ referralPlanAdded, setReferralPlanAdded ] = useState( false );
 
 	const product = useMemo(
 		() => allProducts?.find( ( p ) => p.product_id === license?.productId ),
 		[ allProducts, license?.productId ]
+	);
+
+	const referralPlanAdded = useMemo(
+		() => license && selectedCartItems.some( ( item ) => item.licenseId === license.licenseId ),
+		[ selectedCartItems, license ]
 	);
 
 	const addReferralPlanToCart = useCallback( () => {
@@ -31,7 +36,6 @@ export default function useReferralDevSite(
 			};
 
 			setSelectedCartItems( [ cartProduct ] );
-			setReferralPlanAdded( true );
 		}
 	}, [ license, product, referralPlanAdded, setMarketplaceType, setSelectedCartItems ] );
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-referral-dev-site.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-referral-dev-site.tsx
@@ -1,0 +1,39 @@
+import { useCallback, useContext, useMemo, useState } from 'react';
+import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
+import useFetchDevLicense from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-license';
+import { MarketplaceTypeContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
+import { MARKETPLACE_TYPE_REFERRAL } from 'calypso/a8c-for-agencies/sections/marketplace/hoc/with-marketplace-type';
+import { ShoppingCartItem } from '../../types';
+
+export default function useReferralDevSite(
+	setSelectedCartItems: ( items: ShoppingCartItem[] ) => void,
+	referralBlogId?: number
+) {
+	const { data: allProducts, isLoading: isLoadingProducts } = useProductsQuery();
+	const { data: license, isLoading: isLoadingLicense } = useFetchDevLicense( referralBlogId );
+	const { setMarketplaceType } = useContext( MarketplaceTypeContext );
+	const [ referralPlanAdded, setReferralPlanAdded ] = useState( false );
+
+	const product = useMemo(
+		() => allProducts?.find( ( p ) => p.product_id === license?.productId ),
+		[ allProducts, license?.productId ]
+	);
+
+	const addReferralPlanToCart = useCallback( () => {
+		if ( product && license && ! referralPlanAdded ) {
+			setMarketplaceType( MARKETPLACE_TYPE_REFERRAL );
+
+			const cartProduct: ShoppingCartItem = {
+				...product,
+				quantity: 1,
+				licenseId: license.licenseId,
+				siteUrls: [ license.siteUrl ],
+			};
+
+			setSelectedCartItems( [ cartProduct ] );
+			setReferralPlanAdded( true );
+		}
+	}, [ license, product, referralPlanAdded, setMarketplaceType, setSelectedCartItems ] );
+
+	return { addReferralPlanToCart, isLoading: isLoadingProducts || isLoadingLicense };
+}

--- a/client/a8c-for-agencies/sections/marketplace/types.ts
+++ b/client/a8c-for-agencies/sections/marketplace/types.ts
@@ -3,6 +3,7 @@ import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types
 export type ShoppingCartItem = APIProductFamilyProduct & {
 	quantity: number;
 	siteUrls?: string[];
+	licenseId?: number;
 };
 
 export type MarketplaceType = 'referral' | 'regular';


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8708

## Proposed Changes

This PR is part of the work to enable an agency to refer an existing dev site. With this PR, when a user lands on the checkout page with a `referral_blog_id` param in the URL, it will switch to referral mode and add the license related to the given site to the cart.

## Why are these changes being made?

pdDOJh-3Cl-p2

## Testing Instructions

* Apply this PR to your local
* Update `use-get-tipalti-payee.tsx` by adding the code `select: ( data ) => ( { ...data?.data, IsPayable: true } ),` on line 33. 
* Go to http://agencies.localhost:3000/marketplace/checkout?referral_blog_id={blog_id}
  * Replace the blog_id with a blog_id from a development site
* You should see the cart in the referral mode and with the correct plan added 
* Perform regression tests on existing Checkout flow and Referral flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?