### PR TITLE
Performance Profiler: show saved report state with hash in URL

### DIFF
--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -83,7 +83,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 					'is-loading': ! mobileLoaded,
 				} ) }
 			>
-				<LoadingScreen isSavedReport={ false } key="mobile-loading" />
+				<LoadingScreen isSavedReport={ !! hash } key="mobile-loading" />
 			</div>
 
 			<div
@@ -92,7 +92,7 @@ export const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboar
 					'is-loading': ! desktopLoaded,
 				} ) }
 			>
-				<LoadingScreen isSavedReport={ false } key="desktop-loading" />
+				<LoadingScreen isSavedReport={ !! hash } key="desktop-loading" />
 			</div>
 
 			{ ( ( activeTab === TabType.mobile && mobileLoaded ) ||

--- a/client/performance-profiler/pages/loading-screen/index.tsx
+++ b/client/performance-profiler/pages/loading-screen/index.tsx
@@ -119,6 +119,10 @@ export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 	const translate = useTranslate();
 	const [ step, setStep ] = useState( 0 );
 
+	const heading = isSavedReport
+		? translate( "Your site's results are ready" )
+		: translate( "Testing your site's speed…" );
+
 	const steps = isSavedReport
 		? [ translate( 'Getting your report…' ) ]
 		: [
@@ -203,7 +207,7 @@ export const LoadingScreen = ( { isSavedReport }: LoadingScreenProps ) => {
 	return (
 		<LayoutBlock className="landing-page-header-block">
 			<StyledLoadingScreen>
-				<h2>{ translate( "Testing your site's speed…" ) }</h2>
+				<h2>{ heading }</h2>
 				{ steps.map( ( heading, index ) => (
 					<span key={ index } className={ stepStatus( index, step ) }>
 						<Gridicon icon="checkmark" size={ 18 } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8838

## Proposed Changes

* Use the hash to show a different loading state

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/8838

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a saved report, eg. `/speed-test-tool?url=https://wordpress.com/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA0OX0.ZfaRSmOrFbiJrNRM8y4xEQmlRcMCCK4Xeb6cpts-yCI`
* Check that the loading screen has the updated heading and loading indicator
* Start a new test by visiting `/speed-test-tool?url=wordpress.com` (without the hash)
* Check that the original loading screen is shown

New loading state:
<img width="988" alt="image" src="https://github.com/user-attachments/assets/e1323407-79e9-4c28-98d5-fda2bdd3c18c">

Page load:

https://github.com/user-attachments/assets/84c102db-d46f-4d20-a0e8-9bb9d597b76a

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
