### PR TITLE
Overview: fix plan storage link color

### DIFF
--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -1,7 +1,8 @@
 .plan-storage {
 	display: flex;
+	color: var(--studio-gray-80);
 	&:visited {
-		color: var(--studio-gray-80);
+		color: inherit;
 	}
 }
 

--- a/client/hosting/overview/components/style.scss
+++ b/client/hosting/overview/components/style.scss
@@ -253,6 +253,7 @@ $blueberry-color: #3858e9;
 	display: flex;
 	justify-content: space-between;
 	gap: $grid-unit-10;
+	color: var(--studio-gray-80);
 }
 
 .hosting-overview__plan-storage-title,

--- a/client/hosting/overview/components/style.scss
+++ b/client/hosting/overview/components/style.scss
@@ -253,7 +253,6 @@ $blueberry-color: #3858e9;
 	display: flex;
 	justify-content: space-between;
 	gap: $grid-unit-10;
-	color: var(--studio-gray-80);
 }
 
 .hosting-overview__plan-storage-title,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8685-gh-Automattic/dotcom-forge

## Proposed Changes

Adds a specific rule to ensure the color of the links in the Plan Storage title on free sites is the correct color

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This was an odd bug, and I still don't know entirely what was triggering it. On _some_ free sites (not all) the title text (which is nested inside an `a` tag) would render as blue instead of the dark gray they're intended to be.

The cause was [this style](https://github.com/Automattic/wp-calypso/blob/52d077fd440a59f29ac4a402ca61060d9aa7c2ed/client/blocks/plan-storage/style.scss#L3-L6) not being applied to a subset of free sites.

I still haven't identified the root cause of this. It is limited to free sites, but not all of them. It doesn't appear to be related to whether or not the site has been atomic in the past and reverted. The file in question is being loaded for these sites, and other changes to that file are rendered on the page, but this one style for some reason seems to not get applied, even with a much more specific selector.

As curious as I am, in the interest of resolving the bug efficiently, I've opted for adding the color through a different selector rather than continuing down the rabbit hole. I'll probably come back to appease my curiosity in my free time.

**Before**
![image](https://github.com/user-attachments/assets/545cef33-024e-4da6-80e7-e683ad0ca73f)

**After**
![image](https://github.com/user-attachments/assets/bd14fc24-57fe-47f4-8794-4ed673492f72)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Before testing this PR, load `/overview` for a free site that you have access to. Confirm that the the "Storage" and usage data links are blue as shown in the screenshot above.
- If you have trouble finding a site that reproduces the error, try some a8c owned domains 
- Apply this PR, confirm that the title section of the Plan Storage card renders in dark gray (`--studio-gray-80`)