### PR TITLE
Payment methods: Adjust styling to right align on tablet desktop

### DIFF
--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -139,15 +139,23 @@
 
 .payment-method-backup-toggle {
 	grid-area: payment-method-backup;
-	margin-left: 76px;
-	margin-top: 6px;
+	margin-inline-start: 76px;
+	margin-top: 16px;
 	width: 100%;
+
+	& .components-checkbox-control [data-wp-component="HStack"] {
+		justify-content: start;
+	}
 
 	@include breakpoint-deprecated( ">480px" ) {
 		margin-left: 0;
 		margin-top: 0;
 		text-align: right;
 		width: auto;
+
+		& .components-checkbox-control [data-wp-component="HStack"] {
+			justify-content: end;
+		}
 	}
 }
 


### PR DESCRIPTION
The 'Use as backup' text is incorrectly left aligned on tablet and desktop views:

| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/21e5304f-d809-4e79-9304-760ebfce2d4b) | ![image](https://github.com/user-attachments/assets/6d259816-6432-4a4b-a558-6969b1e1b1f6) |


Related to #93710 

## Proposed Changes

* Update the styles to right align the text on desktop and tablet, and left align (with margin) on mobile

## Testing

- Go to `http://calypso.localhost:3000/purchases/payment-methods/[your-site]` and ensure the 'Use as backup text' is right aligned.
- Check on mobile
- Also check on RTL languages (I haven't checked this yet but will update shortly)