### PR TITLE
Stats: Fix popover colors and scope theme only for the widget

### DIFF
--- a/apps/odyssey-stats/src/styles/scoped-theme-for-widget.scss
+++ b/apps/odyssey-stats/src/styles/scoped-theme-for-widget.scss
@@ -1,6 +1,5 @@
 @import "variables.scss";
 
-:root {
+.stats-widget-content {
 	@include jetpack-theme-for-odyssey-stats;
-	--wp-components-color-accent: var(--color-primary);
 }

--- a/apps/odyssey-stats/src/styles/variables.scss
+++ b/apps/odyssey-stats/src/styles/variables.scss
@@ -13,3 +13,75 @@ $display-type-line-height: 40px;
 	line-height: $display-type-line-height;
 }
 
+@mixin jetpack-theme-for-odyssey-stats {
+	--jetpack-white-off: #f9f9f6;
+
+	--color-primary: var(--studio-jetpack-green);
+	--color-primary-rgb: var(--studio-jetpack-green-rgb);
+	--color-primary-dark: var(--studio-jetpack-green-70);
+	--color-primary-dark-rgb: var(--studio-jetpack-green-70-rgb);
+	--color-primary-light: var(--studio-jetpack-green-30);
+	--color-primary-light-rgb: var(--studio-jetpack-green-30-rgb);
+	--color-primary-0: var(--studio-jetpack-green-0);
+	--color-primary-0-rgb: var(--studio-jetpack-green-0-rgb);
+	--color-primary-5: var(--studio-jetpack-green-5);
+	--color-primary-5-rgb: var(--studio-jetpack-green-5-rgb);
+	--color-primary-10: var(--studio-jetpack-green-10);
+	--color-primary-10-rgb: var(--studio-jetpack-green-10-rgb);
+	--color-primary-20: var(--studio-jetpack-green-20);
+	--color-primary-20-rgb: var(--studio-jetpack-green-20-rgb);
+	--color-primary-30: var(--studio-jetpack-green-30);
+	--color-primary-30-rgb: var(--studio-jetpack-green-30-rgb);
+	--color-primary-40: var(--studio-jetpack-green-40);
+	--color-primary-40-rgb: var(--studio-jetpack-green-40-rgb);
+	--color-primary-50: var(--studio-jetpack-green-50);
+	--color-primary-50-rgb: var(--studio-jetpack-green-rgb);
+	--color-primary-60: var(--studio-jetpack-green-60);
+	--color-primary-60-rgb: var(--studio-jetpack-green-60-rgb);
+	--color-primary-70: var(--studio-jetpack-green-70);
+	--color-primary-70-rgb: var(--studio-jetpack-green-70-rgb);
+	--color-primary-80: var(--studio-jetpack-green-80);
+	--color-primary-80-rgb: var(--studio-jetpack-green-80-rgb);
+	--color-primary-90: var(--studio-jetpack-green-90);
+	--color-primary-90-rgb: var(--studio-jetpack-green-90-rgb);
+	--color-primary-100: var(--studio-jetpack-green-100);
+	--color-primary-100-rgb: var(--studio-jetpack-green-100-rgb);
+
+	/* Theme Properties */
+	--color-accent: var(--studio-gray-50);
+	--color-accent-rgb: var(--studio-gray-50-rgb);
+	--color-accent-dark: var(--studio-gray-70);
+	--color-accent-dark-rgb: var(--studio-gray-70-rgb);
+	--color-accent-light: var(--studio-gray-30);
+	--color-accent-light-rgb: var(--studio-gray-30-rgb);
+	--color-accent-0: var(--studio-gray-0);
+	--color-accent-0-rgb: var(--studio-gray-0-rgb);
+	--color-accent-5: var(--studio-gray-5);
+	--color-accent-5-rgb: var(--studio-gray-5-rgb);
+	--color-accent-10: var(--studio-gray-10);
+	--color-accent-10-rgb: var(--studio-gray-10-rgb);
+	--color-accent-20: var(--studio-gray-20);
+	--color-accent-20-rgb: var(--studio-gray-20-rgb);
+	--color-accent-30: var(--studio-gray-30);
+	--color-accent-30-rgb: var(--studio-gray-30-rgb);
+	--color-accent-40: var(--studio-gray-40);
+	--color-accent-40-rgb: var(--studio-gray-40-rgb);
+	--color-accent-50: var(--studio-gray-50);
+	--color-accent-50-rgb: var(--studio-gray-50-rgb);
+	--color-accent-60: var(--studio-gray-60);
+	--color-accent-60-rgb: var(--studio-gray-60-rgb);
+	--color-accent-70: var(--studio-gray-70);
+	--color-accent-70-rgb: var(--studio-gray-70-rgb);
+	--color-accent-80: var(--studio-gray-80);
+	--color-accent-80-rgb: var(--studio-gray-80-rgb);
+	--color-accent-90: var(--studio-gray-90);
+	--color-accent-90-rgb: var(--studio-gray-90-rgb);
+	--color-accent-100: var(--studio-gray-100);
+	--color-accent-100-rgb: var(--studio-gray-100-rgb);
+
+	--theme-highlight-color: var(--color-primary-50);
+	--theme-highlight-color-rgb: var(--color-primary-50-rgb);
+
+	--geo-chart-color-light: var(--color-accent-5);
+	--geo-chart-color-dark: var(--color-accent);
+}

