### PR TITLE
Performance Profiler: update color styles for insights and metrics

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -179,6 +179,7 @@ export interface PerformanceMetricsItemQueryResponse {
 	id: string;
 	title?: string;
 	description?: string;
+	type: 'warning' | 'fail';
 	displayValue?: string;
 	details?: PerformanceMetricsDetailsQueryResponse;
 }

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -44,8 +44,26 @@ $blueberry-color: #3858e9;
 				}
 			}
 
+			.counter {
+				&.fail {
+					color: var(--studio-red-50);
+				}
+
+				&.warning {
+					color: var(--studio-orange-40);
+				}
+			}
+
 			.value {
 				color: var(--studio-green-40);
+
+				&.fail {
+					color: var(--studio-red-50);
+				}
+
+				&.warning {
+					color: var(--studio-orange-40);
+				}
 			}
 		}
 
@@ -60,8 +78,26 @@ $blueberry-color: #3858e9;
 				}
 			}
 
+			.counter {
+				&.fail {
+					color: var(--studio-red-60);
+				}
+
+				&.warning {
+					color: var(--studio-orange-50);
+				}
+			}
+
 			.value {
 				color: var(--studio-green-50);
+
+				&.fail {
+					color: var(--studio-red-60);
+				}
+
+				&.warning {
+					color: var(--studio-orange-50);
+				}
 			}
 		}
 

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -48,7 +48,6 @@ const Header = styled.div`
 	}
 
 	.counter {
-		color: #3858e9;
 		font-size: 16px;
 		font-weight: 500;
 		margin-right: 8px;

--- a/client/performance-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-header.tsx
@@ -1,4 +1,5 @@
 import { isMobile } from '@automattic/viewport';
+import clsx from 'clsx';
 import Markdown from 'react-markdown';
 import { PerformanceMetricsItemQueryResponse } from 'calypso/data/site-profiler/types';
 
@@ -11,39 +12,30 @@ export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 	const { data, index } = props;
 	const title = data.title ?? '';
 	const value = data.displayValue ?? '';
+	const { type } = data;
 
 	return (
 		<>
-			<span className="counter" style={ { color: data.type === 'fail' ? 'red' : 'orange' } }>
-				{ index + 1 }
-			</span>
+			<span className={ clsx( 'counter', { [ type ]: true } ) }>{ index + 1 }</span>
 			<Markdown
 				components={ {
 					p( props ) {
 						return <p className="title-description">{ props.children }</p>;
 					},
 					code( props ) {
-						return (
-							<span
-								className="value"
-								style={ { color: props.data.type === 'fail' ? 'red' : 'orange' } }
-							>
-								{ props.children }
-							</span>
-						);
+						return <span className="value">{ props.children }</span>;
 					},
 				} }
 			>
 				{ title }
 			</Markdown>
-			{ value && isMobile() && <span className="value is-mobile"> { value }</span> }
+			{ value && isMobile() && (
+				<span className={ clsx( 'value is-mobile', { [ type ]: true } ) }> { value }</span>
+			) }
 			{ value && ! isMobile() && (
 				<span>
 					&nbsp;&minus;&nbsp;
-					<span className="value" style={ { color: data.type === 'fail' ? 'red' : 'orange' } }>
-						{ ' ' }
-						{ value }
-					</span>
+					<span className={ clsx( 'value', { [ type ]: true } ) }> { value }</span>
 				</span>
 			) }
 		</>

--- a/client/performance-profiler/components/metrics-insight/insight-header.tsx
+++ b/client/performance-profiler/components/metrics-insight/insight-header.tsx
@@ -14,14 +14,23 @@ export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 
 	return (
 		<>
-			<span className="counter">{ index + 1 }</span>
+			<span className="counter" style={ { color: data.type === 'fail' ? 'red' : 'orange' } }>
+				{ index + 1 }
+			</span>
 			<Markdown
 				components={ {
 					p( props ) {
 						return <p className="title-description">{ props.children }</p>;
 					},
 					code( props ) {
-						return <span className="value">{ props.children }</span>;
+						return (
+							<span
+								className="value"
+								style={ { color: props.data.type === 'fail' ? 'red' : 'orange' } }
+							>
+								{ props.children }
+							</span>
+						);
 					},
 				} }
 			>
@@ -30,7 +39,11 @@ export const InsightHeader: React.FC< InsightHeaderProps > = ( props ) => {
 			{ value && isMobile() && <span className="value is-mobile"> { value }</span> }
 			{ value && ! isMobile() && (
 				<span>
-					&nbsp;&minus;&nbsp;<span className="value"> { value }</span>
+					&nbsp;&minus;&nbsp;
+					<span className="value" style={ { color: data.type === 'fail' ? 'red' : 'orange' } }>
+						{ ' ' }
+						{ value }
+					</span>
 				</span>
 			) }
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8840

## Proposed Changes

* Update the insight heading color based on the insight type

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/8840

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/speed-test-tool?url=example.com` and scroll down to the insights section
* Check that the insights are ordered with the higher severity ones on the top
* Check that the insights with type fail are shown with red, and insights with type warning are shown with orange headings
* Check for regressions, eg. clicking on the insights, viewing them from a mobile viewport

| Before | After |
|--------|--------|
| ![CleanShot 2024-08-21 at 14 48 25@2x](https://github.com/user-attachments/assets/b7d8d77e-6d6f-4489-8b9c-22e1b1a51c08) | ![CleanShot 2024-08-21 at 14 47 20@2x](https://github.com/user-attachments/assets/ac34efc0-6019-4af9-9a43-f872744e42d8) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
