### PR TITLE
Performance Profiler: Update the thumbnail container to align to the right

### DIFF
--- a/client/performance-profiler/components/screenshot-thumbnail.tsx
+++ b/client/performance-profiler/components/screenshot-thumbnail.tsx
@@ -5,7 +5,7 @@ const Container = styled.div`
 	width: 370px;
 	height: 255px;
 	display: flex;
-	justify-content: center;
+	justify-content: flex-end;
 	align-items: center;
 
 	& > * {


### PR DESCRIPTION
Fixes [Performance Profiler: [FEEDBACK] Fix last tested date with the right margin of container](https://github.com/Automattic/dotcom-forge/issues/8827)

## Proposed Changes
Update the screenshot thumbnail container to align to the right

## Why are these changes being made?

[Performance Profiler: [FEEDBACK] Fix last tested date with the right margin of container](https://github.com/Automattic/dotcom-forge/issues/8827)

## Testing Instructions


 * Go to `/speed-test-tool?url=wordpress.com`
 * Check if the thumbnail is aligned to the right by checking the tested date

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2024-08-20 at 16 33 28@2x](https://github.com/user-attachments/assets/906ccde7-f2d7-4f5c-8f44-fbdbf5191453)|![CleanShot 2024-08-20 at 16 32 48@2x](https://github.com/user-attachments/assets/747c62c2-602b-4750-a889-4646a1b82a4e)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
