### PR TITLE
The development label should be gated behind a feature flag

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Badge, Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import SiteFavicon from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
@@ -17,6 +18,7 @@ const SiteDataField = ( { isLoading, site, isDevSite, onSiteTitleClick }: SiteDa
 	}
 
 	const migrationInProgress = site.sticker?.includes( 'migration-in-progress' );
+	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	return (
 		<Button
@@ -32,14 +34,14 @@ const SiteDataField = ( { isLoading, site, isDevSite, onSiteTitleClick }: SiteDa
 			<div className="sites-dataviews__site-name">
 				<div>{ site.blogname }</div>
 				{ ! migrationInProgress && <div className="sites-dataviews__site-url">{ site.url }</div> }
-				{ ( migrationInProgress || isDevSite ) && (
-					<Badge
-						className="status-badge"
-						type={ migrationInProgress ? 'info-blue' : 'info-purple' }
-					>
-						{ migrationInProgress
-							? translate( 'Migration in progress' )
-							: translate( 'Development' ) }
+				{ migrationInProgress && (
+					<Badge className="status-badge" type="info-blue">
+						{ translate( 'Migration in progress' ) }
+					</Badge>
+				) }
+				{ devSitesEnabled && isDevSite && (
+					<Badge className="status-badge" type="info-purple">
+						{ translate( 'Development' ) }
 					</Badge>
 				) }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/93756
Related to https://github.com/Automattic/wp-calypso/pull/93186

## Proposed Changes

A bug was introduced by the combination of https://github.com/Automattic/wp-calypso/pull/93186 and https://github.com/Automattic/wp-calypso/pull/93408/ where the "Development" badge for free development site was exposed to public users. The free development site feature is not yet released, the badge should be gated behind the respective feature flag `a4a-dev-sites`. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click the Automattic for Agencies live link: https://github.com/Automattic/wp-calypso/pull/93755#issuecomment-2299985773
* Refresh the page after appending `?flags=a4a-dev-sites` to the URL.
* Navigate to "Sites" and assert that the "Development" badge is shown.

<img width="890" alt="Screen Shot 2024-08-20 at 8 29 41 PM" src="https://github.com/user-attachments/assets/a2a61bbb-6788-4bac-acf0-08f2f849f6fc">

* Refresh the page after appending `?flags=-a4a-dev-sites` to the URL (this removes the feature flag).
* Navigate to "Sites" and assert that the "Development" badge is _not_ shown.

<img width="892" alt="Screen Shot 2024-08-20 at 8 29 26 PM" src="https://github.com/user-attachments/assets/5130fc97-160e-4f0b-92a8-33eb44af15f6">