### PR TITLE
Fix flex for credentials form

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -26,13 +26,14 @@
 			display: flex;
 			flex-direction: row;
 			gap: 1em;
-			@media (max-width: 510px) {
+			@media (max-width: 522px) {
 				flex-direction: column;
 				gap: 0;
 			}
 		}
 		.site-migration-credentials__form-field {
 			margin-top: 1em;
+			flex: 1;
 		}
 		.site-migration-credentials__radio-group {
 			display: flex;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

Adjust css flexbox so that the break for mobile happens before the label for the username wraps to a newline.

**Before**
<img width="488" alt="image" src="https://github.com/user-attachments/assets/5b621f24-32e8-4326-8a81-87817b64ec88">

**After**
<img width="474" alt="image" src="https://github.com/user-attachments/assets/4c27c571-33e7-42fa-b1fb-4ead2438f709">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The issue was reported by @markbiek here: p1724334796323449-slack-C0Q664T29

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch to your local environment or add use the Calypso Live link below.
- Open the dev console and activate the feature flag by running the following command:
window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')
- Now get into the flow using the /start URL
- Go through the domain selection step
- Select the free plan on the Plans page
- On the Goals step, select the "Import existing content or website" option and click continue
- Input the source site URL in the Identify step
- Next, select the "Migrate Site" option on the Import or Migrate step
- Select "Do it for me" on the How to migrate step
- Go through the checkout
- Once you complete the checkout, you should land on the new Credentials step
- Verify the username label doesn't look like the **before** screenshot at any width

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?