### PR TITLE
Performance Profiler: hide migration tips for wpcom sites

### DIFF
--- a/client/performance-profiler/components/dashboard-content/index.tsx
+++ b/client/performance-profiler/components/dashboard-content/index.tsx
@@ -19,7 +19,7 @@ export const PerformanceProfilerDashboardContent = ( {
 	performanceReport,
 	url,
 }: PerformanceProfilerDashboardContentProps ) => {
-	const { overall_score, fcp, lcp, cls, inp, ttfb, audits, history, screenshots } =
+	const { overall_score, fcp, lcp, cls, inp, ttfb, audits, history, screenshots, is_wpcom } =
 		performanceReport;
 
 	return (
@@ -42,7 +42,7 @@ export const PerformanceProfilerDashboardContent = ( {
 				/>
 				<NewsletterBanner />
 				<ScreenshotTimeline screenshots={ screenshots ?? [] } />
-				{ audits && <InsightsSection audits={ audits } url={ url } /> }
+				{ audits && <InsightsSection audits={ audits } url={ url } isWpcom={ is_wpcom } /> }
 			</div>
 
 			<Disclaimer />

--- a/client/performance-profiler/components/insights-section/index.tsx
+++ b/client/performance-profiler/components/insights-section/index.tsx
@@ -6,11 +6,12 @@ import './style.scss';
 type InsightsSectionProps = {
 	audits: Record< string, PerformanceMetricsItemQueryResponse >;
 	url: string;
+	isWpcom: boolean;
 };
 
 export const InsightsSection = ( props: InsightsSectionProps ) => {
 	const translate = useTranslate();
-	const { audits } = props;
+	const { audits, isWpcom } = props;
 
 	return (
 		<div className="performance-profiler-insights-section">
@@ -24,6 +25,7 @@ export const InsightsSection = ( props: InsightsSectionProps ) => {
 					insight={ { ...audits[ key ], id: key } }
 					index={ index }
 					url={ props.url }
+					isWpcom={ isWpcom }
 				/>
 			) ) }
 		</div>

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -15,6 +15,7 @@ interface MetricsInsightProps {
 	onClick?: () => void;
 	index: number;
 	url?: string;
+	isWpcom: boolean;
 }
 
 const Card = styled( FoldableCard )`
@@ -62,14 +63,14 @@ const Content = styled.div`
 export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 	const translate = useTranslate();
 
-	const { insight, onClick, index } = props;
+	const { insight, onClick, index, isWpcom } = props;
 
 	const [ retrieveInsight, setRetrieveInsight ] = useState( false );
 	const { data: llmAnswer, isLoading: isLoadingLlmAnswer } = useSupportChatLLMQuery(
 		insight.description ?? '',
 		isEnabled( 'performance-profiler/llm' ) && retrieveInsight
 	);
-	const tip = tips[ insight.id ];
+	const tip = ! isWpcom && tips[ insight.id ];
 
 	if ( props.url && tip ) {
 		tip.link = `https://wordpress.com/setup/hosted-site-migration?from=${ props.url }&ref=performance-profiler-dashboard`;

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -70,10 +70,14 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 		insight.description ?? '',
 		isEnabled( 'performance-profiler/llm' ) && retrieveInsight
 	);
-	const tip = ! isWpcom && tips[ insight.id ];
+	const tip = tips[ insight.id ];
 
 	if ( props.url && tip ) {
 		tip.link = `https://wordpress.com/setup/hosted-site-migration?from=${ props.url }&ref=performance-profiler-dashboard`;
+	}
+
+	if ( tip && isWpcom ) {
+		tip.link = '';
 	}
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8837

## Proposed Changes

* hide the migration tips for wpcom sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

https://github.com/Automattic/dotcom-forge/issues/8837

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a WPCOM site report with the `uses-responsive-images` issue, eg. `/speed-test-tool?url=https%3A%2F%2Fwordpress.com%2F&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6NzA0OX0.ZfaRSmOrFbiJrNRM8y4xEQmlRcMCCK4Xeb6cpts-yCI`
* Open the `Properly size images` issue and check that the migration tip is **not** displayed
* Go to a non-WPCOM site report with the `uses-responsive-images` issue, eg. ``
* Open the `Properly size images` issue and check that the migration tip displayed

| WPCOM | non-WPCOM |
|--------|--------|
| ![CleanShot 2024-08-26 at 10 55 22@2x](https://github.com/user-attachments/assets/f9c4e2e1-7bb9-4caa-a28c-a6d8fc22b7cb) | ![CleanShot 2024-08-23 at 15 19 16@2x](https://github.com/user-attachments/assets/eb42fe1b-ef26-49ae-baa1-c4f78b20379b) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
