### PR TITLE
Checkout: Fix mixed border-radius styles in Billing information form fields

### DIFF
--- a/client/my-sites/checkout/src/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/src/components/wp-contact-form.tsx
@@ -9,13 +9,16 @@ import type { CountryListItem, ContactDetailsType } from '@automattic/wpcom-chec
 const BillingFormFields = styled.div`
 	margin-bottom: 16px;
 
-	& input[type='text'].form-text-input,
+	& input,
+	input[type='text'].form-text-input,
+	input[type='textarea'].form-textarea-input,
 	input[type='url'].form-text-input,
 	input[type='password'].form-text-input,
 	input[type='email'].form-text-input,
 	input[type='tel'].form-text-input,
 	input[type='number'].form-text-input,
 	input[type='search'].form-text-input,
+	.form-select,
 	.form-fieldset.contact-details-form-fields select {
 		border-radius: 3px;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/88437

## Proposed Changes

* Include additional form-field types (textarea, select) to the styling included in the [BillingFormFields](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/checkout/src/components/wp-contact-form.tsx#L9-L41) component styling

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Without these input types being included in the styling, the form fields in `Checkout > Billing information` have inconsistent border radii. The domain contact information form fields are rounded with a 3px border radius. Tax details and non-domain country/postal code fields are squared with a 0px border radius.

**Before**

<img width="610" alt="Before-mixedcorners-domainandtax" src="https://github.com/user-attachments/assets/feee0026-2833-44d5-9eeb-f8ccea78183d">

<img width="655" alt="Before-SquaredCorners-CountryPostal" src="https://github.com/user-attachments/assets/c13b460c-c249-4011-9144-cb177a1ffe0f">

**After**

<img width="606" alt="After-MatchCorners-DomainAndTax" src="https://github.com/user-attachments/assets/3740859f-df35-48d2-80ee-c444316df86f">

<img width="693" alt="After-Rounded-CountyPostalCode" src="https://github.com/user-attachments/assets/4bb68f60-504d-4aa4-bce9-f0237c20627c">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a domain registration product to your shopping cart and go to Checkout
* If the contact form is not already open, click on the `Edit` button next to `Billing information`
* Select a country for which we charge tax AND accept tax exemption details, for example Germany
* Check the `Add tax/VAT details` box if it not already checked
* Notice that the form fields in the tax details have squared corners and the domain contact fields are rounded
* Apply this patch to Calypso
* Refresh checkout and open the `Billing information` form again
* Notice the form fields have consistently rounded corners.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
