### PR TITLE
fix(hosting-overview-refinements): fix rendering atomic website as simple

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -29,6 +29,16 @@ const fetchSites = (
 	} );
 };
 
+export const queryKeyForAllSitesWithThemeSlug = [
+	USE_SITE_EXCERPTS_QUERY_KEY,
+	SITE_EXCERPT_REQUEST_FIELDS,
+	SITE_EXCERPT_REQUEST_OPTIONS,
+	[],
+	'all',
+	[],
+	[ 'theme_slug' ],
+];
+
 export const useSiteExcerptsQuery = (
 	fetchFilter?: string[],
 	sitesFilterFn?: ( site: SiteExcerptData ) => boolean,

--- a/client/hosting/hosting-features/components/hosting-features.tsx
+++ b/client/hosting/hosting-features/components/hosting-features.tsx
@@ -3,6 +3,7 @@ import { FEATURE_SFTP, getPlan, PLAN_BUSINESS } from '@automattic/calypso-produc
 import page from '@automattic/calypso-router';
 import { Dialog } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button, Spinner } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
@@ -10,6 +11,7 @@ import { AnyAction } from 'redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { HostingCard } from 'calypso/components/hosting-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { queryKeyForAllSitesWithThemeSlug } from 'calypso/data/sites/use-site-excerpts-query';
 import { useSiteTransferStatusQuery } from 'calypso/landing/stepper/hooks/use-site-transfer/query';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -40,6 +42,7 @@ const PromoCard = ( { title, text, supportContext }: PromoCardProps ) => (
 
 const HostingFeatures = () => {
 	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
 	const { searchParams } = new URL( document.location.toString() );
 	const showActivationModal = searchParams.get( 'activate' ) !== null;
 	const [ showEligibility, setShowEligibility ] = useState( showActivationModal );
@@ -91,8 +94,11 @@ const HostingFeatures = () => {
 
 		if ( siteTransferData?.status === transferStates.COMPLETED ) {
 			dispatch( fetchAtomicTransfer( siteId ) as unknown as AnyAction );
+			queryClient.invalidateQueries( {
+				queryKey: queryKeyForAllSitesWithThemeSlug,
+			} );
 		}
-	}, [ siteTransferData?.status, siteId, dispatch ] );
+	}, [ siteTransferData?.status, siteId, dispatch, queryClient ] );
 
 	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
 	const promoCards = [


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8771

## Why are these changes being made?
When a site becomes atomic and we redirect a user from "Hosting Features" to "Hosting Overview" - we can notice that we have fglash of incorrect state of UI - initially we see UI from Atomic website and then i an few seconds we see incorrect UI, for Simple site (but the site is Atomic).

## Testing Instructions
Before testing, recommend watching this video and reading the description there p1724404907834529/1724373252.261939-slack-C06ELHR6L9J

### A4A tests
1. Open `https://agencies.automattic.com/`
2. Purchase licences, if you don't have (Left sidebar "Purchase" -> "Issue New License")
3. Click on `Sites` in left sidebar
4. Click on "Needs setup"
5. Click on "Create new site" and proceed
6. Wait till you see the next notification<br /> <img width="531" alt="Screenshot 2024-08-13 at 12 58 24" src="https://github.com/user-attachments/assets/98ea9aab-f607-4998-815a-1c403b9f1020">
7. Copy selected domain on the screenshot above
8. And open new tab with the next URL `http://calypso.localhost:3000/hosting-features/<COPYED_DOMAIN_IN_7TH_STEP>`
9. Assert that you see spinner and copy about "things in progress" <br /><img width="636" alt="Screenshot 2024-08-13 at 13 00 43" src="https://github.com/user-attachments/assets/ae8817f1-da5d-4d06-9c57-3437ea7f5c1b">
10. Wait till it's finished
11. Assert that you are redirected to "Overview" tab and you see tabs list for Atomic website (before it was bug when we see tabs for Simpel websites)
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="339" alt="Screenshot 2024-08-23 at 11 21 55" src="https://github.com/user-attachments/assets/8cb58436-eea3-4027-bda7-b5d3e8f51790">
<td><img width="665" alt="Screenshot 2024-08-23 at 11 20 29" src="https://github.com/user-attachments/assets/6d9c44ef-b01e-4218-b301-f6e0a6ef7235">
</tr>
</table> 

### Manually turning on Hosting Features
1. Purchase domain with `Starter` plan
2. Open "Hosting features" tab on "Sites" page (Let's call this tab as `A` during testing)
3. Copy the URL and open a separate tab (Let's call this tab as `B` during testing, we will use it in the end for testing)
4. In tab A, click `Upgrade now` and proceed with upgrading
5. Now let's repeat the 3-rd step to open one more separate tab (Let's call this tab as `C` during testing, we will use it in the end for testing), so that you will have the next tabs `B` and `C`:<br /><img width="2296" alt="Screenshot 2024-07-29 at 16 12 45" src="https://github.com/user-attachments/assets/7ee4bc76-a06c-43dd-b64f-1b8c9c295a7c">
6. Now, in tab `A` click `Activate now` and proceed
7. During activating process, the copy on tabs B and C should be changed to the next (with CTA buttons hidden)<br /><img width="2293" alt="Screenshot 2024-07-29 at 16 15 28" src="https://github.com/user-attachments/assets/00b3e02f-cf04-482e-8ad8-eebbee3d8528">
8. Wait till it's finished
11. Assert that you are redirected to "Overview" tab and you see tabs list for Atomic website (before it was bug when we see tabs for Simpel websites)
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="339" alt="Screenshot 2024-08-23 at 11 21 55" src="https://github.com/user-attachments/assets/8cb58436-eea3-4027-bda7-b5d3e8f51790">
<td><img width="665" alt="Screenshot 2024-08-23 at 11 20 29" src="https://github.com/user-attachments/assets/6d9c44ef-b01e-4218-b301-f6e0a6ef7235">
</tr>
</table> 





