### PR TITLE
Components: fix TSC build by fixing a component import

### DIFF
--- a/packages/components/src/external-link/index.stories.js
+++ b/packages/components/src/external-link/index.stories.js
@@ -1,5 +1,5 @@
-import { Card } from '../..';
-import ExternalLink from './index';
+import { Card } from '..';
+import ExternalLink from '.';
 
 export default { title: 'packages/components/ExternalLink' };
 


### PR DESCRIPTION
When you run `yarn run postinstall` or `yarn run build-packages` or `tsc --build packages/tsconfig.json`, you'll see many errors from the `components` package:
```
error TS5055: Cannot write file 'wp-calypso/packages/components/dist/types/app-promo-card/index.d.ts' because it would overwrite input file.
```
The TypeScript compiler is treating `dist/types` as _input_ even though it should traverse only `src`. This is caused by a wrong import in `external-link/index.stories.js`, which imports from the `packages/components` directory, and therefore going through `package.json` and its `types` field, dragging all the `dist/types` files into the compilation.

I'm fixing this by changing the import to be from the `src` directory instead, reading the `index.ts` source file instead.

**How to test:**
This happens all the time when you run `yarn install`. Verify that it no longer happens.