### PR TITLE
A4A Dev Sites: Move `a4a-dev-sites` feature flag check to the `JetpackSitesDataViews` component

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -193,7 +193,8 @@ export const JetpackSitesDataViews = ( {
 						);
 					}
 
-					const isDevSite = item.isDevSite ?? false;
+					const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
+					const isDevSite = ( item.isDevSite && devSitesEnabled ) || false;
 
 					return (
 						<>

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Badge, Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import SiteFavicon from 'calypso/a8c-for-agencies/components/items-dashboard/site-favicon';
@@ -18,7 +17,6 @@ const SiteDataField = ( { isLoading, site, isDevSite, onSiteTitleClick }: SiteDa
 	}
 
 	const migrationInProgress = site.sticker?.includes( 'migration-in-progress' );
-	const devSitesEnabled = config.isEnabled( 'a4a-dev-sites' );
 
 	return (
 		<Button
@@ -39,7 +37,7 @@ const SiteDataField = ( { isLoading, site, isDevSite, onSiteTitleClick }: SiteDa
 						{ translate( 'Migration in progress' ) }
 					</Badge>
 				) }
-				{ devSitesEnabled && isDevSite && (
+				{ isDevSite && (
 					<Badge className="status-badge" type="info-purple">
 						{ translate( 'Development' ) }
 					</Badge>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/8842.
Related discussion: p1724242994720339/1724198541.780969-slack-C06JY8QL0TU.

## Proposed Changes

* move the logic that makes sure `isDevSite` is to `true` only if the `a4a-dev-sites` feature flag is enabled as well to the `JetpackSitesDataViews` component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR locally and build the app with `yarn start-a8c-for-agencies`.
2. Head over to the Sites section at http://agencies.localhost:3000/sites/?flags=a4a-dev-sites.
3. There should be no functional changes. Only the free development sites should have the `Development` badge by their name.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?