### PR TITLE
Reader: update wording for `add site` to `add subscription`

### DIFF
--- a/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
+++ b/client/landing/subscriptions/components/add-sites-button/add-sites-button.tsx
@@ -37,7 +37,9 @@ const AddSitesButton = () => {
 				} }
 			>
 				<Gridicon className="subscriptions-add-sites__button-icon" icon="plus" size={ 24 } />
-				<span className="subscriptions-add-sites__button-text">{ translate( 'Add a site' ) }</span>
+				<span className="subscriptions-add-sites__button-text">
+					{ translate( 'New subscription' ) }
+				</span>
 			</Button>
 			<AddSitesModal
 				showModal={ isAddSitesModalVisible }

--- a/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
+++ b/client/landing/subscriptions/components/add-sites-modal/add-sites-modal.tsx
@@ -12,7 +12,7 @@ type AddSitesModalProps = {
 const AddSitesModal = ( { showModal, onClose, onAddFinished }: AddSitesModalProps ) => {
 	const translate = useTranslate();
 
-	const modalTitle = translate( 'Add a site', {
+	const modalTitle = translate( 'Add a New Subscription', {
 		context: 'Modal title',
 	} );
 


### PR DESCRIPTION
Props @ianstewart , fixes #93877

## Proposed Changes

* Change `Add site` to `Add subscription` or similar — `New site` to `New subscription`

* This creates clarity for other WordPress.com actions for adding new websites (own & manager your website) versus the action of adding a new subscription: RSS feed, newsletter, or site by URL

## Testing Instructions

1. Log in, and navigate to Reader: https://wordpress.com/read
2. Click on "Subscriptions" tab: (same URL)
3. Click "Manage": https://wordpress.com/read/subscriptions
4. See the CTA (blue button, primary action) reads Add a site

The new labels (string updates only) should appear as:
* `New Subscription` in the blue button CTA, top right
* `Add a New Subscription` in the modal after clicking the blue button

<img width="1392" alt="Screenshot 2024-08-23 at 13 32 00" src="https://github.com/user-attachments/assets/2c85c0a5-3752-477a-8da9-c2fd38adac9e">
<img width="1392" alt="Screenshot 2024-08-23 at 13 32 03" src="https://github.com/user-attachments/assets/fc8506e7-ee70-4088-974f-e355343a4b13">
