### PR TITLE
add enabled flag to smooch

### DIFF
--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -56,9 +56,7 @@ const HelpCenter: React.FC< Container > = ( {
 		( isHelpCenterShown && isEligibleForChat ) || hasActiveChats,
 		isEligibleForChat || hasActiveChats
 	);
-	const { initSmooch, destroy } = useSmooch(
-		isMessagingScriptLoaded && ( isEligibleForChat || hasActiveChats )
-	);
+	const { initSmooch, destroy } = useSmooch( isMessagingScriptLoaded && hasActiveChats );
 	const ref = useRef( null );
 
 	useZendeskMessagingBindings( HELP_CENTER_STORE, hasActiveChats, isMessagingScriptLoaded );

--- a/packages/zendesk-client/src/use-smooch.ts
+++ b/packages/zendesk-client/src/use-smooch.ts
@@ -50,9 +50,9 @@ const addUnreadCountListener = ( callback: ( unreadCount: number ) => void ) => 
 	Smooch.on( 'unreadCount', callback );
 };
 
-export const useSmooch = () => {
+export const useSmooch = ( enabled: boolean ) => {
 	const [ init, setInit ] = useState( typeof Smooch.getConversations === 'function' );
-	const { data: authData } = useAuthenticateZendeskMessaging( true, 'messenger' );
+	const { data: authData } = useAuthenticateZendeskMessaging( enabled, 'messenger' );
 	const { isPending: isSubmittingZendeskUserFields, mutateAsync: submitUserFields } =
 		useUpdateZendeskUserFields();
 


### PR DESCRIPTION
## Proposed Changes

* Adds an `enabled` flag to the `use-smooch`
* Adds Smooch loading back on the Help Center

## Why are these changes being made?

* Our first attempt generated a lot of authentication requests. This change tries to mitigate that by adding an `enabled` flag to avoid early calls

## Testing Instructions

* Open local calypso. Confirm no authentication requests were made and smooch isn't loading.
* Try to contact support. Confirm smooch is loaded, and the authentication request was made.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
