### PR TITLE
Migration: Remove duplicated event

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -1,9 +1,7 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Gridicon, FormLabel, SelectDropdown } from '@automattic/components';
 import { Title, SubTitle } from '@automattic/onboarding';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useEffect } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import {
 	getImportersAsImporterOption,
@@ -12,12 +10,6 @@ import {
 import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
 import type { ImporterPlatform } from 'calypso/lib/importer/types';
 import './style.scss';
-
-const trackEventName = 'calypso_signup_step_start';
-const trackEventParams = {
-	flow: 'importer',
-	step: 'list',
-};
 
 export interface ImporterOption {
 	value: ImporterPlatform;
@@ -37,7 +29,6 @@ interface Props {
 		platform: ImporterPlatform,
 		backToFlow?: string
 	) => string;
-	skipTracking?: boolean;
 	onNavBack?: () => void;
 }
 
@@ -48,7 +39,6 @@ export default function ListStep( props: Props ) {
 	const backToFlow = urlQueryParams.get( 'backToFlow' );
 	const title = props.title || __( 'Import content from another platform' );
 	const subTitle = props.subTitle || __( 'Select the platform where your content lives' );
-	const skipTracking = props.skipTracking;
 
 	// We need to remove the wix importer from the primary importers list.
 	const primaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'primary' ).filter(
@@ -68,15 +58,6 @@ export default function ListStep( props: Props ) {
 		);
 		submit?.( { platform, url: importerUrl } );
 	};
-
-	const recordImportList = () => {
-		if ( ! skipTracking ) {
-			//FIXME: This is a temporary fix to avoid tracking the import list step. This event apparently is duplicated with the stepper event.
-			recordTracksEvent( trackEventName, trackEventParams );
-		}
-	};
-
-	useEffect( recordImportList, [] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/platform-identification/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/platform-identification/index.tsx
@@ -11,7 +11,6 @@ const PlatformIdentificationStep: Step = ( props ) => {
 			subTitle={ translate(
 				'Tell us which platform your site is built with so we can get started.'
 			) }
-			skipTracking
 			{ ...props }
 		/>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

closes  #93352

## Proposed Changes

* Remove duplicated events from the import list step component
* Remove the flag to skip the event. 


## Why are these changes being made?
* Stepper automatically submits the `calypso_signup_step_start` using the correct flow and step names.

## Testing Instructions
* Install p7H4VZ-3cB-p2

Scenario: Migration flow
* Go to `/setup/migration/platform-identification` and check if there is a single `calypso_signup_step_start`
* Check if there is a single `calypso_signup_step_start` with the correct flow and step name
![image](https://github.com/user-attachments/assets/13a7473a-df8d-4b98-9f2b-fa361609f311)


Scenario: Site setup flow
* Go to `http://calypso.localhost:3000/setup/site-setup/importList?siteSlug=[YOUR_SITE_SLUG]
* Check if there is a single `calypso_signup_step_start` with the correct flow and step name

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?