### PR TITLE
Onboarding: Hide option to use external domain

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -589,7 +589,7 @@ export class RenderDomainsStep extends Component {
 
 	shouldHideUseYourDomain = () => {
 		const { flowName } = this.props;
-		return [ 'domain', 'domain-for-gravatar' ].includes( flowName );
+		return [ 'domain', 'domain-for-gravatar', 'onboarding-with-email' ].includes( flowName );
 	};
 
 	shouldDisplayDomainOnlyExplainer = () => {


### PR DESCRIPTION
🤔 I have something else I want to investigate a bit more before proceeding with this PR - I'll drop a ping when I'm done checking it out.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8216-gh-Automattic/dotcom-forge

## Proposed Changes

Removes the option to use an external domain when signing up through the `onboarding-with-email` flow

**Before**
![image](https://github.com/user-attachments/assets/f41c286f-22cb-45dd-b08c-185692c0a12d)

**After**
![image](https://github.com/user-attachments/assets/4346074a-e2b2-4f11-9317-c70deb5a60a2)

## Why are these changes being made?

If the option to use an external domain is selected it leads to an error state when selecting a plan as the cart is prepped for checkout because we aren't able to create an email subscription for a domain that isn't already connected to a site in the user's account.

## Testing Instructions

- Start at `start/email-with-onboarding`
- Confirm that the option to use your own external domain is not presented
- Search for a domain and select one
- Confirm the rest of the flow works as expected and leads you to the checkout screen with no errors