### PR TITLE
A4A: Remove '?' in the KB link label.

### DIFF
--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -85,7 +85,7 @@ export default function GetStarted() {
 						target="_blank"
 						href="#" // FIXME: Add link to the KB article
 					>
-						{ translate( 'Team members Knowledge Base article?' ) }
+						{ translate( 'Team members Knowledge Base article' ) }
 						<Icon icon={ external } size={ 18 } />
 					</Button>
 					<br />


### PR DESCRIPTION
A minor typo was fixed in the Multi-user support KB link in the Get Started view.

<img width="378" alt="Screenshot 2024-08-23 at 10 30 34 PM" src="https://github.com/user-attachments/assets/a4039f46-4c77-42c1-8154-26486e4d4205">


Context: https://github.com/Automattic/wp-calypso/pull/93669#discussion_r1727249671

## Proposed Changes

* Fix typo

## Why are these changes being made?

*

## Testing Instructions

* Use the A4A live link
* Confirm that nothing breaks

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
