### PR TITLE
Payment methods: fix alignment of 'Use as backup' text 

### DIFF
--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -1,4 +1,5 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useState, useCallback } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -22,6 +23,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const reduxDispatch = useDispatch();
 	const [ isDialogVisible, setIsDialogVisible ] = useState( false );
 	const closeDialog = useCallback( () => setIsDialogVisible( false ), [] );
+	const isNarrowView = useBreakpoint( '<660px' );
 
 	const handleDelete = useCallback( () => {
 		closeDialog();
@@ -59,7 +61,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 				scary
 				borderless
 			>
-				{ text }
+				{ isNarrowView ? <Gridicon icon="trash" /> : text }
 			</Button>
 		);
 	};

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -1,5 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
-import { useBreakpoint } from '@automattic/viewport-react';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useState, useCallback } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -23,7 +22,6 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const reduxDispatch = useDispatch();
 	const [ isDialogVisible, setIsDialogVisible ] = useState( false );
 	const closeDialog = useCallback( () => setIsDialogVisible( false ), [] );
-	const isNarrowView = useBreakpoint( '<660px' );
 
 	const handleDelete = useCallback( () => {
 		closeDialog();
@@ -61,7 +59,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 				scary
 				borderless
 			>
-				{ isNarrowView ? <Gridicon icon="trash" /> : text }
+				{ text }
 			</Button>
 		);
 	};

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -115,6 +115,7 @@
 .payment-method-delete {
 	grid-area: payment-method-delete;
 	margin-top: 12px;
+	text-align: right;
 
 	@include breakpoint-deprecated( ">480px" ) {
 		margin-top: 0;
@@ -140,6 +141,8 @@
 
 .payment-method-backup-toggle {
 	grid-area: payment-method-backup;
+	margin-inline-start: 76px;
+	margin-top: 16px;
 	width: 100%;
 
 	@include breakpoint-deprecated( ">480px" ) {

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -115,16 +115,17 @@
 .payment-method-delete {
 	grid-area: payment-method-delete;
 	margin-top: 12px;
-	text-align: right;
 
 	@include breakpoint-deprecated( ">480px" ) {
 		margin-top: 0;
+		justify-self: flex-end;
 	}
 }
 
 .payment-method-delete__button {
 	text-decoration: underline;
 	padding: 0;
+	text-align: right;
 }
 
 .payment-method-delete-dialog {
@@ -139,23 +140,13 @@
 
 .payment-method-backup-toggle {
 	grid-area: payment-method-backup;
-	margin-inline-start: 76px;
-	margin-top: 16px;
 	width: 100%;
-
-	& .components-checkbox-control [data-wp-component="HStack"] {
-		justify-content: start;
-	}
 
 	@include breakpoint-deprecated( ">480px" ) {
 		margin-left: 0;
 		margin-top: 0;
-		text-align: right;
 		width: auto;
-
-		& .components-checkbox-control [data-wp-component="HStack"] {
-			justify-content: end;
-		}
+		justify-self: flex-end;
 	}
 }
 


### PR DESCRIPTION

Related to #93710



## Proposed Changes

* Removes references to component attributes in CSS declarations.
* Align the `'Delete this payment method'` text in viewports <660px to make it consistent with all widths 
* ~~Ensure that items in the right hand column of the payment methods grid align to the right.~~
* ~~Swap out delete text for trash icon on narrow viewport widths (optional)~~

Checked on Firefox, Chrome and Safari

## Why are these changes being made?

* CSS rules shouldn't target component internals
* ~~The 'Use as backup' text element does not align with the delete text beneath it~~
* ~~The 'Delete this payment method' text bunches up and crowds the space on narrow viewport widths.~~

## Testing Instructions

1. Fire up this branch and head to http://calypso.localhost:3000/me/purchases/payment-methods
2. If you don't have any payment methods added, add some!
3. Check that the 'Use as backup.' text aligns to the right.
4. Narrow the viewport width. Check that the 'Delete this payment method' text aligns right.
5. There should be no other differences between this PR and trunk.


### Before
| <440 | <660 | 1200 |
|--------|--------|--------|
| <img width="384" alt="Screenshot 2024-09-09 at 1 54 38 PM" src="https://github.com/user-attachments/assets/9119617c-65ba-4d23-88e2-75bb5553c334"> | <img width="645" alt="Screenshot 2024-09-09 at 1 56 46 PM" src="https://github.com/user-attachments/assets/1372cea5-a9bc-4fee-8163-a0fad8c1a322"> | <img width="905" alt="Screenshot 2024-09-09 at 1 58 34 PM" src="https://github.com/user-attachments/assets/69529b1d-c7f6-4b75-9395-c5fefced4f77"> | 



### After
| <440 | <660 | 1200 |
|--------|--------|--------|
| <img width="385" alt="Screenshot 2024-09-09 at 1 52 51 PM" src="https://github.com/user-attachments/assets/09e21519-d03f-453c-8efe-2a1effa64330"> | <img width="644" alt="Screenshot 2024-09-09 at 1 55 54 PM" src="https://github.com/user-attachments/assets/9197ab12-7b1c-458e-a27e-c889fccd1c38"> | <img width="903" alt="Screenshot 2024-09-09 at 1 58 30 PM" src="https://github.com/user-attachments/assets/f0879d15-c72f-4e74-a6e9-28660f228d62"> | 











## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
