### PR TITLE
Describe Profile link more explicitly

### DIFF
--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -146,7 +146,11 @@ class ProfileLinks extends Component {
 
 		return (
 			<div>
-				<p>{ this.props.translate( 'Manage which sites appear in your profile.' ) }</p>
+				<p>
+					{ this.props.translate(
+						'Manage which sites appear when people visit your Gravatar profile'
+					) }
+				</p>
 
 				{ this.possiblyRenderError() }
 				{ links }

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -148,7 +148,7 @@ class ProfileLinks extends Component {
 			<div>
 				<p>
 					{ this.props.translate(
-						'Manage which sites appear when people visit your Gravatar profile'
+						'Manage which sites appear when people visit your Gravatar profile.'
 					) }
 				</p>
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR changes the copy for the description of "Profile links".

| Before | After |
|--------|--------|
| <img width="566" alt="Screenshot 2024-08-21 at 15 44 26" src="https://github.com/user-attachments/assets/75026abe-bf90-472e-8d71-6b7de199d754"> | <img width="597" alt="Screenshot 2024-08-21 at 15 55 27" src="https://github.com/user-attachments/assets/06e5ccf5-63f1-41ff-a7eb-0cd4bd1c068b"> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To differentiate it from "Public web address".
Contexts: pbxlJb-69X-p2#comment-3820, https://github.com/Automattic/dotcom-forge/issues/8646

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me
* See the updated copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?