### PR TITLE
Help center: Fix glitch when closing  using 'X' button

### DIFF
--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -58,28 +58,25 @@ const HelpCenterContainer: React.FC< Container > = ( {
 
 	const onDismiss = useCallback( () => {
 		setIsVisible( false );
-		recordTracksEvent( `calypso_inlinehelp_close` );
-	}, [ setIsVisible ] );
-
-	const toggleVisible = () => {
-		if ( ! isVisible ) {
-			handleClose();
-			// after calling handleClose, reset the visibility state to default
+		handleClose();
+		setTimeout( () => {
+			// Set the visibility back to true, it will make the animation work when the Help Center is opened again.
 			setIsVisible( true );
-		}
-	};
+		}, 0 );
+
+		recordTracksEvent( `calypso_inlinehelp_close` );
+	}, [ setIsVisible, handleClose ] );
 
 	const animationProps = {
 		style: {
 			animation: isMobile
-				? `${ isVisible ? 'fadeIn' : 'fadeOut' } .25s ease-out`
-				: `${ isVisible ? 'slideIn' : 'fadeOut' } .25s ease-out`,
+				? `${ isVisible ? 'fadeIn .25s ease-out' : '' }`
+				: `${ isVisible ? 'slideIn .25s ease-out' : '' }`,
 			// These are overwritten by the openingCoordinates.
 			// They are set to avoid Help Center from not loading on the page.
 			...( ! isMobile && { top: 70, left: 'calc( 100vw - 500px )' } ),
 			...openingCoordinates,
 		},
-		onAnimationEnd: toggleVisible,
 	};
 
 	const focusReturnRef = useFocusReturn();

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -61,10 +61,8 @@ const HelpCenterContainer: React.FC< Container > = ( {
 
 	const animationProps = {
 		style: {
-			animation: isMobile ? 'fadeIn .25s ease-out' : 'slideIn .25s ease-out',
 			// These are overwritten by the openingCoordinates.
 			// They are set to avoid Help Center from not loading on the page.
-			...( ! isMobile && { top: 70, left: 'calc( 100vw - 500px )' } ),
 			...openingCoordinates,
 		},
 	};

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -7,7 +7,7 @@ import { Card } from '@wordpress/components';
 import { useFocusReturn, useMergeRefs } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import clsx from 'clsx';
-import { useState, useRef, useEffect, useCallback, FC } from 'react';
+import { useRef, useEffect, useCallback, FC } from 'react';
 import Draggable, { DraggableProps } from 'react-draggable';
 import { MemoryRouter } from 'react-router-dom';
 /**
@@ -48,30 +48,20 @@ const HelpCenterContainer: React.FC< Container > = ( {
 	}, [] );
 
 	const nodeRef = useRef< HTMLDivElement >( null );
-
 	const { setIsMinimized } = useDispatch( HELP_CENTER_STORE );
-	const [ isVisible, setIsVisible ] = useState( true );
 	const isMobile = useMobileBreakpoint();
 	const classNames = clsx( 'help-center__container', isMobile ? 'is-mobile' : 'is-desktop', {
 		'is-minimized': isMinimized,
 	} );
 
 	const onDismiss = useCallback( () => {
-		setIsVisible( false );
 		handleClose();
-		setTimeout( () => {
-			// Set the visibility back to true, it will make the animation work when the Help Center is opened again.
-			setIsVisible( true );
-		}, 0 );
-
 		recordTracksEvent( `calypso_inlinehelp_close` );
-	}, [ setIsVisible, handleClose ] );
+	}, [ handleClose ] );
 
 	const animationProps = {
 		style: {
-			animation: isMobile
-				? `${ isVisible ? 'fadeIn .25s ease-out' : '' }`
-				: `${ isVisible ? 'slideIn .25s ease-out' : '' }`,
+			animation: isMobile ? 'fadeIn .25s ease-out' : 'slideIn .25s ease-out',
 			// These are overwritten by the openingCoordinates.
 			// They are set to avoid Help Center from not loading on the page.
 			...( ! isMobile && { top: 70, left: 'calc( 100vw - 500px )' } ),

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -61,8 +61,6 @@ const HelpCenterContainer: React.FC< Container > = ( {
 
 	const animationProps = {
 		style: {
-			// These are overwritten by the openingCoordinates.
-			// They are set to avoid Help Center from not loading on the page.
 			...openingCoordinates,
 		},
 	};

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -14,6 +14,7 @@ $z-index: 99999;
 		z-index: $z-index;
 		cursor: default;
 		transition: max-height 0.5s;
+		animation: 0.25s ease-out 0s 1 normal none running slideIn;
 
 		button.button-primary,
 		button.button-secondary {
@@ -154,6 +155,7 @@ $z-index: 99999;
 			top: var(--masterbar-height, 0);
 			max-height: calc(100% - 45px);
 			height: calc(100% - var(--masterbar-height, 0));
+			animation: 0.25s ease-out 0s 1 normal none running fadeIn;
 
 			.help-center__container-content {
 				flex: auto;

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -246,16 +246,6 @@ $z-index: 99999;
 		}
 	}
 
-	@keyframes fadeOut {
-		0% {
-			opacity: 1;
-		}
-
-		100% {
-			opacity: 0;
-		}
-	}
-
 	.back-button__help-center {
 		display: flex;
 		color: #000;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8831
Fixes https://github.com/Automattic/dotcom-forge/issues/8831

## Proposed Changes

* Remove the Fade out animation when closing the HelpCenter using the "X". This is causing issues when navigating to other pages with the HelpCenter open.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes the weird behavior when closing the help center ( more detail in this issue https://github.com/Automattic/dotcom-forge/issues/8831 )

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Using the live link go to /home.
2. Open the Help Center
3. Navigate to Domains in WordPress.com
4. Close Help Center
5. Navigate to random pages and editor.
6. We should not see any stuttering animation on close and no regressions.
7. Be sure to try the same in production to verify you can see this bug.

Be sure to try the same in production to verify you can see this bug.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
