### PR TITLE
A4A Dev Sites: Update "Add a site now" button logic and style when no dev licenses are available

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -228,7 +228,7 @@ export default function AddNewSiteButton( {
 								setMenuVisible( false );
 							},
 						},
-						extraContent: hasAvailableDevSites ? (
+						extraContent: (
 							<div>
 								<div className="site-selector-and-importer__popover-site-count">
 									{ translate(
@@ -247,7 +247,7 @@ export default function AddNewSiteButton( {
 									{ translate( 'Create a site now →' ) }
 								</div>
 							</div>
-						) : undefined,
+						),
 					} ) }
 				</div>
 			) }

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -243,7 +243,11 @@ export default function AddNewSiteButton( {
 										}
 									) }
 								</div>
-								<div className="site-selector-and-importer__popover-development-site-cta">
+								<div
+									className={ clsx( 'site-selector-and-importer__popover-development-site-cta', {
+										disabled: ! hasAvailableDevSites,
+									} ) }
+								>
 									{ translate( 'Create a site now →' ) }
 								</div>
 							</div>

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -214,6 +214,10 @@ export default function AddNewSiteButton( {
 						isBanner: true,
 						buttonProps: {
 							onClick: () => {
+								if ( ! hasAvailableDevSites ) {
+									return;
+								}
+
 								if ( paymentMethodRequired ) {
 									page(
 										`${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_SITES_LINK }?add_new_dev_site=true`

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -168,4 +168,8 @@
 	padding-top: 12px;
 	font-size: rem(12px);
 	font-weight: 600;
+
+	&.disabled {
+		color: var(--color-accent-20);
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/8601.

## Proposed Changes

When there are no free dev sites licenses available:
* gray out the "Add a site now" button
* make the whole third column dedicated to creating new dev sites unclickable

![Markup on 2024-08-22 at 11:38:39](https://github.com/user-attachments/assets/8050a09c-5c20-4e48-9feb-c40f98cb973e)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR locally.
2. Make the following temporary change to simulate reaching the limit of available dev sites: 

```diff
diff --git a/client/a8c-for-agencies/components/add-new-site-button/index.tsx b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
index 75338647fd1..2b5ae6f8697 100644
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -115,8 +115,8 @@ export default function AddNewSiteButton( {
 
 	const hasPendingWPCOMSites = allAvailableSites.length > 0;
 
-	const availableDevSites = devLicenses?.available;
-	const hasAvailableDevSites = devLicenses?.available > 0;
+	const availableDevSites = 0;
+	const hasAvailableDevSites = false;
 
 	const popoverContent = (
 		<div className="site-selector-and-importer__popover-content">

```

3. Build the app with `yarn start-a8c-for-agencies`.
4. Head over to the Sites section at http://agencies.localhost:3000/sites/?flags=a4a-dev-sites.
5. Click on the "Add sites" button.
6. The "Add a site now" button should be grayed-out and the whole third popover column shouldn't be clickable.
7. As soon as you remove the temporary code change, it should be possible to create a free dev sites normally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?