### PR TITLE
Uniframe the editor

### DIFF
--- a/client/state/selectors/get-editor-url.ts
+++ b/client/state/selectors/get-editor-url.ts
@@ -24,6 +24,10 @@ export const getEditorUrl = (
 			url = addQueryArgs( { calypsoify: '1' }, url );
 		}
 
+		if ( typeof window !== 'undefined' && window.location.origin !== 'https://wordpress.com' ) {
+			url = addQueryArgs( { calypso_origin: window.location.origin }, url );
+		}
+
 		return url;
 	}
 

--- a/client/state/selectors/should-load-gutenframe.js
+++ b/client/state/selectors/should-load-gutenframe.js
@@ -1,7 +1,9 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
 import { getPreferredEditorView } from 'calypso/state/selectors/get-preferred-editor-view';
 
 export const shouldLoadGutenframe = ( state, siteId, postType = 'post' ) =>
+	isEnabled( 'block-editor/iframe' ) &&
 	isEligibleForGutenframe( state, siteId ) &&
 	getPreferredEditorView( state, siteId, postType ) === 'default';
 

--- a/config/production.json
+++ b/config/production.json
@@ -27,6 +27,7 @@
 		"calypso/ai-assembler": false,
 		"calypso/big-sky": false,
 		"bilmur-script": true,
+		"block-editor/iframe": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -21,6 +21,7 @@
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/collect-credentials": true,
+		"block-editor/iframe": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": true,
 		"calypso/big-sky": true,

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -153,7 +153,7 @@ export class EditorPage {
 		// Lacking a perfect cross-site type (Simple/Atomic) way to check the loading state,
 		// it is a fairly good stand-in.
 		await Promise.all( [
-			this.page.waitForURL( /(\/post\/.+|\/page\/+|\/post-new.php)/, { timeout } ),
+			this.page.waitForURL( /(\/post.php|\/post-new.php|\/edit.php)/, { timeout } ),
 			this.page.waitForResponse( /.*posts.*/, { timeout } ),
 		] );
 	}

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -90,16 +90,6 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 			await imageBlock.upload( testFiles.imageReservedName.fullpath );
 		} );
 
-		it( `${ ImageBlock.blockName } block: upload image file using Calypso media modal `, async function () {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				ImageBlock.blockName,
-				ImageBlock.blockEditorSelector,
-				{ noSearch: true }
-			);
-			const imageBlock = new ImageBlock( page, blockHandle );
-			await imageBlock.uploadThroughMediaLibrary( testFiles.image.fullpath );
-		} );
-
 		it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
 			const blockHandle = await editorPage.addBlockFromSidebar(
 				AudioBlock.blockName,
@@ -149,10 +139,6 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 				// WP 6.6+, see https://github.com/WordPress/wordpress-develop/commit/2358de1767168232ff0e7c17e550b8a99f96002e
 				ImageBlock.validatePublishedContent( page, [ testFiles.imageReservedName.filename ] ),
 			] );
