### PR TITLE
Reader: post author & subscribe button on smaller screen sizes

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -65,22 +65,23 @@ class AuthorCompactProfile extends Component {
 				<a href={ streamUrl } className="author-compact-profile__avatar-link">
 					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
 				</a>
-				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames && (
-					<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>
-						{ author.name }
-					</ReaderAuthorLink>
-				) }
-				{ siteName && (
-					<ReaderSiteStreamLink
-						className="author-compact-profile__site-link"
-						feedId={ feedId }
-						siteId={ siteId }
-						post={ post }
-					>
-						{ siteName }
-					</ReaderSiteStreamLink>
-				) }
-
+				<div className="author-compact-profile__names">
+					{ hasAuthorName && ! hasMatchingAuthorAndSiteNames && (
+						<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>
+							{ author.name }
+						</ReaderAuthorLink>
+					) }
+					{ siteName && (
+						<ReaderSiteStreamLink
+							className="author-compact-profile__site-link"
+							feedId={ feedId }
+							siteId={ siteId }
+							post={ post }
+						>
+							{ siteName }
+						</ReaderSiteStreamLink>
+					) }
+				</div>
 				<div className="author-compact-profile__follow">
 					{ followCount ? (
 						<div className="author-compact-profile__follow-count">

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -7,7 +7,7 @@ import TimeSince from 'calypso/components/time-since';
 import { recordPermalinkClick } from 'calypso/reader/stats';
 import ReaderFullPostHeaderPlaceholder from './placeholders/header';
 
-const ReaderFullPostHeader = ( { post } ) => {
+const ReaderFullPostHeader = ( { post, authorProfile } ) => {
 	const handlePermalinkClick = () => {
 		recordPermalinkClick( 'full_post_title', post );
 	};
@@ -57,6 +57,8 @@ const ReaderFullPostHeader = ( { post } ) => {
 						</a>
 					</span>
 				) : null }
+
+				{ authorProfile }
 			</div>
 			<TagsList post={ post } tagsToShow={ 5 } />
 		</div>
@@ -66,6 +68,7 @@ const ReaderFullPostHeader = ( { post } ) => {
 
 ReaderFullPostHeader.propTypes = {
 	post: PropTypes.object.isRequired,
+	children: PropTypes.node,
 };
 
 export default ReaderFullPostHeader;

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -43,6 +43,7 @@ const ReaderFullPostHeader = ( { post, authorProfile } ) => {
 					</h1>
 				</AutoDirection>
 			) : null }
+			<div className="reader-full-post__author-block">{ authorProfile }</div>
 			<div className="reader-full-post__header-meta">
 				{ post.date ? (
 					<span className="reader-full-post__header-date">
@@ -57,8 +58,6 @@ const ReaderFullPostHeader = ( { post, authorProfile } ) => {
 						</a>
 					</span>
 				) : null }
-
-				{ authorProfile }
 			</div>
 			<TagsList post={ post } tagsToShow={ 5 } />
 		</div>

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -577,7 +577,25 @@ export class FullPostView extends Component {
 							</div>
 						</div>
 						<article className="reader-full-post__story">
-							<ReaderFullPostHeader post={ post } referralPost={ referralPost } />
+							<ReaderFullPostHeader
+								post={ post }
+								referralPost={ referralPost }
+								authorProfile={
+									<AuthorCompactProfile
+										author={ post.author }
+										siteIcon={ get( site, 'icon.img' ) }
+										feedIcon={ feedIcon }
+										siteName={ siteName }
+										siteUrl={ post.site_URL }
+										feedUrl={ get( post, 'feed_URL' ) }
+										followCount={ site && site.subscribers_count }
+										onFollowToggle={ this.openSuggestedFollowsModal }
+										feedId={ +post.feed_ID }
+										siteId={ +post.site_ID }
+										post={ post }
+									/>
+								}
+							/>
 
 							{ post.featured_image && ! isFeaturedImageInContent( post ) && (
 								<ReaderFeaturedImage

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -192,6 +192,138 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 }
 
+.reader-full-post .author-compact-profile {
+	display: inline-flex;
+	flex-direction: column;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		margin-bottom: 35px;
+		padding-right: 10px;
+		position: relative;
+		text-overflow: clip;
+		white-space: nowrap;
+
+		&::after {
+			height: 40px;
+		}
+
+		&:not(.is-placeholder)::after {
+			@include long-content-fade( $size: 15% );
+		}
+	}
+
+	.reader-author-link {
+		margin-top: 0;
+	}
+
+	@include breakpoint-deprecated( "<660px" ) {
+		flex-direction: row;
+		margin-top: 20px;
+
+		.reader-avatar {
+			flex: 1;
+			margin: 0 0 0 -9px;
+
+			&.has-site-and-author-icon,
+			&.has-site-icon,
+			&.has-gravatar {
+				margin: 0 10px 5px 0;
+			}
+
+			&.has-gravatar {
+				.gravatar {
+					height: 32px !important;
+					width: 32px !important;
+					max-width: none;
+				}
+			}
+
+			&.has-site-and-author-icon.has-site-icon.has-gravatar {
+				margin-bottom: -15px;
+
+				.gravatar {
+					height: 24px !important;
+					margin-right: 1em;
+					position: relative;
+					left: 18px;
+					top: -18px;
+					vertical-align: bottom;
+					width: 24px !important;
+				}
+			}
+
+			.site-icon {
+				height: 32px !important;
+				width: 32px !important;
+				line-height: 32px !important;
+				font-size: rem(32px) !important;
+
+				.gridicon {
+					@include breakpoint-deprecated( "<660px" ) {
+						height: 32px !important;
+						width: 32px !important;
+						line-height: 32px !important;
+						font-size: rem(32px) !important;
+					}
+				}
+			}
+		}
+
+		.reader-author-link {
+			font-weight: 600;
+			display: inline;
+			margin-right: 5px;
+
+			&::after {
+				content: ",";
+				font-weight: 400;
+			}
+		}
+
+		.author-compact-profile__site-link {
+			flex: 1 0 0;
+			display: inline;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				margin-top: 0;
+			}
+		}
+
+		.reader-author-link,
+		.author-compact-profile__site-link {
+			padding-top: 5px;
+		}
+
+		.author-compact-profile__follow .follow-button {
+			position: fixed;
+			left: calc(100% - 270px);
+			top: 5px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				background: transparent;
+				position: fixed;
+				z-index: z-index(".reader-full-post__sidebar-comment-like", ".author-compact-profile__follow .follow-button");
+
+				.gridicon {
+					height: 24px;
+					top: 7px;
+					width: 24px;
+				}
+			}
+		}
+
+		.author-compact-profile__follow-count {
+			display: none;
+		}
+
+		.author-compact-profile__follow .follow-button__label {
+			@include breakpoint-deprecated( "<660px" ) {
+				display: none;
+			}
+		}
+	}
+}
+
 .reader-full-post .reader-full-post__sidebar {
 	color: var(--color-text-subtle);
 
@@ -371,17 +503,11 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 }
 
-
 .reader-full-post__header-meta {
 	display: flex;
 	flex-direction: row;
 	font-size: $font-body;
 	max-width: 750px;
-	align-items: center;
-
-	.reader-full-post__header-date {
-		white-space: nowrap;
-	}
 }
 
 .reader-full-post__header-date {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -681,10 +681,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 			text-overflow: clip;
 			white-space: nowrap;
 
-			//&:not(.has-author-link).has-author-icon {
-			//	margin-left: -17px;
-			//}
-
 			&:not(.has-author-icon).has-author-link {
 				grid-template-areas:
 					"links"
@@ -706,7 +702,14 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 			}
 
 			.reader-avatar {
-				margin: 0 10px 5px 0;
+				margin: 0 10px 5px 0 !important;
+				position: relative;
+				top: 2px;
+
+				@include breakpoint-deprecated( "<480px" ) {
+					position: relative;
+					top: 5px;
+				}
 
 				&:not(.has-site-and-author-icon) img {
 					margin-left: -17px;
@@ -747,6 +750,10 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				}
 
 				.reader-author-link {
+					@include breakpoint-deprecated( "<480px" ) {
+						display: none;
+					}
+
 					&::after {
 						content: ", ";
 						font-weight: 400;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -599,7 +599,9 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 					display: inline;
 					margin-right: 5px;
 					padding-top: 0;
+				}
 
+				.reader-author-link {
 					&::after {
 						content: ", ";
 						font-weight: 400;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -676,7 +676,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				"avatar follow";
 			column-gap: 5px;
 			row-gap: 5px;
-			margin-top: 20px;
+			margin: 20px 0 0 0;
 			padding-right: 10px;
 			text-overflow: clip;
 			white-space: nowrap;
@@ -742,6 +742,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 					grid-area: links;
 					display: inline;
 					padding-top: 0;
+					margin-right: 0;
 				}
 
 				.reader-author-link {
@@ -761,9 +762,18 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				margin-top: 0;
 				flex-wrap: inherit;
 
+				.author-compact-profile__follow-count{
+					display: inline-block;
+				}
+
 				.author-compact-profile__follow-count,
 				.follow-button {
 					padding: 5px 5px 5px 0;
+					position: initial;
+
+					&__label {
+						display: inline-block;
+					}
 				}
 			}
 		}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -542,6 +542,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				width: 16px !important;
 				height: 16px !important;
 				line-height: 16px !important;
+				font-size: rem(16px) !important;
 				margin-right: 4px;
 			}
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -762,7 +762,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				margin-top: 0;
 				flex-wrap: inherit;
 
-				.author-compact-profile__follow-count{
+				.author-compact-profile__follow-count {
 					display: inline-block;
 				}
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -192,138 +192,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 }
 
-.reader-full-post .author-compact-profile {
-	display: inline-flex;
-	flex-direction: column;
-
-	@include breakpoint-deprecated( "<660px" ) {
-		margin-bottom: 35px;
-		padding-right: 10px;
-		position: relative;
-		text-overflow: clip;
-		white-space: nowrap;
-
-		&::after {
-			height: 40px;
-		}
-
-		&:not(.is-placeholder)::after {
-			@include long-content-fade( $size: 15% );
-		}
-	}
-
-	.reader-author-link {
-		margin-top: 0;
-	}
-
-	@include breakpoint-deprecated( "<660px" ) {
-		flex-direction: row;
-		margin-top: 20px;
-
-		.reader-avatar {
-			flex: 1;
-			margin: 0 0 0 -9px;
-
-			&.has-site-and-author-icon,
-			&.has-site-icon,
-			&.has-gravatar {
-				margin: 0 10px 5px 0;
-			}
-
-			&.has-gravatar {
-				.gravatar {
-					height: 32px !important;
-					width: 32px !important;
-					max-width: none;
-				}
-			}
-
-			&.has-site-and-author-icon.has-site-icon.has-gravatar {
-				margin-bottom: -15px;
-
-				.gravatar {
-					height: 24px !important;
-					margin-right: 1em;
-					position: relative;
-					left: 18px;
-					top: -18px;
-					vertical-align: bottom;
-					width: 24px !important;
-				}
-			}
-
-			.site-icon {
-				height: 32px !important;
-				width: 32px !important;
-				line-height: 32px !important;
-				font-size: rem(32px) !important;
-
-				.gridicon {
-					@include breakpoint-deprecated( "<660px" ) {
-						height: 32px !important;
-						width: 32px !important;
-						line-height: 32px !important;
-						font-size: rem(32px) !important;
-					}
-				}
-			}
-		}
-
-		.reader-author-link {
-			font-weight: 600;
-			display: inline;
-			margin-right: 5px;
-
-			&::after {
-				content: ",";
-				font-weight: 400;
-			}
-		}
-
-		.author-compact-profile__site-link {
-			flex: 1 0 0;
-			display: inline;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				margin-top: 0;
-			}
-		}
-
-		.reader-author-link,
-		.author-compact-profile__site-link {
-			padding-top: 5px;
-		}
-
-		.author-compact-profile__follow .follow-button {
-			position: fixed;
-			left: calc(100% - 270px);
-			top: 5px;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				background: transparent;
-				position: fixed;
-				z-index: z-index(".reader-full-post__sidebar-comment-like", ".author-compact-profile__follow .follow-button");
-
-				.gridicon {
-					height: 24px;
-					top: 7px;
-					width: 24px;
-				}
-			}
-		}
-
-		.author-compact-profile__follow-count {
-			display: none;
-		}
-
-		.author-compact-profile__follow .follow-button__label {
-			@include breakpoint-deprecated( "<660px" ) {
-				display: none;
-			}
-		}
-	}
-}
-
 .reader-full-post .reader-full-post__sidebar {
 	color: var(--color-text-subtle);
 
@@ -516,77 +384,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 }
 
-/* Mini profile in header */
-.reader-full-post {
-	.reader-full-post__header-meta {
-		@include breakpoint-deprecated( "<660px" ) {
-			flex-wrap: wrap;
-		}
-
-		.author-compact-profile {
-			flex-direction: row;
-			line-height: 1.6;
-
-			@media (min-width: $reader-full-post-desktop-min) {
-				display: none;
-			}
-
-			@include breakpoint-deprecated( "<660px" ) {
-				margin-bottom: 0;
-				margin-top: 0;
-				flex-wrap: wrap;
-				align-items: center;
-			}
-
-			.reader-avatar .site-icon {
-				width: 16px !important;
-				height: 16px !important;
-				line-height: 16px !important;
-				font-size: rem(16px) !important;
-				margin-right: 4px;
-			}
-
-			&__avatar-link {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				flex-shrink: 0;
-			}
-
-			.reader-avatar {
-				margin-bottom: 0;
-
-				@include breakpoint-deprecated( "<660px" ) {
-					margin: 0;
-					margin-right: 5px;
-				}
-			}
-
-			&__site-link {
-				margin-right: 25px;
-
-				@include breakpoint-deprecated( "<660px" ) {
-					padding-top: 0;
-					margin-right: 5px;
-					flex: 0;
-				}
-			}
-
-			.author-compact-profile__follow {
-				margin: 0;
-			}
-
-			.follow-button {
-				@include breakpoint-deprecated( "<660px" ) {
-					position: static;
-					left: auto;
-					top: auto;
-				}
-			}
-		}
-	}
-}
-
 .reader-full-post__header-date {
 	line-height: 1.6;
 
@@ -741,4 +538,87 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 .is-reader-full-post {
 	background: var(--color-surface);
+}
+
+.reader-full-post {
+	.reader-full-post__author-block {
+		.author-compact-profile {
+			display: grid;
+			grid-template-columns: auto 1fr;
+			grid-template-areas:
+				"avatar links"
+				"avatar follow";
+			column-gap: 5px;
+			margin-top: 20px;
+
+			&:not(.has-author-link) {
+				margin-left: -17px;
+			}
+
+			@media (min-width: 1300px) {
+				display: none;
+			}
+
+			&__avatar-link {
+				grid-area: avatar;
+			}
+
+			.reader-avatar {
+				margin: 0 10px 5px 0;
+
+				&:not(.has-site-and-author-icon) img {
+					top: 5px;
+				}
+
+				.gravatar {
+					height: 24px;
+					width: 24px;
+					margin-right: 1em;
+					position: relative;
+					left: 18px;
+					top: -18px;
+					vertical-align: bottom;
+				}
+
+				.site-icon {
+					height: 32px !important;
+					width: 32px !important;
+					line-height: 32px !important;
+					font-size: rem(32px) !important;
+					margin: 0 2px;
+				}
+			}
+
+			&__names {
+				position: relative;
+				top: -2px;
+
+				.reader-author-link,
+				.author-compact-profile__site-link {
+					grid-area: links;
+					display: inline;
+					margin-right: 5px;
+					padding-top: 0;
+
+					&::after {
+						content: ", ";
+						font-weight: 400;
+						white-space: pre;
+					}
+				}
+			}
+
+			&__follow {
+				grid-area: follow;
+				justify-content: initial;
+				position: relative;
+				top: -12px;
+				margin-top: 0;
+
+				.author-compact-profile__follow-count {
+					padding: 5px 5px 5px 0;
+				}
+			}
+		}
+	}
 }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -503,11 +503,87 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	}
 }
 
+
 .reader-full-post__header-meta {
 	display: flex;
 	flex-direction: row;
 	font-size: $font-body;
 	max-width: 750px;
+	align-items: center;
+
+	.reader-full-post__header-date {
+		white-space: nowrap;
+	}
+}
+
+/* Mini profile in header */
+.reader-full-post {
+	.reader-full-post__header-meta {
+		@include breakpoint-deprecated( "<660px" ) {
+			flex-wrap: wrap;
+		}
+
+		.author-compact-profile {
+			flex-direction: row;
+			line-height: 1.6;
+
+			@media (min-width: $reader-full-post-desktop-min) {
+				display: none;
+			}
+
+			@include breakpoint-deprecated( "<660px" ) {
+				margin-bottom: 0;
+				margin-top: 0;
+				flex-wrap: wrap;
+				align-items: center;
+			}
+
+			.reader-avatar .site-icon {
+				width: 16px !important;
+				height: 16px !important;
+				line-height: 16px !important;
+				margin-right: 4px;
+			}
+
+			&__avatar-link {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				flex-shrink: 0;
+			}
+
+			.reader-avatar {
+				margin-bottom: 0;
+
+				@include breakpoint-deprecated( "<660px" ) {
+					margin: 0;
+					margin-right: 5px;
+				}
+			}
+
+			&__site-link {
+				margin-right: 25px;
+
+				@include breakpoint-deprecated( "<660px" ) {
+					padding-top: 0;
+					margin-right: 5px;
+					flex: 0;
+				}
+			}
+
+			.author-compact-profile__follow {
+				margin: 0;
+			}
+
+			.follow-button {
+				@include breakpoint-deprecated( "<660px" ) {
+					position: static;
+					left: auto;
+					top: auto;
+				}
+			}
+		}
+	}
 }
 
 .reader-full-post__header-date {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -549,6 +549,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				"avatar links"
 				"avatar follow";
 			column-gap: 5px;
+			row-gap: 5px;
 			margin-top: 20px;
 			padding-right: 10px;
 			text-overflow: clip;
@@ -556,6 +557,18 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 			&:not(.has-author-link).has-author-icon {
 				margin-left: -17px;
+			}
+
+			&:not(.has-author-icon).has-author-link {
+				grid-template-areas:
+					"links"
+					"follow";
+			}
+
+			&:not(.has-author-link):not(.has-author-icon) {
+				.reader-avatar {
+					margin: 5px 0 0 0;
+				}
 			}
 
 			@media (min-width: 1300px) {
@@ -570,7 +583,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				margin: 0 10px 5px 0;
 
 				&:not(.has-site-and-author-icon) img {
-					top: 5px;
+					top: 7px;
 				}
 
 				.gravatar {
@@ -602,7 +615,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				.author-compact-profile__site-link {
 					grid-area: links;
 					display: inline;
-					margin-right: 5px;
 					padding-top: 0;
 				}
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -667,7 +667,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 }
 
 .reader-full-post {
-	.reader-full-post__author-block {
+	div.reader-full-post__author-block {
 		.author-compact-profile {
 			display: grid;
 			grid-template-columns: auto 1fr;
@@ -702,7 +702,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 			}
 
 			.reader-avatar {
-				margin: 0 10px 5px 0 !important;
+				margin: 0 10px 5px 0;
 				position: relative;
 				top: 2px;
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -550,8 +550,11 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				"avatar follow";
 			column-gap: 5px;
 			margin-top: 20px;
+			padding-right: 10px;
+			text-overflow: clip;
+			white-space: nowrap;
 
-			&:not(.has-author-link) {
+			&:not(.has-author-link).has-author-icon {
 				margin-left: -17px;
 			}
 
@@ -571,16 +574,18 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				}
 
 				.gravatar {
-					height: 24px;
-					width: 24px;
+					height: 24px !important;
+					width: 24px !important;
 					margin-right: 1em;
 					position: relative;
 					left: 18px;
 					top: -18px;
 					vertical-align: bottom;
+					max-width: initial;
 				}
 
-				.site-icon {
+				.site-icon,
+				.gridicon {
 					height: 32px !important;
 					width: 32px !important;
 					line-height: 32px !important;
@@ -616,8 +621,10 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				position: relative;
 				top: -12px;
 				margin-top: 0;
+				flex-wrap: inherit;
 
-				.author-compact-profile__follow-count {
+				.author-compact-profile__follow-count,
+				.follow-button {
 					padding: 5px 5px 5px 0;
 				}
 			}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -681,9 +681,9 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 			text-overflow: clip;
 			white-space: nowrap;
 
-			&:not(.has-author-link).has-author-icon {
-				margin-left: -17px;
-			}
+			//&:not(.has-author-link).has-author-icon {
+			//	margin-left: -17px;
+			//}
 
 			&:not(.has-author-icon).has-author-link {
 				grid-template-areas:
@@ -709,6 +709,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 				margin: 0 10px 5px 0;
 
 				&:not(.has-site-and-author-icon) img {
+					margin-left: -17px;
 					top: 7px;
 				}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93781

## Proposed Changes

This PR shows the site author & subscribe button underneath the post title on smaller screen sizes.

Before | After
--|--
<img width="1227" alt="Screenshot 2024-08-30 at 12 16 09 PM" src="https://github.com/user-attachments/assets/2d0a3361-d82a-46e4-b922-9d0ff1a8cfef">  | <img width="1229" alt="Screenshot 2024-08-30 at 12 15 54 PM" src="https://github.com/user-attachments/assets/e61ef372-6eff-4147-99c8-6c73f406ecd9">

Before | After
--|--
<img width="387" alt="Screenshot 2024-08-30 at 12 17 02 PM" src="https://github.com/user-attachments/assets/0be3f83f-ae01-45e1-9c09-5fb723492e5c">  | <img width="388" alt="Screenshot 2024-08-30 at 12 16 34 PM" src="https://github.com/user-attachments/assets/8b1baae4-cbc1-4fbb-8280-48bbac427d10">



This PR probably needs some eyes from someone from design (cc @JanaMW27)

## Testing Instructions

1. Use Calypso Live
2. View a Reader post and resize your screen to various widths
3. Here is an example of header variants to test:

- /read/blogs/103780599/posts/22023
- /read/blogs/19734/posts/69499
- /read/feeds/160601169/posts/5312674212
- /read/blogs/236514021/posts/4
- /read/blogs/85208038/posts/43734

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
