### PR TITLE
Admin bar: convert Help Center icon from svg to mask so that it follows color scheme

### DIFF
--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -52,6 +52,32 @@
 		padding: 0;
 		width: 43px;
 
+		.ab-item {
+			padding: 0 10px;
+		}
+
+		.ab-icon::before {
+			display: block;
+			content: "";
+			background-image: none;
+			background-color: currentColor;
+			height: 22px;
+			width: 22px;
+			top: 1px;
+			left: 1px;
+			mask-size: contain;
+			mask-position: center;
+			mask-repeat: no-repeat;
+		}
+
+		#help-center-icon.ab-icon::before {
+			mask-image: url(data:image/svg+xml;base64,PHN2ZyBpZD0iaGVscC1jZW50ZXItaWNvbiIgY2xhc3M9ImFiLWljb24iIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgoJPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDJDNi40NzcgMiAyIDYuNDc3IDIgMTJzNC40NzcgMTAgMTAgMTAgMTAtNC40NzcgMTAtMTBTMTcuNTIzIDIgMTIgMnptLTEgMTZ2LTJoMnYyaC0yem0yLTN2LTEuMTQxQTMuOTkxIDMuOTkxIDAgMDAxNiAxMGE0IDQgMCAwMC04IDBoMmMwLTEuMTAzLjg5Ny0yIDItMnMyIC44OTcgMiAyLS44OTcgMi0yIDJhMSAxIDAgMDAtMSAxdjJoMnoiIC8+Cjwvc3ZnPgo=);
+		}
+
+		#help-center-icon-with-notification.ab-icon::before {
+			mask-image: url(data:image/svg+xml;base64,PHN2ZyBpZD0iaGVscC1jZW50ZXItaWNvbi13aXRoLW5vdGlmaWNhdGlvbiIgY2xhc3M9ImFiLWljb24iIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgoJPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDJDNi40NzcgMiAyIDYuNDc3IDIgMTJzNC40NzcgMTAgMTAgMTAgMTAtNC40NzcgMTAtMTBTMTcuNTIzIDIgMTIgMnptLTEgMTZ2LTJoMnYyaC0yem0yLTN2LTEuMTQxQTMuOTkxIDMuOTkxIDAgMDAxNiAxMGE0IDQgMCAwMC04IDBoMmMwLTEuMTAzLjg5Ny0yIDItMnMyIC44OTcgMiAyLS44OTcgMi0yIDJhMSAxIDAgMDAtMSAxdjJoMnoiIC8+Cgk8Y2lyY2xlIGN4PSIxOC41IiBjeT0iNi41IiByPSIzIiBmaWxsPSJ2YXIoIC0tY29sb3ItbWFzdGVyYmFyLXVucmVhZC1kb3QtYmFja2dyb3VuZCwgI2UyNmY1NiApIiBzdHJva2U9IndoaXRlIi8+Cjwvc3ZnPgoK);
+		}
+
 		#help-center-icon-with-notification {
 			display: none;
 		}


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/8821

## Proposed Changes

This PR converts the Help Center icon from svg to mask. This is the only icon in the wp-admin admin bar which still uses SVG.

The benefit is that it will automatically uses the current admin color scheme correctly, whether on admin screens or on frontend one. It's because WP color scheme CSS files provide native styling for icons as `.ab-icon::before`.

Note that this only affect wp-admin screens. Calypso screens use a different help center component to show the icon.

Because of the separate deployment between the widget and the corresponding Jetpack code, we will first provide the new mask. Later, we can remove the old SVG code.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Help Center icon has mismatched color on frontend admin bar.

## Testing Instructions

In this PR instructions, we will just make sure that there's no regression with this added CSS.

1. Prepare a Simple Classic site.
1. Sandbox widges.wp.com and your site.
2. In your sandbox, run `install-plugin.sh hc fix-help-center-icon-svg`
3. Disable cache on your browser to really make sure that it's downloading the latest help-center app.
4. Verify that the help center icon is still working fine both in frontend and admin screens.
5. Follow the next instructions on https://github.com/Automattic/jetpack/pull/39011

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
