### PR TITLE
ToS screenshots: Fix failing screenshots for the checkout page

### DIFF
--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -3,10 +3,7 @@
  */
 import {
 	DataHelper,
-	NavbarComponent,
-	PlansPage,
 	CartCheckoutPage,
-	SidebarComponent,
 	BrowserManager,
 	TestAccount,
 	RestAPIClient,
@@ -36,16 +33,11 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		await page.reload( { waitUntil: 'domcontentloaded', timeout: EXTENDED_TIMEOUT } );
 	} );
 
-	it( 'Navigate to Upgrades > Plans', async function () {
-		const navbarCompnent = new NavbarComponent( page );
-		await navbarCompnent.clickMySites();
-		const sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.navigate( 'Upgrades', 'Plans' );
-	} );
-
 	it( 'Add WordPress.com Business plan to cart', async function () {
-		const plansPage = new PlansPage( page );
-		await Promise.all( [ page.waitForURL( /.*checkout.*/ ), plansPage.selectPlan( 'Business' ) ] );
+		await Promise.all( [
+			page.waitForURL( /.*checkout.*/ ),
+			page.goto( DataHelper.getCalypsoURL( `/checkout/business` ) ),
+		] );
 	} );
 
 	describe.each( DataHelper.getMag16Locales() )(


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* We are seeing failures for the checkout page screenshot. The cause for this is that we click on the "My sites" link in the masterbar at the start, however that no longer leads to the site-specific dashboard, even if there is only one site. So, the tests[ timeout](https://teamcity.a8c.com/repository/download/calypso_ToSAcceptanceTracking/13157842:id/recording/tos-screenshots__checkout__navigate-to-upgrades---plans__1-1.webm) waiting for the "Upgrades" link in the sidebar.
* In this PR, we directly navigate to the checkout page with the BUsiness plan in cart. There is no reason to go to Upgrades > Plans.