### PR TITLE
Add wpcom-upload URL parameter

### DIFF
--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -25,7 +25,10 @@ function getInstallThemeUrl( state, siteId ) {
 	const atomicSite = isAtomicSite( state, siteId );
 	const siteCanInstallThemes = siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES );
 	if ( atomicSite && siteCanInstallThemes ) {
-		return getSiteThemeInstallUrl( state, siteId );
+		const themeInstallUrlObj = new URL( getSiteThemeInstallUrl( state, siteId ) );
+		themeInstallUrlObj.searchParams.append( 'browse', 'popular' );
+		themeInstallUrlObj.searchParams.append( 'wpcom-upload', '1' );
+		return themeInstallUrlObj.toString();
 	}
 
 	const siteSlug = getSiteSlug( state, siteId );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/93594

## Proposed Changes

* This PR adds a URL parameter `wpcom-upload=1` to the "Install new theme" button.
* This parameter is used in this Jetpack PR https://github.com/Automattic/jetpack/pull/39045 to auto open the "Upload theme" dialog.

<img width="1657" alt="Screenshot 2024-08-22 at 6 01 26 PM" src="https://github.com/user-attachments/assets/ce812720-6457-4ca1-854e-e6043f328046">


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the Install New Theme flow for WoA

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can test this PR without Jetpack by going to /themes/[atomic-test-site-slug] and verifying the URL of "Install new theme" button is `/wp-admin/theme-install.php?browse=popular&wpcom-upload=1`
* Verify the parameter matches the one implement here https://github.com/Automattic/jetpack/pull/39045

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
