### PR TITLE
fix(agencies-hosting): hide WP and PHP versions

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/item-preview-pane-header/index.tsx
@@ -62,7 +62,10 @@ export default function ItemPreviewPaneHeader( {
 		extraProps?.siteIconFallback ?? ( itemData.isDotcomSite ? 'wordpress-logo' : 'color' );
 
 	const shouldDisplayVersionNumbers =
-		config.isEnabled( 'hosting-overview-refinements' ) && isAtomic && ( wpVersion || phpVersion );
+		config.isEnabled( 'hosting-overview-refinements' ) &&
+		! itemData.hideEnvDataInHeader &&
+		isAtomic &&
+		( wpVersion || phpVersion );
 
 	const handlePhpVersionClick = () => {
 		dispatch( recordTracksEvent( 'calypso_hosting_php_version_click' ) );

--- a/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
+++ b/client/a8c-for-agencies/components/items-dashboard/item-preview-pane/types.ts
@@ -26,6 +26,7 @@ export interface ItemData {
 	isDotcomSite?: boolean;
 	adminUrl?: string;
 	withIcon?: boolean;
+	hideEnvDataInHeader?: boolean;
 }
 
 export interface PreviewPaneProps {

--- a/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx
@@ -196,6 +196,7 @@ export function OverviewPreviewPane( {
 		url: site.url_with_scheme,
 		blogId: site.blog_id,
 		isDotcomSite: site.is_atomic,
+		hideEnvDataInHeader: true,
 	};
 
 	return (


### PR DESCRIPTION
Related to p1724191497496709-slack-C06ELHR6L9J

## Proposed Changes
Previously we added PHP and WP versions rendering to the Hosting pages header. But it was unintentionally snuck to "a8c for agencies". With this PR we are hiding them there:<br /><img width="306" alt="Screenshot 2024-08-21 at 08 22 48" src="https://github.com/user-attachments/assets/b1650d80-bea3-4489-a65c-3069f1293d0d">



## Testing Instructions
### Calypso
1) Run Calypso
2) Create Atomic website
3) Open `/sites`
4) Select an Atomic websites
5) Assert that you still see WP and PHP versions<br/><img width="425" alt="Screenshot 2024-08-21 at 08 24 14" src="https://github.com/user-attachments/assets/b7a238ae-5a79-4aaf-ad0e-d5814754765e">

### Agencies
1) Run agencies (https://github.com/Automattic/wp-calypso/pull/93747/files)
2) Click on `Sites` in left sidebar
3) Select any website
4) Assert that you don't see WP and PHP versions<br /><img width="323" alt="Screenshot 2024-08-21 at 08 25 41" src="https://github.com/user-attachments/assets/0a5f7fe4-3f61-48ca-9ea4-e79fe2780918">
