### PR TITLE
Show full product display name on my plan page

### DIFF
--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -2,7 +2,6 @@ import {
 	isFreeJetpackPlan,
 	isFreePlan,
 	isJetpackProduct,
-	getJetpackProductDisplayName,
 	getJetpackProductTagline,
 	isJetpackBackup,
 	isJetpackScan,
@@ -30,6 +29,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import ProductExpiration from 'calypso/components/product-expiration';
 import {
 	isExpiring,
+	getDisplayName,
 	isPartnerPurchase,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
 } from 'calypso/lib/purchases';
@@ -108,7 +108,7 @@ class PurchasesListing extends Component {
 		const { currentPlan, translate } = this.props;
 
 		if ( isJetpackProduct( purchase ) ) {
-			return getJetpackProductDisplayName( purchase );
+			return getDisplayName( purchase );
 		}
 
 		if ( currentPlan ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Use getDisplayName instead of getJetpackProductDisplayName to get the product's full display name.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The tier plan information is not displayed in the plan title.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch on your local Calypso env
* Create a Jurassic Ninja site or a self-hosted Jetpack site.
* Go to Jetpack in the admin menu
* Connect Jetpack
* Purchase a Jetpack Stats subscription
* Go to Upgrades - Plans http://calypso.localhost:3000/plans/my-plan/{SITE-SLUG}
* Check the product's full name is displayed

<img width="1598" alt="Screenshot 2024-08-21 at 12 01 24 AM" src="https://github.com/user-attachments/assets/7e86617b-559a-4495-8ada-bec39d487dbf">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
