### PR TITLE
Masterbar: fix various layout regressions

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -613,7 +613,10 @@ body.is-mobile-app-view {
 		// reset flex value on mobile
 		flex: 0 1 auto;
 		padding: 0;
-		width: 46px;
+
+		&:not(.masterbar__item--always-show-content) {
+			width: 46px;
+		}
 
 		.masterbar__item-content {
 			display: none;
@@ -658,12 +661,8 @@ body.is-mobile-app-view {
 
 		@media only screen and (max-width: 781px) {
 			padding: 0;
-		}
 
-		.gridicon {
-			width: 24px;
-			height: 24px;
-			@media only screen and (max-width: 781px) {
+			svg {
 				width: 32px;
 				height: 32px;
 			}
@@ -1241,7 +1240,7 @@ body.is-mobile-app-view {
 	svg {
 		overflow: visible;
 		@media only screen and (max-width: 781px) {
-			width: 32px;
+			width: 52px;
 			height: 32px;
 		}
 	}


### PR DESCRIPTION
There seems to be various regressions in the masterbar:

- too large wpcom icon size on smaller screen widths: caused by https://github.com/Automattic/wp-calypso/pull/93261
- too large icon gaps on smaller screen widths: caused by https://github.com/Automattic/wp-calypso/pull/93195
- weird cart icon gap: not sure how / if it is broken since the beginning.

This PR fixes the above issues.

## Proposed Changes

### >480px < 782px

- Fixed wpcom icon size
- Fixed cart icon width (gap)

|||
|-|-|
|Before|<img width="481" alt="image" src="https://github.com/user-attachments/assets/f5bc6aa4-03a2-4583-a6ed-dbb40aa3c119">|
|After|<img width="481" alt="image" src="https://github.com/user-attachments/assets/9d931edc-52d2-4a79-8327-7444a13e4c73">|
|wp-admin|<img width="481" alt="image" src="https://github.com/user-attachments/assets/931fc5ea-521e-48ae-b5d1-66cb1bc9af16">|


### <= 480px

- Fixed wpcom icon size
- Fixed icon gaps

|||
|-|-|
|Before|<img width="400" alt="image" src="https://github.com/user-attachments/assets/e36eab74-917f-4f3b-8003-dbb5eb49f7fa">|
|After|<img width="400" alt="image" src="https://github.com/user-attachments/assets/a5437b91-239d-467d-a105-0bda68b8c4f0">|
|wp-admin|<img width="400" alt="image" src="https://github.com/user-attachments/assets/3de2d92e-2cf7-4523-9265-ca226e48b8c1">|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes regressions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test various screen widths as explained above. Also test normal Desktop view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
