### PR TITLE
A4A Dev Sites: Redirect to A4A checkout page with referral_blog_id

### DIFF
--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -92,7 +92,7 @@ const LaunchSite = () => {
 	const agencyName = 'MyCoolAgency';
 
 	const handleReferToClient = () => {
-		window.location.href = `https://agencies.automattic.com/marketplace/checkout/referral_blog_id=${ siteId }`;
+		window.location.href = `https://agencies.automattic.com/marketplace/checkout?referral_blog_id=${ siteId }`;
 	};
 
 	return (

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -91,6 +91,10 @@ const LaunchSite = () => {
 	// TODO: retrieve the actual agency name
 	const agencyName = 'MyCoolAgency';
 
+	const handleReferToClient = () => {
+		window.location.href = `https://agencies.automattic.com/marketplace/checkout/referral_blog_id=${ siteId }`;
+	};
+
 	return (
 		<>
 			<SettingsSectionHeader title={ translate( 'Launch site' ) } />
@@ -126,7 +130,7 @@ const LaunchSite = () => {
 						// TODO: add onClick handler
 						isDevelopmentSite && (
 							<div className={ launchSiteClasses }>
-								<Button onClick={ null } disabled={ false }>
+								<Button onClick={ handleReferToClient } disabled={ false }>
 									{ translate( 'Refer to client' ) }
 								</Button>
 							</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8708

## Proposed Changes

* Redirects to A4A checkout page with referral_blog_id

## Why are these changes being made?

pdDOJh-3Cl-p2

## Testing Instructions

* Apply this PR to your local and run with `yarn start`
* Create a new dev site on the A4A and get the blog_id
* Navigate to http://calypso.localhost:3000/settings/general/{blog-id}?referer=a4a-dashboard (replace blog-id with yours)
* Click "Refer to client," and you should be redirected to `https://agencies.automattic.com/marketplace/checkout?referral_blog_id={blog-id}`
* For now, the cart will be empty as it depends on the https://github.com/Automattic/wp-calypso/pull/93738 to be merged

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?