### PR TITLE
Onboarding: hide the skip domain option in the sidebar for email onboarding flow

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -584,7 +584,7 @@ export class RenderDomainsStep extends Component {
 
 	shouldHideDomainExplainer = () => {
 		const { flowName } = this.props;
-		return [ 'domain', 'domain-for-gravatar' ].includes( flowName );
+		return [ 'domain', 'domain-for-gravatar', 'onboarding-with-email' ].includes( flowName );
 	};
 
 	shouldHideUseYourDomain = () => {


### PR DESCRIPTION
Related to 8262-gh-Automattic/dotcom-forge

## Proposed Changes

Hides the"Not ready to choose a domain just yet?" option in the sidebar of the domains step for the `onboarding-with-email` flow

**Before**
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/2b52e0a4-6494-40ae-a975-a47eed1eba86">

**After**
<img width="1458" alt="image" src="https://github.com/user-attachments/assets/a9cdd7bd-5267-4eaf-b15f-d19c2dcac075">

I did consider replacing the 'check plans' domain explainer with the standard one:
<img width="331" alt="image" src="https://github.com/user-attachments/assets/bc6dbe23-5946-48c7-90b8-e839069c9e87">

but the "find a domain you love, **then** select any paid annual plan" (emphasis added) wording felt at odds with a flow that doesn't present plans at the next step. Feels better to just go without anything in that spot to me.

## Why are these changes being made?

In this flow, after selecting a domain the user is taken to the email step, which offers an email address for the domain they've just selected. Skipping the domain step makes this difficult, to say the least, and also renders an address without a tld on the titan signup card. Instead of `yourname@awesomedomain.com` it just renders `yourname@`.

Hiding the option to skip the domain selection prevents this problem entirely.

## Testing Instructions

- Start at https://wordpress.com/start/onboarding-with-email/mailbox-domain
- Perform a search for a domain name and select your favorite
- On the next step, confirm the email address renders properly with the tld included after the `@` character.
