### PR TITLE
Replace the Premium plan by the Personal plan in the no-ads upsell.

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -1,4 +1,4 @@
-import { PLAN_PREMIUM, WPCOM_FEATURES_NO_ADVERTS, getPlan } from '@automattic/calypso-products';
+import { PLAN_PERSONAL, WPCOM_FEATURES_NO_ADVERTS, getPlan } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -39,7 +39,6 @@ export const Sharing = ( {
 	isVip,
 	siteSlug,
 	translate,
-	premiumPlanName,
 } ) => {
 	const adminInterfaceIsWPAdmin = useSelector( ( state ) =>
 		isAdminInterfaceWPAdmin( state, siteId )
@@ -181,11 +180,11 @@ export const Sharing = ( {
 			{ ! isVip && ! isJetpack && (
 				<UpsellNudge
 					event="sharing_no_ads"
-					plan={ PLAN_PREMIUM }
+					plan={ PLAN_PERSONAL }
 					feature={ WPCOM_FEATURES_NO_ADVERTS }
 					description={ translate( 'Prevent ads from showing on your site.' ) }
-					title={ translate( 'No ads with WordPress.com %(premiumPlanName)s', {
-						args: { premiumPlanName },
+					title={ translate( 'No ads with WordPress.com %(upsellPlanName)s', {
+						args: { upsellPlanName: getPlan( PLAN_PERSONAL )?.getTitle() },
 					} ) }
 					tracksImpressionName="calypso_upgrade_nudge_impression"
 					tracksClickName="calypso_upgrade_nudge_cta_click"
@@ -215,7 +214,6 @@ export default connect( ( state ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	const isAtomic = isSiteWpcomAtomic( state, siteId );
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-	const premiumPlanName = getPlan( PLAN_PREMIUM )?.getTitle();
 
 	return {
 		isP2Hub: isSiteP2Hub( state, siteId ),
@@ -227,6 +225,5 @@ export default connect( ( state ) => {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		isJetpack: isJetpack,
-		premiumPlanName,
 	};
 } )( localize( Sharing ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Props to @niranjan-uma-shankar in pau2Xa-6bY-p2#comment-15995, this PR updates the Premium plan upsell by the Personal plan. 

The variable name `premiumPlanName` will thus be wrong, so the PR also updates it into `upsellPlanName` to be more plan name agnostic. 

![CleanShot 2024-08-23 at 14 01 50@2x](https://github.com/user-attachments/assets/28319f6a-7330-4c56-93ce-bd901edb4495)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The minimal required plan for removing ads is Personal rather than Premium. Our hypothesis is that the wrong tier of plan upsell results in the high refund rate we saw for this upsell.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a Free site, go to /marketing/tools
* Make sure you see the no-ads banner upselling the Personal plan
* When you have no stored payment info, clicking on it should redirect to /plans
* When you have stored payment info, clicking on it should show the 1-click checkou modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?