### PR TITLE
Help Center: fix toggle animation

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -7,7 +7,7 @@ import { Card } from '@wordpress/components';
 import { useFocusReturn, useMergeRefs } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import clsx from 'clsx';
-import { useState, useRef, useEffect, useCallback, FC } from 'react';
+import { useRef, useEffect, useCallback, FC } from 'react';
 import Draggable, { DraggableProps } from 'react-draggable';
 import { MemoryRouter } from 'react-router-dom';
 /**
@@ -39,6 +39,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	currentRoute,
 	openingCoordinates,
 } ) => {
+	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 	const { show, isMinimized } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
@@ -50,36 +51,30 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	const nodeRef = useRef< HTMLDivElement >( null );
 
 	const { setIsMinimized } = useDispatch( HELP_CENTER_STORE );
-	const [ isVisible, setIsVisible ] = useState( true );
 	const isMobile = useMobileBreakpoint();
 	const classNames = clsx( 'help-center__container', isMobile ? 'is-mobile' : 'is-desktop', {
 		'is-minimized': isMinimized,
 	} );
 
 	const onDismiss = useCallback( () => {
-		setIsVisible( false );
+		setShowHelpCenter( false );
 		recordTracksEvent( `calypso_inlinehelp_close` );
-	}, [ setIsVisible ] );
+	}, [ setShowHelpCenter ] );
 
-	const toggleVisible = () => {
-		if ( ! isVisible ) {
+	useEffect( () => {
+		if ( ! show ) {
 			handleClose();
-			// after calling handleClose, reset the visibility state to default
-			setIsVisible( true );
 		}
-	};
+	}, [ show, handleClose ] );
 
 	const animationProps = {
 		style: {
-			animation: isMobile
-				? `${ isVisible ? 'fadeIn' : 'fadeOut' } .25s ease-out`
-				: `${ isVisible ? 'slideIn' : 'fadeOut' } .25s ease-out`,
+			animation: isMobile ? 'fadeIn .25s ease-out' : 'slideIn .25s ease-out',
 			// These are overwritten by the openingCoordinates.
 			// They are set to avoid Help Center from not loading on the page.
 			...( ! isMobile && { top: 70, left: 'calc( 100vw - 500px )' } ),
 			...openingCoordinates,
 		},
-		onAnimationEnd: toggleVisible,
 	};
 
 	const focusReturnRef = useFocusReturn();

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -35,7 +35,6 @@ const OptionalDraggable: FC< OptionalDraggableProps > = ( { draggable, ...props 
 
 const HelpCenterContainer: React.FC< Container > = ( {
 	handleClose,
-	hidden,
 	currentRoute,
 	openingCoordinates,
 } ) => {
@@ -77,14 +76,10 @@ const HelpCenterContainer: React.FC< Container > = ( {
 		onTransitionEnd: ( event ) => {
 			/**
 			 * We only want to remove the Help Center if:
-			 * 1. Its set to hidden or not show
-			 * 2. The display has finsihsed transitioning
+			 * 1. isHelpCenterShown is false
+			 * 2. The display has finished transitioning
 			 */
-			if (
-				event.target === nodeRef.current &&
-				( ! show || hidden ) &&
-				event.propertyName === 'display'
-			) {
+			if ( event.target === nodeRef.current && ! show && event.propertyName === 'display' ) {
 				setRenderContainer( false );
 			}
 		},
@@ -96,7 +91,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 
 	const shouldCloseOnEscapeRef = useRef( false );
 
-	shouldCloseOnEscapeRef.current = !! show && ! hidden && ! isMinimized;
+	shouldCloseOnEscapeRef.current = !! show && ! isMinimized;
 
 	useEffect( () => {
 		const handleKeydown = ( e: KeyboardEvent ) => {
@@ -112,14 +107,10 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	}, [ shouldCloseOnEscapeRef, onDismiss ] );
 
 	useEffect( () => {
-		if ( ! hidden && show ) {
+		if ( show ) {
 			setRenderContainer( true );
 		}
-
-		if ( hidden ) {
-			onDismiss();
-		}
-	}, [ show, hidden, onDismiss ] );
+	}, [ show, onDismiss ] );
 
 	if ( ! renderContainer ) {
 		return null;
@@ -138,7 +129,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 						className={ classNames }
 						{ ...containerProps }
 						ref={ cardMergeRefs }
-						hidden={ ! show || hidden }
+						hidden={ ! show }
 					>
 						<HelpCenterHeader
 							isMinimized={ isMinimized }

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -110,7 +110,7 @@ const HelpCenterContainer: React.FC< Container > = ( {
 		if ( show ) {
 			setRenderContainer( true );
 		}
-	}, [ show, onDismiss ] );
+	}, [ show ] );
 
 	if ( ! renderContainer ) {
 		return null;

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -72,10 +72,13 @@ const HelpCenter: React.FC< Container > = ( {
 		};
 	}, [ portalParent, handleClose ] );
 
