### PR TITLE
Fix iframe error when accessing patterns on post command palette

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1047,6 +1047,15 @@ function handleAppBannerShowing( calypsoPort ) {
 	};
 }
 
+function handlePatterns( calypsoPort ) {
+	addEditorListener( '[data-value="Patterns"]', () => {
+		calypsoPort.postMessage( {
+			action: 'goToPatterns',
+			payload: { destinationUrl: '/wp-admin/site-editor.php?postType=wp_block' },
+		} );
+	} );
+}
+
 function initPort( message ) {
 	if ( 'initPort' !== message.data.action ) {
 		return;
@@ -1147,6 +1156,8 @@ function initPort( message ) {
 		handleCheckoutModal( calypsoPort );
 
 		handleAppBannerShowing( calypsoPort );
+
+		handlePatterns( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -37,6 +37,17 @@ function addEditorListener( selector, cb ) {
 	}
 }
 
+function addCommandsInputListener( selector, cb ) {
+	document.querySelector( 'body.is-iframed' )?.addEventListener( 'keydown', ( e ) => {
+		const isInputActive = document.activeElement?.matches( '.commands-command-menu__header input' );
+		const isCommandSelected = document.querySelector( '[data-selected=true]' )?.matches( selector );
+
+		if ( e.key === 'Enter' && isInputActive && isCommandSelected ) {
+			cb( e );
+		}
+	} );
+}
+
 // Calls a callback if the event occured on an element or parent thereof matching
 // the callback's selector. This is needed because elements are added and removed
 // from the DOM dynamically after the listeners are created. We need to handle
@@ -1049,7 +1060,9 @@ function handleAppBannerShowing( calypsoPort ) {
 }
 
 function handlePatterns( calypsoPort ) {
-	addEditorListener( `[data-value="${ __( 'Patterns' ) }"]`, ( e ) => {
+	const selector = `[data-value="${ __( 'Patterns' ) }"]`;
+
+	const callback = ( e ) => {
 		e.preventDefault();
 
 		calypsoPort.postMessage( {
@@ -1059,7 +1072,10 @@ function handlePatterns( calypsoPort ) {
 				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
 			},
 		} );
-	} );
+	};
+
+	addEditorListener( selector, callback );
+	addCommandsInputListener( selector, callback );
 }
 
 function initPort( message ) {

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -6,6 +6,7 @@ import { dispatch, select, subscribe, use } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
@@ -1048,10 +1049,12 @@ function handleAppBannerShowing( calypsoPort ) {
 }
 
 function handlePatterns( calypsoPort ) {
-	addEditorListener( '[data-value="Patterns"]', () => {
+	addEditorListener( `[data-value="${ __( 'Patterns' ) }"]`, () => {
 		calypsoPort.postMessage( {
 			action: 'goToPatterns',
-			payload: { destinationUrl: '/wp-admin/site-editor.php?postType=wp_block' },
+			payload: {
+				destinationUrl: '/wp-admin/site-editor.php?postType=wp_block',
+			},
 		} );
 	} );
 }

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1049,11 +1049,14 @@ function handleAppBannerShowing( calypsoPort ) {
 }
 
 function handlePatterns( calypsoPort ) {
-	addEditorListener( `[data-value="${ __( 'Patterns' ) }"]`, () => {
+	addEditorListener( `[data-value="${ __( 'Patterns' ) }"]`, ( e ) => {
+		e.preventDefault();
+
 		calypsoPort.postMessage( {
 			action: 'goToPatterns',
 			payload: {
 				destinationUrl: '/wp-admin/site-editor.php?postType=wp_block',
+				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
 			},
 		} );
 	} );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -95,6 +95,7 @@ enum WindowActions {
 
 enum EditorActions {
 	GoToAllPosts = 'goToAllPosts', // Unused action in favor of CloseEditor. Maintained here to support cached scripts.
+	GoToPatterns = 'goToPatterns',
 	CloseEditor = 'closeEditor',
 	OpenMediaModal = 'openMediaModal',
 	OpenCheckoutModal = 'openCheckoutModal',
@@ -380,6 +381,10 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			}
 			this.props.setEditorIframeLoaded( false );
 			this.navigate( destinationUrl, unsavedChanges );
+		}
+
+		if ( EditorActions.GoToPatterns === action ) {
+			navigate( `https://${ this.props.siteSlug }${ payload.destinationUrl }` );
 		}
 
 		if ( EditorActions.OpenRevisions === action ) {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -384,7 +384,9 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		}
 
 		if ( EditorActions.GoToPatterns === action ) {
-			navigate( `https://${ this.props.siteSlug }${ payload.destinationUrl }` );
+			const { destinationUrl, unsavedChanges } = payload;
+
+			this.navigate( `https://${ this.props.siteSlug }${ destinationUrl }`, unsavedChanges );
 		}
 
 		if ( EditorActions.OpenRevisions === action ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/92634

## Proposed Changes

* Handle the user's interaction with the `Patterns` command on the command palette through the iframe bridge, so the destination page can be opened as expected instead of being blocked because of it being inside an `iframe`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently, clicking on the `Patterns` command on the command leaves the users with an error page and this message on the console: `Refused to display 'https://xavilc12.wordpress.com/' in a frame because it set 'X-Frame-Options' to 'sameorigin'.`

![image](https://github.com/user-attachments/assets/f6d0736c-6d04-4ef2-90ed-bd15903c3161)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally on the `wp-calypso` folder
* Go to the `apps/wpcom-block-editor` folder inside `wp-calypso`
* Run `yarn dev --sync`, this will add the necessary changes to your sandbox
* Sandbox `widgets.wp.com`
* Open the calypso live preview
* Go to `/post`
* Select a site with the default interface (otherwise, you'll be redirected to wp-admin and won't use the iframe editor)
* Click on the command palette, and then type `Patterns` and click on it
* Check that you are redirected to the patterns page:

![image](https://github.com/user-attachments/assets/ad07a69a-8b94-4c86-b6f9-585a93c0c3e8)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
