### PR TITLE
Rename customized action query string

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -16,7 +16,7 @@ export function getFinalImporterUrl(
 	fromSite: string,
 	platform: ImporterPlatform,
 	backToFlow?: string,
-	migrateEntireSiteFlow?: string
+	customizedActionGoToFlow?: string
 ) {
 	let importerUrl;
 	const encodedFromSite = encodeURIComponent( fromSite );
@@ -46,9 +46,9 @@ export function getFinalImporterUrl(
 		} );
 	}
 
-	if ( migrateEntireSiteFlow ) {
+	if ( customizedActionGoToFlow ) {
 		importerUrl = addQueryArgs( importerUrl, {
-			migrateEntireSiteFlow,
+			customizedActionGoToFlow,
 		} );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/index.tsx
@@ -34,18 +34,20 @@ const ImporterWordpress: FC< Props > = function ( props ) {
 	);
 
 	let customizedActionButtons;
-	if ( queryParams.get( 'ref' ) === MIGRATION_FLOW ) {
-		customizedActionButtons = (
-			<StepNavigationLink
-				direction="forward"
-				handleClick={ () => {
-					props.navigation.submit?.( { action: 'customized-action-flow' } );
-				} }
-				label={ translate( 'I want to migrate my entire site' ) }
-				cssClass={ clsx( 'step-container__navigation-link', 'forward', 'has-underline' ) }
-				borderless
-			/>
-		);
+	switch ( queryParams.get( 'ref' ) ) {
+		case MIGRATION_FLOW:
+			customizedActionButtons = (
+				<StepNavigationLink
+					direction="forward"
+					handleClick={ () => {
+						props.navigation.submit?.( { action: 'customized-action-go-to-flow' } );
+					} }
+					label={ translate( 'I want to migrate my entire site' ) }
+					cssClass={ clsx( 'step-container__navigation-link', 'forward', 'has-underline' ) }
+					borderless
+				/>
+			);
+			break;
 	}
 
 	return (

--- a/client/landing/stepper/declarative-flow/migration/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/migration/helpers/index.ts
@@ -34,10 +34,10 @@ export const goToImporter = ( {
 	replaceHistory = false,
 }: GoToImporterParams ) => {
 	const backToFlow = backToStep ? getFlowPath( backToStep?.slug ) : undefined;
-	const migrateEntireSiteFlow = migrateEntireSiteStep
+	const customizedActionGoToFlow = migrateEntireSiteStep
 		? getFlowPath( migrateEntireSiteStep?.slug )
 		: undefined;
-	const path = getFinalImporterUrl( siteSlug, '', platform, backToFlow, migrateEntireSiteFlow );
+	const path = getFinalImporterUrl( siteSlug, '', platform, backToFlow, customizedActionGoToFlow );
 
 	if ( isWpAdminImporter( path ) ) {
 		return goTo( path, replaceHistory );

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -306,7 +306,7 @@ describe( `${ flow.name }`, () => {
 							from: '',
 							option: 'content',
 							backToFlow: '/migration/platform-identification',
-							migrateEntireSiteFlow: '/migration/migration-upgrade-plan',
+							customizedActionGoToFlow: '/migration/migration-upgrade-plan',
 							siteId: 123,
 							ref: 'migration',
 						},

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -452,10 +452,10 @@ const siteSetupFlow: Flow = {
 							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
 						case 'checkout':
 							return exitFlow( providedDependencies?.checkoutUrl as string );
-						case 'customized-action-flow': {
-							const migrateEntireSiteFlow = urlQueryParams.get( 'migrateEntireSiteFlow' );
-							if ( migrateEntireSiteFlow ) {
-								return goToFlow( migrateEntireSiteFlow );
+						case 'customized-action-go-to-flow': {
+							const customizedActionGoToFlow = urlQueryParams.get( 'customizedActionGoToFlow' );
+							if ( customizedActionGoToFlow ) {
+								return goToFlow( customizedActionGoToFlow );
 							}
 						}
 						default:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* It applies the suggestion from https://github.com/Automattic/wp-calypso/pull/93645#discussion_r1724733266, making it more generic to be used by any other step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To make it more generic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/setup/migration`.
2. Choose the "WordPress" option.
3. Click on "I want to import my content only".
4. Click on "I want to migrate my entire site", and make sure you navigate back to the migration option.
5. Also make sure the same step in other flows continue working properly without any customized action.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
