### PR TITLE
Don't apply user color scheme on checkout pages.

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -253,6 +253,7 @@ class Layout extends Component {
 	 * - the color scheme has changed
 	 * - the global sidebar is visible and the color scheme is not `global`
 	 * - the global sidebar was visible and is now hidden and the color scheme is not `global`
+	 * - the section changed to `checkout` or changes from 'checkout' to something else
 	 * @param prevProps object
 	 */
 	componentDidUpdate( prevProps ) {
@@ -261,7 +262,9 @@ class Layout extends Component {
 			( this.props.isGlobalSidebarVisible && this.props.colorScheme !== 'global' ) ||
 			( prevProps.isGlobalSidebarVisible &&
 				! this.props.isGlobalSidebarVisible &&
-				this.props.colorScheme !== 'global' )
+				this.props.colorScheme !== 'global' ) ||
+			( prevProps.sectionName !== 'checkout' && this.props.sectionName === 'checkout' ) ||
+			( prevProps.sectionName === 'checkout' && this.props.sectionName !== 'checkout' )
 		) {
 			this.refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
 		}
@@ -275,6 +278,11 @@ class Layout extends Component {
 		if ( typeof document !== 'undefined' ) {
 			const classList = document.querySelector( 'body' ).classList;
 			const globalColorScheme = 'global';
+
+			if ( this.props.sectionName === 'checkout' ) {
+				classList.remove( `is-${ prevColorScheme }` );
+				return;
+			}
 
 			if ( this.props.isGlobalSidebarVisible ) {
 				// Force the global color scheme when the global sidebar is visible.

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -257,14 +257,17 @@ class Layout extends Component {
 	 * @param prevProps object
 	 */
 	componentDidUpdate( prevProps ) {
+		const willTransitionFromOrToCheckout =
+			( prevProps.sectionName === 'checkout' && this.props.sectionName !== 'checkout' ) ||
+			( prevProps.sectionName !== 'checkout' && this.props.sectionName === 'checkout' );
+
 		if (
 			prevProps.colorScheme !== this.props.colorScheme ||
 			( this.props.isGlobalSidebarVisible && this.props.colorScheme !== 'global' ) ||
 			( prevProps.isGlobalSidebarVisible &&
 				! this.props.isGlobalSidebarVisible &&
 				this.props.colorScheme !== 'global' ) ||
-			( prevProps.sectionName !== 'checkout' && this.props.sectionName === 'checkout' ) ||
-			( prevProps.sectionName === 'checkout' && this.props.sectionName !== 'checkout' )
+			willTransitionFromOrToCheckout
 		) {
 			this.refreshColorScheme( prevProps.colorScheme, this.props.colorScheme );
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/93746

## Proposed Changes

* Don't apply the user's color scheme on checkout pages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

1. Add a product to your Checkout from your account
2. Notice the color of the links and the highlights when you click on input fields (like first name and last name)
3. In a separate tab, go to me/account
4. Scroll down to Interface settings > Dashboard color scheme (Sunrise and Sunset make it really obvious)
5. Select a color scheme which is different than your current settings and save your changes
6. Go back to Checkout in your original tab, confirm the links and highlights have the same color

Also test navigating through the whole flow, your selected color scheme should be reapplied when exiting the checkout flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
