### PR TITLE
Domains: Fix regex removal of first accent character

### DIFF
--- a/client/lib/domains/get-fixed-domain-search.js
+++ b/client/lib/domains/get-fixed-domain-search.js
@@ -5,5 +5,5 @@ export function getFixedDomainSearch( domainName ) {
 		.toLowerCase()
 		.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )
 		.replace( /^www[0-9]?\./, '' )
-		.replace( /[^a-z0-9-.]/, '' );
+		.replace( /[^a-zA-ZÀ-ÖÙ-öù-ÿĀ-žḀ-ỿ0-9-. ]/g, '' );
 }

--- a/client/lib/domains/test/index.js
+++ b/client/lib/domains/test/index.js
@@ -37,6 +37,28 @@ describe( 'index', () => {
 				expect( getFixedDomainSearch( search ) ).toEqual( search );
 			} );
 		} );
+
+		test( 'should allow accent characters on domain search', () => {
+			const searches = [
+				{
+					search: 'alimentaçãosaudável.com.br',
+					expected: 'alimentaçãosaudável.com.br',
+				},
+				{
+					search: 'meudomínioação.com',
+					expected: 'meudomínioação.com',
+				},
+				{
+					// Should still remove & and * characteres
+					search: 'meudomínioação&*ê.com',
+					expected: 'meudomínioaçãoê.com',
+				},
+			];
+
+			forEach( searches, ( search ) => {
+				expect( getFixedDomainSearch( search.search ) ).toEqual( search.expected );
+			} );
+		} );
 	} );
 
 	describe( '#getDomainSuggestionSearch', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/wp-calypso/issues/93819

## Proposed Changes

* Updates logic that cleans up domain search by allowing accent characters. 
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This will fix the issue leading to the first accent character being removed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Start at [wordpress.com/business-name-generator](https://wordpress.com/business-name-generator/), http://wordpress.com/domains, or [wordpress.com/start/domain](https://wordpress.com/start/domain/)
* For the first option, find one that suits (a word with accents) and choose next. For the other two, type words with accents in the field. Example: `alimentação saudável` (healthy food)
* Verify all characters are replaced with their "regular" versions and the first accent character isn't removed
For example, before these changes, `alimentação saudável` was transformed into `alimentaao saudavel` ( notice the `c ` character has been removed). After these changes you should see the correct transformation `alimentacao saudavel`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
