### PR TITLE
Migration: Persist `from` query param across multiple flows and skip platform identification step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-migrate-message/style.scss
@@ -2,7 +2,7 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .import-hosted-site,
-.migration :not(:has(.list__wrapper)),
+.migration :not(:has(.list__wrapper)):not(.site-migration-instructions--launchpad),
 .site-migration :not(.site-migration-instructions--launchpad),
 .import-focused.migrate-message {
 	.step-container__header {

--- a/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
+++ b/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
@@ -32,7 +32,7 @@ export const useFlowNavigator = ( navigate: Navigate< StepperStep[] > ) => {
 	};
 
 	return {
-		navigate: navigateWithQueryParams,
+		navigateWithQueryParams,
 		getFromPropsOrUrl,
 	};
 };

--- a/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
+++ b/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
@@ -1,0 +1,38 @@
+import { useSearchParams } from 'react-router-dom';
+import { Primitive } from 'utility-types';
+import { addQueryArgs } from 'calypso/lib/url';
+import { Navigate, ProvidedDependencies, StepperStep } from '../../internals/types';
+
+export const useFlowNavigator = ( navigate: Navigate< StepperStep[] > ) => {
+	const [ query ] = useSearchParams();
+
+	const getFromPropsOrUrl = ( key: string, props?: ProvidedDependencies ): Primitive => {
+		const value = props?.[ key ] || query.get( key );
+		return typeof value === 'object' ? undefined : ( value as Primitive );
+	};
+
+	const navigateWithQueryParams = (
+		step: StepperStep,
+		keys: string[] = [],
+		props: ProvidedDependencies = {},
+		options = { replaceHistory: false }
+	) => {
+		const queryParams = keys.reduce(
+			( acc, key ) => {
+				const value = getFromPropsOrUrl( key, props );
+				if ( value ) {
+					acc[ key ] = value;
+				}
+				return acc;
+			},
+			{} as Record< string, Primitive >
+		);
+
+		return navigate( addQueryArgs( queryParams, step.slug ), {}, options.replaceHistory );
+	};
+
+	return {
+		navigate: navigateWithQueryParams,
+		getFromPropsOrUrl,
+	};
+};

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -250,4 +250,12 @@ export default {
 
 		return stepHandlers[ currentStep ];
 	},
+
+	useSideEffect( currentStep, navigate ) {
+		const [ search ] = useSearchParams();
+
+		if ( currentStep === PLATFORM_IDENTIFICATION.slug && search.get( 'from' ) ) {
+			return navigate( SITE_CREATION_STEP.slug );
+		}
+	},
 } satisfies Flow;

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -35,6 +35,18 @@ const {
 	SITE_MIGRATION_ASSISTED_MIGRATION,
 } = STEPS;
 
