### PR TITLE
Notifications: Fix duplicate conflicting stores

### DIFF
--- a/apps/notifications/jest.config.js
+++ b/apps/notifications/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	preset: '../../test/apps/jest-preset.js',
+};

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -5,9 +5,9 @@ import repliesCache from './comment-replies-cache';
 import RestClient from './rest-client';
 import { init as initAPI } from './rest-client/wpcom';
 import { init as initStore, store } from './state';
-import { mergeHandlers } from './state/action-middleware/utils';
 import { SET_IS_SHOWING } from './state/action-types';
 import actions from './state/actions';
+import { addListeners, removeListeners } from './state/create-listener-middleware';
 import Layout from './templates';
 const debug = require( 'debug' )( 'notifications:panel' );
 
@@ -26,6 +26,32 @@ repliesCache.cleanup();
 export const refreshNotes = () => client && client.refreshNotes.call( client );
 
 export const RestClientContext = createContext( client );
+
+const DEFAULT_HANDLERS = {
+	APP_REFRESH_NOTES: [
+		( _store, action ) => {
+			if ( ! client ) {
+				return;
+			}
+
+			if ( 'boolean' === typeof action.isVisible ) {
+				debug( 'APP_REFRESH_NOTES', {
+					isShowing: this.props.isShowing,
+					isVisible: action.isVisible,
+				} );
+				// Use this.props instead of destructuring isShowing, so that this uses
+				// the value on props at any given time and not only the value that was
+				// present on initial mount.
+				client.setVisibility.call( client, {
+					isShowing: this.props.isShowing,
+					isVisible: action.isVisible,
+				} );
+			}
+
+			client.refreshNotes.call( client, action.isVisible );
+		},
+	],
+};
 
 export class Notifications extends PureComponent {
 	static propTypes = {
@@ -54,34 +80,10 @@ export class Notifications extends PureComponent {
 		const { customEnhancer, customMiddleware, isShowing, isVisible, receiveMessage, wpcom } =
 			this.props;
 
-		initStore( {
-			customEnhancer,
-			customMiddleware: mergeHandlers( customMiddleware, {
-				APP_REFRESH_NOTES: [
-					( _store, action ) => {
-						if ( ! client ) {
-							return;
-						}
+		initStore( { customEnhancer } );
 
-						if ( 'boolean' === typeof action.isVisible ) {
-							debug( 'APP_REFRESH_NOTES', {
-								isShowing: this.props.isShowing,
-								isVisible: action.isVisible,
-							} );
-							// Use this.props instead of destructuring isShowing, so that this uses
-							// the value on props at any given time and not only the value that was
-							// present on initial mount.
-							client.setVisibility.call( client, {
-								isShowing: this.props.isShowing,
-								isVisible: action.isVisible,
-							} );
-						}
-
-						client.refreshNotes.call( client, action.isVisible );
-					},
-				],
-			} ),
-		} );
+		store.dispatch( addListeners( customMiddleware ) );
+		store.dispatch( addListeners( DEFAULT_HANDLERS ) );
 
 		initAPI( wpcom );
 
@@ -134,6 +136,12 @@ export class Notifications extends PureComponent {
 		if ( isShowing !== this.props.isShowing || isVisible !== this.props.isVisible ) {
 			client.setVisibility( { isShowing, isVisible } );
 		}
+	}
+
+	componentWillUnmount() {
+		const { customMiddleware } = this.props;
+		store.dispatch( removeListeners( customMiddleware ) );
+		store.dispatch( removeListeners( DEFAULT_HANDLERS ) );
 	}
 
 	render() {

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -27,32 +27,6 @@ export const refreshNotes = () => client && client.refreshNotes.call( client );
 
 export const RestClientContext = createContext( client );
 
-const DEFAULT_HANDLERS = {
-	APP_REFRESH_NOTES: [
-		( _store, action ) => {
-			if ( ! client ) {
-				return;
-			}
-
-			if ( 'boolean' === typeof action.isVisible ) {
-				debug( 'APP_REFRESH_NOTES', {
-					isShowing: this.props.isShowing,
-					isVisible: action.isVisible,
-				} );
-				// Use this.props instead of destructuring isShowing, so that this uses
-				// the value on props at any given time and not only the value that was
-				// present on initial mount.
-				client.setVisibility.call( client, {
-					isShowing: this.props.isShowing,
-					isVisible: action.isVisible,
-				} );
-			}
-
-			client.refreshNotes.call( client, action.isVisible );
-		},
-	],
-};
-
 export class Notifications extends PureComponent {
 	static propTypes = {
 		customEnhancer: PropTypes.func,
@@ -74,6 +48,32 @@ export class Notifications extends PureComponent {
 		receiveMessage: noop,
 	};
 
+	defaultHandlers = {
+		APP_REFRESH_NOTES: [
+			( _store, action ) => {
+				if ( ! client ) {
+					return;
+				}
+
+				if ( 'boolean' === typeof action.isVisible ) {
+					debug( 'APP_REFRESH_NOTES', {
+						isShowing: this.props.isShowing,
+						isVisible: action.isVisible,
+					} );
+					// Use this.props instead of destructuring isShowing, so that this uses
+					// the value on props at any given time and not only the value that was
+					// present on initial mount.
+					client.setVisibility.call( client, {
+						isShowing: this.props.isShowing,
+						isVisible: action.isVisible,
+					} );
+				}
+
+				client.refreshNotes.call( client, action.isVisible );
+			},
+		],
+	};
+
 	constructor( props ) {
 		super( props );
 
@@ -83,7 +83,7 @@ export class Notifications extends PureComponent {
 		initStore( { customEnhancer } );
 
 		store.dispatch( addListeners( customMiddleware ) );
-		store.dispatch( addListeners( DEFAULT_HANDLERS ) );
+		store.dispatch( addListeners( this.defaultHandlers ) );
 
 		initAPI( wpcom );
 
@@ -141,7 +141,7 @@ export class Notifications extends PureComponent {
 	componentWillUnmount() {
 		const { customMiddleware } = this.props;
 		store.dispatch( removeListeners( customMiddleware ) );
-		store.dispatch( removeListeners( DEFAULT_HANDLERS ) );
+		store.dispatch( removeListeners( this.defaultHandlers ) );
 	}
 
 	render() {

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -30,7 +30,7 @@ export const RestClientContext = createContext( client );
 export class Notifications extends PureComponent {
 	static propTypes = {
 		customEnhancer: PropTypes.func,
-		customMiddleware: PropTypes.object,
+		actionHandlers: PropTypes.object,
 		isShowing: PropTypes.bool,
 		isVisible: PropTypes.bool,
 		locale: PropTypes.string,
@@ -41,7 +41,7 @@ export class Notifications extends PureComponent {
 
 	static defaultProps = {
 		customEnhancer: ( a ) => a,
-		customMiddleware: {},
+		actionHandlers: {},
 		isShowing: false,
 		isVisible: false,
 		locale: 'en',
@@ -77,12 +77,12 @@ export class Notifications extends PureComponent {
 	constructor( props ) {
 		super( props );
 
-		const { customEnhancer, customMiddleware, isShowing, isVisible, receiveMessage, wpcom } =
+		const { customEnhancer, actionHandlers, isShowing, isVisible, receiveMessage, wpcom } =
 			this.props;
 
 		initStore( { customEnhancer } );
 
-		store.dispatch( addListeners( customMiddleware ) );
+		store.dispatch( addListeners( actionHandlers ) );
 		store.dispatch( addListeners( this.defaultHandlers ) );
 
 		initAPI( wpcom );
@@ -139,8 +139,8 @@ export class Notifications extends PureComponent {
 	}
 
 	componentWillUnmount() {
-		const { customMiddleware } = this.props;
-		store.dispatch( removeListeners( customMiddleware ) );
+		const { actionHandlers } = this.props;
+		store.dispatch( removeListeners( actionHandlers ) );
 		store.dispatch( removeListeners( this.defaultHandlers ) );
 	}
 

--- a/apps/notifications/src/panel/state/create-listener-middleware.ts
+++ b/apps/notifications/src/panel/state/create-listener-middleware.ts
@@ -1,0 +1,87 @@
+import type { MiddlewareAPI, AnyAction, Action, Middleware } from 'redux';
+
+type Handler = ( storeAPI: MiddlewareAPI, action: Action ) => void;
+
+interface AddListenersAction extends Action {
+	type: 'LISTENER-MIDDLEWARE/ADD_LISTENERS';
+	payload: Record< string, Handler[] >;
+}
+interface RemoveListenersAction extends Action {
+	type: 'LISTENER-MIDDLEWARE/REMOVE_LISTENERS';
+	payload: Record< string, Handler[] >;
+}
+interface ClearListenersAction extends Action {
+	type: 'LISTENER-MIDDLEWARE/CLEAR_LISTENERS';
+}
+type MiddlewareAction = AddListenersAction | RemoveListenersAction | ClearListenersAction;
+
+function createListenerMiddleware(): Middleware {
+	const listeners = new Map< string, Set< Handler > >();
+
+	return ( storeAPI: MiddlewareAPI ) =>
+		( next: ( action: Action ) => void ) =>
+		( anyAction: AnyAction ) => {
+			// We only want to notify listeners of actions that are actions.
+			if ( typeof anyAction !== 'object' || typeof anyAction.type !== 'string' ) {
+				return next( anyAction );
+			}
+
+			const action = anyAction as MiddlewareAction;
+
+			switch ( action.type ) {
+				case 'LISTENER-MIDDLEWARE/ADD_LISTENERS': {
+					for ( const [ type, handlers ] of Object.entries( action.payload ) ) {
+						if ( ! listeners.has( type ) ) {
+							listeners.set( type, new Set< Handler >() );
+						}
+						handlers.forEach( ( handler ) => listeners.get( type )!.add( handler ) );
+					}
+					return;
+				}
+				case 'LISTENER-MIDDLEWARE/REMOVE_LISTENERS': {
+					for ( const [ type, handlers ] of Object.entries( action.payload ) ) {
+						if ( ! listeners.has( type ) ) {
+							continue;
+						}
+						handlers.forEach( ( handler ) => listeners.get( type )!.delete( handler ) );
+					}
+				}
+				case 'LISTENER-MIDDLEWARE/CLEAR_LISTENERS': {
+					listeners.clear();
+					return next( action );
+				}
+				default: {
+					const otherAction = action as Action;
+
+					if ( ! listeners.has( otherAction.type ) ) {
+						return next( otherAction );
+					}
+
+					listeners.get( otherAction.type )!.forEach( ( handler ) => handler( storeAPI, action ) );
+					return next( otherAction );
+				}
+			}
+		};
+}
+
+function addListeners( handlers: Record< string, Handler[] > ): AddListenersAction {
+	return {
+		type: 'LISTENER-MIDDLEWARE/ADD_LISTENERS',
+		payload: handlers,
+	};
+}
+
+function removeListeners( handlers: Record< string, Handler[] > ): RemoveListenersAction {
+	return {
+		type: 'LISTENER-MIDDLEWARE/REMOVE_LISTENERS',
+		payload: handlers,
+	};
+}
+
+function clearListeners(): ClearListenersAction {
+	return {
+		type: 'LISTENER-MIDDLEWARE/CLEAR_LISTENERS',
+	};
+}
+
+export { createListenerMiddleware, addListeners, removeListeners, clearListeners };

--- a/apps/notifications/src/panel/state/create-listener-middleware.ts
+++ b/apps/notifications/src/panel/state/create-listener-middleware.ts
@@ -35,7 +35,8 @@ function createListenerMiddleware(): Middleware {
 						if ( ! listeners.has( type ) ) {
 							listeners.set( type, new Set< Handler >() );
 						}
-						handlers.forEach( ( handler ) => listeners.get( type )!.add( handler ) );
+						const listenersForType = listeners.get( type )!;
+						handlers.forEach( ( handler ) => listenersForType.add( handler ) );
 					}
 					return;
 				}
@@ -44,7 +45,8 @@ function createListenerMiddleware(): Middleware {
 						if ( ! listeners.has( type ) ) {
 							continue;
 						}
-						handlers.forEach( ( handler ) => listeners.get( type )!.delete( handler ) );
+						const listenersForType = listeners.get( type )!;
+						handlers.forEach( ( handler ) => listenersForType.delete( handler ) );
 					}
 				}
 				case 'LISTENER-MIDDLEWARE/CLEAR_LISTENERS': {

--- a/apps/notifications/src/panel/state/create-listener-middleware.ts
+++ b/apps/notifications/src/panel/state/create-listener-middleware.ts
@@ -21,7 +21,8 @@ function createListenerMiddleware(): Middleware {
 	return ( storeAPI: MiddlewareAPI ) =>
 		( next: ( action: Action ) => void ) =>
 		( anyAction: AnyAction ) => {
-			// We only want to notify listeners of actions that are actions.
+			// We only want to notify listeners of actions that are objects.
+			// (That is, ignore thunks and other non-action objects.)
 			if ( typeof anyAction !== 'object' || typeof anyAction.type !== 'string' ) {
 				return next( anyAction );
 			}
@@ -57,7 +58,9 @@ function createListenerMiddleware(): Middleware {
 						return next( otherAction );
 					}
 
-					listeners.get( otherAction.type )!.forEach( ( handler ) => handler( storeAPI, action ) );
+					listeners
+						.get( otherAction.type )!
+						.forEach( ( handler ) => handler( storeAPI, otherAction ) );
 					return next( otherAction );
 				}
 			}

--- a/apps/notifications/src/panel/state/index.js
+++ b/apps/notifications/src/panel/state/index.js
@@ -16,21 +16,22 @@ const reducer = combineReducers( {
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const listenerMiddleware = createListenerMiddleware();
-const withMiddleware = ( customMiddleware ) =>
-	composeEnhancers(
-		applyMiddleware( thunkMiddleware, listenerMiddleware, actionMiddleware( customMiddleware ) )
-	)( createStore );
+const withMiddleware = () =>
+	composeEnhancers( applyMiddleware( thunkMiddleware, listenerMiddleware, actionMiddleware() ) )(
+		createStore
+	);
 
-const store = init();
+let store = null;
+store = init();
 
 // Note: this function has the unexpected side effect of modifying
 // the `store` export. In order to maintain behaviour for consumers,
 // it's being kept this way, but beware this is not a pure function.
-function init( { customEnhancer, customMiddleware = {} } = {} ) {
-	const middle = withMiddleware( customMiddleware );
+function init( { customEnhancer } = {} ) {
+	const middle = withMiddleware();
 	const create = customEnhancer ? customEnhancer( middle ) : middle;
 
-	return create( reducer, reducer( undefined, { type: '@@INIT' } ) );
+	store = create( reducer );
 }
 
 export { store, init };

--- a/apps/notifications/src/panel/state/test/create-listener-middleware.test.ts
+++ b/apps/notifications/src/panel/state/test/create-listener-middleware.test.ts
@@ -1,0 +1,90 @@
+import { legacy_createStore as createStore, applyMiddleware } from 'redux';
+import {
+	createListenerMiddleware,
+	addListeners,
+	removeListeners,
+	clearListeners,
+} from '../create-listener-middleware';
+
+describe( 'createListenerMiddleware', () => {
+	test( 'should create a middleware function', () => {
+		const middleware = createListenerMiddleware();
+		expect( typeof middleware ).toBe( 'function' );
+	} );
+
+	test( 'should call registered listeners when an action is dispatched', () => {
+		const middleware = createListenerMiddleware();
+		const store = createStore( ( state ) => state, applyMiddleware( middleware ) );
+
+		const listener = jest.fn();
+
+		store.dispatch(
+			addListeners( {
+				TEST_ACTION: [ listener ],
+			} )
+		);
+
+		store.dispatch( { type: 'TEST_ACTION' } );
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+		expect( listener ).toHaveBeenCalledWith(
+			{ getState: store.getState, dispatch: expect.any( Function ) },
+			{ type: 'TEST_ACTION' }
+		);
+	} );
+
+	test( 'should not call listeners for unregistered action types', () => {
+		const middleware = createListenerMiddleware();
+		const store = createStore( ( state ) => state, applyMiddleware( middleware ) );
+
+		const listener = jest.fn();
+
+		store.dispatch(
+			addListeners( {
+				TEST_ACTION: [ listener ],
+			} )
+		);
+
+		store.dispatch( { type: 'UNREGISTERED_ACTION' } );
+
+		expect( listener ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should allow removing listeners', () => {
+		const middleware = createListenerMiddleware();
+		const store = createStore( ( state ) => state, applyMiddleware( middleware ) );
+
+		const listener = jest.fn();
+
+		store.dispatch(
+			addListeners( {
+				TEST_ACTION: [ listener ],
+			} )
+		);
+		store.dispatch(
+			removeListeners( {
+				TEST_ACTION: [ listener ],
+			} )
+		);
+
+		store.dispatch( { type: 'TEST_ACTION' } );
+		expect( listener ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should allow clearing listeners', () => {
+		const middleware = createListenerMiddleware();
+		const store = createStore( ( state ) => state, applyMiddleware( middleware ) );
+
+		const listener = jest.fn();
+
+		store.dispatch(
+			addListeners( {
+				TEST_ACTION: [ listener ],
+			} )
+		);
+
+		store.dispatch( clearListeners() );
+
+		store.dispatch( { type: 'TEST_ACTION' } );
+		expect( listener ).not.toHaveBeenCalled();
+	} );
+} );

--- a/apps/notifications/src/standalone/index.jsx
+++ b/apps/notifications/src/standalone/index.jsx
@@ -33,7 +33,7 @@ let store = { dispatch: () => {}, getState: () => {} };
 const customEnhancer = ( next ) => ( reducer, initialState ) =>
 	( store = next( reducer, initialState ) );
 
-const customMiddleware = {
+const ACTION_HANDLERS = {
 	APP_IS_READY: [ () => sendMessage( { action: 'iFrameReady' } ) ],
 	APP_RENDER_NOTES: [
 		( st, { latestType, newNoteCount } ) =>
@@ -163,7 +163,7 @@ const NotesWrapper = ( { wpcom } ) => {
 	return (
 		<Notifications
 			customEnhancer={ customEnhancer }
-			customMiddleware={ customMiddleware }
+			actionHandlers={ ACTION_HANDLERS }
 			isShowing={ isShowing }
 			isVisible={ isVisible }
 			locale={ locale }

--- a/apps/notifications/tsconfig.json
+++ b/apps/notifications/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "@automattic/calypso-build/tsconfig",
 	"exclude": [ "node_modules" ],
 	"compilerOptions": {
-		"allowJs": true
+		"allowJs": true,
+		"types": [ "jest" ]
 	}
 }

--- a/client/layout/global-notifications/index.tsx
+++ b/client/layout/global-notifications/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
 import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
@@ -15,6 +16,7 @@ const GlobalNotifications = () => {
 	const prevIsNotificationsOpen = usePrevious( isNotificationsOpen );
 	const unseenCount = useSelector( ( state: AppState ) => getUnseenCount( state ) );
 	const containerRef = useRef< HTMLDivElement >( null );
+	const currentRoute = useSelector( getCurrentRoute );
 	const dispatch = useDispatch();
 	const toggleNotesFrame = useCallback( ( event: MouseEvent | null ) => {
 		if ( event ) {
@@ -67,6 +69,12 @@ const GlobalNotifications = () => {
 			);
 		}
 	}, [ prevIsNotificationsOpen, isNotificationsOpen, unseenCount, dispatch ] );
+
+	// Get URL and if it matches "/read/notifications", don't render the global notifications panel.
+	// As it will cause duplicate notification store listeners to be registered.
+	if ( currentRoute === '/read/notifications' ) {
+		return null;
+	}
 
 	return (
 		<div className="global-notifications" ref={ containerRef }>

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -59,6 +59,86 @@ export class Notifications extends Component {
 
 	focusedElementBeforeOpen = null;
 
+	actionHandlers = {
+		APP_RENDER_NOTES: [
+			( store, { newNoteCount } ) => {
+				localStorageHelper.set( 'wpnotes_unseen_count', newNoteCount );
+				this.props.setUnseenCount( newNoteCount );
+			},
+		],
+		OPEN_LINK: [
+			( store, { href, tracksEvent } ) => {
+				if ( tracksEvent ) {
+					this.props.recordTracksEventAction( 'calypso_notifications_' + tracksEvent, {
+						link: href,
+					} );
+				}
+				window.open( href, '_blank' );
+			},
+		],
+		OPEN_POST: [
+			( store, { siteId, postId } ) => {
+				this.props.checkToggle();
+				this.props.recordTracksEventAction( 'calypso_notifications_open_post', {
+					site_id: siteId,
+					post_id: postId,
+				} );
+				page( `/read/blogs/${ siteId }/posts/${ postId }` );
+			},
+		],
+		OPEN_COMMENT: [
+			( store, { siteId, postId, commentId } ) => {
+				this.props.checkToggle();
+				this.props.recordTracksEventAction( 'calypso_notifications_open_comment', {
+					site_id: siteId,
+					post_id: postId,
+					comment_id: commentId,
+				} );
+				page( `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` );
+			},
+		],
+		OPEN_SITE: [
+			( store, { siteId } ) => {
+				this.props.checkToggle();
+				this.props.recordTracksEventAction( 'calypso_notifications_open_site', {
+					site_id: siteId,
+				} );
+				page( `/read/blogs/${ siteId }` );
+			},
+		],
+		VIEW_SETTINGS: [
+			() => {
+				this.props.checkToggle();
+				page( '/me/notifications' );
+			},
+		],
+		EDIT_COMMENT: [
+			( store, { siteId, postId, commentId } ) => {
+				this.props.checkToggle();
+				this.props.recordTracksEventAction( 'calypso_notifications_edit_comment', {
+					site_id: siteId,
+					post_id: postId,
+					comment_id: commentId,
+				} );
+				page( `/comment/${ siteId }/${ commentId }?action=edit` );
+			},
+		],
+		ANSWER_PROMPT: [
+			( store, { siteId, href } ) => {
+				this.props.checkToggle();
+				this.props.recordTracksEventAction( 'calypso_notifications_answer_prompt', {
+					site_id: siteId,
+				} );
+				window.open( href, '_blank' );
+			},
+		],
+		CLOSE_PANEL: [
+			() => {
+				this.props.checkToggle();
+			},
+		],
+	};
+
 	componentDidMount() {
 		document.addEventListener( 'click', this.props.checkToggle );
 		document.addEventListener( 'keydown', this.handleKeyPress );
@@ -188,86 +268,6 @@ export class Notifications extends Component {
 			this.props.didForceRefresh();
 		}
 
-		const customMiddleware = {
-			APP_RENDER_NOTES: [
-				( store, { newNoteCount } ) => {
-					localStorageHelper.set( 'wpnotes_unseen_count', newNoteCount );
-					this.props.setUnseenCount( newNoteCount );
-				},
-			],
-			OPEN_LINK: [
-				( store, { href, tracksEvent } ) => {
-					if ( tracksEvent ) {
-						this.props.recordTracksEventAction( 'calypso_notifications_' + tracksEvent, {
-							link: href,
-						} );
-					}
-					window.open( href, '_blank' );
-				},
-			],
-			OPEN_POST: [
-				( store, { siteId, postId } ) => {
-					this.props.checkToggle();
-					this.props.recordTracksEventAction( 'calypso_notifications_open_post', {
-						site_id: siteId,
-						post_id: postId,
-					} );
-					page( `/read/blogs/${ siteId }/posts/${ postId }` );
-				},
-			],
-			OPEN_COMMENT: [
-				( store, { siteId, postId, commentId } ) => {
-					this.props.checkToggle();
-					this.props.recordTracksEventAction( 'calypso_notifications_open_comment', {
-						site_id: siteId,
-						post_id: postId,
-						comment_id: commentId,
-					} );
-					page( `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` );
-				},
-			],
-			OPEN_SITE: [
-				( store, { siteId } ) => {
-					this.props.checkToggle();
-					this.props.recordTracksEventAction( 'calypso_notifications_open_site', {
-						site_id: siteId,
-					} );
-					page( `/read/blogs/${ siteId }` );
-				},
-			],
-			VIEW_SETTINGS: [
-				() => {
-					this.props.checkToggle();
-					page( '/me/notifications' );
-				},
-			],
-			EDIT_COMMENT: [
-				( store, { siteId, postId, commentId } ) => {
-					this.props.checkToggle();
-					this.props.recordTracksEventAction( 'calypso_notifications_edit_comment', {
-						site_id: siteId,
-						post_id: postId,
-						comment_id: commentId,
-					} );
-					page( `/comment/${ siteId }/${ commentId }?action=edit` );
-				},
-			],
-			ANSWER_PROMPT: [
-				( store, { siteId, href } ) => {
-					this.props.checkToggle();
-					this.props.recordTracksEventAction( 'calypso_notifications_answer_prompt', {
-						site_id: siteId,
-					} );
-					window.open( href, '_blank' );
-				},
-			],
-			CLOSE_PANEL: [
-				() => {
-					this.props.checkToggle();
-				},
-			],
-		};
-
 		return (
 			<div
 				id="wpnc-panel"
@@ -277,7 +277,7 @@ export class Notifications extends Component {
 				} ) }
 			>
 				<NotificationsPanel
-					customMiddleware={ customMiddleware }
+					actionHandlers={ this.actionHandlers }
 					isShowing={ this.props.isShowing }
 					isVisible={ this.state.isVisible }
 					locale={ localeSlug }

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -6,6 +6,8 @@ import { trackPageLoad } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
 import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 
 export function notifications( context, next ) {
 	const basePath = sectionify( context.path );
@@ -17,6 +19,12 @@ export function notifications( context, next ) {
 		'reader',
 		'notifications'
 	);
+	const isGlobalNotificationsOpen = getIsNotificationsOpen( state );
+
+	// Close the global notifications panel if it's already open.
+	if ( isGlobalNotificationsOpen ) {
+		context.store.dispatch( toggleNotificationsPanel() );
+	}
 
 	trackPageLoad( basePath, 'Reader > Notifications', mcKey );
 	recordTrack(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #93530, https://github.com/Automattic/wp-calypso/pull/30603#discussion_r254538603.

## Proposed Changes

This PR unifies the notifications stores into one to prevent them from conflicting.

1. `init` is changed to a pure function which returns the initialized store.
2. Add a `createListenerMiddleware` to replace `actionMiddleware`. The new API allows adding listeners (handlers) dynamically without having to merge them beforehand. Some original usages are not migrated though to keep this PR small.
3. Close the global notifications when going to `/read/notifications` to avoid duplicate panels.
4. Don't render the global notifications panel when visiting `/read/notifications` to prevent conflicting listeners from registering at the same time.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

1. See https://github.com/Automattic/wp-calypso/issues/93530#issuecomment-2301347436 for the background issue and motivation. 
2. Some keyboard shortcuts are broken when there are multiple `<Notfications>` rendered on the page.
3. Visiting `/read/notifications` directly via the URL hangs on an infinite loading circle.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the original instructions in https://github.com/Automattic/wp-calypso/issues/93530.

1. Visit `/read/notifications` directly should not result in infinite loading circles.
2. Visit any other page on the reader, open the global notifications panel, and go to `/read/notifications` should close the global notifications panel.
3. Visit other sites by clicking the top left W admin button.
4. Hit <kbd>n</kbd> a few times and ensure the global notifications panel toggles.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
