### PR TITLE
Stepper: New events (slugs) for remaining navigation controls

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -21,10 +21,10 @@ export const HOW_TO_MIGRATE_OPTIONS = {
  * Example: `STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT` -> scope = `STEP_NAV`, action = `SUBMIT`
  */
 export const STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT = 'calypso_signup_actions_submit_step';
-export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK = 'calypso_signup_actions_step_nav_back';
-export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT = 'calypso_signup_actions_step_nav_next';
-export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO = 'calypso_signup_actions_step_nav_go_to';
-export const STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW = 'calypso_signup_actions_step_nav_exit_flow';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK = 'calypso_signup_step_nav_back';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT = 'calypso_signup_step_nav_next';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO = 'calypso_signup_step_nav_go_to';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW = 'calypso_signup_step_nav_exit_flow';
 
 export const STEPPER_TRACKS_EVENTS = < const >[
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,

--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -21,5 +21,15 @@ export const HOW_TO_MIGRATE_OPTIONS = {
  * Example: `STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT` -> scope = `STEP_NAV`, action = `SUBMIT`
  */
 export const STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT = 'calypso_signup_actions_submit_step';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK = 'calypso_signup_actions_step_nav_back';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT = 'calypso_signup_actions_step_nav_next';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO = 'calypso_signup_actions_step_nav_go_to';
+export const STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW = 'calypso_signup_actions_step_nav_exit_flow';
 
-export const STEPPER_TRACKS_EVENTS = < const >[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ];
+export const STEPPER_TRACKS_EVENTS = < const >[
+	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
+	STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK,
+	STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT,
+	STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO,
+	STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW,
+];

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -1,7 +1,14 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { OnboardSelect } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
-import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from 'calypso/landing/stepper/constants';
+import {
+	STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW,
+	STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK,
+	STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT,
+	STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO,
+	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
+} from 'calypso/landing/stepper/constants';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordSubmitStep } from '../../analytics/record-submit-step';
 import type { Flow, Navigate, ProvidedDependencies, StepperStep } from '../../types';
@@ -41,6 +48,30 @@ export const useStepNavigationWithTracking = ( {
 					tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ]
 				);
 				stepNavigation.submit?.( providedDependencies, ...params );
+			},
+			exitFlow: ( to: string ) => {
+				recordTracksEvent( STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW, {
+					...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW ] ?? {} ),
+				} );
+				stepNavigation.exitFlow?.( to );
+			},
+			goBack: () => {
+				recordTracksEvent( STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK, {
+					...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK ] ?? {} ),
+				} );
+				stepNavigation.goBack?.();
+			},
+			goNext: () => {
+				recordTracksEvent( STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT, {
+					...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT ] ?? {} ),
+				} );
+				stepNavigation.goNext?.();
+			},
+			goToStep: ( step: string ) => {
+				recordTracksEvent( STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO, {
+					...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO ] ?? {} ),
+				} );
+				stepNavigation.goToStep?.( step );
 			},
 		} ),
 		[ stepNavigation, intent, flow, currentStepRoute, tracksEventPropsFromFlow ]

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -1,14 +1,7 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { OnboardSelect } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
-import {
-	STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW,
-	STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK,
-	STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT,
-	STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO,
-	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
-} from 'calypso/landing/stepper/constants';
+import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from 'calypso/landing/stepper/constants';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordSubmitStep } from '../../analytics/record-submit-step';
 import type { Flow, Navigate, ProvidedDependencies, StepperStep } from '../../types';
@@ -48,30 +41,6 @@ export const useStepNavigationWithTracking = ( {
 					tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT ]
 				);
 				stepNavigation.submit?.( providedDependencies, ...params );
-			},
-			exitFlow: ( to: string ) => {
-				recordTracksEvent( STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW, {
-					...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_EXIT_FLOW ] ?? {} ),
-				} );
-				stepNavigation.exitFlow?.( to );
-			},
-			goBack: () => {
-				recordTracksEvent( STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK, {
-					...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_GO_BACK ] ?? {} ),
-				} );
-				stepNavigation.goBack?.();
-			},
-			goNext: () => {
-				recordTracksEvent( STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT, {
-					...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_GO_NEXT ] ?? {} ),
-				} );
-				stepNavigation.goNext?.();
-			},
-			goToStep: ( step: string ) => {
-				recordTracksEvent( STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO, {
-					...( tracksEventPropsFromFlow?.[ STEPPER_TRACKS_EVENT_STEP_NAV_GO_TO ] ?? {} ),
-				} );
-				stepNavigation.goToStep?.( step );
 			},
 		} ),
 		[ stepNavigation, intent, flow, currentStepRoute, tracksEventPropsFromFlow ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/91755

## Proposed Changes

Adds the Tracks event slugs for the remaining navigation controls.

Here are the corresponding PRs/events for review:

- goBack -> https://github.com/Automattic/tracks-events-registration/pull/2593
- goNext -> https://github.com/Automattic/tracks-events-registration/pull/2594
- exitFlow -> https://github.com/Automattic/tracks-events-registration/pull/2595
- goToStep -> https://github.com/Automattic/tracks-events-registration/pull/2596

@alshakero  A couple of notes:

- should we add `device` to the events above? (it's also a default to `submit` that's queried and passed through from `recordSubmitStep`)
- `goToStep` and `goNext` are marked as deprecated in `NavigationControls`
- I'm curious why all of these other navigation controls can't have the same signature with `submit` (except for `goToStep` and `exitFlow` the rest don't accept any args). So to accept the `providedDependencies` data. Is this something worth following up on?

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Stepper to have a default Tracks event logging for all the navigation controls.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- This should be reviewed alongside the Tracks events being created. 
  - Are the event names correct?
  - Are the starting set of props correct? (these can be extended later)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