+const steps = [
+	PLATFORM_IDENTIFICATION,
+	SITE_CREATION_STEP,
+	PROCESSING,
+	MIGRATION_UPGRADE_PLAN,
+	MIGRATION_HOW_TO_MIGRATE,
+	MIGRATION_SOURCE_URL,
+	SITE_MIGRATION_INSTRUCTIONS,
+	SITE_MIGRATION_STARTED,
+	SITE_MIGRATION_ASSISTED_MIGRATION,
+];
+
 const plans: { [ key: string ]: string } = {
 	business: PLAN_BUSINESS,
 	'business-2y': PLAN_BUSINESS_2_YEARS,
@@ -261,17 +273,7 @@ export default {
 	name: MIGRATION_FLOW,
 	isSignupFlow: false,
 	useSteps() {
-		return stepsWithRequiredLogin( [
-			PLATFORM_IDENTIFICATION,
-			SITE_CREATION_STEP,
-			PROCESSING,
-			MIGRATION_UPGRADE_PLAN,
-			MIGRATION_HOW_TO_MIGRATE,
-			MIGRATION_SOURCE_URL,
-			SITE_MIGRATION_INSTRUCTIONS,
-			SITE_MIGRATION_STARTED,
-			SITE_MIGRATION_ASSISTED_MIGRATION,
-		] );
+		return stepsWithRequiredLogin( steps );
 	},
 
 	useStepNavigation( currentStep, navigate ) {
@@ -283,8 +285,19 @@ export default {
 	useSideEffect( currentStep, navigate ) {
 		const [ search ] = useSearchParams();
 
-		if ( currentStep === PLATFORM_IDENTIFICATION.slug && search.get( 'from' ) ) {
-			return navigate( SITE_CREATION_STEP.slug );
+		// Handle cases when starting the flow.
+		if ( currentStep === steps[ 0 ].slug ) {
+			// If the plan is already defined, it creates the site and automatically goes to the checkout.
+			const plan = search.get( 'plan' ) ?? '';
+			if ( Object.keys( plans ).includes( plan ) ) {
+				return navigate( SITE_CREATION_STEP.slug, { plan } );
+			}
+
+			// If it has the from, it assumes that it's a WordPress site.
+			// If we need to handle it for other platforms in the future, we should enhance the conditionals.
+			if ( search.get( 'from' ) ) {
+				return navigate( SITE_CREATION_STEP.slug );
+			}
 		}
 	},
 } satisfies Flow;

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -44,31 +44,34 @@ const plans: { [ key: string ]: string } = {
 const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject: Flow ) => {
 	const [ query ] = useSearchParams();
 	const flowPath = ( flowObject.variantSlug ?? flowObject.name ) as string;
-
 	const { navigate, getFromPropsOrUrl } = useFlowNavigator( _navigate );
 
 	const navigateToCheckout = ( {
 		siteId,
 		siteSlug,
+		from,
 		plan,
 		props,
 		forceRedirection,
 	}: {
 		siteId: string;
 		siteSlug: string;
+		from?: string;
 		plan: string;
 		props?: ProvidedDependencies;
 		forceRedirection?: boolean;
 	} ) => {
 		const redirectAfterCheckout = MIGRATION_HOW_TO_MIGRATE.slug;
 		const destination = addQueryArgs(
-			{ siteId, siteSlug },
+			{ siteId, siteSlug, from },
 			`/setup/${ flowPath }/${ redirectAfterCheckout }`
 		);
+
 		const cancelDestination = addQueryArgs(
-			{ siteId, siteSlug },
+			{ siteId, siteSlug, from },
 			`/setup/${ flowPath }/${ MIGRATION_UPGRADE_PLAN.slug }?${ query.toString() }`
 		);
+
 		let extraQueryParams: Record< string, string > | undefined =
 			props?.sendIntentWhenCreatingTrial && plan === PLAN_MIGRATION_TRIAL_MONTHLY
 				? { hosting_intent: HOSTING_INTENT_MIGRATE }
@@ -81,7 +84,6 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 				introductoryOffer: '1',
 			};
 		}
-
 		return goToCheckout( {
 			flowName: flowPath,
 			stepName: MIGRATION_UPGRADE_PLAN.slug,
@@ -157,6 +159,7 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 						siteId,
 						siteSlug,
 						plan: selectedPlan,
+						from,
 						props,
 						forceRedirection: true,
 					} );
@@ -171,6 +174,7 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 			submit: ( props?: ProvidedDependencies ) => {
 				const siteId = getFromPropsOrUrl( 'siteId', props ) as string;
 				const siteSlug = getFromPropsOrUrl( 'siteSlug', props ) as string;
+				const from = getFromPropsOrUrl( 'from', props ) as string;
 
 				const plan = props?.plan as string;
 
@@ -186,7 +190,7 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 				}
 
 				if ( props?.goToCheckout ) {
-					return navigateToCheckout( { siteId, siteSlug, plan, props } );
+					return navigateToCheckout( { siteId, siteSlug, plan, from, props } );
 				}
 			},
 			goBack: ( props?: ProvidedDependencies ) => {

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -121,7 +121,7 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 					} );
 				}
 
-				return navigate( SITE_CREATION_STEP, [ 'platform', 'from', 'platform' ], props, {
+				return navigate( SITE_CREATION_STEP, [ 'platform', 'from' ], props, {
 					replaceHistory: true,
 				} );
 			},

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -41,10 +41,10 @@ const plans: { [ key: string ]: string } = {
 	'business-3y': PLAN_BUSINESS_3_YEARS,
 };
 
-const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject: Flow ) => {
+const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject: Flow ) => {
 	const [ query ] = useSearchParams();
 	const flowPath = ( flowObject.variantSlug ?? flowObject.name ) as string;
-	const { navigate, getFromPropsOrUrl } = useFlowNavigator( _navigate );
+	const { navigateWithQueryParams, getFromPropsOrUrl } = useFlowNavigator( navigate );
 
 	const navigateToCheckout = ( {
 		siteId,
@@ -106,10 +106,14 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 
 				if ( platform === 'wordpress' ) {
 					if ( hasSite ) {
-						return navigate( MIGRATION_UPGRADE_PLAN, [ 'siteId', 'siteSlug', 'from' ], props );
+						return navigateWithQueryParams(
+							MIGRATION_UPGRADE_PLAN,
+							[ 'siteId', 'siteSlug', 'from' ],
+							props
+						);
 					}
 
-					return navigate( SITE_CREATION_STEP, [ 'from' ], props );
+					return navigateWithQueryParams( SITE_CREATION_STEP, [ 'from' ], props );
 				}
 
 				if ( hasSite ) {
@@ -121,14 +125,14 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 					} );
 				}
 
-				return navigate( SITE_CREATION_STEP, [ 'platform', 'from' ], props, {
+				return navigateWithQueryParams( SITE_CREATION_STEP, [ 'platform', 'from' ], props, {
 					replaceHistory: true,
 				} );
 			},
 		},
 		[ SITE_CREATION_STEP.slug ]: {
 			submit: ( props?: ProvidedDependencies ) => {
-				return navigate( PROCESSING, [ 'platform', 'plan', 'from' ], props, {
+				return navigateWithQueryParams( PROCESSING, [ 'platform', 'plan', 'from' ], props, {
 					replaceHistory: true,
 				} );
 			},
@@ -165,9 +169,14 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 					} );
 				}
 
-				return navigate( MIGRATION_UPGRADE_PLAN, [ 'siteId', 'siteSlug', 'from' ], props, {
-					replaceHistory: true,
-				} );
+				return navigateWithQueryParams(
+					MIGRATION_UPGRADE_PLAN,
+					[ 'siteId', 'siteSlug', 'from' ],
+					props,
+					{
+						replaceHistory: true,
+					}
+				);
 			},
 		},
 		[ MIGRATION_UPGRADE_PLAN.slug ]: {
@@ -194,7 +203,11 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 				}
 			},
 			goBack: ( props?: ProvidedDependencies ) => {
-				return navigate( PLATFORM_IDENTIFICATION, [ 'siteId', 'siteSlug', 'plan', 'from' ], props );
+				return navigateWithQueryParams(
+					PLATFORM_IDENTIFICATION,
+					[ 'siteId', 'siteSlug', 'plan', 'from' ],
+					props
+				);
 			},
 		},
 		[ MIGRATION_HOW_TO_MIGRATE.slug ]: {
@@ -202,27 +215,43 @@ const useCreateStepHandlers = ( _navigate: Navigate< StepperStep[] >, flowObject
 				const how = getFromPropsOrUrl( 'how', props );
 
 				if ( how === HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ) {
-					return navigate( SITE_MIGRATION_INSTRUCTIONS, [ 'siteId', 'siteSlug', 'from' ], props );
+					return navigateWithQueryParams(
+						SITE_MIGRATION_INSTRUCTIONS,
+						[ 'siteId', 'siteSlug', 'from' ],
+						props
+					);
 				}
 
-				return navigate( MIGRATION_SOURCE_URL, [ 'siteId', 'siteSlug', 'from' ], props );
+				return navigateWithQueryParams(
+					MIGRATION_SOURCE_URL,
+					[ 'siteId', 'siteSlug', 'from' ],
+					props
+				);
 			},
 		},
 		[ SITE_MIGRATION_INSTRUCTIONS.slug ]: {
 			submit: ( props?: ProvidedDependencies ) => {
-				return navigate( SITE_MIGRATION_STARTED, [ 'siteId', 'siteSlug', 'from' ], props );
+				return navigateWithQueryParams(
+					SITE_MIGRATION_STARTED,
+					[ 'siteId', 'siteSlug', 'from' ],
+					props
+				);
 			},
 		},
 		[ MIGRATION_SOURCE_URL.slug ]: {
 			submit: ( props?: ProvidedDependencies ) => {
-				return navigate(
+				return navigateWithQueryParams(
 					SITE_MIGRATION_ASSISTED_MIGRATION,
 					[ 'siteId', 'siteSlug', 'from' ],
 					props
 				);
 			},
 			goBack: ( props?: ProvidedDependencies ) => {
-				return navigate( MIGRATION_HOW_TO_MIGRATE, [ 'siteId', 'siteSlug', 'from' ], props );
+				return navigateWithQueryParams(
+					MIGRATION_HOW_TO_MIGRATE,
+					[ 'siteId', 'siteSlug', 'from' ],
+					props
+				);
 			},
 		},
 	};

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -383,7 +383,7 @@ describe( `${ flow.name }`, () => {
 	} );
 
 	describe( 'useStepNavigation > goBack', () => {
-		it( 'redirect back user from SOURCE URL TO HOW TO MIGRATE', () => {
+		it( 'redirects back user from SOURCE URL TO HOW TO MIGRATE', () => {
 			const destination = runNavigationBack( {
 				from: STEPS.MIGRATION_SOURCE_URL,
 				query: { siteId: 123, siteSlug: 'example.wordpress.com' },
@@ -394,17 +394,17 @@ describe( `${ flow.name }`, () => {
 				query: { siteId: 123, siteSlug: 'example.wordpress.com' },
 			} );
 		} );
-	} );
 
-	it( 'redirect back user from MIGRATION_UPGRADE_PLAN > PLATFORM_IDENTIFICATION', () => {
-		const destination = runNavigationBack( {
-			from: STEPS.MIGRATION_UPGRADE_PLAN,
-			query: { siteId: 123, siteSlug: 'example.wordpress.com', plan: 'business' },
-		} );
+		it( 'redirects back user from MIGRATION_UPGRADE_PLAN > PLATFORM_IDENTIFICATION', () => {
+			const destination = runNavigationBack( {
+				from: STEPS.MIGRATION_UPGRADE_PLAN,
+				query: { siteId: 123, siteSlug: 'example.wordpress.com', plan: 'business' },
+			} );
 
-		expect( destination ).toMatchDestination( {
-			step: STEPS.PLATFORM_IDENTIFICATION,
-			query: { siteId: 123, siteSlug: 'example.wordpress.com', plan: 'business' },
+			expect( destination ).toMatchDestination( {
+				step: STEPS.PLATFORM_IDENTIFICATION,
+				query: { siteId: 123, siteSlug: 'example.wordpress.com', plan: 'business' },
+			} );
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -82,11 +82,12 @@ describe( `${ flow.name }`, () => {
 				const destination = runNavigation( {
 					from: STEPS.PLATFORM_IDENTIFICATION,
 					dependencies: { platform: 'blogger' },
+					query: { from: 'optional' },
 				} );
 
 				expect( destination ).toMatchDestination( {
 					step: STEPS.SITE_CREATION_STEP,
-					query: { platform: 'blogger' },
+					query: { platform: 'blogger', from: 'optional' },
 				} );
 			} );
 
@@ -94,11 +95,12 @@ describe( `${ flow.name }`, () => {
 				const destination = runNavigation( {
 					from: STEPS.PLATFORM_IDENTIFICATION,
 					dependencies: { platform: 'wordpress', url: 'next-url' },
+					query: { from: 'optional' },
 				} );
 
 				expect( destination ).toMatchDestination( {
 					step: STEPS.SITE_CREATION_STEP,
-					query: {},
+					query: { from: 'optional' },
 				} );
 			} );
 
@@ -106,11 +108,12 @@ describe( `${ flow.name }`, () => {
 				const destination = runNavigation( {
 					from: STEPS.PLATFORM_IDENTIFICATION,
 					dependencies: { siteId: 123, siteSlug: 'example.wordpress.com', platform: 'wordpress' },
+					query: { from: 'optional' },
 				} );
 
 				expect( destination ).toMatchDestination( {
 					step: STEPS.MIGRATION_UPGRADE_PLAN,
-					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
+					query: { siteId: 123, siteSlug: 'example.wordpress.com', from: 'optional' },
 				} );
 			} );
 
@@ -149,12 +152,12 @@ describe( `${ flow.name }`, () => {
 			it( 'redirects user from SITE_CREATION to PROCESSING', () => {
 				const destination = runNavigation( {
 					from: STEPS.SITE_CREATION_STEP,
-					query: {},
+					query: { from: 'optional' },
 				} );
 
 				expect( destination ).toMatchDestination( {
 					step: STEPS.PROCESSING,
-					query: {},
+					query: { from: 'optional' },
 				} );
 			} );
 
@@ -238,16 +241,17 @@ describe( `${ flow.name }`, () => {
 						plan: 'business',
 						siteId: 123,
 						siteSlug: 'example.wordpress.com',
+						from: 'https://example.com',
 					},
 				} );
 
 				expect( goToCheckout ).toHaveBeenCalledWith( {
-					destination: `/setup/migration/migration-how-to-migrate?siteId=123&siteSlug=example.wordpress.com`,
+					destination: `/setup/migration/migration-how-to-migrate?siteId=123&siteSlug=example.wordpress.com&from=https%3A%2F%2Fexample.com`,
 					extraQueryParams: { introductoryOffer: '1' },
 					flowName: 'migration',
 					siteSlug: 'example.wordpress.com',
 					stepName: STEPS.MIGRATION_UPGRADE_PLAN.slug,
-					cancelDestination: `/setup/migration/migration-upgrade-plan?plan=business&siteId=123&siteSlug=example.wordpress.com`,
+					cancelDestination: `/setup/migration/migration-upgrade-plan?plan=business&siteId=123&siteSlug=example.wordpress.com&from=https%3A%2F%2Fexample.com`,
 					plan: 'business-bundle',
 					forceRedirection: true,
 				} );


### PR DESCRIPTION
Related to #93800

## Proposed Changes

* Add `useFlowNavigator` to simplify the navigation between steps passing params. 
* Persist `from` param across the flow when it is available. 

## Why are these changes being made?
* The landing page `/move` is already testing whether the user site is WordPress and setting as a `from` param when calling the migration flow. We want to keep this information to reduce the friction the user has when migrating a flow.

## Testing Instructions
* Go to `/move` 
* Set a WordPress site URL (You can use one of our test sites or any JN)
* Go to `/setup/migration?from=YOUR_SITE_URL_WITH_HTTP` (E.g `/setup/migration?from=https://wordpress.com`)
* Check if a new site was automatically created without selecting a platform
* Check if you have been redirecting to the upgrade plan page
* Make the payment
* Select `Do it for me`
* Check if your source site is already set on the `Enter your site address:` 
* Click `continue`
* On the last step, check if the zendesk ticket was created with `YOUR_SITE_URL_WITH_HTTP`
*  Please re-run the flow using the manual migration option and check if everything works fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
