### PR TITLE
POC Improving /plugins/manage interface to support thousands of plugins x sites

### DIFF
--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -45,7 +45,8 @@ const UrlSearch = ( Component ) =>
 		};
 
 		UNSAFE_componentWillReceiveProps( { search } ) {
-			return ! search && this.setState( { searchOpen: false } );
+			console.log( 'UNSAFE_componentWillReceiveProps' );
+			// return ! search && this.setState( { searchOpen: false } );
 		}
 
 		doSearch = ( query ) => {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -80,10 +80,12 @@ export class PluginsMain extends Component {
 		} = this.props;
 
 		currentPlugins.map( ( plugin ) => {
-			const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
-			if ( ! pluginData ) {
-				this.props.wporgFetchPluginData( plugin.slug );
-			}
+			// Performs parallel requests to Dotorg API, one for each plugin! This completely frozes the site when having more than 100 plugins
+			// This data is also loaded when we click on the plugin, so it's not necessary to load it here if we're okay in not loading the plugin icon for /plugins/manage
+			// const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
+			// if ( ! pluginData ) {
+			// 	this.props.wporgFetchPluginData( plugin.slug );
+			// }
 		} );
 
 		if (
@@ -428,6 +430,7 @@ export class PluginsMain extends Component {
 	}
 
 	render() {
+		console.log( 'my-sites/plugins/main.jsx render()' );
 		if ( ! this.props.isRequestingSites && ! this.props.userCanManagePlugins ) {
 			return <NoPermissionsError title={ this.props.translate( 'Plugins', { textOnly: true } ) } />;
 		}
@@ -585,6 +588,7 @@ export default flow(
 			const visibleSiteIds = siteObjectsToSiteIds( getVisibleSites( sites ) ) ?? [];
 			const siteIds = siteObjectsToSiteIds( sites ) ?? [];
 			const pluginsWithUpdates = getPlugins( state, siteIds, 'updates' );
+			// console.log( 'pluginsWithUpdates: ', pluginsWithUpdates );
 			const allPlugins = getPlugins( state, siteIds, 'all' );
 			const jetpackNonAtomic =
 				isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId );

--- a/client/my-sites/plugins/plugin-management-v2/hooks/use-plugin-version-info.ts
+++ b/client/my-sites/plugins/plugin-management-v2/hooks/use-plugin-version-info.ts
@@ -13,8 +13,63 @@ export default function usePluginVersionInfo(
 	currentVersionsRange: { min: string; max: string };
 	updatedVersions: string[];
 	hasUpdate: boolean;
+	siteCount?: number;
 } {
 	const allSites = useSelector( getSites );
+
+	// if ( plugin.name !== 'Akismet Anti-spam: Spam Protection' ) {
+	// 	return {
+	// 		currentVersionsRange: {
+	// 			min: '1',
+	// 			max: '2',
+	// 		},
+	// 		updatedVersions: [ '3' ],
+	// 		hasUpdate: false,
+	// 	};
+	// }
+	// console.log( 'plugin', plugin );
+
+	// let minVersion = '100.1.1';
+	// let maxVersion = '0.0.0';
+	// let updateVersion = '0';
+	// let siteCount = 0;
+
+	// function getNumberValue( version: string ) {
+	// 	const [ major, minor, patch ] = version.split( '.' ).map( ( v ) => parseInt( v ) );
+	// 	return major * 1000000 + minor * 100 + patch;
+	// }
+
+	// console.log( 'plugin.sites: ', plugin.sites );
+	// console.log( 'allSites: ', allSites );
+
+	// for ( const siteId in plugin.sites ) {
+	// 	if ( getNumberValue( plugin.sites[ siteId ].version ) < getNumberValue( minVersion ) ) {
+	// 		minVersion = plugin.sites[ siteId ].version;
+	// 	}
+
+	// 	if ( getNumberValue( plugin.sites[ siteId ].version ) >= getNumberValue( maxVersion ) ) {
+	// 		maxVersion = plugin.sites[ siteId ].version;
+	// 	}
+
+	// 	if ( plugin.sites[ siteId ].update ) {
+	// 		const canUpdateFiles = allSites.find( ( s ) => s?.ID === parseInt( siteId ) )?.canUpdateFiles;
+
+	// 		if ( canUpdateFiles ) {
+	// 			updateVersion = plugin.sites[ siteId ].update.new_version;
+	// 			siteCount++;
+	// 		}
+	// 	}
+	// }
+
+	// return {
+	// 	currentVersionsRange: {
+	// 		min: minVersion,
+	// 		max: minVersion === maxVersion ? '' : maxVersion,
+	// 	},
+	// 	updatedVersions: [ updateVersion ],
+	// 	hasUpdate: updateVersion !== '0',
+	// 	siteCount,
+	// };
 
 	const sites = plugin?.sites
 		? Object.keys( plugin.sites ).map( ( siteId ) => {
@@ -28,9 +83,14 @@ export default function usePluginVersionInfo(
 
 	const siteIds = siteObjectsToSiteIds( sites );
 
-	const pluginsOnSites: any = useSelector( ( state ) =>
+	const pluginsOnSites2: any = useSelector( ( state ) =>
 		getPluginOnSites( state, siteIds, plugin?.slug )
 	);
+
+	const pluginsOnSites = plugin;
+
+	// console.log( 'pluginsOnSites ', pluginsOnSites );
+	// console.log( 'pluginsOnSites2 ', pluginsOnSites2 );
 
 	const getSitePlugin = ( site: SiteDetails ) => {
 		const siteId = selectedSiteId || site.ID;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
@@ -24,6 +24,7 @@ export default function PluginCommonCard( {
 	columns,
 	renderActions,
 }: Props ) {
+	return <>TODO: why this adds 3 extra seconds?</>;
 	const columnKeys: { [ key: string ]: boolean } = columns.reduce(
 		( obj, cur ) => ( { ...obj, [ cur.key ]: true } ),
 		{}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
@@ -24,7 +24,7 @@ export default function PluginCommonCard( {
 	columns,
 	renderActions,
 }: Props ) {
-	return <>TODO: why this adds 3 extra seconds?</>;
+	// return <>TODO: why this adds 3 extra seconds?</>;
 	const columnKeys: { [ key: string ]: boolean } = columns.reduce(
 		( obj, cur ) => ( { ...obj, [ cur.key ]: true } ),
 		{}

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -80,7 +80,6 @@ export default function PluginRowFormatter( {
 		};
 
 	const moment = useLocalizedMoment();
-	const state = useSelector( ( state ) => state );
 
 	const ago = ( date: MomentInput ) => {
 		return moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
@@ -94,11 +93,13 @@ export default function PluginRowFormatter( {
 			selectedSite && isPluginActionInProgress( state, selectedSite.ID, pluginId, INSTALL_PLUGIN )
 	);
 
-	if ( selectedSite ) {
-		const { activation, autoupdate } = getAllowedPluginActions( item, state, selectedSite );
-		canActivate = activation;
-		canUpdate = autoupdate;
-	}
+	useSelector( ( state ) => {
+		if ( selectedSite ) {
+			const { activation, autoupdate } = getAllowedPluginActions( item, state, selectedSite );
+			canActivate = activation;
+			canUpdate = autoupdate;
+		}
+	} );
 
 	const pluginOnSite = useSelector(
 		( state ) => selectedSite && getPluginOnSite( state, selectedSite.ID, item.slug )
@@ -106,7 +107,7 @@ export default function PluginRowFormatter( {
 
 	const siteCount = item?.sites && Object.keys( item.sites ).length;
 
-	const allStatuses = getPluginActionStatuses( state );
+	const allStatuses = useSelector( ( state ) => getPluginActionStatuses( state ) );
 
 	let currentSiteStatuses = allStatuses.filter(
 		( status ) => status.pluginId === pluginId && status.action !== UPDATE_PLUGIN

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -20,32 +20,29 @@ interface Props {
 	selectedSite?: SiteDetails;
 	className?: string;
 	updatePlugin?: ( plugin: PluginComponentProps ) => void;
-	siteCount?: number;
 }
 
-export default function UpdatePlugin( {
-	plugin,
-	selectedSite,
-	className,
-	updatePlugin,
-	siteCount,
-}: Props ) {
+export default function UpdatePlugin( { plugin, selectedSite, className, updatePlugin }: Props ) {
 	const translate = useTranslate();
-	const state = useSelector( ( state ) => state );
+
 	const [ displayConfirmModal, setDisplayConfirmModal ] = useState( false );
 
-	const { currentVersionsRange, updatedVersions, hasUpdate } = usePluginVersionInfo(
+	const { currentVersionsRange, updatedVersions, hasUpdate, siteCount } = usePluginVersionInfo(
 		plugin,
 		selectedSite?.ID
 	);
 
-	const allowedActions = getAllowedPluginActions( plugin, state, selectedSite );
+	const allowedActions = useSelector( ( state ) => {
+		return getAllowedPluginActions( plugin, state, selectedSite );
+	} );
 
 	let content;
 
-	const allStatuses = getPluginActionStatuses( state );
+	const allStatuses = useSelector( ( state ) => {
+		return getPluginActionStatuses( state );
+	} );
 
-	const updateStatuses = allStatuses.filter(
+	const updateStatuses = allStatuses?.filter(
 		( status ) =>
 			status.pluginId === plugin.id &&
 			status.action === UPDATE_PLUGIN &&

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -25,6 +25,8 @@ interface Props {
 }
 
 export default function UpdatePlugins( { plugins, isWpCom }: Props ): ReactElement | null {
+	console.log( 'will UpdatePlugins' );
+	return;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
@@ -1,4 +1,5 @@
 import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
+import { createSelector } from '@wordpress/data';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -6,22 +7,20 @@ import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { AppState } from 'calypso/types';
 
-export const getAllowedPluginActions = (
-	plugin: PluginComponentProps,
-	state: AppState,
-	selectedSite?: SiteDetails
-) => {
-	const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
-	const siteIsAtomic = selectedSite && isSiteAutomatedTransfer( state, selectedSite?.ID );
-	const siteIsJetpack = selectedSite && isJetpackSite( state, selectedSite?.ID );
-	const hasManagePlugins =
-		selectedSite && siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
-	const isManagedPlugin = siteIsAtomic && autoManagedPlugins.includes( plugin.slug );
-	const canManagePlugins =
-		! selectedSite || ( siteIsJetpack && ! siteIsAtomic ) || ( siteIsAtomic && hasManagePlugins );
+export const getAllowedPluginActions = createSelector(
+	( plugin: PluginComponentProps, state: AppState, selectedSite?: SiteDetails ) => {
+		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
+		const siteIsAtomic = selectedSite && isSiteAutomatedTransfer( state, selectedSite?.ID );
+		const siteIsJetpack = selectedSite && isJetpackSite( state, selectedSite?.ID );
+		const hasManagePlugins =
+			selectedSite && siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_MANAGE_PLUGINS );
+		const isManagedPlugin = siteIsAtomic && autoManagedPlugins.includes( plugin.slug );
+		const canManagePlugins =
+			! selectedSite || ( siteIsJetpack && ! siteIsAtomic ) || ( siteIsAtomic && hasManagePlugins );
 
-	return {
-		autoupdate: ! isManagedPlugin && canManagePlugins,
-		activation: ! isManagedPlugin && canManagePlugins,
-	};
-};
+		return {
+			autoupdate: ! isManagedPlugin && canManagePlugins,
+			activation: ! isManagedPlugin && canManagePlugins,
+		};
+	}
+);

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-statuses.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-statuses.ts
@@ -1,10 +1,11 @@
+import { createSelector } from '@wordpress/data';
 import { getPluginStatusesByType } from 'calypso/state/plugins/installed/selectors';
 import type { AppState } from 'calypso/types';
 
 /**
  * Returns an array of all plugin action statuses(inProgress, completed, error)
  */
-export const getPluginActionStatuses = ( state: AppState ) => {
+export const getPluginActionStatuses = createSelector( ( state: AppState ) => {
 	const inProgressStatuses = getPluginStatusesByType( state, 'inProgress' );
 	const completedStatuses = getPluginStatusesByType( state, 'completed' );
 	const incompletedStatuses = getPluginStatusesByType( state, 'incompleted' );
@@ -18,4 +19,4 @@ export const getPluginActionStatuses = ( state: AppState ) => {
 		...incompletedStatuses,
 		...uptoDateStatuses,
 	];
-};
+} );

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -1,13 +1,14 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isMagnificentLocale } from '@automattic/i18n-utils';
+import { createSelector } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
-export function siteObjectsToSiteIds( sites ) {
-	return sites?.map( ( site ) => site.ID ) ?? [];
-}
+export const siteObjectsToSiteIds = createSelector(
+	( sites ) => sites?.map( ( site ) => site.ID ) ?? []
+);
 
 export function getVisibleSites( sites ) {
 	return sites?.filter( ( site ) => site.visible );

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -129,11 +129,12 @@ export function getPluginsWithUpdates( state, siteIds ) {
 }
 
 export function getPluginsOnSites( state, plugins ) {
-	return Object.values( plugins ).reduce( ( acc, plugin ) => {
-		const siteIds = Object.keys( plugin.sites );
-		acc[ plugin.slug ] = getPluginOnSites( state, siteIds, plugin.slug );
-		return acc;
-	}, {} );
+	// Adds up to 10s to the "freezing time" for 1700 sites
+	// return Object.values( plugins ).reduce( ( acc, plugin ) => {
+	// 	const siteIds = Object.keys( plugin.sites );
+	// 	acc[ plugin.slug ] = getPluginOnSites( state, siteIds, plugin.slug );
+	// 	return acc;
+	// }, {} );
 }
 
 export function getPluginOnSites( state, siteIds, pluginSlug ) {

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -137,9 +137,10 @@ export function getPluginsOnSites( state, plugins ) {
 	// }, {} );
 }
 
-export function getPluginOnSites( state, siteIds, pluginSlug ) {
+// We earn 200ms by using a createSelector selector here
+export const getPluginOnSites = createSelector( ( state, siteIds, pluginSlug ) => {
 	return getPlugins( state, siteIds ).find( ( plugin ) => isEqualSlugOrId( pluginSlug, plugin ) );
-}
+} );
 
 export function getPluginOnSite( state, siteId, pluginSlug ) {
 	const pluginList = getPlugins( state, [ siteId ] );

--- a/client/state/selectors/get-updateable-jetpack-sites.js
+++ b/client/state/selectors/get-updateable-jetpack-sites.js
@@ -1,3 +1,4 @@
+import { createSelector } from '@wordpress/data';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import { canJetpackSiteUpdateFiles } from 'calypso/state/sites/selectors';
 
@@ -6,7 +7,10 @@ import { canJetpackSiteUpdateFiles } from 'calypso/state/sites/selectors';
  * @param   {Object} state Global state tree
  * @returns {Array}        Array of updateable Jetpack sites
  */
-export default function getUpdateableJetpackSites( state ) {
-	const sites = getSelectedOrAllSitesWithPlugins( state );
-	return sites.filter( ( site ) => canJetpackSiteUpdateFiles( state, site.ID ) );
-}
+export default createSelector(
+	( state ) =>
+		getSelectedOrAllSitesWithPlugins( state ).filter( ( site ) =>
+			canJetpackSiteUpdateFiles( state, site.ID )
+		),
+	( state ) => [ state.sites.items ]
+);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Task-related: https://github.com/Automattic/dotcom-forge/issues/8868
Related to p1724346733059889/1724178013.609829-slack-C04H4NY6STW

### Next steps

https://github.com/Automattic/dotcom-forge/issues/8603#issuecomment-2368515444

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?