### PR TITLE
Readonly+disable from_url field when URL is there

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -213,6 +213,8 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 									} }
 									render={ ( { field } ) => (
 										<FormTextInput
+											readOnly={ !! importSiteQueryParam }
+											disabled={ !! importSiteQueryParam }
 											id="site-address"
 											isError={ !! errors.siteAddress }
 											placeholder={ translate( 'Enter your WordPress site address.' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93797

## Proposed Changes

* when users come to the migration form, they've already given input to the URL earlier in the flow, so we disable it here.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To have one less thing to input

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch to your local environment or add use the Calypso Live link below.
- Open the dev console and activate the feature flag by running the following command:
window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')
- Now get into the flow using the /start URL
- Go through the domain selection step
- Select the free plan on the Plans page
- On the Goals step, select the "Import existing content or website" option and click continue
- Input the source site URL in the Identify step
- Next, select the "Migrate Site" option on the Import or Migrate step
- Select "Do it for me" on the How to migrate step
- Go through the checkout
- Once you complete the checkout, you should land on the new Credentials step
- Make sure the Site Address is populated and disabled
- Also, switch to backup URL mode by using the radio button
- You should be able to write an URL, it shouldn't be disabled
- Remove the "from" param from the URL and reload the migration form
- You should be able to manually add the site address now

<img width="807" alt="image" src="https://github.com/user-attachments/assets/245eb87f-a029-48d8-8438-8ad337c47d22">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
