### PR TITLE
Mailing Lists: add title and description for the Developer Newsletter category

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -106,6 +106,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Promotions' );
 		} else if ( 'reports' === category ) {
 			return this.props.translate( 'Reports' );
+		} else if ( 'news_developer' === category ) {
+			return this.props.translate( 'Developer Newsletter' );
 		} else if ( 'scheduled_updates' === category ) {
 			return this.props.translate( 'Scheduled Updates' );
 		} else if ( 'learn' === category ) {
@@ -160,6 +162,10 @@ class MainComponent extends Component {
 		} else if ( 'reports' === category ) {
 			return this.props.translate(
 				'Complimentary reports and updates regarding site performance and traffic.'
+			);
+		} else if ( 'news_developer' === category ) {
+			return this.props.translate(
+				'A once-monthly roundup of notable news for WordPress developers.'
 			);
 		} else if ( 'scheduled_updates' === category ) {
 			return this.props.translate( 'Complimentary reports regarding scheduled plugin updates.' );

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -37,6 +37,7 @@ const options = {
 	news: 'news',
 	digest: 'digest',
 	reports: 'reports',
+	news_developer: 'news_developer',
 	scheduled_updates: 'scheduled_updates',
 	jetpack_marketing: 'jetpack_marketing',
 	jetpack_research: 'jetpack_research',
@@ -132,6 +133,15 @@ class WPCOMNotifications extends Component {
 					title={ translate( 'Reports' ) }
 					description={ translate(
 						'Complimentary reports and updates regarding site performance and traffic.'
+					) }
+				/>
+
+				<EmailCategory
+					name={ options.news_developer }
+					isEnabled={ get( settings, options.news_developer ) }
+					title={ translate( 'Developer Newsletter' ) }
+					description={ translate(
+						'A once-monthly roundup of notable news for WordPress developers.'
 					) }
 				/>
 


### PR DESCRIPTION
This change adds an appropriate title and description for the recently-added "Developer Newsletter" mailing list category.

- Append the following to the Calypso Live URL attched to this PR:
```
mailing-lists/unsubscribe?category=news_developer&email=codefourcomics%40gmail.com&hmac=a279ab2e1e00ef4e2cd033a4128968ec
```

- Confirm that the unsubscribe action works and that the title and description appear as expected:
<img width="1187" alt="Screenshot 2024-08-22 at 1 03 06 PM" src="https://github.com/user-attachments/assets/207e2520-802c-4c33-b619-656969706b03">

- Using the same Calypso Live session, go to `me/notifications/updates` and confirm that the category appears there:

<img width="515" alt="Screenshot 2024-08-22 at 1 25 34 PM" src="https://github.com/user-attachments/assets/9f317ad7-0344-4a15-a250-c28fcebbf797">
