### PR TITLE
Sites dashboard - use admin interface setting for stats item link.

### DIFF
--- a/client/hosting/sites/components/sites-dataviews/sites-site-stats.tsx
+++ b/client/hosting/sites/components/sites-dataviews/sites-site-stats.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import { useSelector } from 'calypso/state';
+import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
 import { hasSiteStatsQueryFailed } from 'calypso/state/stats/lists/selectors';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -72,6 +73,11 @@ export const SiteStats = ( { site }: SiteStatsProps ) => {
 		return siteId && hasSiteStatsQueryFailed( state, siteId, statType, query );
 	} );
 
+	const { isWPAdmin: isClassicView, adminUrl } = useSiteAdminInterfaceData( site.ID );
+	const statsUrl = isClassicView
+		? `${ adminUrl }admin.php?page=stats`
+		: `/stats/day/${ site.slug }`;
+
 	return (
 		<div ref={ ref }>
 			{ inView && (
@@ -79,7 +85,7 @@ export const SiteStats = ( { site }: SiteStatsProps ) => {
 					{ hasStatsLoadingError || site.is_deleted ? (
 						<StatsOffIndicator />
 					) : (
-						<a href={ `/stats/day/${ site.slug }` }>
+						<a href={ statsUrl }>
 							<StatsSparkline siteId={ site.ID } showLoader />
 						</a>
 					) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # Automattic/dotcom-forge#8055

## Proposed Changes

* Updates the stats item in the site dashboard to link to wp-admin instead of calypso when the site is using the classic interface setting.


<img width="1336" alt="Screenshot 2024-08-21 at 10 58 57 AM" src="https://github.com/user-attachments/assets/db5281ee-db58-4247-8d6f-8cd0af8d3477">


BEFORE - clicking the stats link on the dashboard for a classic site loads users into the calypso version. Notice the calypso site sidebar doesnt show jetpack group open with stats selected, as on classic sites this corresponds to the wp-admin page.
<img width="787" alt="Screenshot 2024-08-21 at 10 53 27 AM" src="https://github.com/user-attachments/assets/d10a7651-0303-4494-8651-cd45ec53aa5c">



AFTER - clicking the stats link on the site dashboard for a classic site loads wp-admin as expected.

<img width="642" alt="Screenshot 2024-08-21 at 10 55 57 AM" src="https://github.com/user-attachments/assets/b981b7f6-4063-4d0e-8c34-4e8d8ddc1f51">



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently this takes them to calypso instead of wp-admin, but their preference is for wp-admin. Additionally the calypso site sidebar here doesn't show the item as open as it does in wp-admin (for classic view sites).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso.
* Goto the sites dashboard.
* Find a site with classic interface set, hover over the stats item in the row and verify the breadcrumb points to the sites wp-admin instead of calypso. Verify clicking this loads wp-admin correctly to the stats page.
* Find a site with default interface set, verify this link still goes to the calypso stats page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