+	if ( hidden ) {
+		return null;
+	}
+
 	return createPortal(
 		<HelpCenterContainer
 			handleClose={ handleClose }
-			hidden={ hidden }
 			currentRoute={ currentRoute }
 			openingCoordinates={ openingCoordinates }
 		/>,

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -6,6 +6,27 @@
 $head-foot-height: 50px;
 $z-index: 99999;
 
+@layer {
+	.help-center__container {
+		transition:
+			opacity 0.5s ease-in,
+			scale 0.5s ease-in,
+			display 1.5s ease-in;
+		/* stylelint-disable-next-line property-no-unknown */
+		transition-behavior: allow-discrete;
+
+		/* stylelint-disable-next-line scss/at-rule-no-unknown */
+		@starting-style {
+			opacity: 0;
+			scale: 1.1;
+		}
+
+		&[hidden] {
+			opacity: 0;
+		}
+	}
+}
+
 .help-center {
 	.components-card.help-center__container {
 		position: fixed;
@@ -13,7 +34,6 @@ $z-index: 99999;
 		color: #000;
 		z-index: $z-index;
 		cursor: default;
-		transition: max-height 0.5s;
 
 		button.button-primary,
 		button.button-secondary {

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -6,12 +6,19 @@
 $head-foot-height: 50px;
 $z-index: 99999;
 
-@layer {
-	.help-center__container {
+.help-center {
+	.components-card.help-center__container {
+		position: fixed;
+		background-color: #fff;
+		color: #000;
+		z-index: $z-index;
+		cursor: default;
+
+		/* --- Animation styling --- */
 		transition:
 			opacity 0.5s ease-in,
 			scale 0.5s ease-in,
-			display 1.5s ease-in;
+			display 0.5s ease-in;
 		/* stylelint-disable-next-line property-no-unknown */
 		transition-behavior: allow-discrete;
 
@@ -23,17 +30,9 @@ $z-index: 99999;
 
 		&[hidden] {
 			opacity: 0;
+			display: none;
 		}
-	}
-}
-
-.help-center {
-	.components-card.help-center__container {
-		position: fixed;
-		background-color: #fff;
-		color: #000;
-		z-index: $z-index;
-		cursor: default;
+		/* --- End of animation styling --- */
 
 		button.button-primary,
 		button.button-secondary {
@@ -241,38 +240,6 @@ $z-index: 99999;
 			font-size: $font-body-small;
 			color: $studio-gray-50;
 			margin: 0;
-		}
-	}
-
-	@keyframes fadeIn {
-		0% {
-			opacity: 0;
-		}
-
-		100% {
-			opacity: 1;
-		}
-	}
-
-	@keyframes slideIn {
-		0% {
-			opacity: 0;
-			transform: scale(0);
-		}
-
-		100% {
-			opacity: 1;
-			transform: scale(1);
-		}
-	}
-
-	@keyframes fadeOut {
-		0% {
-			opacity: 1;
-		}
-
-		100% {
-			opacity: 0;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8831

## Proposed Changes

1. Switch `isVisible` state for `renderContainer`.
2. Give the rendering power to `renderContainer` and toggle it after `isHelpCenterShown` is false and the animation has ended.
3. Use the `hidden` property to return null in the main Help Center component rather than passing in to the container.
4. Add `@starting-style` and `transition-behavior` to mange the animation.
5. Remove leftover styles from the previous animation.

## Why are these changes being made?

There are 2 issues being addressed in this PR:

1. From certain pages the Help Center animation was flipped to animate IN while closing.
2. The animation does not occur when toggling the Help Center icon.

The current version of the Help Center had 2 different states that functioned apart from each other to manage the animation and rendering of the container. This is what I believe led to both issues. By connecting the two states we offer a more consistent experience.

## Testing Instructions

1. Using the live link go to `/home`.
6. Open the Help Center
7. Navigate to Domains in WordPress.com
8. Close Help Center
9. Navigate to random pages and editor.
10. We should not see any stuttering animation on close and no regressions.

Be sure to try the same in production to verify you can see this bug.