### PR TITLE
Onboarding - Domain Transfer: Remove the http placeholder

### DIFF
--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -55,7 +55,7 @@
 		max-width: 370px;
 
 		.form-text-input {
-			padding: 9px 28px 9px 68px;
+			padding: 9px 28px 9px 10px;
 			margin-bottom: 9px;
 
 			text-overflow: ellipsis;
@@ -95,14 +95,6 @@
 				fill: var(--color-text);
 			}
 		}
-	}
-
-	& &__domain-input-fieldset::before {
-		content: "https://";
-		color: var(--color-text);
-		position: absolute;
-		left: 16px;
-		top: 10px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/8749

## Proposed Changes

This PR removes the `https` protocol prefix that seems to add more confusion to users and bring more consistency with other similar `URL` inputs. 






## Testing Instructions

1. At the onboarding - domain transfer step observe that the protocol prefix is not there
2. Everything should work as before because this is just a very specific css change

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before            |  After
:-------------------------:|:-------------------------:
<img width="425" alt="before" src="https://github.com/user-attachments/assets/f098ed21-f69d-41e9-97d1-3d69368a759b"> | <img width="425" alt="after" src="https://github.com/user-attachments/assets/78d291eb-63a3-4f09-b910-ca95428ec10d">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
