### PR TITLE
A4A Dev Sites: Submit referral with dev license ID

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -108,7 +108,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 					<span className="product-info__count">{ countInfo }</span>
 				</div>
 				<p className="product-info__description">{ productDescription }</p>
-				<p className="product-info__site-url">{ siteUrls }</p>
+				{ product.licenseId && siteUrls && <p className="product-info__site-url">{ siteUrls }</p> }
 			</div>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -16,6 +16,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 		productInfo?.productSlug && getProductIcon( { productSlug: productInfo?.productSlug } );
 	let productTitle = title;
 	let productDescription = productInfo?.lightboxDescription || productInfo?.tagline;
+	let siteUrls;
 
 	if ( product.family_slug === 'pressable-hosting' ) {
 		const presablePlan = getPressablePlan( product.slug );
@@ -58,6 +59,20 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 				comment: 'The `install` are the count of WordPress installs.',
 			}
 		);
+
+		const formattedSiteUrls = product.siteUrls?.map( ( siteUrl ) =>
+			siteUrl.replace( /^https?:\/\//, '' )
+		);
+
+		siteUrls = product.siteUrls?.length
+			? translate( 'Site: %(sitesList)s', {
+					args: {
+						sitesList: formattedSiteUrls?.join( ',' ) ?? '',
+					},
+					context: 'product description',
+					comment: 'The `sitesList` is the list of site URLs in the plan description.',
+			  } )
+			: '';
 	}
 
 	if ( ! productDescription ) {
@@ -93,6 +108,7 @@ export default function ProductInfo( { product }: { product: ShoppingCartItem } 
 					<span className="product-info__count">{ countInfo }</span>
 				</div>
 				<p className="product-info__description">{ productDescription }</p>
+				<p className="product-info__site-url">{ siteUrls }</p>
 			</div>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -4,7 +4,7 @@ import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { A4A_REFERRALS_DASHBOARD } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { REFERRAL_EMAIL_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -56,6 +56,17 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 
 	const productIds = checkoutItems.map( ( item ) => item.product_id ).join( ',' );
 
+	const licenses = useMemo(
+		() =>
+			checkoutItems
+				.filter( ( item ) => item.licenseId )
+				.map( ( item ) => ( {
+					product_id: item.product_id,
+					license_id: item.licenseId as number,
+				} ) ),
+		[ checkoutItems ]
+	);
+
 	const handleRequestPayment = useCallback( () => {
 		if ( ! hasCompletedForm ) {
 			return;
@@ -67,8 +78,22 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_marketplace_referral_checkout_request_payment_click' )
 		);
-		requestPayment( { client_email: email, client_message: message, product_ids: productIds } );
-	}, [ dispatch, email, hasCompletedForm, message, productIds, requestPayment, translate ] );
+		requestPayment( {
+			client_email: email,
+			client_message: message,
+			product_ids: productIds,
+			licenses: licenses,
+		} );
+	}, [
+		dispatch,
+		email,
+		hasCompletedForm,
+		licenses,
+		message,
+		productIds,
+		requestPayment,
+		translate,
+	] );
 
 	useEffect( () => {
 		if ( isSuccess && !! email ) {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -250,6 +250,12 @@
 		margin-block: 4px 0;
 		color: var(--color-neutral-70);
 	}
+
+	.product-info__site-url {
+		@include a4a-font-body-md;
+		margin-block: 4px 0;
+		color: var(--color-neutral-40);
+	}
 }
 
 .checkout__client-referral-form {

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-request-client-payment-mutation.ts
@@ -8,6 +8,10 @@ export interface MutationRequestClientPaymentVariables {
 	client_email: string;
 	client_message: string;
 	product_ids: string;
+	licenses?: {
+		product_id: number;
+		license_id: number;
+	}[];
 }
 
 interface APIError {
@@ -21,6 +25,7 @@ function mutationRequestClientPayment( {
 	client_message,
 	product_ids,
 	agencyId,
+	licenses,
 }: MutationRequestClientPaymentVariables & { agencyId?: number } ): Promise< ReferralAPIResponse > {
 	if ( ! agencyId ) {
 		throw new Error( 'Agency ID is required request a client payment' );
@@ -28,7 +33,7 @@ function mutationRequestClientPayment( {
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: `/agency/${ agencyId }/referrals`,
-		body: { client_email, client_message, product_ids },
+		body: { client_email, client_message, product_ids, licenses },
 	} );
 }
 

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -136,16 +136,13 @@ const LaunchSite = () => {
 						) }
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>
-					{
-						// TODO: add onClick handler
-						isDevelopmentSite && (
-							<div className={ launchSiteClasses }>
-								<Button onClick={ handleReferToClient } disabled={ false }>
-									{ translate( 'Refer to client' ) }
-								</Button>
-							</div>
-						)
-					}
+					{ isDevelopmentSite && (
+						<div className={ launchSiteClasses }>
+							<Button onClick={ handleReferToClient } disabled={ false }>
+								{ translate( 'Refer to client' ) }
+							</Button>
+						</div>
+					) }
 				</div>
 			</LaunchCard>
 			{ showPreviewLink && (


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8709

## Proposed Changes

- Submit referral with dev license ID
- Add site URL to product description on checkout page

## Why are these changes being made?

pdDOJh-3Cl-p2

## Testing Instructions

* Apply this PR to your local
* Follow instructions here p1724360785902019/1724279860.394739-slack-C02TCEHP3HA to setup Payment Settings
* Go to [http://agencies.localhost:3000/marketplace/checkout?referral_blog_id={blog_id}](http://agencies.localhost:3000/marketplace/checkout?referral_blog_id=%7Bblog_id%7D)
  * Replace the blog_id with a wpcom blog_id from a development site
* Check if the site URL is displayed below the product description
<img width="797" alt="image" src="https://github.com/user-attachments/assets/67b17e12-bab1-464f-9b7e-9c8cc995942b">


* Fill in the "Client email" and "Message" fields
* Open the Network monitor and filter by "referrals"
* Submit the referral and check if the request returns with the correct site and license
```
{
    "id": {id},
    "status": "pending",
    "client": {
        "id": {id},
        "email": "{email}"
    },
    "products": [
        {
            "status": "active",
            "product_id": {id},
            "quantity": 1,
            "site_assigned": "{site_assigned}",
            "license": {
                "license_id": {id},
                "license_key": "{license_key}",
                "quantity": null,
                "parent_jetpack_license_id": null,
                "issued_at": "2024-08-13 14:31:31",
                "attached_at": "2024-08-13 14:31:39",
                "revoked_at": null
            }
        }
    ]
}
```

- Perform regression tests on the referral and checkout flows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?