### PR TITLE
chore(a4a): add README.md with Getting Started instructions

### DIFF
--- a/client/a8c-for-agencies/README.md
+++ b/client/a8c-for-agencies/README.md
@@ -1,0 +1,11 @@
+# Automattic for Agencies (A4A)
+
+## Getting Started
+
+You can try out the front-end of A4A on [https://agencies.automattic.com/](https://agencies.automattic.com/) or install and run it locally:
+
+1. Make sure you have [`git`](https://git-scm.com/), [`node`](https://nodejs.org/), and [`yarn`](https://classic.yarnpkg.com/en/docs/install) installed.
+2. Clone this repository locally.
+3. Add `127.0.0.1 agencies.localhost` to your local `hosts` file.
+4. Execute `yarn` and then `yarn start-a8c-for-agencies` from the root directory of the repository.
+5. Open [`agencies.localhost:3000`](http://agencies.localhost:3000/) in your browser.


### PR DESCRIPTION
Related to p1724168773121679-slack-C7YPUHBB2

## Proposed Changes
Add README.md width Getting Started instruction

## Why are these changes being made?
This was my first time running A4A, and I noticed something that might be helpful for others. When working with new projects, it’s common practice to look for a README.md file in the root directory containing a “Getting Started” guide. However, I couldn’t find one here. Instead, I explored the package.json file and discovered the `start-a8c-for-agencies` npm task. At first, I didn’t realize that I needed to update the hosts file—this became clear later.

Eventually, I found some helpful information in this P2 post: p4TIVU-aUy-p2. However, I believe having a README.md file, as proposed in this PR, would be beneficial—especially since this is an open-source repository. It would provide an accessible entry point for contributors and reduce the initial setup confusion.

## Testing Instructions
Visual review should suffice