### PR TITLE
Remove redirect to fallback

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -151,9 +151,6 @@ const SignupFormSocialFirst = ( {
 				  }
 				: {};
 
-			const redirectToParam =
-				queryArgs?.redirect_to ?? window.location.origin + `/setup/${ flowName }`;
-
 			return (
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
@@ -173,7 +170,7 @@ const SignupFormSocialFirst = ( {
 										{
 											email_address: email,
 											is_signup_existing_account: true,
-											redirect_to: redirectToParam,
+											redirect_to: queryArgs?.redirect_to,
 										},
 										logInUrl
 									)


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/93566

Fixes: https://github.com/Automattic/wp-calypso/issues/93876

## Proposed Changes

This respects the `rediectTo` param if it exists and lets `login` function figure out how to deal with absense rather then setting an incorrect value.


## Testing Instructions

### Case I

1. Go to /start.
2. Click Continue via email.
3. Enter an existing email.
4. You should be redirected to log in.
5. Do log in.
6. Make sure login redirects you to /start/domains. **NOT** /setup/onboarding.

### Case II

1. Go /setup/newsletter/?ref=newsletter-lp
2. Click Continue via email.
3. Enter a new email.
4. You should be redirect back to /setup/newsletter.