### PR TITLE
UI: Add undisclose password icon on credentials form

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,8 +1,11 @@
 import { FormLabel } from '@automattic/components';
 import Card from '@automattic/components/src/card';
 import { NextButton, StepContainer } from '@automattic/onboarding';
+import { Icon } from '@wordpress/components';
+import { seen, unseen } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, type FC } from 'react';
+import { useEffect, useState, type FC } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import getValidationMessage from 'calypso/blocks/import/capture/url-validation-message-helper';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
@@ -37,6 +40,13 @@ const mapApiError = ( error: any ) => {
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip } ) => {
 	const translate = useTranslate();
+
+	const [ passwordHidden, setPasswordHidden ] = useState( true );
+
+	const toggleVisibilityClasses = clsx( {
+		'site-migration-credentials__form-password__toggle': true,
+		'site-migration-credentials__form-password__toggle-visibility': ! passwordHidden,
+	} );
 
 	const validateSiteAddress = ( siteAddress: string ) => {
 		const isSiteAddressValid = CAPTURE_URL_RGX.test( siteAddress );
@@ -270,13 +280,23 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 											required: translate( 'Please enter your WordPress admin password.' ),
 										} }
 										render={ ( { field } ) => (
-											<FormTextInput
-												id="password"
-												type="password"
-												isError={ !! errors.password }
-												placeholder={ translate( 'Password' ) }
-												{ ...field }
-											/>
+											<div className="site-migration-credentials__form-password">
+												<FormTextInput
+													autoComplete="off"
+													id="password"
+													type={ passwordHidden ? 'password' : 'text' }
+													isError={ !! errors.password }
+													placeholder={ translate( 'Password' ) }
+													{ ...field }
+												/>
+												<button
+													className={ toggleVisibilityClasses }
+													onClick={ () => setPasswordHidden( ! passwordHidden ) }
+													type="button"
+												>
+													{ passwordHidden ? <Icon icon={ unseen } /> : <Icon icon={ seen } /> }
+												</button>
+											</div>
 										) }
 									/>
 								</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -271,7 +271,9 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 									/>
 								</div>
 								<div className="site-migration-credentials__form-field">
-									<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
+									<FormLabel htmlFor="site-migration-credentials__password">
+										{ translate( 'Password' ) }
+									</FormLabel>
 									<Controller
 										control={ control }
 										name="password"
@@ -282,6 +284,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 											<div className="site-migration-credentials__form-password">
 												<FormTextInput
 													autoComplete="off"
+													id="site-migration-credentials__password"
 													type={ passwordHidden ? 'password' : 'text' }
 													isError={ !! errors.password }
 													placeholder={ translate( 'Password' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -45,7 +45,6 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 
 	const toggleVisibilityClasses = clsx( {
 		'site-migration-credentials__form-password__toggle': true,
-		'site-migration-credentials__form-password__toggle-visibility': ! passwordHidden,
 	} );
 
 	const validateSiteAddress = ( siteAddress: string ) => {
@@ -283,7 +282,6 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit, onSkip 
 											<div className="site-migration-credentials__form-password">
 												<FormTextInput
 													autoComplete="off"
-													id="password"
 													type={ passwordHidden ? 'password' : 'text' }
 													isError={ !! errors.password }
 													placeholder={ translate( 'Password' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -69,6 +69,29 @@
 			font-size: 0.875rem;
 			margin-top: 0.25rem;
 		}
+
+		.site-migration-credentials__form-password {
+			position: relative;
+		}
+
+		.site-migration-credentials__form-password__toggle {
+			display: block;
+			cursor: pointer;
+			position: absolute;
+			right: 8px;
+			top: 50%;
+			transform: translateY(-50%);
+			user-select: none;
+			line-height: 1;
+
+			svg {
+				fill: var(--color-neutral-20);
+
+				&:hover {
+					fill: var(--color-neutral-40);
+				}
+			}
+		}
 	}
 	.site-migration-credentials__skip {
 		margin-top: 1em;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -72,23 +72,23 @@
 
 		.site-migration-credentials__form-password {
 			position: relative;
-		}
 
-		.site-migration-credentials__form-password__toggle {
-			display: block;
-			cursor: pointer;
-			position: absolute;
-			right: 8px;
-			top: 50%;
-			transform: translateY(-50%);
-			user-select: none;
-			line-height: 1;
+			.site-migration-credentials__form-password__toggle {
+				display: block;
+				cursor: pointer;
+				position: absolute;
+				right: 8px;
+				top: 50%;
+				transform: translateY(-50%);
+				user-select: none;
+				line-height: 1;
 
-			svg {
-				fill: var(--color-neutral-20);
+				svg {
+					fill: var(--color-neutral-20);
 
-				&:hover {
-					fill: var(--color-neutral-40);
+					&:hover {
+						fill: var(--studio-blue-50);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/93837

## Proposed Changes

Add an undisclose password icon on the right hand side of the password field

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The feature is detailed in the designs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch to your local environment or add use the Calypso Live link below.
- Open the dev console and activate the feature flag by running the following command:
`window.sessionStorage.setItem('flags', 'automated-migration/collect-credentials')`
- Now get into the flow using the /start URL
- Go through the domain selection step
- Select the free plan on the Plans page
- On the Goals step, select the "Import existing content or website" option and click continue
- Input the source site URL in the Identify step
- Next, select the "Migrate Site" option on the Import or Migrate step
- Select "Do it for me" on the How to migrate step
- Go through the checkout
- Once you complete the checkout, you should land on the new Credentials step
- Test the undisclose password works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