-		} );
-
-		it( 'Image added via Calypso modal is visible', async function () {
-			await ImageBlock.validatePublishedContent( page, [ testFiles.image.filename ] );
 		} );
 
 		it( `Audio block is visible`, async function () {

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -7,7 +7,6 @@ import {
 	TestAccount,
 	envVariables,
 	EditorPage,
-	RevisionsComponent,
 	RevisionsPage,
 	getTestAccountByFeature,
 	envToFeatureKey,
@@ -27,7 +26,6 @@ describe( `Editor: Revisions`, function () {
 	] );
 
 	let editorPage: EditorPage;
-	let revisionsComponent: RevisionsComponent;
 	let revisionsPage: RevisionsPage;
 	let page: Page;
 
@@ -60,23 +58,12 @@ describe( `Editor: Revisions`, function () {
 	} );
 
 	it( 'Select first revision', async function () {
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			revisionsPage = new RevisionsPage( page );
-			await revisionsPage.selectRevision( 1 );
-		} else {
-			revisionsComponent = new RevisionsComponent( page );
-			await revisionsComponent.selectRevision( 1 );
-		}
+		revisionsPage = new RevisionsPage( page );
+		await revisionsPage.selectRevision( 1 );
 	} );
 
 	it( 'Validate selected revision diff', async function () {
-		let revisionContent: string;
-
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			revisionContent = await page.innerText( '.revisions-diff' );
-		} else {
-			revisionContent = await page.innerText( '.editor-diff-viewer__content' );
-		}
+		const revisionContent = await page.innerText( '.revisions-diff' );
 
 		expect( revisionContent ).toContain( 'Revision 1' );
 		expect( revisionContent ).not.toContain( 'Revision 2' );
@@ -84,14 +71,12 @@ describe( `Editor: Revisions`, function () {
 	} );
 
 	it( 'Load selected revision', async function () {
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			await revisionsPage.loadSelectedRevision();
-		} else {
-			await revisionsComponent.loadSelectedRevision();
-		}
+		await revisionsPage.loadSelectedRevision();
 	} );
 
 	it( 'Validate loaded revision content', async function () {
+		await editorPage.waitUntilLoaded();
+
 		const postContent = await editorPage.getText();
 
 		expect( postContent ).toBe( 'Revision 1' );


### PR DESCRIPTION
(broken) Rebase of https://github.com/Automattic/wp-calypso/pull/87120

This needs ETK changes made in Jetpack. The [ETK changes](https://github.com/Automattic/wp-calypso/pull/87120/files?w=1#diff-bcd9934d2bfc7c88b741688a1dccf9d2fb75a48d6ac87292f95fc769213d6f98) in #87120 were rebased out since ETK was deleted from calypso in the migration to Jetpack.

Related to:

- https://github.com/Automattic/dotcom-forge/issues/5327

Also see the companion post: pfsHM7-4W-p2

## Proposed Changes

This PR removes the iframe around Post (& Page) Editor.

For now, this is done by always redirecting to the corresponding wp-admin URL when the following Calypso URLs are visited:

|Calypso URL|wp-admin URL|
|-|-|
|(create new post)<br><br>/{post,page}/:siteSlug<br>/edit/jetpack-{testimonial,portfolio}/:siteSlug|:siteSlug/wp-admin/post-new.php?post_type=:postType|
|(edit a post)<br><br>/{post,page}/:siteSlug/:postId<br>/edit/jetpack-{testimonial,portfolio}/:siteSlug/:postId|:siteSlug/wp-admin/post.php?post=:postId&action=edit|

Also, this PR makes sure that the back button in the block editor nav sidebar is pointing to the correct view of the "post listing" screen, respecting the current user's preferred style (default or classic):

<img width="604" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/63a06849-a537-4d26-ab99-4a37558d8953">

### Credit

This PR is inspired by @mattwiebe's prior arts:

- https://github.com/Automattic/wp-calypso/pull/74384
- https://github.com/Automattic/wp-calypso/pull/74801

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

(Please read the whole instructions first before testing.)

### A. Testing the URLs

1. Apply the ETK changes to your sandbox.
2. Start with a (sandboxed) Simple site.
3. Test scenarios around Post:
    1. Go to Posts.
    2. Ensure the Default view is set.
    3. Create a new post. Verify that you're redirected to the wp-admin URL.
    4. Go back by clicking the back button from the sidebar (see screenshot above). Verify that you're correctly taken to the Calypso URL.
    5. Repeat steps iii-iv above, but this time edit an existing post.
    6. Go back to Posts.
    7. Now switch to the Classic view.
    8. Repeat steps iii-v above, but this time verify that the back button takes you to the wp-admin URL.
4. Repeat step 3 above, but this time with Pages.
5. Now, prepare an Atomic site.
6. Ensure your Atomic site uses default style (Settings -> Hosting Configuration).
7. Upload the ETK artifact to the Atomic site.
8. Test steps 3-4 above in your Atomic site.
9. Enable Jetpack Testimonial & Portfolio (Settings -> Writing -> Content types)
10. Repeat step 3 with Testimonials and Portfolios.
11. Set your Atomic site to use classic style (Settings -> Hosting Configuration).
12. Repeat steps 8-10, verify that the back button always takes you to the wp-admin URL.

### B. Testing the un-iframed functionalities

While doing the testing above, take some time to test the following. Note that everything should be already fine in theory, as we already show the wp-admin URLs to users with classic view turned on, but just in case.

1. Test core Revisions functionality; verify that you see the Core version, and nothing breaks. Note that Revisions UI only shows up when you have saved the post at least 2 times.

    <img width="361" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/86a59e90-e7ed-4432-8483-9fc767efd578">

2. Test core Media Library functionality; verify that you see the Core version, and nothing breaks.

    <img width="570" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9700e469-aaef-4a9b-908c-9beec0a4a2fa">

3. Test the premium block upsell flow; verify that nothing breaks.

    <img width="453" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/52079c3c-1c50-4c9e-8755-5e5053f8b11e">

