### PR TITLE
Domains: refactor to reuse isDomainRenewable from domains table package

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { Button } from '@automattic/components';
+import { ResponseDomain, DomainType, TransferStatus } from '@automattic/domains-table';
+import { isDomainRenewable } from '@automattic/domains-table/src/utils/is-renewable';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -106,16 +108,13 @@ const RegisteredDomainDetails = ( {
 	};
 
 	const shouldNotRenderRenewButton = () => {
-		return (
-			! domain.subscriptionId ||
-			domain.isPendingRenewal ||
-			domain.pendingRegistrationAtRegistry ||
-			domain.pendingRegistration ||
-			! domain.currentUserCanManage ||
-			( domain.expired && ! domain.isRenewable && ! domain.isRedeemable ) ||
-			( ! isLoadingPurchase && ! purchase ) ||
-			domain.aftermarketAuction
-		);
+		const updatedDomain: ResponseDomain = {
+			...domain,
+			type: domain.type as DomainType,
+			transferStatus: domain.transferStatus as TransferStatus,
+		};
+		r;
+		return ( ! isLoadingPurchase && ! purchase ) || ! isDomainRenewable( updatedDomain );
 	};
 
 	const renderRenewButton = () => {

--- a/packages/domains-table/src/index.ts
+++ b/packages/domains-table/src/index.ts
@@ -2,4 +2,5 @@ export { DomainsTable } from './domains-table';
 export { PrimaryDomainLabel } from './primary-domain-label';
 export { useDomainsTable } from './use-domains-table';
 export type { DomainStatusPurchaseActions } from './utils/resolve-domain-status';
-export type { ResponseDomain } from './utils/types';
+export type { ResponseDomain, DomainType, TransferStatus } from './utils/types';
+export { isDomainRenewable } from './utils/is-renewable';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/93626

## Proposed Changes

* Uses `isDomainRenewable` from domains table package to avoid duplicating logic

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
