### PR TITLE
Newsletter paid importer: add tier creation

### DIFF
--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 
 interface PaidNewsletterStep {
@@ -27,7 +27,8 @@ export const usePaidNewsletterQuery = ( engine: string, currentStep: string, sit
 				}
 			);
 		},
+		placeholderData: keepPreviousData,
 		refetchOnWindowFocus: true,
-		staleTime: 6000, // 1 hour
+		staleTime: 6000, // 10 minutes
 	} );
 };

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -38,6 +38,9 @@ type RecurringPaymentsPlanAddEditModalProps = {
 	product: Product;
 	annualProduct: Product | null;
 	siteId?: number;
+	isOnlyTier?: boolean;
+	hideWelcomeEmailInput?: boolean;
+	hideAdvancedSettings?: boolean;
 };
 
 type StripeMinimumCurrencyAmounts = {
@@ -77,6 +80,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	product,
 	annualProduct /* annual product for tiers */,
 	siteId,
+	isOnlyTier = false,
+	hideWelcomeEmailInput = false,
+	hideAdvancedSettings = false,
 }: RecurringPaymentsPlanAddEditModalProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -363,17 +369,20 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						<FormInputValidation isError text={ translate( 'Please input a name.' ) } />
 					) }
 				</FormFieldset>
-				<FormFieldset className="memberships__dialog-sections-type">
-					<ToggleControl
-						onChange={ ( newValue ) => {
-							setEditedPostIsTier( newValue );
-							setEditedPostPaidNewsletter( newValue );
-						} }
-						checked={ editedPostIsTier }
-						disabled={ !! product.ID }
-						label={ translate( 'Paid newsletter tier' ) }
-					/>
-				</FormFieldset>
+				{ ! isOnlyTier && (
+					<FormFieldset className="memberships__dialog-sections-type">
+						<ToggleControl
+							onChange={ ( newValue ) => {
+								setEditedPostIsTier( newValue );
+								setEditedPostPaidNewsletter( newValue );
+							} }
+							checked={ editedPostIsTier }
+							disabled={ !! product.ID }
+							label={ translate( 'Paid newsletter tier' ) }
+						/>
+					</FormFieldset>
+				) }
+				{ isOnlyTier && <input type="hidden" name="type" value={ TYPE_TIER } /> }
 				{ editing && editedPrice && (
 					<Notice
 						text={ translate(
@@ -492,53 +501,57 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					/>
 				) }
 
-				<FormFieldset className="memberships__dialog-sections-message">
-					<FormLabel htmlFor="renewal_schedule">{ translate( 'Welcome message' ) }</FormLabel>
-					<CountedTextArea
-						value={ editedCustomConfirmationMessage }
-						onChange={ ( event: ChangeEvent< HTMLTextAreaElement > ) =>
-							setEditedCustomConfirmationMessage( event.target.value )
-						}
-						acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
-						showRemainingCharacters
-						placeholder={ translate( 'Thank you for subscribing!' ) }
-					/>
-					<FormSettingExplanation>
-						{ translate( 'The welcome message sent when your customer completes their order.' ) }
-					</FormSettingExplanation>
-				</FormFieldset>
-				<FoldableCard
-					header={ translate( 'Advanced options' ) }
-					hideSummary
-					className="memberships__dialog-advanced-options"
-				>
-					{ ! editedPostIsTier && (
-						<FormFieldset className="memberships__dialog-sections-type">
+				{ ! hideWelcomeEmailInput && (
+					<FormFieldset className="memberships__dialog-sections-message">
+						<FormLabel htmlFor="renewal_schedule">{ translate( 'Welcome message' ) }</FormLabel>
+						<CountedTextArea
+							value={ editedCustomConfirmationMessage }
+							onChange={ ( event: ChangeEvent< HTMLTextAreaElement > ) =>
+								setEditedCustomConfirmationMessage( event.target.value )
+							}
+							acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
+							showRemainingCharacters
+							placeholder={ translate( 'Thank you for subscribing!' ) }
+						/>
+						<FormSettingExplanation>
+							{ translate( 'The welcome message sent when your customer completes their order.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+				) }
+				{ ! hideAdvancedSettings && (
+					<FoldableCard
+						header={ translate( 'Advanced options' ) }
+						hideSummary
+						className="memberships__dialog-advanced-options"
+					>
+						{ ! editedPostIsTier && (
+							<FormFieldset className="memberships__dialog-sections-type">
+								<ToggleControl
+									onChange={ ( newValue ) => {
+										setEditedPostPaidNewsletter( newValue );
+									} }
+									checked={ editedPostPaidNewsletter }
+									disabled={ !! product.ID || editedPostIsTier }
+									label={ translate( 'Add customers to newsletter mailing list' ) }
+								/>
+							</FormFieldset>
+						) }
+						<FormFieldset>
 							<ToggleControl
-								onChange={ ( newValue ) => {
-									setEditedPostPaidNewsletter( newValue );
-								} }
-								checked={ editedPostPaidNewsletter }
-								disabled={ !! product.ID || editedPostIsTier }
-								label={ translate( 'Add customers to newsletter mailing list' ) }
+								onChange={ handlePayWhatYouWant }
+								checked={ editedPayWhatYouWant }
+								label={ translate(
+									'Enable customers to pick their own amount (“Pay what you want”)'
+								) }
+							/>
+							<ToggleControl
+								onChange={ handleMultiplePerUser }
+								checked={ editedMultiplePerUser }
+								label={ translate( 'Enable customers to make the same purchase multiple times' ) }
 							/>
 						</FormFieldset>
-					) }
-					<FormFieldset>
-						<ToggleControl
-							onChange={ handlePayWhatYouWant }
-							checked={ editedPayWhatYouWant }
-							label={ translate(
-								'Enable customers to pick their own amount (“Pay what you want”)'
-							) }
-						/>
-						<ToggleControl
-							onChange={ handleMultiplePerUser }
-							checked={ editedMultiplePerUser }
-							label={ translate( 'Enable customers to make the same purchase multiple times' ) }
-						/>
-					</FormFieldset>
-				</FoldableCard>
+					</FoldableCard>
+				) }
 			</div>
 		</Dialog>
 	);

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -82,7 +82,7 @@ export default function NewsletterImporter( { siteSlug, engine, step }: Newslett
 	const { data: urlData, isFetching } = useAnalyzeUrlQuery( fromSite );
 
 	let stepContent = {};
-	if ( ! isFetchingPaidNewsletter ) {
+	if ( paidNewsletterData?.steps ) {
 		stepContent = paidNewsletterData?.steps[ step ]?.content ?? {};
 	}
 

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -33,6 +33,7 @@ type MapPlanProps = {
 	siteId: string;
 	engine: string;
 	currentStep: string;
+	onProductAdd: () => void;
 };
 
 function displayProduct( product: Product | undefined ) {
@@ -67,6 +68,7 @@ export default function MapPlan( {
 	siteId,
 	engine,
 	currentStep,
+	onProductAdd,
 }: MapPlanProps ) {
 	const { mapStripePlanToProduct } = useMapStripePlanToProductMutation();
 	let active_subscriptions = '';
@@ -146,7 +148,13 @@ export default function MapPlan( {
 								/>
 							</MenuGroup>
 							<MenuGroup label="OR">
-								<MenuItem key="add-new" onClick={ onClose }>
+								<MenuItem
+									key="add-new"
+									onClick={ () => {
+										onClose();
+										onProductAdd();
+									} }
+								>
 									Add Newsletter Tier
 								</MenuItem>
 							</MenuGroup>

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -34,6 +34,7 @@ type MapPlanProps = {
 	engine: string;
 	currentStep: string;
 	onProductAdd: () => void;
+	tierToAdd: any;
 };
 
 function displayProduct( product: Product | undefined ) {
@@ -69,6 +70,7 @@ export default function MapPlan( {
 	engine,
 	currentStep,
 	onProductAdd,
+	tierToAdd,
 }: MapPlanProps ) {
 	const { mapStripePlanToProduct } = useMapStripePlanToProductMutation();
 	let active_subscriptions = '';
@@ -110,58 +112,74 @@ export default function MapPlan( {
 			<div className="map-plan__arrow">
 				<Icon icon={ arrowRight } />
 			</div>
-			<div className="map-plan__select-product">
-				<Button
-					aria-haspopup="true"
-					tabIndex={ 0 }
-					className="map-plan__selected"
-					onClick={ () => {
-						setIsOpen( ! isOpen );
-					} }
-					onKeyDown={ ( event: KeyboardEvent ) => {
-						if ( event.key === 'Enter' || event.key === ' ' ) {
+			{ ! products.length && (
+				<div className="map-plan__select-product">
+					<Button
+						aria-haspopup="true"
+						tabIndex={ 0 }
+						className="map-plan__selected"
+						onClick={ () => {
+							onProductAdd( tierToAdd );
+						} }
+					>
+						Add Newsletter Tier
+					</Button>
+				</div>
+			) }
+			{ !! products.length && (
+				<div className="map-plan__select-product">
+					<Button
+						aria-haspopup="true"
+						tabIndex={ 0 }
+						className="map-plan__selected"
+						onClick={ () => {
 							setIsOpen( ! isOpen );
-						}
-					} }
-				>
-					{ displayProduct( selectedProduct ) }
-				</Button>
-				<DropdownMenu
-					onToggle={ ( openState: boolean ) => {
-						setIsOpen( openState );
-					} }
-					icon={ chevronDown }
-					label="Choose a Newsletter Tier"
-					open={ isOpen }
-				>
-					{ ( { onClose }: { onClose: () => void } ) => (
-						<Fragment>
-							<MenuGroup label="Select">
-								<MenuItemsChoice
-									choices={ getProductChoices( sameIntervalProducts ) }
-									onSelect={ ( productId ) => {
-										handleProductChange( productId );
-										onClose();
-									} }
-									onHover={ () => {} }
-									value={ selectedProductId.toString() }
-								/>
-							</MenuGroup>
-							<MenuGroup label="OR">
-								<MenuItem
-									key="add-new"
-									onClick={ () => {
-										onClose();
-										onProductAdd();
-									} }
-								>
-									Add Newsletter Tier
-								</MenuItem>
-							</MenuGroup>
-						</Fragment>
-					) }
-				</DropdownMenu>
-			</div>
+						} }
+						onKeyDown={ ( event: KeyboardEvent ) => {
+							if ( event.key === 'Enter' || event.key === ' ' ) {
+								setIsOpen( ! isOpen );
+							}
+						} }
+					>
+						{ displayProduct( selectedProduct ) }
+					</Button>
+					<DropdownMenu
+						onToggle={ ( openState: boolean ) => {
+							setIsOpen( openState );
+						} }
+						icon={ chevronDown }
+						label="Choose a Newsletter Tier"
+						open={ isOpen }
+					>
+						{ ( { onClose }: { onClose: () => void } ) => (
+							<Fragment>
+								<MenuGroup label="Select">
+									<MenuItemsChoice
+										choices={ getProductChoices( sameIntervalProducts ) }
+										onSelect={ ( productId ) => {
+											handleProductChange( productId );
+											onClose();
+										} }
+										onHover={ () => {} }
+										value={ selectedProductId.toString() }
+									/>
+								</MenuGroup>
+								<MenuGroup label="OR">
+									<MenuItem
+										key="add-new"
+										onClick={ () => {
+											onClose();
+											onProductAdd( tierToAdd );
+										} }
+									>
+										Add Newsletter Tier
+									</MenuItem>
+								</MenuGroup>
+							</Fragment>
+						) }
+					</DropdownMenu>
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -26,6 +26,20 @@ type Product = {
 	interval: string;
 };
 
+type TierToAdd = {
+	currency: string;
+	price: number;
+	type: string;
+	title: string;
+	interval: string;
+	annualProduct: {
+		currency: string;
+		price: number;
+		type: string;
+		interval: string;
+	};
+};
+
 type MapPlanProps = {
 	plan: Plan;
 	products: Array< Product >;
@@ -33,8 +47,8 @@ type MapPlanProps = {
 	siteId: string;
 	engine: string;
 	currentStep: string;
-	onProductAdd: () => void;
-	tierToAdd: any;
+	onProductAdd: ( arg0: TierToAdd | null ) => void;
+	tierToAdd: TierToAdd;
 };
 
 function displayProduct( product: Product | undefined ) {

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plan.tsx
@@ -26,7 +26,7 @@ type Product = {
 	interval: string;
 };
 
-type TierToAdd = {
+export type TierToAdd = {
 	currency: string;
 	price: number;
 	type: string;
@@ -76,7 +76,7 @@ function getProductChoices( products: Array< Product > ) {
 	} ) );
 }
 
-export default function MapPlan( {
+export function MapPlan( {
 	plan,
 	products,
 	map_plans,

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import {
 	PLAN_YEARLY_FREQUENCY,
@@ -41,15 +41,19 @@ export default function MapPlans( {
 	};
 
 	const products = useSelector( ( state ) => getProductsForSiteId( state, siteId ) );
+	const sizeOfProductsRef = useRef( products.length );
 
+	const sizeOfProducts = products.length;
+	// check if we added new products and if so invalidate the query to check it again.
 	useEffect( () => {
-		if ( ! products ) {
+		if ( sizeOfProducts === sizeOfProductsRef.current || sizeOfProducts === 0 ) {
 			return;
 		}
+		sizeOfProductsRef.current = sizeOfProducts;
 		queryClient.invalidateQueries( {
 			queryKey: [ 'paid-newsletter-importer', siteId, engine, currentStep ],
 		} );
-	}, [ products, siteId, engine, currentStep, queryClient ] );
+	}, [ sizeOfProducts, sizeOfProductsRef, siteId, engine, currentStep, queryClient ] );
 
 	const monthyPlan = cardData.plans.find( ( plan: any ) => plan.plan_interval === 'month' );
 

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
@@ -1,4 +1,6 @@
 import { Card } from '@automattic/components';
+import { useState } from 'react';
+import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../importer-action-buttons/container';
@@ -21,6 +23,10 @@ export default function MapPlans( {
 	engine,
 	currentStep,
 }: Props ) {
+	const [ productToAdd, setProductToAdd ] = useState< Product | null >( null );
+
+	const closeDialog = () => {};
+
 	return (
 		<Card>
 			<h2>Paid newsletter offering</h2>
@@ -43,6 +49,7 @@ export default function MapPlans( {
 						plan={ plan }
 						products={ cardData.available_tiers }
 						map_plans={ cardData.map_plans }
+						onProductAdd={ setProductToAdd }
 					/>
 				) ) }
 			</div>
@@ -66,6 +73,13 @@ export default function MapPlans( {
 					Skip for now
 				</ImporterActionButton>
 			</ImporterActionButtonContainer>
+			{ productToAdd && (
+				<RecurringPaymentsPlanAddEditModal
+					closeDialog={ closeDialog }
+					product={ productToAdd }
+					annualProduct={ productToAdd.annualProduct }
+				/>
+			) }
 		</Card>
 	);
 }

--- a/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/paid-subscribers/map-plans.tsx
@@ -13,7 +13,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import ImporterActionButton from '../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../importer-action-buttons/container';
-import MapPlan from './map-plan';
+import { MapPlan, TierToAdd } from './map-plan';
 
 type Props = {
 	nextStepUrl: string;
@@ -24,6 +24,13 @@ type Props = {
 	currentStep: string;
 };
 
+function formatCurrencyFloat( amount: number, currency: string ) {
+	const formattedCurrency = formatCurrency( amount, currency, {
+		isSmallestUnit: true,
+	} ).replace( /[^\d.-]/g, '' );
+	return parseFloat( formattedCurrency );
+}
+
 export default function MapPlans( {
 	nextStepUrl,
 	skipNextStep,
@@ -32,7 +39,7 @@ export default function MapPlans( {
 	engine,
 	currentStep,
 }: Props ) {
-	const [ productToAdd, setProductToAdd ] = useState< Product | null >( null );
+	const [ productToAdd, setProductToAdd ] = useState< TierToAdd | null >( null );
 
 	const queryClient = useQueryClient();
 
@@ -61,17 +68,13 @@ export default function MapPlans( {
 
 	const tierToAdd = {
 		currency: monthyPlan.plan_currency,
-		price: formatCurrency( monthyPlan.plan_amount_decimal, monthyPlan.plan_currency, {
-			isSmallestUnit: true,
-		} ).replace( /[^\d.-]/g, '' ),
+		price: formatCurrencyFloat( monthyPlan.plan_amount_decimal, monthyPlan.plan_currency ),
 		type: TYPE_TIER,
 		title: 'Newsletter tier',
 		interval: PLAN_MONTHLY_FREQUENCY,
 		annualProduct: {
 			currency: annualPlan.plan_currency,
-			price: formatCurrency( annualPlan.plan_amount_decimal, annualPlan.plan_currency, {
-				isSmallestUnit: true,
-			} ).replace( /[^\d.-]/g, '' ),
+			price: formatCurrencyFloat( annualPlan.plan_amount_decimal, annualPlan.plan_currency ),
 			type: TYPE_TIER,
 			interval: PLAN_YEARLY_FREQUENCY,
 		},


### PR DESCRIPTION
This PR adds the ability to add new  newsletter tiers right from the importer UI. 

## Proposed Changes

* It also make it so that once the newsletter tier is created that we invaldate the current state data. 
* It persists the data better across re fetches so that we don't see the blank screen.

## Why are these changes being made?
See

https://github.com/user-attachments/assets/ccd9c93e-b5fa-4f06-9aa1-1773004714ec



## Testing Instructions

Load this PR. 
Navigate to /import/newsletter/substack/enejtest5.wordpress.com/summary?from=enej0077.substack.com 
Notice that you can now add newsletter tiers. 


*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
