### PR TITLE
Observe reopening of the settings popover

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -700,12 +700,17 @@ async function openLinksInParentFrame( calypsoPort ) {
 					continue;
 				}
 
-				const popoverSlot = node.querySelector( '.components-popover' );
+				// The popoverSlotObserverObserver will observe addedNodes containing components-popover__fallback-container node elemnts which contain the components-popover
+				// The popoverSlotObserver will observe addedNodes containing components-popover node elements
+				const popoverSlot = node?.classList?.contains( 'components-popover' )
+					? node
+					: node.querySelector( '.components-popover' );
 
 				if ( popoverSlot ) {
 					const manageReusableBlocksAnchorElem = popoverSlot.querySelector(
 						'a[href$="site-editor.php?path=%2Fpatterns"]'
 					);
+
 					const manageNavigationMenusAnchorElem = popoverSlot.querySelector(
 						'a[href$="edit.php?post_type=wp_navigation"]'
 					);
@@ -730,8 +735,21 @@ async function openLinksInParentFrame( calypsoPort ) {
 			}
 		}
 	} );
-	const popoverSlotElem = document.querySelector( 'body' );
-	popoverSlotElem && popoverSlotObserver.observe( popoverSlotElem, { childList: true } );
+	const popoverSlotObserverObserver = new window.MutationObserver( ( mutations ) => {
+		for ( const record of mutations ) {
+			for ( const node of record.addedNodes ) {
+				if ( ! node ) {
+					continue;
+				}
+				if ( node?.classList?.contains( 'components-popover__fallback-container' ) ) {
+					popoverSlotObserver.observe( node, { childList: true } );
+				}
+			}
+		}
+	} );
+	const htmlBody = document.querySelector( 'body' );
+	htmlBody && popoverSlotObserver.observe( htmlBody, { childList: true } );
+	htmlBody && popoverSlotObserverObserver.observe( htmlBody, { childList: true } );
 
 	// Sidebar might already be open before this script is executed.
 	// post and site editors

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -48,6 +48,21 @@ function addCommandsInputListener( selector, cb ) {
 	} );
 }
 
+/**
+ * Returns the Popover fallback container if exists or creates a new node
+ */
+const fallbackContainerClassname = 'components-popover__fallback-container';
+const getPopoverFallbackContainer = () => {
+	let container = document.body.querySelector( '.' + fallbackContainerClassname );
+	if ( ! container ) {
+		container = document.createElement( 'div' );
+		container.className = fallbackContainerClassname;
+		document.body.append( container );
+	}
+
+	return container;
+};
+
 // Calls a callback if the event occured on an element or parent thereof matching
 // the callback's selector. This is needed because elements are added and removed
 // from the DOM dynamically after the listeners are created. We need to handle
@@ -700,7 +715,6 @@ async function openLinksInParentFrame( calypsoPort ) {
 					continue;
 				}
 
-				// The popoverSlotObserverObserver will observe addedNodes containing components-popover__fallback-container node elemnts which contain the components-popover
 				// The popoverSlotObserver will observe addedNodes containing components-popover node elements
 				const popoverSlot = node?.classList?.contains( 'components-popover' )
 					? node
@@ -735,21 +749,10 @@ async function openLinksInParentFrame( calypsoPort ) {
 			}
 		}
 	} );
-	const popoverSlotObserverObserver = new window.MutationObserver( ( mutations ) => {
-		for ( const record of mutations ) {
-			for ( const node of record.addedNodes ) {
-				if ( ! node ) {
-					continue;
-				}
-				if ( node?.classList?.contains( 'components-popover__fallback-container' ) ) {
-					popoverSlotObserver.observe( node, { childList: true } );
-				}
-			}
-		}
-	} );
-	const htmlBody = document.querySelector( 'body' );
-	htmlBody && popoverSlotObserver.observe( htmlBody, { childList: true } );
-	htmlBody && popoverSlotObserverObserver.observe( htmlBody, { childList: true } );
+
+	// Observe children of the Popover Container
+	const popoverContainer = getPopoverFallbackContainer();
+	popoverContainer && popoverContainer.observe( popoverContainer, { childList: true } );
 
 	// Sidebar might already be open before this script is executed.
 	// post and site editors

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -752,7 +752,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 
 	// Observe children of the Popover Container
 	const popoverContainer = getPopoverFallbackContainer();
-	popoverContainer && popoverContainer.observe( popoverContainer, { childList: true } );
+	popoverContainer && popoverSlotObserver.observe( popoverContainer, { childList: true } );
 
 	// Sidebar might already be open before this script is executed.
 	// post and site editors

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -715,17 +715,12 @@ async function openLinksInParentFrame( calypsoPort ) {
 					continue;
 				}
 
-				// The popoverSlotObserver will observe addedNodes containing components-popover node elements
-				const popoverSlot = node?.classList?.contains( 'components-popover' )
-					? node
-					: node.querySelector( '.components-popover' );
-
-				if ( popoverSlot ) {
-					const manageReusableBlocksAnchorElem = popoverSlot.querySelector(
+				if ( node?.classList?.contains( 'components-popover' ) ) {
+					const manageReusableBlocksAnchorElem = node.querySelector(
 						'a[href$="site-editor.php?path=%2Fpatterns"]'
 					);
 
-					const manageNavigationMenusAnchorElem = popoverSlot.querySelector(
+					const manageNavigationMenusAnchorElem = node.querySelector(
 						'a[href$="edit.php?post_type=wp_navigation"]'
 					);
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/91796
Fixes https://github.com/Automattic/wp-calypso/issues/83472

## Proposed Changes

* Ensures observation continues on secondary menu clicks

## Testing Instructions
* Sync changes running `install-plugin.sh wpcom-block-editor update/observerobserver` 
* Sandbox `widgets.wp.com`
* Create a new post from `https://wordpress.com/post/{ SITE SLUG }` with a site using the Default admin style
* Open the editor options from the three dots menu on the top right
* Close it and open it again to trigger a re-render
* Click on "Manage Patterns"

<img width="380" alt="Screenshot 2567-08-23 at 17 57 00" src="https://github.com/user-attachments/assets/dc0a45c7-b414-4568-9a35-ca214dc58917">


* Expect to see the pattern manager

<img width="1126" alt="Screenshot 2567-08-23 at 17 55 19" src="https://github.com/user-attachments/assets/223ed444-844f-4f8c-b903-dd186bc27dcd">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
