### PR TITLE
[Wapuu] Fix double scrolling glitch

### DIFF
--- a/packages/odie-client/src/context/use-load-previous-chat.ts
+++ b/packages/odie-client/src/context/use-load-previous-chat.ts
@@ -40,5 +40,5 @@ export const useLoadPreviousChat = ( {
 		}
 	}, [ botNameSlug, chatId, existingChat, loadingChat, odieInitialPromptText ] );
 
-	return { chat, isLoading };
+	return { chat, isLoading: loadingChat || isLoading };
 };

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -1,5 +1,4 @@
-import { Spinner } from '@wordpress/components';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { MessagesContainer } from './components/message/messages-container';
 import { OdieSendMessageButton } from './components/send-message-input';
 import { useOdieAssistantContext, OdieAssistantProvider } from './context';
@@ -12,9 +11,7 @@ export const ODIE_THUMBS_DOWN_RATING_VALUE = 0;
 export const ODIE_THUMBS_UP_RATING_VALUE = 1;
 
 export const OdieAssistant: React.FC = () => {
-	const { chat, trackEvent, currentUser, isLoadingEnvironment, isLoadingExistingChat } =
-		useOdieAssistantContext();
-	const [ asisstantLoaded, setAssistantLoaded ] = useState( false );
+	const { chat, trackEvent, currentUser } = useOdieAssistantContext();
 	const containerRef = useRef< HTMLDivElement >( null );
 	const messagesContainerRef = useRef< HTMLDivElement >( null );
 
@@ -25,35 +22,9 @@ export const OdieAssistant: React.FC = () => {
 	useAutoScroll( messagesContainerRef, chat.messages );
 	useLastMessageVisibility( messagesContainerRef, chat.messages.length );
 
-	useEffect( () => {
-		if ( chat.messages.length > 0 ) {
-			setAssistantLoaded( true );
-		}
-	}, [ chat.messages.length ] );
-
-	if (
-		( isLoadingEnvironment || isLoadingExistingChat ) &&
-		chat.messages.length === 0 &&
-		! asisstantLoaded
-	) {
-		return (
-			<div
-				className="chatbox"
-				style={ {
-					display: 'flex',
-					justifyContent: 'center',
-					alignItems: 'center',
-					height: '100%',
-				} }
-			>
-				<Spinner />
-			</div>
-		);
-	}
-
 	return (
 		<div className="chatbox">
-			<div className="chat-box-message-container" ref={ containerRef }>
+			<div className="chat-box-message-container" ref={ containerRef } id="odie-messages-container">
 				<MessagesContainer currentUser={ currentUser } ref={ messagesContainerRef } />
 			</div>
 			<OdieSendMessageButton containerReference={ messagesContainerRef } />

--- a/packages/odie-client/src/query/index.ts
+++ b/packages/odie-client/src/query/index.ts
@@ -277,6 +277,8 @@ export const useOdieGetChat = (
 		queryFn: () => buildGetChatMessage( botNameSlug, chatId, page, perPage, includeFeedback ),
 		refetchOnWindowFocus: false,
 		enabled: !! chatId && ! chat.chat_id,
+		// 4 hours (we update the messages when a new message is sent, so cache is not stale while we are chatting)
+		staleTime: 4 * 60 * 60 * 1000,
 	} );
 };
 
@@ -322,7 +324,6 @@ export const useOdieSendMessageFeedback = (): UseMutationResult<
 		},
 		onSuccess: ( _, { rating_value, message } ) => {
 			const queryKey = [ 'chat', botNameSlug, chat.chat_id, 1, 30, true ];
-
 			queryClient.setQueryData( queryKey, ( currentChatCache: Chat ) => {
 				if ( ! currentChatCache ) {
 					return;
@@ -331,7 +332,7 @@ export const useOdieSendMessageFeedback = (): UseMutationResult<
 				return {
 					...currentChatCache,
 					messages: currentChatCache.messages.map( ( m ) =>
-						m.internal_message_id === message.internal_message_id ? { ...m, rating_value } : m
+						m.message_id === message.message_id ? { ...m, rating_value } : m
 					),
 				};
 			} );

--- a/packages/odie-client/src/useAutoScroll.ts
+++ b/packages/odie-client/src/useAutoScroll.ts
@@ -1,15 +1,17 @@
 import { RefObject, useEffect } from 'react';
+import { useOdieAssistantContext } from './context';
 import { Message } from './types/';
 
 const useAutoScroll = (
 	messagesContainerRef: RefObject< HTMLDivElement >,
 	messages: Message[]
 ) => {
+	const { isLoadingExistingChat } = useOdieAssistantContext();
 	const lastMessage = messages[ messages.length - 1 ];
 	const lastMessageType = lastMessage?.type;
 	useEffect( () => {
 		const messageCount = messages.length;
-		if ( messageCount < 2 ) {
+		if ( messageCount < 2 || isLoadingExistingChat ) {
 			return;
 		}
 
@@ -68,7 +70,8 @@ const useAutoScroll = (
 		} else {
 			scrollToLastUserMessage();
 		}
-	}, [ messages.length, messagesContainerRef, lastMessageType ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ messages.length, lastMessageType, isLoadingExistingChat ] );
 };
 
 export default useAutoScroll;


### PR DESCRIPTION
## Proposed Changes
Fix glitch in scrolling Wapuu

## Why are these changes being made?
A few reasons are causing an unnecessary number of re renders

1. A component is being defined within another component, this led to a "broken" component due to being mounted and unmounted all the time, this might have caused many users to see the chat component to be unusable, as the scroll was autoscrolling many times
2. I've enabled a longer cache, as when we retrieved a chat, it was causing double re render (when we render the chat in the cache + when we render the fetched chat). As we update the cache when we send a message or send feedback, we always have a updated cache
3. Removed the element used in the reference, if somehow any property changes in the HTML element, it caused another scrolling issue (rare). The component will always be rendered now so the reference will always be the same, no need to be in the useEffect deps array.

## Testing Instructions

Please do a heavy testing in the Wapuu client

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
