### PR TITLE
Jetpack Cloud: Updates Backup menu item label to VaultPress Backup

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -108,7 +108,7 @@ const useMenuItems = ( {
 					icon: cloud,
 					path: '/',
 					link: backupPath( siteSlug ),
-					title: translate( 'Backup' ),
+					title: translate( 'VaultPress Backup' ),
 					trackEventName: 'calypso_jetpack_sidebar_backup_clicked',
 					enabled: isAdmin && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, backupPath( siteSlug ) ),


### PR DESCRIPTION
## Proposed Changes

* Updates the “Backup” menu item in cloud.jetpack.com to “VaultPress Backup”.

Reported in pfln9p-F0-p2#comment-769

## Why are these changes being made?

* The product is referred everywhere as “VaultPress Backup”, so this brings the UI in Jetpack Cloud to alignment.

## Testing Instructions

* Fire up this PR.
* Go to http://jetpack.cloud.localhost:3000/backup/
* Select a site with Backup.
* Ensure the sidebar shows “VaultPress Backup”.

## Screenshots

Before | After
--|--
<img width="273" alt="image" src="https://github.com/user-attachments/assets/5d40fd2a-b5f4-4bd2-ad4c-647dc79d07e8"> | <img width="273" alt="image" src="https://github.com/user-attachments/assets/ea5a755e-056d-4588-8993-35fc4abc5710">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?