### PR TITLE
fix(hosting-overview-refinements): avoid login screen after redirect from Hosting features

### DIFF
--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -63,7 +63,8 @@ const HostingFeatures = () => {
 		refetchInterval: 3000,
 		refetchIntervalInBackground: true,
 	} );
-	// We have some bug at the backend, when the transfer is completed, but isSiteAtomic is still false, so we need such extra condition
+	// `siteTransferData?.isTransferring` is not a fully reliable indicator by itself, which is why
+	// we also look at `siteTransferData.status`
 	const isTransferInProgress =
 		siteTransferData?.isTransferring || siteTransferData?.status === transferStates.COMPLETED;
 

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -63,7 +63,7 @@ const HostingFeatures = () => {
 		refetchInterval: 3000,
 		refetchIntervalInBackground: true,
 	} );
-	// We have some bug at the backend, when the transfer is complited, but isSiteAtomic is still false, so we need such extra condition
+	// We have some bug at the backend, when the transfer is completed, but isSiteAtomic is still false, so we need such extra condition
 	const isTransferInProgress =
 		siteTransferData?.isTransferring || siteTransferData?.status === transferStates.COMPLETED;
 

--- a/client/landing/stepper/hooks/use-site-transfer/query.ts
+++ b/client/landing/stepper/hooks/use-site-transfer/query.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { transferStates, type TransferStates } from 'calypso/state/automated-transfer/constants';
 
@@ -53,7 +53,11 @@ const shouldRefetch = ( status: TransferStates | undefined ) => {
 	return isTransferring( status );
 };
 
-type Options = Pick< UseQueryOptions, 'retry' >;
+type Options = {
+	retry?: number;
+	refetchInterval?: number;
+	refetchIntervalInBackground?: boolean;
+};
 
 /**
  * Query hook to get the site transfer status, pooling the endpoint.
@@ -75,8 +79,10 @@ export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?
 			};
 		},
 		refetchOnWindowFocus: false,
-		refetchInterval: ( { state } ) =>
-			shouldRefetch( state.data?.status ) ? REFETCH_TIME : false,
+		refetchIntervalInBackground: !! options?.refetchIntervalInBackground,
+		refetchInterval:
+			options?.refetchInterval ||
+			( ( { state } ) => ( shouldRefetch( state.data?.status ) ? REFETCH_TIME : false ) ),
 		enabled: !! siteId,
 	} );
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8845

## Proposed Changes
We have "Hosting Features" page where users can activate them.
<img width="995" alt="Screenshot 2024-08-26 at 15 12 07" src="https://github.com/user-attachments/assets/7d32a3fd-575d-47bd-8dd4-f1ac4a6123d3">

So there is next case:
1) A user clicked "Activate" button 
2) Activation process can take some time, so there is a chance that users visits "Hosting Features" again, during activation period
3) That's why every 3 seconds we check for `complited` state of the activation and as soon as it's complicated - we redirect the user from "Hosting Features" to "Hosting Overview" page, and they see another UI (another tabs).
The issue - sometimes, after redirect, users get Login screen. I noticed that if we add around 5 seconds delay - almost always everything good (Login page doesn't appear). So with this PR we have temporary workaround, but would be better to fix it at the backend - return `complited` only when everything is indeed complitted.

<img width="453" alt="Screenshot 2024-08-22 at 13 27 09" src="https://github.com/user-attachments/assets/ee88d0b8-faa6-4d75-b243-b963ca3206a7"> <br />
Simple Website UI. <br />
<img width="444" alt="Screenshot 2024-08-22 at 13 27 28" src="https://github.com/user-attachments/assets/4c729870-fd80-4462-bfd2-61102436bf67"><br />
Atomic Website UI.<br />
<img width="656" alt="Screenshot 2024-08-22 at 13 28 14" src="https://github.com/user-attachments/assets/67b4ea65-9d06-4297-80a6-af3dd15a77f7">



## Testing Instructions

## Testing Instructions
### A4A tests
1. Open `https://agencies.automattic.com/`
2. Purchase licences, if you don't have (Left sidebar "Purchase" -> "Issue New License")
3. Click on `Sites` in left sidebar
4. Click on "Needs setup"
5. Click on "Create new site" and proceed
6. Wait till you see the next notification<br /> <img width="531" alt="Screenshot 2024-08-13 at 12 58 24" src="https://github.com/user-attachments/assets/98ea9aab-f607-4998-815a-1c403b9f1020">
7. Copy selected domain on the screenshot above
8. And open new tab with the next URL `http://calypso.localhost:3000/hosting-features/<COPYED_DOMAIN_IN_7TH_STEP>`
9. Assert that you see spinner and copy about "things in progress" <br /><img width="636" alt="Screenshot 2024-08-13 at 13 00 43" src="https://github.com/user-attachments/assets/ae8817f1-da5d-4d06-9c57-3437ea7f5c1b">
10. Wait till it's finished
11. Assert that you are redirected to "Overview" tab
12. Repeat these steps about 5 times. In about 95+% cases we don't see the Login screen, but there are some extra rare cases when we still see Login screen. I think it's not very critical and I am not sure that it makes sense to increase delay for more them 5 seconds. We can't game the maximum of the possible delay, so IMO 5 seconds is enough.

### Manually turning on Hosting Features
1. Purchase domain with `Starter` plan
2. Open "Hosting features" tab on "Sites" page (Let's call this tab as `A` during testing)
3. Copy the URL and open a separate tab (Let's call this tab as `B` during testing, we will use it in the end for testing)
4. In tab A, click `Upgrade now` and proceed with upgrading
5. Now let's repeat the 3-rd step to open one more separate tab (Let's call this tab as `C` during testing, we will use it in the end for testing), so that you will have the next tabs `B` and `C`:<br /><img width="2296" alt="Screenshot 2024-07-29 at 16 12 45" src="https://github.com/user-attachments/assets/7ee4bc76-a06c-43dd-b64f-1b8c9c295a7c">
6. Now, in tab `A` click `Activate now` and proceed
7. During activating process, the copy on tabs B and C should be changed to the next (with CTA buttons hidden)<br /><img width="2293" alt="Screenshot 2024-07-29 at 16 15 28" src="https://github.com/user-attachments/assets/00b3e02f-cf04-482e-8ad8-eebbee3d8528">
8. Wait till it's finished
9. Assert that you are redirected to "Overview" tab
10. The same as for A4A websites - repeat these steps about 5 times. In about 95+% cases we don't see the Login screen, but there are some extra rare cases when we still see Login screen. I think it's not very critical and I am not sure that it makes sense to increase delay for more them 5 seconds. We can't game the maximum of the possible delay, so IMO 5 seconds is enough.



