### PR TITLE
A4A: Add a multi-user support feature flag and enable the team section in staging.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.ts
@@ -156,7 +156,8 @@ const useMainMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-			...( isSectionNameEnabled( 'a8c-for-agencies-team' )
+			...( isSectionNameEnabled( 'a8c-for-agencies-team' ) &&
+			config.isEnabled( 'a4a-multi-user-support' )
 				? [
 						{
 							icon: people,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -42,6 +42,7 @@
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": true,
+		"a4a-multi-user-support": true,
 		"hosting-overview-refinements": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -35,6 +35,7 @@
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": false,
+		"a4a-multi-user-support": true,
 		"hosting-overview-refinements": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -35,6 +35,7 @@
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": false,
+		"a4a-multi-user-support": false,
 		"hosting-overview-refinements": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -38,6 +38,7 @@
 		"a4a-partner-directory": false,
 		"a4a-hosting-page-redesign": true,
 		"a4a-dev-sites": false,
+		"a4a-multi-user-support": false,
 		"hosting-overview-refinements": true
 	},
 	"enable_all_sections": false,
@@ -56,7 +57,7 @@
 		"a8c-for-agencies-partner-directory": true,
 		"a8c-for-agencies-migrations": true,
 		"a8c-for-agencies-client": true,
-		"a8c-for-agencies-team": false
+		"a8c-for-agencies-team": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
To make it easier to confirm that the changes related to the multi-user support project are working in staging, I enabled the Team section in staging and gated the UI with a feature flag instead.

## Proposed Changes

* Enable `a8c-for-agencies-team` in staging so the route and pages are accessible.
* Add `a4a-multi-user-support` as another flag to gate the feature.

## Why are these changes being made?

* Easier way to verify if the changes went through on staging.

## Testing Instructions

* Check the changes to see if they make sense.
* Use the A4A live link and test that the 'Team' sidebar menu in A4A disappears when the feature flag is disabled. `?flags=-a4a-multi-user-support`.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