--- a/apps/odyssey-stats/src/widget/index.scss
+++ b/apps/odyssey-stats/src/widget/index.scss
@@ -1,5 +1,5 @@
 @import "../styles/widget-base.scss";
-@import "../styles/theme.scss";
+@import "../styles/scoped-theme-for-widget.scss";
 @import "../styles/wp-admin.scss";
 @import "../styles/typography.scss";
 @import "@wordpress/base-styles/breakpoints";

--- a/apps/odyssey-stats/src/widget/index.tsx
+++ b/apps/odyssey-stats/src/widget/index.tsx
@@ -29,7 +29,7 @@ export function init() {
 	setLocale( localeSlug ).then( () =>
 		render(
 			<QueryClientProvider client={ queryClient }>
-				<div id="stats-widget-content" className="stats-widget-content is-section-stats">
+				<div id="stats-widget-content" className="stats-widget-content">
 					<MiniChart
 						siteId={ currentSiteId }
 						gmtOffset={ config( 'gmt_offset' ) }

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -127,17 +127,9 @@ class StatsGeochart extends Component {
 		// support switching color schemes in IE11 thus applying the
 		// defaults as raw hex values here.
 		const chartColorLight =
-			getComputedStyle(
-				document.getElementsByClassName( 'is-section-stats' )?.[ 0 ] || document.body
-			)
-				.getPropertyValue( '--geo-chart-color-light' )
-				.trim() || '#ffdff3';
+			getComputedStyle( document.body ).getPropertyValue( '--color-accent-5' ).trim() || '#ffdff3';
 		const chartColorDark =
-			getComputedStyle(
-				document.getElementsByClassName( 'is-section-stats' )?.[ 0 ] || document.body
-			)
-				.getPropertyValue( '--geo-chart-color-dark' )
-				.trim() || '#d52c82';
+			getComputedStyle( document.body ).getPropertyValue( '--color-accent' ).trim() || '#d52c82';
 
 		const options = {
 			keepAspectRatio: true,


### PR DESCRIPTION
Follow up for https://github.com/Automattic/wp-calypso/pull/93549

## Proposed Changes

Only scope theme for widget; otherwise the popover etc styling would be broken.

## Testing Instructions



* Test Odyssey Stats for simple site with Option 3 - PCYsg-Pp7-p2
* Ensure the dot on the bell look like blow
* Ensure Odyssey Stats and widget still styled right
* Ensure popups are properly styled

<img width="235" alt="image" src="https://github.com/user-attachments/assets/49924fc0-ba18-4b73-a80e-a459f8fe61cf">

<img width="807" alt="image" src="https://github.com/user-attachments/assets/6e065abb-1fe1-4763-9aad-28bd14969dfc">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
