### PR TITLE
Email Onboarding: Fix price stuck at "Loading..."

### DIFF
--- a/client/components/emails/email-signup-titan-card/index.jsx
+++ b/client/components/emails/email-signup-titan-card/index.jsx
@@ -84,7 +84,7 @@ class EmailSignupTitanCard extends Component {
 
 		return (
 			<>
-				<QueryProductsList type="titan" />
+				<QueryProductsList />
 				<Card className={ classes } compact>
 					{ this.renderEmailSuggestion( domainItem ) }
 					{ wrapDivActionContainer(

--- a/client/components/emails/email-signup-titan-card/index.jsx
+++ b/client/components/emails/email-signup-titan-card/index.jsx
@@ -6,6 +6,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import tip from 'calypso/components/domains/register-domain-step/tip';
 import EmailProductPrice from 'calypso/components/emails/email-product-price';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
@@ -83,6 +84,7 @@ class EmailSignupTitanCard extends Component {
 
 		return (
 			<>
+				<QueryProductsList type="titan" />
 				<Card className={ classes } compact>
 					{ this.renderEmailSuggestion( domainItem ) }
 					{ wrapDivActionContainer(

--- a/client/signup/steps/emails/test/index.js
+++ b/client/signup/steps/emails/test/index.js
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import EmailSignupTitanCard from '../index.jsx';
+
+const initialState = {
+	flowName: 'test:flow',
+	stepName: 'test:step2',
+	sites: {
+		items: {
+			1: {},
+		},
+	},
+	ui: {},
+	productsList: {
+		isFetching: false,
+	},
+};
+
+describe( 'Email Step Titan Signup Card', () => {
+	test( 'should display price information', () => {
+		const newInitialState = {
+			...initialState,
+			sites: {
+				...initialState.sites,
+				items: {
+					1: {
+						...initialState.sites.items[ 1 ],
+					},
+				},
+			},
+		};
+		const middlewares = [ thunk ];
+		const mockStore = configureStore( middlewares );
+		const store = mockStore( newInitialState );
+
+		render(
+			<Provider store={ store }>
+				<EmailSignupTitanCard { ...newInitialState } />
+			</Provider>
+		);
+
+		expect( screen.getByText( 'Add' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Loading...' ) ).toBeNull();
+	} );
+} );

--- a/client/signup/steps/emails/test/index.js
+++ b/client/signup/steps/emails/test/index.js
@@ -46,6 +46,6 @@ describe( 'Email Step Titan Signup Card', () => {
 		);
 
 		expect( screen.getByText( 'Add' ) ).toBeInTheDocument();
-		expect( screen.queryByText( 'Loading...' ) ).toBeNull();
+		expect( screen.queryByText( 'Loading…' ) ).toBeNull();
 	} );
 } );

--- a/client/signup/steps/emails/test/index.tsx
+++ b/client/signup/steps/emails/test/index.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';

--- a/client/signup/steps/emails/test/index.tsx
+++ b/client/signup/steps/emails/test/index.tsx
@@ -7,8 +7,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import * as useQueryProductsList from 'calypso/components/data/query-products-list';
-import EmailSignupTitanCard from '../index.jsx';
+import * as queryProductsList from 'calypso/components/data/query-products-list';
+import EmailStep from '../index';
 
 const initialState = {
 	flowName: 'test:flow',
@@ -24,34 +24,23 @@ const initialState = {
 	},
 };
 
-const productListQuerySpy = jest.spyOn( useQueryProductsList, 'default' );
+const productListQuerySpy = jest.spyOn( queryProductsList, 'default' );
 
-describe( 'Email Step Titan Signup Card', () => {
+describe( 'Email Step', () => {
 	test( 'should request a complete product list', () => {
-		const newInitialState = {
-			...initialState,
-			sites: {
-				...initialState.sites,
-				items: {
-					1: {
-						...initialState.sites.items[ 1 ],
-					},
-				},
-			},
-		};
 		const middlewares = [ thunk ];
 		const mockStore = configureStore( middlewares );
-		const store = mockStore( newInitialState );
+		const store = mockStore( initialState );
 
 		render(
 			<Provider store={ store }>
-				<EmailSignupTitanCard { ...newInitialState } />
+				<EmailStep flowName="test:flow" stepName="test:step2" />
 			</Provider>
 		);
 
-		expect( productListQuerySpy ).toHaveBeenCalled();
 		// An empty first argument means we're fetching all products, so we'll
-		// have access to email product data.
-		expect( productListQuerySpy.mock.calls[ 0 ][ 0 ] ).toStrictEqual( {} );
+		// have access to email product data. The second empty prop represents
+		// the React children (we have none).
+		expect( productListQuerySpy ).toHaveBeenCalledWith( {}, {} );
 	} );
 } );

--- a/client/signup/steps/emails/test/index.tsx
+++ b/client/signup/steps/emails/test/index.tsx
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import * as useQueryProductsList from 'calypso/components/data/query-products-list';
 import EmailSignupTitanCard from '../index.jsx';
 
 const initialState = {
@@ -23,8 +24,10 @@ const initialState = {
 	},
 };
 
+const productListQuerySpy = jest.spyOn( useQueryProductsList, 'default' );
+
 describe( 'Email Step Titan Signup Card', () => {
-	test( 'should display price information', () => {
+	test( 'should request a complete product list', () => {
 		const newInitialState = {
 			...initialState,
 			sites: {
@@ -46,7 +49,9 @@ describe( 'Email Step Titan Signup Card', () => {
 			</Provider>
 		);
 
-		expect( screen.getByText( 'Add' ) ).toBeInTheDocument();
-		expect( screen.queryByText( 'Loading…' ) ).toBeNull();
+		expect( productListQuerySpy ).toHaveBeenCalled();
+		// An empty first argument means we're fetching all products, so we'll
+		// have access to email product data.
+		expect( productListQuerySpy.mock.calls[ 0 ][ 0 ] ).toStrictEqual( {} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8261-gh-Automattic/dotcom-forge

## Proposed Changes

- Request a titan-specific product list for the email step of the onboarding flow
- Add unit test to prevent this type of regression in the future

## Why are these changes being made?

Prior to this change, the price would stay stuck at the "Loading..." state. This appears to have been introduced by https://github.com/Automattic/wp-calypso/pull/89716, which added `type='domains'` to the `QueryProductsList` instance rendered during the domains step of onboarding. The goal here was to optimize the request, and only retrieve the products needed for that step.

There have been reports of this bug not being 100% reproducible, but it was _very_ consistent for me. I'm tempted to attribute cases where the price still loaded to caching somewhere from a previous trip through this flow, but that's just a theory.

Because the email step wasn't rendering its own `QueryProductsList`, the list of products stored in state contained only domain related products, and the yearly titan product slug wasn't found. This returned a `null` value for the product and left us with now price data to show customers.

In the spirit of the same optimization as the PR mentioned above, I'd hoped to limit this new request to titan products only, but it turns out Titan products don't have a value set for `productType`, so we'll have to use grab all products for now.  Either way, the next step (plans) makes its own `QueryProductsList`, so it will not be negatively effected by changes to the product list made in the email step.

It's worth noting that the plans step doesn't limit the product type at all, and could perhaps benefit from the same optimization... or, we could look into making a single all-products request at the beginning of onboarding, and then remove subsequent requests from the individual steps... basically instead of requesting products every step of the way, we'd just make One Request To Rule Them All™. There may be reasons that wouldn't work that I'm not familiar with yet, but that feels like a broader conversation for a different issue/PR.

## Testing Instructions

- Start at the beginning of the affected flow: https://wordpress.com/professional-email/. You can also just start at `https://wordpress.com/start/onboarding-with-email/mailbox` to skip the email/account creation step, but I like the full flow for thoroughness. I'm a nerd like that.
- If you do the full flow, enter a new email address, otherwise, skip to the next step
- Enter and select a domain name. We aren't actually going to register it.
- On the email step ("Add Professional Email" at the top of the page), verify that the price and free trial info are displayed correctly
- Click the **Add** button to add email to your new site
- On the next page (the Plans step) confirm that the Plans comparison table loads as expected (this verifies that our change to the previous step isn't disrupting the next step in the flow)