### PR TITLE
[Proposal] Refactor persisted params in the navigation

### DIFF
--- a/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
+++ b/client/landing/stepper/declarative-flow/migration/hooks/use-flow-navigator.ts
@@ -3,7 +3,12 @@ import { Primitive } from 'utility-types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { Navigate, ProvidedDependencies, StepperStep } from '../../internals/types';
 
-export const useFlowNavigator = ( navigate: Navigate< StepperStep[] > ) => {
+interface Options {
+	navigate: Navigate< StepperStep[] >;
+	persistedUrlParams: string[];
+}
+
+export const useFlowNavigator = ( { navigate, persistedUrlParams }: Options ) => {
 	const [ query ] = useSearchParams();
 
 	const getFromPropsOrUrl = ( key: string, props?: ProvidedDependencies ): Primitive => {
@@ -17,7 +22,9 @@ export const useFlowNavigator = ( navigate: Navigate< StepperStep[] > ) => {
 		props: ProvidedDependencies = {},
 		options = { replaceHistory: false }
 	) => {
-		const queryParams = keys.reduce(
+		const allKeys = [ ...persistedUrlParams, ...keys ];
+
+		const queryParams = allKeys.reduce(
 			( acc, key ) => {
 				const value = getFromPropsOrUrl( key, props );
 				if ( value ) {

--- a/client/landing/stepper/declarative-flow/migration/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/index.tsx
@@ -56,7 +56,10 @@ const plans: { [ key: string ]: string } = {
 const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject: Flow ) => {
 	const [ query, setQuery ] = useSearchParams();
 	const flowPath = ( flowObject.variantSlug ?? flowObject.name ) as string;
-	const { navigateWithQueryParams, getFromPropsOrUrl } = useFlowNavigator( navigate );
+	const { navigateWithQueryParams, getFromPropsOrUrl } = useFlowNavigator( {
+		navigate,
+		persistedUrlParams: [ 'siteId', 'siteSlug', 'from' ],
+	} );
 
 	const navigateToCheckout = ( {
 		siteId,
@@ -120,14 +123,10 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 
 				if ( platform === 'wordpress' ) {
 					if ( hasSite ) {
-						return navigateWithQueryParams(
-							MIGRATION_UPGRADE_PLAN,
-							[ 'siteId', 'siteSlug', 'from' ],
-							props
-						);
+						return navigateWithQueryParams( MIGRATION_UPGRADE_PLAN, [], props );
 					}
 
-					return navigateWithQueryParams( SITE_CREATION_STEP, [ 'from' ], props );
+					return navigateWithQueryParams( SITE_CREATION_STEP, [], props );
 				}
 
 				if ( hasSite ) {
@@ -139,14 +138,14 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 					} );
 				}
 
-				return navigateWithQueryParams( SITE_CREATION_STEP, [ 'platform', 'from' ], props, {
+				return navigateWithQueryParams( SITE_CREATION_STEP, [ 'platform' ], props, {
 					replaceHistory: true,
 				} );
 			},
 		},
 		[ SITE_CREATION_STEP.slug ]: {
 			submit: ( props?: ProvidedDependencies ) => {
-				return navigateWithQueryParams( PROCESSING, [ 'platform', 'plan', 'from' ], props, {
+				return navigateWithQueryParams( PROCESSING, [ 'platform', 'plan' ], props, {
 					replaceHistory: true,
 				} );
 			},
@@ -183,14 +182,9 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 					} );
 				}
 
-				return navigateWithQueryParams(
-					MIGRATION_UPGRADE_PLAN,
-					[ 'siteId', 'siteSlug', 'from' ],
-					props,
-					{
-						replaceHistory: true,
-					}
-				);
+				return navigateWithQueryParams( MIGRATION_UPGRADE_PLAN, [], props, {
+					replaceHistory: true,
+				} );
 			},
 		},
 		[ MIGRATION_UPGRADE_PLAN.slug ]: {
@@ -231,11 +225,7 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 					return setQuery( query );
 				}
 
-				return navigateWithQueryParams(
-					PLATFORM_IDENTIFICATION,
-					[ 'siteId', 'siteSlug', 'plan', 'from' ],
-					props
-				);
+				return navigateWithQueryParams( PLATFORM_IDENTIFICATION, [ 'plan' ], props );
 			},
 		},
 		[ MIGRATION_HOW_TO_MIGRATE.slug ]: {
@@ -243,43 +233,23 @@ const useCreateStepHandlers = ( navigate: Navigate< StepperStep[] >, flowObject:
 				const how = getFromPropsOrUrl( 'how', props );
 
 				if ( how === HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ) {
-					return navigateWithQueryParams(
-						SITE_MIGRATION_INSTRUCTIONS,
-						[ 'siteId', 'siteSlug', 'from' ],
-						props
-					);
+					return navigateWithQueryParams( SITE_MIGRATION_INSTRUCTIONS, [], props );
 				}
 
-				return navigateWithQueryParams(
-					MIGRATION_SOURCE_URL,
-					[ 'siteId', 'siteSlug', 'from' ],
-					props
-				);
+				return navigateWithQueryParams( MIGRATION_SOURCE_URL, [], props );
 			},
 		},
 		[ SITE_MIGRATION_INSTRUCTIONS.slug ]: {
 			submit: ( props?: ProvidedDependencies ) => {
-				return navigateWithQueryParams(
-					SITE_MIGRATION_STARTED,
-					[ 'siteId', 'siteSlug', 'from' ],
-					props
-				);
+				return navigateWithQueryParams( SITE_MIGRATION_STARTED, [], props );
 			},
 		},
 		[ MIGRATION_SOURCE_URL.slug ]: {
 			submit: ( props?: ProvidedDependencies ) => {
-				return navigateWithQueryParams(
-					SITE_MIGRATION_ASSISTED_MIGRATION,
-					[ 'siteId', 'siteSlug', 'from' ],
-					props
-				);
+				return navigateWithQueryParams( SITE_MIGRATION_ASSISTED_MIGRATION, [], props );
 			},
 			goBack: ( props?: ProvidedDependencies ) => {
-				return navigateWithQueryParams(
-					MIGRATION_HOW_TO_MIGRATE,
-					[ 'siteId', 'siteSlug', 'from' ],
-					props
-				);
+				return navigateWithQueryParams( MIGRATION_HOW_TO_MIGRATE, [], props );
 			},
 		},
 	};

--- a/client/landing/stepper/declarative-flow/migration/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/migration/test/index.tsx
@@ -87,7 +87,7 @@ describe( `${ flow.name }`, () => {
 
 				expect( destination ).toMatchDestination( {
 					step: STEPS.SITE_CREATION_STEP,
-					query: { platform: 'blogger', from: 'optional' },
+					query: { from: 'optional', platform: 'blogger' },
 				} );
 			} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Reactor of the persisted params, so we don't need to worry about passing them in all the steps with the risk to forget some.

### Future ideas

We still need to continue getting the persisted params to pass along for the `goToCheckout` and `goToImporter`. It would be nice if we could also improve them.

I thought of implementing a `getPersistedProps` in the `useFlowNavigator`, but it doesn't seem a good idea especially because of the variable types.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Code improvement and reduce the risk of future issues while maintaining.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/setup/migration`.
* Navigate in the flow going forth and back, and make sure the props are properly persisted.
* Navigate to `/setup/migration?from=WORDPRESS_SITE_URL` (replace the `from` with a real URL of a WordPress site).
* Navigate in the flow going forth and back, and make sure the props are properly persisted.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
