### PR TITLE
Read new field for base_rewind_id and rewind_step_count

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -40,6 +40,8 @@ const BackupSuccessful = ( {
 	const getDisplayDate = useGetDisplayDate();
 	const displayDate = getDisplayDate( backup.activityTs );
 	const displayDateNoLatest = getDisplayDate( backup.activityTs, false );
+	// TODO To be use in the future
+	//const displayDateBaseRewind = backup.baseRewindId ? getDisplayDate( backup.baseRewindId * 1000, false ) : null;
 
 	const today = applySiteOffset( moment(), {
 		timezone: timezone,

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -62,6 +62,8 @@ export function processItem( item ) {
 			activityDescription: parseBlock( item.content ),
 			activityMedia: get( item, 'image' ),
 			activityMeta,
+			baseRewindId: item.base_rewind_id,
+			rewindStepCount: item.rewind_step_count,
 		},
 		item.rewind_id && { rewindId: item.rewind_id },
 		item.status && { activityStatus: item.status },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/609

## Proposed Changes

* Add changes that will be common to other changes, like reading the new field

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It will be used in next PR to show more information about the backups.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* It only reads the data from the API and allows to use it, but it doesn't add a new functionality. So verifying there are no errors in the console with the change should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
