### PR TITLE
Redirect to previous page when closing cart on hosted site migration

### DIFF
--- a/client/my-sites/checkout/src/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/src/lib/leave-checkout.ts
@@ -38,7 +38,11 @@ export const leaveCheckout = ( {
 	const launchpadURLRegex = /^\/setup\/[a-z][a-z\-_]*[a-z]\/launchpad\b/g;
 	const launchpadURLRegexMatch = redirectToParam?.toString().match( launchpadURLRegex );
 
-	if ( siteSlug && sendMessageToOpener( siteSlug, 'checkoutCancelled' ) ) {
+	if (
+		siteSlug &&
+		sendMessageToOpener( siteSlug, 'checkoutCancelled' ) &&
+		signupFlowName !== 'hosted-site-migration'
+	) {
 		return;
 	}
 

--- a/client/my-sites/checkout/src/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/src/lib/leave-checkout.ts
@@ -1,4 +1,8 @@
-import { isTailoredSignupFlow } from '@automattic/onboarding';
+import {
+	isTailoredSignupFlow,
+	MIGRATION_FLOW,
+	HOSTED_SITE_MIGRATION_FLOW,
+} from '@automattic/onboarding';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import debugFactory from 'debug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -41,7 +45,7 @@ export const leaveCheckout = ( {
 	if (
 		siteSlug &&
 		sendMessageToOpener( siteSlug, 'checkoutCancelled' ) &&
-		signupFlowName !== 'hosted-site-migration'
+		! [ HOSTED_SITE_MIGRATION_FLOW, MIGRATION_FLOW ].includes( signupFlowName )
 	) {
 		return;
 	}


### PR DESCRIPTION
Closes #93851

## Proposed Changes

When initiating the hosted site migration flow from wordpress.com/move the close button of the cart doesn't work. This is because the flow gets opened in a new tab, which causes this to be true and return:

```
if (
		siteSlug &&
		sendMessageToOpener( siteSlug, 'checkoutCancelled' ) &&
	) {
		return;
	}
```

This PR adds an extra check:

```
if (
		siteSlug &&
		sendMessageToOpener( siteSlug, 'checkoutCancelled' ) &&
		signupFlowName !== 'hosted-site-migration'
	) {
		return;
	}
``` 

This will still send the message to opener (in case the behavior is needed), but will not return when the flow is `hosted-site-migration` and will go back to the previous page. 

@andres-blanco since you created the flow, would you mind taking a look at this PR?

An alternative approach would be to add a direct comparison ( `window.opener.location.href.includes("wordpress.com/move)` in leaveCheckout.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

1. Launch Calypso.
2. Use this JSBin to enter the flow in a new window: https://jsbin.com/fusofahejo/edit?html,output 
3. Select "Create a new one", "Migrate site", "I'll do it myself" & "Get the plan & migrate"
4. When presented with the cart, click on the close button
5. You should be redirected to the previous page.


![CleanShot 2024-08-23 at 08 25 58@2x](https://github.com/user-attachments/assets/84d6a7b4-e60a-4124-bba4-fab61d805b81)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
