### PR TITLE
Stats upsell - only show if site has views

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -30,7 +30,7 @@ import PostCardsGroup from './post-cards-group';
 
 import './style.scss';
 
-type AllTimeData = {
+export type AllTimeData = {
 	comments: number;
 	posts: number;
 	views: number;

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -80,6 +80,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			hasPaidStats,
 			isSiteJetpackNotAtomic,
 			isCommercial,
+			hasSignificantViews,
 		}: StatsNoticeProps ) => {
 			const showUpgradeNoticeForWpcomSites = isWpcom && ! isP2 && ! isOwnedByTeam51;
 
@@ -96,7 +97,9 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 				! hasPaidStats &&
 				// Show the notice if the site is not commercial.
 				! isCommercial &&
-				! isVip
+				! isVip &&
+				// Only show the notice if the site has a significant amount of views.
+				hasSignificantViews
 			);
 		},
 		disabled: false,

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -113,7 +113,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	const { views } = useSelector(
 		( state ) => getSiteStatsNormalizedData( state, siteId, 'stats', {} ) || {}
 	) as AllTimeData;
-	const hasSignificantViews = views && views >= SIGNIFICANT_VIEWS_AMOUNT;
+	const hasSignificantViews = !! ( views && views >= SIGNIFICANT_VIEWS_AMOUNT );
 
 	const noticeOptions = {
 		siteId,

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -1,5 +1,6 @@
 import { FEATURE_STATS_PAID } from '@automattic/calypso-products';
 import { useState, useEffect } from 'react';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import {
 	DEFAULT_NOTICES_VISIBILITY,
 	Notices,
@@ -20,13 +21,16 @@ import hasSiteProductJetpackStatsFree from 'calypso/state/sites/selectors/has-si
 import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
 import hasSiteProductJetpackStatsPWYWOnly from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
+import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import { AllTimeData } from '../all-time-highlights-section';
 import useStatsPurchases, { shouldShowPaywallNotice } from '../hooks/use-stats-purchases';
 import ALL_STATS_NOTICES from './all-notice-definitions';
 import { StatsNoticeProps, StatsNoticesProps } from './types';
 import './style.scss';
 
 const TEAM51_OWNER_ID = 70055110;
+const SIGNIFICANT_VIEWS_AMOUNT = 100;
 
 const ensureOnlyOneNoticeVisible = (
 	serverNoticesVisibility: Notices,
@@ -106,6 +110,11 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		! supportCommercialUse &&
 		isSiteJetpackNotAtomic;
 
+	const { views } = useSelector(
+		( state ) => getSiteStatsNormalizedData( state, siteId, 'stats', {} ) || {}
+	) as AllTimeData;
+	const hasSignificantViews = views && views >= SIGNIFICANT_VIEWS_AMOUNT;
+
 	const noticeOptions = {
 		siteId,
 		isOdysseyStats,
@@ -120,6 +129,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		isCommercial,
 		isCommercialOwned,
 		hasPWYWPlanOnly,
+		hasSignificantViews,
 		showPaywallNotice,
 	};
 
@@ -176,10 +186,13 @@ export default function StatsNotices( {
 	}
 
 	return (
-		<NewStatsNotices
-			siteId={ siteId }
-			isOdysseyStats={ isOdysseyStats }
-			statsPurchaseSuccess={ statsPurchaseSuccess }
-		/>
+		<>
+			{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" query={ {} } /> }
+			<NewStatsNotices
+				siteId={ siteId }
+				isOdysseyStats={ isOdysseyStats }
+				statsPurchaseSuccess={ statsPurchaseSuccess }
+			/>
+		</>
 	);
 }

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -21,6 +21,7 @@ export interface StatsNoticeProps {
 	isCommercialOwned?: boolean;
 	hasPWYWPlanOnly?: boolean;
 	showPaywallNotice?: boolean;
+	hasSignificantViews?: boolean;
 }
 
 export interface NoticeBodyProps {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/8779

## Proposed Changes

* We will only show this upsell if the site has more than 100 views.
<img width="799" alt="Screenshot 2024-08-22 at 2 01 10 PM" src="https://github.com/user-attachments/assets/eda9e691-13f1-435e-bf9e-5e9c84e21eed">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Context on issue - "There is no reason to upgrade if you have no stats."
* Too many upsells across the product result in too much visual noise, so we should limit when we show them.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Setup a new test site, or use one that shows this upsell on `*/stats/day/{siteSlug}`
    * If you have a site with 100+ views that shows this upsell, great! (if not there are more instructions) Also use one with less than that. 
* Run this calypso PR.
* Go to the stats page in calypso.
* Verify this banner is still present for sites with 100+ views. And that it disappears for sites with less than that.
* If you don't have a site with 100+ views, adjust the `SIGNIFICANT_VIEWS_AMOUNT` constant in the stats-notices/index.tsx file to a number <= the views on your test site. Reload and verify the banner shows up.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
