### PR TITLE
Update HistoryGraph date formats

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -133,7 +133,7 @@ export type ScreenShotsTimeLine = {
 };
 
 export type PerformanceMetricsHistory = {
-	collection_period: string[];
+	collection_period: Array< string | { year: number; month: number; day: number } >;
 	metrics: {
 		ttfb?: number[];
 		fcp?: number[];

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -61,7 +61,7 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 
 	const dataAvailable = metrics.length > 0 && metrics.some( ( item ) => item !== null );
 	const historicalData = metrics.map( ( item, index ) => {
-		let formattedDate: string = '';
+		let formattedDate: unknown;
 		if ( typeof dates[ index ] === 'string' ) {
 			formattedDate = dates[ index ]; // this is to ensure compability with reports before https://code.a8c.com/D159137
 		} else {

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -62,10 +62,11 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 	const dataAvailable = metrics.length > 0 && metrics.some( ( item ) => item !== null );
 	const historicalData = metrics.map( ( item, index ) => {
 		let formattedDate: unknown;
-		if ( typeof dates[ index ] === 'string' ) {
-			formattedDate = dates[ index ]; // this is to ensure compability with reports before https://code.a8c.com/D159137
+		const date = dates[ index ];
+		if ( 'string' === typeof date ) {
+			formattedDate = date; // this is to ensure compability with reports before https://code.a8c.com/D159137
 		} else {
-			const { year, month, day } = dates[ index ];
+			const { year, month, day } = date;
 			formattedDate = `${ year }-${ month }-${ day }`;
 		}
 

--- a/client/performance-profiler/components/core-web-vitals-display/index.tsx
+++ b/client/performance-profiler/components/core-web-vitals-display/index.tsx
@@ -61,8 +61,16 @@ export const CoreWebVitalsDisplay = ( props: CoreWebVitalsDisplayProps ) => {
 
 	const dataAvailable = metrics.length > 0 && metrics.some( ( item ) => item !== null );
 	const historicalData = metrics.map( ( item, index ) => {
+		let formattedDate: string = '';
+		if ( typeof dates[ index ] === 'string' ) {
+			formattedDate = dates[ index ]; // this is to ensure compability with reports before https://code.a8c.com/D159137
+		} else {
+			const { year, month, day } = dates[ index ];
+			formattedDate = `${ year }-${ month }-${ day }`;
+		}
+
 		return {
-			date: dates[ index ],
+			date: formattedDate,
 			value: formatUnit( item ),
 		};
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8841

## Proposed Changes

* Parse the new date format returned from the backend
* Fall back to the old date format for earlier submissions

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/8841

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to D159137-code, apply the patch and sandbox `public-api`
* Go to `/speed-test` and start a new test for a site
* Wait for the test to finish, and check that the history graph renders correctly
* [Regression] Check an earlier submission and check that the history graph renders correctly (eg. /speed-test-tool?url=https%3A%2F%2Fpost.li%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzAxOX0.674sYJm97Jfd546XiOCWuzg3vE88WwMOFRAvBsyCk5U)
* For both kinds of submissions, the history graph should show the dates on the X axis correctly, and the data points should render as well

![CleanShot 2024-08-22 at 12 04 00@2x](https://github.com/user-attachments/assets/936642f5-5738-4b12-89c2-5465a7f2eeb7)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?