### PR TITLE
A4A: Partner Directory: Add Markdown support hint for the Bio field

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -182,6 +182,20 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 				</FormField>
 				<FormField
 					label={ translate( 'Company bio' ) }
+					description={ translate(
+						'Basic Markdown syntax is supported. {{a}}Learn more about Markdown.{{/a}}',
+						{
+							components: {
+								a: (
+									<a
+										href="https://commonmark.org/help/"
+										target="_blank"
+										rel="noreferrer noopener"
+									/>
+								),
+							},
+						}
+					) }
 					error={ validationError.bio }
 					checks={ [ validateNonEmpty() ] }
 					field={ formData.bioDescription }


### PR DESCRIPTION
## Proposed Changes

This PR adds simple hint text to inform agencies that basic Markdown support is now available.

<img width="705" alt="image" src="https://github.com/user-attachments/assets/7f879bd0-fd97-47f1-9dbf-fa3a45b4d1d7">

## Why are these changes being made?

We want to give the agencies listed in the partner directory to do some basic formatting for the description field.

## Testing Instructions

* Open Automattic for Agencies live link and visit the `/partner-directory/agency-details` link
* Verify the hint text is displayed and points to the right place
* Verify the Markdown support works fine (the supported formatting options are: bold, italic, lists, h2, h3)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
