### PR TITLE
A4A Dev Sites: Fetch actual agency and dev site data for the Launch page

### DIFF
--- a/client/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog.ts
+++ b/client/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export default function useFetchAgencyFromBlog( blogId: number ) {
+	return useQuery( {
+		queryKey: [ 'agency-blog', blogId ],
+		queryFn: () =>
+			wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/blog/${ blogId }`,
+			} ),
+		select: ( data ) => {
+			return {
+				id: data?.id,
+				name: data?.name,
+			};
+		},
+		enabled: !! blogId,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog.ts
+++ b/client/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog.ts
@@ -1,7 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-export default function useFetchAgencyFromBlog( blogId: number ) {
+export default function useFetchAgencyFromBlog(
+	blogId: number,
+	options: { enabled?: boolean } = {}
+) {
+	const { enabled = true, ...restOptions } = options;
+
 	return useQuery( {
 		queryKey: [ 'agency-blog', blogId ],
 		queryFn: () =>
@@ -15,7 +20,8 @@ export default function useFetchAgencyFromBlog( blogId: number ) {
 				name: data?.name,
 			};
 		},
-		enabled: !! blogId,
+		enabled: !! blogId && enabled,
 		refetchOnWindowFocus: false,
+		...restOptions,
 	} );
 }

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -91,7 +91,7 @@ const LaunchSite = () => {
 		data: agency,
 		error: agencyError,
 		isLoading: agencyLoading,
-	} = useFetchAgencyFromBlog( site.ID );
+	} = useFetchAgencyFromBlog( site?.ID );
 	const agencyName = agency?.name;
 
 	return (

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -91,7 +91,7 @@ const LaunchSite = () => {
 		data: agency,
 		error: agencyError,
 		isLoading: agencyLoading,
-	} = useFetchAgencyFromBlog( site?.ID );
+	} = useFetchAgencyFromBlog( site?.ID, { enabled: !! site?.ID && isDevelopmentSite } );
 	const agencyName = agency?.name;
 
 	return (

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -2,6 +2,7 @@ import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products'
 import { Card, CompactCard, Button } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
+import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import SitePreviewLink from 'calypso/components/site-preview-link';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -84,12 +85,14 @@ const LaunchSite = () => {
 
 	const LaunchCard = showPreviewLink ? CompactCard : Card;
 
-	// TODO: replace with actual value whether the site is a development site
-	const urlParams = new URLSearchParams( window.location.search );
-	const isDevelopmentSite = urlParams.get( 'referer' ) === 'a4a-dashboard';
+	const isDevelopmentSite = site?.is_a4a_dev_site || false;
 
-	// TODO: retrieve the actual agency name
-	const agencyName = 'MyCoolAgency';
+	const {
+		data: agency,
+		error: agencyError,
+		isLoading: agencyLoading,
+	} = useFetchAgencyFromBlog( site.ID );
+	const agencyName = agency?.name;
 
 	return (
 		<>
@@ -109,15 +112,19 @@ const LaunchSite = () => {
 						</p>
 						{ isDevelopmentSite && (
 							<p>
-								{ translate(
-									'Once the site is launched, %(agencyName)s will be billed for this site in the next billing cycle.',
-									{
-										args: {
-											agencyName: agencyName,
-										},
-										comment: 'name of the agency that will be billed for the site',
-									}
-								) }
+								{ agencyLoading || agencyError
+									? translate(
+											'Once the site is launched, your agency will be billed for this site in the next billing cycle.'
+									  )
+									: translate(
+											'Once the site is launched, %(agencyName)s will be billed for this site in the next billing cycle.',
+											{
+												args: {
+													agencyName: agencyName,
+												},
+												comment: 'name of the agency that will be billed for the site',
+											}
+									  ) }
 							</p>
 						) }
 					</div>

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -117,10 +117,13 @@ const LaunchSite = () => {
 											'Once the site is launched, your agency will be billed for this site in the next billing cycle.'
 									  )
 									: translate(
-											'Once the site is launched, %(agencyName)s will be billed for this site in the next billing cycle.',
+											'Once the site is launched, {{strong}}%(agencyName)s{{/strong}} will be billed for this site in the next billing cycle.',
 											{
 												args: {
 													agencyName: agencyName,
+												},
+												components: {
+													strong: <strong />,
 												},
 												comment: 'name of the agency that will be billed for the site',
 											}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8667

## Proposed Changes

* introduce new `useFetchAgencyFromBlog` that relies on the endpoint introduced in D159142-code
  * use the endpoint to fetch agency name
* do not rely on the temporary `?referer=a4a-dashboard` URL parameter to display customized message in the site Launch section
  * instead get the information from the `site` object

![Markup on 2024-08-23 at 12:55:07](https://github.com/user-attachments/assets/99d67047-bd87-4cb0-a7e3-869da1e7512f)

ℹ️ Please note this PR does not remove `?referer=a4a-dashboard` URL parameter from the "Prepare for launch" links. I left it out for now so it doesn't make this PR too large / more difficult to test.

ℹ️ Also, agency name is currently HTML-encoded and hence may not render some characters properly. We will need to address this in a separate backend patch.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This PR is part of the Free A4A Development Sites project: pdDOJh-3Cl-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out and build this PR with `yarn start`.
2. Navigate to http://calypso.localhost:3000/settings/general/{blog-id} (`blog-id` needs to be replaced with one of your **dev** blogs ID).
3. A custom copy and a "Refer to client" button should be rendered (as can be seen in the screenshot above).
4. Navigate to the same page again, but this time use a blog ID of a non-dev site. You can also test with a non-agency site, e.g. Atomic site that hasn't been launched yet and was created outside of Agency portal.
5. The new copy and the "Refer to client" button should be gone. The endpoint request related to `useFetchAgencyFromBlog` shouldn't be called. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?