### PR TITLE
Fix migration plan step when introductory offer is disabled

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/with-migration-sticker.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/with-migration-sticker.tsx
@@ -5,6 +5,8 @@ import { Skeleton } from './skeleton';
 import type { UpgradePlanProps } from './types';
 import type { FC } from 'react';
 
+const isIntroductoryOfferEnabled = config.isEnabled( 'migration-flow/introductory-offer' );
+
 const withMigrationSticker =
 	( WrappedComponent: FC< UpgradePlanProps > ) => ( props: UpgradePlanProps ) => {
 		const { site } = props;
@@ -17,7 +19,7 @@ const withMigrationSticker =
 		} = useMigrationStickerMutation();
 
 		useEffect( () => {
-			if ( ! config.isEnabled( 'migration-flow/introductory-offer' ) ) {
+			if ( ! isIntroductoryOfferEnabled ) {
 				return;
 			}
 
@@ -32,7 +34,7 @@ const withMigrationSticker =
 			};
 		}, [ addMigrationSticker, deleteMigrationSticker, siteId ] );
 
-		if ( isIdle || isPending ) {
+		if ( isIntroductoryOfferEnabled && ( isIdle || isPending ) ) {
 			return <Skeleton />;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* The migration plan step wasn't working if the `migration-flow/introductory-offer` was not enabled. This fix this issue.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If we decide to deactivate the introductory offer at some point, it should work.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Deactivate the feature flag `migration-flow/introductory-offer` on `config/development.json`.
* Navigate to `/setup/migration` (it could be any flow).
* Select the "WordPress" option.
* Check that the step is properly loaded without the introductory offer..
* Revert the change on `config/development.json`.
* Make sure the introductory offer continues working properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
