### PR TITLE
Stats: Fixing date input value after selection from a calendar 

### DIFF
--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -24,6 +24,7 @@ const DateControlPickerDate = ( {
 	const [ previewDateStart, setPreviewDateStart ] = useState( startDate );
 	const [ previewDateEnd, setPreviewDateEnd ] = useState( endDate );
 
+	// Updates the selected date in the input field and the calendar after clicking on a date
 	const handleStartSeletion = ( date: string ) => {
 		onStartChange( date.split( 'T' )?.[ 0 ] );
 		setPreviewDateStart( date.split( 'T' )?.[ 0 ] );
@@ -34,6 +35,7 @@ const DateControlPickerDate = ( {
 		setPreviewDateEnd( date.split( 'T' )?.[ 0 ] );
 	};
 
+	// Updates only the visible month in the calendar
 	const handleStartMonthTogglePrevious = ( date: string ) => {
 		setPreviewDateEnd( previewDateStart );
 		setPreviewDateStart( date );
@@ -61,19 +63,11 @@ const DateControlPickerDate = ( {
 			<div className={ `${ BASE_CLASS_NAME }s__inputs` }>
 				<div className={ `${ BASE_CLASS_NAME }s__inputs-input-group` }>
 					<label htmlFor="startDate">{ translate( 'From', { context: 'from date' } ) }</label>
-					<DateInput
-						id="startDate"
-						value={ previewDateStart || startDate }
-						onChange={ handleStartSeletion }
-					/>
+					<DateInput id="startDate" value={ startDate } onChange={ handleStartSeletion } />
 				</div>
 				<div className={ `${ BASE_CLASS_NAME }s__inputs-input-group` }>
 					<label htmlFor="endDate">{ translate( 'To', { context: 'to date' } ) }</label>
-					<DateInput
-						id="endDate"
-						value={ previewDateEnd || endDate }
-						onChange={ handleEndSeletion }
-					/>
+					<DateInput id="endDate" value={ endDate } onChange={ handleEndSeletion } />
 				</div>
 			</div>
 			{ isCalendarEnabled && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/145

## Proposed Changes

* fixing input value when selecting a day from the calendar component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* it's part of the project improving UI for the users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply `stats/date-picker-calendar` to the live branch
* verify that clicking on the calendar updates the proper input above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
