### PR TITLE
Migration: Use new flag to track submit events

### DIFF
--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -264,4 +264,6 @@ export default {
 
 		return stepHandlers[ currentStep ];
 	},
+
+	use__Temporary__ShouldTrackEvent: ( event ) => 'submit' === event,
 } satisfies Flow;


### PR DESCRIPTION
Closes to #93531

## Proposed Changes

* Use the new `use__Temporary__ShouldTrackEvent` to automatically track the submit events


## Testing Instructions

* Install p7H4VZ-3cB-p2 
* Go to /setup/migration 
* Select WordPress
* Check if the following event is triggered.

<img width="649" alt="image" src="https://github.com/user-attachments/assets/03246d3e-5aba-4a9e-a2da-dca0705a719c">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?