### PR TITLE
Security Settings: Don't send wordpress_api_key

### DIFF
--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -144,7 +144,7 @@ const connectComponent = connect( ( state ) => {
 	};
 } );
 
-const getFormSettings = ( includeAkismetKeyField ) => ( settings ) => {
+const getFormSettings = ( settings, props ) => {
 	const settingsToPick = [
 		'akismet',
 		'protect',
@@ -160,7 +160,7 @@ const getFormSettings = ( includeAkismetKeyField ) => ( settings ) => {
 		'jetpack_sso_require_two_step',
 	];
 
-	if ( includeAkismetKeyField || settings.akismet ) {
+	if ( props.includeAkismetKeyField || settings.akismet ) {
 		settingsToPick.push( 'wordpress_api_key' );
 	}
 
@@ -168,11 +168,5 @@ const getFormSettings = ( includeAkismetKeyField ) => ( settings ) => {
 };
 
 export default connectComponent(
-	localize( ( props ) => {
-		const WrappedSiteSettingsFormSecurity = wrapSettingsForm(
-			getFormSettings( props.includeAkismetFields )
-		)( SiteSettingsFormSecurity );
-
-		return <WrappedSiteSettingsFormSecurity { ...props } />;
-	} )
+	localize( wrapSettingsForm( getFormSettings )( SiteSettingsFormSecurity ) )
 );

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -127,8 +127,7 @@ const connectComponent = connect( ( state ) => {
 
 	const hasAkismetFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_AKISMET );
 	const hasAntiSpamFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_ANTISPAM );
-	const hasJetpackAntiSpamProduct =
-		getSiteProducts( state, siteId )?.filter( isJetpackAntiSpam ).length > 0;
+	const hasJetpackAntiSpamProduct = getSiteProducts( state, siteId )?.some( isJetpackAntiSpam );
 
 	const includeAkismetKeyField =
 		! isAtomic && ( hasAkismetFeature || hasAntiSpamFeature || hasJetpackAntiSpamProduct );

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -130,9 +130,8 @@ const connectComponent = connect( ( state ) => {
 	};
 } );
 
-const getFormSettings = ( settings ) =>
-	pick( settings, [
-		'akismet',
+const getFormSettings = ( isAtomic ) => ( settings ) => {
+	const settingsToPick = [
 		'protect',
 		'jetpack_protect_global_whitelist',
 		'jetpack_waf_automatic_rules',
@@ -144,9 +143,22 @@ const getFormSettings = ( settings ) =>
 		'sso',
 		'jetpack_sso_match_by_email',
 		'jetpack_sso_require_two_step',
-		'wordpress_api_key',
-	] );
+	];
+
+	if ( ! isAtomic ) {
+		settingsToPick.push( 'akismet' );
+		settingsToPick.push( 'wordpress_api_key' );
+	}
+
+	return pick( settings, settingsToPick );
+};
 
 export default connectComponent(
-	localize( wrapSettingsForm( getFormSettings )( SiteSettingsFormSecurity ) )
+	localize( ( props ) => {
+		const WrappedSiteSettingsFormSecurity = wrapSettingsForm( getFormSettings( props.isAtomic ) )(
+			SiteSettingsFormSecurity
+		);
+
+		return <WrappedSiteSettingsFormSecurity { ...props } />;
+	} )
 );

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -130,7 +130,7 @@ const connectComponent = connect( ( state ) => {
 	const hasJetpackAntiSpamProduct =
 		getSiteProducts( state, siteId )?.filter( isJetpackAntiSpam ).length > 0;
 
-	const includeAkismetFields =
+	const includeAkismetKeyField =
 		! isAtomic && ( hasAkismetFeature || hasAntiSpamFeature || hasJetpackAntiSpamProduct );
 
 	return {
@@ -141,11 +141,11 @@ const connectComponent = connect( ( state ) => {
 		protectModuleActive,
 		protectModuleUnavailable: siteInDevMode && protectIsUnavailableInDevMode,
 		akismetUnavailable: siteInDevMode && akismetIsUnavailableInDevMode,
-		includeAkismetFields,
+		includeAkismetKeyField,
 	};
 } );
 
-const getFormSettings = ( includeAkismetFields ) => ( settings ) => {
+const getFormSettings = ( includeAkismetKeyField ) => ( settings ) => {
 	const settingsToPick = [
 		'akismet',
 		'protect',
@@ -161,7 +161,7 @@ const getFormSettings = ( includeAkismetFields ) => ( settings ) => {
 		'jetpack_sso_require_two_step',
 	];
 
-	if ( includeAkismetFields || settings.akismet ) {
+	if ( includeAkismetKeyField || settings.akismet ) {
 		settingsToPick.push( 'wordpress_api_key' );
 	}
 

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -129,6 +129,7 @@ const connectComponent = connect( ( state ) => {
 	const hasAntiSpamFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_ANTISPAM );
 	const hasJetpackAntiSpamProduct = getSiteProducts( state, siteId )?.some( isJetpackAntiSpam );
 
+	// This is the same condition as the one in SpamFilteringSettings that's used to determine whether to show the Akismet key field.
 	const includeAkismetKeyField =
 		! isAtomic && ( hasAkismetFeature || hasAntiSpamFeature || hasJetpackAntiSpamProduct );
 

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -44,7 +44,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 		};
 
 		componentDidMount() {
-			this.props.replaceFields( getFormSettings( this.props.settings ) );
+			this.props.replaceFields( getFormSettings( this.props.settings, this.props ) );
 
 			// Check if site_title task is completed
 			fetchLaunchpad( this.props.siteSlug, 'intent-build' ).then( ( { checklist_statuses } ) => {
@@ -124,7 +124,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 
 		updateDirtyFields() {
 			const currentFields = this.props.fields;
-			const persistedFields = getFormSettings( this.props.settings );
+			const persistedFields = getFormSettings( this.props.settings, this.props );
 
 			// Compute the dirty fields by comparing the persisted and the current fields
 			const previousDirtyFields = this.props.dirtyFields;


### PR DESCRIPTION
Fixes #93698

## Proposed Changes

The Security Settings form would try to update `wordpress_api_key` even when not rendering the Akimset section. The Akismet API key field only gets rendered on certain conditions:

Site is not Atomic & 

- Site has bought Jetpack Spam Protection
- Site has installed Akismet manually.

![image](https://github.com/user-attachments/assets/958f4664-de89-4187-a52c-837077d10941)

This PR excludes the `wordpress_api_key` field for all other conditions.

## Testing Instructions

1. Apply this PR
2. Visit http://calypso.localhost:3000/settings/security/youratomicsite 

Change some settings (for example `Always allow specific IP addresses`). No error should occur. 

Using Network Tools, verify that wordpress_api_key is not sent. 

Testing again using a Jurassic Tube JP site. Try with activated & deactivated Jetpack plugin.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
