### PR TITLE
Reader: when adding new blogs via modal, autofocus the URL entry field for accessibility and faster URL entry

### DIFF
--- a/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
+++ b/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
@@ -25,6 +25,7 @@ const AddSitesModal = ( { showModal, onClose, onAddFinished }: AddSitesModalProp
 			title={ modalTitle as string }
 			onRequestClose={ onClose }
 			overlayClassName="add-sites-modal"
+			focusOnMount="firstContentElement"
 		>
 			<p className="add-sites-modal__subtitle">
 				{ translate( 'Subscribe to sites, newsletters, and RSS feeds.' ) }


### PR DESCRIPTION
Fixes #93310

## Proposed Changes

* Adds `focusOnMount` to the Modal component per [Gutenberg modal docs](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/modal/README.md#focusonmount)

## Why are these changes being made?

* Easier URL entry, saving 1 mouse click
* Helps with keyboard accessibilty

## Testing Instructions

* Before: when you click "Add a site" button at top right — the modal's entry field is not auto-focused

<img width="1121" alt="Screenshot 2024-08-23 at 12 22 03" src="https://github.com/user-attachments/assets/1c7d9cf0-6f70-4218-bc9a-d1e48aa804fe">

* After: the modal URL entry field is auto-focused
