### PR TITLE
Plugins Marketplace: Remove the confetti animation after installing a plugin

### DIFF
--- a/client/components/thank-you-v2/index.tsx
+++ b/client/components/thank-you-v2/index.tsx
@@ -14,15 +14,24 @@ interface ThankYouV2Props {
 	footerDetails?: ThankYouFooterDetailProps[];
 	upsellProps?: ThankYouUpsellProps;
 	isGravatarDomain?: boolean;
+	showSuccessAnimation?: boolean;
 }
 
 export default function ThankYouV2( props: ThankYouV2Props ) {
-	const { title, subtitle, headerButtons, products, footerDetails, upsellProps, isGravatarDomain } =
-		props;
+	const {
+		title,
+		subtitle,
+		headerButtons,
+		products,
+		footerDetails,
+		upsellProps,
+		isGravatarDomain,
+		showSuccessAnimation = true,
+	} = props;
 
 	return (
 		<div className="thank-you">
-			<ConfettiAnimation delay={ 1000 } />
+			{ showSuccessAnimation && <ConfettiAnimation delay={ 1000 } /> }
 
 			<ThankYouHeader title={ title } subtitle={ subtitle } buttons={ headerButtons } />
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -177,6 +177,7 @@ const MarketplaceThankYou = ( {
 						headerButtons={ thankYouHeaderAction }
 						products={ products }
 						footerDetails={ footerDetails }
+						showSuccessAnimation={ hasThemes }
 					/>
 				</Main>
 			) }


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/93593

This PR removes the confetti animation after installing a plugin because it feels unnecessary and can be a bit 'too much' especially if we have multiple plugins. 


## Testing Instructions

1. Install a plugin
2. Observe that the confetti animation isn't shown
3. Install a theme and observe that the animation remains as is


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
