### PR TITLE
Revert loading smooch on Help Center

### DIFF
--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -53,8 +53,8 @@ const HelpCenter: React.FC< Container > = ( {
 	const { hasActiveChats, isEligibleForChat } = useChatStatus();
 	const { isMessagingScriptLoaded } = useLoadZendeskMessaging(
 		'zendesk_support_chat_key',
-		isHelpCenterShown && isEligibleForChat,
-		isEligibleForChat
+		( isHelpCenterShown && isEligibleForChat ) || hasActiveChats,
+		isEligibleForChat || hasActiveChats
 	);
 
 	useZendeskMessagingBindings( HELP_CENTER_STORE, hasActiveChats, isMessagingScriptLoaded );

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -3,11 +3,7 @@
  * External Dependencies
  */
 import { initializeAnalytics } from '@automattic/calypso-analytics';
-import {
-	useZendeskMessagingBindings,
-	useLoadZendeskMessaging,
-	useSmooch,
-} from '@automattic/zendesk-client';
+import { useZendeskMessagingBindings, useLoadZendeskMessaging } from '@automattic/zendesk-client';
 import { useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 /**
@@ -59,16 +55,6 @@ const HelpCenter: React.FC< Container > = ( {
 
 	useZendeskMessagingBindings( HELP_CENTER_STORE, hasActiveChats, isMessagingScriptLoaded );
 
-	const { initSmooch, destroy } = useSmooch();
-	const ref = useRef( null );
-
-	useEffect( () => {
-		if ( isMessagingScriptLoaded && ref.current ) {
-			initSmooch( ref.current );
-		}
-		return destroy;
-	}, [ destroy, initSmooch, isMessagingScriptLoaded ] );
-
 	const openingCoordinates = useOpeningCoordinates( isHelpCenterShown, isMinimized );
 
 	useEffect( () => {
@@ -87,15 +73,12 @@ const HelpCenter: React.FC< Container > = ( {
 	}, [ portalParent, handleClose ] );
 
 	return createPortal(
-		<>
-			<HelpCenterContainer
-				handleClose={ handleClose }
-				hidden={ hidden }
-				currentRoute={ currentRoute }
-				openingCoordinates={ openingCoordinates }
-			/>
-			<div className="help-center__smooch-container" ref={ ref } style={ { display: 'none' } } />
-		</>,
+		<HelpCenterContainer
+			handleClose={ handleClose }
+			hidden={ hidden }
+			currentRoute={ currentRoute }
+			openingCoordinates={ openingCoordinates }
+		/>,
 		portalParent
 	);
 };


### PR DESCRIPTION
## Proposed Changes

* Revert loading Smooch on Help Center

## Why are these changes being made?

* Our latest PR to introduced Smooch also increased the number of times our Zendesk Widget was loaded.
This PR reverts that condition.

## Testing Instructions

* The widget should only be loaded if the user has any active chats.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
